### PR TITLE
Add interview changes export

### DIFF
--- a/app/exports/interview_changes_export.yml
+++ b/app/exports/interview_changes_export.yml
@@ -1,0 +1,74 @@
+common_columns:
+- provider_code
+- course_code
+
+custom_columns:
+  audit_id:
+    type: integer
+    description: The id of the audit for the change to the interview
+  audit_created_at:
+    type: datetime
+    description: The time the change was made
+  audit_type:
+    type: string
+    description: Whether the change was a create or an update action
+    enum:
+      - create
+      - update
+  interview_id:
+    type: integer
+    description: The id of the interview being changed
+  candidate_id:
+    type: integer
+    description: The id of the candidate being interviewed
+  application_form_id:
+    type: integer
+    description: The id of the application form of the candidate being interviewed
+  provider_user:
+    type: string
+    description: Email address of the user who made the change, or 'Support' if done by support
+  interview_status:
+    type: string
+    description: Whether the interview was upcoming or past when the change was made
+    enum:
+      - upcoming
+      - past
+  date_and_time:
+    type: datetime
+    description: |
+      The new date_and_time value for the interview, after the change.
+      Left as a blank string if there was no change.
+  cancelled_at:
+    type: datetime
+    description: |
+      The new cancelled_at value for the interview, after the change.
+      Left as a blank string if there was no change.
+  cancellation_reason:
+    type: string
+    description: |
+      The new cancellation_reason value for the interview, after the change.
+      Left as a blank string if there was no change.
+  provider_id:
+    type: interger
+    description: |
+      The new provider_id value for the interview, after the change.
+      Left as a blank string if there was no change.
+  location:
+    type: string
+    description: |
+      The new location value for the interview, after the change.
+      Left as a blank string if there was no change.
+  additional_details:
+    type: string
+    description: |
+      The new additional_details value for the interview, after the change.
+      Left as a blank string if there was no change.
+  interview_preferences:
+    type: string
+    description: The interview preferences given by the candidate
+  application_submitted_at:
+    type: datetime
+    description: When the candidate submitted their application form
+  course_location:
+    type: string
+    description: The name and code of the site the course will take place at

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -50,6 +50,11 @@ class DataExport < ApplicationRecord
       description: 'Anonymised candidate equality and diversity data.',
       class: SupportInterface::EqualityAndDiversityExport,
     },
