### PR TITLE
Refactor offer wizard conditions into separate model

### DIFF
--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -5,8 +5,14 @@ module ProviderInterface
     before_action :requires_make_decisions_permission
 
     def new
-      @wizard = OfferWizard.new(offer_store,
-                                offer_context_params.merge!(current_step: 'select_option', action: action))
+      @wizard = OfferWizard.build_from_application_choice(
+        offer_store,
+        @application_choice,
+        provider_user_id: current_provider_user.id,
+        current_step: 'select_option',
+        decision: :default,
+        action: action,
+      )
       @wizard.save_state!
     end
 
@@ -152,22 +158,6 @@ module ProviderInterface
 
     def make_an_offer_params
       params.require(:make_an_offer)
-    end
-
-    def offer_context_params
-      course_option = @application_choice.course_option
-
-      {
-        provider_user_id: current_provider_user.id,
-        application_choice_id: @application_choice.id,
-        course_id: course_option.course.id,
-        course_option_id: course_option.id,
-        provider_id: course_option.provider.id,
-        study_mode: course_option.study_mode,
-        location_id: course_option.site.id,
-        decision: :default,
-        standard_conditions: MakeAnOffer::STANDARD_CONDITIONS,
-      }
     end
 
     def confirm_application_is_in_decision_pending_state

--- a/app/controllers/provider_interface/offer/conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/conditions_controller.rb
@@ -7,7 +7,7 @@ module ProviderInterface
       end
 
       def create
-        @wizard = OfferWizard.new(offer_store, conditions_params.to_h)
+        @wizard = OfferWizard.new(offer_store, conditions_attributes_for_wizard)
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!
@@ -24,7 +24,7 @@ module ProviderInterface
       end
 
       def update
-        @wizard = OfferWizard.new(offer_store, conditions_params.to_h)
+        @wizard = OfferWizard.new(offer_store, conditions_attributes_for_wizard)
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!
@@ -38,9 +38,18 @@ module ProviderInterface
     private
 
       def conditions_params
-        params.require(:provider_interface_offer_wizard).permit(:further_condition_1, :further_condition_2,
-                                                                :further_condition_3, :further_condition_4,
-                                                                standard_conditions: [])
+        params.require(:provider_interface_offer_wizard)
+              .permit(further_conditions: {}, standard_conditions: [])
+      end
+
+      def conditions_attributes_for_wizard
+        params = conditions_params.to_h
+
+        params['further_conditions'] = params['further_conditions'].values.map do |hash|
+          hash['text']
+        end
+
+        params
       end
     end
   end

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -32,9 +32,13 @@ module ProviderInterface
     def edit; end
 
     def show
-      @wizard = OfferWizard.new(offer_store,
-                                offer_context_params(:change_offer).merge!(current_step: :offer))
-      @wizard.configure_additional_conditions(@application_choice.offer['conditions'] - MakeAnOffer::STANDARD_CONDITIONS)
+      @wizard = OfferWizard.build_from_application_choice(
+        offer_store,
+        @application_choice,
+        provider_user_id: current_provider_user.id,
+        current_step: :offer,
+        decision: :change_offer,
+      )
       @wizard.save_state!
 
       return unless provider_user_can_make_decisions
@@ -102,23 +106,6 @@ module ProviderInterface
         user: current_provider_user,
         current_course: @application_choice.offered_course,
       )
-    end
-
-    def offer_context_params(decision = :default)
-      course_option = @application_choice.offered_option
-      conditions = @application_choice.offer['conditions'] || MakeAnOffer::STANDARD_CONDITIONS
-
-      {
-        provider_user_id: current_provider_user.id,
-        application_choice_id: @application_choice.id,
-        course_id: course_option.course.id,
-        course_option_id: course_option.id,
-        provider_id: course_option.provider.id,
-        study_mode: course_option.study_mode,
-        location_id: course_option.site.id,
-        decision: decision,
-        standard_conditions: conditions,
-      }
     end
 
     helper_method :provider_user_can_make_decisions

