### PR TITLE
Minor improvements to FixLatLongFlipFlops

### DIFF
--- a/app/services/data_migrations/fix_lat_long_flip_flops.rb
+++ b/app/services/data_migrations/fix_lat_long_flip_flops.rb
@@ -14,6 +14,8 @@ module DataMigrations
       deleted_audit_count = 0
       total_audits = audits.count
 
+      log("Before: audits table size is #{audits_table_size}")
+
       providers.find_each do |p|
         log("Cleaning up provider #{p.id} (#{p.name_and_code})")
 
@@ -50,6 +52,8 @@ module DataMigrations
       end
 
       log("Deleted #{deleted_audit_count} lat/long audits out of #{total_audits}") unless dry_run?
+
+      log("After: audits table size is #{audits_table_size}")
     end
 
   private
@@ -78,6 +82,11 @@ module DataMigrations
       log_string << message
 
       Rails.logger.info log_string.join(' ')
+    end
+
+    def audits_table_size
+      query = "SELECT pg_size_pretty(pg_total_relation_size('audits'));"
+      ActiveRecord::Base.connection.execute(query).first['pg_size_pretty']
     end
   end
 end

--- a/app/services/data_migrations/fix_lat_long_flip_flops.rb
+++ b/app/services/data_migrations/fix_lat_long_flip_flops.rb
@@ -20,6 +20,11 @@ module DataMigrations
         audits_for_provider = audits.where(auditable_id: p.id)
         audits_for_provider_count_before_cleanup = audits.where(auditable_id: p.id).count
 
+        if audits_for_provider.empty?
+          log("No audits to clean up for provider #{p.id}")
+          next
+        end
+
         # if we already had lat/lng when we made the first spurious update, delete every audit
         if audits_for_provider.first.audited_changes['latitude'].last.nil?
           delete_audits(

--- a/app/services/data_migrations/fix_lat_long_flip_flops.rb
+++ b/app/services/data_migrations/fix_lat_long_flip_flops.rb
@@ -77,11 +77,16 @@ module DataMigrations
 
     def log(message)
       log_string = %w[FixLatLongFlipFlops]
+      log_string << ["(#{run_name})"]
       log_string << '(dry run)' if dry_run?
       log_string << '-'
       log_string << message
 
       Rails.logger.info log_string.join(' ')
+    end
+
+    def run_name
+      @run_name ||= Faker::Creature::Animal.name
     end
 
     def audits_table_size

--- a/spec/services/data_migrations/fix_lat_long_flip_flops_spec.rb
+++ b/spec/services/data_migrations/fix_lat_long_flip_flops_spec.rb
@@ -86,8 +86,8 @@ RSpec.describe DataMigrations::FixLatLongFlipFlops, with_audited: true do
 
     described_class.new.change
 
-    expect(Rails.logger).to have_received(:info).with('FixLatLongFlipFlops - Before: audits table size is 128 kB')
-    expect(Rails.logger).to have_received(:info).with('FixLatLongFlipFlops - After: audits table size is 128 kB')
+    expect(Rails.logger).to have_received(:info).with(/FixLatLongFlipFlops \([ \w]+\) - Before: audits table size is \d+ kB/)
+    expect(Rails.logger).to have_received(:info).with(/FixLatLongFlipFlops \([ \w]+\) - After: audits table size is \d+ kB/)
   end
 
   it 'logs the result' do
@@ -100,9 +100,9 @@ RSpec.describe DataMigrations::FixLatLongFlipFlops, with_audited: true do
 
     described_class.new.change
 
-    expect(Rails.logger).to have_received(:info).with('FixLatLongFlipFlops - Deleting 1 audits which repeatedly set the lat/long to the same value')
-    expect(Rails.logger).to have_received(:info).with('FixLatLongFlipFlops - Deleting 1 audits which set the lat/long to nil')
-    expect(Rails.logger).to have_received(:info).with('FixLatLongFlipFlops - Deleted 2 lat/long audits out of 3')
+    expect(Rails.logger).to have_received(:info).with(/FixLatLongFlipFlops \([ \w]+\) - Deleting 1 audits which repeatedly set the lat\/long to the same value/)
+    expect(Rails.logger).to have_received(:info).with(/FixLatLongFlipFlops \([ \w]+\) - Deleting 1 audits which set the lat\/long to nil/)
+    expect(Rails.logger).to have_received(:info).with(/FixLatLongFlipFlops \([ \w]+\) - Deleted 2 lat\/long audits out of 3/)
   end
 
   describe 'dry run' do
@@ -123,7 +123,7 @@ RSpec.describe DataMigrations::FixLatLongFlipFlops, with_audited: true do
       described_class.new.change
 
       expect(provider.audits.count).to eq(3)
-      expect(Rails.logger).to have_received(:info).with('FixLatLongFlipFlops (dry run) - Deleting 1 audits which set the lat/long to nil')
+      expect(Rails.logger).to have_received(:info).with(/FixLatLongFlipFlops \([ \w]+\) \(dry run\) - Deleting 1 audits which set the lat\/long to nil/)
     end
   end
 end

--- a/spec/services/data_migrations/fix_lat_long_flip_flops_spec.rb
+++ b/spec/services/data_migrations/fix_lat_long_flip_flops_spec.rb
@@ -75,6 +75,12 @@ RSpec.describe DataMigrations::FixLatLongFlipFlops, with_audited: true do
     expect(p2.audits.count).to eq(1)
   end
 
+  it 'can handle providers without any audits' do
+    create(:provider)
+
+    expect { described_class.new.change }.not_to raise_error
+  end
+
   it 'logs the result' do
     provider = create(:provider)
     provider.update(latitude: 1, longitude: 1)

--- a/spec/services/data_migrations/fix_lat_long_flip_flops_spec.rb
+++ b/spec/services/data_migrations/fix_lat_long_flip_flops_spec.rb
@@ -81,6 +81,15 @@ RSpec.describe DataMigrations::FixLatLongFlipFlops, with_audited: true do
     expect { described_class.new.change }.not_to raise_error
   end
 
+  it 'logs the table size before and after' do
+    allow(Rails.logger).to receive(:info).and_call_original
+
+    described_class.new.change
+
+    expect(Rails.logger).to have_received(:info).with('FixLatLongFlipFlops - Before: audits table size is 128 kB')
+    expect(Rails.logger).to have_received(:info).with('FixLatLongFlipFlops - After: audits table size is 128 kB')
+  end
+
   it 'logs the result' do
     provider = create(:provider)
     provider.update(latitude: 1, longitude: 1)


### PR DESCRIPTION
## Context

The dry run on QA failed because it hit a provider without any audits. & jazz up the logging a bit while we're here.

## Changes proposed in this pull request

- handle audit-less providers
- name each run in the logs
- log `audits` table size before and after

## Link to Trello card

https://trello.com/c/6vbtx9Nm/427-audit-trial-is-full-of-flip-flops