### PR TITLE
[Spike] Integrate subject filter

### DIFF
--- a/app/components/filter_component.html.erb
+++ b/app/components/filter_component.html.erb
@@ -60,6 +60,34 @@
                         </div>
                       </div>
                     <% end %>
+                  <% elsif filter[:type] == :checkbox_filter %>
+                    <div id="<%= filter[:name] %>" class="app-checkbox-filter govuk-!-margin-bottom-7 app-checkbox-filter--enhanced">
+                      <% if active_filters&.find { |f| f[:name] == filter[:name] } %>
+                        <div class="app-checkbox-filter__selected">
+                          <ul class="moj-filter-tags">
+                            <% active_filters.find { |f| f[:name] == filter[:name] }[:options].select { |o| o[:checked] == true }.each do |f| %>
+                              <li>
+                                <a class="moj-filter__tag" href="/remove-subject-filter/<%= f[:label]%>">
+                                  <span class="govuk-visually-hidden">Remove this filter</span> <%= f[:label] %>
+                                </a>
+                              </li>
+                            <% end %>
+                          </ul>
+                        </div>
+                      <% end %>
+                      <div class="app-checkbox-filter__container">
+                        <div class="govuk-checkboxes govuk-checkboxes--small app-checkbox-filter__container-inner">
+                          <% filter[:options].each do |option| %>
+                            <div class="govuk-checkboxes__item">
+                              <input class="govuk-checkboxes__input" id="<%= filter[:name] %>-<%= option[:value] %>" name="<%= filter[:name] %>[]" type="checkbox" <%= 'checked' if option[:checked] %> value="<%= option[:value] %>">
+                              <label class="govuk-label govuk-checkboxes__label" for="<%= filter[:name] %>-<%= option[:value] %>">
+                                <%= option[:label] %>
+                              </label>
+                            </div>
+                          <% end %>
+                        </div>
+                      </div>
+                    </div>
                   <% end %>
                 </fieldset>
               </div>

--- a/app/components/filter_component.rb
+++ b/app/components/filter_component.rb
@@ -12,7 +12,7 @@ class FilterComponent < ViewComponent::Base
     case filter[:type]
     when :search
       [{ title: filter[:value], remove_link: remove_search_tag_link(filter[:name]) }]
-    when :checkboxes
+    when :checkboxes, :checkbox_filter
       filter[:options].each_with_object([]) do |option, arr|
         if option[:checked]
           arr << { title: option[:label], remove_link: remove_checkbox_tag_link(filter[:name], option[:value]) }
@@ -59,6 +59,8 @@ class FilterComponent < ViewComponent::Base
       filter[:primary] != true && filter[:value].present?
     when :checkboxes
       filter[:options].any? { |o| o[:checked] }
+    when :checkbox_filter
+      filter[:options].any? { |o| o[:checked] }
     end
   end
 
@@ -68,6 +70,8 @@ class FilterComponent < ViewComponent::Base
       when :search
         hash[filter[:name]] = filter[:value]
       when :checkboxes
+        hash[filter[:name]] = filter[:options].select { |o| o[:checked] }.map { |o| o[:value] }
+      when :checkbox_filter
         hash[filter[:name]] = filter[:options].select { |o| o[:checked] }.map { |o| o[:value] }
       end
     end

--- a/app/frontend/packs/application-provider.js
+++ b/app/frontend/packs/application-provider.js
@@ -1,6 +1,7 @@
 import { initAll as govUKFrontendInitAll } from 'govuk-frontend'
 import initWarnOnUnsavedChanges from './warn-on-unsaved-changes'
 import filter from './components/paginated_filter'
+import checkbox_filter from './components/checkbox_filter'
 import '../styles/application-provider.scss'
 
 require.context('govuk-frontend/govuk/assets')
@@ -8,3 +9,4 @@ require.context('govuk-frontend/govuk/assets')
 govUKFrontendInitAll()
 initWarnOnUnsavedChanges()
 filter()
+checkbox_filter('#subject', 'Search for subject')

