### PR TITLE
Set up models and services for granular provider notification settings

### DIFF
--- a/app/controllers/provider_interface/notifications_controller.rb
+++ b/app/controllers/provider_interface/notifications_controller.rb
@@ -5,6 +5,11 @@ module ProviderInterface
         send_notifications: notification_params[:send_notifications],
       )
 
+      if FeatureFlag.active?(:configurable_provider_notifications)
+        current_provider_user.notification_preferences
+          .update_all_preferences(notification_params[:send_notifications])
+      end
+
       flash[:success] = 'Email notification settings saved'
       redirect_to provider_interface_notifications_path
     end

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -74,6 +74,12 @@ module SupportInterface
     def toggle_notifications
       provider_user = ProviderUser.find(params[:provider_user_id])
       provider_user.update!(send_notifications: !provider_user.send_notifications)
+
+      if FeatureFlag.active?(:configurable_provider_notifications)
+        provider_user.notification_preferences
+          .update_all_preferences(provider_user.send_notifications)
+      end
+
       flash[:success] = 'Provider user updated'
       redirect_to support_interface_provider_user_path(provider_user)
     end

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -4,6 +4,7 @@ class ProviderUser < ActiveRecord::Base
   has_many :provider_permissions, dependent: :destroy
   has_many :providers, through: :provider_permissions
   has_many :notes, dependent: :destroy
+  has_one :notification_preferences, class_name: 'ProviderUserNotificationPreferences'
   attr_accessor :impersonator
 
   validates :dfe_sign_in_uid, uniqueness: true, allow_nil: true

--- a/app/models/provider_user_notification_preferences.rb
+++ b/app/models/provider_user_notification_preferences.rb
@@ -1,0 +1,5 @@
+class ProviderUserNotificationPreferences < ActiveRecord::Base
+  belongs_to :provider_user
+
+  self.table_name = :provider_user_notifications
+end

--- a/app/models/provider_user_notification_preferences.rb
+++ b/app/models/provider_user_notification_preferences.rb
@@ -11,6 +11,10 @@ class ProviderUserNotificationPreferences < ActiveRecord::Base
     offer_declined
   ].freeze
 
+  def update_all_preferences(value)
+    NOTIFICATION_PREFERENCES.each { |n| update(n => value) }
+  end
+
   def self.notification_preference_exists?(notification_name)
     NOTIFICATION_PREFERENCES.include? notification_name
   end

--- a/app/models/provider_user_notification_preferences.rb
+++ b/app/models/provider_user_notification_preferences.rb
@@ -2,4 +2,16 @@ class ProviderUserNotificationPreferences < ActiveRecord::Base
   belongs_to :provider_user
 
   self.table_name = :provider_user_notifications
+
+  NOTIFICATION_PREFERENCES = %i[
+    application_received
+    application_withdrawn
+    application_rejected_by_default
+    offer_accepted
+    offer_declined
+  ].freeze
+
+  def self.notification_preference_exists?(notification_name)
+    NOTIFICATION_PREFERENCES.include? notification_name
+  end
 end

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -23,7 +23,7 @@ class AcceptOffer
       end
     end
 
-    NotificationsList.for(@application_choice, include_ratifying_provider: true).each do |provider_user|
+    NotificationsList.for(@application_choice, event: :offer_accepted, include_ratifying_provider: true).each do |provider_user|
       ProviderMailer.offer_accepted(provider_user, @application_choice).deliver_later
     end
 

--- a/app/services/accept_unconditional_offer.rb
+++ b/app/services/accept_unconditional_offer.rb
@@ -9,7 +9,7 @@ class AcceptUnconditionalOffer
       @application_choice.update!(accepted_at: Time.zone.now, recruited_at: Time.zone.now)
     end
 
-    NotificationsList.for(@application_choice, include_ratifying_provider: true).each do |provider_user|
+    NotificationsList.for(@application_choice, event: :unconditional_offer_accepted, include_ratifying_provider: true).each do |provider_user|
       ProviderMailer.unconditional_offer_accepted(provider_user, @application_choice).deliver_later
     end
 

--- a/app/services/decline_offer.rb
+++ b/app/services/decline_offer.rb
@@ -12,7 +12,7 @@ class DeclineOffer
       StateChangeNotifier.new(:declined, @application_choice).application_outcome_notification
     end
 
