### PR TITLE
Add matrix job to run rspec tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,3 +82,59 @@ jobs:
     
     - run:  bundle exec rake brakeman
       name: Brakeman
+
+  test:
+    name: Tests
+    needs: [build]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tests: [unit, integration]
+        feature-flags: [on, off]
+        include:
+          - tests: unit
+            include-pattern: spec/**/**/*_spec.rb
+            exclude-pattern: spec/{system,requests}/**/*_spec.rb
+          - tests: integration
+            include-pattern: spec/{system,requests}/**/*_spec.rb            
+            exclude-pattern: spec/**/**/*_spec.rb
+    services:
+      redis: 
+        image: redis:alpine
+        ports:
+          - 6379:6379
+      postgres:
+        image: postgres:11.10
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+        - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    defaults:
+      run:
+        working-directory: /app
+    container: 
+      image: ghcr.io/dfe-digital/apply-teacher-training:paas-${{ github.sha }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GH_CONTAINER_REGISTRY_TOKEN }}
+      env:
+        RAILS_ENV: test
+        DB_HOSTNAME: postgres
+        DB_USERNAME: postgres
+        DB_PASSWORD: postgres
+        REDIS_URL: redis://redis:6379/0
+        DB_PORT: 5432
+    steps:
+      - name: Setup Database
+        run: bundle exec rake db:setup
+
+      - name: ${{ matrix.tests }} tests with feature flags ${{ matrix.feature-flags }}
+        run: bundle exec --verbose rspec --exclude-pattern ${EXCLUDE_PATTERN} --pattern ${INCLUDE_PATTERN} --format documentation
+        env:
+          INCLUDE_PATTERN: ${{ matrix.include-pattern }}
+          EXCLUDE_PATTERN: ${{ matrix.exclude-pattern }}
+          DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}


### PR DESCRIPTION
## Context

Run Unit and Integration tests in GitHub Actions workflow as part of moving to PaaS.

## Changes proposed in this pull request

Run rspec jobs.
Run a matrix of unit, integration tests with feature flags ON and OFF 


FEATURE_FLAG_STATE | Tests | INCLUDE_PATTERN | EXCLUDE_PATTERN
------------ | ------------- |------------ |------------
ON | unit | `specs/**/*_spec.rb` | `spec/{system,requests}/**/*_spec.rb` 
OFF | unit  | `specs/**/*_spec.rb` | `spec/{system,requests}/**/*_spec.rb` 
ON | integration |  `spec/{system,requests}/**/*_spec.rb`  | `specs/**/*_spec.rb`
OFF | integration  | `spec/{system,requests}/**/*_spec.rb ` | `specs/**/*_spec.rb`

To be merged after #4355 

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
