### PR TITLE
Change offerable_courses to scope

### DIFF
--- a/app/queries/get_change_offer_options.rb
+++ b/app/queries/get_change_offer_options.rb
@@ -44,11 +44,9 @@ class GetChangeOfferOptions
 
   def offerable_courses
     make_decisions_courses
-      .where(
-        open_on_apply: true,
-        recruitment_cycle_year: recruitment_cycle_year,
-      )
-      .where(ratifying_provider_is_preserved)
+    .open_on_apply
+    .where(recruitment_cycle_year: recruitment_cycle_year)
+    .where(ratifying_provider_is_preserved)
   end
 
   def make_decisions_courses

--- a/spec/queries/get_change_offer_options_spec.rb
+++ b/spec/queries/get_change_offer_options_spec.rb
@@ -82,9 +82,10 @@ RSpec.describe GetChangeOfferOptions do
   end
 
   describe '#offerable_courses' do
-    it 'returns only courses which are open on apply' do
+    it 'returns only courses which are open on apply and exposed in find' do
       service = service(provider_user, externally_ratified_course)
       create(:course, accredited_provider: ratifying_provider)
+      create(:course, accredited_provider: ratifying_provider, open_on_apply: true, exposed_in_find: false)
       allow(service).to receive(:make_decisions_courses).and_return(Course.all)
       expect(service.offerable_courses).to eq([externally_ratified_course])
     end


### PR DESCRIPTION
## Context
A method in the query service missed out on some key information about a course as it only checked the `open_on_apply` field. There is a scope by the same name which is more appropriate, so this is what's changed! 

https://trello.com/c/pN3s3OPa/3588-offerable-courses-needs-to-use-openonapply-scope

## Changes proposed in this pull request
Changed `#offerable_courses` in `get_change_offer_options.rb` to use the `open_on_apply` scope.
