### PR TITLE
Remove V3 API (1/4) — Apply from Find uses public API

### DIFF
--- a/app/models/teacher_training_public_api/course.rb
+++ b/app/models/teacher_training_public_api/course.rb
@@ -21,11 +21,11 @@ module TeacherTrainingPublicAPI
     end
 
     def sites
-      Location.where(
+      @sites_cache ||= Location.where(
         year: ::RecruitmentCycle.current_year,
         provider_code: provider_code,
         course_code: code,
-      ).includes(:location_status).paginate(per_page: 500)
+      ).includes(:location_status).paginate(per_page: 500).all
     end
 
     def self.fetch(provider_code, course_code)

--- a/app/models/teacher_training_public_api/course.rb
+++ b/app/models/teacher_training_public_api/course.rb
@@ -1,14 +1,40 @@
 module TeacherTrainingPublicAPI
   class Course < TeacherTrainingPublicAPI::Resource
+    # a hack to keep this attribute on a course returned by #fetch, even though
+    # it's not provided by the API. We need it so we can pretend to be an
+    # ordinary course out of the database when rendering the apply-from-find page.
+    attr_accessor :provider_code
+
     belongs_to :recruitment_cycle, through: :provider, param: :year
     belongs_to :provider, param: :provider_code
     has_many :locations
 
+    def name_and_code
+      "#{name} (#{code})"
+    end
+
+    # this needs to behave interchangeably with a course in the database
+    # once it gets to the apply-from-find views, so provide a provider.code
+    # interface like "proper" courses have. This is like what we did in FindAPI.
+    def provider
+      Struct.new(:code).new(provider_code)
+    end
+
+    def sites
+      Location.where(
+        year: ::RecruitmentCycle.current_year,
+        provider_code: provider_code,
+        course_code: code,
+      ).includes(:location_status).paginate(per_page: 500)
+    end
+
     def self.fetch(provider_code, course_code)
-      where(recruitment_cycle_year: RecruitmentCycle.current_year)
+      course = where(year: ::RecruitmentCycle.current_year)
         .where(provider_code: provider_code)
-        .find(course_code)
-        .first
+        .find(course_code).first
+
+      course.provider_code = provider_code
+      course
     rescue JsonApiClient::Errors::NotFound
       nil
     rescue JsonApiClient::Errors::ServerError, JsonApiClient::Errors::ConnectionError => e

--- a/app/models/teacher_training_public_api/location.rb
+++ b/app/models/teacher_training_public_api/location.rb
@@ -4,6 +4,12 @@ module TeacherTrainingPublicAPI
     belongs_to :provider, param: :provider_code
     belongs_to :course, param: :course_code
 
+    def full_address
+      [street_address_1, street_address_2, city, county, postcode]
+        .reject(&:blank?)
+        .join(', ')
+    end
+
     def self.fetch(provider_code, course_code)
       where(recruitment_cycle_year: RecruitmentCycle.current_year)
         .where(provider_code: provider_code)

--- a/app/models/teacher_training_public_api/recruitment_cycle.rb
+++ b/app/models/teacher_training_public_api/recruitment_cycle.rb
@@ -1,0 +1,5 @@
+module TeacherTrainingPublicAPI
+  class RecruitmentCycle < TeacherTrainingPublicAPI::Resource
+    has_many :providers
+  end
+end

--- a/app/services/candidate_interface/apply_from_find_page.rb
+++ b/app/services/candidate_interface/apply_from_find_page.rb
@@ -41,7 +41,11 @@ module CandidateInterface
     end
 
     def fetch_course_from_api
-      TeacherTrainingPublicAPI::Course.fetch(@provider_code, @course_code)
+      Rails.cache.fetch ['course-public-api-request', @provider_code, @course_code], expires_in: 5.minutes do
+        course = TeacherTrainingPublicAPI::Course.fetch(@provider_code, @course_code)
+        course.sites if course # cache subsequent calls to #sites too (this method is memoized)
+        course
+      end
     end
   end
 end

--- a/app/services/candidate_interface/apply_from_find_page.rb
+++ b/app/services/candidate_interface/apply_from_find_page.rb
@@ -41,9 +41,7 @@ module CandidateInterface
     end
 
     def fetch_course_from_api
-      Rails.cache.fetch ['course-api-request', @provider_code, @course_code], expires_in: 5.minutes do
-        FindAPI::Course.fetch(@provider_code, @course_code)
-      end
+      TeacherTrainingPublicAPI::Course.fetch(@provider_code, @course_code)
     end
   end
 end

--- a/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
+++ b/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
@@ -6,7 +6,7 @@ module TeacherTrainingPublicAPI
       until is_last_page
         page_number += 1
         response = TeacherTrainingPublicAPI::Provider
-          .where(year: RecruitmentCycle.current_year)
+          .where(year: ::RecruitmentCycle.current_year)
           .paginate(page: page_number, per_page: 500)
           .all
         sync_providers(response)
