### PR TITLE
Test application generator improvements

### DIFF
--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -13,17 +13,15 @@ module VendorAPI
     end
 
     def generate
-      application_choices = TestApplications.new.generate_for_provider(
+      GenerateTestApplicationsForProvider.new.call(
         provider: current_provider,
         courses_per_application: courses_per_application_param,
         count: count_param,
         for_ratified_courses: for_ratified_courses_param,
       )
 
-      render json: { data: { ids: application_choices.map { |ac| ac.id.to_s } } }
-    rescue TestApplications::NotEnoughCoursesError => e
-      render json: { errors: [{ error: 'ParameterInvalid', message: e }] }, status: :unprocessable_entity
-    rescue TestApplications::ZeroCoursesPerApplicationError => e
+      render json: { data: { message: 'Request submitted. Applications will appear once they have been generated' } }
+    rescue ParameterInvalid => e
       render json: { errors: [{ error: 'ParameterInvalid', message: e }] }, status: :unprocessable_entity
     end
 

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -18,23 +18,6 @@ class TestApplications
 
   attr_reader :time
 
-  def generate_for_provider(provider:, courses_per_application:, count:, for_ratified_courses: false)
-    courses_to_apply_to = if for_ratified_courses
-                            GetCoursesRatifiedByProvider.call(provider: provider)
-                          else
-                            Course.current_cycle.includes(:course_options)
-                              .joins(:course_options).distinct.open_on_apply
-                              .where(provider: provider)
-                          end
-    1.upto(count).flat_map do
-      create_application(
-        recruitment_cycle_year: RecruitmentCycle.current_year,
-        states: [:awaiting_provider_decision] * courses_per_application,
-        courses_to_apply_to: courses_to_apply_to,
-      )
-    end
-  end
-
   def create_application(
     recruitment_cycle_year:,
     states:,
@@ -58,6 +41,8 @@ class TestApplications
       candidate: candidate,
     )
   end
+
+private
 
   def courses_to_apply_to(
     states:,

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -1,6 +1,20 @@
 class TestApplications
   class NotEnoughCoursesError < RuntimeError; end
-  class ZeroCoursesPerApplicationError < RuntimeError; end
+  class ZeroCoursesPerApplicationError < RuntimeError
+    def message
+      'You cannot have zero courses per application'
+    end
+  end
+  class CourseAndStateNumbersDoNotMatchError < RuntimeError
+    def message
+      'The number of states and courses must be equal'
+    end
+  end
+  class OnlyOneCourseWhenApplyingAgainError < RuntimeError
+    def message
+      'You can only apply to one course when applying again'
+    end
+  end
 
   attr_reader :time
 
@@ -28,18 +42,70 @@ class TestApplications
     apply_again: false,
     carry_over: false,
     course_full: false,
-    candidate: nil,
-    decline_by_default_at: 3.days.from_now
+    candidate: nil
   )
+    courses = courses_to_apply_to(
+      states: states,
+      courses_to_choose_from: courses_to_apply_to,
+      course_full: course_full,
+    )
+    create_application_to_courses(
+      recruitment_cycle_year: recruitment_cycle_year,
+      states: states,
+      courses: courses,
+      apply_again: apply_again,
+      carry_over: carry_over,
+      candidate: candidate,
+    )
+  end
+
+  def courses_to_apply_to(
+    states:,
+    courses_to_choose_from:,
+    course_full: false
+  )
+    raise ZeroCoursesPerApplicationError unless states.any?
+
+    selected_courses =
+      if course_full
+        # Always use the first n courses, so that we can reliably generate
+        # application choices to full courses without randomly affecting the
+        # vacancy status of the entire set of available courses.
+        fill_vacancies(courses_to_choose_from.first(states.count))
+      else
+        courses_to_choose_from.sample(states.count)
+      end
+
+    # it does not make sense to apply to the same course multiple times
+    # in the course of the same application, and it's forbidden in the UI.
+    # Throw an exception if we try to do that here.
+    if selected_courses.count < states.count
+      raise NotEnoughCoursesError, "Not enough distinct courses to generate a #{states.count}-course application"
+    end
+
+    selected_courses
+  end
+
+  def create_application_to_courses(
+    recruitment_cycle_year:,
+    states:,
+    courses:,
+    apply_again: false,
+    carry_over: false,
+    candidate: nil
+  )
+    raise CourseAndStateNumbersDoNotMatchError unless courses.count == states.count
+
     initialize_time(recruitment_cycle_year)
 
     if apply_again
-      raise OnlyOneCourseWhenApplyingAgainError, 'You can only apply to one course when applying again' unless states.one?
+      raise OnlyOneCourseWhenApplyingAgainError unless states.one?
 
-      create_application(
+      create_application_to_courses(
         recruitment_cycle_year: recruitment_cycle_year,
+        courses: courses,
         states: [:rejected],
-        courses_to_apply_to: courses_to_apply_to,
+        candidate: candidate,
       )
 
       candidate = candidate.presence || Candidate.last
@@ -47,10 +113,11 @@ class TestApplications
       last_name = candidate.current_application.last_name
       previous_application_form = candidate.current_application
     elsif carry_over
-      create_application(
+      create_application_to_courses(
         recruitment_cycle_year: recruitment_cycle_year - 1,
-        states: %i[rejected declined],
-        courses_to_apply_to: courses_to_apply_to,
+        courses: courses,
+        states: courses.count.times.map { %i[declined rejected].sample },
+        candidate: candidate,
       )
 
       initialize_time(recruitment_cycle_year)
@@ -59,8 +126,6 @@ class TestApplications
       last_name = candidate.current_application.last_name
       previous_application_form = candidate.current_application
     else
-      raise ZeroCoursesPerApplicationError, 'You cannot have zero courses per application' unless states.any?
-
       first_name = Faker::Name.first_name
       last_name = Faker::Name.last_name
       previous_application_form = nil
@@ -70,23 +135,6 @@ class TestApplications
         created_at: time,
         last_signed_in_at: time,
       )
-    end
-
-    courses_to_apply_to =
-      if course_full
-        # Always use the first n courses, so that we can reliably generate
-        # application choices to full courses without randomly affecting the
-        # vacancy status of the entire set of available courses.
-        fill_vacancies(courses_to_apply_to.first(states.size))
-      else
-        courses_to_apply_to.sample(states.count)
-      end
-
-    # it does not make sense to apply to the same course multiple times
-    # in the course of the same application, and it's forbidden in the UI.
-    # Throw an exception if we try to do that here.
-    if courses_to_apply_to.count < states.count
-      raise NotEnoughCoursesError, "Not enough distinct courses to generate a #{states.count}-course application"
     end
 
     Audited.audit_class.as_user(candidate) do
@@ -134,13 +182,12 @@ class TestApplications
 
       fast_forward
 
-      application_choices = courses_to_apply_to.map do |course|
+      application_choices = courses.map do |course|
         FactoryBot.create(
           :application_choice,
           status: 'unsubmitted',
           course_option: course.course_options.first,
           application_form: @application_form,
-          decline_by_default_at: decline_by_default_at,
           created_at: time,
           updated_at: time,
         )

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -240,6 +240,8 @@ private
         FactoryBot.create(:ucas_match, application_form: @application_form) if rand < 0.5
       end
 
+      @application_form.application_choices.update(updated_at: Time.zone.now, audit_comment: 'This application was automatically generated')
+
       application_choices
     end
   end

--- a/app/services/vendor_api/generate_test_applications_for_provider.rb
+++ b/app/services/vendor_api/generate_test_applications_for_provider.rb
@@ -1,0 +1,27 @@
+module VendorAPI
+  class GenerateTestApplicationsForProvider
+    def call(provider:, courses_per_application:, count:, for_ratified_courses: false)
+      raise ParameterInvalid, 'Parameter is invalid (cannot be zero): courses_per_application' if courses_per_application.zero?
+
+      course_ids = course_list_for_provider(provider, for_ratified_courses).pluck(:id)
+
+      raise ParameterInvalid, 'Parameter is invalid (cannot be greater than number of available courses): courses_per_application' if course_ids.count < courses_per_application
+
+      GenerateTestApplicationsForCourses.perform_async(course_ids, courses_per_application, count)
+    end
+
+  private
+
+    def course_list_for_provider(provider, for_ratified_courses)
+      if for_ratified_courses
+        GetCoursesRatifiedByProvider.call(provider: provider)
+      else
+        Course.current_cycle
+              .open_on_apply
+              .joins(:course_options)
+              .distinct
+              .where(provider: provider)
+      end
+    end
+  end
+end

--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,13 @@
+## 22nd March
+
+The following experimental/sandbox endpoint has been updated:
+
+`/test-data/generate` is now asynchronous:
+- A POST request to this endpoint will queue a job to generate the specified test applications.
+- The list of created application IDs will no longer be returned.
+- The new applications will become available as soon as they have been generated.
+- Applications generated in this way will now have their `updated_at` set to the current time, so they can be retrieved using the `GET /applications` endpoint with the `since` parameter.
+
 ## 19th March
 
 Fix a bug where HESA ITT data was not being returned for applications with accepted offers.

--- a/app/workers/generate_test_applications_for_courses.rb
+++ b/app/workers/generate_test_applications_for_courses.rb
@@ -1,0 +1,15 @@
+class GenerateTestApplicationsForCourses
+  include Sidekiq::Worker
+
+  def perform(course_ids, courses_per_application, count)
+    courses_to_apply_to = Course.where(id: course_ids)
+
+    1.upto(count).flat_map do
+      TestApplications.new.create_application(
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+        states: [:awaiting_provider_decision] * courses_per_application,
+        courses_to_apply_to: courses_to_apply_to,
+      )
+    end
+  end
+end

--- a/config/vendor-api-experimental.yml
+++ b/config/vendor-api-experimental.yml
@@ -4,9 +4,9 @@ paths:
       tags:
       - Testing
       summary: Generate test data
-      description: 'Generates n new applications, defaulting to 100 applications with
-        one course choice per application. Does not change existing data. Only available
-        on the Sandbox. EXPERIMENTAL — this endpoint may change or disappear.
+      description: 'Submits a request to generate n new applications, defaulting to 100 applications with
+        one course choice per application. The applications are generated asynchronously, and will appear once they have been generated.
+        Does not change existing data. Only available on the Sandbox. EXPERIMENTAL — this endpoint may change or disappear.
 
         '
       parameters:
@@ -31,8 +31,8 @@ paths:
         schema:
           type: string
       responses:
-        '201':
-          "$ref": "#/components/responses/TestDataGenerated"
+        '200':
+          "$ref": "#/components/responses/OK"
         '401':
           "$ref": "#/components/responses/Unauthorized"
   "/test-data/clear":

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -353,12 +353,6 @@ components:
         application/json:
           schema:
             "$ref": "#/components/schemas/UnprocessableEntityResponse"
-    TestDataGenerated:
-      description: Returned following successful generation of test data
-      content:
-        application/json:
-          schema:
-            "$ref": "#/components/schemas/TestDataGeneratedResponse"
   schemas:
     MultipleApplicationsResponse:
       type: object
@@ -1298,21 +1292,6 @@ components:
             message:
               type: string
               example: OK
-    TestDataGeneratedResponse:
-      type: object
-      properties:
-        data:
-          type: object
-          required:
-          - ids
-          properties:
-            ids:
-              type: array
-              description: An array of IDs corresponding to the generated applications
-              minItems: 1
-              items:
-                type: string
-                maxLength: 10
     ListResponse:
       type: object
       required:

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -149,4 +149,14 @@ RSpec.describe TestApplications do
       expect(application_choice.interviews.count).to eq(1)
     end
   end
+
+  it 'marks any submitted application choices as just updated', with_audited: true do
+    create(:course_option, course: create(:course, :open_on_apply))
+
+    choices = TestApplications.new.create_application(recruitment_cycle_year: 2020, courses_to_apply_to: Course.all, states: %i[awaiting_provider_decision])
+
+    expect(choices.count).to eq(1)
+    expect(choices.first.reload.updated_at).to be_within(1.second).of(Time.zone.now)
+    expect(choices.first.audits.last.comment).to eq('This application was automatically generated')
+  end
 end

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -149,27 +149,4 @@ RSpec.describe TestApplications do
       expect(application_choice.interviews.count).to eq(1)
     end
   end
-
-  describe 'generate_for_provider' do
-    it 'can generate applications only for courses the provider ratifies' do
-      provider = create(:provider)
-      create(:course_option)
-      create(:course_option, course: create(:course, provider: provider))
-      # rubocop:disable FactoryBot/CreateList
-      3.times do
-        create(:course_option, course: create(:course, accredited_provider: provider))
-      end
-      # rubocop:enable FactoryBot/CreateList
-
-      choices = TestApplications.new.generate_for_provider(
-        provider: provider,
-        courses_per_application: 3,
-        count: 2,
-        for_ratified_courses: true,
-      )
-
-      expect(choices.map(&:application_form).uniq.count).to eq(2)
-      expect(choices.map(&:course).map(&:accredited_provider).uniq).to eq([provider])
-    end
-  end
 end

--- a/spec/requests/vendor_api/post_test_data_generate_spec.rb
+++ b/spec/requests/vendor_api/post_test_data_generate_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request do
+RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request, sidekiq: true do
   include VendorAPISpecHelpers
 
   it 'generates test data' do
@@ -39,7 +39,7 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request do
 
     post_api_request '/api/v1/test-data/generate?count=1'
 
-    expect(parsed_response).to be_valid_against_openapi_schema('TestDataGeneratedResponse')
+    expect(parsed_response).to be_valid_against_openapi_schema('OkResponse')
   end
 
   it 'returns error responses on invalid input' do

--- a/spec/services/vendor_api/generate_test_applications_for_provider_spec.rb
+++ b/spec/services/vendor_api/generate_test_applications_for_provider_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe VendorAPI::GenerateTestApplicationsForProvider, sidekiq: true do
+  describe '#call' do
+    it 'generates applications to courses the provider runs' do
+      provider = create(:provider)
+      create(:course_option)
+      # rubocop:disable FactoryBot/CreateList
+      3.times do
+        create(:course_option, course: create(:course, :open_on_apply, provider: provider))
+      end
+      # rubocop:enable FactoryBot/CreateList
+
+      described_class.new.call(
+        provider: provider,
+        courses_per_application: 3,
+        count: 2,
+      )
+
+      choices = provider.application_choices
+      expect(choices.map(&:application_form).uniq.count).to eq(2)
+      expect(choices.map(&:course).map(&:provider).uniq).to eq([provider])
+    end
+
+    it 'can generate applications to courses the provider ratifies' do
+      provider = create(:provider)
+      create(:course_option)
+      create(:course_option, course: create(:course, provider: provider))
+      # rubocop:disable FactoryBot/CreateList
+      3.times do
+        create(:course_option, course: create(:course, accredited_provider: provider))
+      end
+      # rubocop:enable FactoryBot/CreateList
+
+      described_class.new.call(
+        provider: provider,
+        courses_per_application: 3,
+        count: 2,
+        for_ratified_courses: true,
+      )
+
+      choices = provider.accredited_courses.flat_map(&:application_choices)
+      expect(choices.map(&:application_form).uniq.count).to eq(2)
+      expect(choices.map(&:course).map(&:accredited_provider).uniq).to eq([provider])
+    end
+
+    describe 'raises an error' do
+      it 'when a request is made for zero courses per application' do
+        expect {
+          described_class.new.call(
+            provider: create(:provider),
+            courses_per_application: 0,
+            count: 1,
+          )
+        }.to raise_error ParameterInvalid, 'Parameter is invalid (cannot be zero): courses_per_application'
+      end
+
+      it 'when a request is made for more courses than exist' do
+        provider = create(:provider)
+        create(:course_option, course: create(:course, :open_on_apply, provider: provider))
+
+        expect {
+          described_class.new.call(
+            provider: provider,
+            courses_per_application: 2,
+            count: 1,
+          )
+        }.to raise_error ParameterInvalid, 'Parameter is invalid (cannot be greater than number of available courses): courses_per_application'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
The test-data/generate endpoint times out very easily. This is because it is synchronous and has to wait until all applications are generated in order to return a list of IDs

## Changes proposed in this pull request
Make the endpoint asynchronous

Touch test applications after they have been generated so that API users still have a way of getting the applications that have just been generated

Audit the touch for transparency in support about how applications are generated

## Guidance to review
Do all the changes make sense? 

There is some duplication of error detection, but this is so that providers get an instant error if they supply bad params. Maybe worth a refactor to extract the errors out of the generator?

## Link to Trello card
https://trello.com/c/PLTc5qtd/3485-investigate-issues-when-generating-20-test-applications-over-the-api

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
