### PR TITLE
Enable filtering provider users by ID in support UI

### DIFF
--- a/app/components/support_interface/provider_users_table_component.html.erb
+++ b/app/components/support_interface/provider_users_table_component.html.erb
@@ -1,6 +1,7 @@
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">ID</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-third">Name and email address</th>
       <th scope="col" class="govuk-table__header">Providers</th>
       <th scope="col" class="govuk-table__header">Actions</th>
@@ -10,6 +11,9 @@
   <tbody class="govuk-table__body">
     <% table_rows.each do |row| %>
       <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          <%= row[:provider_user].id %>
+        </td>
         <td class="govuk-table__cell">
           <%= govuk_link_to(row[:provider_user].display_name, support_interface_provider_user_path(row[:provider_user])) %><br>
           <span class="govuk-hint" style="word-break: break-all;"><%= row[:provider_user].email_address %></span>

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -6,10 +6,7 @@ module SupportInterface
         .page(params[:page] || 1).per(30)
 
       @provider_users = scope_by_use_of_service
-
-      if params[:q]
-        @provider_users = @provider_users.where("CONCAT(first_name, ' ', last_name, ' ', email_address) ILIKE ?", "%#{params[:q]}%")
-      end
+      @provider_users = scope_by_search_term
 
       @filter = SupportInterface::ProviderUsersFilter.new(params: params)
     end
@@ -96,6 +93,16 @@ module SupportInterface
         @provider_users.where.not(last_signed_in_at: nil)
       else
         @provider_users
+      end
+    end
+
+    def scope_by_search_term
+      return @provider_users if params[:q].blank?
+
+      if params[:q] =~ /^\d+$/
+        @provider_users.where(id: params[:q])
+      else
+        @provider_users.where("CONCAT(first_name, ' ', last_name, ' ', email_address) ILIKE ?", "%#{params[:q]}%")
       end
     end
 

--- a/app/models/support_interface/provider_users_filter.rb
+++ b/app/models/support_interface/provider_users_filter.rb
@@ -28,7 +28,7 @@ module SupportInterface
         },
         {
           type: :search,
-          heading: 'Name or email',
+          heading: 'Name, email or ID',
           value: applied_filters[:q],
           name: 'q',
         },

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -32,6 +32,9 @@ RSpec.feature 'Managing provider users' do
     then_i_should_see_the_list_of_provider_users
     when_i_filter_the_list_of_provider_users
     and_i_should_see_the_user_i_created
+
+    when_i_filter_the_list_of_provider_users_by_id
+    and_i_should_see_the_user_i_created
     and_the_user_should_be_sent_a_welcome_email
 
     and_i_click_on_that_user
@@ -161,6 +164,12 @@ RSpec.feature 'Managing provider users' do
 
   def and_i_should_see_the_user_i_created
     expect(page).to have_content('harrison@example.com')
+  end
+
+  def when_i_filter_the_list_of_provider_users_by_id
+    @new_user = ProviderUser.find_by_email_address('harrison@example.com')
+    fill_in :q, with: @new_user.id
+    click_on 'Apply filters'
   end
 
   def and_the_user_should_be_sent_a_welcome_email


### PR DESCRIPTION
## Changes proposed in this pull request

Enables searching provider users by ID using the existing 'Name or email' input field.
Exposes the ID in the provider users table.

![image](https://user-images.githubusercontent.com/93511/113860653-2ec19e80-979e-11eb-944d-87fd6ae998cf.png)


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/b9vmaVGY/3564-enable-searching-for-provider-users-by-uid-in-support

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
