### PR TITLE
Change edit an existing offer to use new flow

### DIFF
--- a/app/components/collection_select_component.html.erb
+++ b/app/components/collection_select_component.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: form_object, url: form_path, method: :post do |f| %>
+    <%= form_with model: form_object, url: form_path, method: form_method do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_collection_radio_buttons attribute,

--- a/app/components/collection_select_component.rb
+++ b/app/components/collection_select_component.rb
@@ -3,9 +3,10 @@ class CollectionSelectComponent < ViewComponent::Base
 
   attr_reader :attribute, :collection,
               :value_method, :text_method, :hint_method,
-              :form_object, :form_path, :page_title, :caption
+              :form_object, :form_path, :form_method,
+              :page_title, :caption
 
-  def initialize(attribute:, collection:, value_method:, text_method:, hint_method:, form_object:, form_path:, page_title:, caption:)
+  def initialize(attribute:, collection:, value_method:, text_method:, hint_method:, form_object:, form_path:, form_method: :post, page_title:, caption:)
     @attribute = attribute
     @collection = collection
     @value_method = value_method
@@ -13,6 +14,7 @@ class CollectionSelectComponent < ViewComponent::Base
     @hint_method = hint_method
     @form_object = form_object
     @form_path = form_path
+    @form_method = form_method
     @page_title = page_title
     @caption = caption
   end

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -31,8 +31,14 @@ module ProviderInterface
       end
 
       if offer_present?
+        path = if FeatureFlag.active?(:updated_offer_flow)
+                 provider_interface_application_choice_offers_path(application_choice)
+               else
+                 provider_interface_application_choice_offer_path(application_choice)
+               end
+
         sub_navigation_items.push(
-          { name: 'Offer', url: provider_interface_application_choice_offer_path(application_choice) },
+          { name: 'Offer', url: path },
         )
       end
 

--- a/app/components/provider_interface/completed_offer_summary_component.rb
+++ b/app/components/provider_interface/completed_offer_summary_component.rb
@@ -31,7 +31,7 @@ module ProviderInterface
     end
 
     def change_course_path
-      available_courses.many? ? new_provider_interface_application_choice_offer_courses_path(application_choice) : nil
+      available_courses.many? ? edit_provider_interface_application_choice_offer_courses_path(application_choice) : nil
     end
 
     def change_location_path

--- a/app/components/provider_interface/completed_offer_summary_component.rb
+++ b/app/components/provider_interface/completed_offer_summary_component.rb
@@ -27,7 +27,7 @@ module ProviderInterface
     end
 
     def change_provider_path
-      available_providers.many? ? new_provider_interface_application_choice_offer_providers_path(application_choice) : nil
+      available_providers.many? ? edit_provider_interface_application_choice_offer_providers_path(application_choice) : nil
     end
 
     def change_course_path

--- a/app/components/provider_interface/completed_offer_summary_component.rb
+++ b/app/components/provider_interface/completed_offer_summary_component.rb
@@ -1,0 +1,45 @@
+module ProviderInterface
+  class CompletedOfferSummaryComponent < OfferSummaryComponent
+    include ViewHelper
+
+    def rows
+      [
+        { key: 'Training Provider',
+          value: course_option.provider.name_and_code,
+          action: 'Change',
+          change_path: change_provider_path },
+        { key: 'Course',
+          value: course_option.course.name_and_code,
+          action: 'Change',
+          change_path: change_course_path },
+        { key: 'Full time or part time',
+          value: course_option.study_mode.humanize,
+          action: 'Change',
+          change_path: change_study_mode_path },
+        { key: 'Location',
+          value: course_option.site.name_and_address,
+          action: 'Change',
+          change_path: change_location_path },
+        { key: 'Accredited body',
+          value: course_option.course&.accredited_provider&.name_and_code || course_option.provider.name_and_code,
+          change_path: nil },
+      ]
+    end
+
+    def change_provider_path
+      available_providers.many? ? new_provider_interface_application_choice_offer_providers_path(application_choice) : nil
+    end
+
+    def change_course_path
+      available_courses.many? ? new_provider_interface_application_choice_offer_courses_path(application_choice) : nil
+    end
+
+    def change_location_path
+      available_course_options.many? ? new_provider_interface_application_choice_offer_locations_path(application_choice) : nil
+    end
+
+    def change_study_mode_path
+      course.full_time_or_part_time? ? new_provider_interface_application_choice_offer_study_modes_path(application_choice) : nil
+    end
+  end
+end

--- a/app/components/provider_interface/completed_offer_summary_component.rb
+++ b/app/components/provider_interface/completed_offer_summary_component.rb
@@ -41,5 +41,9 @@ module ProviderInterface
     def change_location_path
       available_course_options.many? ? edit_provider_interface_application_choice_offer_locations_path(application_choice) : nil
     end
+
+    def mode
+      :edit
+    end
   end
 end

--- a/app/components/provider_interface/completed_offer_summary_component.rb
+++ b/app/components/provider_interface/completed_offer_summary_component.rb
@@ -39,7 +39,7 @@ module ProviderInterface
     end
 
     def change_study_mode_path
-      course.full_time_or_part_time? ? new_provider_interface_application_choice_offer_study_modes_path(application_choice) : nil
+      course.full_time_or_part_time? ? edit_provider_interface_application_choice_offer_study_modes_path(application_choice) : nil
     end
   end
 end

--- a/app/components/provider_interface/completed_offer_summary_component.rb
+++ b/app/components/provider_interface/completed_offer_summary_component.rb
@@ -34,12 +34,12 @@ module ProviderInterface
       available_courses.many? ? edit_provider_interface_application_choice_offer_courses_path(application_choice) : nil
     end
 
-    def change_location_path
-      available_course_options.many? ? new_provider_interface_application_choice_offer_locations_path(application_choice) : nil
-    end
-
     def change_study_mode_path
       course.full_time_or_part_time? ? edit_provider_interface_application_choice_offer_study_modes_path(application_choice) : nil
+    end
+
+    def change_location_path
+      available_course_options.many? ? edit_provider_interface_application_choice_offer_locations_path(application_choice) : nil
     end
   end
 end

--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -5,7 +5,11 @@
   <h2 class="govuk-heading-m">Conditions of offer</h2>
 
   <div class='govuk-body'>
-    <%= govuk_link_to 'Add or change conditions', [mode, :provider_interface, @application_choice, :offer, :conditions] %>
+    <% if @application_choice.pending_conditions? %>
+      <%= govuk_link_to 'Update status of conditions', provider_interface_application_choice_edit_conditions_path(@application_choice) %>
+    <% else %>
+      <%= govuk_link_to 'Add or change conditions', [mode, :provider_interface, @application_choice, :offer, :conditions] %>
+    <% end %>
   </div>
 
   <% if conditions.any? %>
@@ -15,7 +19,13 @@
           <tr class="govuk-table__row conditions-row">
             <td class="govuk-table__cell"><%= condition %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric">
-              <strong class="govuk-tag govuk-tag--grey app-tag">Pending</strong>
+              <% if conditions_met? %>
+                <strong class="govuk-tag govuk-tag--green app-tag">Met</strong>
+              <% elsif conditions_not_met? %>
+                <strong class="govuk-tag govuk-tag--red app-tag">Not met</strong>
+              <% else %>
+                <strong class="govuk-tag govuk-tag--grey app-tag">Pending</strong>
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -1,4 +1,4 @@
-<div class="app-offer-panel app-banner app-banner--details">
+<div class="app-offer-panel app-banner app-banner--details <%= border_class %>">
   <h2 class="govuk-heading-m">Course details</h2>
   <%= render SummaryCardComponent.new(rows: rows, border: false) %>
 

--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -5,13 +5,17 @@
   <h2 class="govuk-heading-m">Conditions of offer</h2>
 
   <% if editable %>
-    <div class='govuk-body'>
-      <% if @application_choice.pending_conditions? %>
+    <% if @application_choice.pending_conditions? %>
+      <div class='govuk-body'>
         <%= govuk_link_to 'Update status of conditions', provider_interface_application_choice_edit_conditions_path(@application_choice) %>
-      <% else %>
+      </div>
+    <% end %>
+
+    <% if @application_choice.offer? || show_conditions_link %>
+      <div class='govuk-body'>
         <%= govuk_link_to 'Add or change conditions', [mode, :provider_interface, @application_choice, :offer, :conditions] %>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   <% end %>
 
   <% if conditions.any? %>

--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -4,13 +4,15 @@
 
   <h2 class="govuk-heading-m">Conditions of offer</h2>
 
-  <div class='govuk-body'>
-    <% if @application_choice.pending_conditions? %>
-      <%= govuk_link_to 'Update status of conditions', provider_interface_application_choice_edit_conditions_path(@application_choice) %>
-    <% else %>
-      <%= govuk_link_to 'Add or change conditions', [mode, :provider_interface, @application_choice, :offer, :conditions] %>
-    <% end %>
-  </div>
+  <% if editable %>
+    <div class='govuk-body'>
+      <% if @application_choice.pending_conditions? %>
+        <%= govuk_link_to 'Update status of conditions', provider_interface_application_choice_edit_conditions_path(@application_choice) %>
+      <% else %>
+        <%= govuk_link_to 'Add or change conditions', [mode, :provider_interface, @application_choice, :offer, :conditions] %>
+      <% end %>
+    </div>
+  <% end %>
 
   <% if conditions.any? %>
     <table class="govuk-table govuk-!-margin-bottom-2 conditions">

