### PR TITLE
Support - replace 'Reinstate reference' with 'Undo refusal'

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.html.erb
+++ b/app/components/support_interface/reference_with_feedback_component.html.erb
@@ -1,10 +1,10 @@
 <div data-qa="reference">
   <%= render SummaryCardComponent.new(rows: rows, editable: true) do %>
     <%= render(SummaryCardHeaderComponent.new(title: title, heading_level: 3)) do %>
-      <% if reference.cancelled? || reference.feedback_refused? %>
+      <% if reference.feedback_refused? %>
         <div class='app-summary-card__actions'>
           <%= govuk_link_to support_interface_reinstate_reference_path(reference) do %>
-          Reinstate reference<span class="govuk-visually-hidden"> for <%= reference.name %></span>
+          Undo refusal<span class="govuk-visually-hidden"> for <%= reference.name %></span>
           <% end %>
         </div>
       <% elsif reference.feedback_requested? %>

--- a/app/controllers/support_interface/references_controller.rb
+++ b/app/controllers/support_interface/references_controller.rb
@@ -15,7 +15,7 @@ module SupportInterface
     def reinstate; end
 
     def confirm_reinstate
-      RequestReference.new.call(@reference)
+      @reference.update!(feedback_status: 'feedback_requested', audit_comment: 'Reversing reference refusal using Support interface')
       flash[:success] = 'Reference was reinstated'
       redirect_to support_interface_application_form_path(@reference.application_form)
     end

--- a/app/controllers/support_interface/references_controller.rb
+++ b/app/controllers/support_interface/references_controller.rb
@@ -15,7 +15,7 @@ module SupportInterface
     def reinstate; end
 
     def confirm_reinstate
-      @reference.update!(feedback_status: 'feedback_requested', audit_comment: 'Reversing reference refusal using Support interface')
+      UndoReferenceRefusal.new(@reference).call
       flash[:success] = 'Reference was reinstated'
       redirect_to support_interface_application_form_path(@reference.application_form)
     end

--- a/app/services/support_interface/undo_reference_refusal.rb
+++ b/app/services/support_interface/undo_reference_refusal.rb
@@ -1,0 +1,15 @@
+module SupportInterface
+  class UndoReferenceRefusal
+    def initialize(reference)
+      @reference = reference
+    end
+
+    def call
+      @reference.update!(
+        feedback_status: 'feedback_requested',
+        feedback_refused_at: nil,
+        audit_comment: 'Reversing refusal using the Support interface, so that the referee is able to provide a reference again',
+      )
+    end
+  end
+end

--- a/app/views/support_interface/references/reinstate.html.erb
+++ b/app/views/support_interface/references/reinstate.html.erb
@@ -4,20 +4,15 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      Are you sure you want to reinstate this reference?
+      Are you sure you want to undo the referee's refusal to provide a reference?
     </h1>
 
     <p class="govuk-body">
-      Reinstating a reference will:
+      This will allow this referee to provide a reference
     </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>allow this referee to provide a reference</li>
-      <li>prevent the candidate from providing a replacement referee</li>
-    </ul>
-
     <p class="govuk-body">
-      Reinstating a reference does <strong>not send email notifications</strong>.
+      Undoing a refusal does <strong>not send email notifications</strong>.
     </p>
 
     <%= render(SummaryCardComponent.new(rows: [
@@ -32,7 +27,7 @@
     ])) %>
 
     <%= form_with model: @reference, url: support_interface_reinstate_reference_path(@reference), method: :post do |f| %>
-      <%= f.govuk_submit 'Reinstate reference' %>
+      <%= f.govuk_submit 'Undo refusal' %>
     <% end %>
   </div>
 </div>

--- a/spec/components/support_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/support_interface/reference_with_feedback_component_spec.rb
@@ -8,24 +8,15 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
       render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
 
       expect(rendered_component).to include('Cancel reference')
-      expect(rendered_component).not_to include('Reinstate reference')
+      expect(rendered_component).not_to include('Undo refusal')
     end
 
-    it 'Reinstate link is present when the reference is cancelled' do
-      reference = create(:reference, feedback_status: 'cancelled')
-
-      render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
-
-      expect(rendered_component).to include('Reinstate reference')
-      expect(rendered_component).not_to include('Cancel reference')
-    end
-
-    it 'Reinstate link is present when the reference is refused' do
+    it '"Undo refusal" link is present when the reference is refused' do
       reference = create(:reference, feedback_status: 'feedback_refused')
 
       render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
 
