### PR TITLE
Let users manage the type of email notifications they receive

### DIFF
--- a/app/components/provider_user_notification_preferences_component.html.erb
+++ b/app/components/provider_user_notification_preferences_component.html.erb
@@ -1,0 +1,14 @@
+<%= form_with model: notification_preferences, url: form_path, method: :put do |f| %>
+  <div class='govuk-form-group'>
+    <% ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |notification_preference| %>
+      <%= f.govuk_collection_radio_buttons notification_preference,
+        on_off_options,
+        :value,
+        :name,
+        inline: true,
+        legend: { text: t("provider_user_notification_preferences.#{notification_preference}.legend") } %>
+    <% end %>
+  </div>
+
+  <%= f.govuk_submit 'Save settings' %>
+<% end %>

--- a/app/components/provider_user_notification_preferences_component.rb
+++ b/app/components/provider_user_notification_preferences_component.rb
@@ -1,0 +1,16 @@
+class ProviderUserNotificationPreferencesComponent < ViewComponent::Base
+  include ViewHelper
+  attr_reader :notification_preferences, :form_path
+
+  def initialize(notification_preferences, form_path:)
+    @notification_preferences = notification_preferences
+    @form_path = form_path
+  end
+
+  def on_off_options
+    [
+      OpenStruct.new(value: 'true', name: 'On'),
+      OpenStruct.new(value: 'false', name: 'Off'),
+    ]
+  end
+end

--- a/app/components/support_interface/provider_user_summary_component.rb
+++ b/app/components/support_interface/provider_user_summary_component.rb
@@ -1,0 +1,34 @@
+module SupportInterface
+  class ProviderUserSummaryComponent < SummaryListComponent
+    include ViewHelper
+
+    attr_reader :provider_user
+
+    def initialize(provider_user)
+      @provider_user = provider_user
+    end
+
+    def rows
+      [
+        { key: 'First name', value: provider_user.first_name },
+        { key: 'Last name', value: provider_user.last_name },
+        { key: 'Email address', value: provider_user.email_address },
+        { key: 'DfE Sign-in UID', value: provider_user.dfe_sign_in_uid },
+        { key: 'Account created at', value: provider_user.created_at.to_s(:govuk_date_and_time) },
+        { key: 'Last sign in at', value: provider_user.last_signed_in_at&.to_s(:govuk_date_and_time) || 'Not signed in yet' },
+        {
+          key: 'Email notifications',
+          value: boolean_to_word(provider_user.send_notifications?),
+          action: 'notifications',
+          change_path: edit_support_interface_provider_user_path(provider_user, anchor: 'update-email-notifications'),
+        },
+        {
+          key: 'Permissions',
+          value: render(SupportInterface::ProviderUserPermissionsComponent.new(provider_user: provider_user)),
+          action: 'permissions',
+          change_path: edit_support_interface_provider_user_path(provider_user),
+        },
+      ]
+    end
+  end
+end

--- a/app/components/support_interface/provider_user_summary_component.rb
+++ b/app/components/support_interface/provider_user_summary_component.rb
@@ -18,7 +18,7 @@ module SupportInterface
         { key: 'Last sign in at', value: provider_user.last_signed_in_at&.to_s(:govuk_date_and_time) || 'Not signed in yet' },
         {
           key: 'Email notifications',
-          value: boolean_to_word(provider_user.send_notifications?),
+          value: email_notifications_value,
           action: 'notifications',
           change_path: edit_support_interface_provider_user_path(provider_user, anchor: 'update-email-notifications'),
         },
@@ -29,6 +29,19 @@ module SupportInterface
           change_path: edit_support_interface_provider_user_path(provider_user),
         },
       ]
+    end
+
+  private
+
+    def email_notifications_value
+      FeatureFlag.active?(:configurable_provider_notifications) ? render(SummaryCardComponent.new(rows: notification_preferences_rows, border: false)) : boolean_to_word(provider_user.send_notifications?)
+    end
+
+    def notification_preferences_rows
+      rows = ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.map do |type|
+        [t("provider_user_notification_preferences.#{type}.legend"), provider_user.notification_preferences.send(type) ? 'On' : 'Off']
+      end
+      rows.to_h
     end
   end
 end

