### PR TITLE
Add preview for sign_in_email_without_account_email

### DIFF
--- a/spec/mailers/previews/authentication_mailer_preview.rb
+++ b/spec/mailers/previews/authentication_mailer_preview.rb
@@ -3,6 +3,10 @@ class AuthenticationMailerPreview < ActionMailer::Preview
     AuthenticationMailer.sign_up_email(candidate: FactoryBot.build_stubbed(:candidate), token: SecureRandom.hex)
   end
 
+  def sign_in_email_without_account_email
+    AuthenticationMailer.sign_in_without_account_email(to: FactoryBot.build_stubbed(:candidate).email_address)
+  end
+
   def sign_in_email
     AuthenticationMailer.sign_in_email(candidate: FactoryBot.build_stubbed(:candidate), token: SecureRandom.hex)
   end


### PR DESCRIPTION
## Context

This email is missing a preview and so it is not showing up in the documentation within the Support UI.

The email is used [here](https://github.com/DFE-Digital/apply-for-teacher-training/blob/00c05285b1a14791b7ae3554c00639a2915756ff/app/services/candidate_interface/sign_in_candidate.rb#L27).

## Changes proposed in this pull request

Add an entry in the `authentication_mailer_preview`. 

## Guidance to review

It [looks like there is already a test for this email](https://github.com/DFE-Digital/apply-for-teacher-training/blob/998b21879d17e4da1f5d34e71a20b009104dd096/spec/mailers/authentication_mailer_spec.rb#L45). Do I need to add anything else?

## Link to Trello card

https://trello.com/c/66V90gyP/3245-investigate-why-email-notifications-data-extract-has-a-different-list-of-emails-sent-compared-to-qa

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
