### PR TITLE
Only retrieve study modes of course options with vacancies

### DIFF
--- a/app/forms/candidate_interface/pick_course_form.rb
+++ b/app/forms/candidate_interface/pick_course_form.rb
@@ -45,7 +45,7 @@ module CandidateInterface
     end
 
     def single_site?
-      CourseOption.where(course_id: course.id).one?
+      Course.find(course_id).course_options.available.one?
     end
 
     def courses_for_current_cycle

--- a/app/forms/candidate_interface/pick_study_mode_form.rb
+++ b/app/forms/candidate_interface/pick_study_mode_form.rb
@@ -6,7 +6,7 @@ module CandidateInterface
     validates :study_mode, presence: true
 
     def available_sites
-      CourseOption.where(course_id: course_id, study_mode: study_mode)
+      CourseOption.available.where(course_id: course_id, study_mode: study_mode)
     end
 
     def single_site_course?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -85,7 +85,7 @@ class Course < ApplicationRecord
   end
 
   def currently_has_both_study_modes_available?
-    available_study_modes_from_options.count == 2
+    available_study_modes_with_vacancies.count == 2
   end
 
   def supports_study_mode?(mode)
@@ -94,6 +94,10 @@ class Course < ApplicationRecord
 
   def available_study_modes_from_options
     course_options.select(&:site_still_valid).pluck(:study_mode).uniq
+  end
+
+  def available_study_modes_with_vacancies
+    course_options.available.pluck(:study_mode).uniq
   end
 
   def full?

--- a/spec/forms/candidate_interface/pick_course_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_course_form_spec.rb
@@ -135,21 +135,41 @@ RSpec.describe CandidateInterface::PickCourseForm do
 
   describe '#single_site?' do
     let(:provider) { create(:provider, name: 'Royal Academy of Dance', code: 'R55') }
-    let(:course) { create(:course, provider: provider, exposed_in_find: true, open_on_apply: true) }
-    let(:site) { create(:site, provider: provider) }
+    let(:course) { create(:course, :open_on_apply, provider: provider) }
     let(:pick_course_form) { described_class.new(provider_id: provider.id, course_id: course.id) }
+    let(:site) { build(:site, provider: provider) }
 
-    before { create(:course_option, site: site, course: course) }
+    context 'when the is one site for a course' do
+      before do
+        create(:course_option, site: site, course: course)
+      end
 
-    it 'returns true when there is one site for a course' do
-      expect(pick_course_form).to be_single_site
+      it 'returns true' do
+        expect(pick_course_form).to be_single_site
+      end
     end
 
-    it 'returns false when there are more than one site for a course' do
-      another_site = create(:site, provider: provider)
-      create(:course_option, site: another_site, course: course)
+    context 'when the is one site at a course option with no available vacancies' do
+      before do
+        create(:course_option, :no_vacancies, site: site, course: course)
+      end
 
-      expect(pick_course_form).not_to be_single_site
+      it 'returns false' do
+        expect(pick_course_form).not_to be_single_site
+      end
+    end
+
+    context 'when there are multiple sites' do
+      let(:other_site) { build(:site, provider: provider) }
+
+      before do
+        create(:course_option, site: site, course: course)
+        create(:course_option, site: other_site, course: course)
+      end
+
+      it 'returns false' do
+        expect(pick_course_form).not_to be_single_site
+      end
     end
   end
 end

--- a/spec/forms/candidate_interface/pick_study_mode_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_study_mode_form_spec.rb
@@ -1,22 +1,33 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::PickStudyModeForm, type: :model do
-  let!(:course) { create(:course) }
+  let(:course) { build(:course) }
 
   describe '#available_sites' do
-    it 'returns all sites available for the selected course and study mode' do
-      pt_course_one = create(:course_option, course: course, study_mode: :part_time)
-      pt_course_two = create(:course_option, course: course, study_mode: :part_time)
-      create(:course_option, course: course, study_mode: :full_time)
+    before do
+      create_list(:course_option, 2, :no_vacancies, course: course, study_mode: :part_time)
+    end
 
-      form = described_class.new(course_id: course.id, study_mode: :part_time)
+    context 'when there are multiple course sites with no available vacancies for a study mode' do
+      it 'returns no results' do
+        form = described_class.new(course_id: course.id, study_mode: :part_time)
 
-      expect(form.available_sites).to match_array(
-        [
-          pt_course_one,
-          pt_course_two,
-        ],
-      )
+        expect(form.available_sites).to be_empty
+      end
+    end
+
+    context 'when there multiple course sites with available vacancies for a study mode' do
+      let!(:course_options) { create_list(:course_option, 2, :part_time, course: course) }
+
+      before do
+        create_list(:course_option, 2, :full_time, course: course)
+      end
+
+      it 'returns all available sites' do
+        form = described_class.new(course_id: course.id, study_mode: :part_time)
+
+        expect(form.available_sites).to match_array(course_options)
+      end
     end
   end
 


### PR DESCRIPTION
Resolves sentry error caused by candidate ending up on location selection page with no locations rendered due to the selected study mode not having any sites with availability.

https://sentry.io/organizations/dfe-bat/issues/2297226890/?project=1765973&referrer=slack

A new method is introduced as the existing `available_study_mode_from_options` is used on Make Offer, on the provider side, where availability should not be taken into account.


