### PR TITLE
Attempt to fix query timeouts on new feature metrics dashboard

### DIFF
--- a/app/models/apply_again_feature_metrics.rb
+++ b/app/models/apply_again_feature_metrics.rb
@@ -124,8 +124,11 @@ private
 
   def applications_eligible_for_apply_again_not_applied(start_time, end_time)
     applications_eligible_for_apply_again(start_time, end_time)
-      .joins('LEFT OUTER JOIN application_forms AS subsequent_application_form ON application_forms.id = subsequent_application_form.previous_application_form_id')
-      .where(subsequent_application_form: { id: nil })
+      .where.not(
+        'application_forms.id': ApplicationForm.where.not(
+          previous_application_form_id: nil,
+        ).pluck(:previous_application_form_id),
+      )
       .distinct
       .pluck(:id)
       .count


### PR DESCRIPTION
## Context

This PR is an attempt to fix query timeouts introduced by https://github.com/DFE-Digital/apply-for-teacher-training/pull/4288.

See https://sentry.io/organizations/dfe-bat/issues/2283673511/?project=1765973&query=assigned%3Ame&statsPeriod=14d

## Changes proposed in this pull request

The query that goes wrong is:

```
ApplicationForm.apply_1.joins(:application_choices).where('NOT EXISTS (:pending_or_successful)', pending_or_successful: ApplicationChoice .select(1).where( status: ApplicationStateChange.valid_states - ApplicationStateChange::UNSUCCESSFUL_END_STATES).where('application_choices.application_form_id = application_forms.id')).joins(
    "inner join (select auditable_id, max(created_at) as status_last_updated_at
      from audits
      where auditable_type = 'ApplicationChoice'
        and action = 'update'
        and audited_changes#>>'{status, 1}' is not null
      group by auditable_id
    ) as status_audits on status_audits.auditable_id = application_choices.id
      and status_last_updated_at between '#{start_time}' and '#{end_time}'",
  ).joins('LEFT OUTER JOIN application_forms AS subsequent_application_form ON application_forms.id = subsequent_application_form.previous_application_form_id').where(subsequent_application_form: { id: nil }).distinct.pluck(:id)
```

I expected the audit trail condition to be the root cause but based on
testing this on `qa` it looks like its the
`where(subsequent_application_form: { id: nil })`

There are a few alternative ways of expressing the condition _get
applications that don't have a subsequent application_, switching to
`NOT IN` condition seems to stop the timeouts:

```
Alternative without the anti-join
  ApplicationForm.apply_1.joins(:application_choices).where('NOT EXISTS (:pending_or_successful)', pending_or_successful: ApplicationChoice .select(1).where( status: ApplicationStateChange.valid_states - ApplicationStateChange::UNSUCCESSFUL_END_STATES).where('application_choices.application_form_id = application_forms.id')).joins(
      "inner join (select auditable_id, max(created_at) as status_last_updated_at
        from audits
        where auditable_type = 'ApplicationChoice'
          and action = 'update'
          and audited_changes#>>'{status, 1}' is not null
        group by auditable_id
      ) as status_audits on status_audits.auditable_id = application_choices.id
        and status_last_updated_at between '#{start_time}' and '#{end_time}'",
  ).where.not('application_forms.id': ApplicationForm.where.not(previous_application_form_id: nil).pluck(:previous_application_form_id))
```

## Guidance to review

- Is the new query condition logically equivalent?

## Link to Trello card

https://trello.com/c/1X9y1JPl/2981-feature-metric-dashboard-20

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
