### PR TITLE
Qualifications (A level) metrics for Feature Metrics dashboard 2.0 (part 4/4)

### DIFF
--- a/app/models/feature_metrics_dashboard.rb
+++ b/app/models/feature_metrics_dashboard.rb
@@ -21,6 +21,7 @@ class FeatureMetricsDashboard < ApplicationRecord
     load_apply_again_change_rate
     load_apply_again_application_rate
     load_carry_over_counts
+    load_qualifications
   end
 
   def last_updated_at
@@ -55,6 +56,10 @@ private
 
   def carry_over_statistics
     CarryOverFeatureMetrics.new
+  end
+
+  def qualifications_statistics
+    QualificationsFeatureMetrics.new
   end
 
   def load_avg_time_to_get_references
@@ -279,6 +284,53 @@ private
       :carry_over_count_last_month,
       carry_over_statistics.carry_over_count(
         EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        Time.zone.now.beginning_of_month,
+      ),
+    )
+  end
+
+  def load_qualifications
+    write_metric(
+      :pct_applications_with_one_a_level,
+      qualifications_statistics.formatted_a_level_percentage(
+        1,
+        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+      ),
+    )
+    write_metric(
+      :pct_applications_with_one_a_level_this_month,
+      qualifications_statistics.formatted_a_level_percentage(
+        1,
+        Time.zone.now.beginning_of_month,
+      ),
+    )
+    write_metric(
+      :pct_applications_with_one_a_level_last_month,
+      qualifications_statistics.formatted_a_level_percentage(
+        1,
+        Time.zone.now.beginning_of_month - 1.month,
+        Time.zone.now.beginning_of_month,
+      ),
+    )
+    write_metric(
+      :pct_applications_with_three_a_levels,
+      qualifications_statistics.formatted_a_level_percentage(
+        3,
+        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+      ),
+    )
+    write_metric(
+      :pct_applications_with_three_a_levels_this_month,
+      qualifications_statistics.formatted_a_level_percentage(
+        3,
+        Time.zone.now.beginning_of_month,
+      ),
+    )
+    write_metric(
+      :pct_applications_with_three_a_levels_last_month,
+      qualifications_statistics.formatted_a_level_percentage(
+        3,
+        Time.zone.now.beginning_of_month - 1.month,
         Time.zone.now.beginning_of_month,
       ),
     )

--- a/app/models/qualifications_feature_metrics.rb
+++ b/app/models/qualifications_feature_metrics.rb
@@ -1,0 +1,51 @@
+class QualificationsFeatureMetrics
+  include ActionView::Helpers::NumberHelper
+
+  def formatted_a_level_percentage(
+    minimum_count,
+    start_time,
+    end_time = Time.zone.now.end_of_day
+  )
+    applications_with_a_levels_count = applications_with_a_levels_grouped(
+      minimum_count,
+      start_time,
+      end_time,
+    ).count.keys.count
+    all_applications_count = all_applications(start_time, end_time).count
+
+    return 'n/a' if all_applications_count.zero?
+
+    format_as_percentage(applications_with_a_levels_count.to_f / all_applications_count)
+  end
+
+private
+
+  def all_applications(start_time, end_time)
+    ApplicationForm
+      .where(
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+      )
+      .where('application_forms.submitted_at BETWEEN ? AND ?', start_time, end_time)
+      .where(recruitment_cycle_year: RecruitmentCycle.current_year)
+  end
+
+  def applications_with_a_levels_grouped(minimum_count, start_time, end_time)
+    all_applications(start_time, end_time)
+      .joins(:application_qualifications)
+      .where('application_qualifications.level': 'other')
+      .where("application_qualifications.qualification_type IN ('A level', 'A/S level')")
+      .having('count(application_qualifications.id) >= ?', minimum_count)
+      .group('application_forms.id')
+  end
+
+  def format_as_percentage(ratio)
+    return 'n/a' if ratio.nil?
+
+    percentage = number_with_precision(
+      100.0 * ratio,
+      precision: 1,
+      strip_insignificant_zeros: true,
+    )
+    "#{percentage}%"
+  end
+end

