### PR TITLE
Add Register API docs

### DIFF
--- a/app/controllers/api_docs/register_api_docs/open_api_controller.rb
+++ b/app/controllers/api_docs/register_api_docs/open_api_controller.rb
@@ -1,0 +1,9 @@
+module APIDocs
+  module RegisterAPIDocs
+    class OpenAPIController < APIDocsController
+      def spec
+        render plain: RegisterAPISpecification.as_yaml, content_type: 'text/yaml'
+      end
+    end
+  end
+end

--- a/app/controllers/api_docs/register_api_docs/pages_controller.rb
+++ b/app/controllers/api_docs/register_api_docs/pages_controller.rb
@@ -1,0 +1,18 @@
+module APIDocs
+  module RegisterAPIDocs
+    class PagesController < APIDocsController
+      def release_notes
+        render_content_page :release_notes
+      end
+
+    private
+
+      def render_content_page(page_name)
+        @converted_markdown = GovukMarkdown.render(File.read("app/views/api_docs/register_api_docs/pages/#{page_name}.md")).html_safe
+        @page_name = page_name
+
+        render 'rendered_markdown_template'
+      end
+    end
+  end
+end

--- a/app/controllers/api_docs/register_api_docs/reference_controller.rb
+++ b/app/controllers/api_docs/register_api_docs/reference_controller.rb
@@ -1,0 +1,9 @@
+module APIDocs
+  module RegisterAPIDocs
+    class ReferenceController < APIDocsController
+      def reference
+        @api_reference = APIReference.new(RegisterAPISpecification.as_hash)
+      end
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,6 +41,8 @@ module ApplicationHelper
       'api_docs'
     elsif section == 'data-api'
       'data_api_docs'
+    elsif section == 'register-api'
+      'register_api_docs'
     else
       "#{section}_interface"
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,7 @@ module ApplicationHelper
   def current_namespace
     section = request.path.split('/').second
     if section == 'api-docs'
-      'api_docs'
+      'vendor_api_docs'
     elsif section == 'data-api'
       'data_api_docs'
     elsif section == 'register-api'

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -97,6 +97,13 @@ class NavigationItems
       ]
     end
 
+    def for_register_api_docs(current_controller)
+      [
+        NavigationItem.new('Home', api_docs_register_api_docs_home_path, is_active_action(current_controller, 'reference')),
+        NavigationItem.new('Release notes', api_docs_register_api_docs_release_notes_path, is_active_action(current_controller, 'release_notes')),
+      ]
+    end
+
   private
 
     def is_active(current_controller, active_controllers)

--- a/app/lib/register_api_specification.rb
+++ b/app/lib/register_api_specification.rb
@@ -1,0 +1,13 @@
+class RegisterAPISpecification
+  def self.as_yaml
+    spec.to_yaml
+  end
+
+  def self.as_hash
+    spec
+  end
+
+  def self.spec
+    YAML.load_file('config/register-api.yml')
+  end
+end

--- a/app/presenters/register_api/single_application_presenter.rb
+++ b/app/presenters/register_api/single_application_presenter.rb
@@ -42,7 +42,7 @@ module RegisterAPI
           contact_details: contact_details,
           course: course_info_for(application_choice.offered_option),
           qualifications: qualifications,
-          hesa_itt_data: hesa_itt_data.presence || {},
+          hesa_itt_data: hesa_itt_data.presence,
         },
       }
     end

--- a/app/views/api_docs/register_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/register_api_docs/pages/release_notes.md
@@ -1,0 +1,3 @@
+## 7 April 2021
+
+Initial release (v1.0)

--- a/app/views/api_docs/register_api_docs/pages/rendered_markdown_template.html.erb
+++ b/app/views/api_docs/register_api_docs/pages/rendered_markdown_template.html.erb
@@ -1,0 +1,9 @@
+<%= content_for :title, t("page_titles.api_docs.vendor_api_docs.#{@page_name}") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t("page_titles.api_docs.vendor_api_docs.#{@page_name}") %></h1>
+
+    <%= @converted_markdown %>
+  </div>
+</div>

