### PR TITLE
Add ChangeOffer service and new checks in wrapper services

### DIFF
--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -25,16 +25,16 @@ class ChangeOffer
 
     unless change_an_offer.save
       if change_an_offer.errors[:base].include?('The new offer is identical to the current offer')
-        raise IdenticalOffer, 'The new offer is identical to the current offer'
+        raise IdenticalOfferError, 'The new offer is identical to the current offer'
       elsif change_an_offer.errors[:course_option].present?
         raise CourseValidationError, change_an_offer.errors[:course_option].join
       end
     end
   end
 
-  class IdenticalOffer < StandardError; end
+  class IdenticalOfferError < StandardError; end
   class CourseValidationError < StandardError; end
-  class RatifyingProviderChange < StandardError; end
+  class RatifyingProviderChangeError < StandardError; end
   class ConditionsValidationError < StandardError; end
 private
 
@@ -42,7 +42,7 @@ private
     previous_ratifying_provider = application_choice.offered_course.accredited_provider || application_choice.offered_course.provider
     new_ratifiying_provider = course_option.course.accredited_provider || course_option.course.provider
     if previous_ratifying_provider != new_ratifiying_provider
-      raise RatifyingProviderChange, 'The new offer has a different ratifying provider to the current offer'
+      raise RatifyingProviderChangeError, 'The new offer has a different ratifying provider to the current offer'
     end
   end
 

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -47,7 +47,7 @@ private
   end
 
   def check_conditions!
-    if conditions&.count > MAX_CONDITIONS_COUNT
+    if conditions && conditions.count > MAX_CONDITIONS_COUNT
       raise ConditionsValidationError, 'Too many conditions specified (20 or fewer required)'
     elsif conditions.any? { |c| c.length > MAX_CONDITION_LENGTH }
       raise ConditionsValidationError, 'Condition exceeds length limit (255 characters or fewer required)'

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -12,14 +12,32 @@ class ChangeOffer
   end
 
   def save!
+    if offer_changes_ratifying_provider?
+      raise RatifyingProviderChange, 'The new offer has a different ratifying provider to the current offer'
+    end
+
     change_an_offer = ChangeAnOffer.new(actor: actor,
                                         application_choice: application_choice,
                                         course_option: course_option,
                                         offer_conditions: conditions)
-    change_an_offer.save
 
-    if change_an_offer.errors[:base].include?(MakeAnOffer::STATE_TRANSITION_ERROR)
-      ApplicationStateChange.new(application_choice).make_offer!
+    unless change_an_offer.save
+      if change_an_offer.errors[:base].include?('The new offer is identical to the current offer')
+        raise IdenticalOffer, 'The new offer is identical to the current offer'
+      elsif change_an_offer.errors[:course_option].present?
+        raise CourseValidationError, change_an_offer.errors[:course_option].join
+      end
     end
+  end
+
+  class IdenticalOffer < StandardError; end
+  class CourseValidationError < StandardError; end
+  class RatifyingProviderChange < StandardError; end
+private
+
+  def offer_changes_ratifying_provider?
+    previous_ratifying_provider = application_choice.offered_course.accredited_provider || application_choice.offered_course.provider
+    new_ratfiying_provider = course_option.course.accredited_provider || course_option.course.provider
+    previous_ratifying_provider != new_ratfiying_provider
   end
 end

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -1,0 +1,25 @@
+class ChangeOffer
+  attr_reader :actor, :application_choice, :course_option, :conditions
+
+  def initialize(actor:,
+                 application_choice:,
+                 course_option:,
+                 conditions: [])
+    @actor = actor
+    @application_choice = application_choice
+    @course_option = course_option
+    @conditions = conditions
+  end
+
+  def save!
+    change_an_offer = ChangeAnOffer.new(actor: actor,
+                                        application_choice: application_choice,
+                                        course_option: course_option,
+                                        offer_conditions: conditions)
+    change_an_offer.save
+
+    if change_an_offer.errors[:base].include?(MakeAnOffer::STATE_TRANSITION_ERROR)
+      ApplicationStateChange.new(application_choice).make_offer!
+    end
+  end
+end

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -48,7 +48,7 @@ private
   end
 
   def check_conditions!
