### PR TITLE
Make OpenProviderCourses audit the changes it makes

### DIFF
--- a/app/services/open_provider_courses.rb
+++ b/app/services/open_provider_courses.rb
@@ -6,7 +6,7 @@ class OpenProviderCourses
   end
 
   def call
-    if run_courses.or(ratified_courses).update_all(open_on_apply: true).positive?
+    if run_courses.or(ratified_courses).update(open_on_apply: true).any?
       provider.provider_users.each do |provider_user|
         ProviderMailer.courses_open_on_apply(provider_user)
       end

--- a/spec/services/open_provider_courses_spec.rb
+++ b/spec/services/open_provider_courses_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe OpenProviderCourses do
     provider = create(:provider)
     create(:course, exposed_in_find: false, provider: provider)
 
-    expect { OpenProviderCourses.new(provider: provider).call }
+    expect { described_class.new(provider: provider).call }
       .not_to(change { Course.open_on_apply.count })
   end
 
@@ -35,5 +35,15 @@ RSpec.describe OpenProviderCourses do
     }.to(change { ratified_course.reload.open_on_apply? }.from(false).to(true))
 
     expect(other_course.reload).not_to be_open_on_apply
+  end
+
+  it 'creates audits for the changes it makes', with_audited: true do
+    provider = create(:provider)
+    course = create(:course, exposed_in_find: true, provider: provider)
+
+    expect { described_class.new(provider: provider).call }
+      .to(change { course.audits.count }.from(1).to(2))
+
+    expect(course.audits.last.audited_changes.keys).to include('open_on_apply')
   end
 end


### PR DESCRIPTION
## Context
Currently we do not have a record for when courses were opened on apply using this service.

## Changes proposed in this pull request
Change from using update_all which skips callbacks, to looping through and calling update on each course record.

## Guidance to review
Have I missed a nicer way of doing this?

## Link to Trello card
https://trello.com/c/r9aaU0Jm/3466-openprovidercourses-does-not-audit-its-changes-to-openonapply

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
