### PR TITLE
Offers with conditions met can not be withdrawn

### DIFF
--- a/app/components/provider_interface/status_box_components/recruited_component.html.erb
+++ b/app/components/provider_interface/status_box_components/recruited_component.html.erb
@@ -3,9 +3,7 @@
 
   <% if provider_can_respond %>
   <p class="govuk-body govuk-!-margin-bottom-4 govuk-!-display-none-print">
-    <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_new_withdraw_offer_path(application_choice.id) %>
-    or
-    <%= govuk_link_to 'defer offer', provider_interface_application_choice_new_defer_offer_path(application_choice.id) %>
+    <%= govuk_link_to 'Defer offer', provider_interface_application_choice_new_defer_offer_path(application_choice.id) %>
   </p>
   <% end %>
 

--- a/spec/components/provider_interface/status_box_components/recruited_component_spec.rb
+++ b/spec/components/provider_interface/status_box_components/recruited_component_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::StatusBoxComponents::RecruitedComponent do
+  subject(:component) { described_class.new(application_choice: build_stubbed(:application_choice, :with_recruited), options: options) }
+
+  let(:result) { render_inline(component) }
+  let(:options) {}
+
+  context 'when :provider_can_respond' do
+    let(:options) { { provider_can_respond: true } }
+
+    it 'displays the defer offer link' do
+      expect(result.css('.govuk-body a').first.text).to eq('Defer offer')
+      expect(result.css('.govuk-body a').count).to eq(1)
+    end
+  end
+
+  context 'when :provider_can_respond is false' do
+    let(:options) { { provider_can_respond: false } }
+
+    it 'does not display any links' do
+      expect(result.css('.govuk-body a')).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Context

The withdraw_offer transition is only available for application choices in the offer state and as a result attempting to withdraw an offer from the recruited application choice state always results in an error being displayed to the provider user.

## Guidance to review

- Find or transition an offer to the `conditions met` state
- Go to the offer tab
- click Withdraw Offer and confirm 
- An error is displayed indicatin that `The application is not ready for that action`


## Link to Trello card
https://trello.com/c/BsywUKFS/3543-offers-with-conditions-met-can-not-be-withdrawn

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
