### PR TITLE
Redirect back from conditions actions if the application is already r…

### DIFF
--- a/app/controllers/provider_interface/conditions_controller.rb
+++ b/app/controllers/provider_interface/conditions_controller.rb
@@ -1,6 +1,7 @@
 module ProviderInterface
   class ConditionsController < ProviderInterfaceController
     before_action :set_application_choice
+    before_action :redirect_back_if_application_terminated
     before_action :requires_make_decisions_permission
 
     def edit
@@ -39,6 +40,12 @@ module ProviderInterface
       end
 
       redirect_to provider_interface_application_choice_path(@application_choice.id)
+    end
+
+    def redirect_back_if_application_terminated
+      if ApplicationStateChange::TERMINAL_STATES.include?(@application_choice.status.to_sym)
+        redirect_back(fallback_location: provider_interface_application_choice_path(@application_choice))
+      end
     end
   end
 end

--- a/spec/requests/provider_interface/conditions_controller_spec.rb
+++ b/spec/requests/provider_interface/conditions_controller_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ConditionsController, type: :request do
+  include DfESignInHelpers
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions) }
+  let(:provider) { provider_user.providers.first }
+  let(:application_form) { build(:application_form, :minimum_info) }
+  let(:course) { build(:course, :open_on_apply, provider: provider) }
+  let(:course_option) { build(:course_option, course: course) }
+
+  describe 'if application choice is in a recruited state' do
+    let!(:application_choice) do
+      create(:application_choice, :recruited,
+             application_form: application_form,
+             course_option: course_option)
+    end
+    let(:referer) { "http://www.example.com/provider/applications/#{application_choice.id}" }
+
+    before do
+      allow(ProviderUser).to receive(:load_from_session)
+        .and_return(
+          ProviderUser.new(
+            id: provider_user.id,
+            providers: provider_user.providers,
+          ),
+        )
+    end
+
+    context 'GET edit' do
+      it 'redirects back' do
+        get(
+          provider_interface_application_choice_edit_conditions_path(application_choice),
+          params: nil,
+          headers: { 'HTTP_REFERER' => referer },
+        )
+
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(referer)
+      end
+    end
+
+    context 'PATCH confirm_update' do
+      it 'redirects back' do
+        patch(
+          provider_interface_application_choice_confirm_update_conditions_path(application_choice),
+          params: {},
+          headers: { 'HTTP_REFERER' => referer },
+        )
+
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(referer)
+      end
+    end
+
+    context 'PATCH update' do
+      it 'redirects back' do
+        patch(
+          provider_interface_application_choice_update_conditions_path(application_choice),
+          params: {},
+          headers: { 'HTTP_REFERER' => referer },
+        )
+
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(referer)
+      end
+    end
+  end
+end


### PR DESCRIPTION
…ecruited

## Context

Conditions should not be editable or updateable if the application has reached the recruited state.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds a filter to redirect back (falling back to `/provider`) from the conditions `edit/confirm_update/update` actions if the application has reached `recruited` state.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Q6IY6Dk8/3464-prevent-access-to-provider-conditions-controller-views-for-recruited-applications
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
