### PR TITLE
Separate mail templates from different mailers

### DIFF
--- a/app/exports/candidate_email_send_counts_export.yml
+++ b/app/exports/candidate_email_send_counts_export.yml
@@ -17,3 +17,13 @@ custom_columns:
   unique_recipients:
     type: integer
     description: The number of unique recipients of this email
+
+  mailer:
+    type: string
+    description: The number of unique recipients of this email
+    enum:
+      - Authentication mailer
+      - Candidate mailer
+      - Provider mailer
+      - Referee mailer
+      - Support mailer

--- a/app/exports/candidate_email_send_counts_export.yml
+++ b/app/exports/candidate_email_send_counts_export.yml
@@ -20,7 +20,7 @@ custom_columns:
 
   mailer:
     type: string
-    description: The number of unique recipients of this email
+    description: The Rails mailer which sent the email
     enum:
       - Authentication mailer
       - Candidate mailer

--- a/app/services/support_interface/candidate_email_send_counts_export.rb
+++ b/app/services/support_interface/candidate_email_send_counts_export.rb
@@ -7,6 +7,7 @@ module SupportInterface
           send_count: send_count_record.send_count,
           last_sent_at: send_count_record.last_sent_at,
           unique_recipients: send_count_record.unique_recipients,
+          mailer: send_count_record.mailer.humanize,
         }
       end
     end
@@ -16,9 +17,9 @@ module SupportInterface
     def emails_with_total_send_counts
       Email
         .select(
-          'mail_template, COUNT(mail_template) AS send_count, COUNT(DISTINCT "to") AS unique_recipients, MAX(created_at) AS last_sent_at',
+          'mail_template, COUNT(mail_template) AS send_count, COUNT(DISTINCT "to") AS unique_recipients, MAX(created_at) AS last_sent_at, mailer',
         )
-        .group('mail_template')
+        .group('mail_template, mailer')
         .order('mail_template ASC')
     end
   end

--- a/spec/services/support_interface/candidate_email_send_counts_export_spec.rb
+++ b/spec/services/support_interface/candidate_email_send_counts_export_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe SupportInterface::CandidateEmailSendCountsExport do
         two_days_ago = Time.zone.now - 2.days
 
         'application_submitted'.tap do |mail_template|
-          create(:email, mail_template: mail_template, created_at: yesterday)
-          create(:email, mail_template: mail_template, created_at: two_days_ago)
-          create(:email, mail_template: mail_template, created_at: two_days_ago, to: 'another_recipient@email.com')
+          create(:email, mail_template: mail_template, mailer: :candidate_mailer, created_at: yesterday)
+          create(:email, mail_template: mail_template, mailer: :candidate_mailer, created_at: two_days_ago)
+          create(:email, mail_template: mail_template, mailer: :candidate_mailer, created_at: two_days_ago, to: 'another_recipient@email.com')
         end
-        create(:email, mail_template: 'conditions_met', created_at: two_days_ago)
+        create(:email, mail_template: 'conditions_met', mailer: :candidate_mailer, created_at: two_days_ago)
 
         expect(described_class.new.data_for_export).to match_array([
           {
@@ -26,12 +26,40 @@ RSpec.describe SupportInterface::CandidateEmailSendCountsExport do
             send_count: 3,
             last_sent_at: yesterday.utc,
             unique_recipients: 2,
+            mailer: 'Candidate mailer',
           },
           {
             email_template: 'conditions_met',
             send_count: 1,
             last_sent_at: two_days_ago.utc,
             unique_recipients: 1,
+            mailer: 'Candidate mailer',
+          },
+        ])
+      end
+    end
+
+    it 'distinguishes between templates with the same name but from different mailers' do
+      Timecop.freeze(Time.zone.now.round) do
+        yesterday = Time.zone.now - 1.day
+
+        create(:email, mail_template: 'offer_accepted', mailer: :candidate_mailer, created_at: yesterday)
+        create(:email, mail_template: 'offer_accepted', mailer: :provider_mailer, created_at: yesterday)
+
+        expect(described_class.new.data_for_export).to match_array([
+          {
+            email_template: 'offer_accepted',
+            send_count: 1,
+            last_sent_at: yesterday.utc,
+            unique_recipients: 1,
+            mailer: 'Candidate mailer',
+          },
+          {
+            email_template: 'offer_accepted',
+            send_count: 1,
+            last_sent_at: yesterday.utc,
+            unique_recipients: 1,
+            mailer: 'Provider mailer',
           },
         ])
       end


### PR DESCRIPTION
## Context

The "Candidate email send counts" export counts the number of emails sent, with one row per `mail_template`. However, some emails share the same `mail_template` name but are from different mailers, which means they have different content and different recipients. These emails are currently counted as one, but they need to be separated out.

## Changes proposed in this pull request

Update the export by changing the way the groupings work and adding a `mailer` column to make it explicit as to which mailer the `mail_template` is from.

## Guidance to review

Have I missed anything? Was this done on purpose?

## Link to Trello card

https://trello.com/c/66V90gyP/3245-investigate-why-email-notifications-data-extract-has-a-different-list-of-emails-sent-compared-to-qa

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