--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -5,7 +5,7 @@
   <h2 class="govuk-heading-m">Conditions of offer</h2>
 
   <div class='govuk-body'>
-    <%= govuk_link_to 'Add or change conditions', [:new, :provider_interface, @application_choice, :offer, :conditions] %>
+    <%= govuk_link_to 'Add or change conditions', [mode, :provider_interface, @application_choice, :offer, :conditions] %>
   </div>
 
   <% if conditions.any? %>

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -2,9 +2,9 @@ module ProviderInterface
   class OfferSummaryComponent < ViewComponent::Base
     include ViewHelper
 
-    attr_accessor :application_choice, :course, :course_option, :conditions, :available_providers, :available_courses, :available_course_options
+    attr_accessor :application_choice, :course, :course_option, :conditions, :available_providers, :available_courses, :available_course_options, :border
 
-    def initialize(application_choice:, course:, course_option:, conditions:, available_providers: [], available_courses: [], available_course_options: [])
+    def initialize(application_choice:, course:, course_option:, conditions:, available_providers: [], available_courses: [], available_course_options: [], border: true)
       @application_choice = application_choice
       @course_option = course_option
       @conditions = conditions
@@ -12,6 +12,7 @@ module ProviderInterface
       @available_courses = available_courses
       @available_course_options = available_course_options
       @course = course
+      @border = border
     end
 
     def rows
@@ -49,6 +50,12 @@ module ProviderInterface
 
     def change_study_mode_path
       course.full_time_or_part_time? ? new_provider_interface_application_choice_offer_study_modes_path(application_choice) : nil
+    end
+
+  private
+
+    def border_class
+      'no-border' unless border
     end
 
     def mode

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -2,9 +2,9 @@ module ProviderInterface
   class OfferSummaryComponent < ViewComponent::Base
     include ViewHelper
 
-    attr_accessor :application_choice, :course, :course_option, :conditions, :available_providers, :available_courses, :available_course_options, :border
+    attr_accessor :application_choice, :course, :course_option, :conditions, :available_providers, :available_courses, :available_course_options, :border, :editable
 
-    def initialize(application_choice:, course:, course_option:, conditions:, available_providers: [], available_courses: [], available_course_options: [], border: true)
+    def initialize(application_choice:, course:, course_option:, conditions:, available_providers: [], available_courses: [], available_course_options: [], border: true, editable: true)
       @application_choice = application_choice
       @course_option = course_option
       @conditions = conditions
@@ -13,6 +13,7 @@ module ProviderInterface
       @available_course_options = available_course_options
       @course = course
       @border = border
+      @editable = editable
     end
 
     def rows

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -50,5 +50,9 @@ module ProviderInterface
     def change_study_mode_path
       course.full_time_or_part_time? ? new_provider_interface_application_choice_offer_study_modes_path(application_choice) : nil
     end
+
+    def mode
+      :new
+    end
   end
 end

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -52,7 +52,19 @@ module ProviderInterface
       course.full_time_or_part_time? ? new_provider_interface_application_choice_offer_study_modes_path(application_choice) : nil
     end
 
+    def conditions_met?
+      return application_choice.status_before_deferral == 'recruited' if application_choice.status == 'offer_deferred'
+
+      application_state.current_state == :recruited
+    end
+
+    delegate :conditions_not_met?, to: :application_state
+
   private
+
+    def application_state
+      @application_state ||= ApplicationStateChange.new(application_choice)
+    end
 
     def border_class
       'no-border' unless border

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -2,9 +2,9 @@ module ProviderInterface
   class OfferSummaryComponent < ViewComponent::Base
     include ViewHelper
 
-    attr_accessor :application_choice, :course, :course_option, :conditions, :available_providers, :available_courses, :available_course_options, :border, :editable
+    attr_accessor :application_choice, :course, :course_option, :conditions, :available_providers, :available_courses, :available_course_options, :border, :editable, :show_conditions_link
 
-    def initialize(application_choice:, course:, course_option:, conditions:, available_providers: [], available_courses: [], available_course_options: [], border: true, editable: true)
+    def initialize(application_choice:, course:, course_option:, conditions:, available_providers: [], available_courses: [], available_course_options: [], border: true, editable: true, show_conditions_link: false)
       @application_choice = application_choice
       @course_option = course_option
       @conditions = conditions
@@ -14,6 +14,7 @@ module ProviderInterface
       @course = course
       @border = border
       @editable = editable
+      @show_conditions_link = show_conditions_link
     end
 
     def rows

--- a/app/components/provider_interface/read_only_completed_offer_summary_component.rb
+++ b/app/components/provider_interface/read_only_completed_offer_summary_component.rb
@@ -1,0 +1,20 @@
+module ProviderInterface
+  class ReadOnlyCompletedOfferSummaryComponent < CompletedOfferSummaryComponent
+    include ViewHelper
+
+    def rows
+      [
+        { key: 'Training Provider',
+          value: course_option.provider.name_and_code },
+        { key: 'Course',
+          value: course_option.course.name_and_code },
+        { key: 'Full time or part time',
+          value: course_option.study_mode.humanize },
+        { key: 'Location',
+          value: course_option.site.name_and_address },
+        { key: 'Accredited body',
+          value: course_option.course&.accredited_provider&.name_and_code || course_option.provider.name_and_code },
+      ]
+    end
+  end
+end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -42,6 +42,10 @@ module ProviderInterface
     end
 
     def offer
+      if FeatureFlag.active?(:updated_offer_flow)
+        redirect_to provider_interface_application_choice_offers_path(@application_choice) and return
+      end
+
       @status_box_options = { provider_can_respond: @provider_can_respond }
 
       if @application_choice.offer? && @provider_can_respond

--- a/app/controllers/provider_interface/offer/checks_controller.rb
+++ b/app/controllers/provider_interface/offer/checks_controller.rb
@@ -9,6 +9,15 @@ module ProviderInterface
         @courses = available_courses(@wizard.provider_id)
         @course_options = available_course_options(@wizard.course_id, @wizard.study_mode)
       end
+
+      def edit
+        @wizard = OfferWizard.new(offer_store, { current_step: 'check', action: action })
+        @wizard.save_state!
+
+        @providers = available_providers
+        @courses = available_courses(@wizard.provider_id)
+        @course_options = available_course_options(@wizard.course_id, @wizard.study_mode)
+      end
     end
   end
 end

--- a/app/controllers/provider_interface/offer/conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/conditions_controller.rb
@@ -18,6 +18,23 @@ module ProviderInterface
         end
       end
 
+      def edit
+        @wizard = OfferWizard.new(offer_store, { current_step: 'conditions', action: action })
+        @wizard.save_state!
+      end
+
+      def update
+        @wizard = OfferWizard.new(offer_store, conditions_params.to_h)
+
+        if @wizard.valid_for_current_step?
+          @wizard.save_state!
+
+          redirect_to [:edit, :provider_interface, @application_choice, :offer, @wizard.next_step]
+        else
+          render :edit
+        end
+      end
+
     private
 
       def conditions_params

--- a/app/controllers/provider_interface/offer/courses_controller.rb
+++ b/app/controllers/provider_interface/offer/courses_controller.rb
@@ -22,6 +22,27 @@ module ProviderInterface
         end
       end
 
+      def edit
+        @wizard = OfferWizard.new(offer_store, { current_step: 'courses', action: action })
+        @wizard.save_state!
+
+        @courses = available_courses(@wizard.provider_id)
+      end
+
+      def update
+        @wizard = OfferWizard.new(offer_store, course_params.to_h)
+
+        if @wizard.valid_for_current_step?
+          @wizard.save_state!
+
+          redirect_to [:edit, :provider_interface, @application_choice, :offer, @wizard.next_step]
+        else
+          @courses = available_courses(@wizard.provider_id)
+
+          render :edit
+        end
+      end
+
     private
 
       def course_params

--- a/app/controllers/provider_interface/offer/locations_controller.rb
+++ b/app/controllers/provider_interface/offer/locations_controller.rb
@@ -22,6 +22,27 @@ module ProviderInterface
         end
       end
 
+      def edit
+        @wizard = OfferWizard.new(offer_store, { current_step: 'locations', action: action })
+        @wizard.save_state!
+
+        @course_options = available_course_options(@wizard.course_id, @wizard.study_mode)
+      end
+
+      def update
+        @wizard = OfferWizard.new(offer_store, course_option_params.to_h)
+
+        if @wizard.valid_for_current_step?
+          @wizard.save_state!
+
+          redirect_to [:edit, :provider_interface, @application_choice, :offer, @wizard.next_step]
+        else
+          @course_options = available_course_options(@wizard.course_id, @wizard.study_mode)
+
+          render :edit
+        end
+      end
+
     private
 
       def course_option_params

--- a/app/controllers/provider_interface/offer/providers_controller.rb
+++ b/app/controllers/provider_interface/offer/providers_controller.rb
@@ -22,6 +22,27 @@ module ProviderInterface
         end
       end
 
