### PR TITLE
Display DBD information on application page

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -59,7 +59,7 @@
             Review and confirm the deferred offer
           </h2>
 
-          <% if deferred_offer_equivalent_course_option_available %>
+          <% if deferred_offer_equivalent_course_option_available? %>
             <p class="govuk-body">
               The course offered to the candidate in the previous cycle is available in the current cycle.
             </p>

--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -45,7 +45,7 @@
 
           <%= govuk_button_link_to 'Make decision', provider_interface_application_choice_respond_path(application_choice) %>
 
-        <% elsif provider_cannot_respond? -%>
+        <% elsif awaiting_decision_but_cannot_respond? -%>
           <p class="govuk-body">
             <% if time_is_today_or_tomorrow?(application_choice.reject_by_default_at) -%>
               This application will be automatically rejected at <%= time_today_or_tomorrow(application_choice.reject_by_default_at) %>.

--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -54,6 +54,13 @@
               This application will be automatically rejected on <%= application_choice.reject_by_default_at.to_s(:govuk_date) %>.
             <% end -%>
           </p>
+        <% elsif offer_will_be_declined_by_default? -%>
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+            Waiting for candidate’s response
+          </h2>
+          <p class="govuk-body">
+            Your offer will be automatically declined <%= decline_by_default_text %> if the candidate does not respond.
+          </p>
         <% elsif deferred_offer_wizard_applicable? -%>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
             Review and confirm the deferred offer

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -26,7 +26,7 @@ module ProviderInterface
       respond_to_application? ||
         deferred_offer_wizard_applicable? ||
         rejection_reason_required? ||
-        provider_cannot_respond? ||
+        awaiting_decision_but_cannot_respond? ||
         waiting_for_interview?
     end
 
@@ -53,7 +53,7 @@ module ProviderInterface
         application_choice.no_feedback?
     end
 
-    def provider_cannot_respond?
+    def awaiting_decision_but_cannot_respond?
       !provider_can_respond && application_choice.awaiting_provider_decision?
     end
 

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -9,70 +9,91 @@ module ProviderInterface
       @provider_can_respond = provider_can_respond
     end
 
-    def deferred_offer_wizard_applicable
-      application_choice.status == 'offer_deferred' && application_choice.recruitment_cycle == RecruitmentCycle.previous_year
+    def sub_navigation_items
+      sub_navigation_items = [application_navigation_item]
+
+      sub_navigation_items.push(interviews_navigation_item) if interviews_present?
+      sub_navigation_items.push(offer_navigation_item) if offer_present?
+      sub_navigation_items.push(notes_navigation_item)
+      sub_navigation_items.push(timeline_navigation_item)
+      sub_navigation_items.push(feedback_navigation_item) if application_choice.display_provider_feedback?
+      sub_navigation_items.push(emails_navigation_item) if HostingEnvironment.sandbox_mode?
+
+      sub_navigation_items
     end
 
-    def deferred_offer_equivalent_course_option_available
+    def show_inset_text?
+      respond_to_application? ||
+        deferred_offer_wizard_applicable? ||
+        rejection_reason_required? ||
+        provider_cannot_respond? ||
+        waiting_for_interview?
+    end
+
+    def respond_to_application?
+      provider_can_respond && application_choice.awaiting_provider_decision?
+    end
+
+    def deferred_offer_wizard_applicable?
+      provider_can_respond &&
+        application_choice.status == 'offer_deferred' &&
+        application_choice.recruitment_cycle == RecruitmentCycle.previous_year
+    end
+
+    def deferred_offer_equivalent_course_option_available?
       application_choice.status == 'offer_deferred' &&
         application_choice.offered_option.in_next_cycle &&
         application_choice.offered_option.in_next_cycle.course.open_on_apply
     end
 
