### PR TITLE
Distinguish changes that were made by support in application timeline

### DIFF
--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -117,6 +117,8 @@ module ProviderInterface
         'Candidate'
       elsif change.user.is_a?(ProviderUser)
         provider_name(change.user)
+      elsif change.user.is_a?(SupportUser) || change.audit.username =~ /via the Rails console/
+        'Apply support'
       else
         'System'
       end


### PR DESCRIPTION
## Context
Changes are shown to have been made by "System".

## Changes proposed in this pull request
 In the interest of transparency, change this text to "Apply support" where the change was made by support or the rails console.

## Guidance to review
Straightforward hopefully

## Link to Trello card
https://trello.com/c/wsT8mcxt/3483-in-the-application-timeline-ascribe-actions-taken-by-support-users-to-apply-support-or-equivalent

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
