### PR TITLE
Add "Previous applications" table to bottom of dashboard view

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -1,4 +1,4 @@
-<% @application_choices.each do |application_choice| %>
+<% application_choices.each do |application_choice| %>
   <div class="<%= container_class(application_choice) %>" id="course-choice-<%= application_choice.id %>" data-qa="application-choice-<%= application_choice.id %>">
   <% if CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(application_choice.application_form) && @editable %>
     <% if application_choice.course_not_available? %>

--- a/app/components/candidate_interface/previous_applications_component.html.erb
+++ b/app/components/candidate_interface/previous_applications_component.html.erb
@@ -16,7 +16,9 @@
         <span class="app-course-choice__course-name">
           <%= course_name_and_code_for(application_choice) %>
         </span>
-        <%= view_application_url_for(application_choice) %>
+        <%= govuk_link_to candidate_interface_review_previous_application_path(application_choice.application_form.id) do %>
+          View application <span class="govuk-visually-hidden"> for <%= application_choice.course.name %> at <%= application_choice.course.provider.name %></span>
+        <% end %>
       </td>
       <td class="govuk-table__cell">
         <%= render CandidateInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>

--- a/app/components/candidate_interface/previous_applications_component.html.erb
+++ b/app/components/candidate_interface/previous_applications_component.html.erb
@@ -1,3 +1,4 @@
+<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 <table class="govuk-table govuk-!-margin-top-6">
   <caption class="govuk-table__caption govuk-table__caption--m">Your previous applications</caption>
   <thead class="govuk-table__head">

--- a/app/components/candidate_interface/previous_applications_component.html.erb
+++ b/app/components/candidate_interface/previous_applications_component.html.erb
@@ -1,0 +1,27 @@
+<table class="govuk-table govuk-!-margin-top-6">
+  <caption class="govuk-table__caption govuk-table__caption--m">Your previous applications</caption>
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th scope="col" class="govuk-table__header">Course</th>
+    <th scope="col" class="govuk-table__header">Status</th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% application_choices.each do |application_choice| %>
+    <tr class="govuk-table__row" data-qa="application-choice-<%= application_choice.id %>">
+      <td class="govuk-table__cell">
+        <span class="app-course-choice__provider-name">
+          <%= provider_name_for(application_choice) %>
+        </span>
+        <span class="app-course-choice__course-name">
+          <%= course_name_and_code_for(application_choice) %>
+        </span>
+        <%= view_application_url_for(application_choice) %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= render CandidateInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/components/candidate_interface/previous_applications_component.rb
+++ b/app/components/candidate_interface/previous_applications_component.rb
@@ -27,10 +27,6 @@ module CandidateInterface
       application_choice.course.name_and_code
     end
 
-    def view_application_url_for(application_choice)
-      govuk_link_to('View application', candidate_interface_review_previous_application_path(application_choice.application_form.id))
-    end
-
   private
 
     def eligible_current_application_choices

--- a/app/components/candidate_interface/previous_applications_component.rb
+++ b/app/components/candidate_interface/previous_applications_component.rb
@@ -1,0 +1,75 @@
+module CandidateInterface
+  class PreviousApplicationsComponent < ViewComponent::Base
+    include ViewHelper
+
+    def initialize(candidate:)
+      @candidate = candidate
+    end
+
+    def render?
+      application_choices.present?
+    end
+
+    def application_choices
+      (previous_application_choices + eligible_current_application_choices)
+        .compact
+        .sort_by(&:id)
+        .reverse
+    end
+
+    def provider_name_for(application_choice)
+      application_choice
+        .provider
+        .name
+    end
+
+    def course_name_and_code_for(application_choice)
+      application_choice.course.name_and_code
+    end
+
+    def view_application_url_for(application_choice)
+      govuk_link_to('View application', candidate_interface_review_previous_application_path(application_choice.application_form.id))
+    end
+
+  private
+
+    def eligible_current_application_choices
+      if application_choice_has_accepted_state_present?
+        # Reject all applications that have an ACCEPTED_STATE
+        # These will appear in the CandidateInterface::CourseChoicesReview component
+        application_choices_without_accepted_states
+      else
+        []
+      end
+    end
+
+    def application_choices_without_accepted_states
+      current_application_choices
+        .reject { |ac| ApplicationStateChange::ACCEPTED_STATES.include?(ac.status.to_sym) }
+    end
+
+    def application_choice_has_accepted_state_present?
+      current_application_choices.any? { |ac| ApplicationStateChange::ACCEPTED_STATES.include?(ac.status.to_sym) }
+    end
+
+    def current_application_choices
+      @candidate
+        .current_application
+        .application_choices
+        .includes(:course, :provider)
+        .all
+    end
+
+    def previous_application_choices
+      previous_application_forms = @candidate.application_forms.all - [@candidate.current_application]
+
+      if previous_application_forms
+        previous_application_forms
+          .map { |af| af.application_choices.includes(:course, :provider) }
+          .flatten
+      else
+        []
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/submitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/submitted_application_form_controller.rb
@@ -7,6 +7,7 @@ module CandidateInterface
     end
 
     def complete
