### PR TITLE
Read REDIS_URL from VCAP_SERVICES 

### DIFF
--- a/app/lib/apply_redis_connection.rb
+++ b/app/lib/apply_redis_connection.rb
@@ -5,6 +5,9 @@ class ApplyRedisConnection
     if ENV['REDIS_URL'].present?
       # Always use the Redis database defined by the environment, if available.
       ENV['REDIS_URL']
+    elsif ENV.key?('VCAP_SERVICES')
+      # When running on PaaS, the redis service is bound to the app and configuration is available under VCAP_SERVICES
+      JSON.parse(ENV['VCAP_SERVICES'])['redis'][0]['credentials']['uri']
     elsif ENV['TEST_ENV_NUMBER']
       # If we're in the test environment and tests are being run in parallel,
       # use a different database for each process. Add 1 to the environment


### PR DESCRIPTION
## Context

On PaaS redis service is bound to the app
and connection string is read from VCAP_SERVICES

## Changes proposed in this pull request

Read redis connection string from `ENV[VCAP_SERVICES]`

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
