### PR TITLE
Edit a new offer from the review page via the change links

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,8 @@ Metrics/BlockLength:
 RSpec/NestedGroups:
   Enabled: true
   Max: 4
+  Exclude:
+    - 'spec/forms/provider_interface/offer_wizard_spec.rb'
 
 RSpec/ExampleLength:
   Enabled: false

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -15,7 +15,7 @@ module ProviderInterface
         { key: 'Provider',
           value: course_option.provider.name_and_code,
           action: 'Change',
-          change_path: nil },
+          change_path: new_provider_interface_application_choice_offer_providers_path(application_choice) },
         { key: 'Course',
           value: course_option.course.name_and_code,
           action: 'Change',

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -23,7 +23,7 @@ module ProviderInterface
         { key: 'Location',
           value: course_option.site.name_and_address,
           action: 'Change',
-          change_path: nil },
+          change_path: new_provider_interface_application_choice_offer_locations_path(application_choice) },
         { key: 'Full time or part time',
           value: course_option.study_mode.humanize,
           action: 'Change',

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -2,12 +2,16 @@ module ProviderInterface
   class OfferSummaryComponent < ViewComponent::Base
     include ViewHelper
 
-    attr_accessor :application_choice, :course_option, :conditions
+    attr_accessor :application_choice, :course, :course_option, :conditions, :available_providers, :available_courses, :available_course_options
 
-    def initialize(application_choice:, course_option:, conditions:)
+    def initialize(application_choice:, course:, course_option:, conditions:, available_providers: [], available_courses: [], available_course_options: [])
       @application_choice = application_choice
       @course_option = course_option
       @conditions = conditions
+      @available_providers = available_providers
+      @available_courses = available_courses
+      @available_course_options = available_course_options
+      @course = course
     end
 
     def rows
@@ -15,20 +19,36 @@ module ProviderInterface
         { key: 'Provider',
           value: course_option.provider.name_and_code,
           action: 'Change',
-          change_path: new_provider_interface_application_choice_offer_providers_path(application_choice) },
+          change_path: change_provider_path },
         { key: 'Course',
           value: course_option.course.name_and_code,
           action: 'Change',
-          change_path: new_provider_interface_application_choice_offer_courses_path(application_choice) },
+          change_path: change_course_path },
         { key: 'Location',
           value: course_option.site.name_and_address,
           action: 'Change',
-          change_path: new_provider_interface_application_choice_offer_locations_path(application_choice) },
+          change_path: change_location_path },
         { key: 'Full time or part time',
           value: course_option.study_mode.humanize,
           action: 'Change',
-          change_path: new_provider_interface_application_choice_offer_study_modes_path(application_choice) },
+          change_path: change_study_mode_path },
       ]
+    end
+
+    def change_provider_path
+      available_providers.many? ? new_provider_interface_application_choice_offer_providers_path(application_choice) : nil
+    end
+
+    def change_course_path
+      available_courses.many? ? new_provider_interface_application_choice_offer_courses_path(application_choice) : nil
+    end
+
+    def change_location_path
+      available_course_options.many? ? new_provider_interface_application_choice_offer_locations_path(application_choice) : nil
+    end
+
+    def change_study_mode_path
+      course.full_time_or_part_time? ? new_provider_interface_application_choice_offer_study_modes_path(application_choice) : nil
     end
   end
 end

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -27,7 +27,7 @@ module ProviderInterface
         { key: 'Full time or part time',
           value: course_option.study_mode.humanize,
           action: 'Change',
-          change_path: nil },
+          change_path: new_provider_interface_application_choice_offer_study_modes_path(application_choice) },
       ]
     end
   end

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -19,7 +19,7 @@ module ProviderInterface
         { key: 'Course',
           value: course_option.course.name_and_code,
           action: 'Change',
-          change_path: nil },
+          change_path: new_provider_interface_application_choice_offer_courses_path(application_choice) },
         { key: 'Location',
           value: course_option.site.name_and_address,
           action: 'Change',

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -6,7 +6,7 @@ module ProviderInterface
 
     def new
       @wizard = OfferWizard.new(offer_store,
-                                offer_context_params(@application_choice.course_option).merge!(current_step: 'select_option'))
+                                offer_context_params(@application_choice.course_option).merge!(current_step: 'select_option', action: action))
       @wizard.save_state!
     end
 
@@ -183,6 +183,10 @@ module ProviderInterface
     def offer_store
       key = "offer_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
       WizardStateStores::RedisStore.new(key: key)
