### PR TITLE
Add specs to the API docs

### DIFF
--- a/app/components/api_docs/operation_component.html.erb
+++ b/app/components/api_docs/operation_component.html.erb
@@ -68,11 +68,11 @@
 <% if operation.responses.any? %>
   <h4 class="govuk-heading-s">Possible reponses</h4>
 
-  <% operation.responses.each do |response| %>
+  <% operation.responses.each do |code, response| %>
     <details class="govuk-details" data-module="govuk-details">
       <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
-          HTTP <%= response.code %> - <%= response.description %>
+          HTTP <%= code %> - <%= response.description %>
         </span>
       </summary>
       <div class="govuk-details__text">

--- a/app/components/api_docs/operation_component.html.erb
+++ b/app/components/api_docs/operation_component.html.erb
@@ -60,7 +60,7 @@
       </span>
     </summary>
     <div class="govuk-details__text">
-      <%= json_code_sample(operation.request_body.example) %>
+      <%= json_code_sample(operation.request_body.schema.example) %>
     </div>
   </details>
 <% end %>

--- a/app/components/api_docs/operation_component.html.erb
+++ b/app/components/api_docs/operation_component.html.erb
@@ -76,12 +76,12 @@
         </span>
       </summary>
       <div class="govuk-details__text">
-        <% if response.schema_name %>
-          This request will return a <%= govuk_link_to response.schema_name, "##{response.schema_name.parameterize}-object" %> object.
+        <% if response.schema.name %>
+          This request will return a <%= govuk_link_to response.schema.name, "##{response.schema.name.parameterize}-object" %> object.
         <% end %>
 
-        <% if response.example %>
-          <%= json_code_sample(response.example) %>
+        <% if response.schema.example %>
+          <%= json_code_sample(response.schema.example) %>
         <% end %>
       </div>
     </details>

--- a/app/components/api_docs/operation_component.html.erb
+++ b/app/components/api_docs/operation_component.html.erb
@@ -76,7 +76,9 @@
         </span>
       </summary>
       <div class="govuk-details__text">
-        This request will return a <%= govuk_link_to response.schema_name, "##{response.schema_name.parameterize}-object" %> object.
+        <% if response.schema_name %>
+          This request will return a <%= govuk_link_to response.schema_name, "##{response.schema_name.parameterize}-object" %> object.
+        <% end %>
 
         <% if response.example %>
           <%= json_code_sample(response.example) %>

--- a/app/presenters/api_docs/api_operation.rb
+++ b/app/presenters/api_docs/api_operation.rb
@@ -44,7 +44,7 @@ module APIDocs
     def example
       return unless response.content['application/json']
 
-      response.content['application/json']['example'] || SchemaExample.new(schema).as_json
+      SchemaExample.new(schema).as_json
     end
 
     def schema
@@ -76,8 +76,7 @@ module APIDocs
     end
 
     def example
-      request_body.content['application/json']['example'] ||
-        SchemaExample.new(request_body.content['application/json'].schema).as_json
+      SchemaExample.new(request_body.content['application/json'].schema).as_json
     end
   end
 end

--- a/app/presenters/api_docs/api_operation.rb
+++ b/app/presenters/api_docs/api_operation.rb
@@ -35,7 +35,7 @@ module APIDocs
   class Response
     attr_reader :code, :response
 
-    delegate :description, :content, to: :response
+    delegate :description, to: :response
 
     def initialize(code, response)
       @code = code
@@ -62,6 +62,7 @@ module APIDocs
 
   class RequestBody
     attr_reader :request_body
+
     delegate :description, to: :request_body
 
     def initialize(request_body)

--- a/app/presenters/api_docs/api_operation.rb
+++ b/app/presenters/api_docs/api_operation.rb
@@ -41,20 +41,8 @@ module APIDocs
       @response = response
     end
 
-    def example
-      SchemaExample.new(schema).as_json
-    end
-
     def schema
-      response.content['application/json'].schema
-    end
-
-    def schema_name
-      referenced_schema_regex = /#\/components\/schemas\//
-      location = schema.node_context.source_location.to_s
-      if location.match(referenced_schema_regex)
-        location.gsub(referenced_schema_regex, '')
-      end
+      APISchema.new(name: nil, schema: response.content['application/json'].schema)
     end
   end
 
