### PR TITLE
Spike: Rework tests to a randomised time based on the EOC timetable

### DIFF
--- a/spec/support/test_helpers/cycle_timetable_helper.rb
+++ b/spec/support/test_helpers/cycle_timetable_helper.rb
@@ -1,0 +1,39 @@
+module CycleTimetableHelper
+  def mid_cycle
+    rand(previous_end_of_cycle_timetable[:apply_reopens]..current_end_of_cycle_timetable[:apply_1_deadline])
+  end
+
+  def after_apply_1_deadline
+    rand((current_end_of_cycle_timetable[:apply_1_deadline] + 1.day)..current_end_of_cycle_timetable[:stop_applications_to_unavailable_course_options])
+  end
+
+  def after_full_course_deadline
+    rand((current_end_of_cycle_timetable[:stop_applications_to_unavailable_course_options] + 1.day)..current_end_of_cycle_timetable[:apply_2_deadline])
+  end
+
+  def after_apply_2_deadline
+    rand((current_end_of_cycle_timetable[:apply_2_deadline] + 1.day)..current_end_of_cycle_timetable[:find_closes])
+  end
+
+  def after_find_closes
+    rand((current_end_of_cycle_timetable[:find_closes])..current_end_of_cycle_timetable[:find_reopens])
+  end
+
+  def after_find_reopens
+    rand((current_end_of_cycle_timetable[:find_reopens])..current_end_of_cycle_timetable[:apply_reopens])
+  end
+
+  def after_apply_reopens
+    rand((current_end_of_cycle_timetable[:find_reopens])..Date.new(EndOfCycleTimetable::CURRENT_YEAR_FOR_SCHEDULE, 12, 31))
+  end
+
+private
+
+  def previous_end_of_cycle_timetable
+    EndOfCycleTimetable::CYCLE_DATES[EndOfCycleTimetable::CURRENT_YEAR_FOR_SCHEDULE - 1]
+  end
+
+  def current_end_of_cycle_timetable
+    EndOfCycleTimetable::CYCLE_DATES[EndOfCycleTimetable::CURRENT_YEAR_FOR_SCHEDULE]
+  end
+end

--- a/spec/system/candidate_interface/end_of_cycle/candidate_with_unsubmitted_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/end_of_cycle/candidate_with_unsubmitted_application_between_cycles_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate attempts to submit the application after the end-of-cycle cutoff', skip: true do
+RSpec.feature 'Candidate attempts to submit the application after the end-of-cycle cutoff' do
   include CandidateHelper
+  include CycleTimetableHelper
 
   around do |example|
-    Timecop.freeze(Date.new(2020, 8, 24)) { example.run }
+    Timecop.freeze(mid_cycle) { example.run }
   end
 
   scenario 'Candidate with an unsubmitted application between cycles' do
@@ -25,10 +26,6 @@ RSpec.feature 'Candidate attempts to submit the application after the end-of-cyc
     then_i_am_redirected_to_the_carry_over_interstitial
   end
 
-  def and_i_visit_the_application_form_page
-    visit candidate_interface_application_form_path
-  end
-
   def given_i_am_signed_in
     create_and_sign_in_candidate
   end
@@ -38,11 +35,22 @@ RSpec.feature 'Candidate attempts to submit the application after the end-of-cyc
   end
 
   def and_i_return_after_submission_deadline
-    Timecop.travel(Time.zone.local(2020, 8, 25, 12, 0, 0))
+    Timecop.travel(after_apply_1_deadline)
+    and_i_log_in_again
   end
 
   def and_i_visit_the_application_form_page
     visit candidate_interface_application_form_path
+  end
+
+  def then_i_can_only_review_my_application
+    expect(page).not_to have_link 'Check and submit your application'
+    expect(page).to have_content "You cannot submit your application until #{EndOfCycleTimetable.apply_reopens.to_s(:govuk_date)}. You can keep making changes to the rest of your application until then."
+    click_link 'Review your application'
+  end
+
+  def and_i_cannot_submit_my_application
+    expect(page).not_to have_link t('continue')
   end
 
   def when_i_try_to_visit_the_submit_page
@@ -55,22 +63,12 @@ RSpec.feature 'Candidate attempts to submit the application after the end-of-cyc
   end
 
   def when_i_the_new_cycle_opens
-    Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0))
+    Timecop.travel(after_apply_reopens)
   end
 
   def and_i_log_in_again
     logout
     create_and_sign_in_candidate
-  end
-
-  def then_i_can_only_review_my_application
-    expect(page).not_to have_link 'Check and submit your application'
-    expect(page).to have_content 'You cannot submit your application until 13 October 2020. You can keep making changes to the rest of your application until then.'
-    click_link 'Review your application'
-  end
-
-  def and_i_cannot_submit_my_application
-    expect(page).not_to have_link t('continue')
   end
 
   def then_i_am_redirected_to_the_carry_over_interstitial


### PR DESCRIPTION
## Context

At the moment we've got a tonne of hardcoded Timecop times for discreet phases of the cycle. Ideally, we should be using randomised times within these discreet cycles where appropriate. If not we should just be using `Time.zone.now`

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