+    end
+
+    def action
+      'back' if !!params[:back]
     end
   end
 end

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -156,6 +156,7 @@ module ProviderInterface
 
     def offer_context_params(course_option)
       {
+        provider_user_id: current_provider_user.id,
         course_id: course_option.course.id,
         course_option_id: course_option.id,
         provider_id: course_option.provider.id,

--- a/app/controllers/provider_interface/offer/checks_controller.rb
+++ b/app/controllers/provider_interface/offer/checks_controller.rb
@@ -4,6 +4,10 @@ module ProviderInterface
       def new
         @wizard = OfferWizard.new(offer_store, { current_step: 'check' })
         @wizard.save_state!
+
+        @providers = available_providers
+        @courses = available_courses(@wizard.provider_id)
+        @course_options = available_course_options(@wizard.course_id, @wizard.study_mode)
       end
     end
   end

--- a/app/controllers/provider_interface/offer/checks_controller.rb
+++ b/app/controllers/provider_interface/offer/checks_controller.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   module Offer
     class ChecksController < OffersController
       def new
-        @wizard = OfferWizard.new(offer_store, { current_step: 'check' })
+        @wizard = OfferWizard.new(offer_store, { current_step: 'check', action: action })
         @wizard.save_state!
 
         @providers = available_providers

--- a/app/controllers/provider_interface/offer/conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/conditions_controller.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   module Offer
     class ConditionsController < OffersController
       def new
-        @wizard = OfferWizard.new(offer_store, { current_step: 'conditions' })
+        @wizard = OfferWizard.new(offer_store, { current_step: 'conditions', action: action })
         @wizard.save_state!
       end
 

--- a/app/controllers/provider_interface/offer/courses_controller.rb
+++ b/app/controllers/provider_interface/offer/courses_controller.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   module Offer
     class CoursesController < OffersController
       def new
-        @wizard = OfferWizard.new(offer_store, { decision: 'change_offer', current_step: 'courses' })
+        @wizard = OfferWizard.new(offer_store, { decision: 'change_offer', current_step: 'courses', action: action })
         @wizard.save_state!
 
         @courses = available_courses(@wizard.provider_id)

--- a/app/controllers/provider_interface/offer/courses_controller.rb
+++ b/app/controllers/provider_interface/offer/courses_controller.rb
@@ -27,10 +27,6 @@ module ProviderInterface
       def course_params
         params.require(:provider_interface_offer_wizard).permit(:course_id)
       end
-
-      def available_courses(provider_id)
-        Course.where(provider_id: provider_id)
-      end
     end
   end
 end

--- a/app/controllers/provider_interface/offer/courses_controller.rb
+++ b/app/controllers/provider_interface/offer/courses_controller.rb
@@ -1,0 +1,36 @@
+module ProviderInterface
+  module Offer
+    class CoursesController < OffersController
+      def new
+        @wizard = OfferWizard.new(offer_store, { decision: 'change_offer', current_step: 'courses' })
+        @wizard.save_state!
+
+        @courses = available_courses(@wizard.provider_id)
+      end
+
+      def create
+        @wizard = OfferWizard.new(offer_store, course_params.to_h)
+
+        if @wizard.valid_for_current_step?
+          @wizard.save_state!
+
+          redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
+        else
+          @courses = available_courses(@wizard.provider_id)
+
+          render :new
+        end
+      end
+
+    private
+
+      def course_params
+        params.require(:provider_interface_offer_wizard).permit(:course_id)
+      end
+
+      def available_courses(provider_id)
+        Course.where(provider_id: provider_id)
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/offer/locations_controller.rb
+++ b/app/controllers/provider_interface/offer/locations_controller.rb
@@ -5,9 +5,7 @@ module ProviderInterface
         @wizard = OfferWizard.new(offer_store, { decision: 'change_offer', current_step: 'locations' })
         @wizard.save_state!
 
-        @course_options = CourseOption.where( course_id: @wizard.course_id,
-                                             study_mode: @wizard.study_mode).
-                                             includes(:site).order('sites.name')
+        @course_options = available_course_options(@wizard.course_id, @wizard.study_mode)
       end
 
       def create
@@ -18,6 +16,8 @@ module ProviderInterface
 
           redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
         else
+          @course_options = available_course_options(@wizard.course_id, @wizard.study_mode)
+
           render :new
         end
       end
@@ -26,6 +26,11 @@ module ProviderInterface
 
       def course_option_params
         params.require(:provider_interface_offer_wizard).permit(:course_option_id)
+      end
+
+      def available_course_options(course_id, study_mode)
+        CourseOption.where(course_id: course_id, study_mode: study_mode)
+                    .includes(:site).order('sites.name')
       end
     end
   end

--- a/app/controllers/provider_interface/offer/locations_controller.rb
+++ b/app/controllers/provider_interface/offer/locations_controller.rb
@@ -27,11 +27,6 @@ module ProviderInterface
       def course_option_params
         params.require(:provider_interface_offer_wizard).permit(:course_option_id)
       end
-
-      def available_course_options(course_id, study_mode)
-        CourseOption.where(course_id: course_id, study_mode: study_mode)
-                    .includes(:site).order('sites.name')
-      end
     end
   end
 end

--- a/app/controllers/provider_interface/offer/locations_controller.rb
+++ b/app/controllers/provider_interface/offer/locations_controller.rb
@@ -1,0 +1,32 @@
+module ProviderInterface
+  module Offer
+    class LocationsController < OffersController
+      def new
+        @wizard = OfferWizard.new(offer_store, { decision: 'change_offer', current_step: 'locations' })
+        @wizard.save_state!
+
+        @course_options = CourseOption.where( course_id: @wizard.course_id,
+                                             study_mode: @wizard.study_mode).
+                                             includes(:site).order('sites.name')
+      end
+
+      def create
+        @wizard = OfferWizard.new(offer_store, course_option_params.to_h)
+
+        if @wizard.valid_for_current_step?
+          @wizard.save_state!
+
+          redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
+        else
+          render :new
+        end
+      end
+
+    private
+
+      def course_option_params
+        params.require(:provider_interface_offer_wizard).permit(:course_option_id)
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/offer/locations_controller.rb
+++ b/app/controllers/provider_interface/offer/locations_controller.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   module Offer
     class LocationsController < OffersController
       def new
-        @wizard = OfferWizard.new(offer_store, { decision: 'change_offer', current_step: 'locations' })
+        @wizard = OfferWizard.new(offer_store, { decision: 'change_offer', current_step: 'locations', action: action })
         @wizard.save_state!
 
         @course_options = available_course_options(@wizard.course_id, @wizard.study_mode)

--- a/app/controllers/provider_interface/offer/providers_controller.rb
+++ b/app/controllers/provider_interface/offer/providers_controller.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   module Offer
     class ProvidersController < OffersController
       def new
-        @wizard = OfferWizard.new(offer_store, { decision: 'change_offer', current_step: 'providers' })
+        @wizard = OfferWizard.new(offer_store, { decision: 'change_offer', current_step: 'providers', action: action })
         @wizard.save_state!
 
         @providers = available_providers

--- a/app/controllers/provider_interface/offer/providers_controller.rb
+++ b/app/controllers/provider_interface/offer/providers_controller.rb
@@ -27,10 +27,6 @@ module ProviderInterface
       def provider_params
         params.require(:provider_interface_offer_wizard).permit(:provider_id)
       end
-
-      def available_providers
-        current_provider_user.providers
-      end
     end
   end
 end

--- a/app/controllers/provider_interface/offer/providers_controller.rb
+++ b/app/controllers/provider_interface/offer/providers_controller.rb
@@ -1,0 +1,36 @@
+module ProviderInterface
+  module Offer
+    class ProvidersController < OffersController
+      def new
+        @wizard = OfferWizard.new(offer_store, { decision: 'change_offer', current_step: 'providers' })
+        @wizard.save_state!
+
+        @providers = available_providers
+      end
+
+      def create
+        @wizard = OfferWizard.new(offer_store, provider_params.to_h)
+
+        if @wizard.valid_for_current_step?
+          @wizard.save_state!
+
+          redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
+        else
+          @providers = available_providers
+
+          render :new
+        end
+      end
+
+    private
+
+      def provider_params
+        params.require(:provider_interface_offer_wizard).permit(:provider_id)
+      end
+
+      def available_providers
+        current_provider_user.providers
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/offer/study_modes_controller.rb
+++ b/app/controllers/provider_interface/offer/study_modes_controller.rb
@@ -1,0 +1,41 @@
+module ProviderInterface
+  module Offer
+    class StudyModesController < OffersController
+      def new
+        @wizard = OfferWizard.new(offer_store, { decision: 'change_offer', current_step: 'study_modes' })
+        @wizard.save_state!
+
+        @course = Course.find(@wizard.course_id)
+        @study_modes = available_study_modes(@course)
+      end
+
+      def create
+        @wizard = OfferWizard.new(offer_store, study_mode_params.to_h)
+        @wizard.course_option_id = nil if @wizard.course_option_id && @wizard.course_option.study_mode != @wizard.study_mode
+
+        if @wizard.valid_for_current_step?
+          @wizard.save_state!
+
+          redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
+        else
+          @course = Course.find(@wizard.course_id)
+          @study_modes = avalable_study_modes(@course)
+
+          render :new
+        end
+      end
+
+    private
+
+      def study_mode_params
+        params.require(:provider_interface_offer_wizard).permit(:study_mode)
+      end
+
+      def available_study_modes(course)
+        course.available_study_modes_from_options.map do |study_mode|
+          Struct.new(:id, :value).new(study_mode, study_mode.humanize)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/offer/study_modes_controller.rb
+++ b/app/controllers/provider_interface/offer/study_modes_controller.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   module Offer
     class StudyModesController < OffersController
       def new
-        @wizard = OfferWizard.new(offer_store, { decision: 'change_offer', current_step: 'study_modes' })
+        @wizard = OfferWizard.new(offer_store, { decision: 'change_offer', current_step: 'study_modes', action: action })
         @wizard.save_state!
 
         @course = Course.find(@wizard.course_id)

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -40,5 +40,18 @@ module ProviderInterface
 
       redirect_to(provider_interface_application_choice_path(@application_choice))
     end
+
+    def available_providers
+      current_provider_user.providers
+    end
+
+    def available_courses(provider_id)
+      Course.where(provider_id: provider_id)
+    end
+
+    def available_course_options(course_id, study_mode)
+      CourseOption.where(course_id: course_id, study_mode: study_mode)
+                  .includes(:site).order('sites.name')
+    end
   end
 end

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -11,7 +11,7 @@ module ProviderInterface
 
     def create
       @wizard = OfferWizard.new(offer_store)
-      if @wizard.valid?
+      if @wizard.valid?(:save)
         MakeOffer.new(actor: current_provider_user,
                       application_choice: @application_choice,
                       course_option: @wizard.course_option,

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -41,6 +41,10 @@ module ProviderInterface
       redirect_to(provider_interface_application_choice_path(@application_choice))
     end
 
+    def action
+      'back' if !!params[:back]
+    end
+
     def available_providers
       current_provider_user.providers
     end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -10,10 +10,10 @@ module ProviderInterface
                   :further_condition_3, :further_condition_4, :current_step, :decision,
                   :path_history, :action, :provider_user_id
 
-    validates :decision, presence: true
-    validates :course_option_id, presence: true, on: :locations
-    validates :study_mode, presence: true, on: :study_modes
-    validates :course_id, presence: true, on: :courses
+    validates :decision, presence: true, on: %i[select_option]
+    validates :course_option_id, presence: true, on: %i[locations save]
+    validates :study_mode, presence: true, on: %i[study_modes save]
+    validates :course_id, presence: true, on: %i[courses save]
     validates :further_condition_1, :further_condition_2, :further_condition_3, :further_condition_4, length: { maximum: 255 }
 
     def initialize(state_store, attrs = {})

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     include ActiveModel::Model
 
     STEPS = { make_offer: %i[select_option conditions check],
-              change_offer: %i[select_option study_modes locations conditions check] }.freeze
+              change_offer: %i[select_option courses study_modes locations conditions check] }.freeze
 
     attr_accessor :provider_id, :course_id, :course_option_id, :study_mode, :location_id,
                   :standard_conditions, :further_condition_1, :further_condition_2,
@@ -12,6 +12,7 @@ module ProviderInterface
     validates :decision, presence: true
     validates :course_option_id, presence: true, on: :locations
     validates :study_mode, presence: true, on: :study_modes
+    validates :course_id, presence: true, on: :courses
     validates :further_condition_1, :further_condition_2, :further_condition_3, :further_condition_4, length: { maximum: 255 }
 
     def initialize(state_store, attrs = {})

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -2,13 +2,15 @@ module ProviderInterface
   class OfferWizard
     include ActiveModel::Model
 
-    STEPS = { make_offer: %i[select_option conditions check] }.freeze
+    STEPS = { make_offer: %i[select_option conditions check],
+              change_offer: %i[select_option locations conditions check] }.freeze
 
     attr_accessor :provider_id, :course_id, :course_option_id, :study_mode, :location_id,
                   :standard_conditions, :further_condition_1, :further_condition_2,
                   :further_condition_3, :further_condition_4, :current_step, :decision
 
     validates :decision, presence: true
+    validates :course_option_id, presence: true, on: :locations
     validates :further_condition_1, :further_condition_2, :further_condition_3, :further_condition_4, length: { maximum: 255 }
 
     def initialize(state_store, attrs = {})

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -7,7 +7,8 @@ module ProviderInterface
 
     attr_accessor :provider_id, :course_id, :course_option_id, :study_mode, :location_id,
                   :standard_conditions, :further_condition_1, :further_condition_2,
-                  :further_condition_3, :further_condition_4, :current_step, :decision
+                  :further_condition_3, :further_condition_4, :current_step, :decision,
+                  :path_history, :action
 
     validates :decision, presence: true
     validates :course_option_id, presence: true, on: :locations
@@ -19,6 +20,8 @@ module ProviderInterface
       @state_store = state_store
 
       super(last_saved_state.deep_merge(attrs))
+
+      update_path_history(attrs)
     end
 
     def conditions
@@ -55,6 +58,10 @@ module ProviderInterface
       next_step
     end
 
+    def previous_step
+      path_history[path_history.rindex(current_step) - 1]
+    end
+
   private
 
     def save_and_go_to_next_step(step)
@@ -87,6 +94,16 @@ module ProviderInterface
 
     def state
       as_json(except: %w[state_store errors validation_context course_option]).to_json
+    end
+
+    def update_path_history(attrs)
+      @path_history ||= []
+
+      if attrs[:action] == 'back'
+        @path_history.pop
+      elsif attrs.key?(:current_step)
+        @path_history << attrs[:current_step]
+      end
     end
   end
 end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     include ActiveModel::Model
 
     STEPS = { make_offer: %i[select_option conditions check],
-              change_offer: %i[select_option locations conditions check] }.freeze
+              change_offer: %i[select_option study_modes locations conditions check] }.freeze
 
     attr_accessor :provider_id, :course_id, :course_option_id, :study_mode, :location_id,
                   :standard_conditions, :further_condition_1, :further_condition_2,
