### PR TITLE
Remove inline styles

### DIFF
--- a/app/views/candidate_interface/volunteering/role/_form.html.erb
+++ b/app/views/candidate_interface/volunteering/role/_form.html.erb
@@ -5,7 +5,7 @@
 <%= f.govuk_text_field :organisation, label: { text: t('application_form.volunteering.organisation.label'), size: 'm' } %>
 
 <div class="app-work-experience__working-with-children" data-qa="working-with-children">
-  <%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: t('application_form.volunteering.working_with_children.label'), size: 'm' }, inline: true do %>
+  <%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: t('application_form.volunteering.working_with_children.label'), size: 'm' } do %>
     <%= f.govuk_radio_button :working_with_children, true, label: { text: 'Yes' }, link_errors: true %>
     <%= f.govuk_radio_button :working_with_children, false, label: { text: 'No' } %>
   <% end %>

--- a/app/views/candidate_interface/work_history/edit/_form.html.erb
+++ b/app/views/candidate_interface/work_history/edit/_form.html.erb
@@ -22,7 +22,7 @@
 
 <%= f.govuk_text_area :details, label: { text: t('application_form.work_history.details.label'), size: 'm' }, hint: { text: t('application_form.work_history.details.hint_text') }, max_words: 150 %>
 
-<%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: t('application_form.work_history.working_with_children.label'), size: 'm' }, inline: true do %>
+<%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: t('application_form.work_history.working_with_children.label'), size: 'm' } do %>
   <%= f.govuk_radio_button :working_with_children, true, label: { text: t('application_form.work_history.working_with_children.yes.label') }, link_errors: true %>
   <%= f.govuk_radio_button :working_with_children, false, label: { text: t('application_form.work_history.working_with_children.no.label') } %>
 <% end %>


### PR DESCRIPTION
## Context

For consistency, we want to present radio buttons the same way in forms.

## Changes proposed in this pull request

Remove inline styles for ‘Did this role involve working in a school or with children?’ radios for both the volunteering and work experience flows

## Link to Trello card

https://trello.com/c/HsdbS84w/3204-remove-inline-styles-for-did-this-role-involve-working-in-a-school-or-with-children-radios-on-add-a-role

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
