### PR TITLE
Rename service to change_an_offer

### DIFF
--- a/app/controllers/provider_interface/offer_changes_controller.rb
+++ b/app/controllers/provider_interface/offer_changes_controller.rb
@@ -37,7 +37,7 @@ module ProviderInterface
       change_offer_form.step = :update
 
       if change_offer_form.valid?
-        ::ChangeOffer.new(
+        ::ChangeAnOffer.new(
           actor: current_provider_user,
           application_choice: @application_choice,
           course_option: change_offer_form.selected_course_option,

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -18,7 +18,7 @@ module VendorAPI
                       end
 
       if application_choice.offer?
-        change_offer = ChangeOffer.new(
+        change_offer = ChangeAnOffer.new(
           actor: audit_user,
           application_choice: application_choice,
           course_option: course_option,

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -311,7 +311,7 @@ class TestApplications
       year = choice.offered_course.recruitment_cycle_year
       new_course = choice.offered_course.provider.courses
                          .in_cycle(year).with_course_options.sample
-      ChangeOffer.new(
+      ChangeAnOffer.new(
         actor: actor,
         application_choice: choice,
         course_option: new_course.course_options.first,

--- a/app/services/change_an_offer.rb
+++ b/app/services/change_an_offer.rb
@@ -1,4 +1,4 @@
-class ChangeOffer
+class ChangeAnOffer
   include ActiveModel::Validations
   include ImpersonationAuditHelper
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -306,7 +306,7 @@ en:
               blank: Enter the user’s last name
             provider_permissions:
               blank: Please specify a provider
-        change_offer:
+        change_an_offer:
           attributes:
             course_option:
               blank: could not be found

--- a/spec/services/change_an_offer_spec.rb
+++ b/spec/services/change_an_offer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ChangeOffer do
+RSpec.describe ChangeAnOffer do
   include CourseOptionHelpers
   let(:provider_user) { create(:provider_user, :with_provider, :with_make_decisions) }
   let(:provider) { provider_user.providers.first }
@@ -13,7 +13,7 @@ RSpec.describe ChangeOffer do
   end
 
   def service
-    ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option)
+    ChangeAnOffer.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option)
   end
 
   it 'changes offered_course_option_id for the application choice' do
@@ -44,7 +44,7 @@ RSpec.describe ChangeOffer do
   it 'replaces conditions if offer_conditions is supplied' do
     application_choice.update(offer: { 'conditions' => ['DBS check'] })
 
-    with_conditions = ChangeOffer.new(
+    with_conditions = ChangeAnOffer.new(
       actor: provider_user,
       application_choice: application_choice,
       course_option: new_course_option,
@@ -77,7 +77,7 @@ RSpec.describe ChangeOffer do
 
   describe 'course option validation' do
     it 'checks the course option is present' do
-      change = ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option: nil)
+      change = ChangeAnOffer.new(actor: provider_user, application_choice: application_choice, course_option: nil)
 
       expect(change).not_to be_valid
 
@@ -86,7 +86,7 @@ RSpec.describe ChangeOffer do
 
     it 'checks the course option and conditions are different from the current option' do
       application_choice.update(offer: { 'conditions' => ['DBS check'] })
-      change = ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option: application_choice.offered_option, offer_conditions: ['DBS check'])
+      change = ChangeAnOffer.new(actor: provider_user, application_choice: application_choice, course_option: application_choice.offered_option, offer_conditions: ['DBS check'])
 
       expect(change).not_to be_valid
 
@@ -95,7 +95,7 @@ RSpec.describe ChangeOffer do
 
     it 'checks the course is open on apply' do
       new_course_option = create(:course_option, course: create(:course, provider: provider, open_on_apply: false))
-      change = ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option)
+      change = ChangeAnOffer.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option)
 
       expect(change).not_to be_valid
 
@@ -106,21 +106,21 @@ RSpec.describe ChangeOffer do
   describe '#is_identical_to_existing_offer?' do
     it 'returns true when offer and conditions match' do
       application_choice.update(offer: { 'conditions' => ['DBS check'] })
-      change = ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option: application_choice.offered_option, offer_conditions: ['DBS check'])
+      change = ChangeAnOffer.new(actor: provider_user, application_choice: application_choice, course_option: application_choice.offered_option, offer_conditions: ['DBS check'])
 
       expect(change).to be_identical_to_existing_offer
     end
 
     it 'returns false when offer matches, but not conditions' do
       application_choice.update(offer: { 'conditions' => ['Different things'] })
-      change = ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option: application_choice.offered_option, offer_conditions: ['DBS check'])
+      change = ChangeAnOffer.new(actor: provider_user, application_choice: application_choice, course_option: application_choice.offered_option, offer_conditions: ['DBS check'])
 
       expect(change).not_to be_identical_to_existing_offer
     end
 
     it 'returns false when conditions match, but not offer' do
       application_choice.update(offer: { 'conditions' => ['DBS check'] })
-      change = ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option, offer_conditions: ['DBS check'])
+      change = ChangeAnOffer.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option, offer_conditions: ['DBS check'])
 
       expect(change).not_to be_identical_to_existing_offer
     end


### PR DESCRIPTION
## Context

To bring the change_an_offer service name more in line with others in the same scope

## Changes proposed in this pull request

Change all instances of ChangeOffer to ChangeAnOffer.

One locale was set as change_offer, and that resulted in a failing test - this has been updated to change_an_offer as well. 

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
