### PR TITLE
Create export for autosuggest usage

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -25,6 +25,11 @@ class DataExport < ApplicationRecord
       description: 'This provides the compiled results of all feedback received from prompts throughout the application form.',
       class: SupportInterface::CandidateApplicationFeedbackExport,
     },
+    candidate_autosuggest_usage: {
+      name: 'Candidate autosuggest usage',
+      description: 'A summary of values stored in the database via autosuggest components within the candidate application form (Apply 1 only)',
+      class: SupportInterface::CandidateAutofillUsageExport,
+    },
     candidate_email_send_counts: {
       name: 'Candidate email send counts',
       description: "A list of all emails sent by the service, and how many we've sent to date.",

--- a/app/services/support_interface/candidate_autofill_usage_export.rb
+++ b/app/services/support_interface/candidate_autofill_usage_export.rb
@@ -1,0 +1,138 @@
+module SupportInterface
+  class CandidateAutofillUsageExport
+    def data_for_export
+      degree_grade_output +
+        degree_institution_output +
+        degree_subject_output +
+        degree_type_output +
+        other_grade_output +
+        other_type_output
+    end
+
+  private
+
+    def degree_grade_output
+      create_output(
+        level: :degree,
+        attribute: :grade,
+        field_name: 'Degree grade',
+        set_to_check: degree_grades,
+      )
+    end
+
+    def degree_institution_output
+      create_output(
+        level: :degree,
+        attribute: :institution_name,
+        field_name: 'Degree institution',
+        set_to_check: degree_institutions,
+      )
+    end
+
+    def degree_subject_output
+      create_output(
+        level: :degree,
+        attribute: :subject,
+        field_name: 'Degree subject',
+        set_to_check: degree_subjects,
+      )
+    end
+
+    def degree_type_output
+      create_output(
+        level: :degree,
+        attribute: :qualification_type,
+        field_name: 'Degree type',
+        set_to_check: degree_types,
+      )
+    end
+
+    def other_grade_output
+      create_output(
+        level: :other,
+        attribute: :grade,
+        field_name: 'Other grade',
+        set_to_check: other_grades,
+      )
+    end
+
+    def other_type_output
+      create_output(
+        level: :other,
+        attribute: :qualification_type,
+        field_name: 'Other type',
+        set_to_check: other_types,
+      )
+    end
+
+    def create_output(level:, attribute:, field_name:, set_to_check:)
+      counts_for(level: level, attribute: attribute)
+        .map do |value, count|
+        {
+          'Field' => field_name,
+          'Value entered' => value,
+          'Frequency' => count,
+          'Free text?' => !set_to_check.include?(value),
+        }
+      end
+    end
+
+    def counts_for(level:, attribute:)
+      case level
+      when :degree
+        degree_qualifications
+          .group(attribute)
+          .count
+      when :other
+        other_qualifications
+          .group(attribute)
+          .count
+      end
+    end
+
+    def degree_qualifications
+      @degree_qualifications ||= qualification_query('degree')
+    end
+
+    def other_qualifications
+      @other_qualifications ||= qualification_query('other')
+    end
+
+    def qualification_query(level)
+      ApplicationQualification
+        .joins(:application_form)
+        .where(
+          level: level,
+          application_forms: {
+            phase: 'apply_1',
+            recruitment_cycle_year: RecruitmentCycle.current_year,
+          },
+        )
+        .all
+    end
+
+    def degree_grades
+      HESA_DEGREE_GRADES.map(&:second)
+    end
+
+    def degree_institutions
+      HESA_DEGREE_INSTITUTIONS.map(&:second)
+    end
+
+    def degree_subjects
+      HESA_DEGREE_SUBJECTS.map(&:second)
+    end
+
+    def degree_types
+      HESA_DEGREE_TYPES.map(&:third)
+    end
+
+    def other_grades
+      OTHER_UK_QUALIFICATION_GRADES
+    end
+
+    def other_types
+      OTHER_UK_QUALIFICATIONS
+    end
+  end
+end

--- a/spec/services/support_interface/candidate_autofill_usage_export_spec.rb
+++ b/spec/services/support_interface/candidate_autofill_usage_export_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::CandidateAutofillUsageExport do
+  describe '#data_for_export' do
+    context 'degree qualifications' do
+      it 'returns a hash of candidates autofill usage' do
+        application_form = create(:application_form, :minimum_info)
+        degree_qualification = create(:degree_qualification, application_form: application_form)
+        other_qualification = create(
+          :other_qualification,
+          application_form: application_form,
+          grade: 'Pass',
+          qualification_type: 'BTEC',
+        )
+
+        expect(described_class.new.data_for_export).to eq(
+          expected_hash(
+            degree_qualification: degree_qualification,
+            other_qualification: other_qualification,
+            free_text: false,
+          ),
+        )
+      end
+    end
+
+    context 'Phase 2 applications' do
+      it "does not return a hash of candidates' autofill info" do
+        application_form = create(:application_form, :minimum_info, phase: 'apply_2')
+        create(:degree_qualification, application_form: application_form)
+
+        expect(described_class.new.data_for_export).to be_empty
+      end
+    end
+
+    context 'Candidate free text inputs' do
+      it "returns true for 'free_text?' row" do
+        application_form = create(:application_form, :minimum_info, phase: 'apply_1')
+        degree_qualification = create(:degree_qualification,
+                                      grade: 'Not a HESA grade',
+                                      subject: 'Not a HESA subject',
+                                      institution_name: 'Not a HESA institution',
+                                      qualification_type: 'Not a HESA qualification type',
+                                      application_form: application_form)
+        other_qualification = create(:other_qualification,
+                                     grade: 'Not a HESA grade',
+                                     subject: 'Not a HESA subject',
+                                     institution_name: 'Not a HESA institution',
+                                     qualification_type: 'Not a HESA qualification type',
+                                     application_form: application_form)
+
+        expect(described_class.new.data_for_export).to eq(
+          expected_hash(
+            degree_qualification: degree_qualification,
+            other_qualification: other_qualification,
+            free_text: true,
+          ),
+        )
+      end
+    end
+  end
+
+private
+
+  def expected_hash(degree_qualification:, other_qualification:, free_text:)
+    [
+      {
+        'Field' => 'Degree grade',
+        'Value entered' => degree_qualification.grade,
+        'Frequency' => 1,
+        'Free text?' => free_text,
+      },
+      {
+        'Field' => 'Degree institution',
+        'Value entered' => degree_qualification.institution_name,
+        'Frequency' => 1,
+        'Free text?' => free_text,
+      },
+      {
+        'Field' => 'Degree subject',
+        'Value entered' => degree_qualification.subject,
+        'Frequency' => 1,
+        'Free text?' => free_text,
+      },
+      {
+        'Field' => 'Degree type',
+        'Value entered' => degree_qualification.qualification_type,
+        'Frequency' => 1,
+        'Free text?' => free_text,
+      },
+      {
+        'Field' => 'Other grade',
+        'Value entered' => other_qualification.grade,
+        'Frequency' => 1,
+        'Free text?' => free_text,
+      },
+      {
+        'Field' => 'Other type',
+        'Value entered' => other_qualification.qualification_type,
+        'Frequency' => 1,
+        'Free text?' => free_text,
+      },
+    ]
+  end
+end


### PR DESCRIPTION

## Context

```
As a... Designer
I need to... understand how candidates use the autosuggest options within APPLY
So that... we can understand how the structured data is captured
```

## Changes proposed in this pull request

The candidate application uses two types of autofill:
- autocomplete (user must choose from a range of options)
- autosuggest (user has the option to choose from a range of options or submit their own value)

We're interested in the latter, particularly values submitted by the user as 'freetext'

This PR add a downloadable export that breaks down the values submitted via each autosuggest field in the candidate application.

## Guidance to review
- Go the exports dashboard `/support/performance/data-exports/new` and select 'Candidate autosuggest usage'
- I've tried to memoise the db calls where possible. Are there any further optimisations required?


## Link to Trello card

https://trello.com/c/69AeFZwg/3116-data-request-autofill-usage

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