-    def sub_navigation_items
-      sub_navigation_items = [
-        { name: 'Application', url: provider_interface_application_choice_path(application_choice) },
-      ]
-
-      if interviews_present?
-        sub_navigation_items.push(
-          { name: 'Interviews', url: provider_interface_application_choice_interviews_path(application_choice) },
-        )
-      end
-
-      if offer_present?
-        path = if FeatureFlag.active?(:updated_offer_flow)
-                 provider_interface_application_choice_offers_path(application_choice)
-               else
-                 provider_interface_application_choice_offer_path(application_choice)
-               end
-
-        sub_navigation_items.push(
-          { name: 'Offer', url: path },
-        )
-      end
-
-      sub_navigation_items.push(
-        { name: 'Notes', url: provider_interface_application_choice_notes_path(application_choice) },
-      )
-
-      sub_navigation_items.push(
-        { name: 'Timeline', url: provider_interface_application_choice_timeline_path(application_choice) },
-      )
-
-      if application_choice.display_provider_feedback?
-        sub_navigation_items.push(
-          { name: 'Feedback', url: provider_interface_application_choice_feedback_path(application_choice) },
-        )
-      end
-
-      if HostingEnvironment.sandbox_mode?
-        sub_navigation_items.push(
-          { name: 'Emails (Sandbox only)', url: provider_interface_application_choice_emails_path(application_choice) },
-        )
-      end
-
-      sub_navigation_items
-    end
-
-    def rejection_reason_required
-      application_choice.status == 'rejected' &&
+    def rejection_reason_required?
+      provider_can_respond &&
+        application_choice.status == 'rejected' &&
         application_choice.rejected_by_default &&
         application_choice.no_feedback?
     end
 
-    def offer_present?
-      ApplicationStateChange::OFFERED_STATES.include?(application_choice.status.to_sym)
+    def provider_cannot_respond?
+      !provider_can_respond && application_choice.awaiting_provider_decision?
+    end
+
+    def waiting_for_interview?
+      provider_can_respond && application_choice.interviewing?
+    end
+
+  private
+
+    def application_navigation_item
+      { name: 'Application', url: provider_interface_application_choice_path(application_choice) }
+    end
+
+    def interviews_navigation_item
+      { name: 'Interviews', url: provider_interface_application_choice_interviews_path(application_choice) }
+    end
+
+    def offer_navigation_item
+      path = if FeatureFlag.active?(:updated_offer_flow)
+               provider_interface_application_choice_offers_path(application_choice)
+             else
+               provider_interface_application_choice_offer_path(application_choice)
+             end
+      { name: 'Offer', url: path }
+    end
+
+    def notes_navigation_item
+      { name: 'Notes', url: provider_interface_application_choice_notes_path(application_choice) }
+    end
+
+    def timeline_navigation_item
+      { name: 'Timeline', url: provider_interface_application_choice_timeline_path(application_choice) }
+    end
+
+    def feedback_navigation_item
+      { name: 'Feedback', url: provider_interface_application_choice_feedback_path(application_choice) }
+    end
+
+    def emails_navigation_item
+      { name: 'Emails (Sandbox only)', url: provider_interface_application_choice_emails_path(application_choice) }
     end
 
     def interviews_present?
@@ -81,30 +102,8 @@ module ProviderInterface
       application_choice.interviews.kept.any?
     end
 
-    def respond_to_application?
-      provider_can_respond && application_choice.awaiting_provider_decision?
-    end
-
-    def waiting_for_interview?
-      provider_can_respond && application_choice.interviewing?
-    end
-
-    def deferred_offer_wizard_applicable?
-      provider_can_respond && deferred_offer_wizard_applicable
-    end
-
-    def rejection_reason_required?
-      provider_can_respond && rejection_reason_required
-    end
-
-    def provider_cannot_respond?
-      !provider_can_respond && application_choice.awaiting_provider_decision?
-    end
-
-    def show_inset_text?
-      respond_to_application? || deferred_offer_wizard_applicable? ||
-        rejection_reason_required? || provider_cannot_respond? ||
-        waiting_for_interview?
+    def offer_present?
+      ApplicationStateChange::OFFERED_STATES.include?(application_choice.status.to_sym)
     end
   end
 end

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -27,7 +27,8 @@ module ProviderInterface
         deferred_offer_wizard_applicable? ||
         rejection_reason_required? ||
         awaiting_decision_but_cannot_respond? ||
-        waiting_for_interview?
+        waiting_for_interview? ||
+        offer_will_be_declined_by_default?
     end
 
     def respond_to_application?
