### PR TITLE
Fix warnings in the test suite

### DIFF
--- a/spec/models/interview_spec.rb
+++ b/spec/models/interview_spec.rb
@@ -8,13 +8,4 @@ RSpec.describe Interview, type: :model do
     it { is_expected.to validate_presence_of(:provider) }
     it { is_expected.to validate_presence_of(:date_and_time) }
   end
-
-  describe '#offered_course' do
-    it 'calls the application choice offered_course' do
-      allow(interview.application_choice).to receive(:offered_course)
-
-      interview.offered_course
-      expect(interview.application_choice).to have_received(:offered_course)
-    end
-  end
 end

--- a/spec/support/factory_stubs/dual_application_ucas_match_stub.rb
+++ b/spec/support/factory_stubs/dual_application_ucas_match_stub.rb
@@ -1,5 +1,5 @@
 RSpec.configure do |config|
-  config.before(:suite, :create_dual_application_ucas_match_stub) do
+  config.before(:suite) do
     FactoryBot.define do
       factory :dual_application_ucas_match, class: 'UCASMatch' do
         trait :need_to_send_reminder_emails do

--- a/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
@@ -95,7 +95,8 @@ RSpec.feature 'Provider withdraws an offer' do
         @application_offered.id,
       ),
     )
-    expect(page).to have_content @application_offered.offer_withdrawal_reason
+
+    expect(page).to have_content 'We are very sorry but...'
   end
 
   def and_i_can_see_the_application_offer_is_withdrawn


### PR DESCRIPTION
## Context

We shouldn't let these hang around

## Changes proposed in this pull request

- remove redundant metadata on a :suite hook

```
WARNING: `:suite` hooks do not support metadata since they apply to the
suite as a whole rather than any individual example or example group
that has metadata. The metadata you have provided
([:create_dual_application_ucas_match_stub]) will be ignored. Called
from
.../spec/support/factory_stubs/dual_application_ucas_match_stub.rb:2:in
`block in <top (required)>'.
```

- remove a spec that tested `delegate` using a stub

```
WARNING: An expectation of `:offered_course` was set on `nil`. To allow
expectations on `nil` and suppress this message, set
`RSpec::Mocks.configuration.allow_message_expectations_on_nil` to
`true`. To disallow expectations on `nil`, set
`RSpec::Mocks.configuration.allow_message_expectations_on_nil` to
`false`. Called from .../spec/models/interview_spec.rb:14:in `block (3
levels) in <top (required)>'.
```

- assert on a string literal in system spec instead of trying to read
(the possibly wrong?) field off a model

```
Checking for expected text of nil is confusing and/or pointless since it
will always match. Please specify a string or regexp instead.
.../spec/system/provider_interface/provider_withdraws_an_offer_spec.rb:98
```