### PR TITLE
Update the statuses that the DetectInvariant will check for

### DIFF
--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -97,7 +97,7 @@ class DetectInvariants
   def detect_submitted_applications_with_more_than_three_course_choices
     applications_with_too_many_choices = ApplicationForm
       .joins(:application_choices)
-      .where.not(application_choices: { status: 'unsubmitted' })
+      .where(application_choices: { status: (ApplicationStateChange::DECISION_PENDING_STATUSES + ApplicationStateChange::ACCEPTED_STATES) })
       .group('application_forms.id')
       .having('count(application_choices) > 3')
       .sort


### PR DESCRIPTION
## Context

Follow up from PR [#4405](https://github.com/DFE-Digital/apply-for-teacher-training/pull/4405) - this was a bit of a trigger happy approach and would capture applications that had more than three choices, despite being in states that were acceptable i.e. some applications are `WITHDRAWN`

## Changes proposed in this pull request

Changed approach from selecting applications with a status that is _not_ unsubmitted to selecting applications with a status of:

```
DECISION_PENDING_STATUSES = %i[awaiting_provider_decision interviewing]
ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited offer_deferred]
```

## Guidance to review

The mentioned PR contains the full context for the work.

## Link to Trello card

https://trello.com/c/etQENcy9/3198-data-check-alert-when-an-application-is-submitted-with-more-than-3-courses

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
