### PR TITLE
Refactor conditions part of make offer

### DIFF
--- a/app/controllers/provider_interface/offer/conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/conditions_controller.rb
@@ -38,9 +38,7 @@ module ProviderInterface
     private
 
       def conditions_params
-        params.require(:provider_interface_offer_wizard).permit(:further_condition_1, :further_condition_2,
-                                                                :further_condition_3, :further_condition_4,
-                                                                standard_conditions: [])
+        params.require(:provider_interface_offer_wizard).permit(standard_conditions: [], further_conditions: {})
       end
     end
   end

--- a/app/views/provider_interface/offer/conditions/new.html.erb
+++ b/app/views/provider_interface/offer/conditions/new.html.erb
@@ -20,10 +20,13 @@
       <%= f.govuk_fieldset legend: { text: 'Further conditions', size: 'm' } do %>
         <p class="govuk-body">For example, studying a subject knowledge enhancement course.</p>
 
-        <%= f.govuk_text_area :further_condition_1, label: { size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_condition_2, label: { size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_condition_3, label: { size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_condition_4, label: { size: 's' }, rows: 3 %>
+        <% 5.times do |n| %>
+          <%= f.govuk_text_area(
+                :"further_conditions[#{n}]",
+                label: { text: "Condition #{n+1}", size: 's' },
+                rows: 3
+              ) %>
+        <% end %>
       <% end %>
 
       <%= f.govuk_submit t('continue') %>


### PR DESCRIPTION
## Context
We are planning to allow providers to add and remove conditions boxes from the form. In its current state it will be difficult to do that.

## Changes proposed in this pull request
Make the number of condition boxes the only dependency for showing and submitting conditions of an offer.

## Guidance to review
Is this approach the best?

It feels like a battle against rails to get this to work as intended.

## Trello
https://trello.com/c/AMcA4XK8/3514-spike-conditions-of-offer
