### PR TITLE
Add reusable component for selecting a course.

### DIFF
--- a/app/components/provider_interface/select_course_component.html.erb
+++ b/app/components/provider_interface/select_course_component.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: form_object, url: form_path, method: :post do |f| %>
+      <%= f.govuk_collection_radio_buttons :course_id, courses, :id, :name_and_code, :description, legend: { text: page_title, size: 'l' } %>
+      <%= f.govuk_submit t('continue') %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/provider_interface/select_course_component.rb
+++ b/app/components/provider_interface/select_course_component.rb
@@ -1,0 +1,14 @@
+module ProviderInterface
+  class SelectCourseComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :form_object, :form_path, :page_title, :courses
+
+    def initialize(form_object:, form_path:, courses:, page_title: 'Select course')
+      @form_object = form_object
+      @form_path = form_path
+      @courses = courses
+      @page_title = page_title
+    end
+  end
+end

--- a/spec/components/previews/provider_interface/select_course_component_preview.rb
+++ b/spec/components/previews/provider_interface/select_course_component_preview.rb
@@ -1,0 +1,19 @@
+module ProviderInterface
+  class SelectCourseComponentPreview < ViewComponent::Preview
+    class FormObject
+      include ActiveModel::Model
+
+      attr_accessor :course_id
+    end
+
+    def select_course
+      form_path = ''
+      courses = Course.limit(10)
+      form_object = FormObject.new(course_id: courses.last.id)
+
+      render SelectCourseComponent.new(form_object: form_object,
+                                       form_path: form_path,
+                                       courses: courses)
+    end
+  end
+end

--- a/spec/components/provider_interface/select_course_component_spec.rb
+++ b/spec/components/provider_interface/select_course_component_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::SelectCourseComponent do
+  let(:form_object_class) do
+    Class.new do
+      include ActiveModel::Model
+
+      attr_accessor :course_id
+    end
+  end
+
+  let(:form_object) { FormObjectClass.new(course_id: selected_course.id) }
+  let(:courses) { build_stubbed_list(:course, 10) }
+  let(:selected_course) { courses.sample }
+
+  let(:render) do
+    render_inline(described_class.new(form_object: form_object,
+                                      form_path: '',
+                                      courses: courses))
+  end
+
+  before do
+    stub_const('FormObjectClass', form_object_class)
+  end
+
+  it 'renders all courses' do
+    expect(render.css('.govuk-radios__item').length).to eq(courses.count)
+  end
+
+  it 'selects the preselected course' do
+    expect(render.css('.govuk-radios__item input[checked]').first.next_element.text)
+      .to eq(selected_course.name_and_code)
+  end
+end


### PR DESCRIPTION
## Context

Adding a new component for selecting courses as per the reusable pattern.


## Guidance to review

None

## Link to Trello card

https://trello.com/c/0b3x0EvO/3472-select-course-component
## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