@@ -59,6 +60,21 @@ module ProviderInterface
 
     def waiting_for_interview?
       provider_can_respond && application_choice.interviewing?
+    end
+
+    def offer_will_be_declined_by_default?
+      application_choice.offer? && application_choice.decline_by_default_at.present?
+    end
+
+    def decline_by_default_text
+      return unless offer_will_be_declined_by_default?
+
+      if time_is_today_or_tomorrow?(application_choice.decline_by_default_at)
+        "at the end of #{date_and_time_today_or_tomorrow(application_choice.decline_by_default_at)}"
+      else
+        days_remaining = days_until(application_choice.decline_by_default_at.to_date)
+        "in #{days_remaining} (#{application_choice.decline_by_default_at.to_s(:govuk_date_and_time)})"
+      end
     end
 
   private

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -122,6 +122,17 @@ module ViewHelper
     end
   end
 
+  def date_and_time_today_or_tomorrow(time)
+    unless time_is_today_or_tomorrow?(time)
+      raise "#{time} was expected to be today or tomorrow, but is not"
+    end
+
+    date_and_time = time.to_s(:govuk_date_and_time)
+    today_or_tomorrow = time.to_date == Date.tomorrow ? 'tomorrow' : 'today'
+
+    "#{today_or_tomorrow} (#{date_and_time})"
+  end
+
   def days_until(date)
     days = (date - Date.current).to_i
     if days.zero?

--- a/spec/components/provider_interface/application_choice_header_component_spec.rb
+++ b/spec/components/provider_interface/application_choice_header_component_spec.rb
@@ -85,26 +85,33 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
     end
   end
 
-  describe '#deferred_offer_wizard_applicable' do
+  describe '#deferred_offer_wizard_applicable?' do
     it 'is true for a deferred offer belonging to the previous recruitment cycle' do
       application_choice = instance_double(ApplicationChoice, status: 'offer_deferred')
       allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.previous_year)
 
-      expect(described_class.new(application_choice: application_choice).deferred_offer_wizard_applicable).to be true
+      expect(described_class.new(application_choice: application_choice, provider_can_respond: true).deferred_offer_wizard_applicable?).to be true
+    end
+
+    it 'is false if the provider cannot respond to the application' do
+      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred')
+      allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.previous_year)
+
+      expect(described_class.new(application_choice: application_choice, provider_can_respond: false).deferred_offer_wizard_applicable?).to be false
     end
 
     it 'is false when the application status is not deferred' do
       application_choice = instance_double(ApplicationChoice, status: 'withdrawn')
       allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.previous_year)
 
-      expect(described_class.new(application_choice: application_choice).deferred_offer_wizard_applicable).to be false
+      expect(described_class.new(application_choice: application_choice, provider_can_respond: true).deferred_offer_wizard_applicable?).to be false
     end
 
     it 'is false when the application recruitment cycle is current' do
       application_choice = instance_double(ApplicationChoice, status: 'offer_deferred')
       allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.current_year)
 
-      expect(described_class.new(application_choice: application_choice).deferred_offer_wizard_applicable).to be false
+      expect(described_class.new(application_choice: application_choice, provider_can_respond: true).deferred_offer_wizard_applicable?).to be false
     end
   end
 
@@ -115,7 +122,7 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
       allow(course_option).to receive(:in_next_cycle).and_return(course_option)
       allow(application_choice).to receive(:offered_option).and_return(course_option)
 
-      expect(described_class.new(application_choice: application_choice).deferred_offer_equivalent_course_option_available).to be true
+      expect(described_class.new(application_choice: application_choice).deferred_offer_equivalent_course_option_available?).to be true
     end
 
     it 'is false for a deferred offer without an offered option' do
@@ -124,7 +131,7 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
       allow(course_option).to receive(:in_next_cycle).and_return(false)
       allow(application_choice).to receive(:offered_option).and_return(course_option)
 
-      expect(described_class.new(application_choice: application_choice).deferred_offer_equivalent_course_option_available).to be false
+      expect(described_class.new(application_choice: application_choice).deferred_offer_equivalent_course_option_available?).to be false
     end
 
     it 'is false for a deferred offer without an offered option open on apply' do