--- a/app/models/qualifications_feature_metrics.rb
+++ b/app/models/qualifications_feature_metrics.rb
@@ -6,11 +6,11 @@ class QualificationsFeatureMetrics
     start_time,
     end_time = Time.zone.now.end_of_day
   )
-    applications_with_a_levels_count = applications_with_a_levels_grouped(
+    applications_with_a_levels_count = applications_with_a_levels_grouped_counts(
       minimum_count,
       start_time,
       end_time,
-    ).count.keys.count
+    ).keys.count
     all_applications_count = all_applications(start_time, end_time).count
 
     return 'n/a' if all_applications_count.zero?
@@ -29,13 +29,14 @@ private
       .where(recruitment_cycle_year: RecruitmentCycle.current_year)
   end
 
-  def applications_with_a_levels_grouped(minimum_count, start_time, end_time)
+  def applications_with_a_levels_grouped_counts(minimum_count, start_time, end_time)
     all_applications(start_time, end_time)
       .joins(:application_qualifications)
       .where('application_qualifications.level': 'other')
       .where("application_qualifications.qualification_type IN ('A level', 'A/S level')")
       .having('count(application_qualifications.id) >= ?', minimum_count)
       .group('application_forms.id')
+      .count
   end
 
   def format_as_percentage(ratio)

--- a/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
+++ b/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
@@ -358,7 +358,7 @@
       <div id="headline-stat" class="govuk-!-margin-bottom-4">
         <%= render SupportInterface::TileComponent.new(
           count: @dashboard.read_metric(:pct_applications_with_three_a_levels),
-          label: 'candidates input 3 or more AS & A-levels',
+          label: 'candidates added 3 or more AS or A level',
           colour: :blue,
           size: :reduced,
         ) %>

--- a/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
+++ b/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
@@ -325,4 +325,60 @@
       </div>
     </div>
   </div>
+
+  <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Qualifications</h3>
+  <div id="qualifications_dashboard_section" class="govuk-grid-row govuk-!-margin-bottom-4">
+    <div class="govuk-grid-column-one-half">
+      <div id="headline-stat" class="govuk-!-margin-bottom-4">
+        <%= render SupportInterface::TileComponent.new(
+          count: @dashboard.read_metric(:pct_applications_with_one_a_level),
+          label: 'candidates input 1 or more AS & A-levels',
+          colour: :blue,
+          size: :reduced,
+        ) %>
+      </div>
+      <div class="govuk-grid-row govuk-!-margin-bottom-4">
+        <div class="govuk-grid-column-one-half">
+          <%= render SupportInterface::TileComponent.new(
+            count: @dashboard.read_metric(:pct_applications_with_one_a_level_this_month),
+            label: 'this month',
+            size: :reduced,
+          ) %>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= render SupportInterface::TileComponent.new(
+            count: @dashboard.read_metric(:pct_applications_with_one_a_level_last_month),
+            label: 'last month',
+            size: :reduced,
+          ) %>
+        </div>
+      </div>
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <div id="headline-stat" class="govuk-!-margin-bottom-4">
+        <%= render SupportInterface::TileComponent.new(
+          count: @dashboard.read_metric(:pct_applications_with_three_a_levels),
+          label: 'candidates input 3 or more AS & A-levels',
+          colour: :blue,
+          size: :reduced,
+        ) %>
+      </div>
+      <div class="govuk-grid-row govuk-!-margin-bottom-4">
+        <div class="govuk-grid-column-one-half">
+          <%= render SupportInterface::TileComponent.new(
+            count: @dashboard.read_metric(:pct_applications_with_three_a_levels_this_month),
+            label: 'this month',
+            size: :reduced,
+          ) %>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= render SupportInterface::TileComponent.new(
+            count: @dashboard.read_metric(:pct_applications_with_three_a_levels_last_month),
+            label: 'last month',
+            size: :reduced,
+          ) %>
+        </div>
+      </div>
+    </div>
+  </div>
 <% end %>

