### PR TITLE
Email content changes to support unconditional offers

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -217,6 +217,8 @@ class CandidateMailer < ApplicationMailer
 
   def changed_offer(application_choice)
     @application_choice = application_choice
+    @conditions = @application_choice.offer&.dig('conditions') || []
+
     @course_option = @application_choice.course_option
     @offered_course_option = @application_choice.offered_course_option
     @is_awaiting_decision = application_choice.self_and_siblings.any?(&:awaiting_provider_decision?)

--- a/app/views/candidate_mailer/changed_offer.text.erb
+++ b/app/views/candidate_mailer/changed_offer.text.erb
@@ -11,7 +11,11 @@ Course: <%= @offered_course_option.course.name_and_code %>
 Location: <%= @offered_course_option.site.name %>
 Full time or part time: <%= @offered_course_option.course.study_mode.humanize %>
 
-The conditions of your offer have not been changed.
+<% if @conditions.blank? %>
+  <%= @course_option.course.provider.name %> will let you know if they need further information before you can start training.
+<% else %>
+  The conditions of your offer have not been changed.
+<% end %>
 
 If you were not expecting this change, contact <%= @course_option.course.provider.name %> to find out more.
 

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -4,7 +4,11 @@ Dear <%= @application_form.first_name %>,
 
 You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
-<%= render "candidate_mailer/offer_conditions" %>
+<% if @conditions.blank? %>
+  They’ll let you know if they need further information before you can start training.
+<% else %>
+  <%= render "candidate_mailer/offer_conditions" %>
+<% end %>
 
 Contact <%= @provider_name %> if you have any questions about this.
 

--- a/app/views/candidate_mailer/reinstated_offer.text.erb
+++ b/app/views/candidate_mailer/reinstated_offer.text.erb
@@ -7,7 +7,7 @@ You have an offer from <%= @course_option.course.provider.name %> to study <%= @
 <% if @conditions.any? %>
   <%= render "candidate_mailer/offer_conditions" %>
 <% else %>
-  There are no conditions for this offer.
+  <%= @course_option.course.provider.name %> will let you know if they need further information before you can start training.
 <% end %>
 
 # Next steps

--- a/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
+++ b/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
@@ -2,11 +2,9 @@ Dear <%= @application_form.first_name %>,
 
 #You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_code %>
 
-If everything goes well with meeting your conditions, you’ll start <%= @course_name_and_code %> <%= @provider_name %> on <%= @start_date %>.
+The course will start on <%= @start_date %>.
 
-You can check your conditions anytime by signing in to your account:
-
-<%= candidate_magic_link(@application_form.candidate) %>
+<%= @provider_name %> will let you know if they need further information before you can start training.
 
 #What to do if you’re unable to start training in <%= @start_date %>
 

--- a/app/views/provider_mailer/unconditional_offer_accepted.text.erb
+++ b/app/views/provider_mailer/unconditional_offer_accepted.text.erb
@@ -5,9 +5,9 @@ Dear <%= @provider_user.full_name || 'colleague' %>
 
 <%= @application_choice.application_form.full_name %> has accepted your offer to study <%= @application_choice.offered_course.name_and_code %>.
 
-# Tell us when the candidate has met their conditions
+You did not set any conditions for this offer.
 
-Sign in to Manage teacher training applications to update the application status when they’ve met their conditions:
+You can view <%= @application_choice.application_form.full_name %>’s application:
 
 <%= provider_interface_application_choice_url(@application_choice) %>
 

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -33,6 +33,22 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.changed_offer(application_choice)
   end
 
+  def changed_unconditional_offer
+    application_form = application_form_with_course_choices([application_choice_with_offer, application_choice_with_offer])
+    application_choice = FactoryBot.build_stubbed(
+      :submitted_application_choice,
+      status: :offer,
+      offer: { 'conditions' => [] },
+      offered_at: Time.zone.now,
+      offered_course_option: course_option,
+      course_option: course_option,
+      application_form: application_form,
+      decline_by_default_at: 10.business_days.from_now,
+    )
+
+    CandidateMailer.changed_offer(application_choice)
+  end
+
   def chase_reference
     CandidateMailer.chase_reference(reference)
   end
@@ -128,6 +144,24 @@ class CandidateMailerPreview < ActionMailer::Preview
       course_option: course_option,
       status: :offer,
       offer: { conditions: ['DBS check', 'Pass exams'] },
+      offered_at: Time.zone.now,
+      offered_course_option: course_option,
+      decline_by_default_at: 10.business_days.from_now,
+    )
+    other_course_option = FactoryBot.build_stubbed(:course_option, site: site)
+    application_form.application_choices.build(
+      course_option: other_course_option,
+      status: :awaiting_provider_decision,
+    )
+    CandidateMailer.new_offer_decisions_pending(application_choice)
+  end
+
+  def new_unconditional_offer_decisions_pending
+    course_option = FactoryBot.build_stubbed(:course_option, site: site)
+    application_choice = application_form.application_choices.build(
+      course_option: course_option,
+      status: :offer,
+      offer: { 'conditions' => [] },
       offered_at: Time.zone.now,
       offered_course_option: course_option,
       decline_by_default_at: 10.business_days.from_now,
@@ -601,6 +635,11 @@ class CandidateMailerPreview < ActionMailer::Preview
     )
 
     CandidateMailer.ucas_match_resolved_on_apply_email(application_choice)
+  end
+
+  def unconditional_offer_accepted
+    application_choice = FactoryBot.build_stubbed(:application_choice)
+    CandidateMailer.unconditional_offer_accepted(application_choice)
   end
 
 private

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -62,6 +62,10 @@ class ProviderMailerPreview < ActionMailer::Preview
     )
   end
 
+  def unconditional_offer_accepted
+    ProviderMailer.unconditional_offer_accepted(provider_user, application_choice)
+  end
+
 private
 
   def provider


### PR DESCRIPTION
## Context

We've started supporting unconditional offers via the API. https://github.com/DFE-Digital/apply-for-teacher-training/pull/4154 However some of the emails sent when a candidate accepts and offer or when an offer is changed mention the conditions set by the provider.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Update email content to handle unconditional offers.
<!-- If there are UI changes, please include Before and After screenshots. -->

### Provider email on offer acceptance
![image](https://user-images.githubusercontent.com/93511/111340321-6d1cdf80-8670-11eb-866f-d867e03ec691.png)

### Candidate email on offer acceptance
![image](https://user-images.githubusercontent.com/93511/111340488-976e9d00-8670-11eb-9d43-f7c1aeb130ab.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/3FdFF4Wk/3487-email-changes-to-support-unconditional-offers-%F0%9F%91%80
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
