### PR TITLE
Extend test data for feature metrics dashboard

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -21,22 +21,49 @@ class TestApplications
     end
   end
 
-  def create_application(recruitment_cycle_year:, states:, courses_to_apply_to:, apply_again: false, course_full: false, candidate: nil, decline_by_default_at: 3.days.from_now)
+  def create_application(
+    recruitment_cycle_year:,
+    states:,
+    courses_to_apply_to:,
+    apply_again: false,
+    carry_over: false,
+    course_full: false,
+    candidate: nil,
+    decline_by_default_at: 3.days.from_now
+  )
     initialize_time(recruitment_cycle_year)
 
     if apply_again
       raise OnlyOneCourseWhenApplyingAgainError, 'You can only apply to one course when applying again' unless states.one?
 
-      create_application(recruitment_cycle_year: recruitment_cycle_year, states: [:rejected], courses_to_apply_to: courses_to_apply_to)
+      create_application(
+        recruitment_cycle_year: recruitment_cycle_year,
+        states: [:rejected],
+        courses_to_apply_to: courses_to_apply_to,
+      )
 
       candidate = candidate.presence || Candidate.last
       first_name = candidate.current_application.first_name
       last_name = candidate.current_application.last_name
+      previous_application_form = candidate.current_application
+    elsif carry_over
+      create_application(
+        recruitment_cycle_year: recruitment_cycle_year - 1,
+        states: %i[rejected declined],
+        courses_to_apply_to: courses_to_apply_to,
+      )
+
+      initialize_time(recruitment_cycle_year)
+      candidate = candidate.presence || Candidate.last
+      first_name = candidate.current_application.first_name
+      last_name = candidate.current_application.last_name
+      previous_application_form = candidate.current_application
     else
       raise ZeroCoursesPerApplicationError, 'You cannot have zero courses per application' unless states.any?
 
       first_name = Faker::Name.first_name
       last_name = Faker::Name.last_name
+      previous_application_form = nil
       candidate = candidate.presence || FactoryBot.create(
         :candidate,
         email_address: "#{first_name.downcase}.#{last_name.downcase}@example.com",
@@ -88,6 +115,7 @@ class TestApplications
         recruitment_cycle_year: recruitment_cycle_year,
         phase: apply_again ? 'apply_2' : 'apply_1',
         work_history_completed: false,
+        previous_application_form: previous_application_form,
       )
 
       @application_form.application_work_experiences.each { |experience| experience.update!(created_at: time) }

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -75,6 +75,7 @@ class TestApplications
         *traits,
         :with_degree,
         :with_gcses,
+        :with_a_levels,
         application_choices_count: 0,
         full_work_history: true,
         volunteering_experiences_count: 1,

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -28,9 +28,12 @@ class GenerateTestApplications
     create recruitment_cycle_year: 2021, states: %i[interviewing awaiting_provider_decision offer]
     create recruitment_cycle_year: 2021, states: %i[interviewing interviewing]
     create recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision], apply_again: true
+    create recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision], carry_over: true
     create recruitment_cycle_year: 2021, states: %i[offer offer]
     create recruitment_cycle_year: 2021, states: %i[offer_changed]
     create recruitment_cycle_year: 2021, states: %i[offer rejected]
+    create recruitment_cycle_year: 2021, states: %i[offer rejected], carry_over: true
+    create recruitment_cycle_year: 2021, states: %i[offer], apply_again: true
     create recruitment_cycle_year: 2021, states: %i[rejected rejected]
     create recruitment_cycle_year: 2021, states: %i[offer_withdrawn]
     create recruitment_cycle_year: 2021, states: %i[offer_deferred]
@@ -49,12 +52,13 @@ class GenerateTestApplications
 
 private
 
-  def create(recruitment_cycle_year:, states:, apply_again: false, course_full: false)
+  def create(recruitment_cycle_year:, states:, apply_again: false, carry_over: false, course_full: false)
     TestApplications.new.create_application(
       states: states,
       recruitment_cycle_year: recruitment_cycle_year,
       courses_to_apply_to: courses_to_apply_to(recruitment_cycle_year),
       apply_again: apply_again,
+      carry_over: carry_over,
       course_full: course_full,
     )
   end

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -68,13 +68,29 @@ FactoryBot.define do
     end
 
     trait :with_degree do
-      application_qualifications { [association(:degree_qualification, application_form: instance)] }
+      after(:create) do |application_form, _|
+        create(:degree_qualification, application_form: application_form)
+      end
     end
 
     trait :with_gcses do
-      application_qualifications do
-        %i[maths english science].map do |subject|
-          association(:gcse_qualification, application_form: instance, subject: subject)
+      after(:create) do |application_form, _|
+        %i[maths english science].each do |subject|
+          create(:gcse_qualification, application_form: application_form, subject: subject)
+        end
+      end
+    end
+
+    trait :with_a_levels do
+      after(:create) do |application_form, _|
+        %i[Physics Chemistry Biology].sample([1, 2, 3].sample).each do |subject|
+          create(
+            :other_qualification,
+            qualification_type: 'A level',
+            application_form: application_form,
+            subject: subject,
+            grade: %w[A B C D E].sample,
+          )
         end
       end
     end

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe GenerateTestApplications do
     # there is at least one unsubmitted application to a full course
     expect(ApplicationChoice.where(status: 'unsubmitted').map(&:course_option).select(&:no_vacancies?)).not_to be_empty
 
+    # there is at least one successful carried over application
+    expect(ApplicationForm.joins(:application_choices).where('application_choices.status': 'offer', phase: 'apply_1').where.not(previous_application_form_id: nil)).not_to be_empty
+
+    # there is at least one successful apply again application
+    expect(ApplicationForm.joins(:application_choices).where('application_choices.status': 'offer', phase: 'apply_2').where.not(previous_application_form_id: nil)).not_to be_empty
+
     expect(ApplicationChoice.cancelled.first.application_form.application_references.feedback_requested).to be_empty
   end
 end


### PR DESCRIPTION
## Context

When building the latest updates to the feature metrics dashboard a few gaps in the test application data became apparent. e.g. no carried over applications. For testing this dashboard it's useful to plug these gaps and doing so is likely to be useful for other purposes in future I think.

## Changes proposed in this pull request

- [x] Add 1-3 A level qualifications to test applications (previously we only created a degree and GCSEs).
- [x] Add a couple of applications carried over from the previous (2020 at this time) to the current recruitment cycle (2021)
- [x] Add a successful apply again application (not just one in the `awaiting_provider_decision` state)
- [x] Fix issue with factory traits `with_gcses` and `with_degrees` clobbering each other.

## Guidance to review

- Does this make sense from the point of view of making the test data a bit more comprehensive?
- Could it have any consequences I've not foreseen, e.g. sandbox?

## Link to Trello card

https://trello.com/c/1X9y1JPl/2981-feature-metric-dashboard-20

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