--- a/app/forms/provider_interface/offer_condition_field.rb
+++ b/app/forms/provider_interface/offer_condition_field.rb
@@ -1,0 +1,9 @@
+module ProviderInterface
+  class OfferConditionField
+    include ActiveModel::Model
+
+    attr_accessor :id, :text
+
+    validates :text, length: { maximum: 255, too_long: ->(c, _) { "Condition #{c.id + 1} must be %{count} characters or fewer" } }
+  end
+end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -4,10 +4,10 @@ module ProviderInterface
 
     STEPS = { make_offer: %i[select_option conditions check],
               change_offer: %i[select_option providers courses study_modes locations conditions check] }.freeze
+    NUMBER_OF_FURTHER_CONDITIONS = 4
 
     attr_accessor :provider_id, :course_id, :course_option_id, :study_mode, :location_id,
-                  :standard_conditions, :further_condition_1, :further_condition_2,
-                  :further_condition_3, :further_condition_4, :current_step, :decision,
+                  :standard_conditions, :further_conditions, :current_step, :decision,
                   :action, :path_history, :wizard_path_history,
                   :provider_user_id, :application_choice_id
 
@@ -15,19 +15,37 @@ module ProviderInterface
     validates :course_option_id, presence: true, on: %i[locations save]
     validates :study_mode, presence: true, on: %i[study_modes save]
     validates :course_id, presence: true, on: %i[courses save]
-    validates :further_condition_1, :further_condition_2, :further_condition_3, :further_condition_4, length: { maximum: 255 }
+    validate :further_conditions_valid, on: %i[conditions]
     validate :course_option_details, if: :course_option_id, on: :save
 
     def initialize(state_store, attrs = {})
       @state_store = state_store
 
       super(last_saved_state.deep_merge(attrs))
+      setup_further_conditions
       update_path_history(attrs)
     end
 
+    def self.build_from_application_choice(state_store, application_choice, options = {})
+      course_option = application_choice.offered_option
+
+      attrs = {
+        application_choice_id: application_choice.id,
+        course_id: course_option.course.id,
+        course_option_id: course_option.id,
+        provider_id: course_option.provider.id,
+        study_mode: course_option.study_mode,
+        location_id: course_option.site.id,
+        decision: :default,
+        standard_conditions: standard_conditions_from(application_choice.offer),
+        further_conditions: further_conditions_from(application_choice.offer),
+      }.merge(options)
+
+      new(state_store, attrs)
+    end
+
     def conditions
-      @conditions = (standard_conditions + [further_condition_1, further_condition_2,
-                                            further_condition_3, further_condition_4]).reject!(&:blank?)
+      @conditions = (standard_conditions + further_conditions).reject(&:blank?)
     end
 
     def course_option
@@ -62,13 +80,31 @@ module ProviderInterface
 
     delegate :previous_step, to: :wizard_path_history
 
-    def configure_additional_conditions(conditions)
-      conditions.each_with_index do |condition, index|
-        instance_variable_set "@further_condition_#{index + 1}", condition
+    def condition_models
+      @_condition_models ||= further_conditions.map.with_index do |further_condition, index|
+        OfferConditionField.new(id: index, text: further_condition)
       end
     end
 
   private
+
+    def self.standard_conditions_from(offer)
+      return MakeAnOffer::STANDARD_CONDITIONS if offer.blank?
+
+      conditions = offer['conditions']
+      conditions & MakeAnOffer::STANDARD_CONDITIONS
+    end
+
+    private_class_method :standard_conditions_from
+
+    def self.further_conditions_from(offer)
+      return [] if offer.blank?
+
+      conditions = offer['conditions']
+      conditions - MakeAnOffer::STANDARD_CONDITIONS
+    end
+
+    private_class_method :further_conditions_from
 
     def course_option_details
       OfferedCourseOptionDetailsCheck.new(provider_id: provider_id,
@@ -137,7 +173,7 @@ module ProviderInterface
 
     def state
       as_json(
-        except: %w[state_store errors validation_context query_service wizard_path_history],
+        except: %w[state_store errors validation_context query_service wizard_path_history _condition_models],
       ).to_json
     end
 
@@ -147,6 +183,23 @@ module ProviderInterface
                                                    action: attrs[:action].presence)
       @wizard_path_history.update
       @path_history = @wizard_path_history.path_history
