### PR TITLE
Remove V3 API (4/4) — clean up after removing v3 API

### DIFF
--- a/spec/examples/teacher_training_api/pagination_error.json
+++ b/spec/examples/teacher_training_api/pagination_error.json
@@ -1,9 +1,0 @@
-{
-  "errors": [
-    {
-      "status": 400,
-      "title": "BAD REQUEST",
-      "detail": "The requested page param was out of range and invalid for this request."
-    }
-  ]
-}

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -96,11 +96,11 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
       end
 
       it 'correctly updates vacancy status for any existing course options' do
-        stub_course_with_site(provider_code: 'ABC',
-                              course_code: 'ABC1',
-                              course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
-                              site_code: 'A',
-                              vacancy_status: 'full_time_vacancies')
+        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                                   course_code: 'ABC1',
+                                                   course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
+                                                   site_code: 'A',
+                                                   vacancy_status: 'full_time_vacancies')
 
         described_class.new.perform(@existing_provider.id, stubbed_recruitment_cycle_year)
         expect(CourseOption.count).to eq 1
@@ -112,10 +112,10 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
       end
 
       it 'correctly updates withdrawn attribute for an existing course' do
-        stub_course_with_site(provider_code: 'ABC',
-                              course_code: 'ABC1',
-                              course_attributes: [{ study_mode: 'full_time', accredited_body_code: nil, state: 'withdrawn' }],
-                              site_code: 'A')
+        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                                   course_code: 'ABC1',
+                                                   course_attributes: [{ study_mode: 'full_time', accredited_body_code: nil, state: 'withdrawn' }],
+                                                   site_code: 'A')
 
         described_class.new.perform(@existing_provider.id, stubbed_recruitment_cycle_year)
         expect(CourseOption.count).to eq 1
@@ -128,11 +128,11 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
       it 'sets the accredited provider' do
         create :provider, code: 'DEF', name: 'Foobar College'
 
-        stub_course_with_site(provider_code: 'ABC',
-                              course_code: 'ABC1',
-                              course_attributes: [{ accredited_body_code: 'DEF' }],
-                              site_code: 'A',
-                              vacancy_status: 'full_time_vacancies')
+        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                                   course_code: 'ABC1',
+                                                   course_attributes: [{ accredited_body_code: 'DEF' }],
+                                                   site_code: 'A',
+                                                   vacancy_status: 'full_time_vacancies')
 
         described_class.new.perform(@existing_provider.id, stubbed_recruitment_cycle_year)
         course_option = CourseOption.first
@@ -141,10 +141,10 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
       end
 
       it 'does not set the accredited provider if it is the same as the training provider' do
-        stub_course_with_site(provider_code: 'ABC',
-                              course_code: 'ABC1',
-                              course_attributes: [{ accredited_body_code: 'ABC' }],
-                              site_code: 'A')
+        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                                   course_code: 'ABC1',
+                                                   course_attributes: [{ accredited_body_code: 'ABC' }],
+                                                   site_code: 'A')
 
         described_class.new.perform(@existing_provider.id, stubbed_recruitment_cycle_year)
         expect(Course.find_by(code: 'ABC1').accredited_provider).to be_nil
@@ -153,10 +153,10 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
       it 'resets the accredited provider if it is no longer specified' do
         course = create(:course, accredited_provider: create(:provider), code: 'ABC1', provider: create(:provider, code: 'ABC'))
 
-        stub_course_with_site(provider_code: 'ABC',
-                              course_code: 'ABC1',
-                              course_attributes: [{ accredited_body_code: nil }],
-                              site_code: 'A')
+        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                                   course_code: 'ABC1',
+                                                   course_attributes: [{ accredited_body_code: nil }],
+                                                   site_code: 'A')
 
         described_class.new.perform(@existing_provider.id, stubbed_recruitment_cycle_year)
         expect(course.reload.accredited_provider).to be_nil
@@ -164,10 +164,10 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
 
       it 'correctly creates provider relationships' do
         create :provider, code: 'DEF'