@@ -133,7 +140,7 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
       allow(course_option).to receive(:in_next_cycle).and_return(course_option)
       allow(application_choice).to receive(:offered_option).and_return(course_option)
 
-      expect(described_class.new(application_choice: application_choice).deferred_offer_equivalent_course_option_available).to be false
+      expect(described_class.new(application_choice: application_choice).deferred_offer_equivalent_course_option_available?).to be false
     end
   end
 
@@ -142,26 +149,33 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
       application_choice = instance_double(ApplicationChoice, status: 'rejected', rejected_by_default: true, rejection_reason: nil, structured_rejection_reasons: nil)
       allow(application_choice).to receive(:no_feedback?).and_return(true)
 
-      expect(described_class.new(application_choice: application_choice).rejection_reason_required).to be true
+      expect(described_class.new(application_choice: application_choice, provider_can_respond: true).rejection_reason_required?).to be true
+    end
+
+    it 'is false if the provider cannot respond to the application' do
+      application_choice = instance_double(ApplicationChoice, status: 'rejected', rejected_by_default: true, rejection_reason: nil, structured_rejection_reasons: nil)
+      allow(application_choice).to receive(:no_feedback?).and_return(true)
+
+      expect(described_class.new(application_choice: application_choice).rejection_reason_required?).to be false
     end
 
     it 'is false for a rejected by default application with a rejection reason' do
       application_choice = instance_double(ApplicationChoice, status: 'rejected', rejected_by_default: true, rejection_reason: 'NO!')
       allow(application_choice).to receive(:no_feedback?).and_return(false)
 
-      expect(described_class.new(application_choice: application_choice).rejection_reason_required).to be false
+      expect(described_class.new(application_choice: application_choice, provider_can_respond: true).rejection_reason_required?).to be false
     end
 
     it 'is false for a rejected application not rejected by default' do
       application_choice = instance_double(ApplicationChoice, status: 'rejected', rejected_by_default: false, rejection_reason: nil)
 
-      expect(described_class.new(application_choice: application_choice).rejection_reason_required).to be false
+      expect(described_class.new(application_choice: application_choice, provider_can_respond: true).rejection_reason_required?).to be false
     end
 
     it 'is false for a non-rejected application' do
       application_choice = instance_double(ApplicationChoice, status: 'offer_deferred')
 
-      expect(described_class.new(application_choice: application_choice).rejection_reason_required).to be false
+      expect(described_class.new(application_choice: application_choice, provider_can_respond: true).rejection_reason_required?).to be false
     end
   end
 end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -179,6 +179,25 @@ RSpec.describe ViewHelper, type: :helper do
     end
   end
 
+  describe '#date_and_time_today_or_tomorrow' do
+    it 'returns the time tomorrow for a time tomorrow' do
+      time = Time.zone.tomorrow.midnight + 3.hours
+      expect(helper.date_and_time_today_or_tomorrow(time)).to eq 'tomorrow (2 November 2021 at 3am)'
+    end
+
+    it 'returns the bare time for a time today' do
+      Timecop.freeze(Time.zone.now.midnight) do
+        time = Time.zone.now + 6.hours
+        expect(helper.date_and_time_today_or_tomorrow(time)).to eq 'today (1 November 2021 at 6am)'
+      end
+    end
+
+    it 'throws an exception when the time is not today or tomorrow' do
+      time = Time.zone.now + 2.days
+      expect { helper.date_and_time_today_or_tomorrow(time) }.to raise_error(/was expected to be today or tomorrow/)
+    end
+  end
+
   describe '#formatted_percentage' do
     it 'returns the correct value for a whole number percentage' do
       expect(helper.formatted_percentage(5, 10)).to eq '50%'


### PR DESCRIPTION
## Context
Providers find it useful to see how long candidates have to response to their offer, so they know if they should chase them.

## Changes proposed in this pull request
Add to the application choice header component to display text about the application's DBD date.

Small refactor to the component to make it more readable.

## Guidance to review
Per commit to block out refactor noise

## Link to Trello card
https://trello.com/c/x9vTYttQ/3510-display-when-an-offer-will-be-automatically-declined

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
