### PR TITLE
Use GovukComponent::BackLink

### DIFF
--- a/app/frontend/styles/_back_link.scss
+++ b/app/frontend/styles/_back_link.scss
@@ -1,8 +1,3 @@
-.app-back-link {
-  @extend .govuk-back-link;
-  @extend .govuk-\!-display-none-print;
-}
-
 .app-back-link--no-js {
   display: none;
 }

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -15,7 +15,7 @@ module ViewHelper
   end
 
   def govuk_back_link_to(url = :back, body = 'Back')
-    classes = 'app-back-link'
+    classes = 'govuk-!-display-none-print'
 
     if url == :back
       url = controller.request.env['HTTP_REFERER'] || 'javascript:history.back()'
@@ -30,7 +30,7 @@ module ViewHelper
       body = 'Back to application'
     end
 
-    link_to(body, url, class: classes)
+    render GovukComponent::BackLink.new(text: body, href: url, classes: classes)
   end
 
   def govuk_button_link_to(body = nil, url = nil, html_options = nil, &block)

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -29,22 +29,22 @@ RSpec.describe ViewHelper, type: :helper do
   end
 
   describe '#govuk_back_link_to' do
-    it 'returns an anchor tag with the app-back-link class and defaults to "Back"' do
+    it 'returns an anchor tag with the govuk-back-link class and defaults to "Back"' do
       anchor_tag = helper.govuk_back_link_to('https://localhost:0103/snek/ssss')
 
-      expect(anchor_tag).to eq('<a class="app-back-link" href="https://localhost:0103/snek/ssss">Back</a>')
+      expect(anchor_tag).to eq("<a class=\"govuk-back-link govuk-!-display-none-print\" href=\"https://localhost:0103/snek/ssss\">Back</a>\n")
     end
 
-    it 'returns an anchor tag with the app-back-link class and with the body if given' do
+    it 'returns an anchor tag with the govuk-back-link class and with the body if given' do
       anchor_tag = helper.govuk_back_link_to('https://localhost:0103/lion/roar', 'Back to application')
 
-      expect(anchor_tag).to eq('<a class="app-back-link" href="https://localhost:0103/lion/roar">Back to application</a>')
+      expect(anchor_tag).to eq("<a class=\"govuk-back-link govuk-!-display-none-print\" href=\"https://localhost:0103/lion/roar\">Back to application</a>\n")
     end
 
     it 'returns an anchor tag with the app-back-link--no-js class if given :back as an argument' do
       anchor_tag = helper.govuk_back_link_to(:back)
 
-      expect(anchor_tag).to eq('<a class="app-back-link app-back-link--fallback app-back-link--no-js" href="javascript:history.back()">Back</a>')
+      expect(anchor_tag).to eq("<a class=\"govuk-back-link govuk-!-display-none-print app-back-link--fallback app-back-link--no-js\" href=\"javascript:history.back()\">Back</a>\n")
     end
   end
 


### PR DESCRIPTION
## Context

We already have the `govuk_back_link_to` helper for back links, so arguably we don’t need to use this component.

However, calling `GovukComponent::BackLink` from within this helper means we can refactor our back links to stop serving additional and duplicated CSS.

## Changes proposed in this pull request

Calls `GovukComponent::BackLink` from within `govuk_back_link_to`. As the component uses `govuk-back-link` class, we no longer need to add duplicate styles for `app-back-link`.

## Guidance to review

Does this make sense? I think we could do similarly for our button helpers.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