+      @candidate = current_candidate
       @application_form = current_application
     end
 

--- a/app/views/candidate_interface/submitted_application_form/complete.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/complete.html.erb
@@ -11,8 +11,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render(CandidateInterface::ApplicationCompleteContentComponent.new(application_form: @application_form)) %>
-
-    <%= render(CandidateInterface::CourseChoicesReviewComponent.new(application_form: @application_form, editable: false, heading_level: 3, show_status: true, render_link_to_find_when_rejected_on_qualifications: true)) %>
+    <%= render(CandidateInterface::CourseChoicesReviewComponent.new(application_form: @application_form, editable: false, heading_level: 3, show_status: true, render_link_to_find_when_rejected_on_qualifications: true, display_accepted_application_choices: true)) %>
+    <%= render(CandidateInterface::PreviousApplicationsComponent.new(candidate: @candidate)) %>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -392,6 +392,19 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
     end
   end
 
+  describe '#application_choices' do
+    context "when one or more have an 'ACCEPTED_STATE'" do
+      let(:application_form) { create_application_form_with_course_choices(statuses: %w[pending_conditions rejected]) }
+
+      it 'returns only the application choices with ACCEPTED STATES' do
+        component = described_class.new(application_form: application_form, editable: false, show_status: true, display_accepted_application_choices: true)
+
+        expect(component.application_choices.count).to eq(1)
+        expect(component.application_choices.first.status).to eq('pending_conditions')
+      end
+    end
+  end
+
   def create_application_form_with_course_choices(statuses:)
     application_form = build(:application_form)
 

--- a/spec/components/candidate_interface/previous_applications_component_spec.rb
+++ b/spec/components/candidate_interface/previous_applications_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CandidateInterface::PreviousApplicationsComponent do
         expect(result.css('.govuk-table__caption--m').text).to include('Your previous applications')
         expect(result.css('.app-course-choice__provider-name').text).to include(rejected_application_choice.course.provider.name)
         expect(result.css('.app-course-choice__course-name').text).to include(rejected_application_choice.course.name_and_code)
-        expect(result.css('.app-tag').text).to include('Unsuccessful')
+        expect(result.css('.govuk-tag').text).to include('Unsuccessful')
         expect(result.css('.govuk-link').text).to include('View application')
       end
     end
@@ -45,7 +45,7 @@ RSpec.describe CandidateInterface::PreviousApplicationsComponent do
       expect(result.css('.govuk-table__caption--m').text).to include('Your previous applications')
       expect(result.css('.app-course-choice__provider-name').text).to include(unsuccessful_application_choice.course.provider.name)
       expect(result.css('.app-course-choice__course-name').text).to include(unsuccessful_application_choice.course.name_and_code)
-      expect(result.css('.app-tag').text).to include('Unsuccessful')
+      expect(result.css('.govuk-tag').text).to include('Unsuccessful')
       expect(result.css('.govuk-link').text).to include('View application')
     end
   end