--- a/app/controllers/provider_interface/notifications_controller.rb
+++ b/app/controllers/provider_interface/notifications_controller.rb
@@ -1,9 +1,13 @@
 module ProviderInterface
   class NotificationsController < ProviderInterfaceController
     def update
-      SaveProviderUserNotificationPreferences
-        .new(provider_user: current_provider_user)
-        .backfill_notification_preferences!(send_notifications: notification_params[:send_notifications])
+      provider_user_notifications_service = SaveProviderUserNotificationPreferences.new(provider_user: current_provider_user)
+
+      if FeatureFlag.active?(:configurable_provider_notifications)
+        provider_user_notifications_service.update_all_notification_preferences!(notification_preferences_params: notification_preferences_params)
+      else
+        provider_user_notifications_service.backfill_notification_preferences!(send_notifications: notification_params[:send_notifications])
+      end
 
       flash[:success] = 'Email notification settings saved'
       redirect_to provider_interface_notifications_path
@@ -12,7 +16,16 @@ module ProviderInterface
   private
 
     def notification_params
+      return ActionController::Parameters.new unless params.key?(:provider_user)
+
       params.require(:provider_user).permit(:send_notifications)
+    end
+
+    def notification_preferences_params
+      return ActionController::Parameters.new unless params.key?(:provider_user_notification_preferences)
+
+      params.require(:provider_user_notification_preferences)
+        .permit(ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
     end
   end
 end

--- a/app/controllers/support_interface/provider_user_notification_preferences_controller.rb
+++ b/app/controllers/support_interface/provider_user_notification_preferences_controller.rb
@@ -1,14 +1,7 @@
 module SupportInterface
   class ProviderUserNotificationPreferencesController < SupportInterfaceController
-
     def toggle_notifications
-      provider_user = ProviderUser.find(params[:provider_user_id])
-      provider_user.update!(send_notifications: !provider_user.send_notifications)
-
-      if FeatureFlag.active?(:configurable_provider_notifications)
-        provider_user.notification_preferences
-          .update_all_preferences(provider_user.send_notifications)
-      end
+      provider_user_notifications_service.backfill_notification_preferences!(send_notifications: !provider_user.send_notifications)
 
       flash[:success] = 'Provider user updated'
       redirect_to support_interface_provider_user_path(provider_user)
@@ -17,16 +10,21 @@ module SupportInterface
     def update_notifications
       render_404 unless FeatureFlag.active?(:configurable_provider_notifications)
 
-      provider_user = ProviderUser.find(params[:provider_user_id])
-      notification_preferences = provider_user.notification_preferences
+      provider_user_notifications_service.update_all_notification_preferences!(notification_preferences_params: notification_preferences_params)
 
-      if notification_preferences.update!(notification_preferences_params)
-        flash[:success] = 'Provider user notifications updated'
-        redirect_to support_interface_provider_user_path(provider_user)
-      end
+      flash[:success] = 'Provider user notifications updated'
+      redirect_to support_interface_provider_user_path(provider_user)
     end
 
   private
+
+    def provider_user_notifications_service
+      SaveProviderUserNotificationPreferences.new(provider_user: provider_user)
+    end
+
+    def provider_user
+      @provider_user ||= ProviderUser.find(params[:provider_user_id])
+    end
 
     def notification_preferences_params
       return ActionController::Parameters.new unless params.key?(:provider_user_notification_preferences)

--- a/app/controllers/support_interface/provider_user_notification_preferences_controller.rb
+++ b/app/controllers/support_interface/provider_user_notification_preferences_controller.rb
@@ -1,0 +1,38 @@
+module SupportInterface
+  class ProviderUserNotificationPreferencesController < SupportInterfaceController
+
+    def toggle_notifications
+      provider_user = ProviderUser.find(params[:provider_user_id])
+      provider_user.update!(send_notifications: !provider_user.send_notifications)
+
+      if FeatureFlag.active?(:configurable_provider_notifications)
+        provider_user.notification_preferences
+          .update_all_preferences(provider_user.send_notifications)
+      end
+
+      flash[:success] = 'Provider user updated'
+      redirect_to support_interface_provider_user_path(provider_user)
+    end
+
+    def update_notifications
+      render_404 unless FeatureFlag.active?(:configurable_provider_notifications)
+
+      provider_user = ProviderUser.find(params[:provider_user_id])
+      notification_preferences = provider_user.notification_preferences
+
+      if notification_preferences.update!(notification_preferences_params)
+        flash[:success] = 'Provider user notifications updated'
+        redirect_to support_interface_provider_user_path(provider_user)
+      end
+    end
+
+  private
+
+    def notification_preferences_params
+      return ActionController::Parameters.new unless params.key?(:provider_user_notification_preferences)
+
+      params.require(:provider_user_notification_preferences)
+        .permit(ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
+    end
+  end
+end

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -82,6 +82,18 @@ module SupportInterface
       redirect_to support_interface_provider_user_path(provider_user)
     end
 
+    def update_notifications
+      render_404 unless FeatureFlag.active?(:configurable_provider_notifications)
+
+      provider_user = ProviderUser.find(params[:provider_user_id])
+      notification_preferences = provider_user.notification_preferences
+
+      if notification_preferences.update!(notification_preferences_params)
+        flash[:success] = 'Provider user notifications updated'
+        redirect_to support_interface_provider_user_path(provider_user)
+      end
+    end
+
     def impersonate
       @provider_user = ProviderUser.find(params[:provider_user_id])
       dfe_sign_in_user.begin_impersonation! session, @provider_user
@@ -120,6 +132,13 @@ module SupportInterface
             .permit(provider_permissions_forms: {})
             .fetch(:provider_permissions_forms, {})
             .to_h
+    end
+
+    def notification_preferences_params
+      return ActionController::Parameters.new unless params.key?(:provider_user_notification_preferences)
+
+      params.require(:provider_user_notification_preferences)
+        .permit(ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
     end
   end
 end

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -71,29 +71,6 @@ module SupportInterface
       @provider_user = ProviderUser.find(params[:provider_user_id])
     end
 
-    def toggle_notifications
-      provider_user = ProviderUser.find(params[:provider_user_id])
-
-      SaveProviderUserNotificationPreferences
-        .new(provider_user: provider_user)
-        .backfill_notification_preferences!(send_notifications: !provider_user.send_notifications)
-
-      flash[:success] = 'Provider user updated'
-      redirect_to support_interface_provider_user_path(provider_user)
-    end
-
-    def update_notifications
-      render_404 unless FeatureFlag.active?(:configurable_provider_notifications)
-
-      provider_user = ProviderUser.find(params[:provider_user_id])
-      notification_preferences = provider_user.notification_preferences
-
-      if notification_preferences.update!(notification_preferences_params)
-        flash[:success] = 'Provider user notifications updated'
-        redirect_to support_interface_provider_user_path(provider_user)
-      end
-    end
-
     def impersonate
       @provider_user = ProviderUser.find(params[:provider_user_id])
       dfe_sign_in_user.begin_impersonation! session, @provider_user
@@ -132,13 +109,6 @@ module SupportInterface
             .permit(provider_permissions_forms: {})
             .fetch(:provider_permissions_forms, {})
             .to_h
-    end
-
-    def notification_preferences_params
-      return ActionController::Parameters.new unless params.key?(:provider_user_notification_preferences)
-
-      params.require(:provider_user_notification_preferences)
-        .permit(ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
     end
   end
 end

--- a/app/views/provider_interface/notifications/show.html.erb
+++ b/app/views/provider_interface/notifications/show.html.erb
@@ -18,18 +18,18 @@
       <%= t('page_titles.provider.notifications') %>
       <span class="govuk-caption-m govuk-!-margin-top-1">These are sent when an application is submitted, withdrawn, automatically rejected, accepted or declined.</span>
     </h1>
-
-    <%= form_with model: current_provider_user, url: provider_interface_notifications_path, method: :put do |f| %>
-      <div class='govuk-form-group'>
-
-        <%= f.govuk_radio_buttons_fieldset :send_notifications, inline: true, legend: -> { nil } do %>
-          <%= f.govuk_radio_button :send_notifications, 'true', label: { text: 'On' }, link_errors: true %>
-          <%= f.govuk_radio_button :send_notifications, 'false', label: { text: 'Off' } %>
-        <% end %>
-
-      </div>
-      <%= f.govuk_submit 'Save settings' %>
+    <% if FeatureFlag.active?(:configurable_provider_notifications) %>
+      <%= render ProviderUserNotificationPreferencesComponent.new(current_provider_user.notification_preferences, form_path: provider_interface_notifications_path) %>
+    <% else %>
+      <%= form_with model: current_provider_user, url: provider_interface_notifications_path, method: :put do |f| %>
+        <div class='govuk-form-group'>
+          <%= f.govuk_radio_buttons_fieldset :send_notifications, inline: true, legend: -> { nil } do %>
+            <%= f.govuk_radio_button :send_notifications, 'true', label: { text: 'On' }, link_errors: true %>
+            <%= f.govuk_radio_button :send_notifications, 'false', label: { text: 'Off' } %>
+          <% end %>
+        </div>
+        <%= f.govuk_submit 'Save settings' %>
+      <% end %>
     <% end %>
-
   </div>
 </div>

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -13,15 +13,21 @@
       <%= f.govuk_submit 'Update permissions' %>
     <% end %>
 
-    <%= form_with model: @form, url: support_interface_provider_user_toggle_notifications_path(@form.provider_user) do |f| %>
-      <%= render SummaryListComponent.new(rows: {
-        'Send notifications?' => boolean_to_word(@form.provider_user.send_notifications?),
-      }) %>
+    <h1 class='govuk-heading-l' id='update-email-notifications'>Update email notifications</h1>
 
-      <% if @form.provider_user.send_notifications? %>
-        <%= f.govuk_submit 'Disable notifications' %>
-      <% else %>
-        <%= f.govuk_submit 'Enable notifications' %>
+    <% if FeatureFlag.active?(:configurable_provider_notifications) %>
+      <%= render ProviderUserNotificationPreferencesComponent.new(@form.provider_user.notification_preferences, form_path: support_interface_provider_user_update_notifications_path(@form.provider_user)) %>
+    <% else %>
+      <%= form_with model: @form, url: support_interface_provider_user_toggle_notifications_path(@form.provider_user) do |f| %>
+        <%= render SummaryListComponent.new(rows: {
+          'Send notifications?' => boolean_to_word(@form.provider_user.send_notifications?),
+        }) %>
+
+        <% if @form.provider_user.send_notifications? %>
+          <%= f.govuk_submit 'Disable notifications' %>
+        <% else %>
+          <%= f.govuk_submit 'Enable notifications' %>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/support_interface/provider_users/show.html.erb
+++ b/app/views/support_interface/provider_users/show.html.erb
@@ -4,23 +4,4 @@
 
 <%= render 'provider_user_navigation', title: 'Details', provider_user: @provider_user %>
 
-<%= render SummaryListComponent.new(rows: [
-  { key: 'First name', value: @provider_user.first_name },
-  { key: 'Last name', value: @provider_user.last_name },
-  { key: 'Email address', value: @provider_user.email_address },
-  { key: 'DfE Sign-in UID', value: @provider_user.dfe_sign_in_uid },
-  { key: 'Account created at', value: @provider_user.created_at.to_s(:govuk_date_and_time) },
-  { key: 'Last sign in at', value: @provider_user.last_signed_in_at&.to_s(:govuk_date_and_time) || 'Not signed in yet' },
-  {
-    key: 'Send notifications?',
-    value: boolean_to_word(@provider_user.send_notifications?),
-    action: 'notifications',
-    change_path: edit_support_interface_provider_user_path(@provider_user),
-  },
-  {
-    key: 'Permissions',
-    value: render(SupportInterface::ProviderUserPermissionsComponent.new(provider_user: @provider_user)),
-    action: 'permissions',
-    change_path: edit_support_interface_provider_user_path(@provider_user),
-  },
-]) %>
+<%= render SupportInterface::ProviderUserSummaryComponent.new(@provider_user) %>

--- a/config/locales/provider_user_notification_preferences.yml
+++ b/config/locales/provider_user_notification_preferences.yml
@@ -1,0 +1,12 @@
+en:
+  provider_user_notification_preferences:
+    application_received:
+      legend: Application received
+    application_withdrawn:
+      legend: Application withdrawn by candidate
+    application_rejected_by_default:
+      legend: Application automatically rejected
+    offer_accepted:
+      legend: Offer accepted
+    offer_declined:
+      legend: Offer declined

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -947,8 +947,8 @@ Rails.application.routes.draw do
 
       resources :provider_users, only: %i[show index new create edit update], path: :provider do
         get '/audits' => 'provider_users#audits'
-        patch '/toggle-notifications' => 'provider_users#toggle_notifications', as: :toggle_notifications
-        put '/update-notifications' => 'provider_users#update_notifications', as: :update_notifications
+        patch '/toggle-notifications' => 'provider_user_notification_preferences#toggle_notifications', as: :toggle_notifications
+        put '/update-notifications' => 'provider_user_notification_preferences#update_notifications', as: :update_notifications
         post '/impersonate' => 'provider_users#impersonate', as: :impersonate
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -948,6 +948,7 @@ Rails.application.routes.draw do
       resources :provider_users, only: %i[show index new create edit update], path: :provider do
         get '/audits' => 'provider_users#audits'
         patch '/toggle-notifications' => 'provider_users#toggle_notifications', as: :toggle_notifications
+        put '/update-notifications' => 'provider_users#update_notifications', as: :update_notifications
         post '/impersonate' => 'provider_users#impersonate', as: :impersonate
       end
     end

--- a/spec/components/previews/provider_user_notification_preferences_component_preview.rb
+++ b/spec/components/previews/provider_user_notification_preferences_component_preview.rb
@@ -1,0 +1,8 @@
+class ProviderUserNotificationPreferencesComponentPreview < ViewComponent::Preview
+  def notification_preferences
+    render ProviderUserNotificationPreferencesComponent.new(
+      FactoryBot.build(:provider_user_notification_preferences),
+      form_path: '/404',
+    )
+  end
+end

--- a/spec/components/previews/support_interface/provider_user_summary_component_preview.rb
+++ b/spec/components/previews/support_interface/provider_user_summary_component_preview.rb
@@ -1,0 +1,9 @@
+module SupportInterface
+  class ProviderUserSummaryComponentPreview < ViewComponent::Preview
+    def provider_user_summary
+      provider_user = ProviderUserNotificationPreferences.limit(10).sample.provider_user
+
+      render SupportInterface::ProviderUserSummaryComponent.new(provider_user)
+    end
+  end
+end

--- a/spec/components/provider_user_notification_preferences_component_spec.rb
+++ b/spec/components/provider_user_notification_preferences_component_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe ProviderUserNotificationPreferencesComponent do
+  let(:provider_user) { create(:provider_user, send_notifications: true) }
+  let(:notification_preferences) { provider_user.notification_preferences }
+
+  it 'renders correct labels for notification preferences' do
+    result = render_inline(described_class.new(notification_preferences, form_path: '/provider/account/notification-settings'))
+
+    expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[0].text).to include('Application received')
+    expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[1].text).to include('Application withdrawn by candidate')
+    expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[2].text).to include('Application automatically rejected')
+    expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[3].text).to include('Offer accepted')
+    expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[4].text).to include('Offer declined')
+  end
+
+  it 'renders on and off radio buttons' do
+    result = render_inline(described_class.new(notification_preferences, form_path: '/provider/account/notification-settings'))
+
+    expect(result.css(:label, '#govuk-label govuk-radios__label').map(&:text).uniq).to match_array(%w[On Off])
+  end
+end

