### PR TITLE
Unconditional Offers can't be submitted through Manage

### DIFF
--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -84,7 +84,7 @@ module ProviderInterface
         actor: current_provider_user,
         application_choice: @application_choice,
         course_option: course_option,
-        offer_conditions: params.dig(:offer_conditions),
+        offer_conditions: params.fetch(:offer_conditions, []),
       )
 
       if @application_offer.save

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -43,6 +43,32 @@ RSpec.describe MakeAnOffer, sidekiq: true do
     end
   end
 
+  describe '#offer_conditions' do
+    context 'when there are no offer conditions' do
+      it 'returns an empty array' do
+        decision = MakeAnOffer.new(
+          actor: user,
+          application_choice: application_choice,
+          course_option: valid_course_option,
+          offer_conditions: [],
+        )
+        expect(decision.offer_conditions).to eq([])
+      end
+    end
+
+    context 'when no offer conditions are specified' do
+      it 'returns a combination of standard and further conditions' do
+        decision = MakeAnOffer.new(
+          actor: user,
+          application_choice: application_choice,
+          course_option: valid_course_option,
+          further_conditions: [],
+        )
+        expect(decision.offer_conditions).to eq(MakeAnOffer::STANDARD_CONDITIONS)
+      end
+    end
+  end
+
   describe '#save' do
     it 'sets the offered_at date' do
       offer = MakeAnOffer.new(actor: user, application_choice: application_choice, course_option: valid_course_option)


### PR DESCRIPTION
Update service to cater for empty condition array, this ensures support for unconditional offers and enables use of the service to validate data. 

## Link to Trello card

https://trello.com/c/h4CaMKp2/3532-unconditional-offers-cant-be-submitted-through-manage%F0%9F%91%80

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
