### PR TITLE
Offer flow - back button error

### DIFF
--- a/app/services/wizard_path_history.rb
+++ b/app/services/wizard_path_history.rb
@@ -1,4 +1,6 @@
 class WizardPathHistory
+  PREVIOUS_STEP_INDEX = -2
+
   class NoSuchStepError < StandardError
     def message
       'Invalid wizard step'
@@ -22,6 +24,7 @@ class WizardPathHistory
   end
 
   def previous_step
+    return path_history[PREVIOUS_STEP_INDEX] if step.nil?
     raise NoSuchStepError unless path_history.rindex(step)
 
     path_history[path_history.rindex(step) - 1]

--- a/spec/services/wizard_path_history_spec.rb
+++ b/spec/services/wizard_path_history_spec.rb
@@ -56,5 +56,13 @@ RSpec.describe WizardPathHistory do
         expect(service.previous_step).to eq(:step3)
       end
     end
+
+    context 'when no step is specified' do
+      let(:step) {}
+
+      it 'returns the step before the last' do
+        expect(service.previous_step).to eq(:step3)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Changes proposed in this pull request

When no step is specified default to the step before the last.

## Guidance to review

1. Make a new offer or edit an existing offer
2. On the conditions page, enter a condition that exceeds 255 characters
3. Press continue

## Link to Trello card

https://trello.com/c/l3VKxiDF/3576-offer-flow-back-button-error

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
