### PR TITLE
Update audited gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/audited
-  revision: 9b3c366573712801ae43b04e80f827c78397192e
+  revision: 512883ec786e98e0ec149c3ac2c0fd9085e25ec9
   specs:
-    audited (4.9.0)
-      activerecord (>= 4.2, < 6.1)
+    audited (4.10.0)
+      activerecord (>= 4.2, < 6.2)
 
 GEM
   remote: https://rubygems.org/
@@ -202,7 +202,7 @@ GEM
     http-parser (1.2.1)
       ffi-compiler (>= 1.0, < 2.0)
     httpclient (2.8.3)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     io-like (0.3.1)
     json-jwt (1.13.0)


### PR DESCRIPTION

## Context
Our fork of audited at https://github.com/DFE-Digital/audited/ has been
updated with commits from upstream, including changes to support Rails
6.1.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Update the gem so that the lock file is pointing to the appropriate SHA.

Ideally we'd use the original gem, but this will break the mailer previews index page until https://github.com/collectiveidea/audited/pull/532 is merged.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Audits can be tested by changing a candidate's application form in the review app support interface and then checking the history.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/EHl7AXlh
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
