### PR TITLE
Add reusable component for selecting provider

### DIFF
--- a/app/components/provider_interface/select_provider_component.html.erb
+++ b/app/components/provider_interface/select_provider_component.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: form_object, url: form_path, method: :post do |f| %>
+      <%= f.govuk_collection_radio_buttons :provider_id, providers, :id, :name_and_code, legend: { text: page_title, size: 'l' } %>
+      <%= f.govuk_submit t('continue') %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/provider_interface/select_provider_component.rb
+++ b/app/components/provider_interface/select_provider_component.rb
@@ -1,0 +1,14 @@
+module ProviderInterface
+  class SelectProviderComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :form_object, :form_path, :providers, :page_title, :provider_id
+
+    def initialize(form_object:, form_path:, providers:, page_title: 'Select provider')
+      @form_object = form_object
+      @form_path = form_path
+      @providers = providers
+      @page_title = page_title
+    end
+  end
+end

--- a/spec/components/previews/provider_interface/select_provider_component_preview.rb
+++ b/spec/components/previews/provider_interface/select_provider_component_preview.rb
@@ -1,0 +1,19 @@
+module ProviderInterface
+  class SelectProviderComponentPreview < ViewComponent::Preview
+    class FormObject
+      include ActiveModel::Model
+
+      attr_accessor :provider_id
+    end
+
+    def select_provider
+      form_path = ''
+      providers = Provider.limit(10)
+      form_object = FormObject.new(provider_id: providers.last.id)
+
+      render SelectProviderComponent.new(form_object: form_object,
+                                         form_path: form_path,
+                                         providers: providers)
+    end
+  end
+end

--- a/spec/components/provider_interface/select_provider_component_spec.rb
+++ b/spec/components/provider_interface/select_provider_component_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::SelectProviderComponent do
+  let(:form_object_class) do
+    Class.new do
+      include ActiveModel::Model
+
+      attr_accessor :provider_id
+    end
+  end
+
+  let(:form_object) { FormObjectClass.new(provider_id: selected_provider.id) }
+  let(:providers) { build_stubbed_list(:provider, 10) }
+  let(:selected_provider) { providers.sample }
+
+  let(:render) do
+    render_inline(described_class.new(form_object: form_object,
+                                      form_path: '',
+                                      providers: providers))
+  end
+
+  before do
+    stub_const('FormObjectClass', form_object_class)
+  end
+
+  it 'renders all providers' do
+    expect(render.css('.govuk-radios__item').length).to eq(providers.count)
+  end
+
+  it 'selects the preselected provider' do
+    expect(render.css('.govuk-radios__item input[checked]').first.next_element.text)
+      .to eq(selected_provider.name_and_code)
+  end
+end


### PR DESCRIPTION
## Context
New component for use by the Make Offer flow, to enable selecting a provider.

## Changes proposed in this pull request

<img width="1002" alt="Screenshot 2021-03-05 at 22 20 46" src="https://user-images.githubusercontent.com/159200/110180091-10642e00-7e01-11eb-8a5e-8baab82db26a.png">

## Link to Trello card
https://trello.com/c/gYFGRVp1/3474-create-select-provider-component

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
