### PR TITLE
Corrections to autosuggest data export

### DIFF
--- a/app/services/support_interface/candidate_autofill_usage_export.rb
+++ b/app/services/support_interface/candidate_autofill_usage_export.rb
@@ -108,9 +108,12 @@ module SupportInterface
             recruitment_cycle_year: RecruitmentCycle.current_year,
           },
         )
-        .where.not(application_forms: {
-          submitted_at: nil,
-        })
+        .where.not(
+          qualification_type: 'non_uk',
+          application_forms: {
+            submitted_at: nil,
+          },
+        )
         .all
     end
 

--- a/app/services/support_interface/candidate_autofill_usage_export.rb
+++ b/app/services/support_interface/candidate_autofill_usage_export.rb
@@ -108,6 +108,9 @@ module SupportInterface
             recruitment_cycle_year: RecruitmentCycle.current_year,
           },
         )
+        .where.not(application_forms: {
+          submitted_at: nil,
+        })
         .all
     end
 

--- a/spec/services/support_interface/candidate_autofill_usage_export_spec.rb
+++ b/spec/services/support_interface/candidate_autofill_usage_export_spec.rb
@@ -24,8 +24,17 @@ RSpec.describe SupportInterface::CandidateAutofillUsageExport do
     end
 
     context 'Phase 2 applications' do
-      it "does not return a hash of candidates' autofill info" do
+      it "does not return a hash of candidates' autofill usage" do
         application_form = create(:application_form, :minimum_info, phase: 'apply_2')
+        create(:degree_qualification, application_form: application_form)
+
+        expect(described_class.new.data_for_export).to be_empty
+      end
+    end
+
+    context 'Unsubmitted applications' do
+      it "does not return a hash of candidates' autofill usage" do
+        application_form = create(:application_form, :minimum_info, phase: 'apply_1', submitted_at: nil)
         create(:degree_qualification, application_form: application_form)
 
         expect(described_class.new.data_for_export).to be_empty

--- a/spec/services/support_interface/candidate_autofill_usage_export_spec.rb
+++ b/spec/services/support_interface/candidate_autofill_usage_export_spec.rb
@@ -41,6 +41,15 @@ RSpec.describe SupportInterface::CandidateAutofillUsageExport do
       end
     end
 
+    context 'Non UK qualifications' do
+      it "does not return a hash of candidates' autofill usage" do
+        application_form = create(:application_form, :minimum_info, phase: 'apply_1')
+        create(:other_qualification, :non_uk, application_form: application_form)
+
+        expect(described_class.new.data_for_export).to be_empty
+      end
+    end
+
     context 'Candidate free text inputs' do
       it "returns true for 'free_text?' row" do
         application_form = create(:application_form, :minimum_info, phase: 'apply_1')


### PR DESCRIPTION
## Context

Currently the candidate autosuggest data export processes:
- both submitted and unsubmitted applications
- non UK qualifications

## Changes proposed in this pull request

Scope candidate autosuggest data export to applications that have been submitted and UK qualifications only

## Link to Trello card

https://trello.com/c/69AeFZwg/3116-data-request-autofill-usage

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
