### PR TITLE
Fix flaky spec

### DIFF
--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ChangeOffer do
   end
 
   describe '#save!' do
-    let(:application_choice) { create(:application_choice) }
+    let(:application_choice) { create(:application_choice, :with_offer) }
     let(:course_option) { course_option_for_provider(provider: application_choice.course_option.provider) }
     let(:provider_user) { create(:provider_user, providers: [build(:provider)]) }
     let(:conditions) { [Faker::Lorem.sentence] }
@@ -28,7 +28,6 @@ RSpec.describe ChangeOffer do
     end
 
     describe 'if the new offer is identical to the current offer' do
-      let(:application_choice) { create(:application_choice) }
       let(:provider_user) do
         create(:provider_user,
                :with_make_decisions,


### PR DESCRIPTION
- The issue is caused by the application choice status being set to`interviewing`. As that status is only available through `ApplicationStateChange.states_visible_to_provider` when the `interviews` flag is active, it’s causing GetApplicationChoiceForProvider to not use interviewing as one of the available statuses, and as a result not return the application choice, causing ProviderAuthentication to fail.

A more general fix can also be made to the factory, however, as to change an offer we should be in an offer state, given the state does not change, in this instance we should correctly setup the expected data.