+    end
+
+    def setup_further_conditions
+      self.further_conditions = NUMBER_OF_FURTHER_CONDITIONS.times.map do |index|
+        existing_value = further_conditions && further_conditions[index]
+        existing_value.presence || ''
+      end
+    end
+
+    def further_conditions_valid
+      condition_models.map(&:valid?).all?
+
+      condition_models.each do |model|
+        model.errors.each do |key, message|
+          errors.add("further_conditions[#{model.id}][#{key}]", message)
+        end
+      end
     end
   end
 end

--- a/app/views/provider_interface/offer/conditions/edit.html.erb
+++ b/app/views/provider_interface/offer/conditions/edit.html.erb
@@ -20,10 +20,11 @@
       <%= f.govuk_fieldset legend: { text: 'Further conditions', size: 'm' } do %>
         <p class="govuk-body">For example, studying a subject knowledge enhancement course.</p>
 
-        <%= f.govuk_text_area :further_condition_1, label: { size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_condition_2, label: { size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_condition_3, label: { size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_condition_4, label: { size: 's' }, rows: 3 %>
+        <% @wizard.condition_models.each do |model| %>
+          <%= f.fields_for 'further_conditions[]', model do |fc| %>
+            <%= fc.govuk_text_area :text, label: { text: "Condition #{model.id.to_i + 1}", size: 's' }, rows: 3 %>
+          <% end %>
+        <% end %>
       <% end %>
 
       <%= f.govuk_submit t('continue') %>

--- a/app/views/provider_interface/offer/conditions/new.html.erb
+++ b/app/views/provider_interface/offer/conditions/new.html.erb
@@ -20,10 +20,12 @@
       <%= f.govuk_fieldset legend: { text: 'Further conditions', size: 'm' } do %>
         <p class="govuk-body">For example, studying a subject knowledge enhancement course.</p>
 
-        <%= f.govuk_text_area :further_condition_1, label: { size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_condition_2, label: { size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_condition_3, label: { size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_condition_4, label: { size: 's' }, rows: 3 %>
+        <% @wizard.condition_models.each do |model| %>
+          <%= f.fields_for 'further_conditions[]', model do |fc| %>
+            <%= fc.govuk_text_area :text, label: { text: "Condition #{model.id.to_i + 1}", size: 's' }, rows: 3 %>
+          <% end %>
+        <% end %>
+
       <% end %>
 
       <%= f.govuk_submit t('continue') %>

--- a/spec/forms/provider_interface/offer_condition_field_spec.rb
+++ b/spec/forms/provider_interface/offer_condition_field_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::OfferConditionField, type: :model do
+  subject { described_class.new(id: 0) }
+
+  it { is_expected.to validate_length_of(:text).with_message('Condition 1 must be 255 characters or fewer') }
+end

--- a/spec/system/provider_interface/change_make_offer_spec.rb
+++ b/spec/system/provider_interface/change_make_offer_spec.rb
@@ -103,7 +103,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def when_i_add_further_conditions
-    fill_in('provider_interface_offer_wizard[further_condition_1]', with: 'A* on Maths A Level')
+    fill_in('provider_interface_offer_wizard[further_conditions][0][text]', with: 'A* on Maths A Level')
   end
 
   def and_i_click_continue

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -126,7 +126,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def when_i_add_further_conditions
-    fill_in('provider_interface_offer_wizard[further_condition_1]', with: 'A* on Maths A Level')
+    fill_in('provider_interface_offer_wizard[further_conditions][0][text]', with: 'A* on Maths A Level')
   end
 
   def and_i_click_continue


### PR DESCRIPTION
## Context
We are planning on allowing any number of conditions on an offer, so in an attempt to make that change easy, we move away from a hard coded 4 conditions.

## Changes proposed in this pull request
Add a model to manage conditions in the offer wizard
Use fields_for to correctly index the condition params and ensure that error links and field population works

Still to do:
- [x] Fix the tests
- [x] Make the error text consistent with what it used to be

## Link to Trello card
https://trello.com/c/AMcA4XK8/3514-spike-conditions-of-offer
