### PR TITLE
Delete spurious lat/long setting from the audit log

### DIFF
--- a/app/services/data_migrations/fix_lat_long_flip_flops.rb
+++ b/app/services/data_migrations/fix_lat_long_flip_flops.rb
@@ -14,7 +14,7 @@ module DataMigrations
       deleted_audit_count = 0
       total_audits = audits.count
 
-      Provider.find_each do |p|
+      providers.find_each do |p|
         log("Cleaning up provider #{p.id} (#{p.name_and_code})")
 
         audits_for_provider = audits.where(auditable_id: p.id)
@@ -48,6 +48,14 @@ module DataMigrations
     end
 
   private
+
+    def providers
+      if dry_run?
+        Provider.where(sync_courses: true).limit(50)
+      else
+        Provider.all
+      end
+    end
 
     def delete_audits(description, audits)
       log("Deleting #{audits.count} #{description}")

--- a/app/services/data_migrations/fix_lat_long_flip_flops.rb
+++ b/app/services/data_migrations/fix_lat_long_flip_flops.rb
@@ -1,0 +1,37 @@
+module DataMigrations
+  class FixLatLongFlipFlops
+    TIMESTAMP = 20210323203521
+    MANUAL_RUN = true
+
+    def change
+      audits = Audited::Audit.where(
+        "auditable_type = 'Provider' AND
+        action = 'update' AND
+        audited_changes ?& array['latitude', 'longitude'] AND
+        (audited_changes - 'latitude') - 'longitude' = '{}'",
+      ).order(created_at: :asc)
+
+      audit_count = 0
+      total_audits = audits.count
+
+      Provider.find_each do |p|
+        audits_for_provider = audits.where(auditable_id: p.id)
+
+        # if we already had lat/lng when we made the first spurious update, delete every audit
+        if audits_for_provider.first.audited_changes['latitude'].last.nil?
+          audits_for_provider.destroy_all
+
+        # otherwise, delete all the audits except the one that set it for the first time
+        else
+
+          audits_for_provider.where("audited_changes#>>'{longitude, 1}' is null").destroy_all
+          audits_for_provider.where("audited_changes#>>'{longitude, 0}' is null").offset(1).destroy_all
+        end
+
+        audit_count += audits_for_provider.count
+      end
+
+      Rails.logger.info("Deleted #{audit_count} lat/long audits out of #{total_audits}")
+    end
+  end
+end

--- a/app/services/data_migrations/fix_lat_long_flip_flops.rb
+++ b/app/services/data_migrations/fix_lat_long_flip_flops.rb
@@ -15,23 +15,28 @@ module DataMigrations
       total_audits = audits.count
 
       Provider.find_each do |p|
-        Rails.logger.info("FixLatLongFlipFlops: cleaning up provider #{p.id} (#{p.name_and_code})")
+        log("Cleaning up provider #{p.id} (#{p.name_and_code})")
 
         audits_for_provider = audits.where(auditable_id: p.id)
         audits_for_provider_count_before_cleanup = audits.where(auditable_id: p.id).count
 
         # if we already had lat/lng when we made the first spurious update, delete every audit
         if audits_for_provider.first.audited_changes['latitude'].last.nil?
-          delete_audits(audits_for_provider)
+          delete_audits(
+            'lat/long-only audits for this provider (all of them) becase lat/long was set beforehand',
+            audits_for_provider,
+          )
 
         # otherwise, delete all the audits except the one that set it for the first time
         else
 
           delete_audits(
+            'audits which set the lat/long to nil',
             audits_for_provider.where("audited_changes#>>'{longitude, 1}' is null"),
           )
 
           delete_audits(
+            'audits which repeatedly set the lat/long to the same value',
             audits_for_provider.where("audited_changes#>>'{longitude, 0}' is null").offset(1),
           )
         end
@@ -39,13 +44,27 @@ module DataMigrations
         deleted_audit_count += (audits_for_provider_count_before_cleanup - audits_for_provider.count)
       end
 
-      Rails.logger.info("Deleted #{deleted_audit_count} lat/long audits out of #{total_audits}")
+      log("Deleted #{deleted_audit_count} lat/long audits out of #{total_audits}") unless dry_run?
     end
 
   private
 
-    def delete_audits(audits)
-      audits.destroy_all
+    def delete_audits(description, audits)
+      log("Deleting #{audits.count} #{description}")
+      audits.destroy_all unless dry_run?
+    end
+
+    def dry_run?
+      ENV.fetch('FIX_LAT_LONG_DRY_RUN', 'true') == 'true'
+    end
+
+    def log(message)
+      log_string = %w[FixLatLongFlipFlops]
+      log_string << '(dry run)' if dry_run?
+      log_string << '-'
+      log_string << message
+
+      Rails.logger.info log_string.join(' ')
     end
   end
 end