-    NotificationsList.for(@application_choice, include_ratifying_provider: true).each do |provider_user|
+    NotificationsList.for(@application_choice, event: :declined, include_ratifying_provider: true).each do |provider_user|
       ProviderMailer.declined(provider_user, @application_choice).deliver_later
     end
   end

--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -17,7 +17,7 @@ class DeclineOfferByDefault
     end
 
     application_choices.each do |application_choice|
-      NotificationsList.for(application_choice, include_ratifying_provider: true).each do |provider_user|
+      NotificationsList.for(application_choice, event: :declined_by_default, include_ratifying_provider: true).each do |provider_user|
         ProviderMailer.declined_by_default(provider_user, application_choice).deliver_later
       end
     end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -30,6 +30,7 @@ class FeatureFlag
     [:structured_reasons_for_rejection_on_rbd, 'Allows providers to give specific feedback for applications rejected by default', 'Aga Dufrat'],
     [:updated_offer_flow, 'Activates the new make offer flow for providers', 'Despo Pentara'],
     [:unconditional_offers_via_api, 'Activates the ability to accept unconditional offers via the API', 'Steve Laing'],
+    [:configurable_provider_notifications, 'Providers can manage individual email notifications', 'Aga Dufrat'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/services/notifications_list.rb
+++ b/app/services/notifications_list.rb
@@ -1,9 +1,27 @@
 class NotificationsList
-  def self.for(application_choice, include_ratifying_provider: false)
-    return application_choice.provider.provider_users.where(send_notifications: true) if application_choice.accredited_provider.nil? || !include_ratifying_provider
+  NOTIFICATION_PREFERENCE_NAMES_FOR_EVENTS = {
+    application_received: %i[application_submitted chase_provider_decision],
+    application_withdrawn: %i[application_withdrawn],
+    application_rejected_by_default: %i[application_rejected_by_default],
+    offer_accepted: %i[offer_accepted unconditional_offer_accepted],
+    offer_declined: %i[declined declined_by_default],
+  }.freeze
 
-    application_choice.provider.provider_users.where(send_notifications: true).or(
-      application_choice.accredited_provider.provider_users.where(send_notifications: true),
-    )
+  def self.for(application_choice, include_ratifying_provider: false, event: nil)
+    if FeatureFlag.active?(:configurable_provider_notifications)
+      notification_name = NOTIFICATION_PREFERENCE_NAMES_FOR_EVENTS.select { |k, v| k if event.in? v }.keys.first
+      raise 'Undefined type of notification event' unless ProviderUserNotificationPreferences.notification_preference_exists?(notification_name)
+
+      return application_choice.provider.provider_users.joins(:notification_preferences).where("#{notification_name} IS true") if application_choice.accredited_provider.nil? || !include_ratifying_provider
+
+      application_choice.provider.provider_users.or(application_choice.accredited_provider.provider_users)
+        .joins(:notification_preferences).where("#{notification_name} IS true")
+    else
+      return application_choice.provider.provider_users.where(send_notifications: true) if application_choice.accredited_provider.nil? || !include_ratifying_provider
+
+      application_choice.provider.provider_users.where(send_notifications: true).or(
+        application_choice.accredited_provider.provider_users.where(send_notifications: true),
+      )
+    end
   end
 end

--- a/app/services/send_chase_email_to_provider.rb
+++ b/app/services/send_chase_email_to_provider.rb
@@ -1,6 +1,6 @@
 class SendChaseEmailToProvider
   def self.call(application_choice:)
-    NotificationsList.for(application_choice).each do |provider_user|
+    NotificationsList.for(application_choice, event: :chase_provider_decision).each do |provider_user|
       ProviderMailer.chase_provider_decision(provider_user, application_choice).deliver_later
     end
 

--- a/app/services/send_new_application_email_to_provider.rb
+++ b/app/services/send_new_application_email_to_provider.rb
@@ -8,7 +8,7 @@ class SendNewApplicationEmailToProvider
   def call
     return false unless application_choice.awaiting_provider_decision?
 
-    NotificationsList.for(application_choice, include_ratifying_provider: true).each do |provider_user|
+    NotificationsList.for(application_choice, event: :application_submitted, include_ratifying_provider: true).each do |provider_user|
       if application_choice.application_form.has_safeguarding_issues_to_declare?
         ProviderMailer.application_submitted_with_safeguarding_issues(provider_user, application_choice).deliver_later
       else

--- a/app/services/send_reject_by_default_email_to_provider.rb
+++ b/app/services/send_reject_by_default_email_to_provider.rb
@@ -8,7 +8,7 @@ class SendRejectByDefaultEmailToProvider
   def call
     return false unless application_choice.rejected?
 
-    NotificationsList.for(application_choice).each do |provider_user|
+    NotificationsList.for(application_choice, event: :application_rejected_by_default).each do |provider_user|
       ProviderMailer.application_rejected_by_default(provider_user, application_choice).deliver_later
     end
   end

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -25,7 +25,7 @@ private
   attr_reader :application_choice
 
   def send_email_notification_to_provider_users(application_choice)
-    NotificationsList.for(application_choice, include_ratifying_provider: true).each do |provider_user|
+    NotificationsList.for(application_choice, event: :application_withdrawn, include_ratifying_provider: true).each do |provider_user|
       ProviderMailer.application_withdrawn(provider_user, application_choice).deliver_later
     end
   end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -81,6 +81,26 @@
       "note": ""
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "38104ade37d5c61659409d037de157949b23a917a7f5b504534ac0a46fa5cf8f",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/notifications_list.rb",
+      "line": 18,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "application_choice.provider.provider_users.or(application_choice.accredited_provider.provider_users).joins(:notification_preferences).where(\"#{{ :application_received => ([:application_submitted, :chase_provider_decision]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]) }.select do\n k if event.in?(v)\n end.keys.first} IS true\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "NotificationsList",
+        "method": "s(:self).for"
+      },
+      "user_input": "{ :application_received => ([:application_submitted, :chase_provider_decision]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]) }.select do\n k if event.in?(v)\n end.keys.first",
+      "confidence": "Weak",
+      "note": "not a user input"
+    },
+    {
       "warning_type": "Unscoped Find",
       "warning_code": 82,
       "fingerprint": "4c106936481ffa09c60383aed2a7b8e931b1672602d3f5a69ccaf9bd688cbf62",
@@ -147,7 +167,7 @@
       "check_name": "UnscopedFind",
       "message": "Unscoped call to `CourseOption#find`",
       "file": "app/controllers/provider_interface/decisions_controller.rb",
-      "line": 35,
+      "line": 63,
       "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
       "code": "CourseOption.find(params[:course_option_id])",
       "render_path": null,
@@ -181,13 +201,33 @@
       "note": ""
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "8b9afd450cdaed47a32fe72f50753a5a92d16a04993c636d8eac438f9f4079a1",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/notifications_list.rb",
+      "line": 15,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "application_choice.provider.provider_users.joins(:notification_preferences).where(\"#{{ :application_received => ([:application_submitted, :chase_provider_decision]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]) }.select do\n k if event.in?(v)\n end.keys.first} IS true\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "NotificationsList",
+        "method": "s(:self).for"
+      },
+      "user_input": "{ :application_received => ([:application_submitted, :chase_provider_decision]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]) }.select do\n k if event.in?(v)\n end.keys.first",
+      "confidence": "Weak",
+      "note": "not a user input"
+    },
+    {
       "warning_type": "Unscoped Find",
       "warning_code": 82,
       "fingerprint": "c156deb252a43bc828b89928a0bccce9f8d8e776f8e742ed012929f3211205f4",
       "check_name": "UnscopedFind",
       "message": "Unscoped call to `CourseOption#find`",
       "file": "app/controllers/provider_interface/decisions_controller.rb",
-      "line": 22,
+      "line": 50,
       "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
       "code": "CourseOption.find(params[:course_option_id])",
       "render_path": null,
@@ -207,7 +247,7 @@
       "check_name": "UnscopedFind",
       "message": "Unscoped call to `CourseOption#find`",
       "file": "app/controllers/provider_interface/decisions_controller.rb",
-      "line": 53,
+      "line": 81,
       "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
       "code": "CourseOption.find(params[:course_option_id])",
       "render_path": null,
@@ -221,6 +261,6 @@
       "note": ""
     }
   ],