-    if conditions&.count > MAX_CONDITIONS_COUNT
+    if conditions && conditions.count > MAX_CONDITIONS_COUNT
       raise ConditionsValidationError, 'Too many conditions specified (20 or fewer required)'
     elsif conditions.any? { |c| c.length > MAX_CONDITION_LENGTH }
       raise ConditionsValidationError, 'Condition exceeds length limit (255 characters or fewer required)'

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -41,8 +41,8 @@ private
 
   def check_ratifying_provider_is_preserved!
     previous_ratifying_provider = application_choice.offered_course.accredited_provider || application_choice.offered_course.provider
-    new_ratifiying_provider = course_option.course.accredited_provider || course_option.course.provider
-    if previous_ratifying_provider != new_ratifiying_provider
+    new_ratifying_provider = course_option.course.accredited_provider || course_option.course.provider
+    if previous_ratifying_provider != new_ratifying_provider
       raise RatifyingProviderChangeError, 'The offer has a different ratifying provider to the application choice'
     end
   end

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -1,6 +1,9 @@
 class MakeOffer
   attr_reader :actor, :application_choice, :course_option, :conditions
 
+  MAX_CONDITIONS_COUNT = 20
+  MAX_CONDITION_LENGTH = 255
+
   def initialize(actor:,
                  application_choice:,
                  course_option:,
@@ -12,6 +15,10 @@ class MakeOffer
   end
 
   def save!
+    check_ratifying_provider_is_preserved!
+    check_conditions!
+    check_existing_offer!
+
     make_an_offer = MakeAnOffer.new(actor: actor,
                                     application_choice: application_choice,
                                     course_option: course_option,
@@ -19,7 +26,38 @@ class MakeOffer
     make_an_offer.save
 
     if make_an_offer.errors[:base].include?(MakeAnOffer::STATE_TRANSITION_ERROR)
-      ApplicationStateChange.new(application_choice).make_offer!
+      raise NoTransitionAllowedError, MakeAnOffer::STATE_TRANSITION_ERROR
+    elsif make_an_offer.errors[:course_option].present?
+      raise CourseValidationError, make_an_offer.errors[:course_option].join
+    end
+  end
+
+  class CourseValidationError < StandardError; end
+  class RatifyingProviderChangeError < StandardError; end
+  class ConditionsValidationError < StandardError; end
+  class AlreadyOfferedError < StandardError; end
+  class NoTransitionAllowedError < StandardError; end
+private
+
+  def check_ratifying_provider_is_preserved!
+    previous_ratifying_provider = application_choice.offered_course.accredited_provider || application_choice.offered_course.provider
+    new_ratifiying_provider = course_option.course.accredited_provider || course_option.course.provider
+    if previous_ratifying_provider != new_ratifiying_provider
+      raise RatifyingProviderChangeError, 'The offer has a different ratifying provider to the application choice'
+    end
+  end
+
+  def check_conditions!
+    if conditions&.count > MAX_CONDITIONS_COUNT
+      raise ConditionsValidationError, 'Too many conditions specified (20 or fewer required)'
+    elsif conditions.any? { |c| c.length > MAX_CONDITION_LENGTH }
+      raise ConditionsValidationError, 'Condition exceeds length limit (255 characters or fewer required)'
+    end
+  end
+
+  def check_existing_offer!
+    if application_choice.offer?
+      raise AlreadyOfferedError, 'An offer already exists, use ChangeOffer service to modify'
     end
   end
 end

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ChangeOffer do
   let(:original_course_option) { course_option_for_provider(provider: provider) }
   let(:new_course_option) { course_option_for_provider(provider: provider) }
   let(:application_choice) do
-    create(:application_choice, :with_modified_offer, course_option: original_course_option)
+    create(:application_choice, :with_offer, course_option: original_course_option)
   end
 
   let(:service) do
@@ -54,8 +54,16 @@ RSpec.describe ChangeOffer do
       expect(application_choice.offer['conditions']).to eq(['First condition', 'Second condition'])
     end
 
-    it 'resets decline_by_default_at for the application choice' do
-      expect { service.save! && application_choice.reload }.to change(application_choice, :decline_by_default_at)
+    it 'triggers SetDeclineByDefault on the application form' do
+      double = instance_double(SetDeclineByDefault)
+      allow(double).to receive(:call)
+      allow(SetDeclineByDefault).to receive(:new).and_return(double)
+
+      service.save!
+
+      expect(SetDeclineByDefault).to have_received(:new)
+                                         .with(application_form: application_choice.application_form)
+      expect(double).to have_received(:call)
     end
 
     it 'sends an email to the candidate to notify them about the change' do
@@ -103,7 +111,7 @@ RSpec.describe ChangeOffer do
 
     it 'do not error if the change offer conditions' do
       application_choice.update(offer: { 'conditions' => ['Different things'] })
-      change = described_class.new(actor: provider_user, application_choice: application_choice, course_option: application_choice.offered_option, conditions: ['DBS check'])
+      change = described_class.new(actor: provider_user, application_choice: application_choice, course_option: original_course_option, conditions: ['DBS check'])
       expect { change.save! }.not_to raise_error
     end
 
@@ -142,20 +150,31 @@ RSpec.describe ChangeOffer do
 
   describe 'conditions validation' do
     it 'throws exception if number of conditions exceeds 20' do
-      # this check needs to be added to wrapper service
+      too_many = described_class.new(
+          actor: provider_user,
+          application_choice: application_choice,
+          course_option: original_course_option,
+          conditions: Array.new(21) { 'a condition' },
+          )
 
-      expect {
-        service.save!
-      }.to raise_error(
-        Offer::ConditionsValidationError,
-        'Too many conditions specified (20 or fewer required)',
-      )
+      expect { too_many.save! }.to raise_error(
+                                       ChangeOffer::ConditionsValidationError,
+                                       'Too many conditions specified (20 or fewer required)',
+                                       )
     end
 
     it 'throws exception if any conditions are longer than 255 characters' do
-      # this check needs to be added to wrapper service
+      too_long = described_class.new(
+          actor: provider_user,
+          application_choice: application_choice,
+          course_option: original_course_option,
+          conditions: ['a' * 256],
+          )
 
-      skip
+      expect { too_long.save! }.to raise_error(
+                                       ChangeOffer::ConditionsValidationError,
+                                       'Condition exceeds length limit (255 characters or fewer required)',
+                                       )
     end
   end
 end

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -7,12 +7,10 @@ RSpec.describe ChangeOffer do
   let(:original_course_option) { course_option_for_provider(provider: provider) }
   let(:new_course_option) { course_option_for_provider(provider: provider) }
   let(:application_choice) do
-    choice = create(:application_choice, :with_modified_offer, course_option: original_course_option)
-    SetDeclineByDefault.new(application_form: choice.application_form).call
-    choice.reload
+    create(:application_choice, :with_modified_offer, course_option: original_course_option)
   end
 
-  def service
+  let(:service) do
     described_class.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option)
   end
 
@@ -86,7 +84,7 @@ RSpec.describe ChangeOffer do
       }.to raise_error(
         ProviderAuthorisation::NotAuthorisedError,
         'You do not have the required user level permissions to make decisions on applications for this provider.',
-        )
+      )
     end
   end
 