--- a/app/services/data_migrations/fix_lat_long_flip_flops.rb
+++ b/app/services/data_migrations/fix_lat_long_flip_flops.rb
@@ -11,27 +11,41 @@ module DataMigrations
         (audited_changes - 'latitude') - 'longitude' = '{}'",
       ).order(created_at: :asc)
 
-      audit_count = 0
+      deleted_audit_count = 0
       total_audits = audits.count
 
       Provider.find_each do |p|
+        Rails.logger.info("FixLatLongFlipFlops: cleaning up provider #{p.id} (#{p.name_and_code})")
+
         audits_for_provider = audits.where(auditable_id: p.id)
+        audits_for_provider_count_before_cleanup = audits.where(auditable_id: p.id).count
 
         # if we already had lat/lng when we made the first spurious update, delete every audit
         if audits_for_provider.first.audited_changes['latitude'].last.nil?
-          audits_for_provider.destroy_all
+          delete_audits(audits_for_provider)
 
         # otherwise, delete all the audits except the one that set it for the first time
         else
 
-          audits_for_provider.where("audited_changes#>>'{longitude, 1}' is null").destroy_all
-          audits_for_provider.where("audited_changes#>>'{longitude, 0}' is null").offset(1).destroy_all
+          delete_audits(
+            audits_for_provider.where("audited_changes#>>'{longitude, 1}' is null"),
+          )
+
+          delete_audits(
+            audits_for_provider.where("audited_changes#>>'{longitude, 0}' is null").offset(1),
+          )
         end
 
-        audit_count += audits_for_provider.count
+        deleted_audit_count += (audits_for_provider_count_before_cleanup - audits_for_provider.count)
       end
 
-      Rails.logger.info("Deleted #{audit_count} lat/long audits out of #{total_audits}")
+      Rails.logger.info("Deleted #{deleted_audit_count} lat/long audits out of #{total_audits}")
+    end
+
+  private
+
+    def delete_audits(audits)
+      audits.destroy_all
     end
   end
 end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,6 +1,7 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
   'DataMigrations::BackfillExportType',
+  'DataMigrations::FixLatLongFlipFlops',
 ].freeze
 
 def data_migrations

--- a/spec/services/data_migrations/fix_lat_long_flip_flops_spec.rb
+++ b/spec/services/data_migrations/fix_lat_long_flip_flops_spec.rb
@@ -98,7 +98,8 @@ RSpec.describe DataMigrations::FixLatLongFlipFlops, with_audited: true do
     end
 
     it 'logs rather than deleting audits' do
-      provider = create(:provider)
+      # we prefer sync_courses: true providers in the dry run because the impact of breaking one is greater :D
+      provider = create(:provider, sync_courses: true)
       provider.update(latitude: 1, longitude: 1)
       provider.update(latitude: nil, longitude: nil)
 

--- a/spec/services/data_migrations/fix_lat_long_flip_flops_spec.rb
+++ b/spec/services/data_migrations/fix_lat_long_flip_flops_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::FixLatLongFlipFlops do
+  it 'deletes audits that set lat/long to nil', with_audited: true do
+    provider = create(:provider)
+    expect(provider.audits.count).to eq 1
+
+    provider.update(latitude: 1, longitude: 1)
+    expect(provider.audits.count).to eq 2
+
+    provider.update(latitude: nil, longitude: nil)
+    expect(provider.audits.count).to eq 3
+
+    described_class.new.change
+
+    expect(provider.audits.count).to eq 2
+    expect(provider.audits.last.audited_changes).to eq({ 'latitude' => [nil, 1.0], 'longitude' => [nil, 1.0] })
+  end
+
+  it 'deletes duplicated audits that set lat/long', with_audited: true do
+    provider = FactoryBot.create(:provider)
+    expect(provider.audits.count).to eq 1
+
+    provider.update(latitude: 1, longitude: 1)
+    expect(provider.audits.count).to eq 2
+
+    provider.update(latitude: nil, longitude: nil)
+    expect(provider.audits.count).to eq 3
+
+    provider.update(latitude: 1, longitude: 1)
+    expect(provider.audits.count).to eq 4
+
+    described_class.new.change
+
+    expect(provider.audits.count).to eq 2
+    expect(provider.audits.last.audited_changes).to eq({ 'latitude' => [nil, 1.0], 'longitude' => [nil, 1.0] })
+  end
+
+  it 'does not retain an extra audit when lat/long was set at creation time', with_audited: true do
+    provider = create(:provider, latitude: 1, longitude: 1)
+    expect(provider.audits.count).to eq 1
+
+    provider.update(latitude: nil, longitude: nil)
+    expect(provider.audits.count).to eq 2
+
+    provider.update(latitude: 1, longitude: 1)
+    expect(provider.audits.count).to eq 3
+
+    described_class.new.change
+
+    expect(provider.audits.count).to eq 1
+  end
+
+  it 'can handle two providers with different orderings of changes', with_audited: true do
+    p1 = create(:provider)
+    p2 = create(:provider, latitude: 1, longitude: 1)
+
+    p1.update(latitude: 1, longitude: 1)
+    p1.update(latitude: nil, longitude: nil)
+
+    p2.update(latitude: nil, longitude: nil)
+    p2.update(latitude: 1, longitude: 1)
+
+    described_class.new.change
+
+    expect(p1.audits.count).to eq(2)
+    expect(p1.audits.last.audited_changes).to eq({ 'latitude' => [nil, 1.0], 'longitude' => [nil, 1.0] })
+
+    expect(p2.audits.count).to eq(1)
+  end
+
+  it 'logs the result', with_audited: true do
+    provider = create(:provider)
+    provider.update(latitude: 1, longitude: 1)
+    provider.update(latitude: nil, longitude: nil)
+
+    allow(Rails.logger).to receive(:info).and_call_original
+
+    described_class.new.change
+
+    expect(Rails.logger).to have_received(:info).with('Deleted 1 lat/long audits out of 2')
+  end
+end

