### PR TITLE
Add candidate offer withdrawn email

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -309,6 +309,18 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def offer_withdrawn(application_choice)
+    @course_name_and_code = application_choice.offered_option.course.name_and_code
+    @provider_name = application_choice.offered_option.provider.name
+    @withdrawal_reason = application_choice.offer_withdrawal_reason
+    @candidate_magic_link = candidate_magic_link(application_choice.application_form.candidate)
+
+    email_for_candidate(
+      application_choice.application_form,
+      subject: I18n.t!('candidate_mailer.offer_withdrawn.subject', provider_name: @provider_name),
+    )
+  end
+
   def offer_accepted(application_choice)
     @course_name_and_code = application_choice.offered_option.course.name_and_code
     @provider_name = application_choice.offered_option.provider.name

--- a/app/services/withdraw_offer.rb
+++ b/app/services/withdraw_offer.rb
@@ -27,6 +27,9 @@ class WithdrawOffer
         )
         SetDeclineByDefault.new(application_form: @application_choice.application_form).call
       end
+
+      CandidateMailer.offer_withdrawn(@application_choice).deliver_later
+
       true
     end
   rescue Workflow::NoTransitionAllowed

--- a/app/views/candidate_mailer/offer_withdrawn.text.erb
+++ b/app/views/candidate_mailer/offer_withdrawn.text.erb
@@ -1,0 +1,14 @@
+Dear <%= @application_form.first_name %>,
+
+# Offer withdrawn
+
+<%= @provider_name %> has withdrawn their offer for you to study <%= @course_name_and_code %>. They’ve given feedback to explain this decision.
+
+^ # Why the offer was withdrawn
+^ <%= @withdrawal_reason %>
+
+Contact <%= @provider_name %> directly if you have questions about why they’ve withdrawn the offer.
+
+# You can apply again
+
+<%= render 'still_interested_content' %>

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -150,6 +150,8 @@ en:
         The provider has made an offer but withdrew it later.
 
         This is called `rejected` in the API.
+      emails:
+        - candidate_mailer-offer_withdrawn
 
     withdrawn:
       name: Withdrawn

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -20,6 +20,8 @@ en:
       subject: "%{referee_name} has not responded yet"
     chase_reference_again:
       subject: "%{referee_name} has not responded yet"
+    offer_withdrawn:
+      subject: "Offer withdrawn by %{provider_name}"
     offer_accepted:
       subject: "You’ve accepted %{provider_name}’s offer to study %{course_name_and_code}"
     unconditional_offer_accepted:

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -211,6 +211,37 @@ RSpec.describe CandidateMailer, type: :mailer do
     )
   end
 
+  describe '.offer_withdrawn' do
+    let(:email) { described_class.offer_withdrawn(application_form.application_choices.first) }
+    let(:application_choices) do
+      [build_stubbed(
+        :application_choice,
+        status: 'offer_withdrawn',
+        offer_withdrawal_reason: 'You lied to us about secretly being Spiderman',
+        course_option: build_stubbed(
+          :course_option,
+          course: build_stubbed(
+            :course,
+            name: 'Mathematics',
+            code: 'M101',
+            provider: build_stubbed(
+              :provider,
+              name: 'Arachnid College',
+            ),
+          ),
+        ),
+      )]
+    end
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Offer withdrawn by Arachnid College',
+      'greeting' => 'Dear Fred,',
+      'offer details' => 'Arachnid College has withdrawn their offer for you to study Mathematics (M101)',
+      'withdrawal reason' => 'You lied to us about secretly being Spiderman',
+    )
+  end
+
   describe '.offer_accepted' do
     let(:email) { described_class.offer_accepted(application_form.application_choices.first) }
     let(:application_choices) do

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -401,6 +401,16 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.reference_received(reference)
   end
 
+  def offer_withdrawn
+    candidate = FactoryBot.build_stubbed(:candidate)
+    application_choice = FactoryBot.build_stubbed(
+      :application_choice,
+      offer_withdrawal_reason: Faker::Lorem.sentence,
+      application_form: FactoryBot.build_stubbed(:application_form, first_name: 'Geoff', candidate: candidate),
+    )
+    CandidateMailer.offer_withdrawn(application_choice)
+  end
+
   def offer_accepted
     application_choice = FactoryBot.build_stubbed(:application_choice)
     CandidateMailer.offer_accepted(application_choice)


### PR DESCRIPTION
## Context
Candidates are not currently notified if their offer is withdrawn

## Changes proposed in this pull request
Add an email that is sent when a provider withdraws an offer

<img width="400" alt="Screenshot 2021-03-25 at 09 59 09" src="https://user-images.githubusercontent.com/30071178/112454683-db3c6300-8d50-11eb-9db2-68f68fa8b1a5.png">


## Guidance to review
Is there any more documentation to add?

Candidate team requested that this email is added to the `email send counts` export. I don't think there is anything extra to do for this though?

## Link to Trello card
https://trello.com/c/FiLvd1oO/3504-implement-unstructured-email-to-communicate-reasons-why-offer-was-withdrawn-by-provider-to-candidates

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
