### PR TITLE
Reorder application sections as per prototype

### DIFF
--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -34,11 +34,7 @@
 
 <%= render ProviderInterface::CourseDetailsComponent.new(application_choice: @application_choice) %>
 
-<%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>
-
 <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_choice: @application_choice, current_provider_user: current_provider_user) %>
-
-<%= render InterviewPreferencesComponent.new(application_form: @application_choice.application_form) %>
 
 <%= render QualificationsComponent.new(application_form: @application_choice.application_form, application_choice_state: @application_choice.status) %>
 
@@ -53,5 +49,9 @@
 <% if @application_choice.application_form.application_references.feedback_provided.any? %>
   <%= render 'references' %>
 <% end %>
+
+<%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>
+
+<%= render InterviewPreferencesComponent.new(application_form: @application_choice.application_form) %>
 
 <%= render ProviderInterface::DiversityInformationComponent.new(application_choice: @application_choice, current_provider_user: current_provider_user) %>


### PR DESCRIPTION
## Context

The design prototype ordering of sections for an application has been updated.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Reorder Disability, Interview and Diversity sections so that they come after the References section on applications.
<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/111183378-bf45fe00-85a7-11eb-86f8-4c60d424bf65.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/CKysA1Pw/3484-move-interview-needs-and-disability-information-towards-the-bottom-of-the-application-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
