### PR TITLE
Add additional details to the add course page on the support UI

### DIFF
--- a/app/forms/support_interface/application_forms/pick_course_form.rb
+++ b/app/forms/support_interface/application_forms/pick_course_form.rb
@@ -10,7 +10,7 @@ module SupportInterface
       validates :course_code, presence: true
       validate :course_is_open_on_apply, on: :save
 
-      RadioOption = Struct.new(:course_option_id, :course_name, :course_code, :site_name)
+      RadioOption = Struct.new(:course_option_id, :provider_name, :provider_code, :course_name, :course_code, :site_name, :study_mode)
 
       def course_options
         return @course_options if @course_options
@@ -19,7 +19,17 @@ module SupportInterface
           course.course_options
                 .available
                 .reject { |course_option| existing_course_ids.include?(course_option.course_id) }
-                .map { |course_option| RadioOption.new(course_option.id, course.name, course.code, course_option.site.name) }
+                .map do |course_option|
+                  RadioOption.new(
+                    course_option.id,
+                    course.provider.name,
+                    course.provider.code,
+                    course.name,
+                    course.code,
+                    course_option.site.name,
+                    course_option.study_mode.humanize,
+                  )
+                end
         }.flatten
 
         sorted_course_options = course_options.sort_by(&:course_name)

--- a/app/forms/support_interface/application_forms/pick_course_form.rb
+++ b/app/forms/support_interface/application_forms/pick_course_form.rb
@@ -36,6 +36,10 @@ module SupportInterface
         @course_options = sorted_course_options
       end
 
+      def unavailable_courses
+        courses.select { |course| course.course_options.all?(&:no_vacancies?) }
+      end
+
       def save
         return false unless valid?(:save)
 

--- a/app/forms/support_interface/application_forms/pick_course_form.rb
+++ b/app/forms/support_interface/application_forms/pick_course_form.rb
@@ -10,7 +10,16 @@ module SupportInterface
       validates :course_code, presence: true
       validate :course_is_open_on_apply, on: :save
 
-      RadioOption = Struct.new(:course_option_id, :provider_name, :provider_code, :course_name, :course_code, :site_name, :study_mode)
+      RadioOption = Struct.new(
+        :course_option_id,
+        :provider_name,
+        :provider_code,
+        :course_name,
+        :course_code,
+        :site_name,
+        :study_mode,
+        keyword_init: true,
+      )
 
       def course_options
         return @course_options if @course_options
@@ -21,13 +30,13 @@ module SupportInterface
                 .reject { |course_option| existing_course_ids.include?(course_option.course_id) }
                 .map do |course_option|
                   RadioOption.new(
-                    course_option.id,
-                    course.provider.name,
-                    course.provider.code,
-                    course.name,
-                    course.code,
-                    course_option.site.name,
-                    course_option.study_mode.humanize,
+                    course_option_id: course_option.id,
+                    provider_name: course.provider.name,
+                    provider_code: course.provider.code,
+                    course_name: course.name,
+                    course_code: course.code,
+                    site_name: course_option.site.name,
+                    study_mode: course_option.study_mode.humanize,
                   )
                 end
         }.flatten

--- a/app/views/support_interface/application_forms/courses/new.html.erb
+++ b/app/views/support_interface/application_forms/courses/new.html.erb
@@ -8,7 +8,7 @@
         <%= f.govuk_error_summary %>
         <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: 'Which course should be added to the application?', size: 'm' } do %>
           <% @pick_course.course_options.each_with_index do |co, i| %>
-            <%= f.govuk_radio_button :course_option_id, co.course_option_id, label: { text: "#{co.course_name} (#{co.course_code}) - #{co.site_name}" }, link_errors: i.zero? %>
+            <%= f.govuk_radio_button :course_option_id, co.course_option_id, label: { text: "#{co.provider_name} (#{co.provider_code}) - #{co.course_name} (#{co.course_code}) - #{co.site_name} - #{co.study_mode} " }, link_errors: i.zero? %>
           <% end %>
         <% end %>
         <%= f.govuk_submit 'Add course to application' %>

--- a/app/views/support_interface/application_forms/courses/new.html.erb
+++ b/app/views/support_interface/application_forms/courses/new.html.erb
@@ -3,6 +3,16 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
+    <% if @pick_course.unavailable_courses.present? %>
+      <h2 class='govuk-heading-m'>Courses with no vacancies</h2>
+      <% @pick_course.unavailable_courses.each do |course| %>
+        <ul class="govuk-list">
+          <%= "#{course.provider.name} (#{course.provider.code}) - #{course.name} (#{course.code})" %>
+        </ul>
+      <% end %>
+    <% end %>
+
     <% if @pick_course.course_options.present? %>
       <%= form_with model: @pick_course, url: support_interface_application_form_create_course_path(course_code: @pick_course.course_code) do |f| %>
         <%= f.govuk_error_summary %>

--- a/spec/forms/support_interface/application_forms/pick_course_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/pick_course_form_spec.rb
@@ -54,6 +54,18 @@ RSpec.describe SupportInterface::ApplicationForms::PickCourseForm, type: :model 
     end
   end
 
+  describe '#unavailable_courses' do
+    it 'returns courses with no vacacncies' do
+      course1 = create(:course, :open_on_apply, code: 'ABC')
+      course2 = create(:course, :open_on_apply, code: 'ABC')
+      create(:course_option, course: course1)
+      create(:course_option, :no_vacancies, course: course1)
+      create(:course_option, :no_vacancies, course: course2)
+
+      expect(described_class.new(course_code: 'ABC').unavailable_courses).to eq [course2]
+    end
+  end
+
   describe '#save' do
     it 'returns false if not valid' do
       expect(described_class.new.save).to be false


### PR DESCRIPTION
## Context

This PR tackles two defects 

1. Courses that have no vacancies are not returned by design. However, this is really confusing for support staff as there is no indication that the course is full
2. Some courses share a code and name (Physics etc.). This can lead to the page occasionally looking like this.

![image](https://user-images.githubusercontent.com/42515961/111983407-03825280-8b02-11eb-8b5b-122588dceb00.png)

## Changes proposed in this pull request

1. Add a list of full courses for the provided code
2. Expose the provider and study mode to the course options struct 



|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/111983880-8b685c80-8b02-11eb-94bb-2915aedffac1.png)|![image](https://user-images.githubusercontent.com/42515961/111983835-7b507d00-8b02-11eb-9ab2-fda84a91d5be.png)|
## Guidance to review

Does this approach seem reasonable?

## Link to Trello card

https://trello.com/c/g6ygCMtV/3055-support-interface-when-attempting-to-switch-to-a-course-that-has-no-vacancies-its-not-obvious-why-you-cannot-do-so

https://trello.com/c/FIi30t2q/3212-show-additional-detail-on-the-add-course-page-on-the-support-ui

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