--- a/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
+++ b/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
@@ -332,7 +332,7 @@
       <div id="headline-stat" class="govuk-!-margin-bottom-4">
         <%= render SupportInterface::TileComponent.new(
           count: @dashboard.read_metric(:pct_applications_with_one_a_level),
-          label: 'candidates input 1 or more AS & A-levels',
+          label: 'candidates added 1 or more AS or A level',
           colour: :blue,
           size: :reduced,
         ) %>

--- a/spec/models/feature_metrics_dashboard_spec.rb
+++ b/spec/models/feature_metrics_dashboard_spec.rb
@@ -52,12 +52,16 @@ RSpec.describe FeatureMetricsDashboard do
       magic_link_metrics_double = instance_double(MagicLinkFeatureMetrics)
       rfr_metrics_double = instance_double(ReasonsForRejectionFeatureMetrics)
       apply_again_metrics_double = instance_double(ApplyAgainFeatureMetrics)
+      carry_over_metrics_double = instance_double(CarryOverFeatureMetrics)
+      qualifications_metrics_double = instance_double(QualificationsFeatureMetrics)
 
       allow(ReferenceFeatureMetrics).to receive(:new).and_return(reference_metrics_double)
       allow(WorkHistoryFeatureMetrics).to receive(:new).and_return(work_history_metrics_double)
       allow(MagicLinkFeatureMetrics).to receive(:new).and_return(magic_link_metrics_double)
       allow(ReasonsForRejectionFeatureMetrics).to receive(:new).and_return(rfr_metrics_double)
       allow(ApplyAgainFeatureMetrics).to receive(:new).and_return(apply_again_metrics_double)
+      allow(CarryOverFeatureMetrics).to receive(:new).and_return(carry_over_metrics_double)
+      allow(QualificationsFeatureMetrics).to receive(:new).and_return(qualifications_metrics_double)
 
       allow(reference_metrics_double).to receive(:average_time_to_get_references).and_return(1)
       allow(reference_metrics_double).to receive(:percentage_references_within).and_return(2)
@@ -67,6 +71,8 @@ RSpec.describe FeatureMetricsDashboard do
       allow(apply_again_metrics_double).to receive(:formatted_success_rate).and_return('42.8%')
       allow(apply_again_metrics_double).to receive(:formatted_change_rate).and_return('33.3%')
       allow(apply_again_metrics_double).to receive(:formatted_application_rate).and_return('18.7%')
+      allow(carry_over_metrics_double).to receive(:carry_over_count).and_return(20)
+      allow(qualifications_metrics_double).to receive(:formatted_a_level_percentage).and_return('30%')
 
       dashboard = described_class.new
       dashboard.load_updated_metrics
@@ -102,9 +108,15 @@ RSpec.describe FeatureMetricsDashboard do
         'apply_again_application_rate' => '18.7%',
         'apply_again_application_rate_this_month' => '18.7%',
         'apply_again_application_rate_upto_this_month' => '18.7%',
-        'carry_over_count' => 0,
-        'carry_over_count_this_month' => 0,
-        'carry_over_count_last_month' => 0,
+        'carry_over_count' => 20,
+        'carry_over_count_this_month' => 20,
+        'carry_over_count_last_month' => 20,
+        'pct_applications_with_one_a_level' => '30%',
+        'pct_applications_with_one_a_level_this_month' => '30%',
+        'pct_applications_with_one_a_level_last_month' => '30%',
+        'pct_applications_with_three_a_levels' => '30%',
+        'pct_applications_with_three_a_levels_this_month' => '30%',
+        'pct_applications_with_three_a_levels_last_month' => '30%',
       })
     end
   end

--- a/spec/models/qualifications_feature_metrics_spec.rb
+++ b/spec/models/qualifications_feature_metrics_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe QualificationsFeatureMetrics, with_audited: true do
         expect(feature_metrics.formatted_a_level_percentage(1, 1.month.ago)).to eq('0%')
       end
 
-      it 'returns 50% when there one of two applications has A levels' do
+      it 'returns the right percentages for different minimum numbers of A levels' do
         create_application
         create_application(1)
         create_application(3)

