### PR TITLE
Apply again metrics for Feature Metrics dashboard 2 (part 1)

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -224,6 +224,11 @@ class ApplicationForm < ApplicationRecord
     application_choices.includes([:provider]).map(&:provider).uniq
   end
 
+  def successful?
+    application_choices.present? &&
+      application_choices.map(&:status).map(&:to_sym).any? { |status| ApplicationStateChange::SUCCESSFUL_STATES.include?(status) }
+  end
+
   def ended_without_success?
     application_choices.present? &&
       application_choices.map(&:status).map(&:to_sym).all? { |status| ApplicationStateChange::UNSUCCESSFUL_END_STATES.include?(status) }

--- a/app/models/apply_again_feature_metrics.rb
+++ b/app/models/apply_again_feature_metrics.rb
@@ -19,11 +19,35 @@ class ApplyAgainFeatureMetrics
     success_count / (fail_count + success_count)
   end
 
+  def change_rate(
+    start_time,
+    end_time = Time.zone.now.end_of_day
+  )
+    finder = CandidateInterface::FindChangedApplyAgainApplications.new
+    changed = finder.changed_candidate_count(start_time, end_time)
+    total = finder.all_candidate_count(start_time, end_time)
+    return nil if total.zero?
+
+    changed.to_f / total
+  end
+
   def formatted_success_rate(
     start_time,
     end_time = Time.zone.now.end_of_day
   )
-    ratio = success_rate(start_time, end_time)
+    format_as_percentage(success_rate(start_time, end_time))
+  end
+
+  def formatted_change_rate(
+    start_time,
+    end_time = Time.zone.now.end_of_day
+  )
+    format_as_percentage(change_rate(start_time, end_time))
+  end
+
+private
+
+  def format_as_percentage(ratio)
     return 'n/a' if ratio.nil?
 
     percentage = number_with_precision(
@@ -33,8 +57,6 @@ class ApplyAgainFeatureMetrics
     )
     "#{percentage}%"
   end
-
-private
 
   def application_forms(start_time, end_time)
     ApplicationForm

--- a/app/models/apply_again_feature_metrics.rb
+++ b/app/models/apply_again_feature_metrics.rb
@@ -1,0 +1,27 @@
+class ApplyAgainFeatureMetrics
+  def success_rate(
+    start_time,
+    end_time = Time.zone.now.beginning_of_day
+  )
+    application_forms = ApplicationForm
+      .where(
+        phase: 'apply_2',
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+      )
+      .includes(:application_choices)
+
+    # TODO: work out how to implement date filter
+    success_count = 0.0
+    fail_count = 0.0
+    application_forms.find_each do |application_form|
+      if application_form.successful?
+        success_count += 1 
+      elsif application_form.ended_without_success?
+        fail_count += 1
+      end
+    end
+    return 0 if (fail_count + success_count).zero?
+
+    success_count / (fail_count + success_count)
+  end
+end

--- a/app/models/feature_metrics_dashboard.rb
+++ b/app/models/feature_metrics_dashboard.rb
@@ -1,10 +1,12 @@
 class FeatureMetricsDashboard < ApplicationRecord
+  MISSING_VALUE = 'n/a'.freeze
+
   def write_metric(key, value)
     self.metrics = (metrics || {}).merge(key.to_s => value)
   end
 
   def read_metric(key)
-    metrics.fetch(key.to_s)
+    metrics[key.to_s] || MISSING_VALUE
   end
 
   def load_updated_metrics