@@ -100,7 +98,7 @@ RSpec.describe ChangeOffer do
       }.to raise_error(
         ChangeOffer::IdenticalOffer,
         'The new offer is identical to the current offer',
-        )
+      )
     end
 
     it 'do not error if the change offer conditions' do
@@ -124,9 +122,9 @@ RSpec.describe ChangeOffer do
       expect {
         change.save!
       }.to raise_error(
-               ChangeOffer::CourseValidationError,
-               'is not open for applications via the Apply service',
-               )
+        ChangeOffer::CourseValidationError,
+        'is not open for applications via the Apply service',
+      )
     end
 
     it 'throws exception if new course option changes the ratifying provider' do
@@ -136,9 +134,9 @@ RSpec.describe ChangeOffer do
       expect {
         change.save!
       }.to raise_error(
-               ChangeOffer::RatifyingProviderChange,
-               'The new offer has a different ratifying provider to the current offer',
-               )
+        ChangeOffer::RatifyingProviderChange,
+        'The new offer has a different ratifying provider to the current offer',
+      )
     end
   end
 

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -1,0 +1,170 @@
+require 'rails_helper'
+
+RSpec.describe ChangeOffer do
+  include CourseOptionHelpers
+  let(:provider_user) { create(:provider_user, :with_provider, :with_make_decisions) }
+  let(:provider) { provider_user.providers.first }
+  let(:original_course_option) { course_option_for_provider(provider: provider) }
+  let(:new_course_option) { course_option_for_provider(provider: provider) }
+  let(:application_choice) do
+    choice = create(:application_choice, :with_modified_offer, course_option: original_course_option)
+    SetDeclineByDefault.new(application_form: choice.application_form).call
+    choice.reload
+  end
+
+  def service
+    described_class.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option)
+  end
+
+  describe 'database changes and side-effects' do
+    it 'changes offered_course_option_id for the application choice' do
+      expect { service.save! }.to change(application_choice, :offered_course_option_id)
+    end
+
+    it 'does not change offered_at' do
+      expect { service.save! }.not_to change(application_choice, :offered_at)
+    end
+
+    it 'populates offer_changed_at for the application choice' do
+      Timecop.freeze do
+        expect { service.save! }.to change(application_choice, :offer_changed_at).to(Time.zone.now)
+      end
+    end
+
+    it 'groups offer(ed)_ changes in a single audit', with_audited: true do
+      service.save!
+
+      audit_with_option_id =
+        application_choice.audits
+        .where('jsonb_exists(audited_changes, :key)', key: 'offered_course_option_id')
+        .last
+
+      expect(audit_with_option_id.audited_changes).to have_key('offer_changed_at')
+    end
+
+    it 'replaces conditions if conditions is supplied' do
+      application_choice.update(offer: { 'conditions' => ['DBS check'] })
+
+      with_conditions = described_class.new(
+        actor: provider_user,
+        application_choice: application_choice,
+        course_option: new_course_option,
+        conditions: ['First condition', 'Second condition'],
+      )
+
+      expect { with_conditions.save! }.to change(application_choice, :offer)
+      expect(application_choice.offer['conditions']).to eq(['First condition', 'Second condition'])
+    end
+
+    it 'resets decline_by_default_at for the application choice' do
+      expect { service.save! && application_choice.reload }.to change(application_choice, :decline_by_default_at)
+    end
+
+    it 'sends an email to the candidate to notify them about the change' do
+      mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+      allow(CandidateMailer).to receive(:changed_offer).and_return(mail)
+
+      service.save!
+
+      expect(CandidateMailer).to have_received(:changed_offer).with(application_choice)
+      expect(mail).to have_received(:deliver_later)
+    end
+
+    it 'calls `StateChangeNotifier` to send a Slack notification' do
+      allow(StateChangeNotifier).to receive(:call).and_return(nil)
+      service.save!
+      expect(StateChangeNotifier).to have_received(:call).with(:change_an_offer, application_choice: application_choice)
+    end
+  end
+
+  describe 'user authorisation' do
+    let(:provider_user) { create(:provider_user, :with_provider) }
+
+    it 'throws an exception if actor is not authorised to perform this action' do
+      expect {
+        service.save!
+      }.to raise_error(
+        ProviderAuthorisation::NotAuthorisedError,
+        'You are not permitted to view this application. The specified course is not associated with any of your organisations. You do not have the required user level permissions to make decisions on applications for this provider.',
+      )
+    end
+  end
+
+  describe 'repeat offers' do
+    it 'throw an exception if neither offer nor conditions have changed' do
+      application_choice.update(offer: { 'conditions' => ['DBS check'] })
+      change = described_class.new(actor: provider_user, application_choice: application_choice, course_option: application_choice.offered_option, conditions: ['DBS check'])
+
+      # already covered by ChangeAnOffer as an error
+      skip
+    end
+
+    it 'do not error if the change offer conditions' do
+      application_choice.update(offer: { 'conditions' => ['Different things'] })
+      change = described_class.new(actor: provider_user, application_choice: application_choice, course_option: application_choice.offered_option, conditions: ['DBS check'])
+
+      skip
+    end
+
+    it 'do not error when if they change offered course details' do
+      application_choice.update(offer: { 'conditions' => ['DBS check'] })
+      change = described_class.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option, conditions: ['DBS check'])
+
+      skip
+    end
+  end
+
+  describe 'course option validation' do
+    it 'throws exception if course option is absent' do
+      change = described_class.new(actor: provider_user, application_choice: application_choice, course_option: nil)
+
+      # covered by controller
+
+      # TODO service call with invalid course_option_id
+      expect {
+        service.save!
+      }.to raise_error(
+        Offer::CourseValidationError,
+        'Course option id does not match a valid course option',
+      )
+    end
+
+    it 'throws exception unless course is open on apply' do
+      # covered by ChangeAnOffer as an error
+
+      new_course_option = create(:course_option, course: create(:course, provider: provider, open_on_apply: false))
+      change = described_class.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option)
+
+      skip
+    end
+
+    it 'throws exception if new course option changes the ratifying provider' do
+      # this check needs to be added to wrapper service
+      skip
+    end
+  end
+
+  # .save!
+  #   ProviderAuthorisation::NotAuthorisedError,
+  #   Offer::CourseValidationError,
+  #   Offer::ConditionsValidationError,
+
+  describe 'conditions validation' do
+    it 'throws exception if number of conditions exceeds 20' do
+      # this check needs to be added to wrapper service
+
+      expect {
+        service.save!
+      }.to raise_error(
+        Offer::ConditionsValidationError,
+        'Too many conditions specified (20 or fewer required)',
+      )
+    end
+
+    it 'throws exception if any conditions are longer than 255 characters' do
+      # this check needs to be added to wrapper service
+
+      skip
+    end
+  end
+end

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -151,30 +151,30 @@ RSpec.describe ChangeOffer do
   describe 'conditions validation' do
     it 'throws exception if number of conditions exceeds 20' do
       too_many = described_class.new(
-          actor: provider_user,
-          application_choice: application_choice,
-          course_option: original_course_option,
-          conditions: Array.new(21) { 'a condition' },
-          )
+        actor: provider_user,
+        application_choice: application_choice,
+        course_option: original_course_option,
+        conditions: Array.new(21) { 'a condition' },
+      )
 
       expect { too_many.save! }.to raise_error(
-                                       ChangeOffer::ConditionsValidationError,
-                                       'Too many conditions specified (20 or fewer required)',
-                                       )
+        ChangeOffer::ConditionsValidationError,
+        'Too many conditions specified (20 or fewer required)',
+      )
     end
 
     it 'throws exception if any conditions are longer than 255 characters' do
       too_long = described_class.new(
-          actor: provider_user,
-          application_choice: application_choice,
-          course_option: original_course_option,
-          conditions: ['a' * 256],
-          )
+        actor: provider_user,
+        application_choice: application_choice,
+        course_option: original_course_option,
+        conditions: ['a' * 256],
+      )
 
       expect { too_long.save! }.to raise_error(
-                                       ChangeOffer::ConditionsValidationError,
-                                       'Condition exceeds length limit (255 characters or fewer required)',
-                                       )
+        ChangeOffer::ConditionsValidationError,
+        'Condition exceeds length limit (255 characters or fewer required)',
+      )
     end
   end
 end

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe ChangeOffer do
       expect { change.save! }.not_to raise_error
     end
 