@@ -11,6 +11,7 @@ module ProviderInterface
 
     validates :decision, presence: true
     validates :course_option_id, presence: true, on: :locations
+    validates :study_mode, presence: true, on: :study_modes
     validates :further_condition_1, :further_condition_2, :further_condition_3, :further_condition_4, length: { maximum: 255 }
 
     def initialize(state_store, attrs = {})

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     include ActiveModel::Model
 
     STEPS = { make_offer: %i[select_option conditions check],
-              change_offer: %i[select_option courses study_modes locations conditions check] }.freeze
+              change_offer: %i[select_option providers courses study_modes locations conditions check] }.freeze
 
     attr_accessor :provider_id, :course_id, :course_option_id, :study_mode, :location_id,
                   :standard_conditions, :further_condition_1, :further_condition_2,

--- a/app/helpers/offer_path_helper.rb
+++ b/app/helpers/offer_path_helper.rb
@@ -1,0 +1,9 @@
+module OfferPathHelper
+  def offer_path_for(application_choice, step, params = {})
+    if step.to_sym == :select_option
+      new_provider_interface_application_choice_decision_path(application_choice, params)
+    else
+      [:new, :provider_interface, application_choice, :offer, step, params]
+    end
+  end
+end

--- a/app/services/wizard_path_history.rb
+++ b/app/services/wizard_path_history.rb
@@ -1,0 +1,29 @@
+class WizardPathHistory
+  class NoSuchStepError < StandardError
+    def message
+      'Invalid wizard step'
+    end
+  end
+
+  attr_accessor :path_history, :step, :action
+
+  def initialize(path_history, step: nil, action: nil)
+    @path_history = path_history || []
+    @step = step
+    @action = action
+  end
+
+  def update
+    if action == 'back'
+      path_history.pop
+    elsif step
+      path_history << step
+    end
+  end
+
+  def previous_step
+    raise NoSuchStepError unless path_history.rindex(step)
+
+    path_history[path_history.rindex(step) - 1]
+  end
+end

--- a/app/views/provider_interface/decisions/new.html.erb
+++ b/app/views/provider_interface/decisions/new.html.erb
@@ -14,9 +14,8 @@
 
       <%= render ProviderInterface::CourseSummaryComponent.new(course_option: @application_choice.course_option) %>
       <%= f.govuk_radio_buttons_fieldset :decision, legend: { size: 'm' } do %>
-        <%= f.govuk_radio_button :decision,
-          'make_offer',
-          link_errors: true %>
+        <%= f.govuk_radio_button :decision, 'make_offer', link_errors: true %>
+        <%= f.govuk_radio_button :decision, 'change_offer' %>
 
         <%= f.govuk_radio_button :decision, 'rejection' %>
       <% end %>

--- a/app/views/provider_interface/offer/checks/new.html.erb
+++ b/app/views/provider_interface/offer/checks/new.html.erb
@@ -13,7 +13,10 @@
       <%= render ProviderInterface::OfferSummaryComponent.new(application_choice: @application_choice,
                                                               course_option: @wizard.course_option,
                                                               conditions: @wizard.conditions,
-                                                              course: @wizard.course_option.course) %>
+                                                              course: @wizard.course_option.course,
+                                                              available_providers: @providers,
+                                                              available_courses: @courses,
+                                                              available_course_options: @course_options) %>
 
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/app/views/provider_interface/offer/checks/new.html.erb
+++ b/app/views/provider_interface/offer/checks/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_new_offer_path(@application_choice.id)) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
 
 <%= form_with model: @wizard, url: provider_interface_application_choice_offers_path(@application_choice), method: :post do |f| %>
   <h1 class="govuk-heading-l">

--- a/app/views/provider_interface/offer/checks/new.html.erb
+++ b/app/views/provider_interface/offer/checks/new.html.erb
@@ -12,7 +12,8 @@
       <%= f.govuk_error_summary %>
       <%= render ProviderInterface::OfferSummaryComponent.new(application_choice: @application_choice,
                                                               course_option: @wizard.course_option,
-                                                              conditions: @wizard.conditions) %>
+                                                              conditions: @wizard.conditions,
+                                                              course: @wizard.course_option.course) %>
 
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/app/views/provider_interface/offer/conditions/new.html.erb
+++ b/app/views/provider_interface/offer/conditions/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, '' %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
 
 <%= form_with model: @wizard, url: provider_interface_application_choice_offer_conditions_path(@application_choice), method: :post do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/provider_interface/offer/conditions/new.html.erb
+++ b/app/views/provider_interface/offer/conditions/new.html.erb
@@ -1,11 +1,11 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_respond_path(@application_choice)) %>
+<% content_for :before_content, '' %>
 
 <%= form_with model: @wizard, url: provider_interface_application_choice_offer_conditions_path(@application_choice), method: :post do |f| %>
   <%= f.govuk_error_summary %>
 
-  <h1 class="govuk-heading-xl">
-    <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
     <%= t('.title') %>
   </h1>
 

--- a/app/views/provider_interface/offer/courses/new.html.erb
+++ b/app/views/provider_interface/offer/courses/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, '' %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
 
 <%= render CollectionSelectComponent.new(attribute: :course_id,
                                          collection: @courses,

--- a/app/views/provider_interface/offer/courses/new.html.erb
+++ b/app/views/provider_interface/offer/courses/new.html.erb
@@ -9,4 +9,8 @@
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_courses_path,
                                          page_title: t('.title'),
-                                         caption: @application_choice.application_form.full_name) %>
+                                         caption: @application_choice.application_form.full_name) do %>
+  <p class="govuk-body">
+    <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice) %>
+  </p>
+<% end %>

--- a/app/views/provider_interface/offer/courses/new.html.erb
+++ b/app/views/provider_interface/offer/courses/new.html.erb
@@ -1,0 +1,8 @@
+<%= render CollectionSelectComponent.new(attribute: :course_id,
+                                         collection: @courses,
+                                         value_method: :id,
+                                         text_method: :name_and_code,
+                                         hint_method: :description,
+                                         form_object: @wizard,
+                                         form_path: provider_interface_application_choice_offer_courses_path,
+                                         page_title: 'Select course') %>

--- a/app/views/provider_interface/offer/courses/new.html.erb
+++ b/app/views/provider_interface/offer/courses/new.html.erb
@@ -5,4 +5,5 @@
                                          hint_method: :description,
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_courses_path,
-                                         page_title: 'Select course') %>
+                                         page_title: 'Select course',
+                                         caption: @application_choice.application_form.full_name) %>

--- a/app/views/provider_interface/offer/courses/new.html.erb
+++ b/app/views/provider_interface/offer/courses/new.html.erb
@@ -1,3 +1,6 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, '' %>
+
 <%= render CollectionSelectComponent.new(attribute: :course_id,
                                          collection: @courses,
                                          value_method: :id,
@@ -5,5 +8,5 @@
                                          hint_method: :description,
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_courses_path,
-                                         page_title: 'Select course',
+                                         page_title: t('.title'),
                                          caption: @application_choice.application_form.full_name) %>

--- a/app/views/provider_interface/offer/locations/new.html.erb
+++ b/app/views/provider_interface/offer/locations/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, '' %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
 
 <%= render CollectionSelectComponent.new(attribute: :course_option_id,
                                          collection: @course_options,

--- a/app/views/provider_interface/offer/locations/new.html.erb
+++ b/app/views/provider_interface/offer/locations/new.html.erb
@@ -5,4 +5,5 @@
                                          hint_method: :site_full_address,
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_locations_path,
-                                         page_title: 'Select location') %>
+                                         page_title: 'Select location',
+                                         caption: @application_choice.application_form.full_name) %>

--- a/app/views/provider_interface/offer/locations/new.html.erb
+++ b/app/views/provider_interface/offer/locations/new.html.erb
@@ -9,4 +9,8 @@
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_locations_path,
                                          page_title: t('.title'),
-                                         caption: @application_choice.application_form.full_name) %>
+                                         caption: @application_choice.application_form.full_name) do %>
+  <p class="govuk-body">
+    <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice) %>
+  </p>
+<% end %>

--- a/app/views/provider_interface/offer/locations/new.html.erb
+++ b/app/views/provider_interface/offer/locations/new.html.erb
@@ -1,0 +1,8 @@
+<%= render CollectionSelectComponent.new(attribute: :course_option_id,
+                                         collection: @course_options,
+                                         value_method: :id,
+                                         text_method: :site_name,
+                                         hint_method: :site_full_address,
+                                         form_object: @wizard,
+                                         form_path: provider_interface_application_choice_offer_locations_path,
+                                         page_title: 'Select location') %>