+      def edit
+        @wizard = OfferWizard.new(offer_store, { current_step: 'providers', action: action })
+        @wizard.save_state!
+
+        @providers = available_providers
+      end
+
+      def update
+        @wizard = OfferWizard.new(offer_store, provider_params.to_h)
+
+        if @wizard.valid_for_current_step?
+          @wizard.save_state!
+
+          redirect_to [:edit, :provider_interface, @application_choice, :offer, @wizard.next_step]
+        else
+          @providers = available_providers
+
+          render :edit
+        end
+      end
+
     private
 
       def provider_params

--- a/app/controllers/provider_interface/offer/study_modes_controller.rb
+++ b/app/controllers/provider_interface/offer/study_modes_controller.rb
@@ -19,9 +19,33 @@ module ProviderInterface
           redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
         else
           @course = Course.find(@wizard.course_id)
-          @study_modes = avalable_study_modes(@course)
+          @study_modes = available_study_modes(@course)
 
           render :new
+        end
+      end
+
+      def edit
+        @wizard = OfferWizard.new(offer_store, { current_step: 'study_modes', action: action })
+        @wizard.save_state!
+
+        @course = Course.find(@wizard.course_id)
+        @study_modes = available_study_modes(@course)
+      end
+
+      def update
+        @wizard = OfferWizard.new(offer_store, study_mode_params.to_h)
+        @wizard.course_option_id = nil if @wizard.course_option_id && @wizard.course_option.study_mode != @wizard.study_mode
+
+        if @wizard.valid_for_current_step?
+          @wizard.save_state!
+
+          redirect_to [:edit, :provider_interface, @application_choice, :offer, @wizard.next_step]
+        else
+          @course = Course.find(@wizard.course_id)
+          @study_modes = available_study_modes(@course)
+
+          render :edit
         end
       end
 

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -31,8 +31,6 @@ module ProviderInterface
 
     def edit; end
 
-    def update; end
-
     def show
       @wizard = OfferWizard.new(offer_store,
                                 offer_context_params(@application_choice.offered_course_option,
@@ -43,6 +41,24 @@ module ProviderInterface
       @providers = available_providers
       @courses = available_courses(@application_choice.offered_course.provider_id)
       @course_options = available_course_options(@application_choice.offered_course.id, @application_choice.offered_course_option.study_mode)
+    end
+
+    def update
+      @wizard = OfferWizard.new(offer_store)
+      if @wizard.valid?(:save)
+        ChangeAnOffer.new(actor: current_provider_user,
+                          application_choice: @application_choice,
+                          course_option: @wizard.course_option,
+                          offer_conditions: @wizard.conditions).save
+        @wizard.clear_state!
+
+        flash[:success] = t('.success')
+      else
+        @wizard.clear_state!
+
+        flash[:warning] = t('.failure')
+      end
+      redirect_to provider_interface_application_choice_offer_path(@application_choice)
     end
 
   private

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   class OffersController < ProviderInterfaceController
     before_action :set_application_choice
     before_action :confirm_application_is_in_decision_pending_state, except: %i[edit update show]
-    before_action :confirm_application_is_in_offer_state, only: %i[edit update show]
+    before_action :confirm_application_is_in_offered_state, only: %i[edit update show]
     before_action :requires_make_decisions_permission
 
     def new
@@ -75,8 +75,8 @@ module ProviderInterface
       redirect_to(provider_interface_application_choice_path(@application_choice))
     end
 
-    def confirm_application_is_in_offer_state
-      return if %i[offer].include?(@application_choice.status.to_sym)
+    def confirm_application_is_in_offered_state
+      return if ApplicationStateChange::OFFERED_STATES.include?(@application_choice.status.to_sym)
 
       redirect_to(provider_interface_application_choice_path(@application_choice))
     end

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -36,6 +36,7 @@ module ProviderInterface
                                 offer_context_params(@application_choice.offered_course_option,
                                                      @application_choice.offer['conditions'],
                                                      :change_offer).merge!(current_step: :offer))
+      @wizard.configure_additional_conditions(@application_choice.offer['conditions'] - MakeAnOffer::STANDARD_CONDITIONS)
       @wizard.save_state!
 
       @providers = available_providers

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -1,7 +1,8 @@
 module ProviderInterface
   class OffersController < ProviderInterfaceController
     before_action :set_application_choice
-    before_action :confirm_application_is_in_decision_pending_state
+    before_action :confirm_application_is_in_decision_pending_state, except: %i[edit update show]
+    before_action :confirm_application_is_in_offer_state, only: %i[edit update show]
     before_action :requires_make_decisions_permission
 
     def new
@@ -28,6 +29,22 @@ module ProviderInterface
       end
     end
 
+    def edit; end
+
+    def update; end
+
+    def show
+      @wizard = OfferWizard.new(offer_store,
+                                offer_context_params(@application_choice.offered_course_option,
+                                                     @application_choice.offer['conditions'],
+                                                     :change_offer))
+      @wizard.save_state!
+
+      @providers = available_providers
+      @courses = available_courses(@application_choice.offered_course.provider_id)
+      @course_options = available_course_options(@application_choice.offered_course.id, @application_choice.offered_course_option.study_mode)
+    end
+
   private
 
     def offer_store
@@ -37,6 +54,12 @@ module ProviderInterface
 
     def confirm_application_is_in_decision_pending_state
       return if ApplicationStateChange::DECISION_PENDING_STATUSES.include?(@application_choice.status.to_sym)
+
+      redirect_to(provider_interface_application_choice_path(@application_choice))
+    end
+
+    def confirm_application_is_in_offer_state
+      return if %i[offer].include?(@application_choice.status.to_sym)
 
       redirect_to(provider_interface_application_choice_path(@application_choice))
     end
@@ -56,6 +79,19 @@ module ProviderInterface
     def available_course_options(course_id, study_mode)
       CourseOption.where(course_id: course_id, study_mode: study_mode)
                   .includes(:site).order('sites.name')
+    end
+
+    def offer_context_params(course_option, conditions = MakeAnOffer::STANDARD_CONDITIONS, decision = :default)
+      {
+        provider_user_id: current_provider_user.id,
+        course_id: course_option.course.id,
+        course_option_id: course_option.id,
+        provider_id: course_option.provider.id,
+        study_mode: course_option.study_mode,
+        location_id: course_option.site.id,
+        decision: decision,
+        standard_conditions: conditions,
+      }
     end
   end
 end

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -35,7 +35,7 @@ module ProviderInterface
       @wizard = OfferWizard.new(offer_store,
                                 offer_context_params(@application_choice.offered_course_option,
                                                      @application_choice.offer['conditions'],
-                                                     :change_offer))
+                                                     :change_offer).merge!(current_step: :offer))
       @wizard.save_state!
 
       @providers = available_providers

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -60,6 +60,12 @@ module ProviderInterface
 
     delegate :previous_step, to: :wizard_path_history
 
+    def configure_additional_conditions(conditions)
+      conditions.each_with_index do |condition, index|
+        instance_variable_set "@further_condition_#{index + 1}", condition
+      end
+    end
+
   private
 
     def save_and_go_to_next_step(step)

--- a/app/frontend/styles/provider/_offer.scss
+++ b/app/frontend/styles/provider/_offer.scss
@@ -1,6 +1,11 @@
 .app-offer-panel {
   padding: 20px 20px 10px 20px;
   border: 5px solid #b1b4b6;
+
+  &.no-border {
+    border: none;
+    padding: 0 0;
+  }
 }
 
 .conditions-row:last-child > * {

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -51,7 +51,7 @@ class NavigationItems
       items = []
 
       if current_provider_user && !performing_setup
-        items << NavigationItem.new('Applications', provider_interface_applications_path, is_active(current_controller, %w[application_choices decisions offer_changes notes interviews feedback conditions reconfirm_deferred_offers]))
+        items << NavigationItem.new('Applications', provider_interface_applications_path, is_active(current_controller, %w[application_choices decisions offer_changes notes interviews offers feedback conditions reconfirm_deferred_offers]))
         if FeatureFlag.active?(:interviews)
           items << NavigationItem.new('Interview schedule', provider_interface_interview_schedule_path, is_active(current_controller, %w[interview_schedules]))
         end

--- a/app/helpers/offer_path_helper.rb
+++ b/app/helpers/offer_path_helper.rb
@@ -1,9 +1,11 @@
 module OfferPathHelper
-  def offer_path_for(application_choice, step, params = {})
+  def offer_path_for(application_choice, step, mode = :new, params = {})
     if step.to_sym == :select_option
       new_provider_interface_application_choice_decision_path(application_choice, params)
+    elsif step.to_sym == :offer
+      provider_interface_application_choice_offers_path(application_choice)
     else
-      [:new, :provider_interface, application_choice, :offer, step, params]
+      [mode, :provider_interface, application_choice, :offer, step, params]
     end
   end
 end

--- a/app/views/provider_interface/offer/checks/edit.html.erb
+++ b/app/views/provider_interface/offer/checks/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :edit, back: true)) %>
 
 <%= form_with model: @wizard, url: provider_interface_application_choice_offers_path(@application_choice), method: :put do |f| %>
   <h1 class="govuk-heading-l">

