### PR TITLE
Remove V3 API (2/4) — sync subjects from public API, remove refs to V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,13 +148,6 @@ The course and training provider data in the Apply service comes from its
 sister service `Publish`. To populate your local database with course data from
 `Publish`, first start the redis service (`redis-server`) and then run `bundle exec rake setup_local_dev_data`.
 
-We’re in the process of moving to Publish’s new public [Teacher training
-API](https://api.publish-teacher-training-courses.service.gov.uk/#about). At
-the moment the public API _complements_ the old API but does not replace it —
-some data is only available in the public API. To receive public-api-only data
-such as `program_type` and `qualifications` turn on the
-`sync_from_public_teacher_training_api` feature flag.
-
 Among other things, this task also creates a support user with DfE Sign-in UID
 `dev-support` that you can use to sign in to the Support interface in your
 development environment, and a provider user with the UID `dev-provider`.

--- a/app/controllers/support_interface/course_controller.rb
+++ b/app/controllers/support_interface/course_controller.rb
@@ -10,6 +10,7 @@ module SupportInterface
 
     def vacancies
       @course = Course.find(params[:course_id])
+      @course_options = CourseOption.where(course: @course).includes(:site, :course)
     end
 
     def update

--- a/app/controllers/support_interface/tasks_controller.rb
+++ b/app/controllers/support_interface/tasks_controller.rb
@@ -10,7 +10,6 @@ module SupportInterface
         redirect_to support_interface_tasks_path
       when 'sync_providers'
         TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async
-        SyncAllFromFind.perform_async
         flash[:success] = 'Scheduled job to sync providers - this might take a while!'
         redirect_to support_interface_tasks_path
       when 'recalculate_dates'

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -22,7 +22,6 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [
-    [:sync_from_public_teacher_training_api, 'Pull data from the public Teacher training API as well as the old "Find" API', 'Duncan Brown'],
     [:provider_activity_log, 'Show provider users a log of all application activity', 'Michael Nacos'],
     [:export_application_data, 'Providers can export a customised selection of application data', 'Ben Swannack'],
     [:interviews, 'Providers can filter applications by interviewing state', 'Despo Pentara'],

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -54,6 +54,7 @@ module TeacherTrainingPublicAPI
       course.age_range = age_range_in_years(course_from_api)
       course.withdrawn = course_from_api.state == 'withdrawn'
       course.qualifications = course_from_api.qualifications
+      course.subject_codes = course_from_api.subject_codes
     end
 
     def study_mode(course_from_api)

--- a/app/views/support_interface/course/vacancies.html.erb
+++ b/app/views/support_interface/course/vacancies.html.erb
@@ -1,3 +1,3 @@
 <%= render 'course_navigation', title: 'Vacancies' %>
 
-<%= render(SupportInterface::CourseChoicesTableComponent.new(course_options: @course.course_options)) %>
+<%= render(SupportInterface::CourseChoicesTableComponent.new(course_options: @course_options)) %>

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">Sync providers</h2>
-      <p class="govuk-body">This task downloads providers, and the related entities (courses, course options etc.) from the Teacher Training API and Find.</p>
+      <p class="govuk-body">This task downloads providers, and the related entities (courses, course options etc.) from the Teacher Training API.</p>
     </div>
     <div class="govuk-grid-column-one-third">
       <%= govuk_button_to 'Sync providers', support_interface_run_task_path('sync_providers'), class: 'govuk-button--secondary' %>

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -8,8 +8,6 @@ class Clock
 
   error_handler { |error| Raven.capture_exception(error) if defined? Raven }
 
-  every(15.minutes, 'SyncAllFromFind') { SyncAllFromFind.perform_async }
-
   every(1.hour, 'DetectInvariants') { DetectInvariants.perform_async }
   every(1.hour, 'RejectApplicationsByDefault', at: '**:10') { RejectApplicationsByDefaultWorker.perform_async }
   every(1.hour, 'DeclineOffersByDefault', at: '**:15') { DeclineOffersByDefaultWorker.perform_async }

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -43,9 +43,7 @@ class Clock
   end
 
   every(1.hour, 'SyncAllFromTeacherTrainingPublicAPI') do
-    if FeatureFlag.active?(:sync_from_public_teacher_training_api)
-      TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async
-    end
+    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async
   end
 
   every(1.day, 'Generate export for Notifications', at: '23:57') do

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,4 +1,4 @@
-require 'find_sync_check'
+require 'teacher_training_public_api/sync_check'
 
 class SimulatedFailureCheck < OkComputer::Check
   def check
@@ -32,7 +32,7 @@ OkComputer::Registry.register 'sidekiq_default_queue', OkComputer::SidekiqLatenc
 OkComputer::Registry.register 'sidekiq_mailers_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'mailers', threshold: 100) # threshold in seconds
 OkComputer::Registry.register 'sidekiq_retries_count', SidekiqRetriesCheck.new
 OkComputer::Registry.register 'simulated_failure', SimulatedFailureCheck.new
-OkComputer::Registry.register 'find_sync', FindSyncCheck.new
+OkComputer::Registry.register 'ttapi_sync', TeacherTrainingPublicAPI::SyncCheck.new
 OkComputer::Registry.register 'version', OkComputer::AppVersionCheck.new
 
 OkComputer.make_optional %w[version]

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -14,10 +14,10 @@ Raven.configure do |config|
     'ActionDispatch::Http::Parameters::ParseError',
     'Mime::Type::InvalidMimeType',
 
-    # Errors in the Find sync are often transient errors with the Find API. We
+    # Errors in the TTAPI sync are often transient errors with the API. We
     # have monitoring in place to make sure the sync succeeds every couple of
     # hours, so we don't need to be notified of individual failures.
-    'FindSync::SyncError',
+    'TeacherTrainingPublicAPI::SyncError',
 
     # These Postgres errors often occur when Azure has maintenance and drops
     # connections. Most of the time they aren't actionable. We are able to filter

--- a/spec/examples/teacher_training_api/course_list_response.json
+++ b/spec/examples/teacher_training_api/course_list_response.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "string",
+      "id": "12944685",
       "type": "courses",
       "attributes": {
         "about_accredited_body": "UCL Institute of Education is the world’s leading centre for research and teaching in education and related social sciences.",
@@ -56,170 +56,43 @@
         "scholarship_amount": 17000,
         "start_date": "2020-09-01",
         "state": "published",
-        "study_mode": "full_time",
-        "summary": "PGCE with QTS full time"
+        "study_mode": "both",
+        "summary": "PGCE with QTS full time",
+        "subject_codes": [
+          {
+          }
+        ]
       },
       "relationships": {
-        "accredited_body": {
+        "recruitment_cycle": {
           "data": {
-            "type": "string",
-            "id": "string"
-          },
-          "meta": {
+            "type": "recruitment_cycles",
+            "id": "3"
           }
         },
-        "locations": {
-          "data": [
-            {
-              "type": "string",
-              "id": "string"
-            }
-          ]
-        },
-        "modern_languages": {
-          "data": [
-            {
-              "type": "string",
-              "id": "string"
-            }
-          ]
-        },
-        "provider_locations": {
-          "data": [
-            {
-              "type": "string",
-              "id": "string"
-            }
-          ]
+        "accredited_body": {
+          "data": {
+            "type": "providers",
+            "id": "16346"
+          }
         },
         "provider": {
           "data": {
-            "type": "string",
-            "id": "string"
-          },
-          "meta": {
+            "type": "providers",
+            "id": "16288"
           }
-        },
-        "subjects": {
-          "data": [
-            {
-              "type": "string",
-              "id": "string"
-            }
-          ]
         }
       }
     }
   ],
   "included": [
     {
-      "id": "string",
-      "type": "courses",
+      "id": "3",
+      "type": "recruitment_cycles",
       "attributes": {
-        "about_accredited_body": "UCL Institute of Education is the world’s leading centre for research and teaching in education and related social sciences.",
-        "about_course": "The Secondary PGCE consists of three core modules: two Master's-level modules, which are assessed through written assignments, and the Professional Practice module, which is assessed by the observation of practical teaching in placement schools.",
-        "accredited_body_code": "2FR",
-        "age_minimum": 11,
-        "age_maximum": 14,
-        "applications_open_from": "2019-10-08",
-        "bursary_amount": 9000,
-        "bursary_requirements": [
-          {
-          }
-        ],
-        "changed_at": "2019-06-13T10:44:31Z",
-        "code": "3GTY",
-        "course_length": "OneYear",
-        "created_at": "2019-06-13T10:44:31Z",
-        "fee_details": "For those wishing to top up their qualification to the full PGCE, a further £1800 will be payable.",
-        "fee_international": 13000,
-        "fee_domestic": 9200,
-        "financial_support": "You'll get a bursary of £9,000 if you have a degree of 2:2 or above in any subject. You may also be eligible for a loan while you study.",
-        "findable": true,
-        "funding_type": "apprenticeship",
-        "gcse_subjects_required": [
-          {
-          }
-        ],
-        "has_bursary": true,
-        "has_early_career_payments": true,
-        "has_scholarship": true,
-        "has_vacancies": true,
-        "how_school_placements_work": "You will spend two-thirds of your time (120 days) in schools, working with art and design mentors who support you through your two school placements.",
-        "interview_process": "At your interview day you will take part in a combination of group and individual interviews with members of the programme team, and you may also be asked to undertake written or presentation tasks, depending on your subject.",
-        "is_send": true,
-        "last_published_at": "2019-06-13T10:44:31Z",
-        "level": "secondary",
-        "name": "Art and Design",
-        "open_for_applications": true,
-        "other_requirements": "You'll need to provide confirmation you have the health and physical capacity to commence training, and a Disclosure and Barring Service (DBS) certificate.",
-        "personal_qualities": "We are looking for applicants who have the potential to become outstanding teachers, and who are able to work independently on their studies while training in a school context.",
-        "program_type": "scitt_programme",
-        "qualifications": [
-          {
-          }
-        ],
-        "required_qualifications": "A first or second-class UK Bachelor's degree in an appropriate subject, or an overseas qualification of an equivalent standard from a recognised higher education institution.",
-        "required_qualifications_english": "equivalence_test",
-        "required_qualifications_maths": "equivalence_test",
-        "required_qualifications_science": "equivalence_test",
-        "running": true,
-        "salary_details": "Successful applicants will be employed as unqualified teachers on at least Point 1 of the Unqualified Teachers' Pay Scale for the duration of the programme.",
-        "scholarship_amount": 17000,
-        "start_date": "2020-09-01",
-        "state": "published",
-        "study_mode": "full_time",
-        "summary": "PGCE with QTS full time"
-      },
-      "relationships": {
-        "accredited_body": {
-          "data": {
-            "type": "string",
-            "id": "string"
-          },
-          "meta": {
-          }
-        },
-        "locations": {
-          "data": [
-            {
-              "type": "string",
-              "id": "string"
-            }
-          ]
-        },
-        "modern_languages": {
-          "data": [
-            {
-              "type": "string",
-              "id": "string"
-            }
-          ]
-        },
-        "provider_locations": {
-          "data": [
-            {
-              "type": "string",
-              "id": "string"
-            }
-          ]
-        },
-        "provider": {
-          "data": {
-            "type": "string",
-            "id": "string"
-          },
-          "meta": {
-          }
-        },
-        "subjects": {
-          "data": [
-            {
-              "type": "string",
-              "id": "string"
-            }
-          ]
-        }
+        "year": 2021,
+        "application_start_date": "2020-10-13",
+        "application_end_date": "2021-10-03"
       }
     }
   ],

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
       it 'correctly updates withdrawn attribute for an existing course' do
         stub_course_with_site(provider_code: 'ABC',
                               course_code: 'ABC1',
-                              course_attributes: [{ accredited_body_code: nil, state: 'withdrawn' }],
+                              course_attributes: [{ study_mode: 'full_time', accredited_body_code: nil, state: 'withdrawn' }],
                               site_code: 'A')
 
         described_class.new.perform(@existing_provider.id, stubbed_recruitment_cycle_year)

--- a/spec/system/candidate_interface/course_selection/candidate_view_available_courses_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_view_available_courses_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'A candidate can view all providers and courses on Apply' do
-  include FindAPIHelper
-
   scenario 'seeing the list of courses grouped by provider and region' do
     given_the_pilot_is_open
     and_there_are_providers_with_courses_on_apply

--- a/spec/system/support_interface/provider_sync_courses_spec.rb
+++ b/spec/system/support_interface/provider_sync_courses_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.feature 'See provider course syncing' do
   include DfESignInHelpers
-  include FindAPIHelper
   include TeacherTrainingPublicAPIHelper
 
   scenario 'User switches sync courses on Provider' do
@@ -55,13 +54,6 @@ RSpec.feature 'See provider course syncing' do
   end
 
   def when_provider_syncing_runs
-    stub_find_api_all_providers_200([
-      {
-        provider_code: 'ABC',
-        name: 'ABC College',
-      },
-    ])
-
     stub_teacher_training_api_providers(
       specified_attributes: [
         {
@@ -71,19 +63,13 @@ RSpec.feature 'See provider course syncing' do
       ],
     )
 
-    stub_find_api_provider_200(
+    stub_teacher_training_api_courses(provider_code: 'ABC', specified_attributes: [{ code: 'ABC1', accredited_body_code: nil }])
+    stub_teacher_training_api_sites(
       provider_code: 'ABC',
-      provider_name: 'ABC College',
       course_code: 'ABC1',
-      site_code: 'X',
     )
-    stub_course_with_site(provider_code: 'ABC',
-                          course_code: 'ABC1',
-                          course_attributes: [{ accredited_body_code: 'ABC' }],
-                          site_code: 'X')
 
     TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async
-    SyncAllFromFind.perform_async
 
     refresh
   end

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.feature 'Providers and courses' do
   include DfESignInHelpers
-  include FindAPIHelper
   include TeacherTrainingPublicAPIHelper
 
   scenario 'User syncs provider and browses providers' do
@@ -111,21 +110,6 @@ RSpec.feature 'Providers and courses' do
       ],
     )
 
-    stub_find_api_all_providers_200([
-      {
-        provider_code: 'ABC',
-        name: 'Royal Academy of Dance',
-      },
-      {
-        provider_code: 'DEF',
-        name: 'Gorse SCITT',
-      },
-      {
-        provider_code: 'GHI',
-        name: 'Somerset SCITT Consortium',
-      },
-    ])
-
     stub_teacher_training_api_provider(
       provider_code: 'XYZ',
       specified_attributes: {
@@ -139,40 +123,15 @@ RSpec.feature 'Providers and courses' do
                           site_code: 'X',
                           site_attributes: [{ name: 'Main site' }])
 
-    stub_find_api_provider_200_with_accredited_provider(
-      provider_code: 'ABC',
-      provider_name: 'Royal Academy of Dance',
-      course_code: 'ABC1',
-      site_code: 'X',
-      accredited_provider_code: 'XYZ',
-      accredited_provider_name: 'University of Chester',
-      findable: true,
-      study_mode: 'full_time',
-    )
-
     stub_course_with_site(provider_code: 'DEF',
                           course_code: 'DEF1',
                           course_attributes: [{ accredited_body_code: 'ABC' }],
                           site_code: 'Y')
 
-    stub_find_api_provider_200(
-      provider_code: 'DEF',
-      provider_name: 'Gorse SCITT',
-      course_code: 'DEF1',
-      site_code: 'Y',
-    )
-
     stub_course_with_site(provider_code: 'GHI',
                           course_code: 'GHI1',
                           course_attributes: [{ accredited_body_code: 'GHI' }],
                           site_code: 'C')
-
-    stub_find_api_provider_200(
-      provider_code: 'GHI',
-      provider_name: 'Somerset SCITT Consortium',
-      course_code: 'GHI1',
-      site_code: 'C',
-    )
 
     Sidekiq::Testing.inline! do
       click_button 'Sync providers'


### PR DESCRIPTION
### Removing V3 from Apply

1. Apply from Find uses public API
2. **Consume subject codes from the public API and remove remaining references to the v3 API**  👈
3. Delete all TTAPI v3 code
4. Clean up after removing v3 API

## Context

The last thing we need the V3 API for is subject codes for our courses. This PR breaks that last dependency and removes all references to the V3 API code. The next PR will delete it all!

## Guidance to review

This PR has lots of small changes dotted around the codebase, so commit-by-commit!

## Link to Trello card

https://trello.com/c/io8acUsQ/291-sync-all-courses

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