--- a/app/models/feature_metrics_dashboard.rb
+++ b/app/models/feature_metrics_dashboard.rb
@@ -190,19 +190,19 @@ private
   def load_apply_again_success_rate
     write_metric(
       :apply_again_success_rate,
-      apply_again_statistics.success_rate(
+      apply_again_statistics.formatted_success_rate(
         EndOfCycleTimetable.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(
       :apply_again_success_rate_this_month,
-      apply_again_statistics.success_rate(
+      apply_again_statistics.formatted_success_rate(
         Time.zone.now.beginning_of_month,
       ),
     )
     write_metric(
       :apply_again_success_rate_last_month,
-      apply_again_statistics.success_rate(
+      apply_again_statistics.formatted_success_rate(
         Time.zone.now.beginning_of_month - 1.month,
         Time.zone.now.beginning_of_month,
       ),

--- a/app/models/feature_metrics_dashboard.rb
+++ b/app/models/feature_metrics_dashboard.rb
@@ -202,9 +202,9 @@ private
       ),
     )
     write_metric(
-      :apply_again_success_rate_last_month,
+      :apply_again_success_rate_upto_this_month,
       apply_again_statistics.formatted_success_rate(
-        Time.zone.now.beginning_of_month - 1.month,
+        EndOfCycleTimetable.apply_reopens.beginning_of_day,
         Time.zone.now.beginning_of_month,
       ),
     )

--- a/app/models/feature_metrics_dashboard.rb
+++ b/app/models/feature_metrics_dashboard.rb
@@ -15,6 +15,7 @@ class FeatureMetricsDashboard < ApplicationRecord
     load_avg_sign_ins_before_offer
     load_avg_sign_ins_before_recruitment
     load_num_rejections_due_to_qualifications
+    load_apply_again_success_rate
   end
 
   def last_updated_at
@@ -41,6 +42,10 @@ private
 
   def reasons_for_rejection_statistics
     ReasonsForRejectionFeatureMetrics.new
+  end
+
+  def apply_again_statistics
+    ApplyAgainFeatureMetrics.new
   end
 
   def load_avg_time_to_get_references
@@ -178,6 +183,28 @@ private
       :num_rejections_due_to_qualifications_last_month,
       reasons_for_rejection_statistics.rejections_due_to(
         :qualifications_y_n, Time.zone.now.beginning_of_month - 1.month, Time.zone.now.beginning_of_month
+      ),
+    )
+  end
+
+  def load_apply_again_success_rate
+    write_metric(
+      :apply_again_success_rate,
+      apply_again_statistics.success_rate(
+        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+      ),
+    )
+    write_metric(
+      :apply_again_success_rate_this_month,
+      apply_again_statistics.success_rate(
+        Time.zone.now.beginning_of_month,
+      ),
+    )
+    write_metric(
+      :apply_again_success_rate_last_month,
+      apply_again_statistics.success_rate(
+        Time.zone.now.beginning_of_month - 1.month,
+        Time.zone.now.beginning_of_month,
       ),
     )
   end

--- a/app/models/feature_metrics_dashboard.rb
+++ b/app/models/feature_metrics_dashboard.rb
@@ -16,6 +16,7 @@ class FeatureMetricsDashboard < ApplicationRecord
     load_avg_sign_ins_before_recruitment
     load_num_rejections_due_to_qualifications
     load_apply_again_success_rate
+    load_apply_again_change_rate
   end
 
   def last_updated_at
@@ -203,6 +204,28 @@ private
     write_metric(
       :apply_again_success_rate_last_month,
       apply_again_statistics.formatted_success_rate(
+        Time.zone.now.beginning_of_month - 1.month,
+        Time.zone.now.beginning_of_month,
+      ),
+    )
+  end
+
+  def load_apply_again_change_rate
+    write_metric(
+      :apply_again_change_rate,
+      apply_again_statistics.formatted_change_rate(
+        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+      ),
+    )
+    write_metric(
+      :apply_again_change_rate_this_month,
+      apply_again_statistics.formatted_change_rate(
+        Time.zone.now.beginning_of_month,
+      ),
+    )
+    write_metric(
+      :apply_again_change_rate_last_month,
+      apply_again_statistics.formatted_change_rate(
         Time.zone.now.beginning_of_month - 1.month,
         Time.zone.now.beginning_of_month,
       ),

--- a/app/models/magic_link_feature_metrics.rb
+++ b/app/models/magic_link_feature_metrics.rb
@@ -7,6 +7,7 @@ class MagicLinkFeatureMetrics
     end_time = Time.zone.now.beginning_of_day
   )
     records = ApplicationForm
+      .apply_1
       .select(
         'count(DISTINCT audits.id) as audit_count',
         'count(DISTINCT authentication_tokens.id) as token_count',

--- a/app/models/reference_feature_metrics.rb
+++ b/app/models/reference_feature_metrics.rb
@@ -36,6 +36,7 @@ private
 
   def time_to_get_references(start_time, end_time = Time.zone.now)
     applications = ApplicationForm
+      .apply_1
       .joins(:application_references)
       .where('"references".feedback_provided_at BETWEEN ? AND ? AND "references".duplicate = ?', start_time, end_time, false)
       .group('application_forms.id')

--- a/app/models/reference_feature_metrics.rb
+++ b/app/models/reference_feature_metrics.rb
@@ -36,7 +36,6 @@ private
 
   def time_to_get_references(start_time, end_time = Time.zone.now)
     applications = ApplicationForm
-      .apply_1
       .joins(:application_references)
       .where('"references".feedback_provided_at BETWEEN ? AND ? AND "references".duplicate = ?', start_time, end_time, false)
       .group('application_forms.id')
@@ -46,7 +45,7 @@ private
   def time_to_get_for(application, end_time)
     return nil unless application.enough_references_have_been_provided?
 
-    times = application.application_references.feedback_provided.map do |reference|
+    times = application.application_references.feedback_provided.where(duplicate: false).map do |reference|
       [reference.requested_at, reference.feedback_provided_at]
     end
     requested_at_time = times.map(&:first).compact.min

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -9,6 +9,7 @@ class ApplicationStateChange
   OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
   POST_OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer_withdrawn]).freeze
   UNSUCCESSFUL_END_STATES = %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent].freeze
+  SUCCESSFUL_STATES = %i[pending_conditions offer offer_deferred recruited].freeze
   DECISION_PENDING_STATUSES = %i[awaiting_provider_decision interviewing].freeze
   TERMINAL_STATES = UNSUCCESSFUL_END_STATES + %i[recruited].freeze
 

--- a/app/services/candidate_interface/find_changed_apply_again_applications.rb
+++ b/app/services/candidate_interface/find_changed_apply_again_applications.rb
@@ -1,30 +1,41 @@
 module CandidateInterface
   class FindChangedApplyAgainApplications
-    def all_forms
-      apply_again_forms
+    def all_forms(start_time, end_time)
+      apply_again_forms(start_time, end_time)
     end
 
-    def changed_forms
-      apply_again_forms.find_each.lazy.select do |application_form|
+    def changed_forms(start_time, end_time)
+      apply_again_forms(start_time, end_time).find_each.lazy.select do |application_form|
         changed?(application_form)
       end
     end
 
-    def all_candidate_count
-      all_forms.select(:candidate_id).distinct.count
+    def all_candidate_count(
+      start_time = EndOfCycleTimetable.apply_reopens.beginning_of_day,
+      end_time = Time.zone.now.end_of_day
+    )
+      all_forms(start_time, end_time).select(:candidate_id).distinct.count
     end
 
-    def changed_candidate_count
-      changed_forms.map(&:candidate_id).uniq.count
+    def changed_candidate_count(
+      start_time = EndOfCycleTimetable.apply_reopens.beginning_of_day,
+      end_time = Time.zone.now.end_of_day
+    )
+      changed_forms(start_time, end_time).map(&:candidate_id).uniq.count
     end
 
   private
 
-    def apply_again_forms
+    def apply_again_forms(start_time, end_time)
       ApplicationForm
         .where(
           phase: 'apply_2',
           recruitment_cycle_year: RecruitmentCycle.current_year,
+        )
+        .where(
+          'submitted_at BETWEEN ? AND ?',
+          start_time,
+          end_time,
         )
         .includes(:application_qualifications, previous_application_form: [:application_qualifications])
     end

--- a/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
+++ b/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
@@ -213,4 +213,34 @@
       </div>
     </div>
   </div>
+
+  <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Apply again</h3>
+  <div id="apply_again_dashboard_section" class="govuk-grid-row govuk-!-margin-bottom-4">
+    <div class="govuk-grid-column-one-half">
+      <div id="headline-stat" class="govuk-!-margin-bottom-4">
+        <%= render SupportInterface::TileComponent.new(
+          count: @dashboard.read_metric(:apply_again_success_rate),
+          label: 'apply again success rate',
+          colour: :blue,
+          size: :reduced,
+        ) %>
+      </div>
+      <div class="govuk-grid-row govuk-!-margin-bottom-4">
+        <div class="govuk-grid-column-one-half">
+          <%= render SupportInterface::TileComponent.new(
+            count: @dashboard.read_metric(:apply_again_success_rate_this_month),
+            label: 'this month',
+            size: :reduced,
+          ) %>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= render SupportInterface::TileComponent.new(
+            count: @dashboard.read_metric(:apply_again_success_rate_last_month),
+            label: 'last month',
+            size: :reduced,
+          ) %>
+        </div>
+      </div>
+    </div>
+  </div>
 <% end %>

--- a/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
+++ b/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
@@ -242,5 +242,31 @@
         </div>
       </div>
     </div>
+    <div class="govuk-grid-column-one-half">
+      <div id="headline-stat" class="govuk-!-margin-bottom-4">
+        <%= render SupportInterface::TileComponent.new(
+          count: @dashboard.read_metric(:apply_again_change_rate),
+          label: 'candidates that make changes to application when applying again',
+          colour: :blue,
+          size: :reduced,
+        ) %>
+      </div>
+      <div class="govuk-grid-row govuk-!-margin-bottom-4">
+        <div class="govuk-grid-column-one-half">
+          <%= render SupportInterface::TileComponent.new(
+            count: @dashboard.read_metric(:apply_again_change_rate_this_month),
+            label: 'this month',
+            size: :reduced,
+          ) %>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= render SupportInterface::TileComponent.new(
+            count: @dashboard.read_metric(:apply_again_change_rate_last_month),
+            label: 'last month',
+            size: :reduced,
+          ) %>
+        </div>
+      </div>
+    </div>
   </div>
 <% end %>

--- a/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
+++ b/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
@@ -246,7 +246,7 @@
       <div id="headline-stat" class="govuk-!-margin-bottom-4">
         <%= render SupportInterface::TileComponent.new(
           count: @dashboard.read_metric(:apply_again_change_rate),
-          label: 'candidates that make changes to application when applying again',
+          label: 'candidates made changes to their application when applying again',
           colour: :blue,
           size: :reduced,
         ) %>

--- a/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
+++ b/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
@@ -235,8 +235,8 @@
         </div>
         <div class="govuk-grid-column-one-half">
           <%= render SupportInterface::TileComponent.new(
-            count: @dashboard.read_metric(:apply_again_success_rate_last_month),
-            label: 'last month',
+            count: @dashboard.read_metric(:apply_again_success_rate_upto_this_month),
+            label: 'upto this month',
             size: :reduced,
           ) %>
         </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -101,6 +101,46 @@
       "note": "not a user input"
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "37b3066632afad7b480ce45f1b9d1263a923f29bba5edd3afd3e2f78e2cd425e",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/magic_link_feature_metrics.rb",
+      "line": 16,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ApplicationForm.apply_1.select(\"count(DISTINCT audits.id) as audit_count\", \"count(DISTINCT authentication_tokens.id) as token_count\").joins(:application_choices).joins(\"LEFT OUTER JOIN audits ON audits.auditable_id = application_forms.candidate_id AND audits.auditable_type = 'Candidate' AND audits.action = 'update' AND audits.audited_changes#>>'{magic_link_token, 1}' IS NOT NULL AND audits.created_at <= application_choices.#{timestamp}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "MagicLinkFeatureMetrics",
+        "method": "average_magic_link_requests_upto"
+      },
+      "user_input": "timestamp",
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "471859383ef3e9fba03933907e1bb043a8a57520241d275846126e6a2425f2e1",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/apply_again_feature_metrics.rb",
+      "line": 76,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ApplicationForm.where(:phase => \"apply_2\", :recruitment_cycle_year => RecruitmentCycle.current_year).joins(:application_choices).joins(\"inner join (select auditable_id, max(created_at) as status_last_updated_at\\n          from audits\\n          where auditable_type = 'ApplicationChoice'\\n            and action = 'update'\\n            and audited_changes#>>'{status, 1}' is not null\\n          group by auditable_id\\n        ) as status_audits on status_audits.auditable_id = application_choices.id\\n          and status_last_updated_at between '#{start_time}' and '#{end_time}'\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ApplyAgainFeatureMetrics",
+        "method": "application_forms"
+      },
+      "user_input": "start_time",
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
       "warning_type": "Unscoped Find",
       "warning_code": 82,
       "fingerprint": "4c106936481ffa09c60383aed2a7b8e931b1672602d3f5a69ccaf9bd688cbf62",
@@ -261,6 +301,6 @@
       "note": ""
     }
   ],
