### PR TITLE
Refactor queries where multiple args are passed into where.not

### DIFF
--- a/app/services/support_interface/candidate_autofill_usage_export.rb
+++ b/app/services/support_interface/candidate_autofill_usage_export.rb
@@ -110,6 +110,8 @@ module SupportInterface
         )
         .where.not(
           qualification_type: 'non_uk',
+        )
+        .where.not(
           application_forms: {
             submitted_at: nil,
           },

--- a/app/services/support_interface/referee_survey_export.rb
+++ b/app/services/support_interface/referee_survey_export.rb
@@ -1,7 +1,10 @@
 module SupportInterface
   class RefereeSurveyExport
     def call
-      non_duplicate_references = ApplicationReference.includes(:application_form).where.not(questionnaire: nil, duplicate: true)
+      non_duplicate_references = ApplicationReference
+                                  .includes(:application_form)
+                                  .where.not(questionnaire: nil)
+                                  .where.not(duplicate: true)
       references_with_feedback = non_duplicate_references.reject do |reference|
         reference.questionnaire.values.all? { |response| response == ' | ' }
       end


### PR DESCRIPTION
## Context

This functionality is being deprecated in Rails 6.1 and needs to be fixed before we upgrade.

It also stops the deprecation spam we're getting when we run the test suite.

## Changes proposed in this pull request

- Refactor `where.not` queries with multiple args to only pass in one argument

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