--- a/app/views/provider_interface/offer/locations/new.html.erb
+++ b/app/views/provider_interface/offer/locations/new.html.erb
@@ -1,3 +1,6 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, '' %>
+
 <%= render CollectionSelectComponent.new(attribute: :course_option_id,
                                          collection: @course_options,
                                          value_method: :id,
@@ -5,5 +8,5 @@
                                          hint_method: :site_full_address,
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_locations_path,
-                                         page_title: 'Select location',
+                                         page_title: t('.title'),
                                          caption: @application_choice.application_form.full_name) %>

--- a/app/views/provider_interface/offer/providers/new.html.erb
+++ b/app/views/provider_interface/offer/providers/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, '' %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
 
 <%= render CollectionSelectComponent.new(attribute: :provider_id,
                                          collection: @providers,

--- a/app/views/provider_interface/offer/providers/new.html.erb
+++ b/app/views/provider_interface/offer/providers/new.html.erb
@@ -1,0 +1,8 @@
+<%= render CollectionSelectComponent.new(attribute: :provider_id,
+                                         collection: @providers,
+                                         value_method: :id,
+                                         text_method: :name_and_code,
+                                         hint_method: nil,
+                                         form_object: @wizard,
+                                         form_path: provider_interface_application_choice_offer_providers_path,
+                                         page_title: 'Select provider') %>

--- a/app/views/provider_interface/offer/providers/new.html.erb
+++ b/app/views/provider_interface/offer/providers/new.html.erb
@@ -9,4 +9,8 @@
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_providers_path,
                                          page_title: t('.title'),
-                                         caption: @application_choice.application_form.full_name) %>
+                                         caption: @application_choice.application_form.full_name) do %>
+  <p class="govuk-body">
+    <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice) %>
+  </p>
+<% end %>

--- a/app/views/provider_interface/offer/providers/new.html.erb
+++ b/app/views/provider_interface/offer/providers/new.html.erb
@@ -1,3 +1,6 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, '' %>
+
 <%= render CollectionSelectComponent.new(attribute: :provider_id,
                                          collection: @providers,
                                          value_method: :id,
@@ -5,5 +8,5 @@
                                          hint_method: nil,
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_providers_path,
-                                         page_title: 'Select provider',
+                                         page_title: t('.title'),
                                          caption: @application_choice.application_form.full_name) %>

--- a/app/views/provider_interface/offer/providers/new.html.erb
+++ b/app/views/provider_interface/offer/providers/new.html.erb
@@ -5,4 +5,5 @@
                                          hint_method: nil,
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_providers_path,
-                                         page_title: 'Select provider') %>
+                                         page_title: 'Select provider',
+                                         caption: @application_choice.application_form.full_name) %>

--- a/app/views/provider_interface/offer/study_modes/new.html.erb
+++ b/app/views/provider_interface/offer/study_modes/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, '' %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
 
 <%= render CollectionSelectComponent.new(attribute: :study_mode,
                                          collection: @study_modes,

--- a/app/views/provider_interface/offer/study_modes/new.html.erb
+++ b/app/views/provider_interface/offer/study_modes/new.html.erb
@@ -9,4 +9,8 @@
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_study_modes_path,
                                          page_title: t('.title'),
-                                         caption: @application_choice.application_form.full_name) %>
+                                         caption: @application_choice.application_form.full_name) do %>
+  <p class="govuk-body">
+    <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice) %>
+  </p>
+<% end %>

--- a/app/views/provider_interface/offer/study_modes/new.html.erb
+++ b/app/views/provider_interface/offer/study_modes/new.html.erb
@@ -1,0 +1,8 @@
+<%= render CollectionSelectComponent.new(attribute: :study_mode,
+                                         collection: @study_modes,
+                                         value_method: :id,
+                                         text_method: :value,
+                                         hint_method: nil,
+                                         form_object: @wizard,
+                                         form_path: provider_interface_application_choice_offer_study_modes_path,
+                                         page_title: 'Select full time or part time') %>

--- a/app/views/provider_interface/offer/study_modes/new.html.erb
+++ b/app/views/provider_interface/offer/study_modes/new.html.erb
@@ -1,3 +1,6 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, '' %>
+
 <%= render CollectionSelectComponent.new(attribute: :study_mode,
                                          collection: @study_modes,
                                          value_method: :id,
@@ -5,5 +8,5 @@
                                          hint_method: nil,
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_study_modes_path,
-                                         page_title: 'Select full time or part time',
+                                         page_title: t('.title'),
                                          caption: @application_choice.application_form.full_name) %>

--- a/app/views/provider_interface/offer/study_modes/new.html.erb
+++ b/app/views/provider_interface/offer/study_modes/new.html.erb
@@ -5,4 +5,5 @@
                                          hint_method: nil,
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_study_modes_path,
-                                         page_title: 'Select full time or part time') %>
+                                         page_title: 'Select full time or part time',
+                                         caption: @application_choice.application_form.full_name) %>

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -43,3 +43,7 @@ en:
           attributes:
             decision:
               blank: Select if you want to make an offer or reject the application
+            course_option_id:
+              blank: Select location
+            study_mode:
+              blank: Select full time or part time

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -33,6 +33,7 @@ en:
       provider_interface_offer_wizard:
         decision_options:
           make_offer: Make an offer
+          change_offer: Change course details and make an offer
           rejection: Reject application
         further_condition_1: 'Condition 1'
         further_condition_2: 'Condition 2'

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -49,3 +49,5 @@ en:
               blank: Select full time or part time
             course_id:
               blank: Select course
+            provider_id:
+              blank: Select provider

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -47,3 +47,5 @@ en:
               blank: Select location
             study_mode:
               blank: Select full time or part time
+            course_id:
+              blank: Select course

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -5,6 +5,18 @@ en:
         title: Make a decision
         select:  Select decision
     offer:
+      providers:
+        new:
+          title: Select provider
+      courses:
+        new:
+          title: Select course
+      locations:
+        new:
+          title: Select location
+      study_modes:
+        new:
+          title: Select full time or part time
       conditions:
         new:
           title: Conditions of offer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -638,6 +638,7 @@ Rails.application.routes.draw do
       resource :offers, only: %i[create], as: :application_choice_offers
 
       namespace :offer, as: :application_choice_offer do
+        resource :providers, only: %i[new create]
         resource :courses, only: %i[new create]
         resource :locations, only: %i[new create]
         resource :study_modes, only: %i[new create], path: 'study-modes'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -638,6 +638,7 @@ Rails.application.routes.draw do
       resource :offers, only: %i[create], as: :application_choice_offers
 
       namespace :offer, as: :application_choice_offer do
+        resource :courses, only: %i[new create]
         resource :locations, only: %i[new create]
         resource :study_modes, only: %i[new create], path: 'study-modes'
         resource :conditions, only: %i[new create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -639,6 +639,7 @@ Rails.application.routes.draw do
 
       namespace :offer, as: :application_choice_offer do
         resource :locations, only: %i[new create]
+        resource :study_modes, only: %i[new create], path: 'study-modes'
         resource :conditions, only: %i[new create]
         resource :check, only: %i[new]
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -638,6 +638,7 @@ Rails.application.routes.draw do
       resource :offers, only: %i[create], as: :application_choice_offers
 
       namespace :offer, as: :application_choice_offer do
+        resource :locations, only: %i[new create]
         resource :conditions, only: %i[new create]
         resource :check, only: %i[new]
       end

--- a/spec/components/provider_interface/offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/offer_summary_component_spec.rb
@@ -3,10 +3,18 @@ require 'rails_helper'
 RSpec.describe ProviderInterface::OfferSummaryComponent do
   let(:application_choice) { build_stubbed(:application_choice) }
   let(:course_option) { build_stubbed(:course_option) }
+  let(:providers) { [] }
+  let(:course) { build_stubbed(:course) }
+  let(:courses) { [] }
+  let(:course_options) { [] }
   let(:render) do
     render_inline(described_class.new(application_choice: application_choice,
                                       course_option: course_option,
-                                      conditions: ['condition 1', 'condition 2']))
+                                      conditions: ['condition 1', 'condition 2'],
+                                      available_providers: providers,
+                                      available_courses: courses,
+                                      available_course_options: course_options,
+                                      course: course))
   end
 
   def row_text_selector(row_name, render)
@@ -18,6 +26,78 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
     }
 
     render.css('.govuk-summary-list__row')[rows[row_name]].text
