### PR TITLE
Return correct set of valid application states

### DIFF
--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -104,7 +104,9 @@ class ApplicationStateChange
   end
 
   def self.valid_states
-    workflow_spec.states.keys
+    return workflow_spec.states.keys if FeatureFlag.active?(:interviews)
+
+    workflow_spec.states.keys - [:interviewing]
   end
 
   def self.states_visible_to_provider

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -1,28 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationStateChange do
+  before do
+    FeatureFlag.deactivate(:interviews)
+  end
+
   describe '.valid_states' do
     it 'has human readable translations' do
       expect(ApplicationStateChange.valid_states)
-        .to match_array(I18n.t('application_states').keys)
+        .to match_array(I18n.t('application_states').keys - %i[interviewing])
 
       expect(ApplicationStateChange.valid_states)
-        .to match_array(I18n.t('candidate_application_states').keys)
+        .to match_array(I18n.t('candidate_application_states').keys - %i[interviewing])
 
       expect(ApplicationStateChange.valid_states)
-        .to match_array(I18n.t('provider_application_states').keys)
+        .to match_array(I18n.t('provider_application_states').keys - %i[interviewing])
     end
 
     it 'has corresponding entries in the ApplicationChoice#status enum' do
       expect(ApplicationStateChange.valid_states)
-        .to match_array(ApplicationChoice.statuses.keys.map(&:to_sym))
+        .to match_array(ApplicationChoice.statuses.keys.map(&:to_sym) - %i[interviewing])
     end
   end
 
   describe '.states_visible_to_provider' do
     it 'matches the valid states and states not visible' do
-      FeatureFlag.deactivate(:interviews)
-
       expect(ApplicationStateChange.states_visible_to_provider)
         .to match_array(ApplicationStateChange.valid_states - ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER - %i[interviewing])
     end

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -1,37 +1,70 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationStateChange do
-  before do
-    FeatureFlag.deactivate(:interviews)
-  end
-
-  describe '.valid_states' do
-    it 'has human readable translations' do
-      expect(ApplicationStateChange.valid_states)
-        .to match_array(I18n.t('application_states').keys - %i[interviewing])
-
-      expect(ApplicationStateChange.valid_states)
-        .to match_array(I18n.t('candidate_application_states').keys - %i[interviewing])
-
-      expect(ApplicationStateChange.valid_states)
-        .to match_array(I18n.t('provider_application_states').keys - %i[interviewing])
+  context 'when the interview flag is active' do
+    before do
+      FeatureFlag.activate(:interviews)
     end
 
-    it 'has corresponding entries in the ApplicationChoice#status enum' do
-      expect(ApplicationStateChange.valid_states)
-        .to match_array(ApplicationChoice.statuses.keys.map(&:to_sym) - %i[interviewing])
+    describe '.valid_states' do
+      it 'has human readable translations' do
+        expect(ApplicationStateChange.valid_states)
+          .to match_array(I18n.t('application_states').keys)
+
+        expect(ApplicationStateChange.valid_states)
+          .to match_array(I18n.t('candidate_application_states').keys)
+
+        expect(ApplicationStateChange.valid_states)
+          .to match_array(I18n.t('provider_application_states').keys)
+      end
+
+      it 'has corresponding entries in the ApplicationChoice#status enum' do
+        expect(ApplicationStateChange.valid_states)
+          .to match_array(ApplicationChoice.statuses.keys.map(&:to_sym))
+      end
+    end
+
+    describe '.states_visible_to_provider' do
+      it 'matches the valid states and states not visible' do
+        expect(ApplicationStateChange.states_visible_to_provider)
+          .to match_array(ApplicationStateChange.valid_states - ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER)
+      end
     end
   end
 
-  describe '.states_visible_to_provider' do
-    it 'matches the valid states and states not visible' do
-      expect(ApplicationStateChange.states_visible_to_provider)
-        .to match_array(ApplicationStateChange.valid_states - ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER - %i[interviewing])
+  context 'when the interview flag is inactive' do
+    before do
+      FeatureFlag.deactivate(:interviews)
+    end
+
+    describe '.valid_states' do
+      it 'has human readable translations' do
+        expect(ApplicationStateChange.valid_states)
+          .to match_array(I18n.t('application_states').keys - %i[interviewing])
+
+        expect(ApplicationStateChange.valid_states)
+          .to match_array(I18n.t('candidate_application_states').keys - %i[interviewing])
+
+        expect(ApplicationStateChange.valid_states)
+          .to match_array(I18n.t('provider_application_states').keys - %i[interviewing])
+      end
+
+      it 'has corresponding entries in the ApplicationChoice#status enum' do
+        expect(ApplicationStateChange.valid_states)
+          .to match_array(ApplicationChoice.statuses.keys.map(&:to_sym) - %i[interviewing])
+      end
+    end
+
+    describe '.states_visible_to_provider' do
+      it 'matches the valid states and states not visible' do
+        expect(ApplicationStateChange.states_visible_to_provider)
+          .to match_array(ApplicationStateChange.valid_states - ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER - %i[interviewing])
+      end
     end
   end
 
   describe '.states_visible_to_provider_without_deferred' do
-    it 'has corresponding entries in the OpenAPI spec' do
+    it 'has corresponding entries in the OpenAPI spec - excluding the interview state' do
       valid_states_in_openapi = VendorAPISpecification.as_hash['components']['schemas']['ApplicationAttributes']['properties']['status']['enum']
 
       expect(ApplicationStateChange.states_visible_to_provider_without_deferred - %i[interviewing offer_withdrawn])


### PR DESCRIPTION
This fix should resolve random spec failures caused by ProviderAuthorisation issues.

### Root cause
The issue is caused by the `application_choice` factory using a [random value from`valid_states`](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/spec/factories/application_choice.rb#L6) to set the application choice status.

### How?
As the [GetApplicationChoicesForProvider service](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/queries/get_application_choices_for_providers.rb#L19) is queried from the [ProviderAuthorisation](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/services/provider_authorisation.rb#L176) service in order for the application's visibility to be established, it sometimes returns false due to  the`interviewing` state [only being available when the `interview` flag is active](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/services/application_state_change.rb#L110).

### Fix
Only available statuses are exposed through `valid_states`