-  "updated": "2021-03-10 15:05:49 +0000",
+  "updated": "2021-03-15 09:28:21 +0000",
   "brakeman_version": "5.0.0"
 }

--- a/spec/models/apply_again_feature_metrics_spec.rb
+++ b/spec/models/apply_again_feature_metrics_spec.rb
@@ -3,46 +3,46 @@ require 'rails_helper'
 RSpec.describe ApplyAgainFeatureMetrics, with_audited: true do
   subject(:feature_metrics) { described_class.new }
 
+  def create_apply_again_application
+    original_application = create(
+      :completed_application_form,
+    )
+    apply_again_application_form = DuplicateApplication.new(
+      original_application,
+      target_phase: 'apply_2',
+    ).duplicate
+
+    apply_again_application_form
+  end
+
+  def make_offer_for(application_form)
+    application_choice = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      application_form: application_form,
+    )
+    ApplicationStateChange.new(application_choice).make_offer!
+  end
+
+  def reject(application_form)
+    application_choice = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      application_form: application_form,
+    )
+    ApplicationStateChange.new(application_choice).reject!
+  end
+
   describe '#success_rate' do
     context 'without any data' do
-      it 'just returns 0' do
-        expect(feature_metrics.success_rate(1.month.ago)).to eq(0)
+      it 'returns nil' do
+        expect(feature_metrics.success_rate(1.month.ago)).to be_nil
       end
     end
 
     context 'with apply again applications' do
