### PR TITLE
Decrease chances of duplicate emails in test data

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -116,7 +116,7 @@ private
       previous_application_form = nil
       candidate = candidate.presence || FactoryBot.create(
         :candidate,
-        email_address: "#{first_name.downcase}.#{last_name.downcase}@example.com",
+        email_address: "#{first_name.downcase}.#{last_name.downcase}#{rand(10000)}@example.com",
         created_at: time,
         last_signed_in_at: time,
       )


### PR DESCRIPTION
## Context
There are higher volumes of test applications being added to sandbox, and the email addresses we generate aren't complicated enough to avoid duplicates

## Changes proposed in this pull request
Append a number to test email addresses to prevent making duplicate emails

## Guidance to review
Hopefully simple

## Link to Trello card
https://trello.com/c/zS5hJ8CB/3495-error-when-generating-test-data-for-existing-candidate-in-sandbox-via-api

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x]  This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
