### PR TITLE
Never display header as part of conditions component

### DIFF
--- a/app/components/provider_interface/conditions_component.html.erb
+++ b/app/components/provider_interface/conditions_component.html.erb
@@ -1,4 +1,3 @@
-<% if show_header? %><h2 class="govuk-heading-s">Conditions</h2><% end %>
 <table class="govuk-table govuk-!-margin-bottom-2">
   <tbody class="govuk-table__body">
     <% condition_rows.each do |row| %>

--- a/app/components/provider_interface/conditions_component.rb
+++ b/app/components/provider_interface/conditions_component.rb
@@ -4,9 +4,8 @@ module ProviderInterface
 
     attr_reader :application_choice
 
-    def initialize(application_choice:, show_header: true)
+    def initialize(application_choice:)
       @application_choice = application_choice
-      @show_header = show_header
     end
 
     def render?
@@ -33,10 +32,6 @@ module ProviderInterface
 
     def known_conditions_state?
       conditions_met? || application_state.conditions_not_met?
-    end
-
-    def show_header?
-      @show_header
     end
   end
 end

--- a/app/components/provider_interface/deferred_offer_details_component.html.erb
+++ b/app/components/provider_interface/deferred_offer_details_component.html.erb
@@ -4,4 +4,4 @@
 
 <h2 class="govuk-heading-m">Conditions of offer</h2>
 
-<%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice, show_header: false) %>
+<%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
@@ -18,5 +18,5 @@
   </p>
   <% end %>
 
-  <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice, show_header: false) %>
+  <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
 </div>

--- a/app/views/provider_interface/conditions/edit.html.erb
+++ b/app/views/provider_interface/conditions/edit.html.erb
@@ -26,7 +26,7 @@
         Conditions
       </h2>
 
-      <%= render ProviderInterface::ConditionsComponent.new(application_choice: @application_choice, show_header: false) %>
+      <%= render ProviderInterface::ConditionsComponent.new(application_choice: @application_choice) %>
 
       <%= f.govuk_radio_buttons_fieldset :conditions_met, legend: { text: 'Has the candidate met all of the conditions?', size: 'm' } do %>
         <%= f.govuk_radio_button :conditions_met, 'yes', label: { text: 'Yes, they’ve met all of the conditions' }, link_errors: true %>

--- a/app/views/provider_interface/reconfirm_deferred_offers/conditions.html.erb
+++ b/app/views/provider_interface/reconfirm_deferred_offers/conditions.html.erb
@@ -12,7 +12,7 @@
       </h1>
 
       <div class="app-offer-panel govuk-!-margin-bottom-7">
-        <%= render ProviderInterface::ConditionsComponent.new(application_choice: @wizard.modified_application_choice, show_header: false) %>
+        <%= render ProviderInterface::ConditionsComponent.new(application_choice: @wizard.modified_application_choice) %>
       </div>
 
       <% met = @wizard.modified_application_choice.status == 'recruited' ? 'still met' : 'met' %>


### PR DESCRIPTION
As a variety of header sizes is used depending on where this component is referenced from, there is never the need to display the header as part of it as it always duplicates the mention of `Conditions`

## Context

This resolves the double condition header displayed across different application choice states on the offer tba

## Guidance to review

- View the offer summary of an application that is in any of the following states: offer_deferred, declined, conditions_not_met, offer, recruited, pending_conditions, offer_withdrawn 

- The issue can also be replicated on the deferred offer confirmation page, confirm update page and, edit offer page.

### Before

<img width="758" alt="offer_summary_before" src="https://user-images.githubusercontent.com/159200/112495332-b7dadd80-8d7b-11eb-834f-81da33ea435e.png">

### After

<img width="734" alt="offer_summary_after" src="https://user-images.githubusercontent.com/159200/112495374-c1fcdc00-8d7b-11eb-8e1f-4040ccb04245.png">


## Link to Trello card

https://trello.com/c/F3R1jAzt/3538-double-conditions-in-offer-summary-and-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
