### PR TITLE
Update banner and page to follow GDS cookie guidance

### DIFF
--- a/app/controllers/concerns/cookie_preference_concerns.rb
+++ b/app/controllers/concerns/cookie_preference_concerns.rb
@@ -2,11 +2,16 @@ module CookiePreferenceConcerns
   def create
     @cookie_preferences = CookiePreferencesForm.new(consent: cookie_preferences_consent)
     cookies[consent_cookie] = { value: @cookie_preferences.consent, expires: 6.months.from_now }
+    session[:display_cookie_consent_confirmation] = true
 
     link_to_previous_referer
-    flash[:success] = 'Your cookie preferences have been updated.'
-
     redirect_back(fallback_location: cookie_page_path)
+  end
+
+  def hide_confirmation
+    session.delete(:display_cookie_consent_confirmation)
+
+    redirect_back(fallback_location: root_path)
   end
 
 private
@@ -21,6 +26,7 @@ private
     previous_referer_uri = URI(session[:previous_referer]).request_uri if session[:previous_referer].present?
 
     if previous_referer_uri && request_uri.eql?(cookie_page_path) && !previous_referer_uri.eql?(cookie_page_path)
+      flash[:success] = 'Your cookie preferences have been updated.'
       flash[:link] = {
         text: 'Go back to the page you were looking at',
         url: session[:previous_referer],

--- a/app/forms/cookie_preferences_form.rb
+++ b/app/forms/cookie_preferences_form.rb
@@ -4,8 +4,4 @@ class CookiePreferencesForm
   attr_accessor :consent
 
   validates :consent, inclusion: { in: %w[yes no] }
-
-  def initialize(consent:)
-    @consent = consent
-  end
 end

--- a/app/frontend/styles/_button.scss
+++ b/app/frontend/styles/_button.scss
@@ -1,4 +1,0 @@
-// TODO: Remove once implemented cookie banner from design system
-.app-button--cookies {
-  min-width: 12em;
-}

--- a/app/frontend/styles/_cookie_banner.scss
+++ b/app/frontend/styles/_cookie_banner.scss
@@ -1,0 +1,5 @@
+// TODO: Remove once cookie banner implemented using JS (i.e. without `button_to` form buttons)
+
+.app-button-group--align-center .govuk-button-group {
+  align-items: center;
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -41,7 +41,7 @@ $moj-images-path: "~@ministryofjustice/frontend/moj/assets/images/";
 @import "_autocomplete";
 @import "_banner";
 @import "_notification_banner";
-@import "_button";
+@import "_cookie_banner";
 @import "_card";
 @import "_contents-list";
 @import "_diagram";

--- a/app/views/content/cookies.html.erb
+++ b/app/views/content/cookies.html.erb
@@ -1,140 +1,138 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Cookies</h1>
-
-    <h2 class="govuk-heading-l" id="cookies-that-measure-website-use">Cookies that measure website use</h2>
-
-    <p class="govuk-body">
-    We use Google Analytics software to collect information about how you use ‘<%= service_name %>’. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
+    <h1 class="govuk-heading-l">Cookies</h1>
+    <p class='govuk-body'>
+      Cookies are small files saved on your phone, tablet or computer when you visit a website.
     </p>
-
-    <p class="govuk-body">
-      Google Analytics stores information about:
+    <p class='govuk-body'>
+      We use cookies to make this site work and collect information about how you use our service.
     </p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>Whether you’ve visited before
-        <li>the pages you visit on ‘<%= service_name %>’</li>
-        <li>how long you spend on each page </li>
-        <li>how you got to the site </li>
-        <li>what you click on while you’re visiting the site </li>
-    </ul>
-    <p class="govuk-body">
-    We don’t allow Google to use or share our analytics data.
-    </p>
-
-    <p id="preferences" class="govuk-body">
-    <%= form_with model: @cookie_preferences, url: @cookie_settings_path, method: :post do |f| %>
-    <%= f.govuk_collection_radio_buttons :consent,
-      [['yes', 'Yes, opt-in to Google Analytics cookies'], ['no', 'No, do not track my website usage']],
-      :first,
-      :last,
-      legend: { text: 'Do you accept Google Analytics cookies?' } %>
-    <%= f.govuk_submit 'Save preferences' %>
-    <% end %>
-    </p>
-
-    <h2 class="govuk-heading-l" id="how-we-use-cookies">How we use cookies</h2>
 
     <h3 class="govuk-heading-m" id="essential-cookies">Essential cookies</h3>
 
     <p class="govuk-body">
-    Essential ‘<%= service_name %>’ cookies include:
+      Essential ‘<%= service_name %>’ cookies keep your information secure while you use this service. We do not need to ask permission to use them.
     </p>
 
     <table class="govuk-table">
       <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">
-            Name
-          </th>
-          <th scope="col" class="govuk-table__header">
-            Purpose
-          </th>
-          <th scope="col" class="govuk-table__header">
-            Expires
-          </th>
-        </tr>
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">
+          Name
+        </th>
+        <th scope="col" class="govuk-table__header">
+          Purpose
+        </th>
+        <th scope="col" class="govuk-table__header">
+          Expires
+        </th>
+      </tr>
       </thead>
       <tbody class="govuk-table__body govuk-!-font-size-14">
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">
-            _apply_for_postgraduate_teacher_training_session
-          </td>
-          <td class="govuk-table__cell">
-            Stores encrypted session data
-          </td>
-          <td class="govuk-table__cell">
-            When you close your browser
-          </td>
-        </tr>
-        <tr>
-          <td class="govuk-table__cell">
-            <%= "consented-to-#{@application}-cookies" %>
-          </td>
-          <td class="govuk-table__cell">
-            Saves your cookie consent settings
-          </td>
-          <td class="govuk-table__cell">
-            6 months
-          </td>
-        </tr>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          _apply_for_postgraduate_teacher_training_session
+        </td>
+        <td class="govuk-table__cell">
+          Stores encrypted session data
+        </td>
+        <td class="govuk-table__cell">
+          When you close your browser
+        </td>
+      </tr>
+      <tr>
+        <td class="govuk-table__cell">
+          <%= "consented-to-#{@application}-cookies" %>
+        </td>
+        <td class="govuk-table__cell">
+          Saves your cookie consent settings
+        </td>
+        <td class="govuk-table__cell">
+          6 months
+        </td>
+      </tr>
       </tbody>
     </table>
 
-    <h3 class="govuk-heading-m" id="measuring-website-usage">Measuring website usage (Google Analytics)</h3>
+    <h3 class="govuk-heading-m" id="measuring-website-usage">Analytics cookies (optional)</h3>
 
     <p class="govuk-body">
-    Google Analytics sets the following cookies:
+      With your permission, we use Google Analytics to collect data about how you use ‘<%= service_name %>’. This information helps us improve our service.
     </p>
+    <p class="govuk-body">
+      Google is not allowed to use or share our analytics data with anyone.
+    </p>
+    <p class="govuk-body">
+      Google Analytics stores anonymised information about:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>how you got to ‘<%= service_name %>’</li>
+      <li>the pages you visit on this site and how long you spend on them</li>
+      <li>what you click on while you're visiting the site</li>
+    </ul>
+
     <table class="govuk-table">
       <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">
-            Name
-          </th>
-          <th scope="col" class="govuk-table__header">
-            Purpose
-          </th>
-          <th scope="col" class="govuk-table__header">
-            Expires
-          </th>
-        </tr>
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">
+          Name
+        </th>
+        <th scope="col" class="govuk-table__header">
+          Purpose
+        </th>
+        <th scope="col" class="govuk-table__header">
+          Expires
+        </th>
+      </tr>
       </thead>
       <tbody class="govuk-table__body govuk-!-font-size-14">
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">
-            _ga
-          </td>
-          <td class="govuk-table__cell">
-            Used to distinguish anonymous users
-          </td>
-          <td class="govuk-table__cell">
-            2 years
-          </td>
-        </tr>
-        <tr>
-          <td class="govuk-table__cell">
-            _gid
-          </td>
-          <td class="govuk-table__cell">
-            Used to distinguish anonymous users
-          </td>
-          <td class="govuk-table__cell">
-            24 hours
-          </td>
-        </tr>
-        <tr>
-          <td class="govuk-table__cell">
-            _gat_gtag_<%= @cookie_ga_code %>
-          </td>
-          <td class="govuk-table__cell">
-            Throttle requests
-          </td>
-          <td class="govuk-table__cell">
-            10 minutes
-          </td>
-        </tr>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          _ga
+        </td>
+        <td class="govuk-table__cell">
+          Used to distinguish anonymous users
+        </td>
+        <td class="govuk-table__cell">
+          2 years
+        </td>
+      </tr>
+      <tr>
+        <td class="govuk-table__cell">
+          _gid
+        </td>
+        <td class="govuk-table__cell">
+          Used to distinguish anonymous users
+        </td>
+        <td class="govuk-table__cell">
+          24 hours
+        </td>
+      </tr>
+      <tr>
+        <td class="govuk-table__cell">
+          _gat_gtag_<%= @cookie_ga_code %>
+        </td>
+        <td class="govuk-table__cell">
+          Throttle requests
+        </td>
+        <td class="govuk-table__cell">
+          10 minutes
+        </td>
+      </tr>
       </tbody>
     </table>
+
+    <p id="preferences" class="govuk-body">
+    <%= form_with model: @cookie_preferences, url: @cookie_settings_path, method: :post do |f| %>
+      <%= f.govuk_collection_radio_buttons :consent,
+        [%w[yes Yes], %w[no No]],
+        :first,
+        :last,
+        inline: true,
+        legend: { text: 'Do you want to accept Google Analytics cookies?', size: 's' } %>
+      <%= f.govuk_submit 'Save cookie settings' %>
+      <% end %>
+    </p>
   </div>
 </div>

--- a/app/views/content/cookies.html.erb
+++ b/app/views/content/cookies.html.erb
@@ -1,37 +1,37 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Cookies</h1>
-    <p class='govuk-body'>
+    <h1 class="govuk-heading-xl">Cookies</h1>
+    <p class="govuk-body">
       Cookies are small files saved on your phone, tablet or computer when you visit a website.
     </p>
-    <p class='govuk-body'>
-      We use cookies to make this site work and collect information about how you use our service.
+    <p class="govuk-body">
+      We use cookies to make ‘<%= service_name %>’ work and collect information about how you use our service.
     </p>
 
     <h3 class="govuk-heading-m" id="essential-cookies">Essential cookies</h3>
 
     <p class="govuk-body">
-      Essential ‘<%= service_name %>’ cookies keep your information secure while you use this service. We do not need to ask permission to use them.
+      Essential cookies keep your information secure while you use ‘<%= service_name %>’. We do not need to ask permission to use them.
     </p>
 
     <table class="govuk-table">
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-third">
           Name
         </th>
-        <th scope="col" class="govuk-table__header">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-third">
           Purpose
         </th>
-        <th scope="col" class="govuk-table__header">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-third">
           Expires
         </th>
       </tr>
       </thead>
-      <tbody class="govuk-table__body govuk-!-font-size-14">
+      <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
-          _apply_for_postgraduate_teacher_training_session
+          _apply_for_postgraduate<wbr>_teacher_training_session
         </td>
         <td class="govuk-table__cell">
           Stores encrypted session data
@@ -69,30 +69,30 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>how you got to ‘<%= service_name %>’</li>
       <li>the pages you visit on this site and how long you spend on them</li>
-      <li>what you click on while you're visiting the site</li>
+      <li>what you click on while you’re visiting the site</li>
     </ul>
 
     <table class="govuk-table">
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-third">
           Name
         </th>
-        <th scope="col" class="govuk-table__header">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-third">
           Purpose
         </th>
-        <th scope="col" class="govuk-table__header">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-third">
           Expires
         </th>
       </tr>
       </thead>
-      <tbody class="govuk-table__body govuk-!-font-size-14">
+      <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           _ga
         </td>
         <td class="govuk-table__cell">
-          Used to distinguish anonymous users
+          Distinguishes anonymous users
         </td>
         <td class="govuk-table__cell">
           2 years
@@ -103,7 +103,7 @@
           _gid
         </td>
         <td class="govuk-table__cell">
-          Used to distinguish anonymous users
+          Distinguishes anonymous users
         </td>
         <td class="govuk-table__cell">
           24 hours
@@ -114,7 +114,7 @@
           _gat_gtag_<%= @cookie_ga_code %>
         </td>
         <td class="govuk-table__cell">
-          Throttle requests
+          Limits requests
         </td>
         <td class="govuk-table__cell">
           10 minutes
@@ -123,7 +123,6 @@
       </tbody>
     </table>
 
-    <p id="preferences" class="govuk-body">
     <%= form_with model: @cookie_preferences, url: @cookie_settings_path, method: :post do |f| %>
       <%= f.govuk_collection_radio_buttons :consent,
         [%w[yes Yes], %w[no No]],
@@ -132,7 +131,6 @@
         inline: true,
         legend: { text: 'Do you want to accept Google Analytics cookies?', size: 's' } %>
       <%= f.govuk_submit 'Save cookie settings' %>
-      <% end %>
-    </p>
+    <% end %>
   </div>
 </div>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -41,18 +41,27 @@
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 
-    <% unless current_page?(candidate_interface_cookies_path) || current_page?(provider_interface_cookies_path) %>
-      <% if try(:current_namespace).eql?('candidate_interface') && cookies['consented-to-apply-cookies'].blank? %>
-        <%= render 'shared/cookies_banner',
-                   cookies_path: candidate_interface_cookies_path,
-                   cookie_preferences_path: candidate_interface_cookie_preferences_path(consent: 'yes') %>
-
-      <% elsif try(:current_namespace).eql?('provider_interface') && cookies['consented-to-manage-cookies'].blank? %>
-        <%= render 'shared/cookies_banner',
-                   cookies_path: provider_interface_cookies_path,
-                   cookie_preferences_path: provider_interface_cookie_preferences_path(consent: 'yes') %>
-      <% end %>
-    <% end %>
+<% unless current_page?(candidate_interface_cookies_path) || current_page?(provider_interface_cookies_path) %>
+  <% if try(:current_namespace).eql?('candidate_interface') && cookies['consented-to-apply-cookies'].blank? %>
+    <%= render 'shared/cookies_banner',
+      cookies_path: candidate_interface_cookies_path,
+      service_name: 'Apply for teacher training',
+      current_namespace: 'candidate_interface' %>
+  <% elsif try(:current_namespace).eql?('provider_interface') && cookies['consented-to-manage-cookies'].blank? %>
+    <%= render 'shared/cookies_banner',
+      cookies_path: provider_interface_cookies_path,
+      service_name: 'Manage teacher training applications',
+      current_namespace: 'provider_interface' %>
+  <% elsif try(:current_namespace).eql?('candidate_interface') && session[:display_cookie_consent_confirmation] %>
+    <%= render 'shared/cookies_confirmation_banner',
+      consented: cookies['consented-to-apply-cookies'],
+      current_namespace: 'candidate_interface' %>
+  <% elsif try(:current_namespace).eql?('provider_interface') && session[:display_cookie_consent_confirmation] %>
+    <%= render 'shared/cookies_confirmation_banner',
+      consented: cookies['consented-to-manage-cookies'],
+      current_namespace: 'provider_interface' %>
+  <% end %>
+<% end %>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 

--- a/app/views/shared/_cookies_banner.html.erb
+++ b/app/views/shared/_cookies_banner.html.erb
@@ -1,5 +1,6 @@
 <%= govuk_cookie_banner(
   title: "Cookies on #{service_name}",
+  classes: ['app-button-group--align-center'],
   html_attributes: {
     aria: {
       label: "Cookies on #{service_name}",

--- a/app/views/shared/_cookies_banner.html.erb
+++ b/app/views/shared/_cookies_banner.html.erb
@@ -1,15 +1,34 @@
-<div class="govuk-width-container">
-  <div class="govuk-!-width-two-thirds govuk-!-padding-top-4">
-    <h1 class="govuk-heading-m govuk-!-margin-bottom-4">
-      Tell us whether you accept cookies
-    </h1>
-    <p class="govuk-body">
-      We use <%= govuk_link_to 'cookies to collect information', cookies_path %> about how you use ‘<%= service_name %>’. We use this information to make the website work as well as possible and improve government services.
-    </p>
-    <%= form_with model: CookiePreferencesForm.new(consent: 'yes'), url: cookie_preferences_path, method: :post do |f| %>
-      <%= f.govuk_submit('Accept all cookies', classes: 'app-button--cookies') do %>
-        <%= govuk_button_link_to 'Set cookie preferences', cookies_path, class: 'app-button--cookies' %>
-      <% end %>
-    <% end %>
-  </div>
-</div>
+<%= govuk_cookie_banner(
+  title: "Cookies on #{service_name}",
+  html_attributes: {
+    aria: {
+      label: "Cookies on #{service_name}",
+    },
+  },
+) do |cookie_banner| %>
+<%= cookie_banner.with(:body) do %>
+  <p class="govuk-body">We use some essential cookies to make this service work.</p>
+  <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+<% end %>
+<%= cookie_banner.with(:actions) do %>
+  <%= govuk_button_to(
+    'Accept analytics cookies',
+    if current_namespace == 'candidate_interface'
+      candidate_interface_cookie_preferences_path(consent: 'yes')
+    else
+      provider_interface_cookie_preferences_path(consent: 'yes')
+    end,
+    method: :post,
+  ) %>
+<%= govuk_button_to(
+  'Reject analytics cookies',
+  if current_namespace == 'candidate_interface'
+    candidate_interface_cookie_preferences_path(consent: 'no')
+  else
+    provider_interface_cookie_preferences_path(consent: 'no')
+  end,
+  method: :post,
+) %>
+    <%= govuk_link_to('View cookies', cookies_path) %>
+  <% end %>
+<% end %>

--- a/app/views/shared/_cookies_confirmation_banner.html.erb
+++ b/app/views/shared/_cookies_confirmation_banner.html.erb
@@ -9,6 +9,6 @@
     <p>You’ve <%= consented == 'yes' ? 'accepted' : 'rejected' %> analytics cookies. You can <%= govuk_link_to('change your cookie settings', current_namespace == 'candidate_interface' ? candidate_interface_cookies_path : provider_interface_cookies_path) %> at any time.</p>
   <% end %>
   <%= cookie_banner.with(:actions) do %>
-    <%= govuk_button_to('Hide this message', current_namespace == 'canidate_interface' ? candidate_interface_cookie_preferences_hide_confirmation_path : provider_interface_cookie_preferences_hide_confirmation_path, method: :post, classes: 'app-button--cookies') %>
+    <%= govuk_button_to('Hide this message', current_namespace == 'canidate_interface' ? candidate_interface_cookie_preferences_hide_confirmation_path : provider_interface_cookie_preferences_hide_confirmation_path, method: :post) %>
   <% end %>
 <% end %>

--- a/app/views/shared/_cookies_confirmation_banner.html.erb
+++ b/app/views/shared/_cookies_confirmation_banner.html.erb
@@ -1,0 +1,14 @@
+<%= govuk_cookie_banner(
+  html_attributes: {
+    aria: {
+      label: "Cookies on #{service_name}",
+    },
+  },
+) do |cookie_banner| %>
+  <%= cookie_banner.with(:body) do %>
+    <p>You’ve <%= consented == 'yes' ? 'accepted' : 'rejected' %> analytics cookies. You can <%= govuk_link_to('change your cookie settings', current_namespace == 'candidate_interface' ? candidate_interface_cookies_path : provider_interface_cookies_path) %> at any time.</p>
+  <% end %>
+  <%= cookie_banner.with(:actions) do %>
+    <%= govuk_button_to('Hide this message', current_namespace == 'canidate_interface' ? candidate_interface_cookie_preferences_hide_confirmation_path : provider_interface_cookie_preferences_hide_confirmation_path, method: :post, classes: 'app-button--cookies') %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
     get '/terms-of-use', to: 'content#terms_candidate', as: :terms
 
     resources :cookie_preferences, only: 'create', path: 'cookie-preferences'
+    post '/cookie-preferences-hide-confirmation', to: 'cookie_preferences#hide_confirmation', as: :cookie_preferences_hide_confirmation
 
     get '/account', to: 'start_page#create_account_or_sign_in', as: :create_account_or_sign_in
     post '/account', to: 'start_page#create_account_or_sign_in_handler'
@@ -592,6 +593,7 @@ Rails.application.routes.draw do
     get '/covid-19-guidance', to: redirect('/')
 
     resources :cookie_preferences, only: 'create', path: 'cookie-preferences'
+    post '/cookie-preferences-hide-confirmation', to: 'cookie_preferences#hide_confirmation', as: :cookie_preferences_hide_confirmation
 
     get '/getting-ready-for-next-cycle', to: redirect('/provider/guidance-for-the-new-cycle')
     get '/guidance-for-the-new-cycle', to: 'content#guidance_for_the_new_cycle', as: :guidance_for_the_new_cycle

--- a/spec/system/candidate_interface/candidate_content_spec.rb
+++ b/spec/system/candidate_interface/candidate_content_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'Candidate content' do
   end
 
   def and_i_can_see_the_cookie_banner
-    expect(page).to have_content('We use cookies to collect information about how you use ‘Apply for teacher training’')
+    expect(page).to have_content('Cookies on Apply for teacher training')
   end
 
   def when_i_click_on_the_cookies_page
@@ -46,7 +46,7 @@ RSpec.feature 'Candidate content' do
   end
 
   def and_i_can_no_longer_see_the_cookie_banner
-    expect(page).not_to have_content('We use cookies to collect information about how you use ‘Apply for teacher training’')
+    expect(page).not_to have_content('We use cookies to collect information about how you use Apply for teacher training')
   end
 
   def then_i_can_see_the_cookies_page
@@ -55,8 +55,8 @@ RSpec.feature 'Candidate content' do
   end
 
   def and_i_can_opt_in_to_tracking_website_usage
-    choose 'Yes, opt-in to Google Analytics cookies'
-    click_on 'Save preferences'
+    choose 'Yes'
+    click_on 'Save cookie settings'
     expect(page).to have_content('Your cookie preferences have been updated')
   end
 

--- a/spec/system/candidate_interface/cookies/accept_cookies_spec.rb
+++ b/spec/system/candidate_interface/cookies/accept_cookies_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.feature 'Cookie banner' do
+  include ActionView::Helpers::DateHelper
+
+  scenario 'Candidate accepts cookies' do
+    given_i_am_on_the_start_page
+    and_i_can_see_the_cookie_banner
+    when_i_accept_cookies
+    then_i_can_no_longer_see_the_cookie_banner
+    and_i_can_see_that_cookies_have_been_accepted
+    when_i_hide_the_cookies_confirmation_message
+  end
+
+  def given_i_am_on_the_start_page
+    visit '/'
+  end
+
+  def and_i_can_see_the_cookie_banner
+    expect(page).to have_content('Cookies on Apply for teacher training')
+  end
+
+  def when_i_accept_cookies
+    click_on 'Accept analytics cookies'
+  end
+
+  def and_i_can_see_that_cookies_have_been_accepted
+    expect(page).to have_content('You’ve accepted analytics cookies.')
+  end
+
+  def when_i_hide_the_cookies_confirmation_message
+    click_on 'Hide this message'
+  end
+
+  def then_i_can_no_longer_see_the_cookie_banner
+    expect(page).not_to have_content('Cookies on Apply for teacher training')
+  end
+
+  def then_i_can_no_longer_see_the_cookies_confirmation_message
+    expect(page).not_to have_content('You’ve accepted analytics cookies.')
+  end
+end

--- a/spec/system/candidate_interface/cookies/reject_cookies_spec.rb
+++ b/spec/system/candidate_interface/cookies/reject_cookies_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.feature 'Cookie banner' do
+  include ActionView::Helpers::DateHelper
+
+  scenario 'Candidate rejects cookies' do
+    given_i_am_on_the_start_page
+    and_i_can_see_the_cookie_banner
+    when_i_reject_cookies
+    then_i_can_no_longer_see_the_cookie_banner
+    and_i_can_see_that_cookies_have_been_rejected
+    when_i_hide_the_cookies_confirmation_message
+    then_i_can_no_longer_see_the_cookies_confirmation_message
+  end
+
+  def given_i_am_on_the_start_page
+    visit '/'
+  end
+
+  def and_i_can_see_the_cookie_banner
+    expect(page).to have_content('Cookies on Apply for teacher training')
+  end
+
+  def when_i_reject_cookies
+    click_on 'Reject analytics cookies'
+  end
+
+  def and_i_can_see_that_cookies_have_been_rejected
+    expect(page).to have_content('You’ve rejected analytics cookies.')
+  end
+
+  def when_i_hide_the_cookies_confirmation_message
+    click_on 'Hide this message'
+  end
+
+  def then_i_can_no_longer_see_the_cookie_banner
+    expect(page).not_to have_content('Cookies on Apply for teacher training')
+  end
+
+  def then_i_can_no_longer_see_the_cookies_confirmation_message
+    expect(page).not_to have_content('You’ve rejected analytics cookies.')
+  end
+end

--- a/spec/system/provider_interface/cookies/accept_cookies_spec.rb
+++ b/spec/system/provider_interface/cookies/accept_cookies_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.feature 'Cookie banner' do
+  include ActionView::Helpers::DateHelper
+
+  scenario 'Provider accepts cookies' do
+    given_i_am_on_the_start_page
+    and_i_can_see_the_cookie_banner
+    when_i_accept_cookies
+    then_i_can_no_longer_see_the_cookie_banner
+    and_i_can_see_that_cookies_have_been_accepted
+    when_i_hide_the_cookies_confirmation_message
+    then_i_can_no_longer_see_the_cookies_confirmation_message
+  end
+
+  def given_i_am_on_the_start_page
+    visit '/provider'
+  end
+
+  def and_i_can_see_the_cookie_banner
+    expect(page).to have_content('Cookies on Manage teacher training applications')
+  end
+
+  def when_i_accept_cookies
+    click_on 'Accept analytics cookies'
+  end
+
+  def and_i_can_see_that_cookies_have_been_accepted
+    expect(page).to have_content('You’ve accepted analytics cookies.')
+  end
+
+  def when_i_hide_the_cookies_confirmation_message
+    click_on 'Hide this message'
+  end
+
+  def then_i_can_no_longer_see_the_cookie_banner
+    expect(page).not_to have_content('Cookies on Manage teacher training applications')
+  end
+
+  def then_i_can_no_longer_see_the_cookies_confirmation_message
+    expect(page).not_to have_content('You’ve rejected analytics cookies.')
+  end
+end

--- a/spec/system/provider_interface/cookies/reject_cookies_spec.rb
+++ b/spec/system/provider_interface/cookies/reject_cookies_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.feature 'Cookie banner' do
+  include ActionView::Helpers::DateHelper
+
+  scenario 'Provider rejects cookies' do
+    given_i_am_on_the_start_page
+    and_i_can_see_the_cookie_banner
+    when_i_reject_cookies
+    then_i_can_no_longer_see_the_cookie_banner
+    and_i_can_see_that_cookies_have_been_rejected
+    when_i_hide_the_cookies_confirmation_message
+    then_i_can_no_longer_see_the_cookies_confirmation_message
+  end
+
+  def given_i_am_on_the_start_page
+    visit '/provider'
+  end
+
+  def and_i_can_see_the_cookie_banner
+    expect(page).to have_content('Cookies on Manage teacher training applications')
+  end
+
+  def when_i_reject_cookies
+    click_on 'Reject analytics cookies'
+  end
+
+  def and_i_can_see_that_cookies_have_been_rejected
+    expect(page).to have_content('You’ve rejected analytics cookies.')
+  end
+
+  def when_i_hide_the_cookies_confirmation_message
+    click_on 'Hide this message'
+  end
+
+  def then_i_can_no_longer_see_the_cookie_banner
+    expect(page).not_to have_content('Cookies on Manage teacher training applications')
+  end
+
+  def then_i_can_no_longer_see_the_cookies_confirmation_message
+    expect(page).not_to have_content('You’ve rejected analytics cookies.')
+  end
+end

--- a/spec/system/provider_interface/provider_content_spec.rb
+++ b/spec/system/provider_interface/provider_content_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature 'Provider content' do
   end
 
   def and_i_can_see_the_cookie_banner
-    expect(page).to have_content('We use cookies to collect information about how you use ‘Manage teacher training applications’')
+    expect(page).to have_content('Cookies on Manage teacher training applications')
   end
 
   def when_i_click_on_the_cookies_page
@@ -44,7 +44,7 @@ RSpec.feature 'Provider content' do
   end
 
   def and_i_can_no_longer_see_the_cookie_banner
-    expect(page).not_to have_content('We use cookies to collect information about how you use ‘Manage teacher training applications’')
+    expect(page).not_to have_content('We use cookies to collect information about how you use Manage teacher training applications')
   end
 
   def then_i_can_see_the_cookies_page
@@ -52,8 +52,8 @@ RSpec.feature 'Provider content' do
   end
 
   def and_i_can_opt_in_to_tracking_website_usage
-    choose 'Yes, opt-in to Google Analytics cookies'
-    click_on 'Save preferences'
+    choose 'Yes'
+    click_on 'Save cookie settings'
     expect(page).to have_content('Your cookie preferences have been updated')
   end
 


### PR DESCRIPTION
## Context

```
As a... candidate using Apply or provider using Manage
I need to... decide which cookies are are place on my computer
So that... I can opt in of out of having my activity tracked
```

We currently have different implementations for our cookie banners across Find and Apply. These also are somewhat nefarious as they make it more difficult to reject cookies (you need to visit the cookies page to change this setting).

## Changes proposed in this pull request

* The cookie banner uses the markup and styles as outlined in the design system
* The cookie banner component follows [the guidance from GDS](https://design-system.service.gov.uk/components/cookie-banner/)
* The cookie page follows [the guidance from GDS for this pattern](https://design-system.service.gov.uk/patterns/cookies-page/)

![cookies](https://user-images.githubusercontent.com/5256922/113611103-f4dd8480-9645-11eb-9b19-be89d8089486.gif)


## Guidance to review

- Go to `/` or `/provider` to view changes to the cookie banner.
- Go to `/candidate/cookies` and `/provider/cookies` to see changes to cookie guidance
- Note that unlike Find and GiT, this implementation is sans-JS. The intention is to move to a JS implementation in future (@paulrobertlloyd  to confirm)

## Link to Trello card

https://trello.com/c/3wlz7cyM/3061-%F0%9F%8D%AA-update-banner-and-page-to-follow-gds-cookie-guidance-apply

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
