### PR TITLE
Add Zendesk chat widget code in test environments

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -72,14 +72,17 @@
     <% case try(:current_namespace) %>
     <% when 'candidate_interface' %>
       <%= javascript_pack_tag 'application-candidate' %>
+      <%= render 'shared/zendesk_snippet' if HostingEnvironment.test_environment? %>
     <% when 'support_interface' %>
       <%= javascript_pack_tag 'application-support' %>
     <% when 'provider_interface' %>
       <%= javascript_pack_tag 'application-provider' %>
+      <%= render 'shared/zendesk_snippet' if HostingEnvironment.test_environment? %>
     <% when 'api_docs' %>
       <%= javascript_pack_tag 'application-api-docs' %>
     <% else %>
       <%= javascript_pack_tag 'application' %>
     <% end %>
+
   </body>
 </html>

--- a/app/views/shared/_zendesk_snippet.html.erb
+++ b/app/views/shared/_zendesk_snippet.html.erb
@@ -1,0 +1,1 @@
+<script id="ze-snippet" src=https://static.zdassets.com/ekr/snippet.js?key=904d04ae-8027-4ebb-ad39-d0e9f68d6ab1> </script>


### PR DESCRIPTION
## Context

To help the support team test out Zendesk chat, add their JS snippet on candidate pages in non-production envs

## Changes proposed in this pull request

See commit!