### PR TITLE
Add course validation service to offer wizard

### DIFF
--- a/app/services/offered_course_option_details_check.rb
+++ b/app/services/offered_course_option_details_check.rb
@@ -19,9 +19,9 @@ class OfferedCourseOptionDetailsCheck
     course_option_id:,
     study_mode:
   )
-    @provider_id = provider_id
-    @course_id = course_id
-    @course_option_id = course_option_id
+    @provider_id = provider_id.to_i
+    @course_id = course_id.to_i
+    @course_option_id = course_option_id.to_i
     @study_mode = study_mode
   end
 

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe ProviderInterface::OfferWizard do
     it { is_expected.to validate_length_of(:further_condition_2).is_at_most(255) }
     it { is_expected.to validate_length_of(:further_condition_3).is_at_most(255) }
     it { is_expected.to validate_length_of(:further_condition_4).is_at_most(255) }
+
+    context 'if the course option is in an invalid state' do
+      let(:course_option) { create(:course_option) }
+      let(:course_option_id) { course_option.id }
+      let(:course_id) { course_option.course.id }
+      let(:provider_id) { create(:provider).id }
+      let(:study_mode) { course_option.study_mode }
+
+      it 'throws an error' do
+        expect(wizard.valid?(:save)).to eq(false)
+      end
+    end
   end
 
   describe '#next_step' do


### PR DESCRIPTION
## Context

So that the wizard can check that the state is valid prior to saving in the DB. 

## Link to Trello card

https://trello.com/c/BTeMRGjF/3534-integrate-course-offer-details-validation-service-to-offer-wizard

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
