### PR TITLE
Change change offer query course options scoping

### DIFF
--- a/app/queries/get_change_offer_options.rb
+++ b/app/queries/get_change_offer_options.rb
@@ -20,6 +20,7 @@ class GetChangeOfferOptions
 
   def available_study_modes(course:)
     CourseOption
+      .selectable
       .where(course: offerable_courses.find(course.id))
       .group('study_mode')
       .pluck(:study_mode)
@@ -27,6 +28,7 @@ class GetChangeOfferOptions
 
   def available_course_options(course:, study_mode:)
     CourseOption
+      .selectable
       .where(
         course: offerable_courses.find(course.id),
         study_mode: study_mode,

--- a/spec/queries/get_change_offer_options_spec.rb
+++ b/spec/queries/get_change_offer_options_spec.rb
@@ -163,12 +163,28 @@ RSpec.describe GetChangeOfferOptions do
         expect(service.available_study_modes(course: self_ratified_course))
           .to match_array(%w[full_time part_time])
       end
+
+      it 'only returns study modes related to a course option whose site is still valid' do
+        create(:course_option, :part_time, course: self_ratified_course)
+        create(:course_option, :full_time, course: self_ratified_course, site_still_valid: false)
+
+        expect(service.available_study_modes(course: self_ratified_course))
+            .to match_array(%w[part_time])
+      end
     end
 
     describe '#available_course_options' do
       it 'returns a collection of course options for a given course/study_mode' do
         expect(service.available_course_options(course: self_ratified_course, study_mode: 'part_time'))
           .to match_array([course_options.first, course_options.second])
+      end
+
+      it 'only returns course options whose sites are still valid' do
+        valid_course_option = create(:course_option, :part_time, course: self_ratified_course)
+        create(:course_option, :part_time, course: self_ratified_course, site_still_valid: false)
+
+        expect(service.available_course_options(course: self_ratified_course, study_mode: 'part_time'))
+            .to match_array([valid_course_option])
       end
     end
 


### PR DESCRIPTION
## Context

Two of the methods within the get_change_offer_options query service were including results that would lead to invalid options down the line - specifically, they were including course options whose sites were not valid. 

## Changes proposed in this pull request

Added the `selectable` scope to queries that return course options, which limits them to ones which have `site_still_valid: true` 

## Link to Trello card

https://trello.com/c/xFld1KoL/3590-offerable-course-options-should-not-include-sites-that-are-not-valid