--- a/spec/components/support_interface/provider_user_summary_component_spec.rb
+++ b/spec/components/support_interface/provider_user_summary_component_spec.rb
@@ -24,7 +24,27 @@ RSpec.describe SupportInterface::ProviderUserSummaryComponent do
     expect(rendered_component).to include('provider@example.com')
     expect(rendered_component).to include('ABC-UID')
     expect(rendered_component).to include('15 March 2021')
-    expect(rendered_component).to include('Yes')
     expect(rendered_component).to include('The Provider')
+  end
+
+  context 'when the configurable provider notification feature flag is on' do
+    before { FeatureFlag.activate(:configurable_provider_notifications) }
+
+    it 'renders configurable provider notifications' do
+      ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |notification_preference|
+        expect(rendered_component.squish).to include(t("provider_user_notification_preferences.#{notification_preference}.legend"))
+      end
+    end
+  end
+
+  context 'when the configurable provider notification feature flag is off' do
+    before { FeatureFlag.deactivate(:configurable_provider_notifications) }
+
+    it 'renders global provider notifications details' do
+      ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |notification_preference|
+        expect(rendered_component.squish).not_to include(t("provider_user_notification_preferences.#{notification_preference}.legend"))
+      end
+      expect(rendered_component).to include('Yes')
+    end
   end
 end