-  "updated": "2021-02-12 10:44:14 +0000",
+  "updated": "2021-03-10 15:05:49 +0000",
   "brakeman_version": "5.0.0"
 }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -949,6 +949,10 @@ FactoryBot.define do
     last_name { Faker::Name.last_name }
     send_notifications { Faker::Boolean.boolean(true_ratio: 0.5) }
 
+    after(:create) do |user, _evaluator|
+      user.send_notifications ? create(:provider_user_notification_preferences, provider_user: user) : create(:provider_user_notification_preferences, :all_off, provider_user: user)
+    end
+
     trait :with_provider do
       after(:create) do |user, _evaluator|
         create(:provider).provider_users << user
@@ -1003,6 +1007,24 @@ FactoryBot.define do
   factory :provider_permissions do
     provider
     provider_user
+  end
+
+  factory :provider_user_notification_preferences do
+    provider_user
+
+    application_received { true }
+    application_withdrawn { true }
+    application_rejected_by_default { true }
+    offer_accepted { true }
+    offer_declined { true }
+
+    trait :all_off do
+      application_received { false }
+      application_withdrawn { false }
+      application_rejected_by_default { false }
+      offer_accepted { false }
+      offer_declined { false }
+    end
   end
 
   factory :validation_error do

--- a/spec/models/provider_user_notification_preferences_spec.rb
+++ b/spec/models/provider_user_notification_preferences_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe ProviderUserNotificationPreferences do
+  describe '.notification_preference_exists?' do
+    let(:notification_preferences) { build(:provider_user_notification_preferences) }
+
+    it 'returns true for defined notification preferences types' do
+      described_class::NOTIFICATION_PREFERENCES.each do |type|
+        expect(described_class.notification_preference_exists?(type)).to eq(true)
+      end
+    end
+
+    it 'returns false if the notification type is not defined' do
+      expect(described_class.notification_preference_exists?(:application_exploded)).to eq(false)
+    end
+  end
+end

