### PR TITLE
add delegators for accessing course option location details

### DIFF
--- a/app/models/course_option.rb
+++ b/app/models/course_option.rb
@@ -5,6 +5,7 @@ class CourseOption < ApplicationRecord
 
   audited associated_with: :provider
   delegate :provider, to: :course
+  delegate :name, :full_address, to: :site, prefix: true
 
   validates :vacancy_status, presence: true
   validate :validate_providers

--- a/spec/models/course_option_spec.rb
+++ b/spec/models/course_option_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe CourseOption, type: :model do
     end
   end
 
+  describe 'delegators' do
+    it { is_expected.to delegate_method(:name).to(:site).with_prefix }
+    it { is_expected.to delegate_method(:full_address).to(:site).with_prefix }
+  end
+
   describe '.selectable' do
     subject(:course_option) { create(:course_option) }
 


### PR DESCRIPTION
## Context

Exposing location properties on course option model required for mapping correct values to select component. 

## Link to Trello card

https://trello.com/c/lg8bkqS2/3475-create-select-site-component
## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