--- a/spec/components/support_interface/provider_user_summary_component_spec.rb
+++ b/spec/components/support_interface/provider_user_summary_component_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ProviderUserSummaryComponent do
+  let(:provider_user) do
+    create(:provider_user,
+           first_name: 'John',
+           last_name: 'Smith',
+           email_address: 'provider@example.com',
+           dfe_sign_in_uid: 'ABC-UID',
+           last_signed_in_at: Time.zone.local(2021, 0o3, 15, 10, 45, 0),
+           providers: [create(:provider, name: 'The Provider')],
+           send_notifications: true)
+  end
+
+  subject(:rendered_component) do
+    render_inline(
+      SupportInterface::ProviderUserSummaryComponent.new(provider_user),
+    ).text
+  end
+
+  it 'renders all the rows' do
+    expect(rendered_component).to include('John')
+    expect(rendered_component).to include('Smith')
+    expect(rendered_component).to include('provider@example.com')
+    expect(rendered_component).to include('ABC-UID')
+    expect(rendered_component).to include('15 March 2021')
+    expect(rendered_component).to include('Yes')
+    expect(rendered_component).to include('The Provider')
+  end
+end

--- a/spec/system/provider_interface/manage_provider_user_global_notifications_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_global_notifications_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing global notifications' do
+  include DfESignInHelpers
+
+  scenario 'Provider can enable and disable global email notifications' do
+    FeatureFlag.deactivate(:configurable_provider_notifications)
+
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_go_to_my_account
+    and_i_click_on_the_notification_settings_link
+
+    when_i_choose_to_receive_notifications
+    then_i_update_my_notification_preferences
+
+    when_i_choose_not_to_receive_notifications
+    then_i_update_my_notification_preferences
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_user_exists_in_apply_database(send_notifications: false)
+  end
+
+  def when_i_go_to_my_account
+    click_on t('page_titles.provider.account')
+  end
+
+  def and_i_click_on_the_notification_settings_link
+    click_on(t('page_titles.provider.notifications'))
+  end
+
+  def when_i_choose_to_receive_notifications
+    choose 'On'
+    click_on 'Save settings'
+  end
+
+  def then_i_update_my_notification_preferences
+    expect(page).to have_content 'Email notification settings saved'
+  end
+
+  def when_i_choose_not_to_receive_notifications
+    choose 'Off'
+    click_on 'Save settings'
+  end
+end