--- a/app/views/provider_interface/offer/checks/edit.html.erb
+++ b/app/views/provider_interface/offer/checks/edit.html.erb
@@ -1,0 +1,36 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+
+<%= form_with model: @wizard, url: provider_interface_application_choice_offers_path(@application_choice), method: :put do |f| %>
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+    <%= t('.title') %>
+  </h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_error_summary %>
+      <%= render ProviderInterface::CompletedOfferSummaryComponent.new(application_choice: @application_choice,
+                                                                       course_option: @wizard.course_option,
+                                                                       conditions: @wizard.conditions,
+                                                                       course: @wizard.course_option.course,
+                                                                       available_providers: @providers,
+                                                                       available_courses: @courses,
+                                                                       available_course_options: @course_options) %>
+
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive"></span>
+          When you send this offer, you guarantee a place on this course as long as the candidate meets the conditions.
+        </strong>
+      </div>
+
+      <%= f.govuk_submit t('.submit') %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/provider_interface/offer/checks/new.html.erb
+++ b/app/views/provider_interface/offer/checks/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :new, back: true)) %>
 
 <%= form_with model: @wizard, url: provider_interface_application_choice_offers_path(@application_choice), method: :post do |f| %>
   <h1 class="govuk-heading-l">

--- a/app/views/provider_interface/offer/checks/new.html.erb
+++ b/app/views/provider_interface/offer/checks/new.html.erb
@@ -16,7 +16,8 @@
                                                               course: @wizard.course_option.course,
                                                               available_providers: @providers,
                                                               available_courses: @courses,
-                                                              available_course_options: @course_options) %>
+                                                              available_course_options: @course_options,
+                                                              show_conditions_link: true) %>
 
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/app/views/provider_interface/offer/conditions/edit.html.erb
+++ b/app/views/provider_interface/offer/conditions/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :edit, back: true)) %>
 
 <%= form_with model: @wizard, url: provider_interface_application_choice_offer_conditions_path(@application_choice), method: :put do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/provider_interface/offer/conditions/edit.html.erb
+++ b/app/views/provider_interface/offer/conditions/edit.html.erb
@@ -1,0 +1,36 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+
+<%= form_with model: @wizard, url: provider_interface_application_choice_offer_conditions_path(@application_choice), method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
+    <%= t('.title') %>
+  </h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_collection_check_boxes(:standard_conditions,
+                                         standard_conditions_checkboxes,
+                                         :id,
+                                         :name,
+                                         legend: { size: 'm' }) %>
+
+      <%= f.govuk_fieldset legend: { text: 'Further conditions', size: 'm' } do %>
+        <p class="govuk-body">For example, studying a subject knowledge enhancement course.</p>
+
+        <%= f.govuk_text_area :further_condition_1, label: { size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_condition_2, label: { size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_condition_3, label: { size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_condition_4, label: { size: 's' }, rows: 3 %>
+      <% end %>
+
+      <%= f.govuk_submit t('continue') %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice), class: 'govuk-link--no-visited-state' %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/provider_interface/offer/conditions/new.html.erb
+++ b/app/views/provider_interface/offer/conditions/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :new, back: true)) %>
 
 <%= form_with model: @wizard, url: provider_interface_application_choice_offer_conditions_path(@application_choice), method: :post do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/provider_interface/offer/courses/edit.html.erb
+++ b/app/views/provider_interface/offer/courses/edit.html.erb
@@ -1,0 +1,17 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+
+<%= render CollectionSelectComponent.new(attribute: :course_id,
+                                         collection: @courses,
+                                         value_method: :id,
+                                         text_method: :name_and_code,
+                                         hint_method: :description,
+                                         form_object: @wizard,
+                                         form_path: provider_interface_application_choice_offer_courses_path,
+                                         form_method: :put,
+                                         page_title: t('.title'),
+                                         caption: @application_choice.application_form.full_name) do %>
+  <p class="govuk-body">
+    <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice) %>
+  </p>
+<% end %>

--- a/app/views/provider_interface/offer/courses/edit.html.erb
+++ b/app/views/provider_interface/offer/courses/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :edit, back: true)) %>
 
 <%= render CollectionSelectComponent.new(attribute: :course_id,
                                          collection: @courses,

--- a/app/views/provider_interface/offer/courses/new.html.erb
+++ b/app/views/provider_interface/offer/courses/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :new, back: true)) %>
 
 <%= render CollectionSelectComponent.new(attribute: :course_id,
                                          collection: @courses,

--- a/app/views/provider_interface/offer/locations/edit.html.erb
+++ b/app/views/provider_interface/offer/locations/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :edit, back: true)) %>
 
 <%= render CollectionSelectComponent.new(attribute: :course_option_id,
                                          collection: @course_options,

--- a/app/views/provider_interface/offer/locations/edit.html.erb
+++ b/app/views/provider_interface/offer/locations/edit.html.erb
@@ -1,13 +1,13 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
 
-<%= render CollectionSelectComponent.new(attribute: :course_id,
-                                         collection: @courses,
+<%= render CollectionSelectComponent.new(attribute: :course_option_id,
+                                         collection: @course_options,
                                          value_method: :id,
-                                         text_method: :name_and_code,
-                                         hint_method: :description,
+                                         text_method: :site_name,
+                                         hint_method: :site_full_address,
                                          form_object: @wizard,
-                                         form_path: provider_interface_application_choice_offer_courses_path,
+                                         form_path: provider_interface_application_choice_offer_locations_path,
                                          form_method: :put,
                                          page_title: t('.title'),
                                          caption: @application_choice.application_form.full_name) do %>

--- a/app/views/provider_interface/offer/locations/new.html.erb
+++ b/app/views/provider_interface/offer/locations/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :new, back: true)) %>
 
 <%= render CollectionSelectComponent.new(attribute: :course_option_id,
                                          collection: @course_options,

--- a/app/views/provider_interface/offer/providers/edit.html.erb
+++ b/app/views/provider_interface/offer/providers/edit.html.erb
@@ -1,0 +1,17 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+
+<%= render CollectionSelectComponent.new(attribute: :provider_id,
+                                         collection: @providers,
+                                         value_method: :id,
+                                         text_method: :name_and_code,
+                                         hint_method: nil,
+                                         form_object: @wizard,
+                                         form_path: provider_interface_application_choice_offer_providers_path,
+                                         form_method: :put,
+                                         page_title: t('.title'),
+                                         caption: @application_choice.application_form.full_name) do %>
+  <p class="govuk-body">
+    <%= govuk_link_to t('cancel'), provider_interface_application_choice_offers_path(@application_choice) %>
+  </p>
+<% end %>

--- a/app/views/provider_interface/offer/providers/edit.html.erb
+++ b/app/views/provider_interface/offer/providers/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :edit, back: true)) %>
 
 <%= render CollectionSelectComponent.new(attribute: :provider_id,
                                          collection: @providers,

--- a/app/views/provider_interface/offer/providers/new.html.erb
+++ b/app/views/provider_interface/offer/providers/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :new, back: true)) %>
 
 <%= render CollectionSelectComponent.new(attribute: :provider_id,
                                          collection: @providers,

--- a/app/views/provider_interface/offer/study_modes/edit.html.erb
+++ b/app/views/provider_interface/offer/study_modes/edit.html.erb
@@ -1,0 +1,17 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+
+<%= render CollectionSelectComponent.new(attribute: :study_mode,
+                                         collection: @study_modes,
+                                         value_method: :id,
+                                         text_method: :value,
+                                         hint_method: nil,
+                                         form_object: @wizard,
+                                         form_path: provider_interface_application_choice_offer_study_modes_path,
+                                         form_method: :put,
+                                         page_title: t('.title'),
+                                         caption: @application_choice.application_form.full_name) do %>
+  <p class="govuk-body">
+    <%= govuk_link_to t('cancel'), provider_interface_application_choice_offers_path(@application_choice) %>
+  </p>
+<% end %>

--- a/app/views/provider_interface/offer/study_modes/edit.html.erb
+++ b/app/views/provider_interface/offer/study_modes/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :edit, back: true)) %>
 
 <%= render CollectionSelectComponent.new(attribute: :study_mode,
                                          collection: @study_modes,

--- a/app/views/provider_interface/offer/study_modes/new.html.erb
+++ b/app/views/provider_interface/offer/study_modes/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, back: true)) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :new, back: true)) %>
 
 <%= render CollectionSelectComponent.new(attribute: :study_mode,
                                          collection: @study_modes,

--- a/app/views/provider_interface/offers/show.html.erb
+++ b/app/views/provider_interface/offers/show.html.erb
@@ -14,7 +14,7 @@
       </p>
     <% end %>
 
-    <% if provider_user_can_make_decisions %>
+    <% if provider_user_can_make_decisions && @application_choice.offer? %>
       <%= render ProviderInterface::CompletedOfferSummaryComponent.new(application_choice: @application_choice,
                                                                        course_option: @application_choice.offered_course_option,
                                                                        conditions: @application_choice.offer['conditions'],
@@ -32,7 +32,7 @@
                                                                                available_courses: [],
                                                                                available_course_options: [],
                                                                                border: false,
-                                                                               editable: false) %>
+                                                                               editable: provider_user_can_make_decisions) %>
     <% end %>
   </div>
 </div>

--- a/app/views/provider_interface/offers/show.html.erb
+++ b/app/views/provider_interface/offers/show.html.erb
@@ -1,0 +1,12 @@
+<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: true) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render ProviderInterface::CompletedOfferSummaryComponent.new(application_choice: @application_choice,
+                                                                     course_option: @application_choice.offered_course_option,
+                                                                     conditions: @application_choice.offer['conditions'],
+                                                                     course: @application_choice.offered_course,
+                                                                     available_providers: @providers,
+                                                                     available_courses: @courses,
+                                                                     available_course_options: @course_options) %>
+  </div>
+</div>

