### PR TITLE
Change the way a candidate's 'current application' is determined

### DIFF
--- a/app/controllers/candidate_interface/prefill_application_form_controller.rb
+++ b/app/controllers/candidate_interface/prefill_application_form_controller.rb
@@ -28,6 +28,9 @@ module CandidateInterface
         courses_to_apply_to: Course.current_cycle.open_on_apply.joins(:course_options).merge(CourseOption.available),
         candidate: current_candidate,
       )
+
+      destroy_blank_application
+
       example_application_form = example_application_choices.first.application_form
       current_candidate.application_forms << example_application_form
     end
@@ -36,6 +39,11 @@ module CandidateInterface
 
     def prefill_application_or_not_params
       params.fetch(:candidate_interface_prefill_application_or_not_form, {}).permit(:prefill)
+    end
+
+    def destroy_blank_application
+      application_form = current_candidate.application_forms.first
+      application_form.destroy if application_form.blank_application?
     end
   end
 end

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -23,7 +23,7 @@ class Candidate < ApplicationRecord
   end
 
   def current_application
-    application_form = application_forms.last
+    application_form = application_forms.order(:created_at).last
     application_form ||= application_forms.create!
     application_form
   end

--- a/spec/mailers/candidate_mailer_ucas_match_initial_email_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_initial_email_spec.rb
@@ -9,13 +9,12 @@ RSpec.describe CandidateMailer, type: :mailer do
     end
   end
 
-  let(:application_form) { build_stubbed(:application_form, first_name: 'Jane', application_choices: [application_choice]) }
-  let(:provider) { build_stubbed(:provider, name: 'Coventry University') }
-  let(:course_option) { build_stubbed(:course_option, course: build_stubbed(:course, name: 'Physics', code: '3PH5', provider: provider)) }
-  let(:application_choice) { build_stubbed(:application_choice, course_option: course_option) }
-
   describe '.ucas_match_initial_email_duplicate_applications' do
     let(:email) { mailer.ucas_match_initial_email_duplicate_applications(application_form.application_choices.first) }
