### PR TITLE
Fix back links and add page titles to setup_permission views

### DIFF
--- a/app/views/provider_interface/provider_relationship_permissions_setup/check.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/check.html.erb
@@ -1,6 +1,5 @@
-<% content_for :before_content do %>
-  <%= govuk_back_link_to 'Back', previous_page %>
-<% end %>
+<% content_for :browser_title, title_with_error_prefix('Check permissions', @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(previous_page) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-body">

--- a/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
@@ -1,6 +1,5 @@
-<% content_for :before_content do %>
-  <%= govuk_back_link_to 'Back', previous_page %>
-<% end %>
+<% content_for :browser_title, title_with_error_prefix('Set up permissions', @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(previous_page) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION

## Link to Trello card

https://trello.com/c/fC7IkWhn/3491-fix-back-links-in-the-set-up-permissions-wizard

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