--- a/spec/system/provider_interface/manage_provider_user_notifications_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_notifications_spec.rb
@@ -3,18 +3,18 @@ require 'rails_helper'
 RSpec.feature 'Managing notifications' do
   include DfESignInHelpers
 
-  scenario 'Provider can enable and disable email notifications' do
+  scenario 'Provider can enable and disable individaul email notifications' do
+    FeatureFlag.activate(:configurable_provider_notifications)
+
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_sign_in_to_the_provider_interface
 
     when_i_go_to_my_account
     and_i_click_on_the_notification_settings_link
-
-    when_i_choose_to_receive_notifications
-    then_i_update_my_notification_preferences
+    then_i_can_see_all_notifications_are_on_by_default
 
     when_i_choose_not_to_receive_notifications
-    then_i_update_my_notification_preferences
+    then_my_notification_preferences_are_updated
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -30,17 +30,24 @@ RSpec.feature 'Managing notifications' do
     click_on(t('page_titles.provider.notifications'))
   end
 
-  def when_i_choose_to_receive_notifications
-    choose 'On'
-    click_on 'Save settings'
-  end
-
-  def then_i_update_my_notification_preferences
-    expect(page).to have_content 'Email notification settings saved'
+  def then_i_can_see_all_notifications_are_on_by_default
+    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
+      expect(find(:css, "#provider-user-notification-preferences-#{type.to_s.dasherize}-true-field")).to be_checked
+    end
   end
 
   def when_i_choose_not_to_receive_notifications