--- a/spec/models/provider_user_notification_preferences_spec.rb
+++ b/spec/models/provider_user_notification_preferences_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe ProviderUserNotificationPreferences do
+  describe '#update_all_preferences' do
+    let(:notification_preferences) { create(:provider_user_notification_preferences) }
+
+    it 'updates all types of notification preferences' do
+      notification_preferences = create(:provider_user_notification_preferences)
+      notification_preferences.update_all_preferences(false)
+
+      described_class::NOTIFICATION_PREFERENCES.each do |type|
+        expect(notification_preferences.send(type)).to eq(false)
+      end
+    end
+  end
+
   describe '.notification_preference_exists?' do
     let(:notification_preferences) { build(:provider_user_notification_preferences) }
 

--- a/spec/services/decline_offer_by_default_spec.rb
+++ b/spec/services/decline_offer_by_default_spec.rb
@@ -20,22 +20,49 @@ RSpec.describe DeclineOfferByDefault do
     expect(notifier).to have_received(:application_outcome_notification)
   end
 
-  it 'sends emails to the training provider and ratyfing provider', sidekiq: true do
-    training_provider = create(:provider)
-    training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+  context 'when the configurable provider notifications feature flag is off' do
+    before { FeatureFlag.deactivate(:configurable_provider_notifications) }
 
-    ratifying_provider = create(:provider)
-    ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+    it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do
+      training_provider = create(:provider)
+      training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
 
-    course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
-    application_choice = create(:application_choice, :with_offer, course_option: course_option)
+      ratifying_provider = create(:provider)
+      ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
 
-    described_class.new(application_form: application_choice.application_form).call
+      course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
+      application_choice = create(:application_choice, :with_offer, course_option: course_option)
 
-    training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
-    ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
+      described_class.new(application_form: application_choice.application_form).call
 
-    expect(training_provider_email['rails-mail-template'].value).to eq('declined_by_default')
-    expect(ratifying_provider_email['rails-mail-template'].value).to eq('declined_by_default')
+      training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
+      ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
+
+      expect(training_provider_email['rails-mail-template'].value).to eq('declined_by_default')
+      expect(ratifying_provider_email['rails-mail-template'].value).to eq('declined_by_default')
+    end
+  end
+
+  context 'when the configurable provider notifications feature flag is on' do
+    before { FeatureFlag.activate(:configurable_provider_notifications) }
+
+    it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do
+      training_provider = create(:provider)
+      training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+
+      ratifying_provider = create(:provider)
+      ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+
+      course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
+      application_choice = create(:application_choice, status: :offer, course_option: course_option)
+
+      described_class.new(application_form: application_choice.application_form).call
+
+      training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
+      ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
+
+      expect(training_provider_email['rails-mail-template'].value).to eq('declined_by_default')
+      expect(ratifying_provider_email['rails-mail-template'].value).to eq('declined_by_default')
+    end
   end
 end