-    it 'do not error when if they change offered course details' do
+    it 'do not error if they change offered course details' do
       application_choice.update(offer: { 'conditions' => ['DBS check'] })
       change = described_class.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option, conditions: ['DBS check'])
       expect { change.save! }.not_to raise_error

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe ChangeOffer do
       expect {
         change.save!
       }.to raise_error(
-        ChangeOffer::IdenticalOffer,
+        ChangeOffer::IdenticalOfferError,
         'The new offer is identical to the current offer',
       )
     end
@@ -142,7 +142,7 @@ RSpec.describe ChangeOffer do
       expect {
         change.save!
       }.to raise_error(
-        ChangeOffer::RatifyingProviderChange,
+        ChangeOffer::RatifyingProviderChangeError,
         'The new offer has a different ratifying provider to the current offer',
       )
     end

--- a/spec/services/make_offer_spec.rb
+++ b/spec/services/make_offer_spec.rb
@@ -2,69 +2,151 @@ require 'rails_helper'
 
 RSpec.describe MakeOffer do
   include CourseOptionHelpers
-
-  let(:make_offer) do
-    MakeOffer.new(actor: provider_user,
-                  application_choice: application_choice,
-                  course_option: course_option,
-                  conditions: conditions)
+  let(:provider_user) { create(:provider_user, :with_provider, :with_make_decisions) }
+  let(:provider) { provider_user.providers.first }
+  let(:original_course_option) { course_option_for_provider(provider: provider) }
+  let(:new_course_option) { course_option_for_provider(provider: provider) }
+  let(:application_choice) do
+    create(:application_choice, :awaiting_provider_decision, course_option: original_course_option)
   end
 
