### PR TITLE
Update notification_preferences when updating send_notifications

### DIFF
--- a/app/controllers/provider_interface/notifications_controller.rb
+++ b/app/controllers/provider_interface/notifications_controller.rb
@@ -1,14 +1,10 @@
 module ProviderInterface
   class NotificationsController < ProviderInterfaceController
     def update
-      current_provider_user.update!(
-        send_notifications: notification_params[:send_notifications],
-      )
-
-      if FeatureFlag.active?(:configurable_provider_notifications)
-        current_provider_user.notification_preferences
-          .update_all_preferences(notification_params[:send_notifications])
-      end
+      SaveProviderUserNotificationPreferences.new(
+        provider_user: current_provider_user,
+        notification_params: notification_params,
+      ).call!
 
       flash[:success] = 'Email notification settings saved'
       redirect_to provider_interface_notifications_path

--- a/app/controllers/provider_interface/notifications_controller.rb
+++ b/app/controllers/provider_interface/notifications_controller.rb
@@ -1,10 +1,9 @@
 module ProviderInterface
   class NotificationsController < ProviderInterfaceController
     def update
-      SaveProviderUserNotificationPreferences.new(
-        provider_user: current_provider_user,
-        notification_params: notification_params,
-      ).call!
+      SaveProviderUserNotificationPreferences
+        .new(provider_user: current_provider_user)
+        .backfill_notification_preferences!(send_notifications: notification_params[:send_notifications])
 
       flash[:success] = 'Email notification settings saved'
       redirect_to provider_interface_notifications_path

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -74,10 +74,9 @@ module SupportInterface
     def toggle_notifications
       provider_user = ProviderUser.find(params[:provider_user_id])
 
-      SaveProviderUserNotificationPreferences.new(
-        provider_user: provider_user,
-        notification_params: { send_notifications: !provider_user.send_notifications },
-      ).call!
+      SaveProviderUserNotificationPreferences
+        .new(provider_user: provider_user)
+        .backfill_notification_preferences!(send_notifications: !provider_user.send_notifications)
 
       flash[:success] = 'Provider user updated'
       redirect_to support_interface_provider_user_path(provider_user)

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -73,12 +73,11 @@ module SupportInterface
 
     def toggle_notifications
       provider_user = ProviderUser.find(params[:provider_user_id])
-      provider_user.update!(send_notifications: !provider_user.send_notifications)
 
-      if FeatureFlag.active?(:configurable_provider_notifications)
-        provider_user.notification_preferences
-          .update_all_preferences(provider_user.send_notifications)
-      end
+      SaveProviderUserNotificationPreferences.new(
+        provider_user: provider_user,
+        notification_params: { send_notifications: !provider_user.send_notifications },
+      ).call!
 
       flash[:success] = 'Provider user updated'
       redirect_to support_interface_provider_user_path(provider_user)

--- a/app/services/provider_interface/save_provider_user_service.rb
+++ b/app/services/provider_interface/save_provider_user_service.rb
@@ -40,7 +40,7 @@ module ProviderInterface
         first_name: wizard.first_name,
         last_name: wizard.last_name,
       )
-      update_provider_permissions(existing_user)
+      update_provider_permissions!(existing_user)
     end
 
     def create_user
@@ -49,11 +49,18 @@ module ProviderInterface
         first_name: wizard.first_name,
         last_name: wizard.last_name,
       )
-      create_provider_permissions(user)
+      create_notification_preferences!(user)
+      create_provider_permissions!(user)
       user
     end
 
