### PR TITLE
Bump mimemagic to 0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,7 +284,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
## Context
All previous version have been removed from rubygems

see https://github.com/minad/mimemagic/issues/97

## Changes proposed in this pull request

Bump mimemagic to 0.3.6