### PR TITLE
Redirect to the interviews index if the store has been cleared

### DIFF
--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -4,6 +4,7 @@ module ProviderInterface
     before_action :interview_flag_enabled?
     before_action :requires_make_decisions_permission, except: %i[index]
     before_action :confirm_application_is_in_decision_pending_state, except: %i[index]
+    before_action :redirect_to_index_if_store_cleared, only: %i[check commit]
 
     def index
       application_at_interviewable_stage = ApplicationStateChange::INTERVIEWABLE_STATES.include?(
@@ -160,6 +161,10 @@ module ProviderInterface
       return if ApplicationStateChange::DECISION_PENDING_STATUSES.include?(@application_choice.status.to_sym)
 
       redirect_back(fallback_location: provider_interface_application_choice_path(@application_choice))
+    end
+
+    def redirect_to_index_if_store_cleared
+      redirect_to provider_interface_application_choice_interviews_path(@application_choice) if interview_store.read.blank?
     end
   end
 end


### PR DESCRIPTION
## Context

Clicking back after creating or editing an interview takes the user to the 'check' step of the interviews wizard.
The store will be cleared on creating or editing the interview so any attempt to resubmit will cause a 500 error.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Check to see if the store is empty on check and commit steps as an indication that there's no interview to check or save and that the user should be redirected to the interviews index.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/rTjsws8z/3493-pressing-back-button-after-creating-an-interview-returns-a-500

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
