### PR TITLE
Change messaging when candidate adds already chosen course

### DIFF
--- a/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
@@ -26,6 +26,7 @@ module CandidateInterface
           course_id: course_id,
           application_form: current_application,
         )
+        redirect_to_review_page_with_already_added_message and return if @pick_course.already_picked_this_one?
         render :new and return unless @pick_course.valid?
 
         if !@pick_course.open_on_apply?
@@ -73,6 +74,13 @@ module CandidateInterface
 
       def full
         @course = Course.find(params[:course_id])
+      end
+
+    private
+
+      def redirect_to_review_page_with_already_added_message
+        flash[:info] = @pick_course.already_added_error
+        redirect_to candidate_interface_course_choices_review_path
       end
     end
   end

--- a/app/forms/candidate_interface/pick_course_form.rb
+++ b/app/forms/candidate_interface/pick_course_form.rb
@@ -65,6 +65,14 @@ module CandidateInterface
       @course ||= provider.courses.find(course_id)
     end
 
+    def already_picked_this_one?
+      application_form.application_choices.includes([:course]).any? { |application_choice| application_choice.course == course }
+    end
+
+    def already_added_error
+      I18n.t!('errors.application_choices.already_added', course_name_and_code: course.name_and_code)
+    end
+
   private
 
     def provider
@@ -74,8 +82,8 @@ module CandidateInterface
     def user_cant_apply_to_same_course_twice
       return if course_id.blank?
 
-      if application_form.application_choices.includes([:course]).any? { |application_choice| application_choice.course == course }
-        errors[:base] << I18n.t!('errors.application_choices.already_added', course_name_and_code: course.name_and_code)
+      if already_picked_this_one?
+        errors[:base] << already_added_error
       end
     end
   end

--- a/spec/system/candidate_interface/course_selection/candidate_adds_a_course_theyve_already_chosen_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_adds_a_course_theyve_already_chosen_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.feature 'Handling duplicate course choices' do
+  include CandidateHelper
+
+  scenario "candidate adds a course they've already chosen" do
+    given_i_am_signed_in
+    and_i_have_chosen_a_course
+    when_i_add_that_same_course_again
+    then_i_am_taken_to_the_review_page
+    and_i_am_informed_that_ive_already_added_that_course
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_have_chosen_a_course
+    course_option = create(:course_option, course: create(:course, :open_on_apply))
+    @choice = create(
+      :application_choice,
+      status: :unsubmitted,
+      course_option: course_option,
+      application_form: current_candidate.current_application,
+    )
+  end
+
+  def when_i_add_that_same_course_again
+    visit candidate_interface_course_choices_course_path(@choice.provider)
+    choose @choice.course.name
+    click_button 'Continue'
+  end
+
+  def then_i_am_taken_to_the_review_page
+    expect(page).to have_current_path candidate_interface_course_choices_review_path
+  end
+
+  def and_i_am_informed_that_ive_already_added_that_course
+    within '.govuk-notification-banner--info' do
+      expect(page).to have_content "You have already added #{@choice.course.name_and_code}"
+    end
+    expect(ApplicationChoice.count).to eq 1
+  end
+end


### PR DESCRIPTION
## Context
We have a validation in place which ensures that a candidate can't add the
same course to their application twice.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Rather than style this as an error message in the UI, handle the
situation more gracefully by taking the candidate to the course choices
review page and display an info banner informing them they've already
added that course.

**Before**
![image](https://user-images.githubusercontent.com/519250/111470884-37373400-8720-11eb-9cd0-9e2f6844f0cb.png)

**After**
![image](https://user-images.githubusercontent.com/519250/111470447-c5f78100-871f-11eb-8693-a625934df682.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Add a course to an application
- Click back button and add same course
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/UxJswxbz
## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
