### PR TITLE
Remove brackets for the S in degrees on the Review page in Apply

### DIFF
--- a/config/locales/candidate_interface/review_application.yml
+++ b/config/locales/candidate_interface/review_application.yml
@@ -24,8 +24,8 @@ en:
       incomplete: Volunteering with children and young people is not marked as completed
       complete_section: Do you have any experience working with children and young people?
     degrees:
-      incomplete: Degree(s) section not marked as completed
-      complete_section: Enter your degree(s)
+      incomplete: Degree section not marked as completed
+      complete_section: Enter your degrees
     maths_gcse:
       incomplete: Maths GCSE or equivalent not entered
       complete_section: Enter your Maths GCSE or equivalent

--- a/spec/components/candidate_interface/incomplete_section_component_spec.rb
+++ b/spec/components/candidate_interface/incomplete_section_component_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 RSpec.describe CandidateInterface::IncompleteSectionComponent do
   it 'renders a section incomplete banner component' do
     result = render_inline(described_class.new(section: 'degrees', section_path: '#'))
-    expect(result.css('.app-inset-text__title').text).to include('Degree(s) section not marked as completed')
+    expect(result.css('.app-inset-text__title').text).to include('Degree section not marked as completed')
     expect(result.css('.app-inset-text--important .govuk-link')).to be_present
-    expect(result.css('.app-inset-text--important .govuk-link').text).to include('Enter your degree(s)')
+    expect(result.css('.app-inset-text--important .govuk-link').text).to include('Enter your degrees')
   end
 
   it 'renders custom link text if given' do
     result = render_inline(described_class.new(section: 'degrees', section_path: '#', link_text: 'Click here to win'))
-    expect(result.css('.app-inset-text__title').text).to include('Degree(s) section not marked as completed')
+    expect(result.css('.app-inset-text__title').text).to include('Degree section not marked as completed')
     expect(result.css('.app-inset-text--important .govuk-link')).to be_present
     expect(result.css('.app-inset-text--important .govuk-link').text).to include('Click here to win')
   end


### PR DESCRIPTION
## Context

On the review application page in Apply, we have brackets around the S of degrees. We shouldn't do this to emphasise that something could be plural.

## Changes proposed in this pull request

On the application review page:

For the bold blue text removed the brackets and the S so it reads:

*Degree section not marked as completed* instead of *Degree(s) section not marked as completed* 

For the link text underneath removed the brackets but kept the S:

*Enter your degrees* instead of *Enter your degree(s)*

## Guidance to review

|Before|After|
|---|---|
|<img width="511" alt="Screenshot 2021-03-11 at 11 03 25" src="https://user-images.githubusercontent.com/47917431/110777805-73b6eb80-8259-11eb-828b-dcc06ebb9526.png">|![Screenshot 2021-03-11 at 10 44 09](https://user-images.githubusercontent.com/47917431/110777638-3fdbc600-8259-11eb-999b-5932134bb2a5.png)|

## Link to Trello card

https://trello.com/c/QSmZZNZn/3153-remove-brackets-for-the-s-in-degrees-on-the-review-page-in-apply

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