-      def create_apply_again_application
-        original_application = create(
-          :completed_application_form,
-        )
-        apply_again_application_form = DuplicateApplication.new(
-          original_application,
-          target_phase: 'apply_2',
-        ).duplicate
-
-        apply_again_application_form
-      end
-
-      def make_offer_for(application_form)
-        application_choice = create(
-          :application_choice,
-          :awaiting_provider_decision,
-          application_form: application_form,
-        )
-        ApplicationStateChange.new(application_choice).make_offer!
-      end
-
-      def reject(application_form)
-        application_choice = create(
-          :application_choice,
-          :awaiting_provider_decision,
-          application_form: application_form,
-        )
-        ApplicationStateChange.new(application_choice).reject!
-      end
-
       it 'returns 0 when there are no successful apply again applications' do
-        create_apply_again_application
+        reject(create_apply_again_application)
         expect(feature_metrics.success_rate(1.month.ago)).to eq(0)
       end
 
@@ -68,6 +68,35 @@ RSpec.describe ApplyAgainFeatureMetrics, with_audited: true do
         expect(feature_metrics.success_rate(@today - 12.days, @today - 8.days)).to eq(1.0)
         expect(feature_metrics.success_rate(@today - 12.days, @today - 3.days)).to eq(0.5)
         expect(feature_metrics.success_rate(@today - 22.days, @today - 3.days)).to be_within(0.01).of(0.33)