--- a/app/views/api_docs/register_api_docs/reference/reference.html.erb
+++ b/app/views/api_docs/register_api_docs/reference/reference.html.erb
@@ -1,0 +1,80 @@
+<h1 class="govuk-heading-xl"><%= t('page_titles.api_docs.register_api_docs.reference') %></h1>
+
+<p class="govuk-body">
+  This is API documentation for the Apply for teacher training Register API.
+  This API provides data extracts of recruited candidates applications from DfE’s Apply for teacher training service used by the DfE’s Register trainee teachers service.
+</p>
+
+<h2 class="app-contents-list__title">Contents</h2>
+
+<ol class="app-contents-list__list">
+  <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'Developing on the API', '#developing', class: 'app-contents-list__link' %></li>
+  <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+    <%= govuk_link_to 'Endpoints', '#endpoints', class: 'app-contents-list__link' %>
+
+    <ol class="app-contents-list__nested-list">
+    <% @api_reference.operations.each do |operation| %>
+      <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+        <%= govuk_link_to operation.name, "##{operation.anchor}", class: 'app-contents-list__link' %>
+      </li>
+    <% end %>
+    </ol>
+  </li>
+  <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+    <%= govuk_link_to 'Objects', '#objects', class: 'app-contents-list__link' %>
+
+    <ol class="app-contents-list__nested-list">
+      <% @api_reference.schemas.each do |schema| %>
+        <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+          <%= govuk_link_to schema.name, "##{schema.anchor}", class: 'app-contents-list__link' %>
+        </li>
+      <% end %>
+    </ol>
+  </li>
+</ol>
+
+<hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
+
+<h2 class="govuk-heading-l" id="developing">Developing on the API</h2>
+
+<p class="govuk-body">
+  The OpenAPI spec from which this documentation is generated is <%= govuk_link_to 'available in YAML format', api_docs_register_api_docs_spec_url %>.
+</p>
+
+<h3 class="govuk-heading-m">Environments</h3>
+
+<p class="govuk-body">
+  We have a production environment and a sandbox environment for testing.
+</p>
+
+<p class="govuk-body">
+  <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/register-api', 'https://sandbox.apply-for-teacher-training.service.gov.uk/register-api' %>
+</p>
+
+<p class="govuk-body">
+  The <strong>Production</strong> environment is the real environment. Do not
+  perform testing here.
+</p>
+
+<p class="govuk-body">
+  <%= govuk_link_to 'https://www.apply-for-teacher-training.service.gov.uk/register-api', 'https://www.apply-for-teacher-training.service.gov.uk/register-api' %>
+</p>
+
+<h3 id="authentication" class="govuk-heading-m">Authentication</h3>
+
+<p class="govuk-body">
+  All requests must be accompanied by an <code>Authorization</code> request header (not as part of the URL) in the following format:
+</p>
+
+<p class="govuk-body">
+  <code>
+    Authorization: Bearer {token}
+  </code>
+</p>
+
+<p class="govuk-body">
+  Unauthenticated requests will receive an <%= govuk_link_to 'UnauthorizedResponse', '#unauthorizedresponse-object' %>
+  with a <code>401</code> status code.
+</p>
+
+<%= render(APIDocs::APIReferenceComponent.new(@api_reference)) %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -54,6 +54,17 @@
   <%= render(PrimaryNavigationComponent.new(
     items: NavigationItems.for_vendor_api_docs(controller),
   )) %>
+<% when 'register_api_docs' %>
+  <%= render(ProductHeaderComponent.new(
+    classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border",
+    product_name: service_name,
+    service_url: service_link,
+    phase_tag: true,
+    navigation_items: [],
+  )) %>
+  <%= render(PrimaryNavigationComponent.new(
+    items: NavigationItems.for_register_api_docs(controller),
+  )) %>
 <% else %>
   <% components_url = '/rails/view_components' if request.path.match(/^\/rails\/view_components/) %>
   <% components_name = 'ViewComponent Previews' if request.path.match(/^\/rails\/view_components/) %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -43,7 +43,7 @@
       items: NavigationItems.for_provider_primary_nav(try(:current_provider_user), controller, @provider_setup&.pending?),
     )) %>
   <% end %>