-  describe '#save!' do
-    let(:application_choice) { create(:application_choice) }
-    let(:course_option) { course_option_for_provider(provider: application_choice.course_option.provider) }
-    let(:provider_user) { create(:provider_user, providers: [build(:provider)]) }
-    let(:conditions) { [Faker::Lorem.sentence] }
+  let(:service) do
+    described_class.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option)
+  end
 
-    describe 'if the actor is not authorised to perform this action' do
-      it 'throws an exception' do
-        expect {
-          make_offer.save!
-        }.to raise_error(
-          ProviderAuthorisation::NotAuthorisedError,
-          'You are not permitted to view this application. The specified course is not associated with any of your organisations. You do not have the required user level permissions to make decisions on applications for this provider.',
-        )
-      end
+  describe 'database changes and side-effects' do
+    it 'sets offered_course_option_id' do
+      expect { service.save! }.to change(application_choice, :offered_course_option_id)
     end
 
-    describe 'if the application choice cannot transition to the offer state' do
-      let(:application_choice) { create(:application_choice, status: :pending_conditions) }
-      let(:provider_user) do
-        create(:provider_user,
-               :with_make_decisions,
-               providers: [application_choice.course_option.provider])
-      end
-
-      it 'throws an exception' do
-        expect {
-          make_offer.save!
-        }.to raise_error(Workflow::NoTransitionAllowed, 'There is no event make_offer defined for the pending_conditions state')
-      end
+    it 'sets offered_at' do
+      expect { service.save! }.to change(application_choice, :offered_at)
     end
 
