### PR TITLE
Qualifications export - remove N+1 queries

### DIFF
--- a/app/services/support_interface/qualifications_export.rb
+++ b/app/services/support_interface/qualifications_export.rb
@@ -3,12 +3,12 @@ module SupportInterface
     def data_for_export
       application_choices = ApplicationChoice
         .select(:id, :application_form_id, :rejection_reason, :structured_rejection_reasons, :status, :course_option_id)
-        .includes(:course_option, :course, :provider)
+        .includes(:course_option, :course, :provider, application_form: [:application_qualifications])
 
       application_choices.find_each(batch_size: 100).lazy.map do |application_choice|
         application_form = application_choice.application_form
-        course = application_choice.course_option.course
-        qualifications = application_form.application_qualifications
+        course = application_choice.course
+        qualifications = application_form.application_qualifications.all
         a_levels = a_levels(qualifications).sort_by(&:subject)
         degrees = degrees(qualifications).sort_by(&:subject)
 
@@ -64,52 +64,60 @@ module SupportInterface
   private
 
     def maths_gcse_grade(qualifications)
-      maths_gcse = qualifications.where(level: :gcse, subject: :maths).first
+      maths_gcse = qualifications.find { |qualification| qualification.gcse? && qualification.subject == 'maths' }
       maths_gcse.try(:grade)
     end
 
     def science_single_gcse_grade(qualifications)
-      unstructured_grade = qualifications.where(level: :gcse, subject: :science).first.try(:grade)
+      unstructured_grade = unstructured_gcse_science_grade_from(qualifications)
       return unstructured_grade if unstructured_grade.present? && SINGLE_GCSE_GRADES.include?(unstructured_grade)
 
-      science_single_gcse = qualifications.where(level: :gcse, subject: ApplicationQualification::SCIENCE_SINGLE_AWARD).first
-      science_single_gcse.try(:grade)
+      find_science_gcse(
+        qualifications: qualifications,
+        award: ApplicationQualification::SCIENCE_SINGLE_AWARD,
+      ).try(:grade)
     end
 
     def science_double_gcse_grade(qualifications)
-      unstructured_grade = qualifications.where(level: :gcse, subject: :science).first.try(:grade)
+      unstructured_grade = unstructured_gcse_science_grade_from(qualifications)
       return unstructured_grade if unstructured_grade.present? && DOUBLE_GCSE_GRADES.include?(unstructured_grade)
 
-      science_double_gcse = qualifications.where(level: :gcse, subject: ApplicationQualification::SCIENCE_DOUBLE_AWARD).first
-      science_double_gcse.try(:grade)
+      find_science_gcse(
+        qualifications: qualifications,
+        award: ApplicationQualification::SCIENCE_DOUBLE_AWARD,
+      ).try(:grade)
     end
 
     def science_triple_gcse_grade(qualifications)
-      unstructured_grade = qualifications.where(level: :gcse, subject: :science).first.try(:grade)
+      unstructured_grade = unstructured_gcse_science_grade_from(qualifications)
       return unstructured_grade if unstructured_grade.present? && not_single_or_double_award?(unstructured_grade)
 
-      science_triple_gcse = qualifications.where(level: :gcse, subject: ApplicationQualification::SCIENCE_TRIPLE_AWARD).first
+      science_triple_gcse = find_science_gcse(
+        qualifications: qualifications,
+        award: ApplicationQualification::SCIENCE_TRIPLE_AWARD,
+      )
+
       return if science_triple_gcse.try(:constituent_grades).blank?
 
       science_triple_gcse[:constituent_grades].values.map { |hash| hash['grade'] }.join
     end
 
     def english_unstructured_gcse_grade(qualifications)
-      english_unstructured_gcse = qualifications.where(level: :gcse, subject: :english).first
+      english_unstructured_gcse = find_gcse_english(qualifications)
       return nil if english_unstructured_gcse.try(:constituent_grades).present?
 
       english_unstructured_gcse.try(:grade)
     end
 
     def english_structured_gcse_grades(qualifications, subject)
-      constituent_grades = qualifications.where(level: :gcse, subject: :english).first.constituent_grades
+      constituent_grades = constituent_gcse_english_grades_from(qualifications)
       constituent_grades.dig(subject, 'grade')
     rescue StandardError
       nil
     end
 
     def english_other_gcse_grade(qualifications)
-      constituent_grades = qualifications.where(level: :gcse, subject: :english).first.constituent_grades
+      constituent_grades = constituent_gcse_english_grades_from(qualifications)
       constituent_grades.each do |subject, hash|
         return hash['grade'] if ENGLISH_GCSE_SUBJECTS.exclude?(subject)
       end
@@ -118,19 +126,38 @@ module SupportInterface
     end
 
     def a_levels(qualifications)
-      qualifications.where(qualification_type: 'A level').or(qualifications.where(qualification_type: 'AS level')).reject(&:incomplete_other_qualification?).take(5)
+      qualifications
+        .select { |qualification| qualification.qualification_type == 'A level' || qualification.qualification_type == 'AS level' }
+        .reject(&:incomplete_other_qualification?)
+        .take(5)
     end
 
     def degrees(qualifications)
-      qualifications.where(level: 'degree').reject(&:incomplete_degree_information?).take(2)
+      qualifications.select(&:degree?).reject(&:incomplete_degree_information?).take(2)
     end
 
     def other_qualification_count(qualifications)
-      qualifications.where(level: 'other').count
+      qualifications.select(&:other?).size
     end
 
     def not_single_or_double_award?(unstructured_grade)
       SINGLE_GCSE_GRADES.exclude?(unstructured_grade) && DOUBLE_GCSE_GRADES.exclude?(unstructured_grade)
+    end
+
+    def constituent_gcse_english_grades_from(qualifications)
+      find_gcse_english(qualifications).constituent_grades
+    end
+
+    def unstructured_gcse_science_grade_from(qualifications)
+      qualifications.find { |qualification| qualification.gcse? && qualification.subject == 'science' }.try(:grade)
+    end
+
+    def find_gcse_english(qualifications)
+      qualifications.find { |qualification| qualification.gcse? && qualification.subject == 'english' }
+    end
+
+    def find_science_gcse(qualifications:, award:)
+      qualifications.find { |qualification| qualification.gcse? && qualification.subject == award }
     end
 
     ENGLISH_GCSE_SUBJECTS = %w[


### PR DESCRIPTION
## Context

The qualifications export appears to hang in production, and remains "in progress" without completing.

## Changes proposed in this pull request

- The export was performing unnecessary db queries to filter application qualifications. Instead we can preload the qualifications and filter in-memory
- Extracted some methods for code-cleanliness


## Guidance to review

- I managed to replicate the issue locally by using the test application generator to seed my local db with 6000 qualifications
- When I ran the export it would eventually complete but would take around 4 minutes and max out my laptop's memory. Now the export only takes around 7 seconds

## Link to Trello card

https://trello.com/c/LkbuvHIv/3137-qualifications-export-not-completing-on-prod

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