-<% when 'api_docs' %>
+<% when 'vendor_api_docs' %>
   <%= render(ProductHeaderComponent.new(
     classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border",
     product_name: service_name,

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -78,7 +78,7 @@
     <% when 'provider_interface' %>
       <%= javascript_pack_tag 'application-provider' %>
       <%= render 'shared/zendesk_snippet' if HostingEnvironment.test_environment? %>
-    <% when 'api_docs' %>
+    <% when 'api_docs', 'data_api_docs' 'register_api_docs' %>
       <%= javascript_pack_tag 'application-api-docs' %>
     <% else %>
       <%= javascript_pack_tag 'application' %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -29,7 +29,7 @@
       <%= stylesheet_pack_tag 'application-support', media: 'all' %>
     <% when 'provider_interface' %>
       <%= stylesheet_pack_tag 'application-provider', media: 'all' %>
-    <% when 'api_docs', 'data_api_docs' %>
+    <% when 'api_docs', 'data_api_docs', 'register_api_docs' %>
       <%= stylesheet_pack_tag 'application-api-docs', media: 'all' %>
     <% else %>
       <%= stylesheet_pack_tag 'application', media: 'all' %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -29,7 +29,7 @@
       <%= stylesheet_pack_tag 'application-support', media: 'all' %>
     <% when 'provider_interface' %>
       <%= stylesheet_pack_tag 'application-provider', media: 'all' %>
-    <% when 'api_docs', 'data_api_docs', 'register_api_docs' %>
+    <% when /api_docs/ %>
       <%= stylesheet_pack_tag 'application-api-docs', media: 'all' %>
     <% else %>
       <%= stylesheet_pack_tag 'application', media: 'all' %>
@@ -78,7 +78,7 @@
     <% when 'provider_interface' %>
       <%= javascript_pack_tag 'application-provider' %>
       <%= render 'shared/zendesk_snippet' if HostingEnvironment.test_environment? %>
-    <% when 'api_docs', 'data_api_docs' 'register_api_docs' %>
+    <% when /api_docs/ %>
       <%= javascript_pack_tag 'application-api-docs' %>
     <% else %>
       <%= javascript_pack_tag 'application' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -185,6 +185,8 @@ en:
         release_notes: Release notes
         lifecycle: Lifecycle
         alpha_release_notes: Alpha release notes
+      register_api_docs:
+        reference: Apply for teacher training - Register API
     provider:
       confirm_offer: Check and confirm offer
       confirm_reject: Check feedback and reject application

--- a/config/register-api.yml
+++ b/config/register-api.yml
@@ -89,13 +89,6 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/Application"
-    SingleApplicationResponse:
-      type: object
-      required:
-      - data
-      properties:
-        data:
-          "$ref": "#/components/schemas/Application"
     Application:
       type: object
       additionalProperties: false
@@ -539,21 +532,21 @@ components:
           type: array
           items:
             type: string
+            enum:
+            - "00"
+            - "08"
+            - "51"
+            - "53"
+            - "54"
+            - "55"
+            - "56"
+            - "57"
+            - "58"
+            - "96"
           description: The candidate’s disabilities as an array of [2-digit HESA codes for Disability](https://www.hesa.ac.uk/collection/c19053/e/disable)
           example:
             - "00"
             - "51"
-          enum:
-          - "00"
-          - "08"
-          - "51"
-          - "53"
-          - "54"
-          - "55"
-          - "56"
-          - "57"
-          - "58"
-          - "96"
         ethnicity:
           type: string
           nullable: true

--- a/config/register-api.yml
+++ b/config/register-api.yml
@@ -1,0 +1,670 @@
+---
+openapi: 3.0.0
+info:
+  version: v1
+  title: Apply register API
+  contact:
+    name: DfE
+    email: becomingateacher@digital.education.gov.uk
+  description: |
+    API for data extracts of recruited candidates applications from DfE’s Apply for teacher training service
+    used by the DfE’s Register trainee teachers service.
+servers:
+- description: Sandbox (test environment)
+  url: https://sandbox.apply-for-teacher-training.service.gov.uk/register-api
+- description: Production
+  url: https://www.apply-for-teacher-training.service.gov.uk/register-api
+paths:
+  "/applications":
+    get:
+      summary: Get many applications
+      description: |
+        This endpoint can be used to retrieve applications for recruited candidates for a given recruitment cycle year.
+
+        Use the `changed_since` parameter to limit the number of results. This is intended
+        to make it possible to check for new or updated applications regularly.
+      parameters:
+      - name: recruitment_cycle_year
+        description: Include only applications in a given recruitment cycle year visible to providers.
+        in: query
+        required: true
+        example: 2021
+        schema:
+          type: integer
+      - name: changed_since
+        description: Include only applications changed or created on or since a date
+          and time. Times should be in ISO 8601 format.
+        in: query
+        example: 2019-12-06T12:00:00Z
+        schema:
+          type: string
+          format: date-time
+      responses:
+        '200':
+          description: An array of applications
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MultipleApplicationsResponse"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+components:
+  responses:
+    OK:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/OkResponse"
+    NotFound:
+      description: Not found
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/NotFoundResponse"
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/UnauthorizedResponse"
+    UnprocessableEntity:
+      description: Returned when the request body was missing data or contained invalid
+        data
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - "$ref": "#/components/schemas/ParameterMissingResponse"
+              - "$ref": "#/components/schemas/ParameterInvalidResponse"
+  schemas:
+    MultipleApplicationsResponse:
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Application"
+    SingleApplicationResponse:
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          "$ref": "#/components/schemas/Application"
+    Application:
+      type: object
+      additionalProperties: false
+      required:
+      - id
+      - type
+      - attributes
+      properties:
+        id:
+          type: string
+          description: The unique ID of this application
+          maxLength: 10
+          example: 11fc0d3b2f
+        type:
+          type: string
+          description: Type of the object, always "application"
+          enum:
+          - application
+          example: application
+        attributes:
+          "$ref": "#/components/schemas/ApplicationAttributes"
+    ApplicationAttributes:
+      type: object
+      additionalProperties: false
+      required:
+      - support_reference
+      - status
+      - updated_at
+      - submitted_at
+      - recruited_at
+      - candidate
+      - contact_details
+      - course
+      - qualifications
+      properties:
+        support_reference:
+          type: string
+          description: The candidate’s reference number for their application in the Apply system
+          maxLength: 10
+          example: AB1234
+        status:
+          type: string
+          description: |
+            The status of this application. Refer to the [application
+            lifecycle diagram](/api-docs/lifecycle) for states and transitions.
+          enum:
+          - recruited
+          - withdrawn
+          - offer_deferred
+          example: awaiting_provider_decision
+        updated_at:
+          type: string
+          format: date-time
+          description: Time of last change
+          example: 2019-06-13T10:44:31Z
+        submitted_at:
+          type: string
+          format: date-time
+          description: Time of submission
+          example: 2019-06-13T10:44:31Z
+        recruited_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the candidate met their conditions, receiving a firm place on the course
+          example: 2019-06-13T23:59:59Z
+        candidate:
+          "$ref": "#/components/schemas/Candidate"
+        contact_details:
+          "$ref": "#/components/schemas/ContactDetails"
+        course:
+          "$ref": "#/components/schemas/Course"
+        qualifications:
+          "$ref": "#/components/schemas/Qualifications"
+        hesa_itt_data:
+          anyOf:
+          - "$ref": "#/components/schemas/HESAITTData"
+          nullable: true
+          description: Values to populate this candidate’s HESA Initial Teacher
+            Training data return.  Available once an offer has been accepted.
+    Candidate:
+      type: object
+      additionalProperties: false
+      required:
+      - id
+      - first_name
+      - last_name
+      - date_of_birth
+      - nationality
+      - domicile
+      - uk_residency_status
+      - uk_residency_status_code
+      - fee_payer
+      - english_main_language
+      - english_language_qualifications
+      - other_languages
+      - disability_disclosure
+      - disabilities
+      - gender
+      - ethnic_group
+      - ethnic_background
+      properties:
+        id:
+          type: string
+          description: The candidate’s ID in the Apply system
+          maxLength: 10
+          example: C5432
+        first_name:
+          type: string
+          description: The candidate’s first name
+          maxLength: 60
+          example: Boris
+        last_name:
+          type: string
+          description: The candidate’s last name
+          example: Brown
+          maxLength: 60
+        date_of_birth:
+          type: string
+          format: date
+          description: The candidate’s date of birth
+          example: "1985-02-13"
+        nationality:
+          type: array
+          items:
+            type: string
+            pattern: "^[A-Z]{2}$"
+            example: NL
+          maxItems: 5
+          description: One or more ISO 3166-2 country codes
+        domicile:
+          type: string
+          maxLength: 2
+          description: The candidate’s domicile, extracted from their address. Coded according to [the HESA DOMICILE field](https://www.hesa.ac.uk/collection/c20051/a/domicile).
+          example: XF
+        uk_residency_status:
+          type: string
+          maxLength: 256
+          description: The candidate’s UK residency status indicating their right to work and study in the UK. Possible values include "UK Citizen", "Irish Citizen" and "Candidate needs to apply for permission to work and study in the UK". The candidate can also provide details as free text for example "Settled status".
+          example: UK Citizen
+        uk_residency_status_code:
+          type: string
+          maxLength: 1
+          description: |
+            Single alphabetical character code for the candidate’s UK residency status indicating their right to work and study in the UK:
+
+            - A - UK Citizen
+            - B - Irish Citizen
+            - C - Candidate needs to apply for permission to work and study in the UK
+            - D - Candidate's free text response
+          example: 'B'
+          enum:
+            - 'A'
+            - 'B'
+            - 'C'
+            - 'D'
+        fee_payer:
+          type: string
+          maxLength: 2
+          description: Provisional fee payer status based on a candidate's nationality, residency status and domicile.
+          example: '02'
+          enum:
+          - '02'
+          - '99'
+        english_main_language:
+          type: boolean
+          description: Does this candidate have English as a main language?
+          example: true
+        english_language_qualifications:
+          type: string
+          maxLength: 10240
+          nullable: true
+          description: Details of this candidate's English language qualification, if English is not their main language
+          example: 'Name: TOEFL, Grade: 20, Awarded: 1999'
+        other_languages:
+          type: string
+          maxLength: 10240
+          nullable: true
+          description: Details of the candidate’s fluency in other languages
+          example: I am bilingual in Finnish and English
+        disability_disclosure:
+          type: string
+          maxLength: 10240
+          nullable: true
+          description: Voluntary disclosure of disabliity or SEN so providers can
+            provide appropriate support
+          example: I am dyslexic
+        gender:
+          type: string
+          maxLength: 256
+          description: The candidate’s sex
+          nullable: true
+          example: male
+          enum:
+          - male
+          - female
+          - intersex
+          - Prefer not to say
+        disabilities:
+          type: array
+          maxLength: 256
+          description: Candidate's disabilities
+          items:
+            type: string
+            example: blind
+        ethnic_group:
+          type: string
+          maxLength: 256
+          nullable: true
+          description: Candidate's ethnic group
+          example: Asian or Asian British
+          enum:
+          - Asian or Asian British
+          - Black, African, Black British or Caribbean
+          - Mixed or multiple ethnic groups
+          - White
+          - Another ethnic group
+        ethnic_background:
+          type: string
+          maxLength: 256
+          nullable: true
+          description: Candidate's ethnic background
+          example: Chinese
+    ContactDetails:
+      type: object
+      additionalProperties: false
+      required:
+      - address_line1
+      - country
+      - email
+      - phone_number
+      properties:
+        address_line1:
+          type: string
+          description: The candidate’s address line 1
+          maxLength: 50
+          example: 45 Dialstone Lane
+        address_line2:
+          type: string
+          description: The candidate’s address line 2
+          maxLength: 50
+          example: Stockport
+          nullable: true
+        address_line3:
+          type: string
+          description: The candidate’s address line 3
+          maxLength: 50
+          example: Greater Manchester
+          nullable: true
+        address_line4:
+          type: string
+          description: The candidate’s address line 4
+          maxLength: 50
+          example: England
+          nullable: true
+        postcode:
+          type: string
+          description: The candidate’s postcode
+          maxLength: 8
+          example: SK2 6AA
+          nullable: true
+        country:
+          type: string
+          maxLength: 2
+          description: The candidate’s country - ISO 3166-2 country code
+          pattern: "^[A-Z]{2}$"
+          example: GB
+        email:
+          type: string
+          description: The candidate’s email address
+          maxLength: 100
+          example: boris.brown@example.com
+        phone_number:
+          type: string
+          description: The candidate’s phone number
+          maxLength: 50
+          example: "07944386555"
+    Course:
+      type: object
+      additionalProperties: false
+      required:
+      - recruitment_cycle_year
+      - course_code
+      - training_provider_code
+      - site_code
+      - study_mode
+      properties:
+        recruitment_cycle_year:
+          type: integer
+          description: The course’s recruitment cycle year
+          example: 2020
+        training_provider_code:
+          type: string
+          description: The training provider’s code
+          example: 2FR
+          maxLength: 3
+        course_code:
+          type: string
+          description: The course’s code
+          example: 3CVK
+          maxLength: 4
+        site_code:
+          type: string
+          description: The site’s code
+          example: K
+          maxLength: 5
+        study_mode:
+          type: string
+          description: Can be `full_time` or `part_time`
+          example: full_time
+          enum:
+          - full_time
+          - part_time
+    Qualification:
+      type: object
+      additionalProperties: false
+      required:
+      - id
+      - qualification_type
+      - non_uk_qualification_type
+      - subject
+      - grade
+      - start_year
+      - award_year
+      - institution_details
+      - equivalency_details
+      - comparable_uk_degree
+      properties:
+        id:
+          type: integer
+          description: The qualification ID in the Apply system. These IDs are not guaranteed to be unique, for example when a candidate has multiple English GCSEs
+          example: 123
+        qualification_type:
+          type: string
+          maxLength: 256
+          description: The qualification awarded
+          example: BA
+        non_uk_qualification_type:
+          nullable: true
+          type: string
+          maxLength: 256
+          description: For a qualification of type non_uk, this field will contain a free-text description of the qualification type
+          example: High School Diploma
+        subject:
+          type: string
+          description: The subject studied
+          maxLength: 256
+          example: History and Politics
+        grade:
+          type: string
+          maxLength: 256
+          description: The grade awarded. e.g. "2:1" for university degrees, "A" for GCSE, "BA*" for double-award science, or "ABC" for triple-award science. For triple-award science, which is the only possible value with three grades, the grades are in the order Biology, Physics, Chemistry.
+          example: "AA*B"
+        start_year:
+          type: string
+          nullable: true
+          maxLength: 4
+          description: The year the candidate started qualification
+          example: "1989"
+        award_year:
+          type: string
+          maxLength: 4
+          description: The year the award was made
+          example: "1992"
+        institution_details:
+          type: string
+          description: Details about the institution and awarding body
+          maxLength: 256
+          example: University of Huddersfield
+          nullable: true
+        equivalency_details:
+          type: string
+          description: Details of equivalency, if this qualification was awarded overseas
+          example: 'Enic: 4000123456 - Between GCSE and GCSE AS Level - Equivalent to GCSE C'
+          maxLength: 256
+          nullable: true
+        comparable_uk_degree:
+          type: string
+          description: Details of comparable degree, if this qualification was awarded overseas
+          example: masters_degree
+          maxLength: 256
+          nullable: true
+          enum:
+          - bachelor_ordinary_degree
+          - masters_degree
+          - doctor_of_philosophy
+          - post_doctoral_award
+          - postgraduate_certificate_or_diploma
+          - bachelor_honours_degree
+    Qualifications:
+      type: object
+      additionalProperties: false
+      required:
+      - gcses
+      - degrees
+      - other_qualifications
+      - missing_gcses_explanation
+      properties:
+        gcses:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Qualification"
+        degrees:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Qualification"
+        other_qualifications:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Qualification"
+        missing_gcses_explanation:
+          type: string
+          nullable: true
+          maxLength: 10240
+          description: If the candidate lacks any required GCSEs, this field will
+            contain their free-text explanation of why this is the case.
+          example: "Maths GCSE or equivalent: I will take Maths GCSE at my local training
+            provider on 18th August 2020"
+    HESAITTData:
+      type: object
+      additionalProperties: false
+      description: |
+        Information required by HESA for the Initial Teacher Training data
+        return.
+      required:
+      - sex
+      - disability
+      - ethnicity
+      properties:
+        sex:
+          type: string
+          nullable: true
+          description: The candidate’s sex as a [1-digit HESA code for Sex](https://www.hesa.ac.uk/collection/c19053/e/sexid)
+          example: "1"
+          enum:
+          - "1"
+          - "2"
+          - "3"
+        disability:
+          nullable: true
+          type: array
+          items:
+            type: string
+          description: The candidate’s disabilities as an array of [2-digit HESA codes for Disability](https://www.hesa.ac.uk/collection/c19053/e/disable)
+          example:
+            - "00"
+            - "51"
+          enum:
+          - "00"
+          - "08"
+          - "51"
+          - "53"
+          - "54"
+          - "55"
+          - "56"
+          - "57"
+          - "58"
+          - "96"
+        ethnicity:
+          type: string
+          nullable: true
+          description: The candidate’s ethnicity as [a 2-digit HESA code for Ethnicity](https://www.hesa.ac.uk/collection/c19053/e/ethnic)
+          example: "10"
+          enum:
+          - "10"
+          - "15"
+          - "21"
+          - "22"
+          - "29"
+          - "31"
+          - "32"
+          - "33"
+          - "34"
+          - "39"
+          - "41"
+          - "42"
+          - "43"
+          - "49"
+          - "50"
+          - "80"
+          - "90"
+          - "98"
+    Error:
+      type: object
+      additionalProperties: false
+      properties:
+        error:
+          type: string
+          description: Name of the current error
+          example: Unauthorized
+        message:
+          type: string
+          description: Description of the current error
+          example: Please provide a valid authentication token
+      required:
+      - error
+      - message
+    UnauthorizedResponse:
+      type: object
+      required:
+      - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: Unauthorized
+            message: Please provide a valid authentication token
+    ParameterMissingResponse:
+      type: object
+      required:
+      - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: ParameterMissing
+            message: "param is missing or the value is empty: parameter_name"
+    ParameterInvalidResponse:
+      type: object
+      required:
+      - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: ParameterInvalid
+            message: "Parameter is invalid: parameter_name"
+    NotFoundResponse:
+      type: object
+      required:
+      - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: NotFound
+            message: Unable to find Application(s)
+    OkResponse:
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          type: object
+          required:
+          - message
+          properties:
+            message:
+              type: string
+              example: OK
+  securitySchemes:
+    tokenAuth:
+      type: http
+      scheme: bearer
+security:
+- tokenAuth: []

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -995,6 +995,11 @@ Rails.application.routes.draw do
       get '/' => 'reference#reference', as: :home
       get '/spec.yml' => 'open_api#spec', as: :spec
     end
+
+    namespace :register_api_docs, path: '/register-api-docs' do
+      get '/' => 'reference#reference', as: :home
+      get '/spec.yml' => 'open_api#spec', as: :spec
+    end
   end
 
   get '/check', to: 'healthcheck#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -996,7 +996,7 @@ Rails.application.routes.draw do
       get '/spec.yml' => 'open_api#spec', as: :spec
     end
 
-    namespace :register_api_docs, path: '/register-api-docs' do
+    namespace :register_api_docs, path: '/register-api' do
       get '/' => 'reference#reference', as: :home
       get '/spec.yml' => 'open_api#spec', as: :spec
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -999,6 +999,7 @@ Rails.application.routes.draw do
     namespace :register_api_docs, path: '/register-api' do
       get '/' => 'reference#reference', as: :home
       get '/spec.yml' => 'open_api#spec', as: :spec
+      get '/release-notes' => 'pages#release_notes', as: :release_notes
     end
   end
 

--- a/spec/requests/register_api/get_multiple_applications_spec.rb
+++ b/spec/requests/register_api/get_multiple_applications_spec.rb
@@ -7,12 +7,30 @@ RSpec.describe 'GET /register-api/applications', type: :request do
     api_token = ServiceAPIUser.test_data_user.create_magic_link_token!
     get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: api_token
     expect(response).to have_http_status(:unauthorized)
+    expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
   end
 
   it 'allows access to the API for Register users' do
     get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: register_api_token
 
     expect(response).to have_http_status(:success)
+    expect(parsed_response).to be_valid_against_openapi_schema('MultipleApplicationsResponse')
+  end
+
+  it 'returns applications with equality and diversity data' do
+    create(:application_choice, :with_recruited, application_form: create(:completed_application_form, :with_equality_and_diversity_data))
+
+    get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: register_api_token
+
+    expect(parsed_response).to be_valid_against_openapi_schema('MultipleApplicationsResponse')
+  end
+
+  it 'returns applications without equality and diversity data' do
+    create(:application_choice, :with_recruited, application_form: create(:completed_application_form))
+
+    get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: register_api_token
+
+    expect(parsed_response).to be_valid_against_openapi_schema('MultipleApplicationsResponse')
   end
 
   it 'returns an error if the `recruitment_cycle_year` parameter is missing' do
@@ -20,6 +38,7 @@ RSpec.describe 'GET /register-api/applications', type: :request do
 
     expect(response).to have_http_status(422)
     expect(error_response['message']).to eql('param is missing or the value is empty: recruitment_cycle_year')
+    expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse')
   end
 
   it 'returns an error if the `recruitment_cycle_year` parameter is incorrect year' do
@@ -27,6 +46,7 @@ RSpec.describe 'GET /register-api/applications', type: :request do
 
     expect(response).to have_http_status(422)
     expect(error_response['message']).to eql('Parameter is invalid: recruitment_cycle_year')
+    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
   end
 
   it 'returns HTTP status 422 given an unparseable `changed_since` date value' do
@@ -34,6 +54,7 @@ RSpec.describe 'GET /register-api/applications', type: :request do
 
     expect(response).to have_http_status(422)
     expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): changed_since')
+    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
   end
 
   it 'returns HTTP status 422 when encountering a KeyError from ActiveSupport::TimeZone' do
@@ -41,6 +62,7 @@ RSpec.describe 'GET /register-api/applications', type: :request do
 
     expect(response).to have_http_status(422)
     expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): changed_since')
+    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
   end
 
   it 'returns HTTP status 422 given a parseable but nonsensensical `changed_since` date value' do
@@ -48,5 +70,6 @@ RSpec.describe 'GET /register-api/applications', type: :request do
 
     expect(response).to have_http_status(422)
     expect(error_response['message']).to eql('Parameter is invalid (date is nonsense): changed_since')
+    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
   end
 end

--- a/spec/support/register_api/register_api_spec_helper.rb
+++ b/spec/support/register_api/register_api_spec_helper.rb
@@ -20,4 +20,8 @@ module RegisterAPISpecHelper
   def error_response
     parsed_response['errors'].first
   end
+
+  def be_valid_against_openapi_schema(expected)
+    ValidAgainstOpenAPISchemaMatcher.new(expected, RegisterAPISpecification.as_hash)
+  end
 end

--- a/spec/system/api_docs/register_api/register_api_docs_spec.rb
+++ b/spec/system/api_docs/register_api/register_api_docs_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.feature 'Register API docs' do
+  scenario 'User visits Register API docs' do
+    when_i_visit_the_data_api_docs
+    then_i_can_see_the_docs
+  end
+
+  def when_i_visit_the_data_api_docs
+    visit '/register-api-docs'
+  end
+
+  def then_i_can_see_the_docs
+    expect(page).to have_content 'Apply for teacher training - Register API'
+  end
+end

--- a/spec/system/api_docs/register_api/register_api_docs_spec.rb
+++ b/spec/system/api_docs/register_api/register_api_docs_spec.rb
@@ -2,15 +2,21 @@ require 'rails_helper'
 
 RSpec.feature 'Register API docs' do
   scenario 'User visits Register API docs' do
-    when_i_visit_the_data_api_docs
+    when_i_visit_the_register_api_docs
     then_i_can_see_the_docs
+    and_i_can_see_the_release_notes
   end
 
-  def when_i_visit_the_data_api_docs
-    visit '/register-api-docs'
+  def when_i_visit_the_register_api_docs
+    visit '/register-api'
   end
 
   def then_i_can_see_the_docs
     expect(page).to have_content 'Apply for teacher training - Register API'
+  end
+
+  def and_i_can_see_the_release_notes
+    click_link 'Release notes'
+    expect(page).to have_content '7 April 2021'
   end
 end


### PR DESCRIPTION
## Context

We need to document the new shiny API ✨ we made for the Register team 💙 

## Changes proposed in this pull request

Add OpenAPI spec

## Guidance to review

visit `/register-api`

Pay the most attention to the following new attributes:

- gender
- disabilities
- ethnic_group
- ethnic_background
- comparable_uk_degree

We are also missing `ParameterInvalid` response in the Vendor API docs for GET /applications.
I added this as a separate commit which can be dropped or fixed up.

<img width="1014" alt="Screenshot 2021-04-07 at 14 20 04" src="https://user-images.githubusercontent.com/642279/113873145-70594600-97ac-11eb-9f73-94c8c13f0a2c.png">

## Link to Trello card

https://trello.com/c/yo8jZhLa/3499-spike-bare-bones-api-for-register

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
