### PR TITLE
Fix Vendor API flakey tests

### DIFF
--- a/spec/system/vendor_api/vendor_makes_unconditional_offer_spec.rb
+++ b/spec/system/vendor_api/vendor_makes_unconditional_offer_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Vendor makes unconditional offer' do
 
   scenario 'A vendor makes an unconditional offer and this is accepted by the candidate' do
     FeatureFlag.activate(:unconditional_offers_via_api)
+
     given_a_candidate_has_submitted_their_application
     when_i_make_an_unconditional_offer_for_the_application_over_the_api
     then_i_can_see_the_offer_was_made_successfully
@@ -14,26 +15,25 @@ RSpec.feature 'Vendor makes unconditional offer' do
   end
 
   def given_a_candidate_has_submitted_their_application
-    Capybara.session_name = 'candidate_interaction'
-    Capybara.using_session('candidate_interaction') do
-      candidate_completes_application_form
-      candidate_submits_application
-    end
+    candidate_completes_application_form
+    candidate_submits_application
   end
 
   def when_i_make_an_unconditional_offer_for_the_application_over_the_api
-    Capybara.session_name = 'api_request'
-    Capybara.using_session('api_request') do
-      api_token = VendorAPIToken.create_with_random_token!(provider: @provider)
-      page.driver.header 'Authorization', "Bearer #{api_token}"
-      page.driver.header 'Content-Type', 'application/json'
-      @application_choice = @application.application_choices.first
-      @course_option = @application_choice.course_option
-      @provider_user = create(:provider_user, send_notifications: true, providers: [@provider])
-      uri = "/api/v1/applications/#{@application_choice.id}/offer"
+    api_token = VendorAPIToken.create_with_random_token!(provider: @provider)
+    Capybara.current_session.driver.header('Authorization', "Bearer #{api_token}")
+    Capybara.current_session.driver.header('Content-Type', 'application/json')
 
-      @api_response = page.driver.post(uri, unconditional_offer_payload)
-    end
+    @application_choice = @application.application_choices.first
+    @course_option = @application_choice.course_option
+    @provider_user = create(:provider_user, send_notifications: true, providers: [@provider])
+    uri = "/api/v1/applications/#{@application_choice.id}/offer"
+
+    @api_response = page.driver.post(uri, unconditional_offer_payload)
+
+    # Unset session headers
+    Capybara.current_session.driver.header('Authorization', nil)
+    Capybara.current_session.driver.header('Content-Type', nil)
   end
 
   def then_i_can_see_the_offer_was_made_successfully
@@ -46,20 +46,16 @@ RSpec.feature 'Vendor makes unconditional offer' do
   end
 
   def when_the_candidate_accepts_the_unconditional_offer
-    Capybara.using_session('candidate_interaction') do
-      visit candidate_interface_offer_path(@application_choice)
+    visit candidate_interface_offer_path(@application_choice)
 
-      choose 'Accept offer and conditions'
-      click_button 'Continue'
+    choose 'Accept offer and conditions'
+    click_button 'Continue'
 
-      click_button 'Accept offer'
-    end
+    click_button 'Accept offer'
   end
 
   def then_the_candidate_sees_that_they_have_accepted_the_offer
-    Capybara.using_session('candidate_interaction') do
-      expect(page).to have_content "You have accepted your offer for #{@application_choice.course.name_and_code} at #{@application_choice.provider.name}"
-    end
+    expect(page).to have_content "You have accepted your offer for #{@application_choice.course.name_and_code} at #{@application_choice.provider.name}"
   end
 
   def unconditional_offer_payload


### PR DESCRIPTION
## Context

We were getting system flakey tests with the following error:

```
ActionDispatch::Http::Parameters::ParseError:
       783: unexpected token at 'candidate_interface_english_foreign_language_start_form[qualification_status]=has_qualification&candidate_interface_english_foreign_language_start_form[no_qualification_details]=&commit=Continue'
```

By utilising rspec `bisect` we were able to narrow replicating the failure down to the following:

```
rspec ./spec/system/candidate_interface/entering_details/add_other_qualification_spec.rb[1:1] ./spec/system/vendor_api/vendor_makes_unconditional_offer_spec.rb[1:1] --seed 50442
```

## Changes proposed in this pull request

Setting a page driver header to accept `'Content-Type', 'application/json'` in this test was causing other tests to fail as this was persisting across specs and all forms were expected to send requests with this content type.

Unsetting the content type header seems to resolve the issue at the end of the test. I also removed setting the Capybara session in other sections as it didn't seem required anymore.

## Guidance to review

Im not sure this is the best approach for setting the headers for a POST request in the system specs, happy for other suggestions

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