--- a/spec/models/qualifications_feature_metrics_spec.rb
+++ b/spec/models/qualifications_feature_metrics_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe QualificationsFeatureMetrics, with_audited: true do
+  subject(:feature_metrics) { described_class.new }
+
+  def create_application(a_level_count = 0)
+    application_form = create(:completed_application_form, submitted_at: Time.zone.now)
+    a_level_count.times do
+      create(
+        :other_qualification,
+        qualification_type: 'A level',
+        application_form: application_form,
+      )
+    end
+    application_form
+  end
+
+  describe '#formatted_a_level_percentage' do
+    context 'without any data' do
+      it 'returns n/a' do
+        expect(feature_metrics.formatted_a_level_percentage(1, 1.month.ago)).to eq('n/a')
+      end
+    end
+
+    context 'with applications with A levels' do
+      it 'returns 0 when there are no applications with A levels' do
+        create_application
+        expect(feature_metrics.formatted_a_level_percentage(1, 1.month.ago)).to eq('0%')
+      end
+
+      it 'returns 50% when there one of two applications has A levels' do
+        create_application
+        create_application(1)
+        create_application(3)
+        expect(feature_metrics.formatted_a_level_percentage(1, 1.month.ago)).to eq('66.7%')
+        expect(feature_metrics.formatted_a_level_percentage(3, 1.month.ago)).to eq('33.3%')
+      end
+
+      it 'returns the right percentages when there are multiple applications with A levels' do
+        @today = Time.zone.local(2021, 3, 10, 12)
+        Timecop.freeze(@today - 40.days) do
+          create_application
+          create_application(1)
+        end
+        Timecop.freeze(@today - 20.days) do
+          create_application(2)
+        end
+        Timecop.freeze(@today - 5.days) do
+          create_application(3)
+        end
+        Timecop.freeze(@today) do
+          expect(feature_metrics.formatted_a_level_percentage(1, 25.days.ago)).to eq('100%')
+          expect(feature_metrics.formatted_a_level_percentage(3, 25.days.ago)).to eq('50%')
+          expect(feature_metrics.formatted_a_level_percentage(2, 25.days.ago, 10.days.ago)).to eq('100%')
+          expect(feature_metrics.formatted_a_level_percentage(3, 25.days.ago, 10.days.ago)).to eq('0%')
+          expect(feature_metrics.formatted_a_level_percentage(1, 45.days.ago)).to eq('75%')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We are adding a new set of metrics to the feature metrics dashboard. This 3rd PR follows on from https://github.com/DFE-Digital/apply-for-teacher-training/pull/4293 and adds qualification metrics, specifically for A and A/S levels. This is the last of the PRs that adds new functionality for the dashboard.

## Changes proposed in this pull request

- [x] Add new dashboard section for the percentage of applications (submitted within the time ranges) that have specified at least 1 and at least 3 A or A/S levels.

<img width="1157" alt="image" src="https://user-images.githubusercontent.com/450843/111539110-6ae87d00-8765-11eb-90c2-f7135a07760e.png">

- [x] Rebase onto master after https://github.com/DFE-Digital/apply-for-teacher-training/pull/4293 gets merged 

## Guidance to review

- Does the query in `QualificationsFeatureMetrics` make sense?
- Is the copy right?
- With this PR the new dashboard is now feature complete (I think) so should we be refactoring the implementation at this stage? e.g. there are lots of model classes for feature metrics now, all top-level. There is also a CandidateInterface::FindChangedApplyAgainApplications service. I think these should be re-organised. Should we put make them all services? stick them under the SupportInterface or maybe even a SupportInterface::FeatureMetrics namespace? (this can be done as a separate PR but interested in what people think).

Here's a screenshot of all the Feature Metrics 2.0 additions:

<img width="609" alt="image" src="https://user-images.githubusercontent.com/450843/112128456-5d485280-8bbe-11eb-92c9-e76e38eea2c9.png">


## Link to Trello card

https://trello.com/c/1X9y1JPl/2981-feature-metric-dashboard-20

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
