### PR TITLE
Add nil check for date

### DIFF
--- a/app/services/support_interface/work_history_break_export.rb
+++ b/app/services/support_interface/work_history_break_export.rb
@@ -29,7 +29,7 @@ module SupportInterface
         output = {
           'Candidate id' => application_form.candidate_id,
           'Application id' => application_form.id,
-          'Application submitted' => application_form.submitted_at.to_date,
+          'Application submitted' => application_form.submitted_at.present? ? application_form.submitted_at.strftime('%d/%m/%Y') : nil,
           'Course choice statuses' => application_form.application_choices.map(&:status).sort,
           'Start of working life' => start_of_working_life(application_form),
           'Total time in employment (months)' => total_time_in_employment(application_form),

--- a/spec/services/support_interface/work_history_break_export_spec.rb
+++ b/spec/services/support_interface/work_history_break_export_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe SupportInterface::WorkHistoryBreakExport do
           {
             'Candidate id' => candidate.id,
             'Application id' => application_form.id,
-            'Application submitted' => Date.new(2020, 12, 31),
+            'Application submitted' => '31/12/2020',
             'Course choice statuses' => %w[offer],
             'Start of working life' => Date.new(2000, 1, 1),
             'Total time in employment (months)' => 72,


### PR DESCRIPTION
## Context

To fix bug on export, https://sentry.io/organizations/dfe-bat/issues/2253951569/?project=1765973&referrer=slack.

## Changes proposed in this pull request

Add a nil check.
I've also changed the date format to make it more readable in the export, by removing the timestamps which are irrelevant. 

## Guidance to review

Is there a better, more idiomatic way to do this? I struggled to find one, but it's hard to google for.

## Link to Trello card

https://trello.com/c/0XkC7SCE/2985-change-the-unexplainedbreaksinworkhistoryexport-to-workhistorybreakexport-and-include-all-workhistory-breaks

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
