### PR TITLE
Smol support bugs

### DIFF
--- a/app/views/support_interface/providers/no_relationships.html.erb
+++ b/app/views/support_interface/providers/no_relationships.html.erb
@@ -1,3 +1,3 @@
-<%= render 'provider_navigation', title: 'Details' %>
+<%= render 'provider_navigation', title: 'Relationships' %>
 
 <p class="govuk-body">This provider has no relationships to manage.</p>

--- a/app/views/support_interface/sessions/confirm_environment.html.erb
+++ b/app/views/support_interface/sessions/confirm_environment.html.erb
@@ -6,7 +6,7 @@
 
     <%= form_with(url: support_interface_confirm_environment_path, model: @confirmation) do |f| %>
       <%= f.hidden_field :from %>
-      <%= f.govuk_text_field :environment, label: { text: "Type '#{HostingEnvironment.environment_name}' to confirm that you want to proceed", size: 'm' } %>
+      <%= f.govuk_text_field :environment, label: { text: "Type ‘#{HostingEnvironment.environment_name}’ to confirm that you want to proceed", size: 'm' } %>
       <%= f.govuk_submit t('continue') %>
     <% end %>
   </div>

--- a/app/views/support_interface/sessions/confirm_environment.html.erb
+++ b/app/views/support_interface/sessions/confirm_environment.html.erb
@@ -6,7 +6,7 @@
 
     <%= form_with(url: support_interface_confirm_environment_path, model: @confirmation) do |f| %>
       <%= f.hidden_field :from %>
-      <%= f.govuk_text_field :environment, label: { text: "Type ‘#{HostingEnvironment.environment_name}’ to confirm that you want to proceed", size: 'm' } %>
+      <%= f.govuk_text_field :environment, label: { text: "Type ‘#{HostingEnvironment.environment_name}’ to confirm that you want to proceed", size: 'm' }, width: 20 %>
       <%= f.govuk_submit t('continue') %>
     <% end %>
   </div>

--- a/spec/system/support_interface/feature_flags_spec.rb
+++ b/spec/system/support_interface/feature_flags_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Feature flags', with_audited: true do
 
   def when_i_activate_the_feature
     within(pilot_open_summary_card) { click_link 'Confirm environment to make changes' }
-    fill_in 'Type \'test\' to confirm that you want to proceed', with: 'test'
+    fill_in 'Type ‘test’ to confirm that you want to proceed', with: 'test'
     click_button 'Continue'
 
     within(pilot_open_summary_card) { click_button 'Activate' }


### PR DESCRIPTION
* Ensure breadcrumb is correct for `Providers → [Provider] → Relationships` when there are no relationships
* Use smart quotes on confirm environment field label, and make it 20 characters wide