-      expect(rendered_component).to include('Reinstate reference')
+      expect(rendered_component).to include('Undo refusal')
       expect(rendered_component).not_to include('Cancel reference')
     end
   end

--- a/spec/services/support_interface/undo_reference_refusal_spec.rb
+++ b/spec/services/support_interface/undo_reference_refusal_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::UndoReferenceRefusal do
+  describe '#call' do
+    it 'reverts a refused reference into the "feedback_requested" state' do
+      reference = create(:reference, :feedback_refused)
+      described_class.new(reference).call
+
+      expect(reference).to be_feedback_requested
+      expect(reference.feedback_refused_at).to eq nil
+    end
+  end
+end

--- a/spec/system/support_interface/cancel_reference_spec.rb
+++ b/spec/system/support_interface/cancel_reference_spec.rb
@@ -11,10 +11,6 @@ RSpec.feature 'Cancelling references' do
     when_i_click_to_cancel_the_reference
     and_i_confirm_i_really_want_to_cancel_the_reference
     then_the_reference_is_cancelled
-
-    when_i_click_to_reinstate_the_reference
-    and_i_confirm_i_really_want_to_reinstate_the_reference
-    then_the_reference_is_reinstated
   end
 
   def given_i_am_a_support_user
@@ -41,18 +37,5 @@ RSpec.feature 'Cancelling references' do
   def then_the_reference_is_cancelled
     expect(page).to have_content 'Reference was cancelled'
     expect(page).to have_content 'Cancelled'
-  end
-
-  def when_i_click_to_reinstate_the_reference
-    click_on 'Reinstate reference for Harry'
-  end
-
-  def and_i_confirm_i_really_want_to_reinstate_the_reference
-    click_on 'Reinstate reference'
-  end
-
-  def then_the_reference_is_reinstated
-    expect(page).to have_content 'Reference was reinstated'
-    expect(page).to have_content 'Requested'
   end
 end

--- a/spec/system/support_interface/undo_reference_refusal_spec.rb
+++ b/spec/system/support_interface/undo_reference_refusal_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.feature 'Undo reference refusal' do
+  include DfESignInHelpers
+  include CandidateHelper
+
+  scenario 'Support agent reverses a reference refusal' do
+    given_i_am_a_support_user
+    and_there_is_an_application_with_a_refused_reference
+    and_i_visit_the_application
+
+    when_i_undo_the_refusal
+    then_the_refusal_is_undone
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_an_application_with_a_refused_reference
+    @application_with_reference = create(:application_form)
+    create(:reference, :feedback_refused, name: 'Harry', application_form: @application_with_reference)
+  end
+
+  def and_i_visit_the_application
+    visit support_interface_application_form_path(@application_with_reference)
+    within_summary_row 'Reference status' do
+      expect(page).to have_content 'Reference declined'
+    end
+  end
+
+  def when_i_undo_the_refusal
+    click_link 'Undo refusal for Harry'
+    click_button 'Undo refusal'
+  end
+
+  def then_the_refusal_is_undone
+    within_summary_row 'Reference status' do
+      expect(page).to have_content 'Requested'
+    end
+  end
+end


### PR DESCRIPTION



## Context
The 'Reinstate reference' feature is intended to allow support agents to
put cancelled and refused references back into a `feedback_requested`
state. It currently has a few issues:

- Candidates can now re-request cancelled references on their own,
  making that aspect of the feature mostly redundant.
- An error is triggered for refused references because the
  ReferenceActionsPolicy doesn't currently permit the move from
  `feedback_refused` to `feedback_requested`.
- The copy on the confirmation page states that no email will be sent,
  however the current implementation invokes a service object that sends
  email.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Rather than address these issues independently, this commit reworks
'Reinstate reference' into an 'Undo refusal' feature. This discards
handling of cancelled references and only appears for references that
are `feedback_refused`. The feature is useful in scenarios where a
referee has accidentally declined a reference request and wants Support
to make it active again.
<!-- If there are UI changes, please include Before and After screenshots. -->


![Screenshot_20210316_095810](https://user-images.githubusercontent.com/519250/111290500-20201580-863e-11eb-89a5-499f419d56ba.png)

## Guidance to review
- In the support interface, find an application with a reference in the `feedback_refused` state (or create this situation via the console)
- Click 'Undo refusal' and follow the flow through.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/2eAoTvSM/3130-uk-naric-name-change-to-uk-enic


<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
