### PR TITLE
Fix Support and Candidate autocompletes

### DIFF
--- a/app/frontend/packs/autocompletes/candidate/__snapshots__/candidate-autocomplete-inputs.spec.js.snap
+++ b/app/frontend/packs/autocompletes/candidate/__snapshots__/candidate-autocomplete-inputs.spec.js.snap
@@ -5,14 +5,14 @@ Array [
   Object {
     "autocompleteId": "country-autocomplete",
     "inputIds": Array [
-      "#candidate-interface-contact-details-form-country-field",
-      "#candidate-interface-contact-details-form-country-field-error",
-      "#candidate-interface-degree-institution-form-institution-country-field",
-      "#candidate-interface-degree-institution-form-institution-country-field-error",
-      "#candidate-interface-gcse-institution-country-form-institution-country-field",
-      "#candidate-interface-gcse-institution-country-form-institution-country-field-error",
-      "#candidate-interface-other-qualification-details-form-institution-country-field",
-      "#candidate-interface-other-qualification-form-institution-country-field-error",
+      "candidate-interface-contact-details-form-country-field",
+      "candidate-interface-contact-details-form-country-field-error",
+      "candidate-interface-degree-institution-form-institution-country-field",
+      "candidate-interface-degree-institution-form-institution-country-field-error",
+      "candidate-interface-gcse-institution-country-form-institution-country-field",
+      "candidate-interface-gcse-institution-country-form-institution-country-field-error",
+      "candidate-interface-other-qualification-details-form-institution-country-field",
+      "candidate-interface-other-qualification-form-institution-country-field-error",
     ],
   },
   Object {

--- a/app/frontend/packs/autocompletes/candidate/__snapshots__/candidate-autocomplete-inputs.spec.js.snap
+++ b/app/frontend/packs/autocompletes/candidate/__snapshots__/candidate-autocomplete-inputs.spec.js.snap
@@ -12,7 +12,7 @@ Array [
       "candidate-interface-gcse-institution-country-form-institution-country-field",
       "candidate-interface-gcse-institution-country-form-institution-country-field-error",
       "candidate-interface-other-qualification-details-form-institution-country-field",
-      "candidate-interface-other-qualification-form-institution-country-field-error",
+      "candidate-interface-other-qualification-details-form-institution-country-field-error",
     ],
   },
   Object {

--- a/app/frontend/packs/autocompletes/candidate/candidate-autocomplete-inputs.js
+++ b/app/frontend/packs/autocompletes/candidate/candidate-autocomplete-inputs.js
@@ -1,13 +1,13 @@
 const countryAutocompleteInputs = {
   inputIds: [
-    '#candidate-interface-contact-details-form-country-field',
-    '#candidate-interface-contact-details-form-country-field-error',
-    '#candidate-interface-degree-institution-form-institution-country-field',
-    '#candidate-interface-degree-institution-form-institution-country-field-error',
-    '#candidate-interface-gcse-institution-country-form-institution-country-field',
-    '#candidate-interface-gcse-institution-country-form-institution-country-field-error',
-    '#candidate-interface-other-qualification-details-form-institution-country-field',
-    '#candidate-interface-other-qualification-form-institution-country-field-error'
+    'candidate-interface-contact-details-form-country-field',
+    'candidate-interface-contact-details-form-country-field-error',
+    'candidate-interface-degree-institution-form-institution-country-field',
+    'candidate-interface-degree-institution-form-institution-country-field-error',
+    'candidate-interface-gcse-institution-country-form-institution-country-field',
+    'candidate-interface-gcse-institution-country-form-institution-country-field-error',
+    'candidate-interface-other-qualification-details-form-institution-country-field',
+    'candidate-interface-other-qualification-form-institution-country-field-error'
   ],
   autocompleteId: 'country-autocomplete'
 }

--- a/app/frontend/packs/autocompletes/candidate/candidate-autocomplete-inputs.js
+++ b/app/frontend/packs/autocompletes/candidate/candidate-autocomplete-inputs.js
@@ -7,7 +7,7 @@ const countryAutocompleteInputs = {
     'candidate-interface-gcse-institution-country-form-institution-country-field',
     'candidate-interface-gcse-institution-country-form-institution-country-field-error',
     'candidate-interface-other-qualification-details-form-institution-country-field',
-    'candidate-interface-other-qualification-form-institution-country-field-error'
+    'candidate-interface-other-qualification-details-form-institution-country-field-error'
   ],
   autocompleteId: 'country-autocomplete'
 }

--- a/app/frontend/packs/autocompletes/support/__snapshots__/support-autocomplete-inputs.spec.js.snap
+++ b/app/frontend/packs/autocompletes/support/__snapshots__/support-autocomplete-inputs.spec.js.snap
@@ -5,14 +5,14 @@ Array [
   Object {
     "autocompleteId": "api-token-autocomplete",
     "inputIds": Array [
-      "#vendor-api-token-provider-id-field.govuk-select",
+      "vendor-api-token-provider-id-field",
     ],
   },
   Object {
     "autocompleteId": "country-autocomplete",
     "inputIds": Array [
-      "#support-interface-application-forms-edit-address-details-form-country-field",
-      "#support-interface-application-forms-edit-address-details-form-country-field-error",
+      "support-interface-application-forms-edit-address-details-form-country-field",
+      "support-interface-application-forms-edit-address-details-form-country-field-error",
     ],
   },
 ]

--- a/app/frontend/packs/autocompletes/support/support-autocomplete-inputs.js
+++ b/app/frontend/packs/autocompletes/support/support-autocomplete-inputs.js
@@ -1,14 +1,14 @@
 const apiTokenAutocomplete = {
   inputIds: [
-    '#vendor-api-token-provider-id-field.govuk-select'
+    'vendor-api-token-provider-id-field'
   ],
   autocompleteId: 'api-token-autocomplete'
 }
 
 const countryAutocompleteInputs = {
   inputIds: [
-    '#support-interface-application-forms-edit-address-details-form-country-field',
-    '#support-interface-application-forms-edit-address-details-form-country-field-error'
+    'support-interface-application-forms-edit-address-details-form-country-field',
+    'support-interface-application-forms-edit-address-details-form-country-field-error'
   ],
   autocompleteId: 'country-autocomplete'
 }


### PR DESCRIPTION
We included # at the head of IDs, and in one case a .classs suffix, which didn't work with getElementById. This broke a few autocompletes for candidates and in support.