### PR TITLE
Fix redirection and request spec for Make offer

### DIFF
--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -169,7 +169,7 @@ module ProviderInterface
     def confirm_application_is_in_decision_pending_state
       return if ApplicationStateChange::DECISION_PENDING_STATUSES.include?(@application_choice.status.to_sym)
 
-      redirect_back(fallback_location: provider_interface_application_choice_path(@application_choice))
+      redirect_to(provider_interface_application_choice_path(@application_choice))
     end
 
     def provider_interface_offer_params

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -1,7 +1,7 @@
 module ProviderInterface
   class OffersController < ProviderInterfaceController
     before_action :set_application_choice
-    before_action :application_choice_allowed_to_make_decision
+    before_action :confirm_application_is_in_decision_pending_state
     before_action :requires_make_decisions_permission
 
     def new
@@ -35,10 +35,10 @@ module ProviderInterface
       WizardStateStores::RedisStore.new(key: key)
     end
 
-    def application_choice_allowed_to_make_decision
-      return unless ApplicationStateChange::DECISION_PENDING_STATUSES.include?(@application_choice.status)
+    def confirm_application_is_in_decision_pending_state
+      return if ApplicationStateChange::DECISION_PENDING_STATUSES.include?(@application_choice.status.to_sym)
 
-      redirect_back(fallback_location: provider_interface_application_choice_path(@application_choice))
+      redirect_to(provider_interface_application_choice_path(@application_choice))
     end
   end
 end

--- a/spec/requests/provider_interface/decisions_controller_spec.rb
+++ b/spec/requests/provider_interface/decisions_controller_spec.rb
@@ -17,7 +17,15 @@ RSpec.describe ProviderInterface::DecisionsController, type: :request do
     end
 
     before do
-      user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+      allow(DfESignInUser).to receive(:load_from_session)
+        .and_return(
+          DfESignInUser.new(
+            email_address: provider_user.email_address,
+            dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+            first_name: provider_user.first_name,
+            last_name: provider_user.last_name,
+          ),
+        )
     end
 
     context 'GET new' do

--- a/spec/requests/provider_interface/decisions_controller_spec.rb
+++ b/spec/requests/provider_interface/decisions_controller_spec.rb
@@ -35,5 +35,13 @@ RSpec.describe ProviderInterface::DecisionsController, type: :request do
         expect(response.status).to eq(302)
       end
     end
+
+    context 'POST create' do
+      it 'responds with 302' do
+        post provider_interface_application_choice_decision_path(application_choice)
+
+        expect(response.status).to eq(302)
+      end
+    end
   end
 end

--- a/spec/requests/provider_interface/offers_controller_spec.rb
+++ b/spec/requests/provider_interface/offers_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::OffersController, type: :request do
+  include DfESignInHelpers
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions) }
+  let(:provider) { provider_user.providers.first }
+  let(:application_form) { build(:application_form, :minimum_info) }
+  let(:course) { build(:course, :open_on_apply, provider: provider) }
+  let(:course_option) { build(:course_option, course: course) }
+
+  describe 'if application choice is not in a pending decision state' do
+    let!(:application_choice) do
+      create(:application_choice, :withdrawn,
+             application_form: application_form,
+             course_option: course_option)
+    end
+
+    before do
+      allow(DfESignInUser).to receive(:load_from_session)
+        .and_return(
+          DfESignInUser.new(
+            email_address: provider_user.email_address,
+            dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+            first_name: provider_user.first_name,
+            last_name: provider_user.last_name,
+          ),
+        )
+    end
+
+    context 'GET new' do
+      it 'responds with 302' do
+        get new_provider_interface_application_choice_offer_path(application_choice)
+
+        expect(response.status).to eq(302)
+      end
+    end
+
+    context 'POST create' do
+      it 'responds with 302' do
+        post provider_interface_application_choice_offers_path(application_choice)
+
+        expect(response.status).to eq(302)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

- Fix DecisionController request spec (invalid stubbing of DfeSignIn causes false pass)
- Update redirect path of Decisions and Offers controllers (by redirecting back we can keep re-entering invalid paths) e.g. if page has been left open and offer has already been made, we are redirected back to pages that can't be accessed.
- Fix redirect condition for OffersController and add specs to verify

## Link to Trello card

Related to:
https://trello.com/c/TbL2H8ck/3459-edit-a-new-offer-from-the-review-page-via-the-change-links

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
