### PR TITLE
Alert when an application is submitted with more than three course choices

### DIFF
--- a/spec/workers/detect_invariants_spec.rb
+++ b/spec/workers/detect_invariants_spec.rb
@@ -107,5 +107,23 @@ RSpec.describe DetectInvariants do
         ),
       )
     end
+
+    it 'detects submitted applications with more than three course choices' do
+      create(:completed_application_form, submitted_application_choices_count: 3)
+      bad_application_form = create(:completed_application_form, submitted_application_choices_count: 4)
+
+      DetectInvariants.new.perform
+
+      expect(Raven).to have_received(:capture_exception).once
+      expect(Raven).to have_received(:capture_exception).with(
+        DetectInvariants::SubmittedApplicationHasMoreThanThreeChoices.new(
+          <<~MSG,
+            The following application forms have been submitted with more than three course choices
+
+            http://localhost:3000/support/applications/#{bad_application_form.id}
+          MSG
+        ),
+      )
+    end
   end
 end


### PR DESCRIPTION
## Context

We currently don't receive an alert if an application has been submitted with more than three course choices. This isn't something we allow so need to be aware if this state ever occurs.

## Changes proposed in this pull request

Added a new check to the DataInvariant worker to alert if this happens

## Guidance to review

Are there any scenarios I've not considered?

## Link to Trello card

https://trello.com/c/etQENcy9/3198-data-check-alert-when-an-application-is-submitted-with-more-than-3-courses

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
