### PR TITLE
Create readonly database connection string for BLAZER on PaaS

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -104,3 +104,9 @@ resource "cloudfoundry_service_instance" "redis" {
   space        = data.cloudfoundry_space.space.id
   service_plan = data.cloudfoundry_service.redis.service_plans[var.redis_service_plan]
 }
+
+resource "cloudfoundry_service_key" "postgres-readonly-key" {
+  name             = "${local.postgres_service_name}-readonly-key"
+  service_instance = cloudfoundry_service_instance.postgres.id
+  params_json      = jsonencode({ read_only = true })
+}

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -48,8 +48,10 @@ locals {
     sandbox = "sandbox"
     prod    = "www"
   }
-  web_app_routes           = [cloudfoundry_route.web_app_service_gov_uk_route, cloudfoundry_route.web_app_cloudapps_digital_route]
-  web_app_env_variables    = merge(var.app_environment_variables, { SERVICE_TYPE = "web" })
-  clock_app_env_variables  = merge(var.app_environment_variables, { SERVICE_TYPE = "clock" })
-  worker_app_env_variables = merge(var.app_environment_variables, { SERVICE_TYPE = "worker" })
+  web_app_routes               = [cloudfoundry_route.web_app_service_gov_uk_route, cloudfoundry_route.web_app_cloudapps_digital_route]
+  postgres_readonly_connection = cloudfoundry_service_key.postgres-readonly-key.credentials.uri
+  app_environment_variables    = merge(var.app_environment_variables, { BLAZER_DATABASE_URL = local.postgres_readonly_connection })
+  web_app_env_variables        = merge(local.app_environment_variables, { SERVICE_TYPE = "web" })
+  clock_app_env_variables      = merge(local.app_environment_variables, { SERVICE_TYPE = "clock" })
+  worker_app_env_variables     = merge(local.app_environment_variables, { SERVICE_TYPE = "worker" })
 }


### PR DESCRIPTION
## Context

Provide a readonly connection string for `BLAZER_DATABASE_URL`

## Changes proposed in this pull request

Create a service-key for the PaaS database with a readonly connection property.


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
