### PR TITLE
Enable autocompletes for 'choose a provider' and 'choose a course'

### DIFF
--- a/app/frontend/packs/autocompletes/candidate/__snapshots__/candidate-autocomplete-inputs.spec.js.snap
+++ b/app/frontend/packs/autocompletes/candidate/__snapshots__/candidate-autocomplete-inputs.spec.js.snap
@@ -33,13 +33,15 @@ Array [
   Object {
     "autocompleteId": "provider-autocomplete",
     "inputIds": Array [
-      "#pick-provider-form .govuk-select",
+      "candidate-interface-pick-provider-form-provider-id-field",
+      "candidate-interface-pick-provider-form-provider-id-field-error",
     ],
   },
   Object {
     "autocompleteId": "course-autocomplete",
     "inputIds": Array [
-      "#pick-course-form .govuk-select",
+      "candidate-interface-pick-course-form-course-id-field",
+      "candidate-interface-pick-course-form-course-id-field-error",
     ],
   },
 ]

--- a/app/frontend/packs/autocompletes/candidate/candidate-autocomplete-inputs.js
+++ b/app/frontend/packs/autocompletes/candidate/candidate-autocomplete-inputs.js
@@ -30,14 +30,16 @@ const nationalityAutocompleteInputs = {
 
 const providerAutocompleteInputs = {
   inputIds: [
-    "#pick-provider-form .govuk-select"
+    "candidate-interface-pick-provider-form-provider-id-field",
+    "candidate-interface-pick-provider-form-provider-id-field-error",
   ],
   autocompleteId: 'provider-autocomplete'
 }
 
 const courseAutocompleteInputs = {
   inputIds: [
-    "#pick-course-form .govuk-select"
+    "candidate-interface-pick-course-form-course-id-field",
+    "candidate-interface-pick-course-form-course-id-field-error"
   ],
   autocompleteId: 'course-autocomplete'
 }


### PR DESCRIPTION
## Context

'Choose a course' and 'choose a provider' autocompletes are not working. 
Possibly a bug cause by the recent refactoring (sorry)

## Changes proposed in this pull request

Enable the autocompletes! 💪 

<img width="573" alt="course_autocomplete" src="https://user-images.githubusercontent.com/5256922/112173707-b8de0480-8bed-11eb-8972-a12113829139.png">


<img width="596" alt="provider_autocomplete" src="https://user-images.githubusercontent.com/5256922/112173752-c3000300-8bed-11eb-8024-db127d7254f0.png">

## Link to Trello card

https://trello.com/c/Ipfca34Q/3217-choose-provider-and-course-autocompletes-not-working

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