+  end
+
+  def row_link_selector(row_number)
+    render.css('.govuk-summary-list__row')[row_number].css('a')&.first&.attr('href')
+  end
+
+  context 'when multiple provider options' do
+    let(:providers) { build_stubbed_list(:provider, 2) }
+
+    it 'renders a change link' do
+      provider_change_link = Rails.application.routes.url_helpers.new_provider_interface_application_choice_offer_providers_path(application_choice)
+      expect(row_link_selector(0)).to eq(provider_change_link)
+    end
+  end
+
+  context 'when only one provider option' do
+    let(:providers) { [build_stubbed(:provider)] }
+
+    it 'renders no change link' do
+      expect(row_link_selector(0)).to eq(nil)
+    end
+  end
+
+  context 'when multiple courses' do
+    let(:courses) { build_stubbed_list(:course, 2) }
+
+    it 'renders a change link' do
+      course_change_link = Rails.application.routes.url_helpers.new_provider_interface_application_choice_offer_courses_path(application_choice)
+      expect(row_link_selector(1)).to eq(course_change_link)
+    end
+  end
+
+  context 'when only one course' do
+    let(:courses) { [build_stubbed(:course)] }
+
+    it 'renders no change link' do
+      expect(row_link_selector(1)).to eq(nil)
+    end
+  end
+
+  context 'when multiple course options' do
+    let(:course_options) { build_stubbed_list(:course_option, 2) }
+
+    it 'renders a change link' do
+      course_options_change_link = Rails.application.routes.url_helpers.new_provider_interface_application_choice_offer_locations_path(application_choice)
+      expect(row_link_selector(2)).to eq(course_options_change_link)
+    end
+  end
+
+  context 'when only one course option' do
+    let(:course_options) { [build_stubbed(:course_option)] }
+
+    it 'renders no change link' do
+      expect(row_link_selector(2)).to eq(nil)
+    end
+  end
+
+  context 'when multiple study modes' do
+    let(:course) { build_stubbed(:course, study_mode: :full_time_or_part_time) }
+
+    it 'renders a change link' do
+      study_mode_change_link = Rails.application.routes.url_helpers.new_provider_interface_application_choice_offer_study_modes_path(application_choice)
+      expect(row_link_selector(3)).to eq(study_mode_change_link)
+    end
+  end
+
+  context 'when only one study mode' do
+    let(:course) { build_stubbed(:course, study_mode: :full_time) }
+
+    it 'renders no change link' do
+      expect(row_link_selector(3)).to eq(nil)
+    end
   end
 
   it 'renders the new course option details' do

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -44,11 +44,63 @@ RSpec.describe ProviderInterface::OfferWizard do
   end
 
   describe '#next_step' do
-    context 'make offer decision' do
+    context 'when making an offer' do
       let(:decision) { :make_offer }
 
       context 'when current_step is :select_option' do
         let(:current_step) { :select_option }
+
+        it 'returns :conditions' do
+          expect(wizard.next_step).to eq(:conditions)
+        end
+      end
+
+      context 'when current_step is :conditions' do
+        let(:current_step) { :conditions }
+
+        it 'returns :conditions' do
+          expect(wizard.next_step).to eq(:check)
+        end
+      end
+    end
+
+    context 'when changing an offer' do
+      let(:decision) { :change_offer }
+
+      context 'when current_step is :select_option' do
+        let(:current_step) { :select_option }
+
+        it 'returns :providers' do
+          expect(wizard.next_step).to eq(:providers)
+        end
+      end
+
+      context 'when current_step is :providers' do
+        let(:current_step) { :providers }
+
+        it 'returns :courses' do
+          expect(wizard.next_step).to eq(:courses)
+        end
+      end
+
+      context 'when current_step is :courses' do
+        let(:current_step) { :courses }
+
+        it 'returns :study_modes' do
+          expect(wizard.next_step).to eq(:study_modes)
+        end
+      end
+
+      context 'when current_step is :study_modes' do
+        let(:current_step) { :study_modes }
+
+        it 'returns :locations' do
+          expect(wizard.next_step).to eq(:locations)
+        end
+      end
+
+      context 'when current_step is :locations' do
+        let(:current_step) { :locations }
 
         it 'returns :conditions' do
           expect(wizard.next_step).to eq(:conditions)

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -205,14 +205,7 @@ RSpec.describe ProviderInterface::OfferWizard do
   end
 
   describe '#previous_step' do
-    before do
-      wizard.path_history = %i[provider courses locations]
-      wizard.current_step = :locations
-    end
-
-    it 'returns the step before the current_step' do
-      expect(wizard.previous_step).to eq(:courses)
-    end
+    it { is_expected.to delegate_method(:previous_step).to(:wizard_path_history) }
   end
 
   describe '#conditions' do

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe ProviderInterface::OfferWizard do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:decision) }
     it { is_expected.to validate_presence_of(:course_option_id).on(:locations) }
+    it { is_expected.to validate_presence_of(:study_mode).on(:study_modes) }
     it { is_expected.to validate_length_of(:further_condition_1).is_at_most(255) }
     it { is_expected.to validate_length_of(:further_condition_2).is_at_most(255) }
     it { is_expected.to validate_length_of(:further_condition_3).is_at_most(255) }

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe ProviderInterface::OfferWizard do
     it { is_expected.to validate_presence_of(:decision) }
     it { is_expected.to validate_presence_of(:course_option_id).on(:locations) }
     it { is_expected.to validate_presence_of(:study_mode).on(:study_modes) }
+    it { is_expected.to validate_presence_of(:course_id).on(:courses) }
     it { is_expected.to validate_length_of(:further_condition_1).is_at_most(255) }
     it { is_expected.to validate_length_of(:further_condition_2).is_at_most(255) }
     it { is_expected.to validate_length_of(:further_condition_3).is_at_most(255) }

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -183,6 +183,17 @@ RSpec.describe ProviderInterface::OfferWizard do
     end
   end
 
+  describe '#previous_step' do
+    before do
+      wizard.path_history = %i[provider courses locations]
+      wizard.current_step = :locations
+    end
+
+    it 'returns the step before the current_step' do
+      expect(wizard.previous_step).to eq(:courses)
+    end
+  end
+
   describe '#conditions' do
     let(:standard_conditions) { ['', MakeAnOffer::STANDARD_CONDITIONS.last] }
     let(:further_condition_3) { 'They must graduate from their current course with an Honors' }

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe ProviderInterface::OfferWizard do
   before { allow(store).to receive(:read) }
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:decision) }
-    it { is_expected.to validate_presence_of(:course_option_id).on(:locations) }
-    it { is_expected.to validate_presence_of(:study_mode).on(:study_modes) }
-    it { is_expected.to validate_presence_of(:course_id).on(:courses) }
+    it { is_expected.to validate_presence_of(:decision).on(:select_option) }
+    it { is_expected.to validate_presence_of(:course_option_id).on(:locations).on(:save) }
+    it { is_expected.to validate_presence_of(:study_mode).on(:study_modes).on(:save) }
+    it { is_expected.to validate_presence_of(:course_id).on(:courses).on(:save) }
     it { is_expected.to validate_length_of(:further_condition_1).is_at_most(255) }
     it { is_expected.to validate_length_of(:further_condition_2).is_at_most(255) }
     it { is_expected.to validate_length_of(:further_condition_3).is_at_most(255) }

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe ProviderInterface::OfferWizard do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:decision) }
+    it { is_expected.to validate_presence_of(:course_option_id).on(:locations) }
     it { is_expected.to validate_length_of(:further_condition_1).is_at_most(255) }
     it { is_expected.to validate_length_of(:further_condition_2).is_at_most(255) }
     it { is_expected.to validate_length_of(:further_condition_3).is_at_most(255) }

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -70,8 +70,29 @@ RSpec.describe ProviderInterface::OfferWizard do
       context 'when current_step is :select_option' do
         let(:current_step) { :select_option }
 
-        it 'returns :providers' do
-          expect(wizard.next_step).to eq(:providers)
+        context 'when there are multiple available providers' do
+          before do
+            provider_user = instance_double(ProviderUser, providers: build_stubbed_list(:provider, 2))
+            allow(ProviderUser).to receive(:find).and_return(provider_user)
+          end
+
+          it 'returns :providers' do
+            expect(wizard.next_step).to eq(:providers)
+          end
+        end
+
+        context 'when there is only one available provider' do
+          before do
+            courses = build_stubbed_list(:course, 2)
+            provider = instance_double(Provider, id: :stub_id, courses: courses)
+            provider_user = instance_double(ProviderUser, providers: [provider])
+            allow(ProviderUser).to receive(:find).and_return(provider_user)
+            allow(store).to receive(:write)
+          end
+
+          it 'returns :courses' do
+            expect(wizard.next_step).to eq(:courses)
+          end
         end
       end
 

--- a/spec/helpers/offer_path_helper_spec.rb
+++ b/spec/helpers/offer_path_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe OfferPathHelper do
+  let(:application_choice) { build_stubbed(:application_choice) }
+
+  describe '#offer_path_for' do
+    context 'when :select_option' do
+      it 'returns the decision path' do
+        expect(helper.offer_path_for(application_choice, 'select_option'))
+          .to eq(new_provider_interface_application_choice_decision_path(application_choice, {}))
+      end
+    end
+
+    context 'when any other step' do
+      it 'returns the step based path' do
+        expect(helper.offer_path_for(application_choice, :other_step))
+          .to eq([:new, :provider_interface, application_choice, :offer, :other_step, {}])
+      end
+    end
+  end
+end