-        stub_course_with_site(provider_code: 'ABC',
-                              course_code: 'ABC1',
-                              course_attributes: [{ accredited_body_code: 'DEF', study_mode: 'full_time' }],
-                              site_code: 'A')
+        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                                   course_code: 'ABC1',
+                                                   course_attributes: [{ accredited_body_code: 'DEF', study_mode: 'full_time' }],
+                                                   site_code: 'A')
 
         expect {
           described_class.new.perform(@existing_provider.id, stubbed_recruitment_cycle_year)
@@ -181,10 +181,10 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
       end
 
       it 'does not create provider relationships for self ratifying providers' do
-        stub_course_with_site(provider_code: 'ABC',
-                              course_code: 'ABC1',
-                              course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
-                              site_code: 'A')
+        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                                   course_code: 'ABC1',
+                                                   course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
+                                                   site_code: 'A')
 
         expect {
           described_class.new.perform(@existing_provider.id, stubbed_recruitment_cycle_year)
@@ -192,10 +192,10 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
       end
 
       it 'does not create provider relationships when the course accredited_provider attribute points back to the same provider' do
-        stub_course_with_site(provider_code: 'ABC',
-                              course_code: 'ABC1',
-                              course_attributes: [{ accredited_body_code: 'ABC', study_mode: 'full_time' }],
-                              site_code: 'A')
+        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                                   course_code: 'ABC1',
+                                                   course_attributes: [{ accredited_body_code: 'ABC', study_mode: 'full_time' }],
+                                                   site_code: 'A')
 
         expect {
           described_class.new.perform(@existing_provider.id, stubbed_recruitment_cycle_year)
@@ -203,10 +203,10 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
       end
 
       it 'stores full_time/part_time information within courses' do
-        stub_course_with_site(provider_code: 'ABC',
-                              course_code: 'ABC1',
-                              course_attributes: [{ accredited_body_code: 'ABC', study_mode: 'both' }],
-                              site_code: 'A')
+        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                                   course_code: 'ABC1',
+                                                   course_attributes: [{ accredited_body_code: 'ABC', study_mode: 'both' }],
+                                                   site_code: 'A')
 
         described_class.new.perform(@existing_provider.id, stubbed_recruitment_cycle_year)
         expect(Course.find_by(code: 'ABC1').study_mode).to eq 'full_time_or_part_time'
@@ -244,11 +244,11 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
       end
 
       it 'correctly handles existing course options with invalid sites' do
-        stub_course_with_site(provider_code: 'ABC',
-                              course_code: 'ABC1',
-                              course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
-                              site_code: 'A',
-                              vacancy_status: 'full_time_vacancies')
+        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                                   course_code: 'ABC1',
+                                                   course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
+                                                   site_code: 'A',
+                                                   vacancy_status: 'full_time_vacancies')
 
         described_class.new.perform(@existing_provider.id, stubbed_recruitment_cycle_year)
         expect(Course.count).to eq 1
@@ -278,12 +278,12 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
     context 'ingesting a provider when it existed in the previous recruitment cycle' do
       before do
         @existing_provider = create :provider, code: 'ABC', sync_courses: true
-        stub_course_with_site(provider_code: 'ABC',
-                              course_code: 'ABC1',
-                              recruitment_cycle_year: 2020,
-                              course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
-                              site_code: 'A',
-                              vacancy_status: 'full_time_vacancies')
+        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                                   course_code: 'ABC1',
+                                                   recruitment_cycle_year: 2020,
+                                                   course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
+                                                   site_code: 'A',
+                                                   vacancy_status: 'full_time_vacancies')
 
         described_class.new.perform(@existing_provider.id, 2020)
       end
@@ -291,12 +291,12 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
       it 'creates separate courses for the courses in this cycle' do
         expect(Course.count).to eq 1
 
-        stub_course_with_site(provider_code: 'ABC',
-                              course_code: 'ABC1',
-                              recruitment_cycle_year: 2021,
-                              course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
-                              site_code: 'A',
-                              vacancy_status: 'full_time_vacancies')
+        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                                   course_code: 'ABC1',
+                                                   recruitment_cycle_year: 2021,
+                                                   course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
+                                                   site_code: 'A',
+                                                   vacancy_status: 'full_time_vacancies')
 
         described_class.new.perform(@existing_provider.id, 2021)
         expect(Course.count).to eq 2
