### PR TITLE
Account for KeyError being raised by ActiveSupport::TimeZone

### DIFF
--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -35,12 +35,16 @@ module VendorAPI
     end
 
     def since_param
-      since = Time.zone.iso8601(params.fetch(:since))
-      raise ParameterInvalid, 'Parameter is invalid (date is nonsense): since' unless since.year.positive?
+      since_value = params.fetch(:since)
 
-      since
-    rescue ArgumentError
-      raise ParameterInvalid, 'Parameter is invalid (should be ISO8601): since'
+      begin
+        since = Time.zone.iso8601(since_value)
+        raise ParameterInvalid, 'Parameter is invalid (date is nonsense): since' unless since.year.positive?
+
+        since
+      rescue ArgumentError, KeyError
+        raise ParameterInvalid, 'Parameter is invalid (should be ISO8601): since'
+      end
     end
   end
 end

--- a/spec/requests/vendor_api/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/get_multiple_applications_spec.rb
@@ -72,6 +72,16 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
     expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): since')
   end
 
+  it 'returns HTTP status 422 when encountering a KeyError from ActiveSupport::TimeZone' do
+    get_api_request '/api/v1/applications?since=12936'
+
+    expect(response).to have_http_status(422)
+
+    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+
+    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): since')
+  end
+
   it 'returns HTTP status 422 given a parseable but nonsensensical `since` date value' do
     get_api_request '/api/v1/applications?since=-004713-03-23T11:52:19.448Z' # this happened
 


### PR DESCRIPTION
## Context

It's possible to supply a value which is parsed internally by `ActiveSupport::TimeZone` (by `Date._iso8601`) but doesn't contain the expected fields.
A `KeyError` is raised in this case, which is possibly due to over-optimistic expectations in the `ActiveSupport::TimeZone.iso8601` method or a bug in the underlying call to `Date._iso8601`.

<!-- Why are you making this change? What might surprise someone about it? -->

I've also raised an issue [here](https://github.com/rails/rails/issues/41763) arguably this is a problem with the ruby `Date._iso8601` method but may be of interest to the rails maintainers.

## Changes proposed in this pull request

This commit rescues from this type of error to gracefully handle the invalid parameter format.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Details of Sentry exception https://sentry.io/organizations/dfe-bat/issues/2296340364/?project=1765973&referrer=slack

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Oy3lRIEA/3539-gracefully-handle-api-parameters-we-do-not-support
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
