### PR TITLE
Run rspec in parallel by default

### DIFF
--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -54,5 +54,10 @@ task :compile_assets do
   sh 'RAILS_ENV=test rails webpacker:compile'
 end
 
+desc 'Run rspec in parallel without performance'
+task :parallel_rspec_without_performance do
+  sh "bundle exec parallel_rspec --exclude-pattern=#{performance_test_pattern} spec"
+end
+
 desc 'Run all the tests'
-task run_tests: %i[compile_assets linting spec_without_performance brakeman jest]
+task run_tests: %i[compile_assets linting parallel_rspec_without_performance brakeman jest]


### PR DESCRIPTION
## Context

Run rspec in parallel by default as agreed in a dev retro to speed up development.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

- set up https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/parallel_tests.md
- run `bundle exec rake`

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
