### PR TITLE
Expect exact matches on api request paths when filtering

### DIFF
--- a/spec/system/support_interface/view_vendor_api_requests_spec.rb
+++ b/spec/system/support_interface/view_vendor_api_requests_spec.rb
@@ -68,9 +68,9 @@ RSpec.feature 'Vendor API Requests' do
   end
 
   def then_i_see_the_api_request
-    expect(page).to have_content('/api/v1/applications/9999/offer')
-    expect(page).to have_content(vendor_api_path(@first_application_choice))
-    expect(page).to have_content(vendor_api_path(@last_application_choice))
+    expect(page).to have_selector('p.govuk-body', exact_text: '/api/v1/applications/9999/offer')
+    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path(@first_application_choice))
+    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path(@last_application_choice))
   end
 
   def and_i_see_the_status_of_the_request
@@ -95,9 +95,9 @@ RSpec.feature 'Vendor API Requests' do
   end
 
   def then_i_only_see_api_requests_filtered_by_status
-    expect(page).not_to have_content(vendor_api_path(@first_application_choice))
-    expect(page).to have_content(vendor_api_path(@last_application_choice))
-    expect(page).to have_content('/api/v1/applications/9999/offer')
+    expect(page).not_to have_selector('p.govuk-body', exact_text: vendor_api_path(@first_application_choice))
+    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path(@last_application_choice))
+    expect(page).to have_selector('p.govuk-body', exact_text: '/api/v1/applications/9999/offer')
   end
 
   def and_i_clear_filters
@@ -110,9 +110,9 @@ RSpec.feature 'Vendor API Requests' do
   end
 
   def then_i_see_api_requests_filtered_by_request_method
-    expect(page).to have_content(vendor_api_path(@first_application_choice))
-    expect(page).to have_content(vendor_api_path(@last_application_choice))
-    expect(page).not_to have_content('/api/v1/applications/9999/offer')
+    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path(@first_application_choice))
+    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path(@last_application_choice))
+    expect(page).not_to have_selector('p.govuk-body', exact_text: '/api/v1/applications/9999/offer')
   end
 
   def when_i_search_for_a_specific_request_path
@@ -121,8 +121,8 @@ RSpec.feature 'Vendor API Requests' do
   end
 
   def then_i_only_see_api_requests_filtered_by_the_search
-    expect(page).to have_content(vendor_api_path(@first_application_choice))
-    expect(page).not_to have_content(vendor_api_path(@last_application_choice))
+    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path(@first_application_choice))
+    expect(page).not_to have_selector('p.govuk-body', exact_text: vendor_api_path(@last_application_choice))
   end
 
   def when_i_filter_by_provider
@@ -132,7 +132,7 @@ RSpec.feature 'Vendor API Requests' do
   end
 
   def then_i_only_see_api_requests_filtered_by_provider
-    expect(page).not_to have_content(vendor_api_path(@first_application_choice))
-    expect(page).to have_content(vendor_api_path(@last_application_choice))
+    expect(page).not_to have_selector('p.govuk-body', exact_text: vendor_api_path(@first_application_choice))
+    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path(@last_application_choice))
   end
 end


### PR DESCRIPTION
## Context

This test was failing intermittently when one of the factory generated applications had a path which was a substring of another.
The `have_content` matcher was not precise enough to distinguish the substring eg. `/api/v1/applications/99` and `/api/v1/applications/9999/offer`

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Switch to `have_selector` with an exact text match to fix.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

Broke master.
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
