### PR TITLE
Update Before You Start view link

### DIFF
--- a/app/views/candidate_interface/unsubmitted_application_form/before_you_start.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/before_you_start.html.erb
@@ -9,7 +9,7 @@
 
     <hr class="govuk-section-break govuk-section-break--m">
 
-    <%= govuk_button_link_to 'Choose a course', candidate_interface_course_choices_index_path, class: 'govuk-!-margin-bottom-5' %>
+    <%= govuk_button_link_to 'Choose a course', candidate_interface_course_choices_choose_path, class: 'govuk-!-margin-bottom-5' %>
     <p class="govuk-body">or</p>
     <%= govuk_link_to 'Go to your application form', candidate_interface_application_form_path, class: 'govuk-body' %>
   </div>

--- a/spec/system/candidate_interface/signup_and_signin/candidate_is_redirected_to_before_you_start_page_on_first_sign_in_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_is_redirected_to_before_you_start_page_on_first_sign_in_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'A new candidate is encouraged to select a course' do
     then_i_should_see_the_before_you_start_page
     and_i_should_see_an_account_created_flash_message
     when_i_click_choose_a_course
-    then_i_should_see_the_course_choices_index_page
+    then_i_should_see_the_course_choices_choose_page
 
     when_i_sign_out
     when_i_visit_apply
@@ -76,8 +76,8 @@ RSpec.feature 'A new candidate is encouraged to select a course' do
     click_link 'Choose a course'
   end
 
-  def then_i_should_see_the_course_choices_index_page
-    expect(page).to have_current_path(candidate_interface_course_choices_index_path)
+  def then_i_should_see_the_course_choices_choose_page
+    expect(page).to have_current_path(candidate_interface_course_choices_choose_path)
   end
 
   def when_i_visit_the_before_you_start_page


### PR DESCRIPTION
## Context

In the case that user proceeds from the before you start page there is a duplication of information. This is not the case if proceeding from the application form. Therefore, this PR updates the link on that to redirect in this situation.

## Changes proposed in this pull request

This PR updates the link.

View to be removed:

![image](https://user-images.githubusercontent.com/62567622/110116377-509ac080-7daf-11eb-8bc3-0d2ceb2482e9.png)


## Guidance to review

Test in review app, let me know if there's any unintended knock on to this approach or any refactor that could happen controller wise.

## Link to Trello card

https://trello.com/c/b22m649k/2947-add-a-course-first-flow-shows-the-same-guidance-twice

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
