### PR TITLE
WIP Read REDIS_URL from VCAP_SERVICES

### DIFF
--- a/app/lib/apply_redis_connection.rb
+++ b/app/lib/apply_redis_connection.rb
@@ -5,6 +5,9 @@ class ApplyRedisConnection
     if ENV['REDIS_URL'].present?
       # Always use the Redis database defined by the environment, if available.
       ENV['REDIS_URL']
+    elsif ENV.key?('VCAP_SERVICES')
+      # When running on PaaS, the redis service is bound to the app and configuration is available under VCAP_SERVICES
+      JSON.parse(ENV['VCAP_SERVICES'])['redis'][0]['credentials']['uri']
     elsif ENV['TEST_ENV_NUMBER']
       # If we're in the test environment and tests are being run in parallel,
       # use a different database for each process. Add 1 to the environment

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -112,10 +112,15 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
   # Whitelist the production domains for HostAuthorization
+  config.logger.info('Authorised Hosts are:')
   HostingEnvironment.authorised_hosts.each do |host|
+    config.logger.info(host)
     config.hosts << host
   end
 
+  # Configure Redis
+  Redis.current = Redis.new(url: ApplyRedisConnection.url)
+  
   class FixAzureXForwardedForMiddleware
     def initialize(app)
       @app = app

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -27,7 +27,7 @@ end
 OkComputer.mount_at = 'integrations/monitoring'
 
 OkComputer::Registry.register 'postgres', OkComputer::ActiveRecordCheck.new
-OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ENV['REDIS_URL'])
+OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ApplyRedisConnection.url)
 OkComputer::Registry.register 'sidekiq_default_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'default', threshold: 100) # threshold in seconds
 OkComputer::Registry.register 'sidekiq_mailers_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'mailers', threshold: 100) # threshold in seconds
 OkComputer::Registry.register 'sidekiq_retries_count', SidekiqRetriesCheck.new


### PR DESCRIPTION
On PaaS redis service is bound to the app
and connection string is read from VCAP_SERVICES

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