--- a/app/views/provider_interface/offers/show.html.erb
+++ b/app/views/provider_interface/offers/show.html.erb
@@ -3,6 +3,10 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Offer</div>
     <p class="govuk-body govuk-!-margin-bottom-7">
+      <% if %i[pending_conditions recruited].include?(@application_choice.status.to_sym)  %>
+        <%= govuk_link_to 'Defer offer', provider_interface_application_choice_new_defer_offer_path(@application_choice) %>
+      <% end %>
+
       <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_withdraw_offer_path(@application_choice) %>
     </p>
     <%= render ProviderInterface::CompletedOfferSummaryComponent.new(application_choice: @application_choice,

--- a/app/views/provider_interface/offers/show.html.erb
+++ b/app/views/provider_interface/offers/show.html.erb
@@ -1,23 +1,38 @@
-<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: true) %>
+<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: provider_user_can_make_decisions) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Offer</div>
-    <p class="govuk-body govuk-!-margin-bottom-7">
-      <% if %i[pending_conditions recruited].include?(@application_choice.status.to_sym) %>
-        <%= govuk_link_to 'Defer offer', provider_interface_application_choice_new_defer_offer_path(@application_choice) %>
-      <% end %>
+    <% if provider_user_can_make_decisions %>
+      <p class="govuk-body govuk-!-margin-bottom-7">
+        <% if %i[pending_conditions recruited].include?(@application_choice.status.to_sym) %>
+          <%= govuk_link_to 'Defer offer', provider_interface_application_choice_new_defer_offer_path(@application_choice) %>
+        <% end %>
 
-      <% if @application_choice.offer? %>
-        <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_withdraw_offer_path(@application_choice) %>
-      <% end %>
-    </p>
-    <%= render ProviderInterface::CompletedOfferSummaryComponent.new(application_choice: @application_choice,
-                                                                     course_option: @application_choice.offered_course_option,
-                                                                     conditions: @application_choice.offer['conditions'],
-                                                                     course: @application_choice.offered_course,
-                                                                     available_providers: @providers,
-                                                                     available_courses: @courses,
-                                                                     available_course_options: @course_options,
-                                                                     border: false) %>
+        <% if @application_choice.offer? %>
+          <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_withdraw_offer_path(@application_choice) %>
+        <% end %>
+      </p>
+    <% end %>
+
+    <% if provider_user_can_make_decisions %>
+      <%= render ProviderInterface::CompletedOfferSummaryComponent.new(application_choice: @application_choice,
+                                                                       course_option: @application_choice.offered_course_option,
+                                                                       conditions: @application_choice.offer['conditions'],
+                                                                       course: @application_choice.offered_course,
+                                                                       available_providers: @providers,
+                                                                       available_courses: @courses,
+                                                                       available_course_options: @course_options,
+                                                                       border: false) %>
+    <% else %>
+      <%= render ProviderInterface::ReadOnlyCompletedOfferSummaryComponent.new(application_choice: @application_choice,
+                                                                               course_option: @application_choice.offered_course_option,
+                                                                               conditions: @application_choice.offer['conditions'],
+                                                                               course: @application_choice.offered_course,
+                                                                               available_providers: [],
+                                                                               available_courses: [],
+                                                                               available_course_options: [],
+                                                                               border: false,
+                                                                               editable: false) %>
+    <% end %>
   </div>
 </div>

--- a/app/views/provider_interface/offers/show.html.erb
+++ b/app/views/provider_interface/offers/show.html.erb
@@ -3,11 +3,13 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Offer</div>
     <p class="govuk-body govuk-!-margin-bottom-7">
-      <% if %i[pending_conditions recruited].include?(@application_choice.status.to_sym)  %>
+      <% if %i[pending_conditions recruited].include?(@application_choice.status.to_sym) %>
         <%= govuk_link_to 'Defer offer', provider_interface_application_choice_new_defer_offer_path(@application_choice) %>
       <% end %>
 
-      <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_withdraw_offer_path(@application_choice) %>
+      <% if @application_choice.offer? %>
+        <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_withdraw_offer_path(@application_choice) %>
+      <% end %>
     </p>
     <%= render ProviderInterface::CompletedOfferSummaryComponent.new(application_choice: @application_choice,
                                                                      course_option: @application_choice.offered_course_option,

--- a/app/views/provider_interface/offers/show.html.erb
+++ b/app/views/provider_interface/offers/show.html.erb
@@ -1,12 +1,17 @@
 <%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: true) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Offer</div>
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_withdraw_offer_path(@application_choice) %>
+    </p>
     <%= render ProviderInterface::CompletedOfferSummaryComponent.new(application_choice: @application_choice,
                                                                      course_option: @application_choice.offered_course_option,
                                                                      conditions: @application_choice.offer['conditions'],
                                                                      course: @application_choice.offered_course,
                                                                      available_providers: @providers,
                                                                      available_courses: @courses,
-                                                                     available_course_options: @course_options) %>
+                                                                     available_course_options: @course_options,
+                                                                     border: false) %>
   </div>
 </div>

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -13,6 +13,8 @@ en:
       courses:
         new:
           title: Select course
+        edit:
+          title: Select course
       locations:
         new:
           title: Select location

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -18,6 +18,8 @@ en:
       locations:
         new:
           title: Select location
+        edit:
+          title: Select location
       study_modes:
         new:
           title: Select full time or part time

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -8,6 +8,8 @@ en:
       providers:
         new:
           title: Select provider
+        edit:
+          title: Select training provider
       courses:
         new:
           title: Select course

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -28,6 +28,8 @@ en:
       conditions:
         new:
           title: Conditions of offer
+        edit:
+          title: Conditions of offer
       checks:
         new:
           title: Check and send offer

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -21,6 +21,8 @@ en:
       study_modes:
         new:
           title: Select full time or part time
+        edit:
+          title: Select full time or part time
       conditions:
         new:
           title: Conditions of offer

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -34,10 +34,15 @@ en:
         new:
           title: Check and send offer
           submit: Send offer
+        edit:
+          title: Check and send new offer
+          submit: Send new offer
     offers:
       failure: Sorry, there is a problem with the service.
       create:
         success: Offer sent
+      update:
+        success: New offer sent
   helpers:
     label:
       provider_interface_offer_wizard:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -638,7 +638,7 @@ Rails.application.routes.draw do
       resource :offers, only: %i[create show], as: :application_choice_offers
 
       namespace :offer, as: :application_choice_offer do
-        resource :providers, only: %i[new create]
+        resource :providers, only: %i[new create edit update]
         resource :courses, only: %i[new create]
         resource :locations, only: %i[new create]
         resource :study_modes, only: %i[new create], path: 'study-modes'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -642,7 +642,7 @@ Rails.application.routes.draw do
         resource :courses, only: %i[new create edit update]
         resource :study_modes, only: %i[new create edit update], path: 'study-modes'
         resource :locations, only: %i[new create edit update]
-        resource :conditions, only: %i[new create]
+        resource :conditions, only: %i[new create edit update]
         resource :check, only: %i[new]
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -641,7 +641,7 @@ Rails.application.routes.draw do
         resource :providers, only: %i[new create edit update]
         resource :courses, only: %i[new create edit update]
         resource :study_modes, only: %i[new create edit update], path: 'study-modes'
-        resource :locations, only: %i[new create]
+        resource :locations, only: %i[new create edit update]
         resource :conditions, only: %i[new create]
         resource :check, only: %i[new]
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -640,8 +640,8 @@ Rails.application.routes.draw do
       namespace :offer, as: :application_choice_offer do
         resource :providers, only: %i[new create edit update]
         resource :courses, only: %i[new create edit update]
+        resource :study_modes, only: %i[new create edit update], path: 'study-modes'
         resource :locations, only: %i[new create]
-        resource :study_modes, only: %i[new create], path: 'study-modes'
         resource :conditions, only: %i[new create]
         resource :check, only: %i[new]
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -639,7 +639,7 @@ Rails.application.routes.draw do
 
       namespace :offer, as: :application_choice_offer do
         resource :providers, only: %i[new create edit update]
-        resource :courses, only: %i[new create]
+        resource :courses, only: %i[new create edit update]
         resource :locations, only: %i[new create]
         resource :study_modes, only: %i[new create], path: 'study-modes'
         resource :conditions, only: %i[new create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -635,7 +635,7 @@ Rails.application.routes.draw do
       resource :decision, only: %i[new create], as: :application_choice_decision
 
       resource :offers, only: %i[new], as: :application_choice_offer
-      resource :offers, only: %i[create show], as: :application_choice_offers
+      resource :offers, only: %i[create show update], as: :application_choice_offers
 
       namespace :offer, as: :application_choice_offer do
         resource :providers, only: %i[new create edit update]
@@ -643,7 +643,7 @@ Rails.application.routes.draw do
         resource :study_modes, only: %i[new create edit update], path: 'study-modes'
         resource :locations, only: %i[new create edit update]
         resource :conditions, only: %i[new create edit update]
-        resource :check, only: %i[new]
+        resource :check, only: %i[new edit]
       end
 
       get '/rbd-feedback' => 'feedback#new', as: :application_choice_new_rbd_feedback

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -635,7 +635,7 @@ Rails.application.routes.draw do
       resource :decision, only: %i[new create], as: :application_choice_decision
 
       resource :offers, only: %i[new], as: :application_choice_offer
-      resource :offers, only: %i[create], as: :application_choice_offers
+      resource :offers, only: %i[create show], as: :application_choice_offers
 
       namespace :offer, as: :application_choice_offer do
         resource :providers, only: %i[new create]

--- a/spec/components/collection_select_component_spec.rb
+++ b/spec/components/collection_select_component_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe CollectionSelectComponent do
                                       hint_method: nil,
                                       form_object: form_object,
                                       form_path: '',
+                                      form_method: :put,
                                       page_title: 'Select provider',
                                       caption: 'Jane Doe'))
   end

