### PR TITLE
Account for index already existing when running migration

### DIFF
--- a/db/migrate/20210319163050_add_auditable_type_id_index_to_audits.rb
+++ b/db/migrate/20210319163050_add_auditable_type_id_index_to_audits.rb
@@ -1,7 +1,15 @@
 class AddAuditableTypeIdIndexToAudits < ActiveRecord::Migration[6.0]
   disable_ddl_transaction!
 
-  def change
+  def up
+    return if index_exists?(:audits, %i[auditable_type id])
+
     add_index :audits, %i[auditable_type id], algorithm: :concurrently
+  end
+
+  def down
+    return unless index_exists?(:audits, %i[auditable_type id])
+
+    remove_index :audits, column: %i[auditable_type id], algorithm: :concurrently
   end
 end

--- a/db/migrate/20210319163050_add_auditable_type_id_index_to_audits.rb
+++ b/db/migrate/20210319163050_add_auditable_type_id_index_to_audits.rb
@@ -4,12 +4,14 @@ class AddAuditableTypeIdIndexToAudits < ActiveRecord::Migration[6.0]
   def up
     return if index_exists?(:audits, %i[auditable_type id])
 
+    execute 'SET statement_timeout = 0'
     add_index :audits, %i[auditable_type id], algorithm: :concurrently
   end
 
   def down
     return unless index_exists?(:audits, %i[auditable_type id])
 
+    execute 'SET statement_timeout = 0'
     remove_index :audits, column: %i[auditable_type id], algorithm: :concurrently
   end
 end


### PR DESCRIPTION
## Context
The migration failed on staging, but actually added the index. This prevents it from failing when run again

## Changes proposed in this pull request
Let the migration succeed if the index has already been added

## Guidance to review
Anything I missed?

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
