### PR TITLE
Naming and ordering changes in Other qualifications section

### DIFF
--- a/app/components/candidate_interface/other_qualifications_review_component.html.erb
+++ b/app/components/candidate_interface/other_qualifications_review_component.html.erb
@@ -16,5 +16,5 @@
 <% end %>
 
 <% if @qualifications.empty? %>
-  <p class="govuk-body">No academic or other qualifications entered.</p>
+  <p class="govuk-body">No other qualifications entered.</p>
 <% end %>

--- a/app/helpers/other_qualifications_helper.rb
+++ b/app/helpers/other_qualifications_helper.rb
@@ -1,0 +1,9 @@
+module OtherQualificationsHelper
+  def other_qualifications_title(application_form)
+    if application_form.international?
+      I18n.t('page_titles.other_qualifications_international')
+    else
+      I18n.t('page_titles.other_qualifications')
+    end
+  end
+end

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -74,7 +74,7 @@
     <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
   <% end %>
 
-  <h3 class="govuk-heading-m"><%= t('page_titles.other_qualification') %></h3>
+  <h3 class="govuk-heading-m"><%= other_qualifications_title(@application_form) %></h3>
   <%= render(CandidateInterface::OtherQualificationsReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
 </section>
 

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -52,8 +52,6 @@
 
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.qualifications') %></h2>
-  <h3 class="govuk-heading-m"><%= t('page_titles.degree') %></h3>
-  <%= render(CandidateInterface::DegreesReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, show_incomplete: true, missing_error: missing_error)) %>
   <h3 class="govuk-heading-m"><%= t('page_titles.english_gcse') %></h3>
   <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.english_gcse, subject: 'english', editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
 
@@ -76,6 +74,9 @@
 
   <h3 class="govuk-heading-m"><%= other_qualifications_title(@application_form) %></h3>
   <%= render(CandidateInterface::OtherQualificationsReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
+
+  <h3 class="govuk-heading-m"><%= t('page_titles.degree') %></h3>
+  <%= render(CandidateInterface::DegreesReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, show_incomplete: true, missing_error: missing_error)) %>
 </section>
 
 <section class="govuk-!-margin-bottom-8">

--- a/app/views/candidate_interface/other_qualifications/details/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/edit.html.erb
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl">Academic and other relevant qualifications</span>
+        <span class="govuk-caption-xl"><%= other_qualifications_title(current_application) %></span>
         Edit <%= @form.qualification_type_name %> qualification
       </h1>
 

--- a/app/views/candidate_interface/other_qualifications/details/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/new.html.erb
@@ -11,7 +11,7 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl">Academic and other relevant qualifications</span>
+        <span class="govuk-caption-xl"><%= other_qualifications_title(current_application) %></span>
         Add <%= @form.qualification_type_name %> qualification
       </h1>
 

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -1,10 +1,10 @@
-<% content_for :title, t('page_titles.other_qualification') %>
+<% content_for :title, other_qualifications_title(@application_form) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= t('page_titles.other_qualification') %>
+      <%= other_qualifications_title(@application_form) %>
     </h1>
 
     <%= govuk_button_link_to t('application_form.other_qualification.another.button'), candidate_interface_other_qualification_type_path, class: 'govuk-button--secondary' %>

--- a/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
@@ -1,7 +1,7 @@
 <%= f.govuk_error_summary %>
 
 <h1 class="govuk-heading-xl">
-  <%= t('page_titles.add_other_qualification') %>
+  <%= other_qualifications_title(current_application) %>
 </h1>
 
 <%= render 'candidate_interface/other_qualifications/shared/instructions' %>

--- a/app/views/candidate_interface/other_qualifications/type/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.add_other_qualification'), @form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(other_qualifications_title(current_application), @form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/other_qualifications/type/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.add_other_qualification'), @form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(other_qualifications_title(current_application), @form.errors.any?) %>
 <% if current_application.application_qualifications.other.blank? %>
   <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 <% else %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -89,13 +89,6 @@
       <ol class="app-task-list">
         <li class="app-task-list__item">
           <%= render(TaskListItemComponent.new(
-            text: t('page_titles.degree'),
-            completed: @application_form_presenter.degrees_completed?,
-            path: @application_form_presenter.degrees_path,
-          )) %>
-        </li>
-        <li class="app-task-list__item">
-          <%= render(TaskListItemComponent.new(
             text: t('page_titles.english_gcse'),
             completed: @application_form_presenter.english_gcse_completed?,
             path: @application_form_presenter.english_gcse_added? ? candidate_interface_gcse_review_path(subject: :english) : candidate_interface_gcse_details_edit_type_path(subject: :english),
@@ -131,6 +124,13 @@
             text: other_qualifications_title(@application_form),
             completed: @application_form_presenter.other_qualifications_completed?,
             path: @application_form_presenter.other_qualification_path, show_incomplete: false
+          )) %>
+        </li>
+        <li class="app-task-list__item">
+          <%= render(TaskListItemComponent.new(
+            text: t('page_titles.degree'),
+            completed: @application_form_presenter.degrees_completed?,
+            path: @application_form_presenter.degrees_path,
           )) %>
         </li>
       </ol>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -128,7 +128,7 @@
         <% end %>
         <li class="app-task-list__item">
           <%= render(TaskListItemComponent.new(
-            text: t('page_titles.other_qualification'),
+            text: other_qualifications_title(@application_form),
             completed: @application_form_presenter.other_qualifications_completed?,
             path: @application_form_presenter.other_qualification_path, show_incomplete: false
           )) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,8 +121,8 @@ en:
     which_study_mode: Full time or part time?
     edit_degree: Edit degree
     edit_degree_type: Edit degree type