+        expect(feature_metrics.success_rate(@today - 50.days, @today - 40.days)).to be_nil
+      end
+    end
+  end
+
+  describe '#formatted_success_rate' do
+    context 'without any data' do
+      it 'returns n/a' do
+        expect(feature_metrics.formatted_success_rate(1.month.ago)).to eq('n/a')
+      end
+    end
+
+    context 'with apply again applications' do
+      it 'returns correctly formatted values within given time ranges' do
+        @today = Time.zone.local(2020, 12, 31, 12)
+        Timecop.freeze(@today - 20.days) do
+          create_apply_again_application
+          reject(create_apply_again_application)
+        end
+        Timecop.freeze(@today - 10.days) do
+          make_offer_for(create_apply_again_application)
+        end
+        Timecop.freeze(@today - 5.days) do
+          reject(create_apply_again_application)
+        end
+        expect(feature_metrics.formatted_success_rate(@today - 12.days, @today - 8.days)).to eq('100%')
+        expect(feature_metrics.formatted_success_rate(@today - 12.days, @today - 3.days)).to eq('50%')
+        expect(feature_metrics.formatted_success_rate(@today - 22.days, @today - 3.days)).to eq('33.3%')
+        expect(feature_metrics.formatted_success_rate(@today - 50.days, @today - 40.days)).to eq('n/a')
       end
     end
   end