-    choose 'Off'
+    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
+      choose "provider-user-notification-preferences-#{type.to_s.dasherize}-false-field"
+    end
     click_on 'Save settings'
+  end
+
+  def then_my_notification_preferences_are_updated
+    expect(page).to have_content 'Email notification settings saved'
+
+    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
+      expect(find(:css, "#provider-user-notification-preferences-#{type.to_s.dasherize}-false-field")).to be_checked
+    end
   end
 end

--- a/spec/system/support_interface/managing_provider_user_notification_preferences_spec.rb
+++ b/spec/system/support_interface/managing_provider_user_notification_preferences_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing provider user notification preferences' do
+  include DfESignInHelpers
+  include DsiAPIHelper
+
+  scenario 'editing the settings' do
+    FeatureFlag.activate(:configurable_provider_notifications)
+
+    given_dfe_signin_is_configured
+    and_i_am_a_support_user
+    and_a_provider_user_exist
+
+    when_i_visit_the_support_console
+    and_i_navigate_to_provider_users_page
+    and_i_click_on_the_user
+    and_i_click_the_change_link
+    then_i_can_see_all_notifications_are_on_by_default
+
+    when_i_update_all_notifications_to_be_off
+    then_the_notification_preferences_are_updated
+  end
+
+  def given_dfe_signin_is_configured
+    set_dsi_api_response(success: true)
+  end
+
+  def and_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_a_provider_user_exist
+    @provider_user = create(:provider_user, send_notifications: true)
+  end
+
+  def when_i_visit_the_support_console
+    visit support_interface_path
+  end
+
+  def and_i_navigate_to_provider_users_page
+    click_link 'Providers'
+    click_link 'Provider users'
+  end
+
+  def and_i_click_on_the_user
+    click_link @provider_user.full_name
+  end
+
+  def and_i_click_the_change_link
+    click_on 'Change notifications'
+  end
+
+  def then_i_can_see_all_notifications_are_on_by_default
+    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
+      expect(find(:css, "#provider-user-notification-preferences-#{type.to_s.dasherize}-true-field")).to be_checked
+    end
+  end
+
+  def when_i_update_all_notifications_to_be_off
+    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
+      choose "provider-user-notification-preferences-#{type.to_s.dasherize}-false-field"
+    end
+    click_on 'Save settings'
+  end
+
+  def then_the_notification_preferences_are_updated
+    expect(page).to have_content 'Provider user notifications updated'
+  end
+end

--- a/spec/system/support_interface/managing_provider_user_notification_preferences_spec.rb
+++ b/spec/system/support_interface/managing_provider_user_notification_preferences_spec.rb
@@ -65,5 +65,12 @@ RSpec.feature 'Managing provider user notification preferences' do
 
   def then_the_notification_preferences_are_updated
     expect(page).to have_content 'Provider user notifications updated'
+
+    within '.app-summary-card__body' do
+      rows = all('.govuk-summary-list__row')
+      (0..(ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.count - 1)).each do |i|
+        expect(rows[i].text).to include('Off')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

> As a provider user 
> I need the ability to choose the type of email notification I receive
> So that I only get notified about the things I need

## Changes proposed in this pull request

<img width="664" alt="Screenshot 2021-03-12 at 18 03 27" src="https://user-images.githubusercontent.com/38078064/110981421-0beac880-835f-11eb-8271-71bccac95f31.png">


## Guidance to review

- test the provider interface `/provider/account/notification-settings`
- test the support interface `/support/users/provider/:id`

## Link to Trello card

https://trello.com/c/YzNo7PT3/3448-let-users-manage-the-type-of-email-notifications-they-receive

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
