### PR TITLE
Revert application choices updated_at for stale applications

### DIFF
--- a/app/services/data_migrations/revert_application_choice_updated_at_timestamps.rb
+++ b/app/services/data_migrations/revert_application_choice_updated_at_timestamps.rb
@@ -27,9 +27,9 @@ module DataMigrations
         )
 
         application_form.application_choices.each do |application_choice|
-          latest_application_choices_audits_created_at = application_choice.audits.last.created_at
+          latest_application_choices_audits_created_at = application_choice.audits.order(:created_at).last.created_at
 
-          if application_form.audits.last == audit && latest_application_choice_audits_created_at < audit.created_at
+          if application_form.audits.order(:created_at).last == audit && latest_application_choice_audits_created_at < audit.created_at
             application_choice.update_column('updated_at', latest_application_choices_audits_created_at)
           end
         end

--- a/app/services/data_migrations/revert_application_choice_updated_at_timestamps.rb
+++ b/app/services/data_migrations/revert_application_choice_updated_at_timestamps.rb
@@ -1,0 +1,39 @@
+module DataMigrations
+  class RevertApplicationChoiceUpdatedAtTimestamps
+    TIMESTAMP = 20210319132110
+    MANUAL_RUN = false
+
+    def change
+      ApplicationForm
+      .joins(:audits)
+      .where(
+        "auditable_type = 'ApplicationForm' AND
+        action = 'update' AND
+        audited_changes#>>'{second_nationality, 0}' = '' AND
+        audited_changes#>>'{second_nationality, 1}' is null
+        AND audits.created_at between ? AND ?",
+        Time.zone.local(2021, 3, 17, 12, 30),
+        Time.zone.local(2021, 3, 17, 13),
+      )
+      .includes(:audits)
+      .find_each do |application_form|
+        audit = application_form.audits.where(
+          "action = 'update' AND
+          audited_changes#>>'{second_nationality, 0}' = '' AND
+          audited_changes#>>'{second_nationality, 1}' is null
+          AND audits.created_at between ? AND ?",
+          Time.zone.local(2021, 3, 17, 12, 30),
+          Time.zone.local(2021, 3, 17, 13),
+        )
+
+        application_form.application_choices.each do |application_choice|
+          latest_application_choices_audits_created_at = application_choice.audits.last.created_at
+
+          if application_form.audits.last == audit && latest_application_choice_audits_created_at < audit.created_at
+            application_choice.update_column('updated_at', latest_application_choices_audits_created_at)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not edit this line - services added below by generator
+  'DataMigrations::RevertApplicationChoiceUpdatedAtTimestamps',
 ].freeze
 
 def data_migrations

--- a/spec/services/data_migrations/revert_application_choice_updated_at_timestamps_spec.rb
+++ b/spec/services/data_migrations/revert_application_choice_updated_at_timestamps_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RevertApplicationChoiceUpdatedAtTimestamps do
+  describe '#change' do
+    it 'updates the updated_at for application_choices in the desired state to the previous audits created_at', with_audited: true do
+      targeted_update_time = Time.zone.local(2021, 3, 17, 12, 45)
+      Timecop.freeze(targeted_update_time - 1.day) do
+        @application_form = create(:completed_application_form, second_nationality: '')
+        @stale_application_choice = create(:application_choice, :awaiting_provider_decision, application_form: @application_form)
+        @active_application_choice = create(:application_choice, :awaiting_provider_decision, application_form: @application_form)
+        @stale_application_choice.offer!
+      end
+
+      Timecop.freeze(targeted_update_time) do
+        @application_form.update!(second_nationality: nil)
+      end
+
+      Timecop.freeze(targeted_update_time + 1.day) do
+        @active_application_choice.offer!
+      end
+
+      described_class.new.change
+
+      expect(@stale_application_choice.updated_at).to eq targeted_update_time - 1.day
+      expect(@active_application_choice.updated_at).to eq targeted_update_time + 1.day
+    end
+  end
+end


### PR DESCRIPTION
## Context

Quite a few old applications were touched as part of a data cleanup. When the second nationality attribute was updated, it touched all the associated application choices which has triggered them to be passed through the API.

See https://www.apply-for-teacher-training.service.gov.uk/support/applications/2393/audit for an example.

This PR reverts the application choices updated_at to the previous audits created_at time. It will only do this if the latest audit on the application form is the one that updated second_nationality from '' to nil.

## Changes proposed in this pull request

Adds a service that gets all the audits that updated `second_nationality` from `''` to `nil` between 12:30 - 1pm on the 17/03/2020 and reverts the updated_at time to the previous audit on the application choices created_at.

It will only do this if the latest audit on the application choice is the one that updated second_nationality so live applications will be unaffected

## Guidance to review

This isn't a perfect solution as it uses the created_at for the latest audit on the application choice and a subsequent update on the application form could have been made for an attribute that triggers a touch on its application choices.

I think this probably falls under 'close enough' though, as a complete solution that also collects audits for those attrs being updated would be quite a bit more work. Would you agree?
 
## Link to Trello card

https://trello.com/c/NYBG2nb9/3203-some-nationalities-being-rendered-incorrectly-on-production

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