--- a/spec/components/candidate_interface/previous_applications_component_spec.rb
+++ b/spec/components/candidate_interface/previous_applications_component_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::PreviousApplicationsComponent do
+  let(:candidate) { create(:candidate) }
+
+  describe 'a current application ' do
+    context 'with a single application choice with an ACCEPTED state' do
+      let(:current_application_form) { create_application_form_with_course_choices(statuses: [status], candidate: candidate) }
+
+      ApplicationStateChange::ACCEPTED_STATES.each do |status|
+        let(:status) { status }
+
+        it "does not render the component for accepted state: '#{status}'" do
+          result = render_inline(described_class.new(candidate: candidate))
+
+          expect(result.css('.govuk-table__caption--m').text).to be_empty
+        end
+      end
+    end
+
+    context "with an application choice 'pending_conditions' and another that has been 'rejected'" do
+      let(:current_application_form) { create_application_form_with_course_choices(statuses: %w[pending_conditions rejected], candidate: candidate) }
+
+      it 'renders component with rejected application choice in a table' do
+        rejected_application_choice = current_application_form.application_choices.last
+        result = render_inline(described_class.new(candidate: candidate))
+
+        expect(result.css('.govuk-table__caption--m').text).to include('Your previous applications')
+        expect(result.css('.app-course-choice__provider-name').text).to include(rejected_application_choice.course.provider.name)
+        expect(result.css('.app-course-choice__course-name').text).to include(rejected_application_choice.course.name_and_code)
+        expect(result.css('.app-tag').text).to include('Unsuccessful')
+        expect(result.css('.govuk-link').text).to include('View application')
+      end
+    end
+  end
+
+  describe 'a previous application exists with a rejected application choice' do
+    let(:previous_application_form) { create(:application_form, candidate: candidate, submitted_at: 10.days.ago) }
+    let!(:current_application_form) { create(:application_form, candidate: candidate, submitted_at: 3.days.ago, previous_application_form_id: previous_application_form.id) }
+    let!(:unsuccessful_application_choice) { create(:application_choice, :with_rejection, application_form: previous_application_form) }
+
+    it 'renders component with rejected application choice in a table' do
+      result = render_inline(described_class.new(candidate: candidate))
+
+      expect(result.css('.govuk-table__caption--m').text).to include('Your previous applications')
+      expect(result.css('.app-course-choice__provider-name').text).to include(unsuccessful_application_choice.course.provider.name)
+      expect(result.css('.app-course-choice__course-name').text).to include(unsuccessful_application_choice.course.name_and_code)
+      expect(result.css('.app-tag').text).to include('Unsuccessful')
+      expect(result.css('.govuk-link').text).to include('View application')
+    end
+  end
+
+  describe '#application_choices' do
+    context "when an application choice has an 'ACCEPTED_STATE'" do
+      let!(:application_form) { create_application_form_with_course_choices(statuses: %w[pending_conditions rejected], candidate: candidate) }
+
+      it 'returns only the application choices that do not have ACCEPTED STATES' do
+        component = described_class.new(candidate: candidate)
+
+        expect(component.application_choices.count).to eq(1)
+        expect(component.application_choices.first.status).to eq('rejected')
+      end
+    end
+
+    context 'when there are application choices associated with multiple application forms' do
+      let(:previous_application_form) { create(:application_form, candidate: candidate, submitted_at: 10.days.ago) }
+      let!(:first_unsuccessful_application_choice) { create(:application_choice, :with_rejection, id: 1, application_form: previous_application_form) }
+      let!(:second_unsuccessful_application_choice) { create(:application_choice, :with_rejection, id: 2, application_form: current_application_form) }
+      let!(:third_unsuccessful_application_choice) { create(:application_choice, :with_accepted_offer, id: 3, application_form: current_application_form) }
+      let!(:current_application_form) { create(:application_form, candidate: candidate, submitted_at: 3.days.ago, previous_application_form_id: previous_application_form.id) }
+
+      it "returns all previous application choices and current application choices that do not have an 'ACCEPTED_STATE'" do
+        component = described_class.new(candidate: candidate)
+
+        expect(component.application_choices).to match_array([second_unsuccessful_application_choice, first_unsuccessful_application_choice])
+      end
+    end
+  end
+
+  def create_application_form_with_course_choices(statuses:, candidate:)
+    application_form = create(:application_form, candidate: candidate)
+
+    statuses.each do |status|
+      create(
+        :application_choice,
+        application_form: application_form,
+        status: status,
+      )
+    end
+
+    application_form
+  end
+end

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -204,7 +204,9 @@ RSpec.feature 'Candidate submits the application' do
   end
 
   def when_i_click_view_application
-    click_link 'View application'
+    within '.govuk-hint' do
+      click_link 'View application'
+    end
   end
 
   def then_i_can_see_my_submitted_application


### PR DESCRIPTION
## Context

To enable candidates to see feedback or content from previous applications, this adds a summary table to the bottom of the dashboard.

The table displays 1 row per course applied to, not per "round", so 3 courses applied to in one application should display as 3 rows.

In addition, when a candidate has accepted an offer, any other courses they applied to at the same time should appear within this table, rather than further up the page as a more detailed summary.

## Changes proposed in this pull request

- Create PreviousApplications component
- Any application choices from previous application forms **and** any application choices from current application forms that do not have an [ACCEPTED](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/services/application_state_change.rb#L8) state will appear in the PreviousApplications component
- Where a current application has an application choice in an ACCEPTED state, all other application choices (not in the ACCEPTED state) will no longer be displayed in the CourseChoicesReview component. These will instead be displayed in the PreviousApplications component that appears below

# Screenshot 

<img width="465" alt="application_choices_v2" src="https://user-images.githubusercontent.com/5256922/112493541-2a4abe00-8d7a-11eb-8601-97ff3ebb47bb.png">

## Link to Trello card

https://trello.com/c/5oEXieEN/3193-add-previous-applications-table-to-bottom-of-dashboard-view

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