@@ -306,12 +306,12 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
         existing_course = Course.find_by(recruitment_cycle_year: 2020)
         existing_course.update(open_on_apply: true)
 
-        stub_course_with_site(provider_code: 'ABC',
-                              course_code: 'ABC1',
-                              recruitment_cycle_year: 2021,
-                              course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
-                              site_code: 'A',
-                              vacancy_status: 'full_time_vacancies')
+        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                                   course_code: 'ABC1',
+                                                   recruitment_cycle_year: 2021,
+                                                   course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
+                                                   site_code: 'A',
+                                                   vacancy_status: 'full_time_vacancies')
 
         described_class.new.perform(@existing_provider.id, 2021)
 

--- a/spec/services/teacher_training_public_api/sync_provider_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_provider_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe TeacherTrainingPublicAPI::SyncProvider, sidekiq: true do
 
       it 'correctly updates the Provider#region_code' do
         provider_from_api = fake_api_provider(code: 'ABC', region_code: 'north_west')
-        stub_course_with_site(provider_code: 'ABC',
-                              course_code: 'ABC1',
-                              course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
-                              site_code: 'A',
-                              vacancy_status: 'full_time_vacancies')
+        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                                   course_code: 'ABC1',
+                                                   course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
+                                                   site_code: 'A',
+                                                   vacancy_status: 'full_time_vacancies')
 
         described_class.new(provider_from_api: provider_from_api, recruitment_cycle_year: stubbed_recruitment_cycle_year).call
         expect(Provider.count).to eq 1

--- a/spec/support/test_helpers/teacher_training_public_api_helper.rb
+++ b/spec/support/test_helpers/teacher_training_public_api_helper.rb
@@ -39,7 +39,7 @@ module TeacherTrainingPublicAPIHelper
     )
   end
 
-  def stub_course_with_site(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, course_code:, site_code:, vacancy_status: 'full_time_vacancies', course_attributes: [], site_attributes: [])
+  def stub_teacher_training_api_course_with_site(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, course_code:, site_code:, vacancy_status: 'full_time_vacancies', course_attributes: [], site_attributes: [])
     course_attributes = course_attributes.any? ? [course_attributes.first.merge(code: course_code)] : [{ code: course_code }]
     site_attributes = site_attributes.any? ? [site_attributes.first.merge(code: site_code)] : [{ code: site_code }]
     stub_teacher_training_api_courses(recruitment_cycle_year: recruitment_cycle_year, provider_code: provider_code, specified_attributes: course_attributes)

--- a/spec/support/test_helpers/teacher_training_public_api_helper.rb
+++ b/spec/support/test_helpers/teacher_training_public_api_helper.rb
@@ -10,18 +10,6 @@ module TeacherTrainingPublicAPIHelper
       headers: { 'Content-Type': 'application/vnd.api+json' },
       body: build_response_body('provider_list_response.json', specified_attributes),
     )
-
-    # Fake the error the API sends on exceeding the pagination limit
-    stub_request(
-      :get,
-      "#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers",
-    ).with(
-      query: { page: { page: 2, per_page: 500 } },
-    ).to_return(
-      status: 400,
-      headers: { 'Content-Type': 'application/vnd.api+json' },
-      body: pagination_error_response,
-    )
   end
 
   def stub_teacher_training_api_providers_with_multiple_pages(recruitment_cycle_year: RecruitmentCycle.current_year)
@@ -138,12 +126,6 @@ private
     end
 
     api_response.to_json
-  end
-
-  def pagination_error_response
-    File.read(
-      Rails.root.join('spec/examples/teacher_training_api/pagination_error.json'),
-    )
   end
 
   def paginated_response(page_number)

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -117,21 +117,21 @@ RSpec.feature 'Providers and courses' do
       },
     )
 
-    stub_course_with_site(provider_code: 'ABC',
-                          course_code: 'ABC1',
-                          course_attributes: [{ accredited_body_code: 'XYZ', qualifications: %w[qts pgce], name: 'Primary' }],
-                          site_code: 'X',
-                          site_attributes: [{ name: 'Main site' }])
+    stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                               course_code: 'ABC1',
+                                               course_attributes: [{ accredited_body_code: 'XYZ', qualifications: %w[qts pgce], name: 'Primary' }],
+                                               site_code: 'X',
+                                               site_attributes: [{ name: 'Main site' }])
 
