### PR TITLE
Interview csv fixes

### DIFF
--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -1,6 +1,7 @@
 module ProviderInterface
   class ApplicationTimelineComponent < ViewComponent::Base
     include ViewHelper
+    include AuditHelper
     attr_reader :application_choice
 
     def initialize(application_choice:)
@@ -117,7 +118,7 @@ module ProviderInterface
         'Candidate'
       elsif change.user.is_a?(ProviderUser)
         provider_name(change.user)
-      elsif change.user.is_a?(SupportUser) || change.audit.username =~ /via the Rails console/
+      elsif change_by_support?(change.audit)
         'Apply support'
       else
         'System'

--- a/app/helpers/audit_helper.rb
+++ b/app/helpers/audit_helper.rb
@@ -1,0 +1,5 @@
+module AuditHelper
+  def change_by_support?(audit)
+    audit.user.is_a?(SupportUser) || !!(audit.username =~ /via the Rails console/)
+  end
+end

--- a/app/services/support_interface/interview_changes_export.rb
+++ b/app/services/support_interface/interview_changes_export.rb
@@ -1,5 +1,7 @@
 module SupportInterface
   class InterviewChangesExport
+    include AuditHelper
+
     def data_for_export
       rows = interview_audits.find_each(batch_size: 100).lazy.map do |audit|
         row_for_audit(audit)
@@ -95,7 +97,7 @@ module SupportInterface
     end
 
     def audit_user(audit)
-      if audit.user_type == 'SupportUser'
+      if change_by_support?(audit)
         'Support'
       elsif audit.user.present?
         audit.user.email_address

--- a/app/services/support_interface/interview_changes_export.rb
+++ b/app/services/support_interface/interview_changes_export.rb
@@ -1,9 +1,11 @@
 module SupportInterface
   class InterviewChangesExport
     def data_for_export
-      interview_audits.find_each(batch_size: 100).map do |audit|
+      rows = interview_audits.find_each(batch_size: 100).lazy.map do |audit|
         row_for_audit(audit)
-      end.compact
+      end
+
+      rows.reject(&:nil?)
     end
 
     def row_for_audit(audit)

--- a/app/services/support_interface/interview_changes_export.rb
+++ b/app/services/support_interface/interview_changes_export.rb
@@ -3,11 +3,13 @@ module SupportInterface
     def data_for_export
       interview_audits.find_each(batch_size: 100).map do |audit|
         row_for_audit(audit)
-      end
+      end.compact
     end
 
     def row_for_audit(audit)
       interview = audit.auditable
+      return if interview.blank?
+
       application_choice = interview.application_choice
       {
         audit_id: audit.id,

--- a/spec/helpers/audit_helper_spec.rb
+++ b/spec/helpers/audit_helper_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe AuditHelper, type: :helper do
+  describe 'change_by_support?' do
+    let(:user) { nil }
+    let(:username) { nil }
+    let(:audit) do
+      create(
+        :application_choice_audit,
+        user: user,
+        username: username,
+      )
+    end
+
+    subject { change_by_support?(audit) }
+
+    context 'user is a SupportUser' do
+      let(:user) { build_stubbed(:support_user) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'change was made in the rails console' do
+      let(:username) { 'Developer via the Rails console' }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'change was made by a different user' do
+      let(:username) { 'Ghost man' }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/services/support_interface/interview_changes_export_spec.rb
+++ b/spec/services/support_interface/interview_changes_export_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe SupportInterface::InterviewChangesExport do
         created_at: 1.day.ago,
       )
     end
+    let!(:orphaned_audit) do
+      # This represents an audit for a hard-deleted interview, and should be ignored in the export
+      create(
+        :interview_audit,
+        auditable_id: 123,
+        action: 'create',
+        created_at: 2.days.ago,
+      )
+    end
 
     around do |example|
       Timecop.freeze(2021, 11, 5, 15) { example.run }

--- a/spec/services/support_interface/interview_changes_export_spec.rb
+++ b/spec/services/support_interface/interview_changes_export_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe SupportInterface::InterviewChangesExport do
 
   describe '#row_for_audit' do
     let(:user) { create(:provider_user) }
+    let(:username) { nil }
     let(:changes) do
       {
         'location' => 'Zoom',
@@ -118,6 +119,7 @@ RSpec.describe SupportInterface::InterviewChangesExport do
         :interview_audit,
         interview: interview,
         user: user,
+        username: username,
         changes: changes,
         action: action,
         created_at: audit_created_at,
@@ -234,6 +236,15 @@ RSpec.describe SupportInterface::InterviewChangesExport do
         let(:user) { create(:support_user) }
 
         it 'sets provider_user to Support' do
+          expect(row[:provider_user]).to eq('Support')
+        end
+      end
+
+      context 'when the change was done in the rails console' do
+        let(:user) { nil }
+        let(:username) { 'Ben 10 via the Rails console' }
+
+        it 'sets provider_user to Automated process' do
           expect(row[:provider_user]).to eq('Support')
         end
       end


### PR DESCRIPTION
## Context
There are a couple of issues with the interviews export in prod and QA
## Changes proposed in this pull request
Account for interviews that have been hard deleted on QA.
Lazy-get the audits to avoid a timeout

## Guidance to review
Make sense?

## Link to Trello card

https://trello.com/c/3mIxkctF/3525-interview-changes-csv-export-query-times-out-on-production

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