--- a/spec/models/apply_again_feature_metrics_spec.rb
+++ b/spec/models/apply_again_feature_metrics_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe ApplyAgainFeatureMetrics do
+  subject(:feature_metrics) { described_class.new }
+
+  describe '#success_rate' do
+    context 'without any data' do
+      it 'just returns 0' do
+        expect(feature_metrics.success_rate(1.month.ago)).to eq(0)
+      end
+    end
+
+    context 'with apply again applications' do
+      def create_apply_again_application
+        original_application = create(
+          :completed_application_form,
+        )
+        apply_again_application_form = DuplicateApplication.new(
+          original_application,
+          target_phase: 'apply_2',
+        ).duplicate
+        
+        apply_again_application_form
+      end
+
+      def make_offer_for(application_form)
+        create(
+          :application_choice,
+          :with_offer,
+          application_form: application_form,
+        )
+      end
+
+      def reject(application_form)
+        create(
+          :application_choice,
+          :with_rejection,
+          application_form: application_form,
+        )
+      end
+
+      it 'returns 0 when there are no successful apply again applications' do
+        create_apply_again_application
+        expect(feature_metrics.success_rate(1.month.ago)).to eq(0)
+      end
+
+      it 'returns 0.5 when 50% of apply again applications are successful' do
+        reject(create_apply_again_application)
+        make_offer_for(create_apply_again_application)
+        expect(feature_metrics.success_rate(1.month.ago)).to eq(0.5)
+      end
+    end
+  end
+end

--- a/spec/models/apply_again_feature_metrics_spec.rb
+++ b/spec/models/apply_again_feature_metrics_spec.rb
@@ -100,4 +100,31 @@ RSpec.describe ApplyAgainFeatureMetrics, with_audited: true do
       end
     end
   end
+
+  describe '#formatted_change_rate' do
+    context 'without any data' do
+      it 'returns n/a' do
+        expect(feature_metrics.formatted_change_rate(1.month.ago)).to eq('n/a')
+      end
+    end
+
+    context 'with apply again applications' do
+      it 'returns correctly formatted values within given time ranges' do
+        @today = Time.zone.local(2021, 3, 10, 12)
+        Timecop.freeze(@today - 20.days) do
+          apply_again_application_form = create_apply_again_application
+          apply_again_application_form.update!(submitted_at: Time.zone.now)
+        end
+        Timecop.freeze(@today - 5.days) do
+          apply_again_application_form = create_apply_again_application
+          apply_again_application_form.update!(submitted_at: Time.zone.now, becoming_a_teacher: 'New statement')
+        end
+        Timecop.freeze(@today) do
+          expect(feature_metrics.formatted_change_rate(25.days.ago, 10.days.ago)).to eq('0%')
+          expect(feature_metrics.formatted_change_rate(10.days.ago)).to eq('100%')
+          expect(feature_metrics.formatted_change_rate(25.days.ago)).to eq('50%')
+        end
+      end
+    end
+  end
 end

--- a/spec/models/apply_again_feature_metrics_spec.rb
+++ b/spec/models/apply_again_feature_metrics_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe ApplyAgainFeatureMetrics do
       end
 
       it 'returns 0.5 when 50% of apply again applications are successful' do
+        create_apply_again_application
         reject(create_apply_again_application)
         make_offer_for(create_apply_again_application)
         expect(feature_metrics.success_rate(1.month.ago)).to eq(0.5)

--- a/spec/models/feature_metrics_dashboard_spec.rb
+++ b/spec/models/feature_metrics_dashboard_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe FeatureMetricsDashboard do
         'num_rejections_due_to_qualifications_last_month' => 5,
         'apply_again_success_rate' => '42.8%',
         'apply_again_success_rate_this_month' => '42.8%',
-        'apply_again_success_rate_last_month' => '42.8%',
+        'apply_again_success_rate_upto_this_month' => '42.8%',
         'apply_again_change_rate' => '33.3%',
         'apply_again_change_rate_this_month' => '33.3%',
         'apply_again_change_rate_last_month' => '33.3%',

--- a/spec/models/feature_metrics_dashboard_spec.rb
+++ b/spec/models/feature_metrics_dashboard_spec.rb
@@ -40,11 +40,8 @@ RSpec.describe FeatureMetricsDashboard do
       expect(dashboard.read_metric(:test)).to eq 'value'
     end
 
-    it 'raises if the key is not found' do
-      expect { dashboard.read_metric('testttt') }.to raise_error(
-        KeyError,
-        /key not found: "testttt"/,
-      )
+    it 'returns a placeholder "missing value" if the key is not found' do
+      expect(dashboard.read_metric(:testttt)).to eq 'n/a'
     end
   end
 

