### PR TITLE
Apply again metrics for Feature Metrics dashboard 2.0 (part 2/4)

### DIFF
--- a/app/models/feature_metrics_dashboard.rb
+++ b/app/models/feature_metrics_dashboard.rb
@@ -19,6 +19,7 @@ class FeatureMetricsDashboard < ApplicationRecord
     load_num_rejections_due_to_qualifications
     load_apply_again_success_rate
     load_apply_again_change_rate
+    load_apply_again_application_rate
   end
 
   def last_updated_at
@@ -229,6 +230,28 @@ private
       :apply_again_change_rate_last_month,
       apply_again_statistics.formatted_change_rate(
         Time.zone.now.beginning_of_month - 1.month,
+        Time.zone.now.beginning_of_month,
+      ),
+    )
+  end
+
+  def load_apply_again_application_rate
+    write_metric(
+      :apply_again_application_rate,
+      apply_again_statistics.formatted_application_rate(
+        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+      ),
+    )
+    write_metric(
+      :apply_again_application_rate_this_month,
+      apply_again_statistics.formatted_application_rate(
+        Time.zone.now.beginning_of_month,
+      ),
+    )
+    write_metric(
+      :apply_again_application_rate_upto_this_month,
+      apply_again_statistics.formatted_application_rate(
+        EndOfCycleTimetable.apply_reopens.beginning_of_day,
         Time.zone.now.beginning_of_month,
       ),
     )

--- a/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
+++ b/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
@@ -268,5 +268,31 @@
         </div>
       </div>
     </div>
+    <div class="govuk-grid-column-one-half">
+      <div id="headline-stat" class="govuk-!-margin-bottom-4">
+        <%= render SupportInterface::TileComponent.new(
+          count: @dashboard.read_metric(:apply_again_application_rate),
+          label: 'candidates that applied again after an unsuccessful first application',
+          colour: :blue,
+          size: :reduced,
+        ) %>
+      </div>
+      <div class="govuk-grid-row govuk-!-margin-bottom-4">
+        <div class="govuk-grid-column-one-half">
+          <%= render SupportInterface::TileComponent.new(
+            count: @dashboard.read_metric(:apply_again_application_rate_this_month),
+            label: 'this month',
+            size: :reduced,
+          ) %>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= render SupportInterface::TileComponent.new(
+            count: @dashboard.read_metric(:apply_again_application_rate_upto_this_month),
+            label: 'upto this month',
+            size: :reduced,
+          ) %>
+        </div>
+      </div>
+    </div>
   </div>
 <% end %>

--- a/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
+++ b/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
@@ -272,7 +272,7 @@
       <div id="headline-stat" class="govuk-!-margin-bottom-4">
         <%= render SupportInterface::TileComponent.new(
           count: @dashboard.read_metric(:apply_again_application_rate),
-          label: 'candidates that applied again after an unsuccessful first application',
+          label: 'candidates applied again after an unsuccessful first application',
           colour: :blue,
           size: :reduced,
         ) %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -83,26 +83,6 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "38104ade37d5c61659409d037de157949b23a917a7f5b504534ac0a46fa5cf8f",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/services/notifications_list.rb",
-      "line": 18,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "application_choice.provider.provider_users.or(application_choice.accredited_provider.provider_users).joins(:notification_preferences).where(\"#{{ :application_received => ([:application_submitted, :chase_provider_decision]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]) }.select do\n k if event.in?(v)\n end.keys.first} IS true\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "NotificationsList",
-        "method": "s(:self).for"
-      },
-      "user_input": "{ :application_received => ([:application_submitted, :chase_provider_decision]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]) }.select do\n k if event.in?(v)\n end.keys.first",
-      "confidence": "Weak",
-      "note": "not a user input"
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
       "fingerprint": "37b3066632afad7b480ce45f1b9d1263a923f29bba5edd3afd3e2f78e2cd425e",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -123,11 +103,31 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "38104ade37d5c61659409d037de157949b23a917a7f5b504534ac0a46fa5cf8f",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/notifications_list.rb",
+      "line": 18,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "application_choice.provider.provider_users.or(application_choice.accredited_provider.provider_users).joins(:notification_preferences).where(\"#{{ :application_received => ([:application_submitted, :chase_provider_decision]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]) }.select do\n k if event.in?(v)\n end.keys.first} IS true\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "NotificationsList",
+        "method": "s(:self).for"
+      },
+      "user_input": "{ :application_received => ([:application_submitted, :chase_provider_decision]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]) }.select do\n k if event.in?(v)\n end.keys.first",
+      "confidence": "Weak",
+      "note": "not a user input"
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "471859383ef3e9fba03933907e1bb043a8a57520241d275846126e6a2425f2e1",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/apply_again_feature_metrics.rb",
-      "line": 76,
+      "line": 95,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "ApplicationForm.where(:phase => \"apply_2\", :recruitment_cycle_year => RecruitmentCycle.current_year).joins(:application_choices).joins(\"inner join (select auditable_id, max(created_at) as status_last_updated_at\\n          from audits\\n          where auditable_type = 'ApplicationChoice'\\n            and action = 'update'\\n            and audited_changes#>>'{status, 1}' is not null\\n          group by auditable_id\\n        ) as status_audits on status_audits.auditable_id = application_choices.id\\n          and status_last_updated_at between '#{start_time}' and '#{end_time}'\")",
       "render_path": null,