-    describe 'if the provided details are correct' do
-      let(:application_choice) { create(:application_choice, status: :awaiting_provider_decision) }
-      let(:provider_user) do
-        create(:provider_user,
-               :with_make_decisions,
-               providers: [application_choice.course_option.provider])
-      end
+    it 'generates an audit event combining status change with offered_course_option_id', with_audited: true do
+      service.save!
 
-      it 'then it executes the service without errors ' do
-        set_declined_by_default = instance_double(SetDeclineByDefault, call: true)
-        send_new_offer_email_to_candidate = instance_double(SendNewOfferEmailToCandidate, call: true)
-        allow(SetDeclineByDefault)
-          .to receive(:new).with(application_form: application_choice.application_form)
-          .and_return(set_declined_by_default)
-        allow(SendNewOfferEmailToCandidate)
-          .to receive(:new).with(application_choice: application_choice)
-          .and_return(send_new_offer_email_to_candidate)
+      audit_with_status_change = application_choice.reload.audits.find_by('jsonb_exists(audited_changes, ?)', 'status')
+      expect(audit_with_status_change.audited_changes).to have_key('offered_course_option_id')
+    end
 
-        make_offer.save!
+    it 'sets conditions' do
+      with_conditions = described_class.new(
+        actor: provider_user,
+        application_choice: application_choice,
+        course_option: new_course_option,
+        conditions: ['First condition', 'Second condition'],
+      )
 
