### PR TITLE
Integrate GetChangeOfferOptions into new offer flows

### DIFF
--- a/app/components/provider_interface/completed_offer_summary_component.rb
+++ b/app/components/provider_interface/completed_offer_summary_component.rb
@@ -27,7 +27,7 @@ module ProviderInterface
     end
 
     def change_provider_path
-      available_providers.many? ? edit_provider_interface_application_choice_offer_providers_path(application_choice) : nil
+      available_providers.length > 1 ? edit_provider_interface_application_choice_offer_providers_path(application_choice) : nil
     end
 
     def change_course_path

--- a/app/components/provider_interface/completed_offer_summary_component.rb
+++ b/app/components/provider_interface/completed_offer_summary_component.rb
@@ -31,7 +31,7 @@ module ProviderInterface
     end
 
     def change_course_path
-      available_courses.many? ? edit_provider_interface_application_choice_offer_courses_path(application_choice) : nil
+      available_courses.length > 1 ? edit_provider_interface_application_choice_offer_courses_path(application_choice) : nil
     end
 
     def change_study_mode_path
@@ -39,7 +39,7 @@ module ProviderInterface
     end
 
     def change_location_path
-      available_course_options.many? ? edit_provider_interface_application_choice_offer_locations_path(application_choice) : nil
+      available_course_options.length > 1 ? edit_provider_interface_application_choice_offer_locations_path(application_choice) : nil
     end
 
     def mode

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -39,7 +39,7 @@ module ProviderInterface
     end
 
     def change_provider_path
-      available_providers.many? ? new_provider_interface_application_choice_offer_providers_path(application_choice) : nil
+      available_providers.length > 1 ? new_provider_interface_application_choice_offer_providers_path(application_choice) : nil
     end
 
     def change_course_path

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -43,11 +43,11 @@ module ProviderInterface
     end
 
     def change_course_path
-      available_courses.many? ? new_provider_interface_application_choice_offer_courses_path(application_choice) : nil
+      available_courses.length > 1 ? new_provider_interface_application_choice_offer_courses_path(application_choice) : nil
     end
 
     def change_location_path
-      available_course_options.many? ? new_provider_interface_application_choice_offer_locations_path(application_choice) : nil
+      available_course_options.length > 1 ? new_provider_interface_application_choice_offer_locations_path(application_choice) : nil
     end
 
     def change_study_mode_path

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -6,7 +6,7 @@ module ProviderInterface
 
     def new
       @wizard = OfferWizard.new(offer_store,
-                                offer_context_params(@application_choice.course_option).merge!(current_step: 'select_option', action: action))
+                                offer_context_params.merge!(current_step: 'select_option', action: action))
       @wizard.save_state!
     end
 
@@ -154,9 +154,12 @@ module ProviderInterface
       params.require(:make_an_offer)
     end
 