@@ -299,8 +299,28 @@
       "user_input": "params[:course_option_id]",
       "confidence": "Weak",
       "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "dee8e3d32c167d6090d7a67d1bc9add167f8ef7b154fcc1d1311fc7aad779a84",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/apply_again_feature_metrics.rb",
+      "line": 121,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ApplicationForm.apply_1.joins(:application_choices).where(\"NOT EXISTS (:pending_or_successful)\", :pending_or_successful => ApplicationChoice.select(1).where(:status => (ApplicationStateChange.valid_states - [:withdrawn, :cancelled, :rejected, :declined, :conditions_not_met, :offer_withdrawn, :application_not_sent])).where(\"application_choices.application_form_id = application_forms.id\")).joins(\"inner join (select auditable_id, max(created_at) as status_last_updated_at\\n          from audits\\n          where auditable_type = 'ApplicationChoice'\\n            and action = 'update'\\n            and audited_changes#>>'{status, 1}' is not null\\n          group by auditable_id\\n        ) as status_audits on status_audits.auditable_id = application_choices.id\\n          and status_last_updated_at between '#{start_time}' and '#{end_time}'\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ApplyAgainFeatureMetrics",
+        "method": "applications_eligible_for_apply_again"
+      },
+      "user_input": "start_time",
+      "confidence": "Medium",
+      "note": ""
     }
   ],
-  "updated": "2021-03-15 09:28:21 +0000",
+  "updated": "2021-03-17 16:17:09 +0000",
   "brakeman_version": "5.0.0"
 }

--- a/spec/models/apply_again_feature_metrics_spec.rb
+++ b/spec/models/apply_again_feature_metrics_spec.rb
@@ -139,33 +139,21 @@ RSpec.describe ApplyAgainFeatureMetrics, with_audited: true do
         @today = Time.zone.local(2021, 3, 10, 12)
         Timecop.freeze(@today - 20.days) do
           @application_forms = create_list(:completed_application_form, 3)
-          create(
-            :application_choice,
-            :with_rejection,
-            application_form: @application_forms[0],
-          )
+          reject(@application_forms[0])
         end
         Timecop.freeze(@today - 10.days) do
-          create(
-            :application_choice,
-            :with_rejection,
-            application_form: @application_forms[1],
-          )
+          reject(@application_forms[1])
         end
         Timecop.freeze(@today - 5.days) do
-          create(
-            :application_choice,
-            :with_rejection,
-            application_form: @application_forms[2],
-          )
+          reject(@application_forms[2])
         end
         Timecop.freeze(@today) do
           create_apply_again_application(@application_forms[1])
           create_apply_again_application(@application_forms[2])
 
           expect(feature_metrics.formatted_application_rate(25.days.ago)).to eq('66.7%')
-          # expect(feature_metrics.formatted_application_rate(15.days.ago)).to eq('100%')
-          # expect(feature_metrics.formatted_application_rate(2.days.ago)).to eq('n/a')
+          expect(feature_metrics.formatted_application_rate(15.days.ago)).to eq('100%')
+          expect(feature_metrics.formatted_application_rate(2.days.ago)).to eq('n/a')
         end
       end
     end

--- a/spec/models/feature_metrics_dashboard_spec.rb
+++ b/spec/models/feature_metrics_dashboard_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe FeatureMetricsDashboard do
       allow(rfr_metrics_double).to receive(:rejections_due_to).and_return(5)
       allow(apply_again_metrics_double).to receive(:formatted_success_rate).and_return('42.8%')
       allow(apply_again_metrics_double).to receive(:formatted_change_rate).and_return('33.3%')
+      allow(apply_again_metrics_double).to receive(:formatted_application_rate).and_return('18.7%')
 
       dashboard = described_class.new
       dashboard.load_updated_metrics
@@ -98,6 +99,9 @@ RSpec.describe FeatureMetricsDashboard do
         'apply_again_change_rate' => '33.3%',
         'apply_again_change_rate_this_month' => '33.3%',
         'apply_again_change_rate_last_month' => '33.3%',
+        'apply_again_application_rate' => '18.7%',
+        'apply_again_application_rate_this_month' => '18.7%',
+        'apply_again_application_rate_upto_this_month' => '18.7%',
       })
     end
   end


### PR DESCRIPTION
## Context

We are adding a new set of metrics to the feature metrics dashboard. This second PR follows on from https://github.com/DFE-Digital/apply-for-teacher-training/pull/4266 and adds Apply again application rates (the % of candidates with failed applications, in this cycle, that have applied again). More PRs to follow.

## Changes proposed in this pull request

- [x] This PR adds the final sub-section to the _Apply again_ section of the feature metrics dashboard:


<img width="1157" alt="image" src="https://user-images.githubusercontent.com/450843/111487296-242c6000-8730-11eb-9fb0-618fb2323da5.png">


- [x] Extends `ApplyAgainFeatureMetrics` with `apply_again_application_rate` and `formatted_apply_again_application_rate` methods.
- [x] The above methods can be filtered by dates, this limits the search to applications that became eligible for Apply again within the given time range.
- [x] Rebase and change base to master after https://github.com/DFE-Digital/apply-for-teacher-training/pull/4266 is merged

## Guidance to review

- Date filtering for application rate is a bit messy (like the success rates) because it requires a join to the audits table.
- Can we improve the content (labels for each metric).
- No feature flag, does this make sense?

## Link to Trello card

https://trello.com/c/1X9y1JPl/2981-feature-metric-dashboard-20

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
