### PR TITLE
Migration to backfill the export_type column in Data Exports

### DIFF
--- a/app/services/data_migrations/backfill_export_type.rb
+++ b/app/services/data_migrations/backfill_export_type.rb
@@ -1,0 +1,14 @@
+module DataMigrations
+  class BackfillExportType
+    TIMESTAMP = 20210326113829
+    MANUAL_RUN = false
+
+    def change
+      data_exports = DataExport.all.where(export_type: nil)
+
+      data_exports.each do |export|
+        export.update!(export_type: export.name.parameterize.underscore)
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillExportType',
 ].freeze
 
 def data_migrations

--- a/spec/factories/data_export.rb
+++ b/spec/factories/data_export.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :data_export do
+    name { 'Active provider user permissions' }
+    export_type { 'Active provider user permissions' }
+  end
+end

--- a/spec/services/data_migrations/backfill_export_type_spec.rb
+++ b/spec/services/data_migrations/backfill_export_type_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillExportType do
+  it 'backfills the export_type column in Data Exports' do
+    data_export = create(:data_export, export_type: nil)
+
+    described_class.new.change
+    expect(data_export.reload.export_type).to eq 'active_provider_user_permissions'
+  end
+end


### PR DESCRIPTION
## Context

This is to backfill the new column added in [#4364](https://github.com/DFE-Digital/apply-for-teacher-training/pull/4364)

## Changes proposed in this pull request

backfill any export_types columns that are still nil 

## Guidance to review

Also part of [4318](https://github.com/DFE-Digital/apply-for-teacher-training/pull/4318)

## Link to Trello card

https://trello.com/c/VOjhcHfX/3159-data-directory

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