-        expect(SetDeclineByDefault).to have_received(:new).with(application_form: application_choice.application_form)
-        expect(SendNewOfferEmailToCandidate).to have_received(:new).with(application_choice: application_choice)
-      end
+      expect { with_conditions.save! }.to change(application_choice, :offer)
+      expect(application_choice.offer['conditions']).to eq(['First condition', 'Second condition'])
+    end
+
+    it 'triggers SetDeclineByDefault on the application form' do
+      double = instance_double(SetDeclineByDefault)
+      allow(double).to receive(:call)
+      allow(SetDeclineByDefault).to receive(:new).and_return(double)
+
+      service.save!
+
+      expect(SetDeclineByDefault).to have_received(:new)
+        .with(application_form: application_choice.application_form)
+      expect(double).to have_received(:call)
+    end
+
+    it 'sends an email to the candidate to notify them about the offer' do
+      double = instance_double(SendNewOfferEmailToCandidate)
+      allow(double).to receive(:call)
+      allow(SendNewOfferEmailToCandidate).to receive(:new).and_return(double)
+
+      service.save!
+
+      expect(SendNewOfferEmailToCandidate).to have_received(:new)
+        .with(application_choice: application_choice)
+      expect(double).to have_received(:call)
+    end
+  end
+
+  describe 'user authorisation' do
+    let(:provider_user) { create(:provider_user, :with_provider) }
+
+    it 'throws an exception if actor is not authorised to perform this action' do
+      expect {
+        service.save!
+      }.to raise_error(
+        ProviderAuthorisation::NotAuthorisedError,
+        'You do not have the required user level permissions to make decisions on applications for this provider.',
+      )
+    end
+  end
+
+  describe 'repeat offers' do
+    it 'throw an exception if an offer is already in place' do
+      application_choice.update(offer: { 'conditions' => ['DBS check'] })
+      change = described_class.new(actor: provider_user, application_choice: application_choice, course_option: application_choice.offered_option, conditions: ['DBS check'])
+
+      expect {
+        change.save!
+      }.to raise_error(
+        MakeOffer::AlreadyOfferedError,
+        'An offer already exists, use ChangeOffer service to modify',
+      )
+    end
+  end
+
+  describe 'course option validation' do
+    it 'throws exception unless course is open on apply' do
+      new_course_option = create(:course_option, course: create(:course, provider: provider, open_on_apply: false))
+      change = described_class.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option)
+
+      expect {
+        change.save!
+      }.to raise_error(
+        MakeOffer::CourseValidationError,
+        'is not open for applications via the Apply service',
+      )
+    end
+
+    it 'throws exception if new course option changes the ratifying provider' do
+      new_course_option = create(:course_option, course: create(:course, :with_accredited_provider, provider: provider))
+      change = described_class.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option)
+
+      expect {
+        change.save!
+      }.to raise_error(
+        MakeOffer::RatifyingProviderChangeError,
+        'The new offer has a different ratifying provider to the current offer',
+      )
+    end
+  end
+
+  describe 'conditions validation' do
+    it 'throws exception if number of conditions exceeds 20' do
+      too_many = described_class.new(
+        actor: provider_user,
+        application_choice: application_choice,
+        course_option: original_course_option,
+        conditions: Array.new(21) { 'a condition' },
+      )
+
+      expect { too_many.save! }.to raise_error(
+        MakeOffer::ConditionsValidationError,
+        'Too many conditions specified (20 or fewer required)',
+      )
+    end
+
+    it 'throws exception if any conditions are longer than 255 characters' do
+      too_long = described_class.new(
+        actor: provider_user,
+        application_choice: application_choice,
+        course_option: original_course_option,
+        conditions: ['a' * 256],
+      )
+
+      expect { too_long.save! }.to raise_error(
+        MakeOffer::ConditionsValidationError,
+        'Condition exceeds length limit (255 characters or fewer required)',
+      )
     end
   end
 end

--- a/spec/services/make_offer_spec.rb
+++ b/spec/services/make_offer_spec.rb
@@ -102,9 +102,9 @@ RSpec.describe MakeOffer do
       expect {
         offer.save!
       }.to raise_error(
-               MakeOffer::NoTransitionAllowedError,
-               MakeAnOffer::STATE_TRANSITION_ERROR,
-               )
+        MakeOffer::NoTransitionAllowedError,
+        MakeAnOffer::STATE_TRANSITION_ERROR,
+      )
     end
   end
 

--- a/spec/system/provider_interface/change_make_offer_spec.rb
+++ b/spec/system/provider_interface/change_make_offer_spec.rb
@@ -6,13 +6,16 @@ RSpec.feature 'Provider makes an offer' do
 
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
   let(:provider) { provider_user.providers.first }
+  let(:ratifying_provider) { create(:provider) }
   let(:application_form) { build(:application_form, :minimum_info) }
   let!(:application_choice) do
     create(:application_choice, :awaiting_provider_decision,
            application_form: application_form,
            course_option: course_option)
   end
-  let(:course) { build(:course, :open_on_apply, :full_time, provider: provider) }
+  let(:course) do
+    build(:course, :open_on_apply, :full_time, provider: provider, accredited_provider: ratifying_provider)
+  end
   let(:course_option) { build(:course_option, course: course) }
 
   before do
@@ -144,8 +147,8 @@ RSpec.feature 'Provider makes an offer' do
   def given_the_provider_user_can_offer_multiple_provider_courses
     @selected_provider = create(:provider, :with_signed_agreement)
     create(:provider_permissions, provider: @selected_provider, provider_user: provider_user, make_decisions: true)
