### PR TITLE
Don’t attempt to sync courses when no provider can be found

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -6,7 +6,7 @@ module TeacherTrainingPublicAPI
     sidekiq_options retry: 3, queue: :low_priority
 
     def perform(provider_id, recruitment_cycle_year, run_in_background: true)
-      @provider = ::Provider.find(provider_id)
+      @provider = ::Provider.find_by!(id: provider_id)
       @run_in_background = run_in_background
 
       TeacherTrainingPublicAPI::Course.where(
@@ -17,6 +17,8 @@ module TeacherTrainingPublicAPI
       end
     rescue JsonApiClient::Errors::ApiError
       raise TeacherTrainingPublicAPI::SyncError
+    rescue ActiveRecord::RecordNotFound
+      Rails.logger.info("Unable to SyncCourses as provider with id #{provider_id} can't be found")
     end
 
   private

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -4,6 +4,19 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
   include TeacherTrainingPublicAPIHelper
 
   describe '.call' do
+    context 'when there is no provider for the given id' do
+      it 'logs the missing provider details and does not raise an error' do
+        allow(Rails.logger).to receive(:info)
+
+        expect {
+          described_class.new.perform(999, Time.zone.now.year)
+        }.not_to raise_error
+
+        expect(Rails.logger)
+          .to have_received(:info).with('Unable to SyncCourses as provider with id 999 can\'t be found')
+      end
+    end
+
     context 'ingesting an existing provider configured to sync courses, sites and course_options' do
       before do
         @existing_provider = create :provider, code: 'ABC', sync_courses: true, provider_type: 'scitt', region_code: 'south_west', postcode: 'SK2 6AA'


### PR DESCRIPTION
### Why? 
We are getting around 1K false errors per week posted on sentry, making it extremely difficult to identify and resolve actual issues.

Resolves sentry error:
https://sentry.io/organizations/dfe-bat/issues/2220591200/?project=1765973&query=is%3Aunresolved

> JsonApiClient::Errors::NotFound
> Couldn't find resource at: https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2021/providers/nil
