### PR TITLE
Qualifications export: Don't load all application choices in memory at once

### DIFF
--- a/app/services/support_interface/qualifications_export.rb
+++ b/app/services/support_interface/qualifications_export.rb
@@ -2,10 +2,10 @@ module SupportInterface
   class QualificationsExport
     def data_for_export
       application_choices = ApplicationChoice
-                                .select(:id, :application_form_id, :rejection_reason, :structured_rejection_reasons, :status, :course_option_id)
-                                .includes(:course_option, :course, :provider)
+        .select(:id, :application_form_id, :rejection_reason, :structured_rejection_reasons, :status, :course_option_id)
+        .includes(:course_option, :course, :provider)
 
-      application_choices.map do |application_choice|
+      application_choices.find_each(batch_size: 100).lazy.map do |application_choice|
         application_form = application_choice.application_form
         course = application_choice.course_option.course
         qualifications = application_form.application_qualifications
@@ -56,6 +56,7 @@ module SupportInterface
 
           'Number of other qualifications provided' => other_qualification_count(qualifications),
         }
+
         output
       end
     end


### PR DESCRIPTION
## Context

- The qualifications export appears to hang in production, and remains "in progress" without completing.
- The qualifications export is loading all application choices in memory and we suspect this is causing the background worker to run out of memory on production when the export is generated

## Changes proposed in this pull request

- Load application choices in batches (via `#find_each` ) 

## Guidance to review

- Unfortunately, we need to deploy out to prod to see if this has worked or not!
- Thanks @stevehook for helping to debug this!

## Link to Trello card

https://trello.com/c/LkbuvHIv/3137-qualifications-export-not-completing-on-prod

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