--- a/spec/services/wizard_path_history_spec.rb
+++ b/spec/services/wizard_path_history_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe WizardPathHistory do
+  describe '#initialize' do
+    context 'when no path_history is set' do
+      it 'initializes it to an empty array' do
+        service = described_class.new(nil)
+
+        expect(service.path_history).to eq([])
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:service) { described_class.new(%i[step1 step2], step: step, action: action) }
+
+    context 'when action is `back`' do
+      let(:action) { 'back' }
+      let(:step) { nil }
+
+      it 'removes and returns the last item of path_history' do
+        service = described_class.new(%i[step1 step2], action: 'back')
+
+        expect(service.update).to eq(:step2)
+        expect(service.path_history).to eq([:step1])
+      end
+    end
+
+    context 'when action is not `back` and step is provided' do
+      let(:action) { nil }
+      let(:step) { :step3 }
+
+      it 'appends the step to the path_history' do
+        service.update
+
+        expect(service.path_history).to eq(%i[step1 step2 step3])
+      end
+    end
+  end
+
+  describe '#previous_step' do
+    let(:service) { described_class.new(%i[step1 step2 step3 step2], step: step, action: 'back') }
+
+    context 'when an invalid step is specified' do
+      let(:step) { :step }
+
+      it 'raises a NoSuchStepError' do
+        expect { service.previous_step }.to raise_error(WizardPathHistory::NoSuchStepError)
+      end
+    end
+
+    context 'when a step is specified' do
+      let(:step) { :step2 }
+
+      it 'returns the latest previous step' do
+        expect(service.previous_step).to eq(:step3)
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/change_make_offer_spec.rb
+++ b/spec/system/provider_interface/change_make_offer_spec.rb
@@ -1,0 +1,185 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider makes an offer' do
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
+  let(:provider) { provider_user.providers.first }
+  let(:application_form) { build(:application_form, :minimum_info) }
+  let!(:application_choice) do
+    create(:application_choice, :awaiting_provider_decision,
+           application_form: application_form,
+           course_option: course_option)
+  end
+  let(:course) { build(:course, :open_on_apply, :full_time, provider: provider) }
+  let(:course_option) { build(:course_option, course: course) }
+
+  before do
+    FeatureFlag.activate(:updated_offer_flow)
+  end
+
+  scenario 'Making an offer for the requested course option' do
+    given_i_am_a_provider_user
+    and_i_am_permitted_to_make_decisions_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+
+    given_the_provider_user_can_offer_multiple_provider_courses
+
+    when_i_visit_the_provider_interface
+    and_i_click_an_application_choice_awaiting_decision
+    and_i_click_on_make_decision
+    then_i_see_the_decision_page
+
+    when_i_choose_to_change_and_make_an_offer
+    then_i_am_taken_to_the_change_provider_page
+
+    when_i_select_a_different_provider
+    and_i_click_continue
+
+    when_i_select_a_different_course
+    and_i_click_continue
+
+    when_i_select_a_different_study_mode
+    and_i_click_continue
+
+    when_i_select_a_new_location
+    and_i_click_continue
+
+    then_the_conditions_page_is_loaded
+    and_i_click_continue
+
+    then_the_review_page_is_loaded
+    and_i_can_confirm_the_changed_offer_details
+
+    when_i_send_the_offer
+    then_i_see_that_the_offer_was_successfuly_made
+  end
+
+  def given_i_am_a_provider_user
+    user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+  end
+
+  def and_i_am_permitted_to_make_decisions_for_my_provider
+    permit_make_decisions!
+  end
+
+  def and_i_sign_in_to_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def when_i_visit_the_provider_interface
+    visit provider_interface_applications_path
+  end
+
+  def and_i_click_an_application_choice_awaiting_decision
+    click_on application_choice.application_form.full_name
+  end
+
+  def and_i_click_on_make_decision
+    click_on 'Make decision'
+  end
+
+  def then_i_see_the_decision_page
+    expect(page).to have_content('Make a decision')
+    expect(page).to have_content('Course applied for')
+  end
+
+  def when_i_choose_to_change_and_make_an_offer
+    choose 'Change course details and make an offer'
+    and_i_click_continue
+  end
+
+  def then_the_conditions_page_is_loaded
+    expect(page).to have_content('Conditions of offer')
+  end
+
+  def and_the_default_conditions_are_checked
+    expect(find("input[value='Fitness to train to teach check']")).to be_checked
+    expect(find("input[value='Disclosure and Barring Service (DBS) check']")).to be_checked
+  end
+
+  def when_i_add_further_conditions
+    fill_in('provider_interface_offer_wizard[further_condition_1]', with: 'A* on Maths A Level')
+  end
+
+  def and_i_click_continue
+    click_on t('continue')
+  end
+
+  def then_the_review_page_is_loaded
+    expect(page).to have_content('Check and send offer')
+  end
+
+  def and_i_can_confirm_my_answers
+    within('.app-offer-panel') do
+      expect(page).to have_content('A* on Maths A Level')
+    end
+  end
+
+  def then_i_am_taken_to_the_change_location_page
+    expect(page).to have_content('Select location')
+  end
+
+  def when_i_select_a_new_location
+    choose @selected_course_option.site_name
+  end
+
+  def then_i_am_taken_to_the_change_study_mode_page
+    expect(page).to have_content('Select study mode')
+  end
+
+  def when_i_select_a_different_study_mode
+    choose @selected_course_option.study_mode.humanize
+  end
+
+  def when_i_select_a_different_course
+    choose @selected_course.name_and_code
+  end
+
+  def then_i_am_taken_to_the_change_course_page
+    expect(page).to have_content('Select course')
+  end
+
+  def given_the_provider_user_can_offer_multiple_provider_courses
+    @selected_provider = create(:provider, :with_signed_agreement)
+    create(:provider_permissions, provider: @selected_provider, provider_user: provider_user, make_decisions: true)
+    courses = [create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider),
+               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider)]
+    @selected_course = courses.sample
+
+    course_options = [create(:course_option, :part_time, course: @selected_course),
+                      create(:course_option, :full_time, course: @selected_course),
+                      create(:course_option, :full_time, course: @selected_course),
+                      create(:course_option, :part_time, course: @selected_course)]
+
+    @selected_course_option = course_options.sample
+  end
+
+  def then_i_am_taken_to_the_change_provider_page
+    expect(page).to have_content('Select provider')
+  end
+
+  def when_i_select_a_different_provider
+    choose @selected_provider.name_and_code
+  end
+
+  def and_i_can_confirm_the_changed_offer_details
+    within('.app-summary-card__body') do
+      expect(page).to have_content(@selected_provider.name_and_code)
+      expect(page).to have_content(@selected_course.name_and_code)
+      expect(page).to have_content(@selected_course_option.study_mode.humanize)
+      expect(page).to have_content(@selected_course_option.site.name_and_address)
+    end
+  end
+
+  def when_i_send_the_offer
+    click_on 'Send offer'
+  end
+
+  def then_i_see_that_the_offer_was_successfuly_made
+    within('.govuk-notification-banner--success') do
+      expect(page).to have_content('Offer sent')
+    end
+  end
+end

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -92,6 +92,33 @@ RSpec.feature 'Provider makes an offer' do
     and_i_can_confirm_the_new_study_mode_selection
     and_i_can_confirm_the_new_location_selection
 
+    # provider
+
+    given_the_provider_user_can_offer_multiple_provider_courses
+    when_i_click_change_provider
+    then_i_am_taken_to_the_change_provider_page
+
+    when_i_select_a_different_provider
+    and_i_click_continue
+
+    when_i_select_a_different_course
+    and_i_click_continue
+
+    when_i_select_a_different_study_mode
+    and_i_click_continue
+
+    when_i_select_a_new_location
+    and_i_click_continue
+
+    then_the_conditions_page_is_loaded
+    and_i_click_continue
+    then_the_review_page_is_loaded
+
+    and_i_can_confirm_the_new_provider_selection
+    and_i_can_confirm_the_new_course_selection
+    and_i_can_confirm_the_new_study_mode_selection
+    and_i_can_confirm_the_new_location_selection
+
     when_i_send_the_offer
     then_i_see_that_the_offer_was_successfuly_made
   end
@@ -237,6 +264,41 @@ RSpec.feature 'Provider makes an offer' do
   def and_i_can_confirm_the_new_course_selection
     within(:xpath, "////div[@class='govuk-summary-list__row'][2]") do
       expect(page).to have_content(@selected_course.name_and_code)
+    end
+  end
+
+  def given_the_provider_user_can_offer_multiple_provider_courses
+    @selected_provider = create(:provider, :with_signed_agreement)
+    create(:provider_permissions, provider: @selected_provider, provider_user: provider_user, make_decisions: true)
+    courses = [create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider),
+               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider)]
+    @selected_course = courses.sample
+
+    course_options = [create(:course_option, :part_time, course: @selected_course),
+                      create(:course_option, :full_time, course: @selected_course),
+                      create(:course_option, :full_time, course: @selected_course),
+                      create(:course_option, :part_time, course: @selected_course)]
+
+    @selected_course_option = course_options.sample
+  end
+
+  def when_i_click_change_provider
+    within(:xpath, "////div[@class='govuk-summary-list__row'][1]") do
+      click_on 'Change'
+    end
+  end
+
+  def then_i_am_taken_to_the_change_provider_page
+    expect(page).to have_content('Select provider')
+  end
+
+  def when_i_select_a_different_provider
+    choose @selected_provider.name_and_code
+  end
+
+  def and_i_can_confirm_the_new_provider_selection
+    within(:xpath, "////div[@class='govuk-summary-list__row'][1]") do
+      expect(page).to have_content(@selected_provider.name_and_code)
     end
   end
 

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -24,9 +24,7 @@ RSpec.feature 'Provider makes an offer' do
     and_i_am_permitted_to_make_decisions_for_my_provider
     and_i_sign_in_to_the_provider_interface
 
-    given_the_course_has_multiple_course_options
-    given_the_course_has_course_options_with_both_study_modes
-    given_the_selected_provider_has_multiple_courses
+    given_the_provider_has_multiple_courses
     given_the_provider_user_can_offer_multiple_provider_courses
 
     when_i_visit_the_provider_interface
