### PR TITLE
API: attach HESA data when applications have accepted offers

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -58,11 +58,13 @@ module VendorAPI
           safeguarding_issues_details_url: safeguarding_issues_details_url,
         },
       }
-      if application_choice.status == 'recruited'
+
+      if ApplicationStateChange::ACCEPTED_STATES.include? application_choice.status.to_sym
         hash[:attributes][:hesa_itt_data] = hesa_itt_data
       else
         hash[:attributes][:hesa_itt_data] = nil
       end
+
       hash
     end
 

--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,7 @@
+## 19th March
+
+Fix a bug where HESA ITT data was not being returned for applications with accepted offers.
+
 ## 9th March
 
 Changes to existing attributes:

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -47,12 +47,12 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
   end
 
   describe 'attributes.hesa_itt_data' do
-    context "when an application choice has status 'recruited'" do
+    context 'when an application choice has had an accepted offer' do
       let(:application_choice) do
         application_form = create(:application_form,
                                   :minimum_info,
                                   :with_equality_and_diversity_data)
-        create(:application_choice, status: 'recruited', application_form: application_form)
+        create(:application_choice, :with_accepted_offer, application_form: application_form)
       end
 
       it 'returns the hesa_itt_data attribute of an application' do
@@ -68,12 +68,12 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       end
     end
 
-    context "when an application choice does not have status 'recruited'" do
+    context 'when an application choice has not had an accepted offer' do
       let(:application_choice) do
         application_form = create(:application_form,
                                   :minimum_info,
                                   :with_equality_and_diversity_data)
-        create(:application_choice, status: 'offer', application_form: application_form)
+        create(:application_choice, :with_offer, application_form: application_form)
       end
 
       it 'the hesa_itt_data attribute of an application is nil' do


### PR DESCRIPTION
This was out of sync with policy and the docs.

## Context

Pointed it out in Slack https://ukgovernmentdfe.slack.com/archives/CTHFLRFHB/p1615975251002000

## Changes proposed in this pull request

Provide HESA data when the application is in the correct state(s)

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
