### PR TITLE
Text updates on Make Offer flow

### DIFF
--- a/app/components/provider_interface/course_summary_component.html.erb
+++ b/app/components/provider_interface/course_summary_component.html.erb
@@ -1,5 +1,5 @@
 <div class="app-banner app-banner--details govuk-!-margin-bottom-7 govuk-!-padding-4">
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Course details</h2>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Course applied for</h2>
   <section class="app-summary-card no-border">
     <div class="app-summary-card__body">
       <%= render SummaryListComponent.new(rows: rows) %>

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -15,7 +15,7 @@ en:
     offers:
       failure: Sorry, there is a problem with the service.
       create:
-        success: Offer successffuly made
+        success: Offer sent
   helpers:
     label:
       provider_interface_offer_wizard:

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature 'Provider makes an offer' do
 
   def then_i_see_the_decision_page
     expect(page).to have_content('Make a decision')
-    expect(page).to have_content('Course details')
+    expect(page).to have_content('Course applied for')
   end
 
   def when_i_choose_to_make_an_offer
@@ -109,7 +109,7 @@ RSpec.feature 'Provider makes an offer' do
 
   def then_i_see_that_the_offer_was_successfuly_made
     within('.govuk-notification-banner--success') do
-      expect(page).to have_content('Offer successffuly made')
+      expect(page).to have_content('Offer sent')
     end
   end
 end

--- a/spec/system/provider_interface/provider_responds_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_responds_to_application_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature 'Provider responds to application' do
   end
 
   def then_i_can_see_the_course_details
-    expect(page).to have_content 'Course details'
+    expect(page).to have_content 'Course applied for'
   end
 
   def and_i_am_given_the_option_to_make_an_offer


### PR DESCRIPTION
On Adam’s request.

https://ukgovernmentdfe.slack.com/archives/CPH8J9G65/p1615988073024800?thread_ts=1615987809.022100&cid=CPH8J9G65

## Link to Trello card

Related to:
https://trello.com/c/TbL2H8ck/3459-edit-a-new-offer-from-the-review-page-via-the-change-links

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