-    def create_provider_permissions(user)
+    def create_notification_preferences!(user)
+      SaveProviderUserNotificationPreferences
+        .new(provider_user: user)
+        .backfill_notification_preferences!(send_notifications: user.send_notifications)
+    end
+
+    def create_provider_permissions!(user)
       wizard.provider_permissions.each do |provider_id, permission|
         provider_permission = ProviderPermissions.new(
           provider_id: provider_id,
@@ -66,7 +73,7 @@ module ProviderInterface
       end
     end
 
-    def update_provider_permissions(user)
+    def update_provider_permissions!(user)
       wizard.provider_permissions.each do |provider_id, permission|
         provider_permission = ProviderPermissions.find_or_initialize_by(
           provider_id: provider_id,

--- a/app/services/save_provider_user.rb
+++ b/app/services/save_provider_user.rb
@@ -7,11 +7,18 @@ class SaveProviderUser
 
   def call!
     @provider_user.save!
+    save_provider_user_notification_preferences!
     update_provider_permissions!
     @provider_user.reload
   end
 
 private
+
+  def save_provider_user_notification_preferences!
+    SaveProviderUserNotificationPreferences
+      .new(provider_user: @provider_user)
+      .backfill_notification_preferences!(send_notifications: @provider_user.send_notifications)
+  end
 
   def update_provider_permissions!
     ActiveRecord::Base.transaction do

--- a/app/services/save_provider_user_notification_preferences.rb
+++ b/app/services/save_provider_user_notification_preferences.rb
@@ -1,22 +1,47 @@
 class SaveProviderUserNotificationPreferences
-  attr_reader :notification_params, :provider_user
+  attr_reader :provider_user
 
-  def initialize(provider_user:, notification_params: {})
+  def initialize(provider_user:)
     @provider_user = provider_user
-    @notification_params = notification_params
   end
 
-  def call!
-    return false unless notification_params.key?(:send_notifications)
+  def backfill_notification_preferences!(send_notifications:)
+    return false if send_notifications.nil?
 
-    provider_user.update!(send_notifications: notification_params[:send_notifications])
-    provider_user_notification_preferences.update_all_preferences(notification_params[:send_notifications])
+    update_provider_user!(send_notifications)
+    provider_user_notification_preferences.update_all_preferences(send_notifications)
+  end
+
+  def update_all_notification_preferences!(notification_preferences_params: {})
+    return false if notification_preferences_params.empty?
+
+    provider_user_notification_preferences.update!(notification_preferences_params)
+    update_provider_user!(send_notifications_from_notificaion_prefernces)
   end
 
 private
 
+  def update_provider_user!(send_notifications)
+    provider_user.assign_attributes(send_notifications: send_notifications)
+
+    provider_user.save! if provider_user.send_notifications_changed?
+  end
+
   def provider_user_notification_preferences
-    provider_user.notification_preferences ||
+    @provider_user_notification_preferences ||= provider_user.notification_preferences ||
       ProviderUserNotificationPreferences.create!(provider_user: provider_user)
+  end
+
+  def send_notifications_from_notificaion_prefernces
+    values =
+      provider_user_notification_preferences
+        .attributes
+        .with_indifferent_access
+        .values_at(*ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
+        .uniq
+
+    return true if values.count > 1
+
+    values.first
   end
 end

--- a/app/services/save_provider_user_notification_preferences.rb
+++ b/app/services/save_provider_user_notification_preferences.rb
@@ -1,0 +1,22 @@
+class SaveProviderUserNotificationPreferences
+  attr_reader :notification_params, :provider_user
+
+  def initialize(provider_user:, notification_params: {})
+    @provider_user = provider_user
+    @notification_params = notification_params
+  end
+
+  def call!
+    return false unless notification_params.key?(:send_notifications)
+
+    provider_user.update!(send_notifications: notification_params[:send_notifications])
+    provider_user_notification_preferences.update_all_preferences(notification_params[:send_notifications])
+  end
+
+private
+
+  def provider_user_notification_preferences
+    provider_user.notification_preferences ||
+      ProviderUserNotificationPreferences.create!(provider_user: provider_user)
+  end
+end

--- a/spec/factories/provider_user.rb
+++ b/spec/factories/provider_user.rb
@@ -6,8 +6,14 @@ FactoryBot.define do
     last_name { Faker::Name.last_name }
     send_notifications { Faker::Boolean.boolean(true_ratio: 0.5) }
 
-    after(:create) do |user, _evaluator|
-      user.send_notifications ? create(:provider_user_notification_preferences, provider_user: user) : create(:provider_user_notification_preferences, :all_off, provider_user: user)
+    transient do
+      create_notification_preference { true }
+    end
+
+    after(:create) do |user, evaluator|
+      if evaluator.create_notification_preference
+        user.send_notifications ? create(:provider_user_notification_preferences, provider_user: user) : create(:provider_user_notification_preferences, :all_off, provider_user: user)
+      end
     end
 
     trait :with_provider do

--- a/spec/services/provider_interface/save_provider_user_service_spec.rb
+++ b/spec/services/provider_interface/save_provider_user_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ProviderInterface::SaveProviderUserService do
   end
 
   def setup_actor
-    actor = create :provider_user
+    actor = create :provider_user, create_notification_preference: false
     @providers.each do |provider|
       actor.provider_permissions.create(provider: provider, manage_users: true)
     end
@@ -36,6 +36,13 @@ RSpec.describe ProviderInterface::SaveProviderUserService do
     expect(first_permission.make_decisions).to be false
     expect(second_permission.manage_users).to be false
     expect(second_permission.make_decisions).to be true
+  end
+
+  it 'adds the notification preferences record to a ProviderUser' do
+    wizard = setup_wizard_double
+    actor = setup_actor
+
+    expect { described_class.new(actor: actor, wizard: wizard).call! }.to change(ProviderUserNotificationPreferences, :count).by(1)
   end
 
   it 'invokes a service to persist the current state for an existing user' do

--- a/spec/services/save_provider_user_notification_preferences_spec.rb
+++ b/spec/services/save_provider_user_notification_preferences_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe SaveProviderUserNotificationPreferences do
+  describe 'save!' do
+    let(:provider_user) { create(:provider_user, send_notifications: false) }
+
+    subject(:service) { described_class.new(provider_user: provider_user, notification_params: { send_notifications: true }) }
+
+    it 'updates #send_notifications for a provider user' do
+      service.call!
+
+      expect(provider_user.send_notifications).to be true
+    end
+
+    it 'updates #notification_preferences for a provider user' do
+      service.call!
+
+      ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |pref|
+        expect(provider_user.notification_preferences.send(pref)).to be true
+      end
+    end
+
+    it 'creates and updates #notification_preferences for a provider user with no preferences' do
+      # Remove the notification preferences to emulate an existing user with no association set up yet.
+      provider_user.notification_preferences.delete
+      provider_user.reload
+
+      service.call!
+
+      provider_user.reload
+
+      ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |pref|
+        expect(provider_user.notification_preferences.send(pref)).to be true
+      end
+    end
+  end
+end

--- a/spec/services/save_provider_user_notification_preferences_spec.rb
+++ b/spec/services/save_provider_user_notification_preferences_spec.rb
@@ -1,36 +1,136 @@
 require 'rails_helper'
 
 RSpec.describe SaveProviderUserNotificationPreferences do
-  describe 'save!' do
-    let(:provider_user) { create(:provider_user, send_notifications: false) }
+  let(:create_notification_preference) { false }
+  let(:send_notifications) { false }
+  let!(:provider_user) { create(:provider_user, create_notification_preference: create_notification_preference, send_notifications: send_notifications) }
 
-    subject(:service) { described_class.new(provider_user: provider_user, notification_params: { send_notifications: true }) }
+  subject(:service) { described_class.new(provider_user: provider_user) }
 
-    it 'updates #send_notifications for a provider user' do
-      service.call!
-
-      expect(provider_user.send_notifications).to be true
+  describe 'backfill_notification_preferences!' do
+    it 'returns false if no value for #send_notifications is set' do
+      expect(service.backfill_notification_preferences!(send_notifications: nil)).to be(false)
     end
 
-    it 'updates #notification_preferences for a provider user' do
-      service.call!
+    context 'when no notification preferences exist for a provider user' do
+      it 'updates #send_notifications for a provider user' do
+        service.backfill_notification_preferences!(send_notifications: true)
 
-      ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |pref|
-        expect(provider_user.notification_preferences.send(pref)).to be true
+        expect(provider_user.send_notifications).to be(true)
+      end
+
+      it 'creates the #notification_preferences for the provider user' do
+        expect { service.backfill_notification_preferences!(send_notifications: true) }.to change(ProviderUserNotificationPreferences, :count).by(1)
+      end
+
+      it 'sets the correct value for the #notification_preferences for a provider user' do
+        service.backfill_notification_preferences!(send_notifications: true)
+
+        ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |preference|
+          expect(provider_user.reload.notification_preferences.send(preference)).to be(true)
+        end
       end
     end
 
-    it 'creates and updates #notification_preferences for a provider user with no preferences' do
-      # Remove the notification preferences to emulate an existing user with no association set up yet.
-      provider_user.notification_preferences.delete
-      provider_user.reload
+    context 'when notification preferences exist for a user' do
+      let(:create_notification_preference) { true }
 
-      service.call!
+      it 'updates #send_notifications for a provider user' do
+        service.backfill_notification_preferences!(send_notifications: true)
 
-      provider_user.reload
+        expect(provider_user.send_notifications).to be(true)
+      end
 
-      ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |pref|
-        expect(provider_user.notification_preferences.send(pref)).to be true
+      it 'does not create #notification_preferences for a provider user' do
+        expect { service.backfill_notification_preferences!(send_notifications: true) }.not_to change(ProviderUserNotificationPreferences, :count)
+      end
+
+      it 'sets the correct value for the #notification_preferences for a provider user' do
+        service.backfill_notification_preferences!(send_notifications: true)
+
+        ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |preference|
+          expect(provider_user.reload.notification_preferences.send(preference)).to be(true)
+        end
+      end
+    end
+
+    context 'when send notification preference is unchanged' do
+      let(:send_notifications) { false }
+
+      it 'does not update #send_notifications for a provider user' do
+        expect { service.backfill_notification_preferences!(send_notifications: false) }.not_to change(provider_user, :send_notifications)
+        expect(provider_user.send_notifications).to be(false)
+      end
+
+      it 'sets the correct value for the #notification_preferences for a provider user' do
+        service.backfill_notification_preferences!(send_notifications: false)
+
+        ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |preference|
+          expect(provider_user.reload.notification_preferences.send(preference)).to be(false)
+        end
+      end
+    end
+  end
+
+  describe 'update_all_notification_preferences!' do
+    it 'returns false if no value for #notification_preferences_params is set' do
+      expect(service.update_all_notification_preferences!).to be(false)
+    end
+
+    context 'when all #notification_preferences_params values are the same' do
+      let(:send_notifications) { true }
+      let(:notification_preferences_params) do
+        {
+          application_received: false,
+          application_withdrawn: false,
+          application_rejected_by_default: false,
+          offer_accepted: false,
+          offer_declined: false,
+        }
+      end
+
+      it 'updates #send_notifications for a provider user' do
+        service.update_all_notification_preferences!(notification_preferences_params: notification_preferences_params)
+
+        expect(provider_user.send_notifications).to be(false)
+      end
+
+      it 'sets the correct value for the #notification_preferences for a provider user' do
+        service.update_all_notification_preferences!(notification_preferences_params: notification_preferences_params)
+
+        ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |preference|
+          expect(provider_user.reload.notification_preferences.send(preference)).to be(false)
+        end
+      end
+    end
+
+    context 'when #notification_preferences_params values are different' do
+      let(:notification_preferences_params) do
+        {
+          application_received: true,
+          application_withdrawn: false,
+          application_rejected_by_default: false,
+          offer_accepted: true,
+          offer_declined: false,
+        }
+      end
+
+      it 'updates #send_notifications for a provider user' do
+        service.update_all_notification_preferences!(notification_preferences_params: notification_preferences_params)
+
+        expect(provider_user.send_notifications).to be(true)
+      end
+
+      it 'sets the correct value for the #notification_preferences for a provider user' do
+        service.update_all_notification_preferences!(notification_preferences_params: notification_preferences_params)
+
+        expect(provider_user.reload.notification_preferences.attributes).to include(
+          'application_received' => true,
+          'application_withdrawn' => false,
+          'application_rejected_by_default' => false,
+          'offer_accepted' => true,
+          'offer_declined' => false,
+        )
       end
     end
   end

--- a/spec/services/save_provider_user_spec.rb
+++ b/spec/services/save_provider_user_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SaveProviderUser do
   let(:provider) { create(:provider) }
   let(:another_provider) { create(:provider) }
   let(:new_provider) { create(:provider) }
-  let(:provider_user) { create(:provider_user, providers: [provider, another_provider]) }
+  let(:provider_user) { create(:provider_user, create_notification_preference: false, providers: [provider, another_provider]) }
   let(:provider_ids) { { selected: [another_provider.id], deselected: [provider.id] } }
   let(:deselected_provider_permissions) { provider_user.provider_permissions.where(provider: provider) }
   let(:provider_permissions) do
@@ -62,6 +62,10 @@ RSpec.describe SaveProviderUser do
       result = service.call!
 
       expect(result.authorisation.providers_that_actor_can_manage_users_for).to eq([another_provider])
+    end
+
+    it 'adds the notification preferences record to a ProviderUser' do
+      expect { service.call! }.to change(ProviderUserNotificationPreferences, :count).by(1)
     end
   end
 end


### PR DESCRIPTION
## Context

Notification preferences should be created and/or updated when #send_notifications is modified to ensure we have notification preference parity for feature launch.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds a namespace-neutral service which handles saving notification preferences. For the time being this updates `ProviderUser#send_notifications` and creates and/or updates `ProviderUserNotificationPreferences` for the same user.

The service is called from both provider interface and support interface controllers where the user preferences can be changed.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Does this PR miss any other places where the notification preferences can be written?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Wm7NAOrk/3449-migrate-provider-user-notification-settings-to-new-structure
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