-    courses = [create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider),
-               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider)]
+    courses = [create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider),
+               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)]
     @selected_course = courses.sample
 
     course_options = [create(:course_option, :part_time, course: @selected_course),

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -6,13 +6,16 @@ RSpec.feature 'Provider makes an offer' do
 
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
   let(:provider) { provider_user.providers.first }
+  let(:ratifying_provider) { create(:provider) }
   let(:application_form) { build(:application_form, :minimum_info) }
   let!(:application_choice) do
     create(:application_choice, :awaiting_provider_decision,
            application_form: application_form,
            course_option: course_option)
   end
-  let(:course) { build(:course, :open_on_apply, :full_time, provider: provider) }
+  let(:course) do
+    build(:course, :open_on_apply, :full_time, provider: provider, accredited_provider: ratifying_provider)
+  end
   let(:course_option) { build(:course_option, course: course) }
 
   before do
@@ -161,7 +164,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def given_the_provider_has_multiple_courses
-    @provider_available_course = create(:course, :open_on_apply, study_mode: :full_time, provider: provider)
+    @provider_available_course = create(:course, :open_on_apply, study_mode: :full_time, provider: provider, accredited_provider: ratifying_provider)
     create(:course, :open_on_apply, provider: provider)
     course_options = [create(:course_option, :full_time, course: @provider_available_course),
                       create(:course_option, :full_time, course: @provider_available_course),
@@ -198,8 +201,8 @@ RSpec.feature 'Provider makes an offer' do
   def given_the_provider_user_can_offer_multiple_provider_courses
     @available_provider = create(:provider, :with_signed_agreement)
     create(:provider_permissions, provider: @available_provider, provider_user: provider_user, make_decisions: true)
-    courses = [create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider),
-               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider)]
+    courses = [create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider),
+               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider)]
     @selected_provider_available_course = courses.sample
 
     course_options = [create(:course_option, :part_time, course: @selected_provider_available_course),


### PR DESCRIPTION
### Context

The new `MakeOffer`/`ChangeOffer` flow introduces new restrictions around which courses can be offered. In particular, it is important the ratifying provider is preserved, at least for now.

The `MakeOffer`/`ChangeOffer` services (and their underlying `MakeAnOffer`/`ChangeAnOffer` services which will be removed eventually) are the last defence against problematic offers, as the UI is meant to suppress any options which could be problematic. When it comes to the API, however, these services are the only checks for the course options and conditions specified.

### Changes proposed in this pull request

This PR introduces a `ChangeOffer` service, which wraps `ChangeAnOffer` and exposes a `save!` method, which raises exceptions if any errors are detected.

The wrapper performs additional checks. In particular:

- Checks the current ratifying provider doesn't change in the updated offer
- Validates the length of conditions, for consistency with `MakeOffer`

This PR also adds more checks to the `MakeOffer` service:

- Checks the ratifying provider doesn't change, compared to the original application choice
- Checks whether the application is already in the 'offer' state (which wouldn't raise an invalid transition)

### Guidance to review

We are adding a wrapper rather than refactoring `ChangeAnOffer` because our launch plan for the new offer wizard/flow involves preserving the existing functionality unchanged until the feature flag is activated. When this happens, Manage users will be taken through the new flow, which calls the wrapper service containing the additional rules.

The API is still using `MakeAnOffer` and `ChangeAnOffer`. The plan is to adapt the relevant controller, when we are ready, to work with the new interface and rescue the errors in order to pass them to the API consumers.

There is some duplication between the tests for `ChangeOffer` and `ChangeAnOffer`. This is intentional, as our plan is to remove `ChangeAnOffer` completely in the future, at which point we'll just delete the  `ChangeAnOffer` spec.

Do the exceptions raised make sense? There are six different types across the two services:

- CourseValidationError
- ConditionsValidationError
- RatifyingProviderChangeError
- IdenticalOfferError
- AlreadyOfferedError
- NoTransitionAllowedError

These are defined within `MakeOffer` and `ChangeOffer`, but could be extracted to an `Offer` set of validations when we remodel offers/conditions, so that they are reused. `IdenticalOfferError`, however, is specific to `ChangeOffer`, in the same way as `AlreadyOfferedError` and `NoTransitionAllowedError` are specific to `MakeOffer`.

### Link to Trello card

[Update MakeOffer/ChangeOffer services with new rules](https://trello.com/c/9I0RTTts)

### Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary -> _API has not been updated_
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
