### PR TITLE
Upsert ProviderUserNotificationPreferences

### DIFF
--- a/app/services/data_migrations/upsert_provider_user_send_notifications.rb
+++ b/app/services/data_migrations/upsert_provider_user_send_notifications.rb
@@ -1,0 +1,13 @@
+module DataMigrations
+  class UpsertProviderUserSendNotifications
+    TIMESTAMP = 20210315142623
+    MANUAL_RUN = false
+
+    def change
+      ProviderUser.find_each do |provider_user|
+        preferences = ProviderUserNotificationPreferences.find_or_create_by(provider_user: provider_user)
+        preferences.update_all_preferences(provider_user.send_notifications)
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::UpsertProviderUserSendNotifications',
   'DataMigrations::UpdateAuthenticationTokenTypes',
 ].freeze
 

--- a/spec/services/data_migrations/upsert_provider_user_send_notifications_spec.rb
+++ b/spec/services/data_migrations/upsert_provider_user_send_notifications_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::UpsertProviderUserSendNotifications do
+  describe 'change' do
+    let(:provider_user) { create(:provider_user, send_notifications: true) }
+    let(:another_provider_user) { create(:provider_user, send_notifications: true) }
+    let(:notification_preferences) do
+      create(
+        :provider_user_notification_preferences,
+        provider_user: provider_user,
+        application_received: false,
+        application_withdrawn: false,
+        application_rejected_by_default: false,
+        offer_accepted: false,
+        offer_declined: false,
+      )
+    end
+
+    subject(:migration) { described_class.new }
+
+    before do
+      provider_user.notification_preferences.delete
+      provider_user.update!(notification_preferences: notification_preferences)
+      another_provider_user.notification_preferences.delete
+    end
+
+    it 'updates existing ProviderUserNotificationPreferences with the ProviderUser#send_notifications value' do
+      migration.change
+
+      notification_preferences.reload
+
+      expect(notification_preferences.application_received).to be true
+      expect(notification_preferences.application_withdrawn).to be true
+      expect(notification_preferences.application_rejected_by_default).to be true
+      expect(notification_preferences.offer_accepted).to be true
+      expect(notification_preferences.offer_declined).to be true
+    end
+
+    it 'inserts new ProviderUserNotificationPreferences' do
+      expect { migration.change }.to change(ProviderUserNotificationPreferences, :count).by(1)
+
+      expect(another_provider_user.notification_preferences.application_received).to be true
+      expect(another_provider_user.notification_preferences.application_withdrawn).to be true
+      expect(another_provider_user.notification_preferences.application_rejected_by_default).to be true
+      expect(another_provider_user.notification_preferences.offer_accepted).to be true
+      expect(another_provider_user.notification_preferences.offer_declined).to be true
+    end
+  end
+end


### PR DESCRIPTION
## Context

Please do not merge yet.
We need to populate `ProviderUserNotificationPreferences` for existing `ProviderUser`s

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This takes the boolean value from `ProviderUser#send_notifications` and creates or updates `ProviderUserNotificationPreferences` for existing provider users with each preference set to the same value.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Wm7NAOrk/3449-migrate-provider-user-notification-settings-to-new-structure
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