@@ -69,10 +57,6 @@ module APIDocs
 
     def schema
       APISchema.new(name: nil, schema: request_body.content['application/json'].schema)
-    end
-
-    def example
-      SchemaExample.new(request_body.content['application/json'].schema).as_json
     end
   end
 end

--- a/app/presenters/api_docs/api_operation.rb
+++ b/app/presenters/api_docs/api_operation.rb
@@ -42,14 +42,10 @@ module APIDocs
     end
 
     def example
-      return unless response.content['application/json']
-
       SchemaExample.new(schema).as_json
     end
 
     def schema
-      return unless response.content['application/json']
-
       response.content['application/json'].schema
     end
 

--- a/app/presenters/api_docs/api_operation.rb
+++ b/app/presenters/api_docs/api_operation.rb
@@ -28,17 +28,16 @@ module APIDocs
              to: :operation
 
     def responses
-      operation.responses.map { |code, response| Response.new(code, response) }
+      operation.responses.to_h.transform_values { |response_definition| Response.new(response_definition) }
     end
   end
 
   class Response
-    attr_reader :code, :response
+    attr_reader :response
 
     delegate :description, to: :response
 
-    def initialize(code, response)
-      @code = code
+    def initialize(response)
       @response = response
     end
 

--- a/app/presenters/api_docs/api_operation.rb
+++ b/app/presenters/api_docs/api_operation.rb
@@ -17,9 +17,7 @@ module APIDocs
     end
 
     def request_body
-      return unless operation.request_body
-
-      RequestBody.new(operation.request_body)
+      DescriptionAndSchema.new(operation.request_body) if operation.request_body
     end
 
     delegate :summary,
@@ -28,35 +26,21 @@ module APIDocs
              to: :operation
 
     def responses
-      operation.responses.to_h.transform_values { |response_definition| Response.new(response_definition) }
+      operation.responses.to_h.transform_values { |response| DescriptionAndSchema.new(response) }
     end
   end
 
-  class Response
-    attr_reader :response
+  class DescriptionAndSchema
+    attr_reader :definition
 
-    delegate :description, to: :response
+    delegate :description, to: :definition
 
-    def initialize(response)
-      @response = response
+    def initialize(definition)
+      @definition = definition
     end
 
     def schema
-      APISchema.new(name: nil, schema: response.content['application/json'].schema)
-    end
-  end
-
-  class RequestBody
-    attr_reader :request_body
-
-    delegate :description, to: :request_body
-
-    def initialize(request_body)
-      @request_body = request_body
-    end
-
-    def schema
-      APISchema.new(name: nil, schema: request_body.content['application/json'].schema)
+      APISchema.new(name: nil, schema: definition.content['application/json'].schema)
     end
   end
 end

--- a/app/presenters/api_docs/api_operation.rb
+++ b/app/presenters/api_docs/api_operation.rb
@@ -40,7 +40,7 @@ module APIDocs
     end
 
     def schema
-      APISchema.new(definition.content['application/json'].schema)
+      APIDocs::APISchema.new(definition.content['application/json'].schema)
     end
   end
 end

--- a/app/presenters/api_docs/api_operation.rb
+++ b/app/presenters/api_docs/api_operation.rb
@@ -54,8 +54,11 @@ module APIDocs
     end
 
     def schema_name
+      referenced_schema_regex = /#\/components\/schemas\//
       location = schema.node_context.source_location.to_s