-    def offer_context_params(course_option)
+    def offer_context_params
+      course_option = @application_choice.course_option
+
       {
         provider_user_id: current_provider_user.id,
+        application_choice_id: @application_choice.id,
         course_id: course_option.course.id,
         course_option_id: course_option.id,
         provider_id: course_option.provider.id,

--- a/app/controllers/provider_interface/offer/locations_controller.rb
+++ b/app/controllers/provider_interface/offer/locations_controller.rb
@@ -5,7 +5,7 @@ module ProviderInterface
         @wizard = OfferWizard.new(offer_store, { decision: 'change_offer', current_step: 'locations', action: action })
         @wizard.save_state!
 
-        @course_options = available_course_options(@wizard.course_id, @wizard.study_mode)
+        @course_options = available_course_options(@wizard.course_id, @wizard.study_mode).includes([:site])
       end
 
       def create

--- a/app/controllers/provider_interface/offer/locations_controller.rb
+++ b/app/controllers/provider_interface/offer/locations_controller.rb
@@ -26,7 +26,7 @@ module ProviderInterface
         @wizard = OfferWizard.new(offer_store, { current_step: 'locations', action: action })
         @wizard.save_state!
 
-        @course_options = available_course_options(@wizard.course_id, @wizard.study_mode)
+        @course_options = available_course_options(@wizard.course_id, @wizard.study_mode).includes([:site])
       end
 
       def update

--- a/app/controllers/provider_interface/offer/study_modes_controller.rb
+++ b/app/controllers/provider_interface/offer/study_modes_controller.rb
@@ -56,9 +56,10 @@ module ProviderInterface
       end
 
       def available_study_modes(course)
-        course.available_study_modes_from_options.map do |study_mode|
-          Struct.new(:id, :value).new(study_mode, study_mode.humanize)
-        end
+        GetChangeOfferOptions.new(
+          user: current_provider_user,
+          current_course: @application_choice.offered_course,
+        ).available_study_modes(course: course)
       end
     end
   end

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -85,13 +85,6 @@ module ProviderInterface
       'back' if !!params[:back]
     end
 
-    def query_service
-      @query_service ||= GetChangeOfferOptions.new(
-        user: current_provider_user,
-        current_course: @application_choice.offered_course,
-      )
-    end
-
     def available_providers
       query_service.available_providers
     end
@@ -102,6 +95,13 @@ module ProviderInterface
 
     def available_course_options(course_id, study_mode)
       query_service.available_course_options(course: Course.find(course_id), study_mode: study_mode)
+    end
+
+    def query_service
+      @query_service ||= GetChangeOfferOptions.new(
+        user: current_provider_user,
+        current_course: @application_choice.offered_course,
+      )
     end
 
     def offer_context_params(decision = :default)

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -31,7 +31,7 @@ module ProviderInterface
     end
 
     def course_option
-      @course_option = CourseOption.find(course_option_id)
+      CourseOption.find(course_option_id)
     end
 
     def save_state!
@@ -93,25 +93,41 @@ module ProviderInterface
 
     def query_service
       @query_service ||= GetChangeOfferOptions.new(
-        user: ProviderUser.find(provider_user_id),
-        current_course: ApplicationChoice.find(application_choice_id).offered_course,
+        user: provider_user,
+        current_course: application_choice.offered_course,
       )
     end
 
-    def available_study_modes
-      query_service.available_study_modes(course: Course.find(course_id))
+    def provider
+      Provider.find(provider_id)
     end
 
-    def available_course_options
-      query_service.available_course_options(course: Course.find(course_id), study_mode: study_mode)
+    def course
+      Course.find(course_id)
     end
 
-    def available_courses
-      query_service.available_courses(provider: Provider.find(provider_id))
+    def provider_user
+      ProviderUser.find(provider_user_id)
+    end
+
+    def application_choice
+      ApplicationChoice.find(application_choice_id)
     end
 
     def available_providers
       query_service.available_providers
+    end
+
+    def available_courses
+      query_service.available_courses(provider: provider)
+    end
+
+    def available_study_modes
+      query_service.available_study_modes(course: course)
+    end
+
+    def available_course_options
+      query_service.available_course_options(course: course, study_mode: study_mode)
     end
 
     def last_saved_state
@@ -121,7 +137,7 @@ module ProviderInterface
 
     def state
       as_json(
-        except: %w[state_store errors validation_context query_service course_option wizard_path_history],
+        except: %w[state_store errors validation_context query_service wizard_path_history],
       ).to_json
     end
 

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -52,10 +52,10 @@ module ProviderInterface
 
       next_step = STEPS[decision.to_sym][index + 1]
 
-      return save_and_go_to_next_step(next_step) if next_step.eql?(:providers) && available_providers.one?
-      return save_and_go_to_next_step(next_step) if next_step.eql?(:courses) && available_courses.one?
-      return save_and_go_to_next_step(next_step) if next_step.eql?(:study_modes) && available_study_modes.one?
-      return save_and_go_to_next_step(next_step) if next_step.eql?(:locations) && available_course_options.one?
+      return save_and_go_to_next_step(next_step) if next_step.eql?(:providers) && available_providers.length == 1
+      return save_and_go_to_next_step(next_step) if next_step.eql?(:courses) && available_courses.length == 1
+      return save_and_go_to_next_step(next_step) if next_step.eql?(:study_modes) && available_study_modes.length == 1
+      return save_and_go_to_next_step(next_step) if next_step.eql?(:locations) && available_course_options.length == 1
 
       next_step
     end

--- a/app/views/provider_interface/offer/study_modes/edit.html.erb
+++ b/app/views/provider_interface/offer/study_modes/edit.html.erb
@@ -3,8 +3,8 @@
 
 <%= render CollectionSelectComponent.new(attribute: :study_mode,
                                          collection: @study_modes,
-                                         value_method: :id,
-                                         text_method: :value,
+                                         value_method: :to_s,
+                                         text_method: :humanize,
                                          hint_method: nil,
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_study_modes_path,

--- a/app/views/provider_interface/offer/study_modes/new.html.erb
+++ b/app/views/provider_interface/offer/study_modes/new.html.erb
@@ -3,8 +3,8 @@
 
 <%= render CollectionSelectComponent.new(attribute: :study_mode,
                                          collection: @study_modes,
-                                         value_method: :id,
-                                         text_method: :value,
+                                         value_method: :to_s,
+                                         text_method: :humanize,
                                          hint_method: nil,
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_study_modes_path,

--- a/spec/system/provider_interface/change_make_offer_spec.rb
+++ b/spec/system/provider_interface/change_make_offer_spec.rb
@@ -6,13 +6,16 @@ RSpec.feature 'Provider makes an offer' do
 
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
   let(:provider) { provider_user.providers.first }
+  let(:ratifying_provider) { create(:provider) }
   let(:application_form) { build(:application_form, :minimum_info) }
   let!(:application_choice) do
     create(:application_choice, :awaiting_provider_decision,
            application_form: application_form,
            course_option: course_option)
   end
-  let(:course) { build(:course, :open_on_apply, :full_time, provider: provider) }
+  let(:course) do
+    build(:course, :open_on_apply, :full_time, provider: provider, accredited_provider: ratifying_provider)
+  end
   let(:course_option) { build(:course_option, course: course) }
 
   before do
@@ -144,14 +147,28 @@ RSpec.feature 'Provider makes an offer' do
   def given_the_provider_user_can_offer_multiple_provider_courses
     @selected_provider = create(:provider, :with_signed_agreement)
     create(:provider_permissions, provider: @selected_provider, provider_user: provider_user, make_decisions: true)
-    courses = [create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider),
-               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider)]
+    courses = [create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider),
+               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)]
     @selected_course = courses.sample
 
     course_options = [create(:course_option, :part_time, course: @selected_course),
                       create(:course_option, :full_time, course: @selected_course),
                       create(:course_option, :full_time, course: @selected_course),
                       create(:course_option, :part_time, course: @selected_course)]
