### PR TITLE
Amend banner content to include easter holiday

### DIFF
--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -4,8 +4,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= render NotificationMessageComponent.new(:info,
-                                                  message: '20 December 2020 to 1 January 2021 do not count as working days',
-                                                  secondary_message: 'The Christmas period will not be included when calculating dates for applications to be automatically rejected. This is to match the dates used by UCAS.') %>
+                                                  message: '2 April to 16 April 2021 do not count as working days',
+                                                  secondary_message: 'This period will not be included when calculating dates for applications to be automatically rejected. This is to match the dates used by UCAS.') %>
     </div>
   </div>
 <% end %>

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -28,8 +28,8 @@
   <div class="govuk-width-container">
     <div class="govuk-width-container govuk-!-margin-top-4">
       <%= render NotificationMessageComponent.new(:info,
-                                                  message: '20 December 2020 to 1 January 2021 do not count as working days',
-                                                  secondary_message: 'The Christmas period will not be included when calculating dates for applications to be automatically rejected. This is to match the dates used by UCAS.') %>
+                                                  message: '2 April to 16 April 2021 do not count as working days',
+                                                  secondary_message: 'This period will not be included when calculating dates for applications to be automatically rejected. This is to match the dates used by UCAS.') %>
     </div>
   </div>
 <% end %>

--- a/spec/system/provider_interface/providers_can_view_information_in_the_banner_spec.rb
+++ b/spec/system/provider_interface/providers_can_view_information_in_the_banner_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Provider can view information in the banner' do
   end
 
   def then_i_see_information_about_working_days_changes
-    expect(page).to have_content '20 December 2020 to 1 January 2021 do not count as working days'
+    expect(page).to have_content '2 April to 16 April 2021 do not count as working days'
   end
 
   def when_feature_flag_is_off
@@ -31,6 +31,6 @@ RSpec.feature 'Provider can view information in the banner' do
   end
 
   def then_i_dont_see_information_about_working_days_changes
-    expect(page).not_to have_content '20 December 2020 to 1 January 2021 do not count as working days'
+    expect(page).not_to have_content '2 April to 16 April 2021 do not count as working days'
   end
 end


### PR DESCRIPTION
## Context

The DFE Apply service will need to align dates with UCAS teacher training to ensure that candidates and providers have a fairly consistent experience, and to help with fairness.

We need to let all users know of changes to the RBD date due to the Easter break. 

## Changes proposed in this pull request

Amend existing banner behind feature flag from Christmas content to easter
## Guidance to review

did I miss anything?

## Link to Trello card

https://trello.com/c/bXoJBZOW/3579-let-providers-know-that-2-april-to-16-april-are-non-working-days-meaning-those-days-arent-counted-for-rbd


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