+    interviews_export: {
+      name: 'Interview changes',
+      description: 'A list of changes made to interviews for analysis of the Interviews feature',
+      class: SupportInterface::InterviewChangesExport,
+    },
     notifications_export: {
       name: 'Notifications',
       description: 'Data to enable performance assesment of Notification feature.',

--- a/app/services/support_interface/interview_changes_export.rb
+++ b/app/services/support_interface/interview_changes_export.rb
@@ -1,0 +1,103 @@
+module SupportInterface
+  class InterviewChangesExport
+    def data_for_export
+      interview_audits.map do |audit|
+        row_for_audit(audit)
+      end
+    end
+
+    def row_for_audit(audit)
+      interview = audit.auditable
+      application_choice = interview.application_choice
+      {
+        audit_id: audit.id,
+        audit_created_at: audit.created_at,
+        audit_type: audit.action,
+        interview_id: interview.id,
+        candidate_id: application_choice.candidate.id,
+        application_form_id: application_choice.application_form.id,
+        provider_code: application_choice.provider.code,
+        provider_user: audit_user(audit),
+        interview_status: interview_status(interview, audit),
+        interview_preferences: application_choice.application_form.interview_preferences,
+        application_submitted_at: application_choice.application_form.submitted_at,
+        course_code: application_choice.course.code,
+        course_location: application_choice.site.name_and_code,
+      }.merge(interview_change(audit))
+    end
+
+  private
+
+    def interview_audits
+      Audited::Audit.where(auditable_type: 'Interview').includes(
+        :user,
+        auditable: {
+          application_choice: %i[application_form course site candidate provider],
+        },
+      )
+    end
+
+    def interview_status(interview, audit)
+      if audit.created_at < interview_time_when_change_made(interview, audit)
+        'upcoming'
+      else
+        'past'
+      end
+    end
+
+    def interview_time_when_change_made(interview, audit)
+      # We want to return the time the interview was scheduled for at the time of the audit.
+      # If the time was changed, then return the original time from the audited_changes.
+      # If the time was not changed, then it is either an upcoming interview (since the validation means you can't make it in the past)
+      # or it is a cancellation and the interview time on the interview model is representative.
+      interview_time_from_audit(audit).presence || interview.date_and_time
+    end
+
+    def interview_time_from_audit(audit)
+      audited_time = audit.audited_changes['date_and_time']
+      if audited_time.is_a?(Array)
+        Time.zone.parse(audited_time.first)
+      elsif audited_time.present?
+        Time.zone.parse(audited_time)
+      end
+    end
+
+    def interview_change(audit)
+      changes = changed_attributes(audit)
+      {
+        date_and_time: change_to_attr(changes, 'date_and_time'),
+        cancelled_at: change_to_attr(changes, 'cancelled_at'),
+        cancellation_reason: change_to_attr(changes, 'cancellation_reason'),
+        provider_id: change_to_attr(changes, 'provider_id'),
+        location: change_to_attr(changes, 'location'),
+        additional_details: change_to_attr(changes, 'additional_details'),
+      }
+    end
+
+    def changed_attributes(audit)
+      if audit.action == 'update'
+        audit.audited_changes.transform_values(&:last)
+      else
+        audit.audited_changes
+      end
+    end
+
+    def change_to_attr(changes, attr)
+      if changes.keys.include?(attr)
+        changes[attr]
+      else
+        ''
+      end
+    end
+
+    def audit_user(audit)
+      if audit.user_type == 'SupportUser'
+        'Support'
+      elsif audit.user.present?
+        audit.user.email_address
+      else
+        'Automated process'
+      end
+    end
+  end
+end

--- a/app/services/support_interface/interview_changes_export.rb
+++ b/app/services/support_interface/interview_changes_export.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class InterviewChangesExport
     def data_for_export
-      interview_audits.map do |audit|
+      interview_audits.find_each(batch_size: 100).map do |audit|
         row_for_audit(audit)
       end
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1283,7 +1283,8 @@ FactoryBot.define do
     after(:build) do |audit, evaluator|
       audit.auditable_type = 'Interview'
       audit.auditable_id = evaluator.interview.id
-      audit.associated = evaluator.application_choice
+      audit.associated = evaluator.interview.application_choice
+      audit.user_type = evaluator.user.class.to_s
       audit.audited_changes = evaluator.changes
     end
   end

--- a/spec/services/support_interface/interview_changes_export_spec.rb
+++ b/spec/services/support_interface/interview_changes_export_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe SupportInterface::InterviewChangesExport do
       Timecop.freeze(2021, 11, 5, 15) { example.run }
     end
 
+    it_behaves_like 'a data export'
+
     it 'returns a list of hashes with the correct values' do
       expect(described_class.new.data_for_export).to match_array([
         {

--- a/spec/services/support_interface/interview_changes_export_spec.rb
+++ b/spec/services/support_interface/interview_changes_export_spec.rb
@@ -1,0 +1,239 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::InterviewChangesExport do
+  let(:interview) { create(:interview, date_and_time: 1.day.from_now) }
+
+  describe '#data_for_export' do
+    let!(:create_interview_audit) do
+      create(
+        :interview_audit,
+        interview: interview,
+        changes: {
+          'location' => interview.location,
+          'provider_id' => interview.provider_id,
+          'cancelled_at' => nil,
+          'date_and_time' => interview.date_and_time.to_s,
+          'additional_details' => nil,
+          'cancellation_reason' => nil,
+          'application_choice_id' => interview.application_choice_id,
+        },
+        action: 'create',
+        created_at: 2.days.ago,
+      )
+    end
+    let!(:edit_interview_audit) do
+      create(
+        :interview_audit,
+        interview: interview,
+        changes: {
+          'location' => [interview.location, 'Google Meet'],
+          'date_and_time' => [interview.date_and_time.to_s, 2.days.from_now.to_s],
+          'additional_details' => [nil, 'Wear a bowtie'],
+        },
+        action: 'update',
+        created_at: 1.day.ago,
+      )
+    end
+
+    around do |example|
+      Timecop.freeze(2021, 11, 5, 15) { example.run }
+    end
+
+    it 'returns a list of hashes with the correct values' do
+      expect(described_class.new.data_for_export).to match_array([
+        {
+          audit_id: create_interview_audit.id,
+          audit_created_at: create_interview_audit.created_at,
+          audit_type: 'create',
+          interview_id: interview.id,
+          candidate_id: interview.application_choice.candidate.id,
+          application_form_id: interview.application_choice.application_form.id,
+          provider_code: interview.application_choice.provider.code,
+          provider_user: create_interview_audit.user.email_address,
+          interview_status: 'upcoming',
+          interview_preferences: interview.application_choice.application_form.interview_preferences,
+          application_submitted_at: interview.application_choice.application_form.submitted_at,
+          course_code: interview.application_choice.course.code,
+          course_location: interview.application_choice.site.name_and_code,
+          date_and_time: 1.day.from_now.to_s,
+          cancelled_at: nil,
+          cancellation_reason: nil,
+          provider_id: interview.provider_id,
+          location: interview.location,
+          additional_details: nil,
+        },
+        {
+          audit_id: edit_interview_audit.id,
+          audit_created_at: edit_interview_audit.created_at,
+          audit_type: 'update',
+          interview_id: interview.id,
+          candidate_id: interview.application_choice.candidate.id,
+          application_form_id: interview.application_choice.application_form.id,
+          provider_code: interview.application_choice.provider.code,
+          provider_user: edit_interview_audit.user.email_address,
+          interview_status: 'upcoming',
+          interview_preferences: interview.application_choice.application_form.interview_preferences,
+          application_submitted_at: interview.application_choice.application_form.submitted_at,
+          course_code: interview.application_choice.course.code,
+          course_location: interview.application_choice.site.name_and_code,
+          date_and_time: 2.days.from_now.to_s,
+          cancelled_at: '',
+          cancellation_reason: '',
+          provider_id: '',
+          location: 'Google Meet',
+          additional_details: 'Wear a bowtie',
+        },
+      ])
+    end
+  end
+
+  describe '#row_for_audit' do
+    let(:user) { create(:provider_user) }
+    let(:changes) do
+      {
+        'location' => 'Zoom',
+        'provider_id' => '1234',
+        'cancelled_at' => nil,
+        'date_and_time' => 1.day.from_now.to_s,
+        'additional_details' => nil,
+        'cancellation_reason' => nil,
+        'application_choice_id' => interview.application_choice_id,
+      }
+    end
+    let(:action) { 'create' }
+    let(:audit_created_at) { 1.hour.ago }
+    let(:audit) do
+      create(
+        :interview_audit,
+        interview: interview,
+        user: user,
+        changes: changes,
+        action: action,
+        created_at: audit_created_at,
+      )
+    end
+    let(:row) { described_class.new.row_for_audit(audit) }
+
+    context 'when audit creates an interview' do
+      it 'sets the audit_type to create' do
+        expect(row[:audit_type]).to eq('create')
+      end
+
+      it 'sets correct initial interview attributes' do
+        expect(row[:provider_id]).to eq('1234')
+        expect(row[:date_and_time]).to eq(1.day.from_now.to_s)
+        expect(row[:cancelled_at]).to be_blank
+        expect(row[:cancellation_reason]).to be_blank
+        expect(row[:location]).to eq('Zoom')
+        expect(row[:additional_details]).to be_blank
+      end
+    end
+
+    context 'when audit edits an interview' do
+      let(:action) { 'update' }
+      let(:changes) do
+        {
+          'location' => ['Zoom', 'Google Meet'],
+          'date_and_time' => [1.day.from_now.to_s, 2.days.from_now.to_s],
+          'additional_details' => [nil, 'Wear a bowtie'],
+        }
+      end
+
+      it 'sets the audit_type to update' do
+        expect(row[:audit_type]).to eq('update')
+      end
+
+      it 'sets the interview status to upcoming' do
+        expect(row[:interview_status]).to eq('upcoming')
+      end
+
+      it 'sets correct interview attributes' do
+        expect(row[:provider_id]).to be_blank
+        expect(row[:date_and_time]).to eq(2.days.from_now.to_s)
+        expect(row[:cancelled_at]).to be_blank
+        expect(row[:cancellation_reason]).to be_blank
+        expect(row[:location]).to eq('Google Meet')
+        expect(row[:additional_details]).to eq('Wear a bowtie')
+      end
+    end
+
+    context 'when audit cancels an interview' do
+      let(:action) { 'update' }
+      let(:changes) do
+        {
+          'cancelled_at' => [nil, 1.hour.ago.to_s],
+          'cancellation_reason' => [nil, 'No reply to our email'],
+        }
+      end
+
+      it 'sets correct interview attributes' do
+        expect(row[:provider_id]).to be_blank
+        expect(row[:date_and_time]).to be_blank
+        expect(row[:cancelled_at]).to eq(1.hour.ago.to_s)
+        expect(row[:cancellation_reason]).to eq('No reply to our email')
+        expect(row[:location]).to be_blank
+        expect(row[:additional_details]).to be_blank
+      end
+    end
+
+    context 'when audit edits an interview that would have already occurred' do
+      let(:interview) { create(:interview, date_and_time: 1.day.ago) }
+      let(:action) { 'update' }
+      let(:changes) do
+        {
+          'date_and_time' => [1.day.ago.to_s, 2.days.from_now.to_s],
+          'location' => ['Zoom', 'New Zoom link'],
+        }
+      end
+
+      it 'sets correct interview attributes' do
+        expect(row[:provider_id]).to be_blank
+        expect(row[:date_and_time]).to eq(2.days.from_now.to_s)
+        expect(row[:cancelled_at]).to be_blank
+        expect(row[:cancellation_reason]).to be_blank
+        expect(row[:location]).to eq('New Zoom link')
+        expect(row[:additional_details]).to be_blank
+      end
+
+      it 'sets the interview status to past' do
+        expect(row[:interview_status]).to eq('past')
+      end
+    end
+
+    describe 'application related columns' do
+      it 'returns columns relating to the application' do
+        expect(row[:candidate_id]).to eq(interview.application_choice.candidate.id)
+        expect(row[:application_form_id]).to eq(interview.application_choice.application_form_id)
+        expect(row[:provider_code]).to eq(interview.application_choice.provider.code)
+        expect(row[:interview_preferences]).to eq(interview.application_choice.application_form.interview_preferences)
+        expect(row[:application_submitted_at]).to eq(interview.application_choice.application_form.submitted_at)
+        expect(row[:course_code]).to eq(interview.application_choice.course.code)
+        expect(row[:course_location]).to eq(interview.application_choice.site.name_and_code)
+      end
+    end
+
+    describe 'provider_user' do
+      context 'when the change is made by a provider user' do
+        it 'sets provider_user to the email address of the user' do
+          expect(row[:provider_user]).to eq(user.email_address)
+        end
+      end
+
+      context 'when the change is made by a support user' do
+        let(:user) { create(:support_user) }
+
+        it 'sets provider_user to Support' do
+          expect(row[:provider_user]).to eq('Support')
+        end
+      end
+
+      context 'when the change does not have an associated user' do
+        let(:user) { nil }
+
+        it 'sets provider_user to Automated process' do
+          expect(row[:provider_user]).to eq('Automated process')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
To enable analysis on:
- Who is scheduling interviews
- How many interviews are being scheduled
- Are interviews being changed?
- What kind of changes are being made?
- Are interviews being cancelled? 
- Why are they being cancelled?

## Changes proposed in this pull request
Add an interview changes export and documentation for it to support

## Guidance to review
Are there any gaps in the export that will make the analysis difficult?

## Link to Trello card
https://trello.com/c/7eXWJiJd/3453-create-interviews-csv-extracts-to-be-accessed-in-support-performance

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