--- a/spec/components/provider_interface/completed_offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/completed_offer_summary_component_spec.rb
@@ -67,34 +67,34 @@ RSpec.describe ProviderInterface::CompletedOfferSummaryComponent do
     end
   end
 
-  context 'when multiple course options' do
-    let(:course_options) { build_stubbed_list(:course_option, 2) }
+  context 'when multiple study modes' do
+    let(:course) { build_stubbed(:course, study_mode: :full_time_or_part_time) }
 
     it 'renders a change link' do
-      course_options_change_link = Rails.application.routes.url_helpers.edit_provider_interface_application_choice_offer_locations_path(application_choice)
-      expect(row_link_selector(2)).to eq(course_options_change_link)
+      study_mode_change_link = Rails.application.routes.url_helpers.edit_provider_interface_application_choice_offer_study_modes_path(application_choice)
+      expect(row_link_selector(2)).to eq(study_mode_change_link)
     end
   end
 
-  context 'when only one course option' do
-    let(:course_options) { [build_stubbed(:course_option)] }
+  context 'when only one study mode' do
+    let(:course) { build_stubbed(:course, study_mode: :full_time) }
 
     it 'renders no change link' do
       expect(row_link_selector(2)).to eq(nil)
     end
   end
 
-  context 'when multiple study modes' do
-    let(:course) { build_stubbed(:course, study_mode: :full_time_or_part_time) }
+  context 'when multiple course options' do
+    let(:course_options) { build_stubbed_list(:course_option, 2) }
 
     it 'renders a change link' do
-      study_mode_change_link = Rails.application.routes.url_helpers.edit_provider_interface_application_choice_offer_study_modes_path(application_choice)
-      expect(row_link_selector(3)).to eq(study_mode_change_link)
+      course_options_change_link = Rails.application.routes.url_helpers.edit_provider_interface_application_choice_offer_locations_path(application_choice)
+      expect(row_link_selector(3)).to eq(course_options_change_link)
     end
   end
 
-  context 'when only one study mode' do
-    let(:course) { build_stubbed(:course, study_mode: :full_time) }
+  context 'when only one course option' do
+    let(:course_options) { [build_stubbed(:course_option)] }
 
     it 'renders no change link' do
       expect(row_link_selector(3)).to eq(nil)

--- a/spec/components/provider_interface/completed_offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/completed_offer_summary_component_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::CompletedOfferSummaryComponent do
+  let(:application_choice) { build_stubbed(:application_choice) }
+  let(:course_option) { build_stubbed(:course_option, course: course) }
+  let(:providers) { [] }
+  let(:course) { build_stubbed(:course, accredited_provider: build(:provider)) }
+  let(:courses) { [] }
+  let(:course_options) { [] }
+  let(:render) do
+    render_inline(described_class.new(application_choice: application_choice,
+                                      course_option: course_option,
+                                      conditions: ['condition 1', 'condition 2'],
+                                      available_providers: providers,
+                                      available_courses: courses,
+                                      available_course_options: course_options,
+                                      course: course))
+  end
+
+  def row_text_selector(row_name, render)
+    rows = {
+      provider: 0,
+      course: 1,
+      full_or_part_time: 2,
+      location: 3,
+      accredited_provider: 4,
+    }
+
+    render.css('.govuk-summary-list__row')[rows[row_name]].text
+  end
+
+  def row_link_selector(row_number)
+    render.css('.govuk-summary-list__row')[row_number].css('a')&.first&.attr('href')
+  end
+
+  context 'when multiple provider options' do
+    let(:providers) { build_stubbed_list(:provider, 2) }
+
+    it 'renders a change link' do
+      provider_change_link = Rails.application.routes.url_helpers.edit_provider_interface_application_choice_offer_providers_path(application_choice)
+      expect(row_link_selector(0)).to eq(provider_change_link)
+    end
+  end
+
+  context 'when only one provider option' do
+    let(:providers) { [build_stubbed(:provider)] }
+
+    it 'renders no change link' do
+      expect(row_link_selector(0)).to eq(nil)
+    end
+  end
+
+  context 'when multiple courses' do
+    let(:courses) { build_stubbed_list(:course, 2) }
+
+    it 'renders a change link' do
+      course_change_link = Rails.application.routes.url_helpers.edit_provider_interface_application_choice_offer_courses_path(application_choice)
+      expect(row_link_selector(1)).to eq(course_change_link)
+    end
+  end
+
+  context 'when only one course' do
+    let(:courses) { [build_stubbed(:course)] }
+
+    it 'renders no change link' do
+      expect(row_link_selector(1)).to eq(nil)
+    end
+  end
+
+  context 'when multiple course options' do
+    let(:course_options) { build_stubbed_list(:course_option, 2) }
+
+    it 'renders a change link' do
+      course_options_change_link = Rails.application.routes.url_helpers.edit_provider_interface_application_choice_offer_locations_path(application_choice)
+      expect(row_link_selector(2)).to eq(course_options_change_link)
+    end
+  end
+
+  context 'when only one course option' do
+    let(:course_options) { [build_stubbed(:course_option)] }
+
+    it 'renders no change link' do
+      expect(row_link_selector(2)).to eq(nil)
+    end
+  end
+
+  context 'when multiple study modes' do
+    let(:course) { build_stubbed(:course, study_mode: :full_time_or_part_time) }
+
+    it 'renders a change link' do
+      study_mode_change_link = Rails.application.routes.url_helpers.edit_provider_interface_application_choice_offer_study_modes_path(application_choice)
+      expect(row_link_selector(3)).to eq(study_mode_change_link)
+    end
+  end
+
+  context 'when only one study mode' do
+    let(:course) { build_stubbed(:course, study_mode: :full_time) }
+
+    it 'renders no change link' do
+      expect(row_link_selector(3)).to eq(nil)
+    end
+  end
+
+  it 'renders the new course option details' do
+    expect(row_text_selector(:provider, render)).to include(course_option.provider.name)
+    expect(row_text_selector(:course, render)).to include(course_option.course.name_and_code)
+    expect(row_text_selector(:location, render)).to include(course_option.site.name_and_address)
+    expect(row_text_selector(:full_or_part_time, render)).to include(course_option.study_mode.humanize)
+    expect(row_text_selector(:accredited_provider, render)).to include(course_option.course.accredited_provider.name_and_code)
+  end
+
+  it 'renders conditions' do
+    expect(render.css('.conditions').text).to include('condition 1')
+    expect(render.css('.conditions').text).to include('condition 2')
+  end
+end

--- a/spec/components/provider_interface/offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/offer_summary_component_spec.rb
@@ -1,19 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::OfferSummaryComponent do
+  include Rails.application.routes.url_helpers
+
   let(:application_choice) { build_stubbed(:application_choice) }
   let(:course_option) { build_stubbed(:course_option) }
   let(:providers) { [] }
   let(:course) { build_stubbed(:course) }
   let(:courses) { [] }
   let(:course_options) { [] }
+  let(:editable) { true }
   let(:render) do
     render_inline(described_class.new(application_choice: application_choice, course_option: course_option,
                                       conditions: ['condition 1'],
                                       available_providers: providers,
                                       available_courses: courses,
                                       available_course_options: course_options,
-                                      course: course))
+                                      course: course,
+                                      editable: editable))
   end
 
   def row_text_selector(row_name, render)
@@ -131,6 +135,24 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
       it 'renders conditions as met' do
         expect(render.css('.conditions-row .govuk-tag')[0].text).to eq('Pending')
         expect(render.css('.conditions-row .govuk-table__cell')[0].text).to eq('condition 1')
+      end
+    end
+  end
+
+  describe '#editable' do
+    context 'when true' do
+      let(:editable) { true }
+
+      it 'displays the conditions change link' do
+        expect(render.css('.govuk-body').css('a').first.attr('href')).to eq(new_provider_interface_application_choice_offer_conditions_path(application_choice))
+      end
+    end
+
+    context 'when false' do
+      let(:editable) { false }
+
+      it 'does not display the conditions change link' do
+        expect(render.css('.govuk-body').css('a').first).to eq(nil)
       end
     end
   end

--- a/spec/components/provider_interface/offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/offer_summary_component_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
   let(:courses) { [] }
   let(:course_options) { [] }
   let(:render) do
