### PR TITLE
Show caption conditionally on the notifications settings page

### DIFF
--- a/app/views/provider_interface/notifications/show.html.erb
+++ b/app/views/provider_interface/notifications/show.html.erb
@@ -16,7 +16,11 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
       <%= t('page_titles.provider.notifications') %>
-      <span class="govuk-caption-m govuk-!-margin-top-1">These are sent when an application is submitted, withdrawn, automatically rejected, accepted or declined.</span>
+      <% if FeatureFlag.active?(:configurable_provider_notifications) %>
+        <span class="govuk-caption-m govuk-!-margin-top-1">Choose which email notifications you want to receive.</span>
+      <% else %>
+        <span class="govuk-caption-m govuk-!-margin-top-1">These are sent when an application is submitted, withdrawn, automatically rejected, accepted or declined.</span>
+      <% end %>
     </h1>
     <% if FeatureFlag.active?(:configurable_provider_notifications) %>
       <%= render ProviderUserNotificationPreferencesComponent.new(current_provider_user.notification_preferences, form_path: provider_interface_notifications_path) %>


### PR DESCRIPTION
## Context

It got missed out.

## Changes proposed in this pull request

Show caption conditionally on the notifications settings page

## Guidance to review

Visit `provider/account/notification-settings`

## Link to Trello card

https://trello.com/c/m7izA4Sh/3585-amend-hint-text-on-notifications

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
