### PR TITLE
Add line break in release notes markdown to properly render bullet list

### DIFF
--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -3,6 +3,7 @@
 The following experimental/sandbox endpoint has been updated:
 
 `/test-data/generate` is now asynchronous:
+
 - A POST request to this endpoint will queue a job to generate the specified test applications.
 - The list of created application IDs will no longer be returned.
 - The new applications will become available as soon as they have been generated.


### PR DESCRIPTION
## Context
This doesn't render properly on the site. It looks fine elsewhere though