--- a/spec/services/decline_offer_spec.rb
+++ b/spec/services/decline_offer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DeclineOffer do
 
     Timecop.freeze do
       expect {
-        DeclineOffer.new(application_choice: application_choice).save!
+        described_class.new(application_choice: application_choice).save!
       }.to change { application_choice.declined_at }.to(Time.zone.now)
 
       expect(StateChangeNotifier).to have_received(:new).with(:declined, application_choice)
@@ -18,22 +18,49 @@ RSpec.describe DeclineOffer do
     end
   end
 
-  it 'sends emails to the training provider and ratyfing provider', sidekiq: true do
-    training_provider = create(:provider)
-    training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+  context 'when the configurable provider notifications feature flag is off' do
+    before { FeatureFlag.deactivate(:configurable_provider_notifications) }
 
-    ratifying_provider = create(:provider)
-    ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+    it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do
+      training_provider = create(:provider)
+      training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
 
-    course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
-    application_choice = create(:application_choice, :with_offer, course_option: course_option)
+      ratifying_provider = create(:provider)
+      ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
 
-    DeclineOffer.new(application_choice: application_choice).save!
+      course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
+      application_choice = create(:application_choice, :with_offer, course_option: course_option)
 
-    training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
-    ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
+      described_class.new(application_choice: application_choice).save!
 
-    expect(training_provider_email['rails-mail-template'].value).to eq('declined')
-    expect(ratifying_provider_email['rails-mail-template'].value).to eq('declined')
+      training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
+      ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
+
+      expect(training_provider_email['rails-mail-template'].value).to eq('declined')
+      expect(ratifying_provider_email['rails-mail-template'].value).to eq('declined')
+    end
+  end
+
+  context 'when the configurable provider notifications feature flag is on' do
+    before { FeatureFlag.activate(:configurable_provider_notifications) }
+
+    it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do
+      training_provider = create(:provider)
+      training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+
+      ratifying_provider = create(:provider)
+      ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+
+      course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
+      application_choice = create(:application_choice, status: :offer, course_option: course_option)
+
+      described_class.new(application_choice: application_choice).save!
+
+      training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
+      ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
+
+      expect(training_provider_email['rails-mail-template'].value).to eq('declined')
+      expect(ratifying_provider_email['rails-mail-template'].value).to eq('declined')
+    end
   end
 end

--- a/spec/services/notifications_list_spec.rb
+++ b/spec/services/notifications_list_spec.rb
@@ -2,26 +2,65 @@ require 'rails_helper'
 
 RSpec.describe NotificationsList do
   describe '.for' do
-    it 'returns training provider users for the application choice by default' do
-      application_choice = create(:application_choice)
+    context 'when the configurable provider notifications feature flag is on' do
+      before { FeatureFlag.activate(:configurable_provider_notifications) }
 
-      create(:provider_user, send_notifications: false, providers: [application_choice.course.provider])
-      create(:provider_user, send_notifications: true)
-      provider_user = create(:provider_user, send_notifications: true, providers: [application_choice.course.provider])
+      it 'raises an error for an undefined type of event' do
+        application_choice = build(:application_choice)
 
-      expect(NotificationsList.for(application_choice).to_a).to eql([provider_user])
+        expect { NotificationsList.for(application_choice, event: 'application_exploded') }.to raise_error('Undefined type of notification event')
+      end
+
+      it 'returns training provider users for the application choice for a given type of event' do
+        application_choice = create(:application_choice)
+
+        create(:provider_user_notification_preferences, :all_off, provider_user: create(:provider_user, send_notifications: false, providers: [application_choice.course.provider]))
+        create(:provider_user_notification_preferences)
+
+        provider_user = create(:provider_user, send_notifications: true, providers: [application_choice.course.provider])
+
+        expect(NotificationsList.for(application_choice, event: :offer_accepted).to_a).to eql([provider_user])
+      end
+
+      it 'returns training and ratifying provider users for the application choice for a given type of event' do
+        ratifying_provider = create(:provider)
+        ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+
+        application_choice = create(:application_choice, course_option: create(:course_option, course: create(:course, accredited_provider: ratifying_provider)))
+
+        training_provider_user = create(:provider_user, send_notifications: true, providers: [application_choice.course.provider])
+
+        create(:provider_user_notification_preferences, :all_off, provider_user: create(:provider_user, send_notifications: false, providers: [application_choice.course.provider]))
+        create(:provider_user_notification_preferences)
+
+        expect(NotificationsList.for(application_choice, include_ratifying_provider: true, event: :offer_accepted).to_a).to match_array([training_provider_user, ratifying_provider_user])
+      end
     end
 
