### PR TITLE
Add change_offer wrapper and refactor make offer wrapper

### DIFF
--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -1,0 +1,32 @@
+class ChangeOffer
+  attr_reader :actor, :application_choice, :course_option, :conditions
+
+  def initialize(actor:,
+                 application_choice:,
+                 course_option:,
+                 conditions: [])
+    @actor = actor
+    @application_choice = application_choice
+    @course_option = course_option
+    @conditions = conditions
+  end
+
+  def save!
+    change_an_offer = ChangeAnOffer.new(actor: actor,
+                                        application_choice: application_choice,
+                                        course_option: course_option,
+                                        offer_conditions: conditions)
+    unless change_an_offer.save
+      if change_an_offer.errors[:base].include?('The new offer is identical to the current offer')
+        raise IdenticalOfferError, 'The new offer is identical to the current offer'
+      elsif change_an_offer.errors[:course_option].present?
+        raise CourseValidationError, change_an_offer.errors[:course_option].join
+      else
+        raise 'Unable to complete save on change_an_offer'
+      end
+    end
+  end
+
+  class IdenticalOfferError < StandardError; end
+  class CourseValidationError < StandardError; end
+end

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -16,10 +16,13 @@ class MakeOffer
                                     application_choice: application_choice,
                                     course_option: course_option,
                                     offer_conditions: conditions)
-    make_an_offer.save
 
-    if make_an_offer.errors[:base].include?(MakeAnOffer::STATE_TRANSITION_ERROR)
-      ApplicationStateChange.new(application_choice).make_offer!
+    unless make_an_offer.save
+      if make_an_offer.errors[:base].include?(MakeAnOffer::STATE_TRANSITION_ERROR)
+        ApplicationStateChange.new(application_choice).make_offer!
+      else
+        raise 'Unable to complete save on make_an_offer'
+      end
     end
   end
 end

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.describe ChangeOffer do
+  include CourseOptionHelpers
+
+  let(:change_offer) do
+    ChangeOffer.new(actor: provider_user,
+                    application_choice: application_choice,
+                    course_option: course_option,
+                    conditions: conditions)
+  end
+
+  describe '#save!' do
+    let(:application_choice) { create(:application_choice) }
+    let(:course_option) { course_option_for_provider(provider: application_choice.course_option.provider) }
+    let(:provider_user) { create(:provider_user, providers: [build(:provider)]) }
+    let(:conditions) { [Faker::Lorem.sentence] }
+
+    describe 'if the actor is not authorised to perform this action' do
+      it 'throws an exception' do
+        expect {
+          change_offer.save!
+        }.to raise_error(
+          ProviderAuthorisation::NotAuthorisedError,
+          'You are not permitted to view this application. The specified course is not associated with any of your organisations. You do not have the required user level permissions to make decisions on applications for this provider.',
+        )
+      end
+    end
+
+    describe 'if the new offer is identical to the current offer' do
+      let(:application_choice) { create(:application_choice) }
+      let(:provider_user) do
+        create(:provider_user,
+               :with_make_decisions,
+               providers: [application_choice.offered_option.provider])
+      end
+
+      let(:change_offer) do
+        ChangeOffer.new(actor: provider_user,
+                        application_choice: application_choice,
+                        course_option: application_choice.offered_option,
+                        conditions: ['DBS check'])
+      end
+
+      it 'raises an IdenticalOfferError' do
+        application_choice.update(offer: { 'conditions' => ['DBS check'] })
+
+        expect {
+          change_offer.save!
+        }.to raise_error(
+          ChangeOffer::IdenticalOfferError,
+          'The new offer is identical to the current offer',
+        )
+      end
+    end
+
+    describe 'if the new offer is for a course not open on apply' do
+      let(:course_option) do
+        course_option_for_provider(
+          provider: application_choice.course_option.provider,
+          course: create(:course, provider: application_choice.course_option.provider, open_on_apply: false),
+        )
+      end
+
+      let(:provider_user) do
+        create(:provider_user,
+               :with_make_decisions,
+               providers: [application_choice.course_option.provider])
+      end
+
+      it 'raises a Course Validation Error' do
+        expect {
+          change_offer.save!
+        }.to raise_error(
+          ChangeOffer::CourseValidationError,
+          'is not open for applications via the Apply service',
+        )
+      end
+    end
+
+    describe 'if the .save returns false for any reason' do
+      it 'throws an exception' do
+        change_an_offer = instance_double(ChangeAnOffer)
+        allow(ChangeAnOffer).to receive(:new).and_return(change_an_offer)
+        allow(change_an_offer).to receive(:save).and_return(false)
+        allow(change_an_offer).to receive(:errors).and_return({ base: [] })
+
+        expect {
+          change_offer.save!
+        }.to raise_error('Unable to complete save on change_an_offer')
+      end
+    end
+
+    describe 'if the provided details are correct' do
+      let(:application_choice) { create(:application_choice, status: :awaiting_provider_decision) }
+      let(:provider_user) do
+        create(:provider_user,
+               :with_make_decisions,
+               providers: [application_choice.course_option.provider])
+      end
+
+      it 'then it executes the service without errors ' do
+        set_declined_by_default = instance_double(SetDeclineByDefault, call: true)
+        allow(SetDeclineByDefault)
+            .to receive(:new).with(application_form: application_choice.application_form)
+                    .and_return(set_declined_by_default)
+
+        change_offer.save!
+
+        expect(SetDeclineByDefault).to have_received(:new).with(application_form: application_choice.application_form)
+      end
+    end
+  end
+end

--- a/spec/services/make_offer_spec.rb
+++ b/spec/services/make_offer_spec.rb
@@ -42,6 +42,19 @@ RSpec.describe MakeOffer do
       end
     end
 
+    describe 'if the .save returns false for any reason' do
+      it 'throws an exception' do
+        make_an_offer = instance_double(MakeAnOffer)
+        allow(MakeAnOffer).to receive(:new).and_return(make_an_offer)
+        allow(make_an_offer).to receive(:save).and_return(false)
+        allow(make_an_offer).to receive(:errors).and_return({ base: [] })
+
+        expect {
+          make_offer.save!
+        }.to raise_error('Unable to complete save on make_an_offer')
+      end
+    end
+
     describe 'if the provided details are correct' do
       let(:application_choice) { create(:application_choice, status: :awaiting_provider_decision) }
       let(:provider_user) do
@@ -54,11 +67,11 @@ RSpec.describe MakeOffer do
         set_declined_by_default = instance_double(SetDeclineByDefault, call: true)
         send_new_offer_email_to_candidate = instance_double(SendNewOfferEmailToCandidate, call: true)
         allow(SetDeclineByDefault)
-          .to receive(:new).with(application_form: application_choice.application_form)
-          .and_return(set_declined_by_default)
+            .to receive(:new).with(application_form: application_choice.application_form)
+                    .and_return(set_declined_by_default)
         allow(SendNewOfferEmailToCandidate)
-          .to receive(:new).with(application_choice: application_choice)
-          .and_return(send_new_offer_email_to_candidate)
+            .to receive(:new).with(application_choice: application_choice)
+                    .and_return(send_new_offer_email_to_candidate)
 
         make_offer.save!
 


### PR DESCRIPTION
## Context

Adding wrapper services for make_an_offer and change_an_offer for the Offer workflow stuff

## Changes proposed in this pull request

Added a change_offer wrapper to the change_an_offer service, and refactored the make_offer wrapper to simplify the validation. 

## Trello card

https://trello.com/c/9I0RTTts
