### PR TITLE
Ensure the date and time passed to TimeLimitCalculator has timezone i…

### DIFF
--- a/app/services/set_decline_by_default.rb
+++ b/app/services/set_decline_by_default.rb
@@ -23,7 +23,7 @@ class SetDeclineByDefault
 
     dbd_time_limit = TimeLimitCalculator.new(
       rule: :decline_by_default,
-      effective_date: final_decision_date,
+      effective_date: final_decision_date.in_time_zone,
     ).call
 
     dbd_days = dbd_time_limit[:days]


### PR DESCRIPTION
…nformation



## Context

ActiveRecord `maximum` returns the max value as a `Time` (and it seems without timezone info).
When passed to `TimeLimitCalculator` the resulting calculated times are also without timezone information. 
The time zone appears to be applied on AR update and so the offset is added. For end of day times this skews the value to the following day at 00:59am.

eg.
(Wrong)
```ruby
TimeLimitCalculator.new(
  rule: :decline_by_default,
  effective_date: ApplicationChoice.where(status: 'offer').maximum(:offered_at),
).call[:time_in_future].in_time_zone

=> Thu, 29 Apr 2021 00:59:59 BST +01:00
```

vs.

(Right)
```ruby
TimeLimitCalculator.new(
  rule: :decline_by_default,
  effective_date: ApplicationChoice.where(status: 'offer').maximum(:offered_at).in_time_zone,
).call[:time_in_future].in_time_zone

=> Wed, 28 Apr 2021 23:59:59 BST +01:00
```

We have seen this happen for decline by default date times around the summer time BST adjustments.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- This commit ensures that when setting the decline by default date we pass the `TimeLimitCalculator` a time with zone information so that the results we get back also have zone information.
- Also removes the spec instance double of `TimeLimitCalculator` as this was always returning a `TimeWithZone` which made replicating the issue difficult.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Should TimeLimitCalculator be responsible for ensuring time zones are applied? I have made changes to the smallest possible part of the code in the relevant service but I wonder if this should always be done in the calculator?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/zV3V9xml/3542-dbd-generated-before-clocks-change-set-to-1259am-rather-than-1159pm
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
