### PR TITLE
Deduplicate sites on the Apply from Find page

### DIFF
--- a/app/views/candidate_interface/apply_from_find/_apply_using_ucas.html.erb
+++ b/app/views/candidate_interface/apply_from_find/_apply_using_ucas.html.erb
@@ -44,7 +44,7 @@
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-          <% @course.sites.each do |site| %>
+          <% @course.sites.uniq.each do |site| %>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><span class='govuk-!-font-weight-bold'><%= site.name %></span>
                 <br>


### PR DESCRIPTION
A course `has_many :sites, through: :course options`. In the event there are multiple options with the same site, `course.sites` will return the same site n times. This means they're duplicated on the Apply from Find page unless we `distinct` them. 

https://trello.com/c/1kapllsj/3135-locations-are-listed-twice

### Before

<img width="664" alt="Screenshot 2021-03-23 at 13 20 44" src="https://user-images.githubusercontent.com/642279/112152823-9abad900-8bda-11eb-87e1-e3fd3501e1e3.png">

### After

<img width="668" alt="Screenshot 2021-03-23 at 13 20 33" src="https://user-images.githubusercontent.com/642279/112152840-9ee6f680-8bda-11eb-9332-a1d1279742d0.png">
