### PR TITLE
Update TAD export documentation to include deferred status

### DIFF
--- a/app/exports/tad_export.yml
+++ b/app/exports/tad_export.yml
@@ -40,6 +40,7 @@ custom_columns:
     - conditions_not_met
     - declined
     - declined_by_default
+    - deferred
     - interviewing
     - offer
     - offer_deferred


### PR DESCRIPTION
When getting relevant applications we are checking `.where.not(submitted_at: nil)` which means that deferred applications are also included.

For more details see recent analysis: https://docs.google.com/document/d/14q7WsvV-_Bn6oophwIHcD0utZrFSzO9DkwIzM2Ky7A4/edit#heading=h.7heei0m7t6nz