@@ -43,51 +41,12 @@ RSpec.feature 'Provider makes an offer' do
     then_the_review_page_is_loaded
     and_i_can_confirm_my_answers
 
-    # locations
-    when_i_click_change_location
-    then_i_am_taken_to_the_change_location_page
-
-    when_i_select_a_new_location
-    and_i_click_continue
-
-    then_the_conditions_page_is_loaded
-    and_i_click_continue
-    then_the_review_page_is_loaded
-    and_i_can_confirm_the_new_location_selection
-
-    # study mode
-    given_the_course_has_course_options_with_both_study_modes
-    when_i_click_change_study_mode
-    then_i_am_taken_to_the_change_study_mode_page
-
-    when_i_select_a_different_study_mode
-    and_i_click_continue
-
-    when_i_select_a_new_location
-    and_i_click_continue
-
-    then_the_conditions_page_is_loaded
-    and_i_click_continue
-    then_the_review_page_is_loaded
-
-    and_i_can_confirm_the_new_study_mode_selection
-    and_i_can_confirm_the_new_location_selection
-
-    # course
-
-    given_the_selected_provider_has_multiple_courses
     when_i_click_change_course
     then_i_am_taken_to_the_change_course_page
-
-    when_i_select_a_different_course
+    when_i_select_a_course_with_one_study_mode
     and_i_click_continue
-
-    when_i_select_a_different_study_mode
-    and_i_click_continue
-
     when_i_select_a_new_location
     and_i_click_continue
-
     then_the_conditions_page_is_loaded
     and_i_click_continue
     then_the_review_page_is_loaded
@@ -96,24 +55,17 @@ RSpec.feature 'Provider makes an offer' do
     and_i_can_confirm_the_new_study_mode_selection
     and_i_can_confirm_the_new_location_selection
 
-    # provider
-
-    given_the_provider_user_can_offer_multiple_provider_courses
     when_i_click_change_provider
     then_i_am_taken_to_the_change_provider_page
 
     when_i_select_a_different_provider
     and_i_click_continue
-
     when_i_select_a_different_course
     and_i_click_continue
-
     when_i_select_a_different_study_mode
     and_i_click_continue
-
     when_i_select_a_new_location
     and_i_click_continue
-
     then_the_conditions_page_is_loaded
     and_i_click_continue
     then_the_review_page_is_loaded
@@ -188,23 +140,6 @@ RSpec.feature 'Provider makes an offer' do
     end
   end
 
-  def given_the_course_has_multiple_course_options
-    course_options = create_list(:course_option, 3, :full_time, course: course)
-    @course_available_course_option = course_options.sample
-  end
-
-  def when_i_click_change_location
-    @selected_course_option = @course_available_course_option
-
-    within(:xpath, "////div[@class='govuk-summary-list__row'][3]") do
-      click_on 'Change'
-    end
-  end
-
-  def then_i_am_taken_to_the_change_location_page
-    expect(page).to have_content('Select location')
-  end
-
   def when_i_select_a_new_location
     choose @selected_course_option.site_name
   end
@@ -213,26 +148,6 @@ RSpec.feature 'Provider makes an offer' do
     within(:xpath, "////div[@class='govuk-summary-list__row'][3]") do
       expect(page).to have_content(@selected_course_option.site.name_and_address)
     end
-  end
-
-  def when_i_click_change_study_mode
-    @selected_course_option = @study_mode_course_option
-
-    within(:xpath, "////div[@class='govuk-summary-list__row'][4]") do
-      click_on 'Change'
-    end
-  end
-
-  def given_the_course_has_course_options_with_both_study_modes
-    course_options = [create(:course_option, :part_time, course: course),
-                      create(:course_option, :full_time, course: course)]
-    course.update(study_mode: :full_time_or_part_time)
-
-    @study_mode_course_option = course_options.first
-  end
-
-  def then_i_am_taken_to_the_change_study_mode_page
-    expect(page).to have_content('Select full time or part time')
   end
 
   def when_i_select_a_different_study_mode
@@ -245,12 +160,12 @@ RSpec.feature 'Provider makes an offer' do
     end
   end
 
-  def given_the_selected_provider_has_multiple_courses
-    @provider_available_course = create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: provider)
-    course_options = [create(:course_option, :part_time, course: @provider_available_course),
+  def given_the_provider_has_multiple_courses
+    @provider_available_course = create(:course, :open_on_apply, study_mode: :full_time, provider: provider)
+    create(:course, :open_on_apply, provider: provider)
+    course_options = [create(:course_option, :full_time, course: @provider_available_course),
                       create(:course_option, :full_time, course: @provider_available_course),
-                      create(:course_option, :full_time, course: @provider_available_course),
-                      create(:course_option, :part_time, course: @provider_available_course)]
+                      create(:course_option, :full_time, course: @provider_available_course)]
 
     @provider_available_course_option = course_options.sample
   end
@@ -258,6 +173,8 @@ RSpec.feature 'Provider makes an offer' do
   def when_i_select_a_different_course
     choose @selected_course.name_and_code
   end
+
+  alias_method :when_i_select_a_course_with_one_study_mode, :when_i_select_a_different_course
 
   def when_i_click_change_course
     @selected_course = @provider_available_course
@@ -283,20 +200,20 @@ RSpec.feature 'Provider makes an offer' do
     create(:provider_permissions, provider: @available_provider, provider_user: provider_user, make_decisions: true)
     courses = [create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider),
                create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider)]
-    @provider_available_course = courses.sample
+    @selected_provider_available_course = courses.sample
 
-    course_options = [create(:course_option, :part_time, course: @provider_available_course),
-                      create(:course_option, :full_time, course: @provider_available_course),
-                      create(:course_option, :full_time, course: @provider_available_course),
-                      create(:course_option, :part_time, course: @provider_available_course)]
+    course_options = [create(:course_option, :part_time, course: @selected_provider_available_course),
+                      create(:course_option, :full_time, course: @selected_provider_available_course),
+                      create(:course_option, :full_time, course: @selected_provider_available_course),
+                      create(:course_option, :part_time, course: @selected_provider_available_course)]
 
-    @provider_available_course_option = course_options.sample
+    @selected_provider_available_course_option = course_options.sample
   end
 
   def when_i_click_change_provider
     @selected_provider = @available_provider
-    @selected_course = @provider_available_course
-    @selected_course_option = @provider_available_course_option
+    @selected_course = @selected_provider_available_course
+    @selected_course_option = @selected_provider_available_course_option
 
     within(:xpath, "////div[@class='govuk-summary-list__row'][1]") do
       click_on 'Change'

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -38,6 +38,19 @@ RSpec.feature 'Provider makes an offer' do
     then_the_review_page_is_loaded
     and_i_can_confirm_my_answers
 
+    given_the_course_has_multiple_course_options
+    when_i_click_change_location
+    then_i_am_taken_to_the_change_location_page
+
+    when_i_select_a_new_location
+    and_i_click_continue
+
+    #common steps, will be repeated every time we go back
+    then_the_conditions_page_is_loaded
+    and_i_click_continue
+    then_the_review_page_is_loaded
+    and_i_can_confirm_the_new_location_selection
+
     when_i_send_the_offer
     then_i_see_that_the_offer_was_successfuly_made
   end
@@ -100,6 +113,31 @@ RSpec.feature 'Provider makes an offer' do
   def and_i_can_confirm_my_answers
     within('.app-offer-panel') do
       expect(page).to have_content('A* on Maths A Level')
+    end
+  end
+
+  def given_the_course_has_multiple_course_options
+    course_options = create_list(:course_option, 3, course: course)
+    @selected_course_option = course_options.sample
+  end
+
+  def when_i_click_change_location
+    within(:xpath, "////div[@class='govuk-summary-list__row'][3]") do
+      click_on 'Change'
+    end
+  end
+
+  def then_i_am_taken_to_the_change_location_page
+    expect(page).to have_content('Select location')
+  end
+
+  def when_i_select_a_new_location
+    choose @selected_course_option.site_name
+  end
+
+  def and_i_can_confirm_the_new_location_selection
+    within(:xpath, "////div[@class='govuk-summary-list__row'][3]") do
+      expect(page).to have_content(@selected_course_option.site.name_and_address)
     end
   end
 

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -24,6 +24,11 @@ RSpec.feature 'Provider makes an offer' do
     and_i_am_permitted_to_make_decisions_for_my_provider
     and_i_sign_in_to_the_provider_interface
 
+    given_the_course_has_multiple_course_options
+    given_the_course_has_course_options_with_both_study_modes
+    given_the_selected_provider_has_multiple_courses
+    given_the_provider_user_can_offer_multiple_provider_courses
+
     when_i_visit_the_provider_interface
     and_i_click_an_application_choice_awaiting_decision
     and_i_click_on_make_decision
@@ -39,7 +44,6 @@ RSpec.feature 'Provider makes an offer' do
     and_i_can_confirm_my_answers
 
     # locations
-    given_the_course_has_multiple_course_options
     when_i_click_change_location
     then_i_am_taken_to_the_change_location_page
 
@@ -186,10 +190,12 @@ RSpec.feature 'Provider makes an offer' do
 
   def given_the_course_has_multiple_course_options
     course_options = create_list(:course_option, 3, :full_time, course: course)