@@ -22,7 +22,7 @@ module TeacherTrainingPublicAPI
       providers_from_api.each do |provider_from_api|
         TeacherTrainingPublicAPI::SyncProvider.new(
           provider_from_api: provider_from_api,
-          recruitment_cycle_year: RecruitmentCycle.current_year,
+          recruitment_cycle_year: ::RecruitmentCycle.current_year,
         ).call
       end
     end

--- a/spec/examples/teacher_training_api/course_single_response.json
+++ b/spec/examples/teacher_training_api/course_single_response.json
@@ -1,0 +1,100 @@
+{
+  "data": {
+    "id": "12944685",
+    "type": "courses",
+    "attributes": {
+      "about_accredited_body": "UCL Institute of Education is the world’s leading centre for research and teaching in education and related social sciences.",
+      "about_course": "The Secondary PGCE consists of three core modules: two Master's-level modules, which are assessed through written assignments, and the Professional Practice module, which is assessed by the observation of practical teaching in placement schools.",
+      "accredited_body_code": "2FR",
+      "age_minimum": 11,
+      "age_maximum": 14,
+      "applications_open_from": "2019-10-08",
+      "bursary_amount": 9000,
+      "bursary_requirements": [
+        {
+        }
+      ],
+      "changed_at": "2019-06-13T10:44:31Z",
+      "code": "3GTY",
+      "course_length": "OneYear",
+      "created_at": "2019-06-13T10:44:31Z",
+      "fee_details": "For those wishing to top up their qualification to the full PGCE, a further £1800 will be payable.",
+      "fee_international": 13000,
+      "fee_domestic": 9200,
+      "financial_support": "You'll get a bursary of £9,000 if you have a degree of 2:2 or above in any subject. You may also be eligible for a loan while you study.",
+      "findable": true,
+      "funding_type": "apprenticeship",
+      "gcse_subjects_required": [
+        {
+        }
+      ],
+      "has_bursary": true,
+      "has_early_career_payments": true,
+      "has_scholarship": true,
+      "has_vacancies": true,
+      "how_school_placements_work": "You will spend two-thirds of your time (120 days) in schools, working with art and design mentors who support you through your two school placements.",
+      "interview_process": "At your interview day you will take part in a combination of group and individual interviews with members of the programme team, and you may also be asked to undertake written or presentation tasks, depending on your subject.",
+      "is_send": true,
+      "last_published_at": "2019-06-13T10:44:31Z",
+      "level": "secondary",
+      "name": "Art and Design",
+      "open_for_applications": true,
+      "other_requirements": "You'll need to provide confirmation you have the health and physical capacity to commence training, and a Disclosure and Barring Service (DBS) certificate.",
+      "personal_qualities": "We are looking for applicants who have the potential to become outstanding teachers, and who are able to work independently on their studies while training in a school context.",
+      "program_type": "scitt_programme",
+      "qualifications": [
+        {
+        }
+      ],
+      "required_qualifications": "A first or second-class UK Bachelor's degree in an appropriate subject, or an overseas qualification of an equivalent standard from a recognised higher education institution.",
+      "required_qualifications_english": "equivalence_test",
+      "required_qualifications_maths": "equivalence_test",
+      "required_qualifications_science": "equivalence_test",
+      "running": true,
+      "salary_details": "Successful applicants will be employed as unqualified teachers on at least Point 1 of the Unqualified Teachers' Pay Scale for the duration of the programme.",
+      "scholarship_amount": 17000,
+      "start_date": "2020-09-01",
+      "state": "published",
+      "study_mode": "both",
+      "summary": "PGCE with QTS full time",
+      "subject_codes": [
+        {
+        }
+      ]
+    },
+    "relationships": {
+      "recruitment_cycle": {
+        "data": {
+          "type": "recruitment_cycles",
+          "id": "3"
+        }
+      },
+      "accredited_body": {
+        "data": {
+          "type": "providers",
+          "id": "16346"
+        }
+      },
+      "provider": {
+        "data": {
+          "type": "providers",
+          "id": "16288"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "3",
+      "type": "recruitment_cycles",
+      "attributes": {
+        "year": 2021,
+        "application_start_date": "2020-10-13",
+        "application_end_date": "2021-10-03"
+      }
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/services/candidate_interface/apply_from_find_page_spec.rb
+++ b/spec/services/candidate_interface/apply_from_find_page_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::ApplyFromFindPage do
-  include FindAPIHelper
+  include TeacherTrainingPublicAPIHelper
 
   describe '#execute' do
     context 'When a course is in the apply database' do
       it 'sets the course_is_on_apply and course_on_find attributes to true' do
         FeatureFlag.activate('pilot_open')
+
         course = create(:course, open_on_apply: true, exposed_in_find: true)
         service = described_class.new(provider_code: course.provider.code,
                                       course_code: course.code)
@@ -21,9 +22,19 @@ RSpec.describe CandidateInterface::ApplyFromFindPage do
     context 'When a course is not in the apply database, but is in the find database' do
       it 'sets the course_on_find attributes to true' do
         FeatureFlag.activate('pilot_open')
-        stub_find_api_course_200('A999', 'B999', 'potions')
+
+        stub_teacher_training_api_course(
+          provider_code: 'A999',
+          course_code: 'B999',
+          specified_attributes: { name: 'potions' },
+        )
+        stub_teacher_training_api_sites(
+          provider_code: 'A999',
+          course_code: 'B999',
+        )
         service = described_class.new(provider_code: 'A999',
                                       course_code: 'B999')
+
         service.determine_whether_course_is_on_find_or_apply
 
         expect(service.course_on_find?).to be_truthy

--- a/spec/support/test_helpers/teacher_training_public_api_helper.rb
+++ b/spec/support/test_helpers/teacher_training_public_api_helper.rb
@@ -62,6 +62,10 @@ module TeacherTrainingPublicAPIHelper
     stub_teacher_training_list_api_request("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses/#{course_code}/locations?include=location_status", response_body)
   end
 
+  def stub_teacher_training_api_course_404(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, course_code:)
+    stub_404("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses/#{course_code}")
+  end
+
   def fake_api_provider(provider_attributes = {})
     api_response = JSON.parse(
       File.read(
@@ -161,6 +165,14 @@ private
       status: 200,
       headers: { 'Content-Type': 'application/vnd.api+json' },
       body: api_response.to_json,
+    )
+  end
+
+  def stub_404(url)
+    stub_request(
+      :get, url
+    ).to_return(
+      status: 404,
     )
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_apply_from_find_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'A candidate arriving from Find with a course and provider code' do
-  include FindAPIHelper
+  include TeacherTrainingPublicAPIHelper
 
   scenario 'seeing their course information on the landing page' do
     given_the_pilot_is_open
@@ -55,12 +55,14 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
   end
 
   def when_i_arrive_from_find_with_invalid_course_parameters
-    stub_find_api_course_404('NOT', 'REAL')
+    stub_teacher_training_api_course_404(provider_code: 'NOT', course_code: 'REAL')
     visit candidate_interface_apply_from_find_path providerCode: 'NOT', courseCode: 'REAL'
   end
 
   def when_i_arrive_from_find_to_a_course_that_is_not_synced_in_apply
-    stub_find_api_course_200('FINDABLE', 'COURSE', 'Biology')
+    stub_teacher_training_api_course(provider_code: 'FINDABLE', course_code: 'COURSE', specified_attributes: { name: 'Biology' })
+    stub_teacher_training_api_sites(provider_code: 'FINDABLE', course_code: 'COURSE', specified_attributes: [{ name: 'Main site', code: 'A' }])
+
     visit candidate_interface_apply_from_find_path providerCode: 'FINDABLE', courseCode: 'COURSE'
   end
 
@@ -81,7 +83,10 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
       @course_on_apply = create(:course, exposed_in_find: true, open_on_apply: true, code: 'DEF1', name: 'Potions', provider: create(:provider, code: 'DEF'))
       @course_options_on_apply = create_list(:course_option, 3, course: @course_on_apply)
     end
-    stub_find_api_course_200(@course_on_apply.provider.code, @course_on_apply.code, 'Potions')
+
+    stub_teacher_training_api_course(provider_code: 'DEF', course_code: 'DEF1', specified_attributes: { name: 'Potions' })
+    stub_teacher_training_api_sites(provider_code: 'DEF', course_code: 'DEF1')
+
     visit candidate_interface_apply_from_find_path providerCode: 'DEF', courseCode: 'DEF1'
   end
 

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -128,9 +128,9 @@ RSpec.feature 'Providers and courses' do
 
     stub_teacher_training_api_provider(
       provider_code: 'XYZ',
-      specified_attributes: [{
+      specified_attributes: {
         code: 'XYZ',
-      }],
+      },
     )
 
     stub_course_with_site(provider_code: 'ABC',


### PR DESCRIPTION
### Removing V3 from Apply

**1. Apply from Find uses public API** 👈
2. Consume subject codes from the public API and remove remaining references to the v3 API
3. Delete all TTAPI v3 code
4. Clean up after removing v3 API

## Context

The only place in the app we use the v3 Teacher Training API is the [apply-from-find page](https://qa.apply-for-teacher-training.service.gov.uk/candidate/apply?providerCode=1CS&courseCode=2DGY). After this PR, that uses the new public/v1 API.

## Changes proposed in this pull request

- Bring the `TeacherTrainingPublicAPI` models up to scratch to support this, porting code where necessary from V3, ie methods on `Course`.
- update stubs and tests to support this new API call
- hook up `ApplyFromFindPage` to use the new API

## Guidance to review

As the `Course` response from the Public API doesn't include the provider code, I added it as an `attr` on the model. Technically we ought to `include=provider` on the request but that made the stubbing more complicated — enough so that I preferred to do this.

## Link to Trello card

https://trello.com/c/io8acUsQ/291-sync-all-courses

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
