### PR TITLE
Add data migration to update user_type to new ServiceAPIUser

### DIFF
--- a/app/services/data_migrations/update_authentication_token_types.rb
+++ b/app/services/data_migrations/update_authentication_token_types.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class UpdateAuthenticationTokenTypes
+    TIMESTAMP = 20210323103052
+    MANUAL_RUN = false
+
+    def change
+      AuthenticationToken.where(user_type: 'DataAPIUser').update_all(user_type: 'ServiceAPIUser')
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
-  # do not edit this line - services added below by generator
+  # do not delete or edit this line - services added below by generator
+  'DataMigrations::UpdateAuthenticationTokenTypes',
 ].freeze
 
 def data_migrations

--- a/spec/services/data_migrations/update_authentication_token_types_spec.rb
+++ b/spec/services/data_migrations/update_authentication_token_types_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::UpdateAuthenticationTokenTypes do
+  it 'updates authentication tokens with user type `DataAPIUser` to `ServiceAPIUser`' do
+    authentication_token = create(:authentication_token)
+
+    # Since the DataAPIUser was removed, we have to set this outside the factory to avoid callbacks
+    authentication_token.update_column(:user_type, 'DataAPIUser')
+    described_class.new.change
+
+    expect(authentication_token.reload.user_type).to eq('ServiceAPIUser')
+  end
+
+  it 'does not update other authentication tokens with a different user type' do
+    authentication_token = create(:authentication_token)
+    described_class.new.change
+
+    expect(authentication_token.reload.user_type).to eq('SupportUser')
+  end
+end


### PR DESCRIPTION
## Context

We have moved away from the old `DataAPIUser`, update existing authentication tokens to use the new type: `ServiceAPIUser`.

## Changes proposed in this pull request

Add a data migration to update existing authentication token user types

## Guidance to review

Due to callbacks for the polymorphic type existence, I am using update methods without callbacks


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