-    @selected_course_option = course_options.sample
+    @course_available_course_option = course_options.sample
   end
 
   def when_i_click_change_location
+    @selected_course_option = @course_available_course_option
+
     within(:xpath, "////div[@class='govuk-summary-list__row'][3]") do
       click_on 'Change'
     end
@@ -210,6 +216,8 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def when_i_click_change_study_mode
+    @selected_course_option = @study_mode_course_option
+
     within(:xpath, "////div[@class='govuk-summary-list__row'][4]") do
       click_on 'Change'
     end
@@ -220,7 +228,7 @@ RSpec.feature 'Provider makes an offer' do
                       create(:course_option, :full_time, course: course)]
     course.update(study_mode: :full_time_or_part_time)
 
-    @selected_course_option = course_options.first
+    @study_mode_course_option = course_options.first
   end
 
   def then_i_am_taken_to_the_change_study_mode_page
@@ -238,13 +246,13 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def given_the_selected_provider_has_multiple_courses
-    @selected_course = create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: provider)
-    course_options = [create(:course_option, :part_time, course: @selected_course),
-                      create(:course_option, :full_time, course: @selected_course),
-                      create(:course_option, :full_time, course: @selected_course),
-                      create(:course_option, :part_time, course: @selected_course)]
+    @provider_available_course = create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: provider)
+    course_options = [create(:course_option, :part_time, course: @provider_available_course),
+                      create(:course_option, :full_time, course: @provider_available_course),
+                      create(:course_option, :full_time, course: @provider_available_course),
+                      create(:course_option, :part_time, course: @provider_available_course)]
 
-    @selected_course_option = course_options.sample
+    @provider_available_course_option = course_options.sample
   end
 
   def when_i_select_a_different_course
@@ -252,6 +260,9 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def when_i_click_change_course
+    @selected_course = @provider_available_course
+    @selected_course_option = @provider_available_course_option
+
     within(:xpath, "////div[@class='govuk-summary-list__row'][2]") do
       click_on 'Change'
     end
@@ -268,21 +279,25 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def given_the_provider_user_can_offer_multiple_provider_courses
-    @selected_provider = create(:provider, :with_signed_agreement)
-    create(:provider_permissions, provider: @selected_provider, provider_user: provider_user, make_decisions: true)
-    courses = [create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider),
-               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider)]
-    @selected_course = courses.sample
+    @available_provider = create(:provider, :with_signed_agreement)
+    create(:provider_permissions, provider: @available_provider, provider_user: provider_user, make_decisions: true)
+    courses = [create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider),
+               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider)]
+    @provider_available_course = courses.sample
 
-    course_options = [create(:course_option, :part_time, course: @selected_course),
-                      create(:course_option, :full_time, course: @selected_course),
-                      create(:course_option, :full_time, course: @selected_course),
-                      create(:course_option, :part_time, course: @selected_course)]
+    course_options = [create(:course_option, :part_time, course: @provider_available_course),
+                      create(:course_option, :full_time, course: @provider_available_course),
+                      create(:course_option, :full_time, course: @provider_available_course),
+                      create(:course_option, :part_time, course: @provider_available_course)]
 
-    @selected_course_option = course_options.sample
+    @provider_available_course_option = course_options.sample
   end
 
   def when_i_click_change_provider
+    @selected_provider = @available_provider
+    @selected_course = @provider_available_course
+    @selected_course_option = @provider_available_course_option
+
     within(:xpath, "////div[@class='govuk-summary-list__row'][1]") do
       click_on 'Change'
     end

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -38,6 +38,7 @@ RSpec.feature 'Provider makes an offer' do
     then_the_review_page_is_loaded
     and_i_can_confirm_my_answers
 
+    # locations
     given_the_course_has_multiple_course_options
     when_i_click_change_location
     then_i_am_taken_to_the_change_location_page
@@ -45,12 +46,12 @@ RSpec.feature 'Provider makes an offer' do
     when_i_select_a_new_location
     and_i_click_continue
 
-    #common steps, will be repeated every time we go back
     then_the_conditions_page_is_loaded
     and_i_click_continue
     then_the_review_page_is_loaded
     and_i_can_confirm_the_new_location_selection
 
+    # study mode
     given_the_course_has_course_options_with_both_study_modes
     when_i_click_change_study_mode
     then_i_am_taken_to_the_change_study_mode_page
@@ -65,6 +66,29 @@ RSpec.feature 'Provider makes an offer' do
     and_i_click_continue
     then_the_review_page_is_loaded
 
+    and_i_can_confirm_the_new_study_mode_selection
+    and_i_can_confirm_the_new_location_selection
+
+    # course
+
+    given_the_selected_provider_has_multiple_courses
+    when_i_click_change_course
+    then_i_am_taken_to_the_change_course_page
+
+    when_i_select_a_different_course
+    and_i_click_continue
+
+    when_i_select_a_different_study_mode
+    and_i_click_continue
+
+    when_i_select_a_new_location
+    and_i_click_continue
+
+    then_the_conditions_page_is_loaded
+    and_i_click_continue
+    then_the_review_page_is_loaded
+
+    and_i_can_confirm_the_new_course_selection
     and_i_can_confirm_the_new_study_mode_selection
     and_i_can_confirm_the_new_location_selection
 
@@ -183,6 +207,36 @@ RSpec.feature 'Provider makes an offer' do
   def and_i_can_confirm_the_new_study_mode_selection
     within(:xpath, "////div[@class='govuk-summary-list__row'][4]") do
       expect(page).to have_content(@selected_course_option.study_mode.humanize)
+    end
+  end
+
+  def given_the_selected_provider_has_multiple_courses
+    @selected_course = create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: provider)
+    course_options = [create(:course_option, :part_time, course: @selected_course),
+                      create(:course_option, :full_time, course: @selected_course),
+                      create(:course_option, :full_time, course: @selected_course),
+                      create(:course_option, :part_time, course: @selected_course)]
+
+    @selected_course_option = course_options.sample
+  end
+
+  def when_i_select_a_different_course
+    choose @selected_course.name_and_code
+  end
+
+  def when_i_click_change_course
+    within(:xpath, "////div[@class='govuk-summary-list__row'][2]") do
+      click_on 'Change'
+    end
+  end
+
+  def then_i_am_taken_to_the_change_course_page
+    expect(page).to have_content('Select course')
+  end
+
+  def and_i_can_confirm_the_new_course_selection
+    within(:xpath, "////div[@class='govuk-summary-list__row'][2]") do
+      expect(page).to have_content(@selected_course.name_and_code)
     end
   end
 

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Provider makes an offer' do
            application_form: application_form,
            course_option: course_option)
   end
-  let(:course) { build(:course, :open_on_apply, provider: provider) }
+  let(:course) { build(:course, :open_on_apply, :full_time, provider: provider) }
   let(:course_option) { build(:course_option, course: course) }
 
   before do
@@ -49,6 +49,23 @@ RSpec.feature 'Provider makes an offer' do
     then_the_conditions_page_is_loaded
     and_i_click_continue
     then_the_review_page_is_loaded
+    and_i_can_confirm_the_new_location_selection
+
+    given_the_course_has_course_options_with_both_study_modes
+    when_i_click_change_study_mode
+    then_i_am_taken_to_the_change_study_mode_page
+
+    when_i_select_a_different_study_mode
+    and_i_click_continue
+
+    when_i_select_a_new_location
+    and_i_click_continue
+
+    then_the_conditions_page_is_loaded
+    and_i_click_continue
+    then_the_review_page_is_loaded
+
+    and_i_can_confirm_the_new_study_mode_selection
     and_i_can_confirm_the_new_location_selection
 
     when_i_send_the_offer
@@ -117,7 +134,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def given_the_course_has_multiple_course_options
-    course_options = create_list(:course_option, 3, course: course)
+    course_options = create_list(:course_option, 3, :full_time, course: course)
     @selected_course_option = course_options.sample
   end
 
@@ -138,6 +155,34 @@ RSpec.feature 'Provider makes an offer' do
   def and_i_can_confirm_the_new_location_selection
     within(:xpath, "////div[@class='govuk-summary-list__row'][3]") do
       expect(page).to have_content(@selected_course_option.site.name_and_address)
+    end
+  end
+
+  def when_i_click_change_study_mode
+    within(:xpath, "////div[@class='govuk-summary-list__row'][4]") do
+      click_on 'Change'
+    end
+  end
+
+  def given_the_course_has_course_options_with_both_study_modes
+    course_options = [create(:course_option, :part_time, course: course),
+                      create(:course_option, :full_time, course: course)]
+    course.update(study_mode: :full_time_or_part_time)
+
+    @selected_course_option = course_options.first
+  end
+
+  def then_i_am_taken_to_the_change_study_mode_page
+    expect(page).to have_content('Select full time or part time')
+  end
+
+  def when_i_select_a_different_study_mode
+    choose @selected_course_option.study_mode.humanize
+  end
+
+  def and_i_can_confirm_the_new_study_mode_selection
+    within(:xpath, "////div[@class='govuk-summary-list__row'][4]") do
+      expect(page).to have_content(@selected_course_option.study_mode.humanize)
     end
   end
 


### PR DESCRIPTION
*Note that we are not retrieving the correct set of data, as we will be done on a separate card by integrating the new `GetChangeOfferOptions` query service.


## Link to Trello card

https://trello.com/c/TbL2H8ck/3459-edit-a-new-offer-from-the-review-page-via-the-change-links

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