-    other_qualification: Academic and other relevant qualifications
-    add_other_qualification: Academic and other relevant qualifications
+    other_qualifications: A levels and other qualifications
+    other_qualifications_international: Other qualifications
     qualification_details: Qualification details
     edit_other_qualification: Edit qualification
     destroy_other_qualification: Are you sure you want to delete this qualification?

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -62,7 +62,7 @@ module CandidateHelper
     click_link 'Science GCSE or equivalent'
     candidate_explains_a_missing_gcse
 
-    click_link 'Academic and other relevant qualifications'
+    click_link 'A levels and other qualifications'
     candidate_fills_in_their_other_qualifications
 
     click_link 'Why do you want to teach'

--- a/spec/system/candidate_interface/entering_details/candidate_deletes_and_adds_other_qualifications_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_deletes_and_adds_other_qualifications_after_completing_the_section_spec.rb
@@ -43,11 +43,11 @@ RSpec.feature 'Candidates academic and other relevant qualifications' do
   end
 
   def then_the_other_qualificaitons_section_should_be_marked_as_complete
-    expect(page.text).to include 'Academic and other relevant qualifications Completed'
+    expect(page.text).to include 'A levels and other qualifications Completed'
   end
 
   def when_i_click_the_other_qualifications_link
-    click_link 'Academic and other relevant qualifications'
+    click_link 'A levels and other qualifications'
   end
 
   def and_visit_my_application_page
@@ -74,7 +74,7 @@ RSpec.feature 'Candidates academic and other relevant qualifications' do
   end
 
   def then_the_other_qualifications_section_should_not_be_marked_as_complete
-    expect(page.text).not_to include 'Academic and other relevant qualifications Complete'
+    expect(page.text).not_to include 'A levels and other qualifications Complete'
   end
 
   def and_i_click_on_delete_degree

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_btec_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_btec_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def when_i_click_on_other_qualifications
-    click_link t('page_titles.other_qualification')
+    click_link t('page_titles.other_qualifications')
   end
 
   def then_i_see_the_select_qualification_type_page

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
@@ -104,7 +104,7 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def when_i_click_on_other_qualifications
-    click_link t('page_titles.other_qualification')
+    click_link t('page_titles.other_qualifications')
   end
 
   def then_i_see_the_select_qualification_type_page
@@ -348,7 +348,7 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def and_that_the_section_is_completed
-    expect(page).to have_css('#academic-and-other-relevant-qualifications-badge-id', text: 'Completed')
+    expect(page).to have_css('#a-levels-and-other-qualifications-badge-id', text: 'Completed')
   end
 
   def when_i_do_not_select_any_type_option; end
@@ -369,6 +369,6 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def and_that_the_section_is_not_marked_as_complete_or_incomplete
-    expect(page).not_to have_css('#academic-and-other-relevant-qualifications-badge-id')
+    expect(page).not_to have_css('#a-levels-and-other-qualifications-badge-id')
   end
 end

--- a/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Non-uk Other qualifications' do
   scenario 'International candidate enters their other non-uk qualification' do
     given_i_am_signed_in
     and_i_visit_the_site
+    and_i_am_an_international_candidate
 
     when_i_click_on_other_qualifications
     then_i_see_the_select_qualification_type_page
@@ -76,8 +77,13 @@ RSpec.feature 'Non-uk Other qualifications' do
     visit candidate_interface_application_form_path
   end
 
+  def and_i_am_an_international_candidate
+    click_link 'Contact information'
+    candidate_fills_in_international_contact_details
+  end
+
   def when_i_click_on_other_qualifications
-    click_link t('page_titles.other_qualification')
+    click_link t('page_titles.other_qualifications_international')
   end
 
   def then_i_see_the_select_qualification_type_page
@@ -216,7 +222,7 @@ RSpec.feature 'Non-uk Other qualifications' do
   end
 
   def and_that_the_section_is_completed
-    expect(page).to have_css('#academic-and-other-relevant-qualifications-badge-id', text: 'Completed')
+    expect(page).to have_css('#other-qualifications-badge-id', text: 'Completed')
   end
 
   def then_i_see_the_qualification_type_error

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -96,7 +96,7 @@ RSpec.feature 'International candidate submits the application' do
     click_link 'Science GCSE or equivalent'
     candidate_explains_a_missing_gcse
 
-    click_link 'Academic and other relevant qualifications'
+    click_link 'Other qualifications'
     candidate_fills_in_their_other_qualifications
 
     click_link 'Why do you want to teach'


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We want to encourage candidates to enter A levels if they have them.
This commit is part of a series of changes designed to achieve this.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Here we rename the section of the application where A levels can be
entered as follows:

- 'A levels and other qualifications' for UK candidates
- 'Other qualifications' for international candidates

Notable code changes:

- Add a view helper to decide which title to use based on the state of
  the application form
- Remove a redundant 'add_other_qualification' locale string
- Use locale strings in the "type" form view templates, as these
  currently have a couple of hard-coded titles

Also, reorder the qualifications section, putting degrees at the bottom so that the order reflects a typical
chronology for these qualifications.

**UK candidate unsubmitted app**
![image](https://user-images.githubusercontent.com/519250/113154553-041c9680-9230-11eb-958e-344c9154c652.png)

**International candidate unsubmitted app**
![image](https://user-images.githubusercontent.com/519250/113155203-b18faa00-9230-11eb-813d-ba992a7589c0.png)

**Review page**
![image](https://user-images.githubusercontent.com/519250/113154217-b142df00-922f-11eb-92e9-59887b5db223.png)

## Guidance to review
- Can view the screens above in the review app, changing the candidate address to switch between UK/International.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/2Aba0zo2
## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
