### PR TITLE
Add index to audits table to improve query performance

### DIFF
--- a/db/migrate/20210319163050_add_auditable_type_id_index_to_audits.rb
+++ b/db/migrate/20210319163050_add_auditable_type_id_index_to_audits.rb
@@ -1,0 +1,7 @@
+class AddAuditableTypeIdIndexToAudits < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :audits, %i[auditable_type id], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_16_154831) do
+ActiveRecord::Schema.define(version: 2021_03_19_163050) do
 
   create_sequence "application_choices_id_seq"
   create_sequence "application_experiences_id_seq"
@@ -262,6 +262,7 @@ ActiveRecord::Schema.define(version: 2021_03_16_154831) do
     t.datetime "created_at"
     t.index ["associated_type", "associated_id"], name: "associated_index"
     t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
+    t.index ["auditable_type", "id"], name: "index_audits_on_auditable_type_and_id"
     t.index ["created_at"], name: "index_audits_on_created_at"
     t.index ["request_uuid"], name: "index_audits_on_request_uuid"
     t.index ["user_id", "user_type"], name: "user_index"


### PR DESCRIPTION
## Context
The interview changes export does not work on production due to a query timeout.

The query it is trying to do is:
```
SELECT * FROM audits WHERE auditable_type='Interview' ORDER BY id LIMIT 100;
```

The query planner chooses a sub-optimal plan for this:

```
EXPLAIN SELECT * FROM audits WHERE auditable_type='Interview' ORDER BY id LIMIT 100;
                                         QUERY PLAN                                         
--------------------------------------------------------------------------------------------
 Limit  (cost=0.44..42156.20 rows=100 width=309)
   ->  Index Scan using audits_pkey on audits  (cost=0.44..1051495.98 rows=48664 width=309)
         Filter: ((auditable_type)::text = 'Interview'::text)
```

Due to the distribution of values in the auditable_type column, it does not utilise the index on auditable_type, rather opting to sort first and then filter on the condition for audit type.

There are 18 million "Course" type audits, and only 21 million audits in total. Therefore the worst case scenario for the query if using the index first, would be (if we ask for "Course" type):
- Find rows matching the condition (18 million), using the index
- Sort 18 million rows on id
- Pick the first 100

This is clearly worse than:
- Get the highest rows by id using the id index
- Go down the list until you have 100 that match the condition

Since the condition is matched by almost all rows.

## Changes proposed in this pull request
Add an index to audits on auditable_type, id.

This index is selected by the query planner because it improves the worst case scenario above:
- Find rows matching the condition and sort on id (the index makes this easy)
- Pick the first 100 rows

The index will be added concurrently, which does not block access to the table during the process. See https://www.postgresql.org/docs/9.1/sql-createindex.html
> When this option is used, PostgreSQL will build the index without taking any locks that prevent concurrent inserts, updates, or deletes on the table; whereas a standard index build locks out writes (but not reads) on the table until it's done.

We have run `CREATE INDEX CONCURRENTLY auditable_type_id_index ON audits (auditable_type, id);` on a recent replica database, and it completed in 5 minutes.

## Guidance to review
Have we missed anything?

## Link to Trello card
https://trello.com/c/3mIxkctF/3525-interview-changes-csv-export-query-times-out-on-production

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