-    stub_course_with_site(provider_code: 'DEF',
-                          course_code: 'DEF1',
-                          course_attributes: [{ accredited_body_code: 'ABC' }],
-                          site_code: 'Y')
+    stub_teacher_training_api_course_with_site(provider_code: 'DEF',
+                                               course_code: 'DEF1',
+                                               course_attributes: [{ accredited_body_code: 'ABC' }],
+                                               site_code: 'Y')
 
-    stub_course_with_site(provider_code: 'GHI',
-                          course_code: 'GHI1',
-                          course_attributes: [{ accredited_body_code: 'GHI' }],
-                          site_code: 'C')
+    stub_teacher_training_api_course_with_site(provider_code: 'GHI',
+                                               course_code: 'GHI1',
+                                               course_attributes: [{ accredited_body_code: 'GHI' }],
+                                               site_code: 'C')
 
     Sidekiq::Testing.inline! do
       click_button 'Sync providers'

--- a/spec/system/teacher_training_public_api/site_is_deleted_spec.rb
+++ b/spec/system/teacher_training_public_api/site_is_deleted_spec.rb
@@ -74,9 +74,9 @@ RSpec.describe 'Sync sites' do
       ],
     )
 
-    stub_course_with_site(provider_code: 'ABC',
-                          course_code: 'ABC1',
-                          site_code: 'A')
+    stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                               course_code: 'ABC1',
+                                               site_code: 'A')
   end
 
   def then_the_course_option_for_that_site_is_deleted

--- a/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
+++ b/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe 'Sync from Teacher Training API' do
 
   def given_there_is_a_full_time_course_on_the_teacher_training_api
     @provider = create :provider, code: 'ABC', sync_courses: true
-    stub_course_with_site(provider_code: 'ABC',
-                          course_code: 'ABC1',
-                          course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
-                          site_code: 'A',
-                          vacancy_status: 'full_time_vacancies')
+    stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                               course_code: 'ABC1',
+                                               course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
+                                               site_code: 'A',
+                                               vacancy_status: 'full_time_vacancies')
   end
 
   def when_sync_provider_is_called
@@ -49,11 +49,11 @@ RSpec.describe 'Sync from Teacher Training API' do
   end
 
   def given_the_course_becomes_full_time_and_part_time
-    stub_course_with_site(provider_code: 'ABC',
-                          course_code: 'ABC1',
-                          course_attributes: [{ accredited_body_code: nil, study_mode: 'both' }],
-                          site_code: 'A',
-                          vacancy_status: 'both_full_time_and_part_time_vacancies')
+    stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                               course_code: 'ABC1',
+                                               course_attributes: [{ accredited_body_code: nil, study_mode: 'both' }],
+                                               site_code: 'A',
+                                               vacancy_status: 'both_full_time_and_part_time_vacancies')
   end
 
   def then_a_part_time_course_option_is_created_with_vacancies
@@ -63,11 +63,11 @@ RSpec.describe 'Sync from Teacher Training API' do
   end
 
   def given_the_course_returns_to_full_time
-    stub_course_with_site(provider_code: 'ABC',
-                          course_code: 'ABC1',
-                          course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
-                          site_code: 'A',
-                          vacancy_status: 'full_time_vacancies')
+    stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                               course_code: 'ABC1',
+                                               course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
+                                               site_code: 'A',
+                                               vacancy_status: 'full_time_vacancies')
   end
 
   def then_the_part_time_course_option_is_set_to_no_vacancies


### PR DESCRIPTION
### Removing V3 from Apply

1. Apply from Find uses public API
1. Consume subject codes from the public API and remove remaining references to the v3 API
1. Delete all TTAPI v3 code
1. **Clean up after removing v3 API** 👈

## Context

A couple of last things to tidy up on our public/v1 code now v3 is all gone

## Changes proposed in this pull request

- rename a test helper
- remove some unused code to do with the way the public/v1 API used to paginate