--- a/spec/services/data_migrations/fix_lat_long_flip_flops_spec.rb
+++ b/spec/services/data_migrations/fix_lat_long_flip_flops_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe DataMigrations::FixLatLongFlipFlops do
-  it 'deletes audits that set lat/long to nil', with_audited: true do
+RSpec.describe DataMigrations::FixLatLongFlipFlops, with_audited: true do
+  it 'deletes audits that set lat/long to nil' do
     provider = create(:provider)
     expect(provider.audits.count).to eq 1
 
@@ -17,7 +17,7 @@ RSpec.describe DataMigrations::FixLatLongFlipFlops do
     expect(provider.audits.last.audited_changes).to eq({ 'latitude' => [nil, 1.0], 'longitude' => [nil, 1.0] })
   end
 
-  it 'deletes duplicated audits that set lat/long', with_audited: true do
+  it 'deletes duplicated audits that set lat/long' do
     provider = FactoryBot.create(:provider)
     expect(provider.audits.count).to eq 1
 
@@ -36,7 +36,7 @@ RSpec.describe DataMigrations::FixLatLongFlipFlops do
     expect(provider.audits.last.audited_changes).to eq({ 'latitude' => [nil, 1.0], 'longitude' => [nil, 1.0] })
   end
 
-  it 'does not retain an extra audit when lat/long was set at creation time', with_audited: true do
+  it 'does not retain an extra audit when lat/long was set at creation time' do
     provider = create(:provider, latitude: 1, longitude: 1)
     expect(provider.audits.count).to eq 1
 
@@ -51,7 +51,7 @@ RSpec.describe DataMigrations::FixLatLongFlipFlops do
     expect(provider.audits.count).to eq 1
   end
 
-  it 'can handle two providers with different orderings of changes', with_audited: true do
+  it 'can handle two providers with different orderings of changes' do
     p1 = create(:provider)
     p2 = create(:provider, latitude: 1, longitude: 1)
 
@@ -69,15 +69,16 @@ RSpec.describe DataMigrations::FixLatLongFlipFlops do
     expect(p2.audits.count).to eq(1)
   end
 
-  it 'logs the result', with_audited: true do
+  it 'logs the result' do
     provider = create(:provider)
     provider.update(latitude: 1, longitude: 1)
     provider.update(latitude: nil, longitude: nil)
+    provider.update(latitude: 1, longitude: 1)
 
     allow(Rails.logger).to receive(:info).and_call_original
 
     described_class.new.change
 
-    expect(Rails.logger).to have_received(:info).with('Deleted 1 lat/long audits out of 2')
+    expect(Rails.logger).to have_received(:info).with('Deleted 2 lat/long audits out of 3')
   end
 end


### PR DESCRIPTION
## Context

We have 1.3 million audit entries that consist of the lat/long flipping back and forth:

<img width="790" alt="Screenshot 2021-03-24 at 07 39 59" src="https://user-images.githubusercontent.com/642279/112272476-2896d280-8c74-11eb-8485-db0b757cfdc3.png">

## Changes proposed in this pull request

- Find all the entries that consist only of lat/long changes
- for each provider, ascertain whether one of these entries originally set the lat/long
- if so, delete all the lat/long-only audit logs for that provider but that one
- if not, delete all the lat/long audit logs for that provider

## Guidance to review

The SQL could definitely do with another pair of eyes! And could we dry-run this somehow?

## Link to Trello card

https://trello.com/c/6vbtx9Nm/427-audit-trial-is-full-of-flip-flops

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
