### PR TITLE
Update migration to catch old export name

### DIFF
--- a/app/services/data_migrations/backfill_export_type.rb
+++ b/app/services/data_migrations/backfill_export_type.rb
@@ -7,7 +7,9 @@ module DataMigrations
       data_exports = DataExport.all.where(export_type: nil)
 
       data_exports.each do |export|
-        export.update!(export_type: export.name.parameterize.underscore)
+        export_type = export.name == 'Unexplained breaks in work history' ? 'work_history_break' : export.name.parameterize.underscore
+
+        export.update!(export_type: export_type)
       end
     end
   end

--- a/spec/services/data_migrations/backfill_export_type_spec.rb
+++ b/spec/services/data_migrations/backfill_export_type_spec.rb
@@ -7,4 +7,11 @@ RSpec.describe DataMigrations::BackfillExportType do
     described_class.new.change
     expect(data_export.reload.export_type).to eq 'active_provider_user_permissions'
   end
+
+  it 'correctly backfills old work_history_break exports' do
+    data_export = create(:data_export, name: 'Unexplained breaks in work history', export_type: nil)
+
+    described_class.new.change
+    expect(data_export.reload.export_type).to eq 'work_history_break'
+  end
 end


### PR DESCRIPTION
## Context

Only a small subset of export history records are being shown.

Only `data_export` records with an `export_type` are shown. This field is automatically filled for all new export downloads. We wrote a migration to backfill the old `data_export` records but this migration failed to run successfully because one of the exports was renamed (`Unexplained breaks in work history` to `Work history break`).


## Changes proposed in this pull request

This PR updates the migration to catch this particular case. 

## Guidance to review

It would be good if you could test it locally please.

1) Run this migration on master. Open `backfill_export_type.rb` and change line 4 to `MANUAL_RUN = true`. Then run `rake data:migrate:manual[DataMigrations::BackfillExportType]`. It should fail with this error, (if you have a `data_export` with the name "Unexplained breaks in work history").

![image](https://user-images.githubusercontent.com/33458055/113727788-5b69ad80-96ed-11eb-9b59-c252aedce4e8.png)

2. Take a look at the data in your `data_exports` table. The older records (>1 month) probably won't have the `export_type` filled in.
3. Then run this migration on this branch and it should succeed. To run this migration a second time you will have to remove the latest record in the `data_migrations` table
4. Take a look at the data in your `data_exports` table. The older records should now have the `export_type` filled in.

## Link to Trello card

https://trello.com/c/K5o3HiH8/3258-fix-export-history-bug

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
