### PR TITLE
Restrict access to provider/interview controller

### DIFF
--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -3,6 +3,7 @@ module ProviderInterface
     before_action :set_application_choice
     before_action :interview_flag_enabled?
     before_action :requires_make_decisions_permission, except: %i[index]
+    before_action :confirm_application_is_in_decision_pending_state, except: %i[index]
 
     def index
       application_at_interviewable_stage = ApplicationStateChange::INTERVIEWABLE_STATES.include?(
@@ -153,6 +154,12 @@ module ProviderInterface
     def cancel_interview_store
       key = "cancel_interview_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
       WizardStateStores::RedisStore.new(key: key)
+    end
+
+    def confirm_application_is_in_decision_pending_state
+      return if ApplicationStateChange::DECISION_PENDING_STATUSES.include?(@application_choice.status.to_sym)
+
+      redirect_back(fallback_location: provider_interface_application_choice_path(@application_choice))
     end
   end
 end

--- a/spec/requests/provider_interface/interviews_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews_controller_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::InterviewsController, type: :request do
+  include DfESignInHelpers
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions) }
+  let(:provider) { provider_user.providers.first }
+  let(:application_form) { build(:application_form, :minimum_info) }
+  let(:course) { build(:course, :open_on_apply, provider: provider) }
+  let(:course_option) { build(:course_option, course: course) }
+  let(:interview) { create(:interview, application_choice: application_choice) }
+
+  describe 'if application choice is not in a pending decision state' do
+    let!(:application_choice) do
+      create(:application_choice, :withdrawn,
+             application_form: application_form,
+             course_option: course_option)
+    end
+
+    before do
+      allow(DfESignInUser).to receive(:load_from_session).and_return(provider_user)
+
+      FeatureFlag.activate(:interviews)
+
+      user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+    end
+
+    context 'GET new' do
+      it 'responds with 302' do
+        get new_provider_interface_application_choice_interview_path(application_choice)
+
+        expect(response.status).to eq(302)
+      end
+    end
+
+    context 'GET edit' do
+      it 'responds with 302' do
+        get edit_provider_interface_application_choice_interview_path(application_choice, interview)
+
+        expect(response.status).to eq(302)
+      end
+    end
+
+    context 'GET cancel' do
+      it 'responds with 302' do
+        get cancel_provider_interface_application_choice_interview_path(application_choice, interview)
+
+        expect(response.status).to eq(302)
+      end
+    end
+
+    context 'POST commit' do
+      it 'responds with 302' do
+        post confirm_provider_interface_application_choice_interviews_path(application_choice)
+
+        expect(response.status).to eq(302)
+      end
+    end
+
+    context 'PUT update' do
+      it 'responds with 302' do
+        put update_provider_interface_application_choice_interview_path(application_choice, interview)
+
+        expect(response.status).to eq(302)
+      end
+    end
+
+    context 'POST confirm_cancel' do
+      it 'responds with 302' do
+        post cancel_confirm_provider_interface_application_choice_interview_path(application_choice, interview)
+
+        expect(response.status).to eq(302)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Restrict access to new/edit and cancel interviews to applications that are not in a decision pending state.

Resolves sentry error:
https://sentry.io/organizations/dfe-bat/issues/2254465436/?project=1765973&query=is%3Aunresolved

## Link to Trello card
https://trello.com/c/g6fB7c3z/3473-prevent-providerusers-from-getting-to-new-interview-page-for-applications-that-are-not-in-a-decision-making-state

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
