### PR TITLE
Alert when an application is submitted with the same course

### DIFF
--- a/spec/workers/detect_invariants_spec.rb
+++ b/spec/workers/detect_invariants_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe DetectInvariants do
             One or more application choices are still in `awaiting_references` or
             `application_complete` state, but all these states have been removed:
 
-            http://localhost:3000/support/application-choices/#{application_choice_bad.id}
-            http://localhost:3000/support/application-choices/#{application_choice_bad_too.id}
+            #{HostingEnvironment.application_url}/support/application-choices/#{application_choice_bad.id}
+            #{HostingEnvironment.application_url}/support/application-choices/#{application_choice_bad_too.id}
           MSG
         ),
       )
@@ -46,7 +46,7 @@ RSpec.describe DetectInvariants do
             One or more references are still pending on these applications,
             even though they've already been submitted:
 
-            http://localhost:3000/support/applications/#{weird_application_form.id}
+            #{HostingEnvironment.application_url}/support/applications/#{weird_application_form.id}
           MSG
         ),
       )
@@ -77,7 +77,7 @@ RSpec.describe DetectInvariants do
           <<~MSG,
             The following application forms have had edits by a candidate who is not the owner of the application:
 
-            http://localhost:3000/support/applications/#{suspect_form.id}
+            #{HostingEnvironment.application_url}/support/applications/#{suspect_form.id}
           MSG
         ),
       )
@@ -102,7 +102,7 @@ RSpec.describe DetectInvariants do
           <<~MSG,
             The following application forms have course choices from the previous recruitment cycle
 
-            http://localhost:3000/support/applications/#{bad_form_this_year.id}
+            #{HostingEnvironment.application_url}/support/applications/#{bad_form_this_year.id}
           MSG
         ),
       )
@@ -120,7 +120,7 @@ RSpec.describe DetectInvariants do
           <<~MSG,
             The following application forms have been submitted with more than three course choices
 
-            http://localhost:3000/support/applications/#{bad_application_form.id}
+            #{HostingEnvironment.application_url}/support/applications/#{bad_application_form.id}
           MSG
         ),
       )
@@ -142,7 +142,7 @@ RSpec.describe DetectInvariants do
           <<~MSG,
             The following applications have been submitted containing the same course choice multiple times
 
-            http://localhost:3000/support/applications/#{application_form.id}
+            #{HostingEnvironment.application_url}/support/applications/#{application_form.id}
           MSG
         ),
       )


### PR DESCRIPTION
## Context

We should get an alert when a candidate has applied to the same course multiple times, which they shouldn't be able to do.

## Changes proposed in this pull request

Adding a new `detect_applications_submitted_with_the_same_course` method to the `DetectInvariants` alerts.

## Guidance to review

Can anyone suggest an alternative to:

`applications_with_the_same_choice = ApplicationForm.joins(application_choices: [:course_option]).includes(application_choices: [:course_option]).where.not(submitted_at: nil).group('application_forms.id, application_choices.id, course_options.id').select { |af| af.application_choices.map(&:course).count != af.application_choices.map(&:course).uniq.count }`

Various approaches were tried earlier but all would cause the `detect_submitted_applications_with_more_than_three_course_choices` to fire off... however, it was a challenge to understand why...

## Link to Trello card

https://trello.com/c/6e3BbrsO/3196-data-check-alert-when-a-application-is-submitted-for-the-same-course

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