--- a/spec/models/feature_metrics_dashboard_spec.rb
+++ b/spec/models/feature_metrics_dashboard_spec.rb
@@ -54,15 +54,21 @@ RSpec.describe FeatureMetricsDashboard do
       work_history_metrics_double = instance_double(WorkHistoryFeatureMetrics)
       magic_link_metrics_double = instance_double(MagicLinkFeatureMetrics)
       rfr_metrics_double = instance_double(ReasonsForRejectionFeatureMetrics)
+      apply_again_metrics_double = instance_double(ApplyAgainFeatureMetrics)
+
       allow(ReferenceFeatureMetrics).to receive(:new).and_return(reference_metrics_double)
       allow(WorkHistoryFeatureMetrics).to receive(:new).and_return(work_history_metrics_double)
       allow(MagicLinkFeatureMetrics).to receive(:new).and_return(magic_link_metrics_double)
       allow(ReasonsForRejectionFeatureMetrics).to receive(:new).and_return(rfr_metrics_double)
+      allow(ApplyAgainFeatureMetrics).to receive(:new).and_return(apply_again_metrics_double)
+
       allow(reference_metrics_double).to receive(:average_time_to_get_references).and_return(1)
       allow(reference_metrics_double).to receive(:percentage_references_within).and_return(2)
       allow(work_history_metrics_double).to receive(:average_time_to_complete).and_return(3)
       allow(magic_link_metrics_double).to receive(:average_magic_link_requests_upto).and_return(4)
       allow(rfr_metrics_double).to receive(:rejections_due_to).and_return(5)
+      allow(apply_again_metrics_double).to receive(:formatted_success_rate).and_return('42.8%')
+      allow(apply_again_metrics_double).to receive(:formatted_change_rate).and_return('33.3%')
 
       dashboard = described_class.new
       dashboard.load_updated_metrics
@@ -89,6 +95,12 @@ RSpec.describe FeatureMetricsDashboard do
         'num_rejections_due_to_qualifications' => 5,
         'num_rejections_due_to_qualifications_this_month' => 5,
         'num_rejections_due_to_qualifications_last_month' => 5,
+        'apply_again_success_rate' => '42.8%',
+        'apply_again_success_rate_this_month' => '42.8%',
+        'apply_again_success_rate_last_month' => '42.8%',
+        'apply_again_change_rate' => '33.3%',
+        'apply_again_change_rate_this_month' => '33.3%',
+        'apply_again_change_rate_last_month' => '33.3%',
       })
     end
   end

--- a/spec/models/reference_feature_metrics_spec.rb
+++ b/spec/models/reference_feature_metrics_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe ReferenceFeatureMetrics, with_audited: true do
         @application_form3 = create(:application_form)
         @references3 = create_list(:reference, 2, application_form: @application_form3)
         @references3.each { |reference| RequestReference.new.call(reference) }
+
       end
       Timecop.freeze(@today - 10.days) do
         SubmitReference.new(reference: @references1.first, send_emails: false).save!
@@ -41,6 +42,7 @@ RSpec.describe ReferenceFeatureMetrics, with_audited: true do
       end
       Timecop.freeze(@today - 1.day) do
         SubmitReference.new(reference: @references2.second, send_emails: false).save!
+        @apply_again_application_form = DuplicateApplication.new(@application_form1, target_phase: :apply_2).clone
       end
       Timecop.freeze(@today) do
         SubmitReference.new(reference: @references2.first, send_emails: false).save!

--- a/spec/models/reference_feature_metrics_spec.rb
+++ b/spec/models/reference_feature_metrics_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe ReferenceFeatureMetrics, with_audited: true do
         @application_form3 = create(:application_form)
         @references3 = create_list(:reference, 2, application_form: @application_form3)
         @references3.each { |reference| RequestReference.new.call(reference) }
-
       end
       Timecop.freeze(@today - 10.days) do
         SubmitReference.new(reference: @references1.first, send_emails: false).save!

