### PR TITLE
Reword "Conditions met" status to "Offer confirmed"

### DIFF
--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -47,7 +47,7 @@ en:
     offer: Offer received
     offer_withdrawn: Offer withdrawn
     pending_conditions: Offer accepted
-    recruited: Conditions met
+    recruited: Offer confirmed
     rejected: Unsuccessful
     application_not_sent: Application not sent
     unsubmitted: Not submitted yet


### PR DESCRIPTION
Currently we display "Conditions met" as the status for courses where the provider has confirmed that the candidate has met all the conditions required for the course.

However, some courses don’t have any conditions at all, or at least any conditions specified on the service (there might be some administrative conditions off-service). In these scenarios, the status doesn’t make sense.

Whilst we _could_ have a different status label for those who have accepted unconditional offers only, it would be simpler if we could find a new label that works in all scenarios.

"Offer confirmed" is potentially a more positive-sounding label than "Conditions met", and is also consistent with the language used on the service when the candidate has not yet met the conditions, which states:

> You’ve accepted the offer from [provider name]
>
> Before your offer is confirmed, there are some final conditions to meet.

Note: before January 2020, we were displaying "Recruited" in this state, but this [was changed to Conditions met](https://github.com/DFE-Digital/apply-for-teacher-training/pull/1010). Reverting back to "Recruited" could be an option, but perhaps this is a bit jargon-y, and more of a provider-facing term?

## Screenshots

### Before

<img width="725" alt="Screenshot 2021-03-25 at 13 22 16" src="https://user-images.githubusercontent.com/30665/112480913-64ae5e00-8d6e-11eb-9e31-fb118002aed0.png">

### After

<img width="734" alt="Screenshot 2021-03-25 at 13 22 05" src="https://user-images.githubusercontent.com/30665/112480943-6d069900-8d6e-11eb-9121-6beb68bae40f.png">

### Pending conditions state (for context)

<img width="760" alt="Screenshot 2021-03-25 at 13 22 28" src="https://user-images.githubusercontent.com/30665/112481007-7abc1e80-8d6e-11eb-9faa-814e8b62df61.png">
