### PR TITLE
Hide interview link in activity log if it has been cancelled

### DIFF
--- a/app/components/provider_interface/activity_log_event_component.html.erb
+++ b/app/components/provider_interface/activity_log_event_component.html.erb
@@ -22,7 +22,7 @@
             <%= event_content %>
           </p>
         <% end %>
-        <% if link[:url].present? %>
+        <% if link.present? && link[:url].present? %>
           <p class="app-timeline__event_link"><a class="govuk-link" href="<%= link[:url] %>"><%= link[:text] %></a></p>
         <% end %>
       </div>

--- a/app/components/provider_interface/activity_log_event_component.rb
+++ b/app/components/provider_interface/activity_log_event_component.rb
@@ -147,6 +147,8 @@ module ProviderInterface
     end
 
     def interview_link(audit)
+      return if audit.auditable.cancelled?
+
       {
         url: routes.provider_interface_application_choice_interviews_path(audit.associated, anchor: "interview-#{audit.auditable.id}"),
         text: 'View interview',

--- a/app/components/provider_interface/activity_log_event_component.rb
+++ b/app/components/provider_interface/activity_log_event_component.rb
@@ -94,40 +94,20 @@ module ProviderInterface
     end
 
     def link
-      routes = Rails.application.routes.url_helpers
-
       case event.application_status_at_event
       when 'offer'
-        {
-          url: routes.provider_interface_application_choice_offer_path(application_choice),
-          text: 'View offer',
-        }
+        offer_link
       when 'pending_conditions'
-        {
-          url: routes.provider_interface_application_choice_offer_path(application_choice),
-          text: 'View offer',
-        }
+        offer_link
       else
         if changes['reject_by_default_feedback_sent_at'].present?
-          {
-            url: routes.provider_interface_application_choice_feedback_path(application_choice),
-            text: 'View feedback',
-          }
+          feedback_link
         elsif changes['offer_changed_at'].present? && application_choice.status == 'offer'
-          {
-            url: routes.provider_interface_application_choice_offer_path(application_choice),
-            text: 'View offer',
-          }
+          offer_link
         elsif event.audit.auditable.is_a?(Interview)
-          {
-            url: routes.provider_interface_application_choice_interviews_path(event.audit.associated, anchor: "interview-#{event.audit.auditable.id}"),
-            text: 'View interview',
-          }
+          interview_link(event.audit)
         else
-          {
-            url: routes.provider_interface_application_choice_path(application_choice),
-            text: 'View application',
-          }
+          application_link
         end
       end
     end
@@ -137,6 +117,40 @@ module ProviderInterface
       return "#{user} cancelled interview with #{candidate}" if event.audit.audited_changes.key?('cancelled_at')
 
       "#{user} updated interview with #{candidate}"
+    end
+
+  private
+
+    def routes
+      @_routes ||= Rails.application.routes.url_helpers
+    end
+
+    def application_link
+      {
+        url: routes.provider_interface_application_choice_path(application_choice),
+        text: 'View application',
+      }
+    end
+
+    def offer_link
+      {
+        url: routes.provider_interface_application_choice_offer_path(application_choice),
+        text: 'View offer',
+      }
+    end
+
+    def feedback_link
+      {
+        url: routes.provider_interface_application_choice_feedback_path(application_choice),
+        text: 'View feedback',
+      }
+    end
+
+    def interview_link(audit)
+      {
+        url: routes.provider_interface_application_choice_interviews_path(audit.associated, anchor: "interview-#{audit.auditable.id}"),
+        text: 'View interview',
+      }
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -551,7 +551,7 @@ FactoryBot.define do
 
       after(:build) do |application_choice, _evaluator|
         application_choice.status = :awaiting_provider_decision
-        application_choice.interviews << build(:interview, provider: application_choice.provider, cancelled_at: Time.zone.now)
+        application_choice.interviews << build(:interview, :cancelled, provider: application_choice.provider)
       end
     end
 
@@ -780,6 +780,11 @@ FactoryBot.define do
 
     trait :past_date_and_time do
       date_and_time { (2...10).to_a.sample.business_days.ago - (0..8).to_a.sample.hours }
+    end
+
+    trait :cancelled do
+      cancelled_at { 1.day.ago }
+      cancellation_reason { Faker::Lorem.paragraph(sentence_count: 2) }
     end
   end
 


### PR DESCRIPTION
## Context
Interviews can be cancelled and will no longer be displayed in the UI. The link to interviews was still present in the activity log however, which meant that we were linking to something that does not exist

## Changes proposed in this pull request
Hide interview link when associated interview has been cancelled

## Guidance to review
Per commit

## Link to Trello card
https://trello.com/c/Z3qSD93D/3476-hide-view-interview-link-from-interview-activity-log-when-cancelled

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
