### PR TITLE
Remove Rails/ApplicationRecord Cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -104,10 +104,6 @@ Lint/AmbiguousBlockAssociation:
 Rails/ApplicationController:
   Enabled: false
 
-# We do not use ApplicationRecord
-Rails/ApplicationRecord:
-  Enabled: false
-
 # Rails does not actually allow "dynamic find_by", so this cop yields false positives
 # like `VendorApiToken.find_by_unhashed_token` (which we implement ourselves)
 Rails/DynamicFindBy:

--- a/app/models/provider_agreement.rb
+++ b/app/models/provider_agreement.rb
@@ -1,4 +1,4 @@
-class ProviderAgreement < ActiveRecord::Base
+class ProviderAgreement < ApplicationRecord
   belongs_to :provider
   belongs_to :provider_user
   attr_accessor :accept_agreement

--- a/app/models/provider_permissions.rb
+++ b/app/models/provider_permissions.rb
@@ -1,4 +1,4 @@
-class ProviderPermissions < ActiveRecord::Base
+class ProviderPermissions < ApplicationRecord
   VALID_PERMISSIONS = %i[
     manage_users
     manage_organisations

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -1,4 +1,4 @@
-class ProviderUser < ActiveRecord::Base
+class ProviderUser < ApplicationRecord
   include AuthenticatedUsingMagicLinks
 
   has_many :provider_permissions, dependent: :destroy

--- a/app/models/provider_user_notification_preferences.rb
+++ b/app/models/provider_user_notification_preferences.rb
@@ -1,4 +1,4 @@
-class ProviderUserNotificationPreferences < ActiveRecord::Base
+class ProviderUserNotificationPreferences < ApplicationRecord
   belongs_to :provider_user
 
   self.table_name = :provider_user_notifications

--- a/app/models/support_user.rb
+++ b/app/models/support_user.rb
@@ -1,4 +1,4 @@
-class SupportUser < ActiveRecord::Base
+class SupportUser < ApplicationRecord
   include Discard::Model
   include AuthenticatedUsingMagicLinks
 


### PR DESCRIPTION
- We are now using ApplicationRecord across all models. 

The models updated as part of this PR were implemented after this Cop was ignored, and thus look like they unintentionally inherited ActiveRecord::Base

## Link to Trello card

https://trello.com/c/XANNLBur/432-should-we-continue-using-rubocop-govuk