-      location.gsub(/#\/components\/schemas\//, '')
+      if location.match(referenced_schema_regex)
+        location.gsub(referenced_schema_regex, '')
+      end
     end
   end
 

--- a/app/presenters/api_docs/api_operation.rb
+++ b/app/presenters/api_docs/api_operation.rb
@@ -40,7 +40,7 @@ module APIDocs
     end
 
     def schema
-      APISchema.new(name: nil, schema: definition.content['application/json'].schema)
+      APISchema.new(definition.content['application/json'].schema)
     end
   end
 end

--- a/app/presenters/api_docs/api_reference.rb
+++ b/app/presenters/api_docs/api_reference.rb
@@ -22,7 +22,7 @@ module APIDocs
 
     def schemas
       document.components.schemas.values.map do |schema|
-        APISchema.new(schema)
+        APIDocs::APISchema.new(schema)
       end
     end
 

--- a/app/presenters/api_docs/api_reference.rb
+++ b/app/presenters/api_docs/api_reference.rb
@@ -21,8 +21,8 @@ module APIDocs
     end
 
     def schemas
-      document.components.schemas.map do |name, schema|
-        APISchema.new(name: name, schema: schema)
+      document.components.schemas.values.map do |schema|
+        APISchema.new(schema)
       end
     end
 

--- a/app/presenters/api_docs/api_schema.rb
+++ b/app/presenters/api_docs/api_schema.rb
@@ -1,6 +1,6 @@
 module APIDocs
   class APISchema
-    attr_reader :name, :schema
+    attr_reader :schema
     delegate :description, :required, to: :schema
 
     def initialize(name:, schema:)
@@ -28,6 +28,20 @@ module APIDocs
 
     def anchor
       "#{name.parameterize}-object"
+    end
+
+    def example
+      SchemaExample.new(schema).as_json
+    end
+
+    def name
+      @name || begin
+        referenced_schema_regex = /#\/components\/schemas\//
+        location = schema.node_context.source_location.to_s
+        if location.match(referenced_schema_regex)
+          location.gsub(referenced_schema_regex, '')
+        end
+      end
     end
 
     class Property

--- a/app/presenters/api_docs/api_schema.rb
+++ b/app/presenters/api_docs/api_schema.rb
@@ -3,8 +3,7 @@ module APIDocs
     attr_reader :schema
     delegate :description, :required, to: :schema
 
-    def initialize(name:, schema:)
-      @name = name
+    def initialize(schema)
       @schema = schema
     end
 
@@ -35,12 +34,10 @@ module APIDocs
     end
 
     def name
-      @name || begin
-        referenced_schema_regex = /#\/components\/schemas\//
-        location = schema.node_context.source_location.to_s
-        if location.match(referenced_schema_regex)
-          location.gsub(referenced_schema_regex, '')
-        end
+      referenced_schema_regex = /#\/components\/schemas\//
+      location = schema.node_context.source_location.to_s
+      if location.match(referenced_schema_regex)
+        location.gsub(referenced_schema_regex, '')
       end
     end
 

--- a/spec/components/api_docs/operation_component_spec.rb
+++ b/spec/components/api_docs/operation_component_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe APIDocs::OperationComponent do
+  describe 'linking to the schema of the response object we return' do
+    let :spec_with_schema_reference do
+      OpenAPIExampleSpec.build_with <<~YAML
+        paths:
+          "/post-a-string":
+            post:
+              responses:
+                422:
+                  description: An error
+                  content:
+                    application/json:
+                      schema:
+                        "$ref": "#/components/schemas/ErrorResponse"
+        components:
+          schemas:
+            ErrorResponse:
+              type: object
+              properties:
+                error_messages:
+                  type: array
+                  example: ['Bad word', 'Misspelled']
+                  items:
+                    type: string
+      YAML
+    end
+
+    let :spec_without_schema_reference do
+      OpenAPIExampleSpec.build_with <<~YAML
+        paths:
+          "/post-a-string":
+            post:
+              responses:
+                422:
+                  description: An error
+                  content:
+                    application/json:
+                      schema:
+                        type: string
+      YAML
+    end
+
+    it 'links when the schema refers to a named object' do
+      operation = APIDocs::APIReference.new(spec_with_schema_reference).operations.first
+
+      result = render_inline described_class.new(operation)
+
+      expect(result.text).to include 'This request will return a ErrorResponse object'
+    end
+
+    it 'doesn’t link when the schema is inline' do
+      operation = APIDocs::APIReference.new(spec_without_schema_reference).operations.first
+
+      result = render_inline described_class.new(operation)
+
+      expect(result.text).not_to include 'This request will return'
+    end
+  end
+end

--- a/spec/presenters/api_docs/api_operation_spec.rb
+++ b/spec/presenters/api_docs/api_operation_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe APIDocs::APIOperation do
+  subject :api_operation do
+    # the spec itself is the interface we care about so this
+    # is inevitably a bit of an integration test
+    reference = APIDocs::APIReference.new(spec)
+    reference.operations.first
+  end
+
+  let :spec do
+    OpenAPIExampleSpec.build_with <<~YAML
+      paths:
+        "/post-a-string":
+          post:
+            summary: Post a string
+            description: This endpoint accepts and returns a string
+            requestBody:
+              required: true
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      my_string:
+                        type: string
+                        example: "I AM A STRING FROM THE CLIENT"
+            responses:
+              200:
+                description: A string
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        my_string:
+                          type: string
+                          example: "I AM A STRING FROM THE API"
+              422:
+                description: An error
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        error_messages:
+                          type: array
+                          example: ['Bad word', 'Misspelled']
+                          items:
+                            type: string
+    YAML
+  end
+
+  describe '#name' do
+    it 'renders the HTTP verb plus the name of the path' do
+      expect(api_operation.name).to eq 'POST /post-a-string'
+    end
+  end
+
+  describe '#anchor' do
+    it 'renders an identifier suitable for using as an href= anchor' do
+      expect(api_operation.anchor).to eq 'post-post-a-string'
+    end
+  end
+
+  describe '#request_body' do
+    it 'provides a schema and example for the request body' do
+      expect(api_operation.request_body.example).to eq('my_string' => 'I AM A STRING FROM THE CLIENT')
+      expect(api_operation.request_body.schema).to be_a APIDocs::APISchema
+    end
+  end
+
+  describe '#responses' do
+    it 'returns all the responses' do
+      expect(api_operation.responses.first.code).to eq '200'
+      expect(api_operation.responses.first.example).to eq('my_string' => 'I AM A STRING FROM THE API')
+
+      expect(api_operation.responses.second.code).to eq '422'
+      expect(api_operation.responses.second.example).to eq('error_messages' => ['Bad word', 'Misspelled'])
+    end
+  end
+end

--- a/spec/presenters/api_docs/api_operation_spec.rb
+++ b/spec/presenters/api_docs/api_operation_spec.rb
@@ -41,13 +41,17 @@ RSpec.describe APIDocs::APIOperation do
                 content:
                   application/json:
                     schema:
-                      type: object
-                      properties:
-                        error_messages:
-                          type: array
-                          example: ['Bad word', 'Misspelled']
-                          items:
-                            type: string
+                      "$ref": "#/components/schemas/ErrorResponse"
+      components:
+        schemas:
+          ErrorResponse:
+            type: object
+            properties:
+              error_messages:
+                type: array
+                example: ['Bad word', 'Misspelled']
+                items:
+                  type: string
     YAML
   end
 
@@ -74,6 +78,14 @@ RSpec.describe APIDocs::APIOperation do
     it 'returns all the responses in a hash' do
       expect(api_operation.responses['200'].example).to eq('my_string' => 'I AM A STRING FROM THE API')
       expect(api_operation.responses['422'].example).to eq('error_messages' => ['Bad word', 'Misspelled'])
+    end
+
+    it 'returns a meaningful schema_name for an referenced schema' do
+      expect(api_operation.responses['422'].schema_name).to eq 'ErrorResponse'
+    end
+
+    it 'returns no schema_name for an inline schema' do
+      expect(api_operation.responses['200'].schema_name).to be nil
     end
   end
 end

--- a/spec/presenters/api_docs/api_operation_spec.rb
+++ b/spec/presenters/api_docs/api_operation_spec.rb
@@ -71,12 +71,9 @@ RSpec.describe APIDocs::APIOperation do
   end
 
   describe '#responses' do
-    it 'returns all the responses' do
-      expect(api_operation.responses.first.code).to eq '200'
-      expect(api_operation.responses.first.example).to eq('my_string' => 'I AM A STRING FROM THE API')
-
-      expect(api_operation.responses.second.code).to eq '422'
-      expect(api_operation.responses.second.example).to eq('error_messages' => ['Bad word', 'Misspelled'])
+    it 'returns all the responses in a hash' do
+      expect(api_operation.responses['200'].example).to eq('my_string' => 'I AM A STRING FROM THE API')
+      expect(api_operation.responses['422'].example).to eq('error_messages' => ['Bad word', 'Misspelled'])
     end
   end
 end

--- a/spec/presenters/api_docs/api_operation_spec.rb
+++ b/spec/presenters/api_docs/api_operation_spec.rb
@@ -68,24 +68,24 @@ RSpec.describe APIDocs::APIOperation do
   end
 
   describe '#request_body' do
-    it 'provides a schema and example for the request body' do
-      expect(api_operation.request_body.example).to eq('my_string' => 'I AM A STRING FROM THE CLIENT')
-      expect(api_operation.request_body.schema).to be_a APIDocs::APISchema
+    it 'provides a schema for the request body' do
+      expect(api_operation.request_body.schema.example).to eq('my_string' => 'I AM A STRING FROM THE CLIENT')
+      expect(api_operation.request_body.schema.name).to be_nil
     end
   end
 
   describe '#responses' do
     it 'returns all the responses in a hash' do
-      expect(api_operation.responses['200'].example).to eq('my_string' => 'I AM A STRING FROM THE API')
-      expect(api_operation.responses['422'].example).to eq('error_messages' => ['Bad word', 'Misspelled'])
+      expect(api_operation.responses['200'].schema.example).to eq('my_string' => 'I AM A STRING FROM THE API')
+      expect(api_operation.responses['422'].schema.example).to eq('error_messages' => ['Bad word', 'Misspelled'])
     end
 
-    it 'returns a meaningful schema_name for an referenced schema' do
-      expect(api_operation.responses['422'].schema_name).to eq 'ErrorResponse'
+    it 'returns a named schema for an referenced schema' do
+      expect(api_operation.responses['422'].schema.name).to eq 'ErrorResponse'
     end
 
-    it 'returns no schema_name for an inline schema' do
-      expect(api_operation.responses['200'].schema_name).to be nil
+    it 'returns an anonymous schema for an inline schema' do
+      expect(api_operation.responses['200'].schema.name).to be nil
     end
   end
 end

--- a/spec/presenters/api_docs/api_reference_spec.rb
+++ b/spec/presenters/api_docs/api_reference_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe APIDocs::APIReference do
+  subject :reference do
+    described_class.new(spec_definition)
+  end
+
+  describe '#operations' do
+    let(:spec_definition) do
+      OpenAPIExampleSpec.build_with <<~YAML
+        paths:
+          "/get-a-string":
+            get:
+              summary: Get a string
+              description: This endpoint returns a string
+              responses:
+                200:
+                  description: A string
+                  content:
+                    application/json:
+                      schema:
+                        type: string
+      YAML
+    end
+
+    it 'returns operations' do
+      expect(reference.operations.count).to eq 1
+      expect(reference.operations.first.name).to eq 'GET /get-a-string'
+    end
+  end
+
+  describe '#schemas' do
+    let(:spec_definition) do
+      OpenAPIExampleSpec.build_with <<~YAML
+        components:
+          schemas:
+            Foo:
+              type: string
+      YAML
+    end
+
+    it 'returns schemas' do
+      expect(reference.schemas.count).to eq 1
+      expect(reference.schemas.first.name).to eq 'Foo'
+    end
+  end
+end

--- a/spec/presenters/api_docs/api_schema_spec.rb
+++ b/spec/presenters/api_docs/api_schema_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe APIDocs::APISchema do
   describe '#object_schema_name' do
     let :schema do
       @document = Openapi3Parser.load(VendorAPISpecification.as_hash)
-      schema_name, raw_schema = @document.components.schemas.find { |schema_name, _schema| schema_name == 'ApplicationAttributes' }
-      APIDocs::APISchema.new(name: schema_name, schema: raw_schema)
+      _schema_name, raw_schema = @document.components.schemas.find { |schema_name, _schema| schema_name == 'ApplicationAttributes' }
+      APIDocs::APISchema.new(raw_schema)
     end
 
     it 'finds the object_schema_name specified with $ref' do

--- a/spec/support/open_api_example_spec.rb
+++ b/spec/support/open_api_example_spec.rb
@@ -1,0 +1,14 @@
+class OpenAPIExampleSpec
+  BOILERPLATE = <<~YAML
+    openapi: '3.0.0'
+    info:
+      version: 'v1'
+    paths: {}
+  YAML
+  .freeze
+
+  def self.build_with(yaml)
+    spec = YAML.safe_load(BOILERPLATE)
+    spec.merge(YAML.safe_load(yaml))
+  end
+end


### PR DESCRIPTION
## Context

Following #4254 and #4329 we can build new API docs easily! The code that builds the docs lacks specs, though, and it's quite hard to follow. 

## Changes proposed in this pull request

- add specs for the public interfaces of the main classes `APIReference` and `APIOperation`
- refactor a bit to try to give `APIOperation` and `APISchema` (which `APIOperation` depends on) slightly clearer roles

## Guidance to review

Commit by commit!

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
