### PR TITLE
Humanize compared attribute

### DIFF
--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -22,7 +22,7 @@ class DateValidator < ActiveModel::EachValidator
     return record.errors.add(attribute, invalid_date_locale(options), article: article(attribute), attribute: humanize(attribute)) if is_invalid?(value)
     return record.errors.add(attribute, :future, article: article(attribute), attribute: humanize(attribute)) if value > Time.zone.today && options[:future]
 
-    record.errors.add(attribute, :before, article: article(attribute), attribute: humanize(attribute), compared_attribute: options[:before]) if options[:before] && !before?(record, value, options[:before])
+    record.errors.add(attribute, :before, article: article(attribute), attribute: humanize(attribute), compared_attribute: humanize(options[:before])) if options[:before] && !before?(record, value, options[:before])
   end
 
 private

--- a/spec/support/shared_examples/month_and_year_date_validations.rb
+++ b/spec/support/shared_examples/month_and_year_date_validations.rb
@@ -73,7 +73,7 @@ RSpec.shared_examples 'month and year date validations' do |date_field, validati
                                  :before,
                                  article: article(date_field),
                                  attribute: humanize(date_field),
-                                 compared_attribute: compared_attribute)).to eq(true)
+                                 compared_attribute: humanize(compared_attribute))).to eq(true)
     end
   end
 end

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe DateValidator do
+  include DateAndYearConcerns
+
   let(:test_date_validator) do
     Class.new do
       include ActiveModel::Validations
@@ -198,7 +200,7 @@ RSpec.describe DateValidator do
 
         it 'returns :before error' do
           expect(model).to be_invalid
-          expect(model.errors[:date]).to contain_exactly(I18n.t('errors.messages.before', article: 'a', attribute: :date, compared_attribute: :other_date))
+          expect(model.errors[:date]).to contain_exactly(I18n.t('errors.messages.before', article: 'a', attribute: :date, compared_attribute: humanize(:other_date)))
         end
       end
     end


### PR DESCRIPTION
## Context

We need to humanize the error message for date validations that compare two dates.


## Changes proposed in this pull request

Before
![image](https://user-images.githubusercontent.com/33458055/110819546-31f06a00-8286-11eb-86e1-734cb40a33f0.png)

After
![image](https://user-images.githubusercontent.com/33458055/110819627-43d20d00-8286-11eb-8314-e818b6e17f6d.png)


## Guidance to review

Will this have any negative side effects?

## Link to Trello card

https://trello.com/c/iGPeDu77/3142-date-validation-error-message-bug

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
