### PR TITLE
Fix deprecation warning on loading Sidekiq::Web

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -7,4 +7,3 @@ Sidekiq.configure_server do |config|
 end
 
 require 'sidekiq/web'
-Sidekiq::Web.set :sessions, false


### PR DESCRIPTION
This setting no longer does anything:

https://github.com/mperham/sidekiq/blob/master/Changes.md#620

The Sidekiq web interface is still accessible with a valid support session, and still inaccessible without one.