+
+    create(
+      :provider_relationship_permissions,
+      training_provider: provider,
+      ratifying_provider: ratifying_provider,
+      ratifying_provider_can_make_decisions: true,
+    )
+
+    create(
+      :provider_relationship_permissions,
+      training_provider: @selected_provider,
+      ratifying_provider: ratifying_provider,
+      ratifying_provider_can_make_decisions: true,
+    )
 
     @selected_course_option = course_options.sample
   end

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -6,13 +6,16 @@ RSpec.feature 'Provider makes an offer' do
 
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
   let(:provider) { provider_user.providers.first }
+  let(:ratifying_provider) { create(:provider) }
   let(:application_form) { build(:application_form, :minimum_info) }
   let!(:application_choice) do
     create(:application_choice, :awaiting_provider_decision,
            application_form: application_form,
            course_option: course_option)
   end
-  let(:course) { build(:course, :open_on_apply, :full_time, provider: provider) }
+  let(:course) do
+    build(:course, :open_on_apply, :full_time, provider: provider, accredited_provider: ratifying_provider)
+  end
   let(:course_option) { build(:course_option, course: course) }
 
   before do
@@ -161,7 +164,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def given_the_provider_has_multiple_courses
-    @provider_available_course = create(:course, :open_on_apply, study_mode: :full_time, provider: provider)
+    @provider_available_course = create(:course, :open_on_apply, study_mode: :full_time, provider: provider, accredited_provider: ratifying_provider)
     create(:course, :open_on_apply, provider: provider)
     course_options = [create(:course_option, :full_time, course: @provider_available_course),
                       create(:course_option, :full_time, course: @provider_available_course),
@@ -198,8 +201,8 @@ RSpec.feature 'Provider makes an offer' do
   def given_the_provider_user_can_offer_multiple_provider_courses
     @available_provider = create(:provider, :with_signed_agreement)
     create(:provider_permissions, provider: @available_provider, provider_user: provider_user, make_decisions: true)
-    courses = [create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider),
-               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider)]
+    courses = [create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider),
+               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider)]
     @selected_provider_available_course = courses.sample
 
     course_options = [create(:course_option, :part_time, course: @selected_provider_available_course),

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -210,6 +210,20 @@ RSpec.feature 'Provider makes an offer' do
                       create(:course_option, :full_time, course: @selected_provider_available_course),
                       create(:course_option, :part_time, course: @selected_provider_available_course)]
 
+    create(
+      :provider_relationship_permissions,
+      training_provider: provider,
+      ratifying_provider: ratifying_provider,
+      ratifying_provider_can_make_decisions: true,
+    )
+
+    create(
+      :provider_relationship_permissions,
+      training_provider: @available_provider,
+      ratifying_provider: ratifying_provider,
+      ratifying_provider_can_make_decisions: true,
+    )
+
     @selected_provider_available_course_option = course_options.sample
   end
 


### PR DESCRIPTION
## Context

The new offer flows do not yet use `GetChangeOfferOptions` to generate and display the lists of providers, courses etc. shown in the wizard. This PR addresses this.

## Changes proposed in this pull request

Change `OffersController`, `Offer::StudyModesController` and `OfferWizard` to use `GetChangeOfferOptions` when accessing `available_providers`, `available_courses` etc.

Add `application_choice_id` to the wizard's json blob at the start of offer flows, in `OffersController` and `DecisionsController`.

Fix use of `CollectionSelectComponent` for study modes.

Fix offer summary components when using `available_providers`.

## Guidance to review

`application_choice_id` is needed because of the extra logic in `GetChangeOfferOptions` around preserving the HEI/ratifying provider, based on the current course in the application choice.

Setting `application_choice_id` at the start of each flow and not for every step is ok because the key used when persisting wizard state in Redis is application_choice-specific.

Changing the provider is still possible in the context of self-ratified courses, but it's trickier to set up, as it requires the provider to be ratifying courses run by other organisations.

In the offer summary components, `available_providers.many?` fails because the underlying `available_providers.size` chooses to perform a `count` and this returns a hash. Forcing the code to use `length` addresses this.

## Link to Trello card

https://trello.com/c/we8DLCos

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
