### PR TITLE
Prevent users from being able to add new users to providers they don't have the right permissions for

### DIFF
--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -27,7 +27,7 @@ module ProviderInterface
 
     def update_providers
       @wizard = wizard_for(providers_params.merge(current_step: 'providers'))
-      @available_providers = current_provider_user.providers
+      @available_providers = available_providers
 
       if @wizard.valid_for_current_step?
         @wizard.save_state!

--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -40,7 +40,7 @@ module ProviderInterface
     def edit_permissions
       @wizard = wizard_for(current_step: 'permissions', current_provider_id: params[:provider_id])
       @wizard.save_state!
-      @provider = current_provider_user.providers.find(params[:provider_id])
+      @provider = available_providers.find(params[:provider_id])
     end
 
     def update_permissions
@@ -50,7 +50,7 @@ module ProviderInterface
         @wizard.save_state!
         redirect_to next_redirect
       else
-        @provider = current_provider_user.providers.find(params[:provider_id])
+        @provider = available_providers.find(params[:provider_id])
         render :edit_permissions
       end
     end

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -27,6 +27,8 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
     when_i_fill_in_email_address_and_name
     and_i_press_continue
     then_i_see_the_select_organisations_form
+    and_i_press_continue
+    and_i_see_an_error_telling_me_to_select_a_provider
     and_select_organisations_only_lists_providers_i_can_manage
 
     when_i_select_one_provider
@@ -128,6 +130,10 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
 
   def then_i_see_the_select_organisations_form
     expect(page).to have_content('Select organisations this user will have access to')
+  end
+
+  def and_i_see_an_error_telling_me_to_select_a_provider
+    expect(page).to have_content('Error: Select which organisations this user will have access to')
   end
 
   def and_select_organisations_only_lists_providers_i_can_manage


### PR DESCRIPTION
## Context

The update action was for the provider user invitation controller is using the user's list of providers regardless of whether the user could manage other users for that organisation.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Ensures the list of providers throughout the wizard flow is comprised of organisations the current provider user has permissions to manage users for.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

The system spec already contains a test for the correct list of providers, so I added the necessary failing validation step to ensure the bug is fixed.

Steps to reproduce bug:

- Make sure that you're a user associated with at least two organisations, with manage user permissions for one provider, and not the other
- Log into Manage, and select invite user (enter contact details)
- Don't select an organisation on the next page
- The error page allows the user to select any organisation that they are associated with, not just the orgs they have manage user permissions for

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/kgbH65A2/3480-prevent-users-from-being-able-to-add-new-users-to-providers-they-dont-have-the-right-permissions-for
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
