### PR TITLE
Add codes to help vendors use the uk residency status to help calculate a provisional fee status

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -111,9 +111,7 @@ module VendorAPI
 
       return application_form.right_to_work_or_study_details if application_form.right_to_work_or_study_yes?
 
-      return 'Candidate needs to apply for permission to work and study in the UK' if application_form.right_to_work_or_study_no?
-
-      'Candidate does not know'
+      'Candidate needs to apply for permission to work and study in the UK'
     end
 
     def provisional_fee_payer_status

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -34,6 +34,7 @@ module VendorAPI
             nationality: application_choice.nationalities,
             domicile: application_form.domicile,
             uk_residency_status: uk_residency_status,
+            uk_residency_status_code: uk_residency_status_code,
             fee_payer: provisional_fee_payer_status,
             english_main_language: application_form.english_main_language,
             english_language_qualifications: application_form.english_language_qualification_details,
@@ -112,6 +113,14 @@ module VendorAPI
       return application_form.right_to_work_or_study_details if application_form.right_to_work_or_study_yes?
 
       'Candidate needs to apply for permission to work and study in the UK'
+    end
+
+    def uk_residency_status_code
+      return 'A' if application_choice.nationalities.include?('GB')
+      return 'B' if application_choice.nationalities.include?('IE')
+      return 'D' if application_form.right_to_work_or_study_yes?
+
+      'C'
     end
 
     def provisional_fee_payer_status

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,13 @@
+## 9th March
+
+Changes to existing attributes:
+
+- Update return values of `uk_residency_status` to correspond with candidate application options. Removes 'Candidate does not know' and the value 'Candidate needs to apply for permission to work and study in the UK' is returned where the candidate has answered `no` or `decide_later`.
+
+New attributes:
+
+- Adds `uk_residency_status_code` field. Single alphabetical character code for the candidate’s UK residency status indicating their right to work and study in the UK.
+
 ## 29th February
 
 - deprecate `Qualification.awarding_body` as this field has always been null.

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -592,8 +592,24 @@ components:
         uk_residency_status:
           type: string
           maxLength: 256
-          description: The candidate’s UK residency status indicating their right to work and study in the UK. Possible values include "UK Citizen", "Irish Citizen", "Candidate needs to apply for permission to work and study in the UK" and "Candidate does not know". The candidate can also provide details as free text for example "Settled status".
+          description: The candidate’s UK residency status indicating their right to work and study in the UK. Possible values include "UK Citizen", "Irish Citizen" and "Candidate needs to apply for permission to work and study in the UK". The candidate can also provide details as free text for example "Settled status".
           example: UK Citizen
+        uk_residency_status_code:
+          type: string
+          maxLength: 1
+          description: |
+            Single alphabetical character code for the candidate’s UK residency status indicating their right to work and study in the UK:
+
+            - A - UK Citizen
+            - B - Irish Citizen
+            - C - Candidate needs to apply for permission to work and study in the UK
+            - D - Candidate's free text response
+          example: 'B'
+          enum:
+            - 'A'
+            - 'B'
+            - 'C'
+            - 'D'
         fee_payer:
           type: string
           maxLength: 2

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       expect(response.dig(:attributes, :candidate, :uk_residency_status)).to eq('Candidate needs to apply for permission to work and study in the UK')
     end
 
-    it 'returns correct message if the candidates answered they do not know if they have the right to work/study in the UK' do
+    it 'returns correct message if the candidate has answered they do not know if they have the right to work/study in the UK' do
       application_form = create(:application_form,
                                 :minimum_info,
                                 first_nationality: 'Canadian',
@@ -260,7 +260,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
 
-      expect(response.dig(:attributes, :candidate, :uk_residency_status)).to eq('Candidate does not know')
+      expect(response.dig(:attributes, :candidate, :uk_residency_status)).to eq('Candidate needs to apply for permission to work and study in the UK')
     end
   end
 

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -63,6 +63,7 @@ RSpec.feature 'Vendor receives the application', recruitment_cycle: 2020 do
           nationality: %w[GB US],
           domicile: @application.domicile,
           uk_residency_status: 'UK Citizen',
+          uk_residency_status_code: 'A',
           fee_payer: '02',
           english_main_language: true,
           other_languages: nil,


### PR DESCRIPTION
## Context

Providers need to figure out whether someone can be treated as a home/EU student, or an overseas student in order to see whether they are eligible for a student loan (Student Finance) and bursary funding.

Tribal have asked whether we can provide codes for this field, so that they can automate a calculation
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Simplifies the return values of `uk_residency_status` by removing the _Candidate does not know_ value. The value _Candidate needs to apply for permission to work and study in the UK_ is returned where the candidate has answered 'no' or 'decide_later'.
- Adds the field `uk_residency_status_code` which employs the same logic as `uk_residency_status` but returns one of `A`, `B`, `C` or `D` depending on candidate nationalities, answers and details given for residency.

<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/110463723-2f491580-80ca-11eb-9d2e-74659f4e236e.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/C3BRMbD0/3467-add-codes-to-help-vendors-use-the-ukresidencystatus-to-help-calculate-a-provisional-fee-status
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
