### PR TITLE
Add service to validate course detail combination.

### DIFF
--- a/app/services/offered_course_option_details_check.rb
+++ b/app/services/offered_course_option_details_check.rb
@@ -1,0 +1,35 @@
+class OfferedCourseOptionDetailsCheck
+  class InvalidStateError < StandardError
+    attr_accessor :detail
+
+    def initialize(detail)
+      @detail = detail.to_s.humanize(capitalize: false)
+    end
+
+    def message
+      "Invalid #{detail} for CourseOption"
+    end
+  end
+
+  attr_reader :provider_id, :course_id, :course_option_id, :study_mode, :recruitment_cycle_year
+
+  def initialize(
+    provider_id:,
+    course_id:,
+    course_option_id:,
+    study_mode:
+  )
+    @provider_id = provider_id
+    @course_id = course_id
+    @course_option_id = course_option_id
+    @study_mode = study_mode
+  end
+
+  def validate!
+    course_option = CourseOption.find(course_option_id)
+
+    raise InvalidStateError, :provider if course_option.course.provider_id != provider_id
+    raise InvalidStateError, :course if course_option.course_id != course_id
+    raise InvalidStateError, :study_mode if course_option.study_mode != study_mode
+  end
+end

--- a/spec/services/offered_course_option_details_check_spec.rb
+++ b/spec/services/offered_course_option_details_check_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe OfferedCourseOptionDetailsCheck do
+  let(:course_option) { create(:course_option, study_mode: :full_time) }
+
+  it 'is successful when all the provided details correspond to the course option' do
+    service = described_class.new(provider_id: course_option.provider.id,
+                                  course_id: course_option.course.id,
+                                  course_option_id: course_option.id,
+                                  study_mode: course_option.study_mode)
+
+    expect { service.validate! }.not_to raise_error
+  end
+
+  it 'throws an InvalidProviderError when the provider does not correspond to the course option' do
+    provider = create(:provider)
+    service = described_class.new(provider_id: provider.id,
+                                  course_id: course_option.course.id,
+                                  course_option_id: course_option.id,
+                                  study_mode: course_option.study_mode)
+
+    expect { service.validate! }.to raise_error(OfferedCourseOptionDetailsCheck::InvalidStateError, 'Invalid provider for CourseOption')
+  end
+
+  it 'throws an InvalidCourseError when the course does not correspond to the course option' do
+    course = create(:course)
+    service = described_class.new(provider_id: course_option.provider.id,
+                                  course_id: course.id,
+                                  course_option_id: course_option.id,
+                                  study_mode: course_option.study_mode)
+
+    expect { service.validate! }.to raise_error(OfferedCourseOptionDetailsCheck::InvalidStateError, 'Invalid course for CourseOption')
+  end
+
+  it 'throws an InvalidStudyModeError when the study mode does not correspond to the course option' do
+    study_mode = :part_time
+    service = described_class.new(provider_id: course_option.provider.id,
+                                  course_id: course_option.course.id,
+                                  course_option_id: course_option.id,
+                                  study_mode: study_mode)
+
+    expect { service.validate! }.to raise_error(OfferedCourseOptionDetailsCheck::InvalidStateError, 'Invalid study mode for CourseOption')
+  end
+end


### PR DESCRIPTION
## Context

Add service to check whether course details are valid.

## Link to Trello card

https://trello.com/c/tr4toE9e/3530-add-offer-validation-service

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