--- a/spec/services/candidate_interface/find_changed_apply_again_applications_spec.rb
+++ b/spec/services/candidate_interface/find_changed_apply_again_applications_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::FindChangedApplyAgainApplications do
+  around do |example|
+    Timecop.freeze(Time.zone.local(2021, 3, 1)) do
+      example.run
+    end
+  end
+
   def setup_apply_again_application
     @original_application = create(
       :completed_application_form,
@@ -11,6 +17,7 @@ RSpec.describe CandidateInterface::FindChangedApplyAgainApplications do
       @original_application,
       target_phase: 'apply_2',
     ).duplicate
+    @apply_again_application.update(submitted_at: Time.zone.now)
   end
 
   def setup_multiple_apply_again_applications
@@ -27,6 +34,8 @@ RSpec.describe CandidateInterface::FindChangedApplyAgainApplications do
       @apply_again_application,
       target_phase: 'apply_2',
     ).duplicate
+    @apply_again_application.update(submitted_at: Time.zone.now)
+    @second_apply_again_application.update(submitted_at: Time.zone.now)
   end
 
   context 'with two apply again applications' do

--- a/spec/system/support_interface/feature_metrics_dashboard_spec.rb
+++ b/spec/system/support_interface/feature_metrics_dashboard_spec.rb
@@ -171,7 +171,7 @@ RSpec.feature 'Feature metrics dashboard' do
   def and_i_should_see_apply_again_metrics
     within('#apply_again_dashboard_section') do
       expect(page).to have_content('50% apply again success rate')
-      expect(page).to have_content('n/a last month')
+      expect(page).to have_content('n/a upto this month')
       expect(page).to have_content('50% this month')
     end
   end

--- a/spec/system/support_interface/feature_metrics_dashboard_spec.rb
+++ b/spec/system/support_interface/feature_metrics_dashboard_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'Feature metrics dashboard' do
     )
   end
 
-  def apply_again_and_reject_application(application_form)
+  def apply_again_and_offer_application(application_form)
     apply_again_application_form = DuplicateApplication.new(
       application_form,
       target_phase: 'apply_2',
@@ -71,7 +71,7 @@ RSpec.feature 'Feature metrics dashboard' do
     apply_again_application_form
   end
 
-  def apply_again_and_offer_application(application_form)
+  def apply_again_and_reject_application(application_form)
     apply_again_application_form = DuplicateApplication.new(
       application_form,
       target_phase: 'apply_2',


### PR DESCRIPTION
## Context

We are adding a new set of metrics to the feature metrics dashboard. The first batch in this PR will be for Apply again success rates and change rates. More PRs to follow.

## Changes proposed in this pull request

- [x] Add _Apply again_ section to feature metrics dashboard
- [x] `ApplyAgainFeatureMetrics` service to fetch success rates and change rates
- [x] `ApplyAgainFeatureMetrics` filters by date range. For success rates it uses the last status change date to determine when the success happened. For change rates we use the `submitted_at` date to determine when the change happened. (see discussion on card).
- [x] Update system spec
- [x] Changed the default behaviour for missing `FeatureMetricDashboard` keys to just show a _n/a_ rather than throw an exception. This is so that the dashboard runs without errors even if we are waiting for the background job to populate new keys.

<img width="1213" alt="image" src="https://user-images.githubusercontent.com/450843/110797998-a1a82a00-8271-11eb-92f8-56eb60e619fb.png">

## Guidance to review

- Success is defined as the ratio of `apply again applications that have at least one successful choice / apply again applications for which all the choices have an outcome`. `successful choice` means having status `offer_deferred`, `pending_conditions` or `recruited`. `have an outcome` means having status `withdrawn`, `offer_withdrawn`, `rejected`, `conditions_not_met`, `declined`, `cancelled`, `offer`, `offer_deferred`, `pending_conditions` or `recruited`
- Date filtering for success rate is a bit messy because it requires a join to the audits table. Is there a simpler way?
- There are lots of model classes for feature metrics now, all top-level. There is also a `CandidateInterface::FindChangedApplyAgainApplications` service. I think these should be re-organised. Should we put make them all services? stick them under the `SupportInterface` or maybe even a `SupportInterface::FeatureMetrics` namespace? (this can be done as a separate PR but interested in what people think).
- Does the layout and content make sense? (Probably best to review this in the whole when the full set of changes is available but any input welcome).
- Is it OK to not put this behind a feature flag? Will shipping bits as they are ready confuse people?

## Link to Trello card

https://trello.com/c/1X9y1JPl/2981-feature-metric-dashboard-20

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