--- a/app/frontend/packs/components/checkbox_filter.js
+++ b/app/frontend/packs/components/checkbox_filter.js
@@ -1,0 +1,164 @@
+let CheckboxFilter = function(params) {
+  this.params = params
+  this.container = $(params.container)
+  this.container.addClass('app-checkbox-filter--enhanced')
+  this.checkboxes = this.container.find("input[type='checkbox']")
+  this.checkboxesContainer = this.container.find('.app-checkbox-filter__container')
+  this.checkboxesInnerContainer = this.checkboxesContainer.children('.app-checkbox-filter__container-inner')
+  this.legend = this.container.find('legend')
+  this.legend.addClass('govuk-visually-hidden')
+  this.setupStatusBox()
+  this.setupHeading()
+  this.setupTextBox()
+  this.setupHeight()
+}
+
+CheckboxFilter.prototype.setupHeading = function() {
+  this.heading = $('<p class="app-checkbox-filter__title" aria-hidden="true">' + this.legend.text() + '</p>')
+  this.container.prepend(this.heading)
+}
+
+CheckboxFilter.prototype.setupTextBox = function() {
+  var tagContainer = this.container.find('.app-checkbox-filter__selected')
+  if(tagContainer[0]) {
+    tagContainer.after(this.getTextBoxHtml())
+  } else {
+    this.heading.after(this.getTextBoxHtml())
+  }
+
+  this.textBox = this.container.find('.app-checkbox-filter__filter-input')
+  this.textBox.on('keyup', $.proxy(this, 'onTextBoxKeyUp'))
+}
+
+CheckboxFilter.prototype.getTextBoxHtml = function() {
+  var id = this.container[0].id
+  var html = ''
+  html += '<label for="' + id + '-checkbox-filter__filter-input" class="govuk-label govuk-visually-hidden">' + this.params.textBox.label + '</label>'
+  html += '<input id="' + id + '-checkbox-filter__filter-input" class="app-checkbox-filter__filter-input govuk-input" type="text" aria-describedby="' + id + '-checkboxes-status" aria-controls="' + id + '-checkboxes" autocomplete="off" spellcheck="false">'
+  return html
+}
+
+CheckboxFilter.prototype.setupStatusBox = function() {
+  this.statusBox = $('<div class="govuk-visually-hidden" role="status" id="' + this.container[0].id + '-checkboxes-status"></div>')
+  this.updateStatusBox({
+    foundCount: this.getAllVisibleCheckboxes().length,
+    checkedCount: this.getAllVisibleCheckedCheckboxes().length
+  })
+  this.container.append(this.statusBox)
+}
+
+CheckboxFilter.prototype.updateStatusBox = function(params) {
+  var status = '%found% options found, %selected% selected'
+  status = status.replace(/%found%/, params.foundCount)
+  status = status.replace(/%selected%/, params.checkedCount)
+  this.statusBox.html(status)
+}
+
+CheckboxFilter.prototype.onTextBoxKeyUp = function(e) {
+  var ENTER_KEY = 13
+  if (e.keyCode === ENTER_KEY) {
+    e.preventDefault()
+  } else {
+    this.filterCheckboxes()
+  }
+}
+
+CheckboxFilter.prototype.cleanString = function(text) {
+  text = text.replace(/&/g, 'and')
+  text = text.replace(/[’',:–-]/g, '') // remove punctuation characters
+  text = text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // escape special characters
+  return text.trim().replace(/\s\s+/g, ' ').toLowerCase() // replace multiple spaces with one
+}
+
+CheckboxFilter.prototype.filterCheckboxes = function() {
+  var textValue = this.cleanString(this.textBox.val())
+
+  var allCheckboxes = this.getAllCheckboxes()
+  // hide all checkboxes
+  allCheckboxes.hide()
+
+  for(var i = 0; i < allCheckboxes.length; i++ ) {
+    var labelValue = this.cleanString($(allCheckboxes[i]).find('.govuk-checkboxes__label').text())
+    if(labelValue.search(textValue) !== -1) {
+      $(allCheckboxes[i]).show()
+    }
+  }
+
+  this.updateStatusBox({
+    foundCount: this.getAllVisibleCheckboxes().length,
+    checkedCount: this.getAllVisibleCheckedCheckboxes().length
+  })
+}
+
+CheckboxFilter.prototype.getAllCheckboxes = function() {
+  return this.checkboxesContainer.find('.govuk-checkboxes__item')
+}
+
+CheckboxFilter.prototype.getAllVisibleCheckboxes = function() {
+  return this.getAllCheckboxes().filter(function(i, el) {
+    return $(el).css('display') == 'block'
+  })
+}
+
+CheckboxFilter.prototype.getAllVisibleCheckedCheckboxes = function() {
+  return this.getAllVisibleCheckboxes().filter(function(i, el) {
+    return $(el).find('.govuk-checkboxes__input')[0].checked
+  })
+}
+
+CheckboxFilter.prototype.setContainerHeight = function(height) {
+  this.checkboxesContainer.css({
+    height: height
+  })
+}
+
+CheckboxFilter.prototype.isCheckboxInView = function(index, option) {
+  var $checkbox = $(option)
+  var initialOptionContainerHeight = this.checkboxesContainer.height()
+  var optionListOffsetTop = this.checkboxesInnerContainer.offset().top
+  var distanceFromTopOfContainer = $checkbox.offset().top - optionListOffsetTop
+  return distanceFromTopOfContainer < initialOptionContainerHeight
+}
+
+CheckboxFilter.prototype.getVisibleCheckboxes = function() {
+  var visibleCheckboxes = this.checkboxes.filter(this.isCheckboxInView.bind(this))
+  // add an extra checkbox, if the label of the first is too long it collapses onto itself
+  visibleCheckboxes = visibleCheckboxes.add(this.checkboxes[visibleCheckboxes.length])
+  return visibleCheckboxes
+}
+
+CheckboxFilter.prototype.setupHeight = function() {
+  var initialOptionContainerHeight = this.checkboxesContainer.height()
+  var height = this.checkboxesInnerContainer.outerHeight(true)
+
+  // check whether this is hidden by progressive disclosure,
+  // because height calculations won't work
+  if (this.checkboxesContainer[0].offsetParent === null) {
+    initialOptionContainerHeight = 200
+    height = 200
+  }
+
+  // Resize if the list is only slightly bigger than its container
+  if (height < initialOptionContainerHeight + 50) {
+    this.setContainerHeight(height + 1)
+    return
+  }
+
+  // Resize to cut last item cleanly in half
+  var lastVisibleCheckbox = this.getVisibleCheckboxes().last()
+  var position = lastVisibleCheckbox.parent()[0].offsetTop // parent element is relative
+  this.setContainerHeight(position + (lastVisibleCheckbox.height() / 1.5))
+}
+
+const checkbox_filter = (containerId, label) => {
+  const $containerEl = $(containerId)
+
+  if ($containerEl.length) {
+    new CheckboxFilter({
+      container: $(containerId),
+      textBox: { label: label }
+    })
+  }
+}
+
+export default checkbox_filter

--- a/app/frontend/styles/application-provider.scss
+++ b/app/frontend/styles/application-provider.scss
@@ -1,3 +1,4 @@
 @import "application";
 @import "provider/all";
 @import "components/paginated_filter";
+@import "components/checkbox_filter";

--- a/app/frontend/styles/components/_checkbox_filter.scss
+++ b/app/frontend/styles/components/_checkbox_filter.scss
@@ -1,0 +1,135 @@
+.app-checkbox-filter {
+  position: relative;
+  margin-bottom: govuk-spacing(2);
+  padding: 0;
+
+  @include govuk-media-query($from: desktop) {
+    // Redefine scrollbars on desktop where these lists are scrollable
+    // so they are always visible in option lists
+    ::-webkit-scrollbar {
+      width: 7px;
+      -webkit-appearance: none;
+    }
+
+    ::-webkit-scrollbar-thumb {
+      border-radius: 4px;
+
+      // scss-lint:disable ColorVariable
+      // sass-lint:disable no-color-literals
+      background-color: rgba(0, 0, 0, .5);
+      -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .87);
+      // scss-lint:enable ColorVariable
+      // sass-lint:enable no-color-literals
+    }
+  }
+}
+
+.app-checkbox-filter__title {
+  @include govuk-font(19, $weight: bold);
+  margin-bottom: govuk-spacing(3);
+}
+
+.app-checkbox-filter__container {
+  position: relative;
+  max-height: 200px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  // margin-left: - govuk-spacing(2);
+  background-color: govuk-colour("white");
+  border-bottom: 1px solid $govuk-border-colour;
+}
+
+.app-checkbox-filter__container-inner {
+  @include govuk-clearfix;
+  padding: govuk-spacing(1) govuk-spacing(2);
+}
+
+.app-checkbox-filter__filter {
+  position: relative;
+  padding: govuk-spacing(2) 0 govuk-spacing(2) 0;
+  background: govuk-colour("white");
+}
+
+.app-checkbox-filter__filter-input {
+  @include govuk-font(19);
+  margin-bottom: govuk-spacing(2);
+  padding-left: 33px;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='currentColor'%3E%3C/path%3E%3C/svg%3E") govuk-colour("white") no-repeat -5px -3px;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Tags
+////////////////////////////////////////////////////////////////////////////////
+
+.app-checkbox-filter__selected {
+  margin-top: - govuk-spacing(1);
+  margin-bottom: govuk-spacing(2);
+  ul:last-of-type {
+    margin-bottom: 0; // IE9 +
+  }
+
+}
+
+.app-checkbox-filter__heading {
+  @include govuk-font($size: 19, $weight: bold);
+  margin: 0;
+}
+
+.app-checkbox-filter__tags {
+  font-size: 0;
+  margin-bottom: govuk-spacing(4); // Needs to adjust to 15px on mobile
+  padding-left: 0;
+
+  li {
+    display: inline-block;
+    margin-right: govuk-spacing(1);
+  }
+
+}
+
+.app-checkbox-filter--enhanced .app-checkbox-filter__selected {
+  margin-top: - govuk-spacing(3);
+  margin-bottom: govuk-spacing(3);
+}
+
+.app-checkbox-filter__tag {
+  @include govuk-font(16);
+  background-color: govuk-colour("white");
+  border: 1px solid govuk-colour("black");
+  color: govuk-colour("black");
+  display: inline-block;
+  margin-top: govuk-spacing(1);
+  padding: govuk-spacing(1);
+  text-decoration: none;
+
+  &:link,
+  &:visited {
+    color: govuk-colour("black");
+  }
+
+  &:focus {
+    color: $govuk-focus-text-colour;
+    background-color: $govuk-focus-colour;
+  }
+
+  &:hover {
+    background-color: govuk-colour("black");
+    color: govuk-colour("white");
+  }
+
+  &:after {
+    background-image: url("/public/images/icon-tag-remove-cross.svg");
+    content: '';
+    display: inline-block;
+    font-weight: bold;
+    height: 10px;
+    margin-left: govuk-spacing(1);
+    vertical-align: middle;
+    width: 10px;
+  }
+
+  &:hover:after {
+    background-image: url("/public/images/icon-tag-remove-cross-white.svg");
+  }
+
+}

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -18,7 +18,7 @@ module ProviderInterface
     end
 
     def filters
-      ([] << search_filter << recruitment_cycle_filter << status_filter << provider_filter << accredited_provider_filter).concat(provider_locations_filters).compact
+      ([] << search_filter << recruitment_cycle_filter << status_filter << provider_filter << accredited_provider_filter << subject_filter).concat(provider_locations_filters).compact
     end
 
     def filtered?
@@ -41,7 +41,7 @@ module ProviderInterface
   private
 
     def parse_params(params)
-      params.permit(:remove, :candidate_name, recruitment_cycle_year: [], provider: [], status: [], accredited_provider: [], provider_location: []).to_h
+      params.permit(:remove, :candidate_name, recruitment_cycle_year: [], provider: [], status: [], accredited_provider: [], provider_location: [], subject: []).to_h
     end
 
     def save_filter_state!
@@ -159,6 +159,62 @@ module ProviderInterface
           end,
         }
       end
+    end
+
+    def subject_filter
+      {
+        type: :checkbox_filter,
+        heading: 'Search for subject',
+        name: 'subject',
+        options: [
+          OpenStruct.new(id: 1, name: 'Art & Design'),
+          OpenStruct.new(id: 2, name: 'Biology'),
+          OpenStruct.new(id: 3, name: 'Business studies'),
+          OpenStruct.new(id: 4, name: 'Chemistry'),
+          OpenStruct.new(id: 5, name: 'Citizenship'),
+          OpenStruct.new(id: 6, name: 'Classics'),
+          OpenStruct.new(id: 7, name: 'Communications and media studies'),
+          OpenStruct.new(id: 8, name: 'Computer science'),
+          OpenStruct.new(id: 9, name: 'Dance'),
+          OpenStruct.new(id: 10, name: 'Design and technology'),
+          OpenStruct.new(id: 11, name: 'Drama'),
+          OpenStruct.new(id: 12, name: 'Economics'),
+          OpenStruct.new(id: 13, name: 'English'),
+          OpenStruct.new(id: 14, name: 'English as a second or other language'),
+          OpenStruct.new(id: 15, name: 'French'),
+          OpenStruct.new(id: 16, name: 'Geography'),
+          OpenStruct.new(id: 17, name: 'German'),
+          OpenStruct.new(id: 18, name: 'Health and social care'),
+          OpenStruct.new(id: 19, name: 'History'),
+          OpenStruct.new(id: 20, name: 'Italian'),
+          OpenStruct.new(id: 21, name: 'Japanese'),
+          OpenStruct.new(id: 22, name: 'Mandarin'),
+          OpenStruct.new(id: 23, name: 'Mathematics'),
+          OpenStruct.new(id: 24, name: 'Modern languages (other)'),
+          OpenStruct.new(id: 25, name: 'Music'),
+          OpenStruct.new(id: 26, name: 'Physical education'),
+          OpenStruct.new(id: 27, name: 'Physics'),
+          OpenStruct.new(id: 28, name: 'Primary'),
+          OpenStruct.new(id: 29, name: 'Primary with English'),
+          OpenStruct.new(id: 30, name: 'Primary with geography and history'),
+          OpenStruct.new(id: 31, name: 'Primary with mathematics'),
+          OpenStruct.new(id: 32, name: 'Primary with modern languages'),
+          OpenStruct.new(id: 33, name: 'Primary with physical education'),
+          OpenStruct.new(id: 34, name: 'Primary with science'),
+          OpenStruct.new(id: 35, name: 'Psychology'),
+          OpenStruct.new(id: 36, name: 'Religious education'),
+          OpenStruct.new(id: 37, name: 'Russian'),
+          OpenStruct.new(id: 38, name: 'Science'),
+          OpenStruct.new(id: 38, name: 'Social sciences'),
+          OpenStruct.new(id: 38, name: 'Spanish'),
+        ].map do |s|
+          {
+            value: s.id,
+            label: s.name,
+            checked: applied_filters[:subject]&.include?(s.id.to_s),
+          }
+        end,
+      }
     end
   end
 end

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -52,6 +52,10 @@ class FilterApplicationChoicesForProviders
       application_choices.where('sites.id' => provider_location)
     end
 
+    def course_subject(application_choices, _subjects)
+      application_choices
+    end
+
     def create_filter_query(application_choices, filters)
       filtered_application_choices = search(application_choices, filters[:candidate_name])
       filtered_application_choices = recruitment_cycle_year(filtered_application_choices, filters[:recruitment_cycle_year])
@@ -59,6 +63,7 @@ class FilterApplicationChoicesForProviders
       filtered_application_choices = accredited_provider(filtered_application_choices, filters[:accredited_provider])
       filtered_application_choices = status(filtered_application_choices, filters[:status])
       filtered_application_choices = provider_location(filtered_application_choices, filters[:provider_location])
+      filtered_application_choices = course_subject(filtered_application_choices, filters[:subject])
       filtered_application_choices
     end
   end


### PR DESCRIPTION
## Context

https://trello.com/c/anMxp90Q/3559-spike-add-a-subject-filter-to-applications
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Feasibility spike, no real issues with integration. More details on Trello.

![image](https://user-images.githubusercontent.com/93511/113721216-396d2c80-96e7-11eb-9815-9b19678856c1.png)


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Not addressed in this PR: Filtering the list of applications in `FilterApplicationChoicesForProviders` as this will need to be done in conjunction with subject names being available in the database. This will behave like a standard checkbox filter so nothing new here.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/anMxp90Q/3559-spike-add-a-subject-filter-to-applications
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
