### PR TITLE
Update notification preferences in one transaction

### DIFF
--- a/app/models/provider_user_notification_preferences.rb
+++ b/app/models/provider_user_notification_preferences.rb
@@ -12,7 +12,9 @@ class ProviderUserNotificationPreferences < ApplicationRecord
   ].freeze
 
   def update_all_preferences(value)
-    NOTIFICATION_PREFERENCES.each { |n| update(n => value) }
+    NOTIFICATION_PREFERENCES.each { |notification| assign_attributes(notification => value) }
+
+    save!
   end
 
   def self.notification_preference_exists?(notification_name)


### PR DESCRIPTION
## Context

To avoid multiple queries to the database, assign notification preferences before saving the record in one transaction.

## Changes proposed in this pull request

Utilise `assign_attributes` before saving the preferences record

## Guidance to review

Does it make sense?

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