-    render_inline(described_class.new(application_choice: application_choice,
-                                      course_option: course_option,
-                                      conditions: ['condition 1', 'condition 2'],
+    render_inline(described_class.new(application_choice: application_choice, course_option: course_option,
+                                      conditions: ['condition 1'],
                                       available_providers: providers,
                                       available_courses: courses,
                                       available_course_options: course_options,
@@ -107,8 +106,32 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
     expect(row_text_selector(:full_or_part_time, render)).to include(course_option.study_mode.humanize)
   end
 
-  it 'renders conditions' do
-    expect(render.css('.conditions').text).to include('condition 1')
-    expect(render.css('.conditions').text).to include('condition 2')
+  context 'when conditions are set' do
+    context 'when application is recruited' do
+      let(:application_choice) { build_stubbed(:application_choice, :with_recruited) }
+
+      it 'renders conditions as met' do
+        expect(render.css('.conditions-row .govuk-tag')[0].text).to eq('Met')
+        expect(render.css('.conditions-row .govuk-table__cell')[0].text).to eq('condition 1')
+      end
+    end
+
+    context 'when application is on conditions_not_met' do
+      let(:application_choice) { build_stubbed(:application_choice, :with_conditions_not_met) }
+
+      it 'renders conditions as met' do
+        expect(render.css('.conditions-row .govuk-tag')[0].text).to eq('Not met')
+        expect(render.css('.conditions-row .govuk-table__cell')[0].text).to eq('condition 1')
+      end
+    end
+
+    context 'when application is on offer state' do
+      let(:application_choice) { build_stubbed(:application_choice, :with_offer) }
+
+      it 'renders conditions as met' do
+        expect(render.css('.conditions-row .govuk-tag')[0].text).to eq('Pending')
+        expect(render.css('.conditions-row .govuk-table__cell')[0].text).to eq('condition 1')
+      end
+    end
   end
 end

--- a/spec/components/provider_interface/offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/offer_summary_component_spec.rb
@@ -143,15 +143,27 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
     context 'when true' do
       let(:editable) { true }
 
-      it 'displays the conditions change link' do
-        expect(render.css('.govuk-body').css('a').first.attr('href')).to eq(new_provider_interface_application_choice_offer_conditions_path(application_choice))
+      context 'when application is in offer state' do
+        let(:application_choice) { build_stubbed(:application_choice, :with_offer) }
+
+        it 'displays the conditions change link' do
+          expect(render.css('.govuk-body').css('a').first.attr('href')).to eq(new_provider_interface_application_choice_offer_conditions_path(application_choice))
+        end
+      end
+
+      context 'when application is in condititions_pending state' do
+        let(:application_choice) { build_stubbed(:application_choice, :with_accepted_offer) }
+
+        it 'displays the update condition link' do
+          expect(render.css('.govuk-body').css('a').first.attr('href')).to eq(provider_interface_application_choice_edit_conditions_path(application_choice))
+        end
       end
     end
 
     context 'when false' do
       let(:editable) { false }
 
-      it 'does not display the conditions change link' do
+      it 'does not display any change links' do
         expect(render.css('.govuk-body').css('a').first).to eq(nil)
       end
     end

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -219,4 +219,13 @@ RSpec.describe ProviderInterface::OfferWizard do
                                        further_condition_3])
     end
   end
+
+  describe '#configure_additional_conditions' do
+    it 'sets further conditions when any defined' do
+      wizard.configure_additional_conditions(['Swimming diploma', 'GCSE A Level in Languages'])
+
+      expect(wizard.further_condition_1).to eq('Swimming diploma')
+      expect(wizard.further_condition_2).to eq('GCSE A Level in Languages')
+    end
+  end
 end

--- a/spec/helpers/offer_path_helper_spec.rb
+++ b/spec/helpers/offer_path_helper_spec.rb
@@ -4,17 +4,35 @@ RSpec.describe OfferPathHelper do
   let(:application_choice) { build_stubbed(:application_choice) }
 
   describe '#offer_path_for' do
-    context 'when :select_option' do
-      it 'returns the decision path' do
-        expect(helper.offer_path_for(application_choice, 'select_option'))
-          .to eq(new_provider_interface_application_choice_decision_path(application_choice, {}))
+    context 'when mode is :new' do
+      context 'when :select_option' do
+        it 'returns the decision path' do
+          expect(helper.offer_path_for(application_choice, 'select_option'))
+            .to eq(new_provider_interface_application_choice_decision_path(application_choice, {}))
+        end
+      end
+
+      context 'when any other step' do
+        it 'returns the step based path' do
+          expect(helper.offer_path_for(application_choice, :other_step))
+            .to eq([:new, :provider_interface, application_choice, :offer, :other_step, {}])
+        end
       end
     end
 
-    context 'when any other step' do
-      it 'returns the step based path' do
-        expect(helper.offer_path_for(application_choice, :other_step))
-          .to eq([:new, :provider_interface, application_choice, :offer, :other_step, {}])
+    context 'when mode is :edit' do
+      context 'when :offer' do
+        it 'returns the offer path' do
+          expect(helper.offer_path_for(application_choice, 'offer', :edit))
+            .to eq(provider_interface_application_choice_offers_path(application_choice, {}))
+        end
+      end
+
+      context 'when any other step' do
+        it 'returns the step edit path' do
+          expect(helper.offer_path_for(application_choice, :other_step, :edit))
+            .to eq([:edit, :provider_interface, application_choice, :offer, :other_step, {}])
+        end
       end
     end
   end

--- a/spec/requests/provider_interface/offers_controller_spec.rb
+++ b/spec/requests/provider_interface/offers_controller_spec.rb
@@ -9,23 +9,23 @@ RSpec.describe ProviderInterface::OffersController, type: :request do
   let(:course) { build(:course, :open_on_apply, provider: provider) }
   let(:course_option) { build(:course_option, course: course) }
 
+  before do
+    allow(DfESignInUser).to receive(:load_from_session)
+      .and_return(
+        DfESignInUser.new(
+          email_address: provider_user.email_address,
+          dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+          first_name: provider_user.first_name,
+          last_name: provider_user.last_name,
+        ),
+      )
+  end
+
   describe 'if application choice is not in a pending decision state' do
     let!(:application_choice) do
       create(:application_choice, :withdrawn,
              application_form: application_form,
              course_option: course_option)
-    end
-
-    before do
-      allow(DfESignInUser).to receive(:load_from_session)
-        .and_return(
-          DfESignInUser.new(
-            email_address: provider_user.email_address,
-            dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
-            first_name: provider_user.first_name,
-            last_name: provider_user.last_name,
-          ),
-        )
     end
 
     context 'GET new' do
@@ -39,6 +39,30 @@ RSpec.describe ProviderInterface::OffersController, type: :request do
     context 'POST create' do
       it 'responds with 302' do
         post provider_interface_application_choice_offers_path(application_choice)
+
+        expect(response.status).to eq(302)
+      end
+    end
+  end
+
+  describe 'if application choice is not in an offer state' do
+    let!(:application_choice) do
+      create(:application_choice, :awaiting_provider_decision,
+             application_form: application_form,
+             course_option: course_option)
+    end
+
+    context 'GET edit' do
+      it 'responds with 302' do
+        get edit_provider_interface_application_choice_offer_providers_path(application_choice)
+
+        expect(response.status).to eq(302)
+      end
+    end
+
+    context 'PUT update' do
+      it 'responds with 302' do
+        put provider_interface_application_choice_offer_providers_path(application_choice)
 
         expect(response.status).to eq(302)
       end

--- a/spec/requests/provider_interface/offers_controller_spec.rb
+++ b/spec/requests/provider_interface/offers_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ProviderInterface::OffersController, type: :request do
     end
   end
 
-  describe 'if application choice is not in an offer state' do
+  describe 'if application choice is not in an offered state' do
     let!(:application_choice) do
       create(:application_choice, :awaiting_provider_decision,
              application_form: application_form,

--- a/spec/system/provider_interface/change_existing_offer_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_spec.rb
@@ -1,0 +1,186 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider changes an existing offer' do
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
+  let(:provider) { provider_user.providers.first }
+  let(:application_form) { build(:application_form, :minimum_info) }
+  let!(:application_choice) do
+    create(:application_choice, :with_offer,
+           application_form: application_form,
+           offered_course_option: course_option)
+  end
+  let(:course) { build(:course, :open_on_apply, :full_time, provider: provider) }
+  let(:course_option) { build(:course_option, course: course) }
+
+  before do
+    FeatureFlag.activate(:updated_offer_flow)
+  end
+
+  scenario 'Changing an offer which has already been made' do
+    given_i_am_a_provider_user
+    and_i_am_permitted_to_make_decisions_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+
+    given_the_provider_user_can_offer_multiple_provider_courses
+
+    when_i_visit_the_provider_interface
+    and_i_click_an_application_choice_with_an_offer
+    and_i_click_on_the_offer_tab
+    then_i_see_the_offer_details
+
+    when_i_choose_to_change_the_provider
+    then_i_am_taken_to_the_change_provider_page
+
+    when_i_select_a_different_provider
+    and_i_click_continue
+
+    when_i_select_a_different_course
+    and_i_click_continue
+
+    when_i_select_a_different_study_mode
+    and_i_click_continue
+
+    when_i_select_a_new_location
+    and_i_click_continue
+
+    then_the_conditions_page_is_loaded
+    and_i_click_continue
+
+    then_the_review_page_is_loaded
+    and_i_can_confirm_the_changed_offer_details
+
+    when_i_send_the_offer
+    then_i_see_that_the_offer_was_successfully_updated
+  end
+
+  def given_i_am_a_provider_user
+    user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+  end
+
+  def and_i_am_permitted_to_make_decisions_for_my_provider
+    permit_make_decisions!
+  end
+
+  def and_i_sign_in_to_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def when_i_visit_the_provider_interface
+    visit provider_interface_applications_path
+  end
+
+  def and_i_click_an_application_choice_with_an_offer
+    click_on application_choice.application_form.full_name
+  end
+
+  def and_i_click_on_the_offer_tab
+    click_on 'Offer'
+  end
+
+  def then_i_see_the_offer_details
+    expect(page).to have_content('Course details')
+    expect(page).to have_content('Conditions of offer')
+  end
+
+  def when_i_choose_to_change_the_provider
+    within(:xpath, "////div[@class='govuk-summary-list__row'][1]") do
+      click_on 'Change'
+    end
+  end
+
+  def then_the_conditions_page_is_loaded
+    expect(page).to have_content('Conditions of offer')
+  end
+
+  def and_the_default_conditions_are_checked
+    expect(find("input[value='Fitness to train to teach check']")).to be_checked
+    expect(find("input[value='Disclosure and Barring Service (DBS) check']")).to be_checked
+  end
+
+  def when_i_add_further_conditions
+    fill_in('provider_interface_offer_wizard[further_condition_1]', with: 'A* on Maths A Level')
+  end
+
+  def and_i_click_continue
+    click_on t('continue')
+  end
+
+  def then_the_review_page_is_loaded
+    expect(page).to have_content('Check and send offer')
+  end
+
+  def and_i_can_confirm_my_answers
+    within('.app-offer-panel') do
+      expect(page).to have_content('A* on Maths A Level')
+    end
+  end
+
+  def then_i_am_taken_to_the_change_location_page
+    expect(page).to have_content('Select location')
+  end
+
+  def when_i_select_a_new_location
+    choose @selected_course_option.site_name
+  end
+
+  def then_i_am_taken_to_the_change_study_mode_page
+    expect(page).to have_content('Select study mode')
+  end
+
+  def when_i_select_a_different_study_mode
+    choose @selected_course_option.study_mode.humanize
+  end
+
+  def when_i_select_a_different_course
+    choose @selected_course.name_and_code
+  end
+
+  def then_i_am_taken_to_the_change_course_page
+    expect(page).to have_content('Select course')
+  end
+
+  def given_the_provider_user_can_offer_multiple_provider_courses
+    @selected_provider = create(:provider, :with_signed_agreement)
+    create(:provider_permissions, provider: @selected_provider, provider_user: provider_user, make_decisions: true)
+    courses = [create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider),
+               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider)]
+    @selected_course = courses.sample
+
+    course_options = [create(:course_option, :part_time, course: @selected_course),
+                      create(:course_option, :full_time, course: @selected_course),
+                      create(:course_option, :full_time, course: @selected_course),
+                      create(:course_option, :part_time, course: @selected_course)]
+
+    @selected_course_option = course_options.sample
+  end
+
+  def then_i_am_taken_to_the_change_provider_page
+    expect(page).to have_content('Select training provider')
+  end
+
+  def when_i_select_a_different_provider
+    choose @selected_provider.name_and_code
+  end
+
+  def and_i_can_confirm_the_changed_offer_details
+    within('.app-summary-card__body') do
+      expect(page).to have_content(@selected_provider.name_and_code)
+      expect(page).to have_content(@selected_course.name_and_code)
+      expect(page).to have_content(@selected_course_option.study_mode.humanize)
+      expect(page).to have_content(@selected_course_option.site.name_and_address)
+    end
+  end
+
+  def when_i_send_the_offer
+    click_on 'Send offer'
+  end
+
+  def then_i_see_that_the_offer_was_successfully_updated
+    within('.govuk-notification-banner--success') do
+      expect(page).to have_content('New offer sent')
+    end
+  end
+end

--- a/spec/system/provider_interface/change_existing_offer_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature 'Provider changes an existing offer' do
   end
 
   def then_the_review_page_is_loaded
-    expect(page).to have_content('Check and send offer')
+    expect(page).to have_content('Check and send new offer')
   end
 
   def and_i_can_confirm_my_answers
@@ -175,7 +175,7 @@ RSpec.feature 'Provider changes an existing offer' do
   end
 
   def when_i_send_the_offer
-    click_on 'Send offer'
+    click_on 'Send new offer'
   end
 
   def then_i_see_that_the_offer_was_successfully_updated

--- a/spec/system/provider_interface/provider_changes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_an_offer_spec.rb
@@ -5,6 +5,10 @@ RSpec.feature 'Provider changes an offer' do
   include DfESignInHelpers
   include ProviderUserPermissionsHelper
 
+  before do
+    FeatureFlag.deactivate(:updated_offer_flow)
+  end
+
   scenario 'Provider changes an offer' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_two_providers
@@ -49,7 +53,7 @@ RSpec.feature 'Provider changes an offer' do
   def and_an_offered_application_choice_exists_for_one_of_my_providers
     # Course @course_option_one belongs to is exclusively full time
     @course_option_one = course_option_for_provider(provider: @provider, study_mode: 'full_time')
-    @application_offered = create(:application_choice, :with_offer, course_option: @course_option_one)
+    @application_offered = create(:application_choice, :with_offer, course_option: @course_option_one, offered_course_option: @course_option_one)
   end
 
   def and_other_full_time_and_part_time_courses_exist_for_this_provider

--- a/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature 'Confirm conditions met' do
     @application_choice = create(
       :application_choice,
       :with_accepted_offer,
-      course_option: course_option,
+      offered_course_option: course_option,
       application_form: @application_form,
     )
     visit provider_interface_application_choice_path(@application_choice.id)

--- a/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature 'Confirm conditions not met' do
     @application_choice = create(
       :application_choice,
       :with_accepted_offer,
-      course_option: @course_option,
+      offered_course_option: @course_option,
       application_form: @application_form,
     )
     visit provider_interface_application_choice_path(@application_choice.id)
@@ -62,7 +62,7 @@ RSpec.feature 'Confirm conditions not met' do
     conditions_met = create(
       :application_choice,
       :with_recruited,
-      course_option: course_option_for_provider_code(provider_code: @provider.code),
+      offered_course_option: course_option_for_provider_code(provider_code: @provider.code),
     )
     visit provider_interface_application_choice_path(conditions_met.id)
   end

--- a/spec/system/provider_interface/provider_defers_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_defers_an_offer_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Provider defers an offer' do
     then_i_am_asked_to_confirm_deferral_of_the_offer
 
     when_i_confirm_deferral_of_the_offer
-    then_i_am_back_to_the_application_page
+    then_i_am_back_at_the_offer_page
     and_i_can_see_the_application_offer_is_deferred
   end
 
@@ -27,7 +27,10 @@ RSpec.feature 'Provider defers an offer' do
 
   def and_an_offered_application_choice_exists_for_my_provider
     course_option = course_option_for_provider_code(provider_code: 'ABC')
-    @application_offered = create(:application_choice, status: 'pending_conditions', accepted_at: 1.day.ago, course_option: course_option, application_form: create(:completed_application_form, first_name: 'Alice', last_name: 'Wunder'))
+    @application_offered = create(:application_choice,
+                                  :with_completed_application_form,
+                                  :with_accepted_offer,
+                                  offered_course_option: course_option)
   end
 
   def and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
@@ -62,14 +65,13 @@ RSpec.feature 'Provider defers an offer' do
     click_on 'Confirm offer deferral'
   end
 
-  def then_i_am_back_to_the_application_page
-    expect(page).to have_current_path(
-      provider_interface_application_choice_offer_path(
-        @application_offered.id,
-      ),
-    )
-    expect(page).to have_content @application_offered.application_form.first_name
-    expect(page).to have_content @application_offered.application_form.last_name
+  def then_i_am_back_at_the_offer_page
+    within '.govuk-heading-xl' do
+      expect(page).to have_content @application_offered.application_form.first_name
+      expect(page).to have_content @application_offered.application_form.last_name
+    end
+
+    expect(page).to have_content 'Offer'
   end
 
   def and_i_can_see_the_application_offer_is_deferred

--- a/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'Provider withdraws an offer' do
 
   def and_an_offered_application_choice_exists_for_my_provider
     course_option = course_option_for_provider_code(provider_code: 'ABC')
-    @application_offered = create(:application_choice, status: 'offer', offered_at: Time.zone.now, course_option: course_option, application_form: create(:completed_application_form, first_name: 'Alice', last_name: 'Wunder'))
+    @application_offered = create(:application_choice, :with_offer, offered_course_option: course_option)
   end
 
   def and_i_am_permitted_to_see_applications_for_my_provider


### PR DESCRIPTION
## Context

Enables the provider to edit the details of an existing offer made to a candidate.

### Clarification required: 
- [x] When is the offer tab displayed? What states can the application be in?
- [x] When should Defer offer link be displayed? In what application states?
- [x] How/When can conditions be marked as met? Map completed_offer_summary component to relevant actions.
- [ ] Clarify rules around text displayed on edit offer summary page (link to [Slack discussion](https://ukgovernmentdfe.slack.com/archives/CPH8J9G65/p1616516153113100?thread_ts=1616496274.102500&cid=CPH8J9G65)) **Out of scope**
- [x] An offer can only be edited in the offered state.
- [x] Enable all provider users to access offer tab, only ones with make decision can  

## Link to Trello card

https://trello.com/c/8Yc9CIab/3460-change-edit-an-existing-offer-to-use-new-flow

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