-    it 'returns training and ratifying provider users for the application choice when specified' do
-      ratifying_provider = create(:provider)
-      ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
-      application_choice = create(:application_choice, course_option: create(:course_option, course: create(:course, accredited_provider: ratifying_provider)))
+    context 'when the configurable provider notifications feature flag is off' do
+      before { FeatureFlag.deactivate(:configurable_provider_notifications) }
 
-      create(:provider_user, send_notifications: false, providers: [application_choice.course.provider])
-      create(:provider_user, send_notifications: true)
-      training_provider_user = create(:provider_user, send_notifications: true, providers: [application_choice.course.provider])
+      it 'returns training provider users for the application choice by default' do
+        application_choice = create(:application_choice)
 
-      expect(NotificationsList.for(application_choice, include_ratifying_provider: true).to_a).to match_array([training_provider_user, ratifying_provider_user])
+        create(:provider_user, send_notifications: false, providers: [application_choice.course.provider])
+        create(:provider_user, send_notifications: true)
+        provider_user = create(:provider_user, send_notifications: true, providers: [application_choice.course.provider])
+
+        expect(NotificationsList.for(application_choice).to_a).to eql([provider_user])
+      end
+
+      it 'returns training and ratifying provider users for the application choice when specified' do
+        ratifying_provider = create(:provider)
+        ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+        application_choice = create(:application_choice, course_option: create(:course_option, course: create(:course, accredited_provider: ratifying_provider)))
+
+        create(:provider_user, send_notifications: false, providers: [application_choice.course.provider])
+        create(:provider_user, send_notifications: true)
+        training_provider_user = create(:provider_user, send_notifications: true, providers: [application_choice.course.provider])
+
+        expect(NotificationsList.for(application_choice, include_ratifying_provider: true).to_a).to match_array([training_provider_user, ratifying_provider_user])
+      end
     end
   end
 end

--- a/spec/services/send_chase_email_to_provider_spec.rb
+++ b/spec/services/send_chase_email_to_provider_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe SendChaseEmailToProvider do
 
     before do
       create(:provider_permissions, provider_id: application_choice.provider.id, provider_user_id: provider_user.id)
+      create(:provider_user_notification_preferences, provider_user: provider_user)
       described_class.call(application_choice: application_choice)
     end
 

--- a/spec/services/send_new_application_email_to_provider_spec.rb
+++ b/spec/services/send_new_application_email_to_provider_spec.rb
@@ -3,23 +3,50 @@ require 'rails_helper'
 RSpec.describe SendNewApplicationEmailToProvider, sidekiq: true do
   include CourseOptionHelpers
 
-  it 'sends an email to the training provider and ratifying provider' do
-    training_provider = create(:provider)
-    training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+  context 'when the configurable provider notifications feature flag is off' do
+    before { FeatureFlag.deactivate(:configurable_provider_notifications) }
 
-    ratifying_provider = create(:provider)
-    ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+    it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do
+      training_provider = create(:provider)
+      training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
 
-    option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
-    choice = create(:application_choice, :with_completed_application_form, :awaiting_provider_decision, course_option: option)
+      ratifying_provider = create(:provider)
+      ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
 
-    SendNewApplicationEmailToProvider.new(application_choice: choice).call
+      course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
+      application_choice = create(:application_choice, :with_completed_application_form, :awaiting_provider_decision, course_option: course_option)
 
-    training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
-    ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
+      described_class.new(application_choice: application_choice).call
 