+    let(:application_form) { build_stubbed(:application_form, first_name: 'Jane', application_choices: [application_choice]) }
+    let(:provider) { build_stubbed(:provider, name: 'Coventry University') }
+    let(:course_option) { build_stubbed(:course_option, course: build_stubbed(:course, name: 'Physics', code: '3PH5', provider: provider)) }
+    let(:application_choice) { build_stubbed(:application_choice, course_option: course_option) }
 
     it_behaves_like(
       'a mail with subject and content',
@@ -29,7 +28,8 @@ RSpec.describe CandidateMailer, type: :mailer do
 
   describe '.ucas_match_initial_email_multiple_acceptances' do
     let(:email) { mailer.ucas_match_initial_email_multiple_acceptances(candidate) }
-    let(:candidate) { build_stubbed(:candidate, application_forms: [application_form]) }
+    let(:candidate) { create(:candidate, application_forms: [application_form]) }
+    let(:application_form) { create(:application_form, :minimum_info, first_name: 'Jane') }
 
     it_behaves_like(
       'a mail with subject and content',

--- a/spec/mailers/candidate_mailer_ucas_match_reminder_email_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_reminder_email_spec.rb
@@ -9,15 +9,14 @@ RSpec.describe CandidateMailer, type: :mailer do
 
   subject(:mailer) { described_class }
 
-  let(:ucas_match) { build_stubbed(:ucas_match, candidate_last_contacted_at: Time.zone.local(2020, 11, 16)) }
-  let(:application_form) { build_stubbed(:application_form, first_name: 'Jane', application_choices: [application_choice]) }
-  let(:provider) { build_stubbed(:provider, name: 'City University') }
-  let(:course_option) { build_stubbed(:course_option, course: course) }
-  let(:course) { build_stubbed(:course, name: 'Physics', code: '3PH5', provider: provider) }
-  let(:application_choice) { build_stubbed(:application_choice, course_option: course_option) }
-
   describe '.ucas_match_reminder_email_duplicate_applications' do
     let(:email) { mailer.ucas_match_reminder_email_duplicate_applications(application_form.application_choices.first, ucas_match) }
+    let(:ucas_match) { build_stubbed(:ucas_match, candidate_last_contacted_at: Time.zone.local(2020, 11, 16)) }
+    let(:application_form) { build_stubbed(:application_form, first_name: 'Jane', application_choices: [application_choice]) }
+    let(:provider) { build_stubbed(:provider, name: 'City University') }
+    let(:course_option) { build_stubbed(:course_option, course: course) }
+    let(:course) { build_stubbed(:course, name: 'Physics', code: '3PH5', provider: provider) }
+    let(:application_choice) { build_stubbed(:application_choice, course_option: course_option) }
 
     it_behaves_like(
       'a mail with subject and content',
@@ -31,7 +30,9 @@ RSpec.describe CandidateMailer, type: :mailer do
 
   describe '.ucas_match_reminder_email_multiple_acceptances' do
     let(:email) { mailer.ucas_match_reminder_email_multiple_acceptances(candidate.ucas_match) }
-    let(:candidate) { build_stubbed(:candidate, ucas_match: ucas_match, application_forms: [application_form]) }
+    let(:ucas_match) { create(:ucas_match, candidate_last_contacted_at: Time.zone.local(2020, 11, 16)) }
+    let(:candidate) { create(:candidate, ucas_match: ucas_match, application_forms: [application_form]) }
+    let(:application_form) { create(:application_form, first_name: 'Jane') }
 
     it_behaves_like(
       'a mail with subject and content',

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -579,7 +579,8 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def ucas_match_initial_email_multiple_acceptances
-    candidate = FactoryBot.build_stubbed(:candidate, application_forms: [application_form])
+    application_form = FactoryBot.create(:application_form, :minimum_info, first_name: 'Gemma')
+    candidate = FactoryBot.create(:candidate, application_forms: [application_form])
 
     CandidateMailer.ucas_match_initial_email_multiple_acceptances(candidate)
   end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -37,17 +37,23 @@ RSpec.describe Candidate, type: :model do
   end
 
   describe '#current_application' do
+    let(:candidate) { create(:candidate) }
+
     it 'returns an existing application_form' do
-      candidate = create(:candidate)
       application_form = create(:application_form, candidate: candidate)
 
       expect(candidate.current_application).to eq(application_form)
     end
 
     it 'creates an application_form if there are none' do
-      candidate = create(:candidate)
-
       expect { candidate.current_application }.to change { candidate.application_forms.count }.from(0).to(1)
+    end
+
+    it 'returns the most recent application' do
+      first_application = create(:application_form, candidate: candidate, created_at: 3.days.ago)
+      create(:application_form, candidate: candidate, created_at: 10.days.ago)
+
+      expect(candidate.current_application.created_at).to eq(first_application.created_at)
     end
   end
 


### PR DESCRIPTION
## Context

We've noticed some tricky bugs occur in code that relies on the `current_application` method in the Candidate model (see https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/models/candidate.rb#L26)

It's possible that `application_forms.last` may not always return what is thought to be the latest application form if prior to this, the application_forms  array has been mutated in some way.

Instead the safer option would be to order by created date 
 `application_forms.order(:created_at).last` 

## Replicating the bug

In the console find a candidate with multiple application forms (or create them)

```
# previously the '#current_application' returns the application form with the largest id (or creates and application form and returns it)

def current_application
  application_form = application_forms.last
  ...
end


# At this point the current_application id is as expected

candidate.current_application.id = x

# Somewhere else in the code, we try to determine a candidate's previous applications (as an array). Note how the 'current_application' is subtracted from all applications

previous_applications = candidate.application_forms - [ candidate.current_application ]

# But now the current_application id is  x - 1
candidate.current_application.id = x

```

## Changes proposed in this pull request

- Determine the current application by sorting all application forms by created date and return the most recent application form
- The above change has impacted pre-filling of blank applications (in Sandbox). Blank applications are destroyed in order to make [the system test](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb) green. See https://github.com/DFE-Digital/apply-for-teacher-training/pull/4418/commits/41d60d0ffd128c8d43449e25aa829b3740ae9a50 for context


## Link to Trello card

https://trello.com/c/tOE6GT5l/3247-change-the-way-a-candidates-current-application-is-determined

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
