### PR TITLE
Fix validation errors on site select page

### DIFF
--- a/app/controllers/candidate_interface/course_choices/site_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/site_selection_controller.rb
@@ -3,7 +3,6 @@ module CandidateInterface
     class SiteSelectionController < BaseController
       def new
         candidate_is_updating_a_choice = params[:course_choice_id]
-        @available_sites = PickSiteForm.available_sites(params.fetch(:course_id), params.fetch(:study_mode))
 
         if candidate_is_updating_a_choice
           @course_choice_id = params[:course_choice_id]
@@ -36,6 +35,13 @@ module CandidateInterface
           )
           .call
       end
+
+    private
+
+      def available_sites
+        PickSiteForm.available_sites(params.fetch(:course_id), params.fetch(:study_mode))
+      end
+      helper_method :available_sites
     end
   end
 end

--- a/app/views/candidate_interface/course_choices/site_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/site_selection/new.html.erb
@@ -12,7 +12,7 @@
             <%= f.govuk_error_summary %>
 
             <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: t('page_titles.which_location'), size: 'xl', tag: 'h1' } do %>
-              <% @available_sites.each_with_index do |option, i| %>
+              <% available_sites.each_with_index do |option, i| %>
                 <%= f.govuk_radio_button :course_option_id, option.id, label: { text: option.site.name }, hint: { text: option.site.full_address }, link_errors: i.zero? %>
               <% end %>
             <% end %>


### PR DESCRIPTION
We're missing an instance variable when re-rendering the form after a
validation error. Use a helper method to retrieve available sites
instead, so that both actions in SiteSelectionController have access to
this data.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