-    expect(training_provider_email['rails-mail-template'].value).to eq('application_submitted')
-    expect(ratifying_provider_email['rails-mail-template'].value).to eq('application_submitted')
+      training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
+      ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
+
+      expect(training_provider_email['rails-mail-template'].value).to eq('application_submitted')
+      expect(ratifying_provider_email['rails-mail-template'].value).to eq('application_submitted')
+    end
+  end
+
+  context 'when the configurable provider notifications feature flag is on' do
+    before { FeatureFlag.activate(:configurable_provider_notifications) }
+
+    it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do
+      training_provider = create(:provider)
+      training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+
+      ratifying_provider = create(:provider)
+      ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+
+      course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
+      application_choice = create(:application_choice, :with_completed_application_form, :awaiting_provider_decision, course_option: course_option)
+
+      described_class.new(application_choice: application_choice).call
+
+      training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
+      ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
+
+      expect(training_provider_email['rails-mail-template'].value).to eq('application_submitted')
+      expect(ratifying_provider_email['rails-mail-template'].value).to eq('application_submitted')
+    end
   end
 
   it 'sends a different email when the candidate supplied safeguarding information' do
@@ -30,7 +57,7 @@ RSpec.describe SendNewApplicationEmailToProvider, sidekiq: true do
     form = create(:completed_application_form, :with_safeguarding_issues_disclosed)
     choice = create(:application_choice, :awaiting_provider_decision, course_option: option, application_form: form)
 
-    SendNewApplicationEmailToProvider.new(application_choice: choice).call
+    described_class.new(application_choice: choice).call
 
     email = ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == 'application_submitted_with_safeguarding_issues' }
 

--- a/spec/services/send_reject_by_default_email_to_provider_spec.rb
+++ b/spec/services/send_reject_by_default_email_to_provider_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe SendRejectByDefaultEmailToProvider do
+  include CourseOptionHelpers
+
+  it 'returns false if the application is not in rejected state' do
+    application_choice = build(:application_choice, :awaiting_provider_decision)
+
+    expect(described_class.new(application_choice: application_choice).call).to eq(false)
+  end
+
+  context 'when the configurable provider notifications feature flag is off' do
+    before { FeatureFlag.deactivate(:configurable_provider_notifications) }
+
+    it 'sends a notification email to the training provider', sidekiq: true do
+      training_provider = create(:provider)
+      training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+
+      application_choice = create(:application_choice, :with_rejection_by_default, application_form: create(:application_form, :minimum_info), course_option: course_option_for_provider(provider: training_provider))
+
+      described_class.new(application_choice: application_choice).call
+
+      training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
+
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(training_provider_email['rails-mail-template'].value).to eq('application_rejected_by_default')
+    end
+  end
+
+  context 'when the configurable provider notifications feature flag is on' do
+    before { FeatureFlag.activate(:configurable_provider_notifications) }
+
+    it 'sends a notification email to the training provider', sidekiq: true do
+      training_provider = create(:provider)
+      training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+
+      application_choice = create(:application_choice, :with_rejection_by_default, application_form: create(:application_form, :minimum_info), course_option: course_option_for_provider(provider: training_provider))
+
+      described_class.new(application_choice: application_choice).call
+
+      training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
+
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(training_provider_email['rails-mail-template'].value).to eq('application_rejected_by_default')
+    end
+  end
+end

--- a/spec/system/reject_by_default_spec.rb
+++ b/spec/system/reject_by_default_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature 'Reject by default' do
 
   def and_the_provider_user_has_send_notifications_enabled
     @provider_user.update(send_notifications: true)
+    create(:provider_user_notification_preferences, provider_user: @provider_user)
   end
 
   def and_there_is_a_candidate


### PR DESCRIPTION
## Context

As a provider user 
I need the ability to choose the type of email notification I receive
So that I only get notified about the things I need

## Changes proposed in this pull request

- add a feature flag
- add ProviderUserNotification model
- update NotificationsList service
- add a service to update all notification events
- update email sending services to account for different type of preferences

No UI changes.

## Guidance to review

Initially wanted to call the table 'provider_user_notification_preferences' but index name was too long.

To test:
- turn on the feature flag `FeatureFlag.activate(:configurable_provider_notifications)`
- create ProviderUserNotification  in the rails console and change it via provider interface and support interface
- check the values in the rails console

## Link to Trello card

https://trello.com/c/AtNkf165/3438-%F0%9F%8F%88-set-up-models-and-services-for-granular-provider-notification-settings

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
