### PR TITLE
Use GovukLinkHelper helpers from govuk-components

### DIFF
--- a/app/components/candidate_interface/add_reference_component.html.erb
+++ b/app/components/candidate_interface/add_reference_component.html.erb
@@ -1,13 +1,13 @@
 <div class="govuk-inset-text">
   <% if no_viable_references? %>
     <p class="govuk-body">You need 2 references before you can submit your application.</p>
-    <%= govuk_button_link_to 'Add a referee', candidate_interface_references_start_path %>
+    <%= govuk_link_to 'Add a referee', candidate_interface_references_start_path, button: true %>
   <% elsif one_viable_reference? %>
     <p class="govuk-body">You need 2 references before you can submit your application.</p>
-    <%= govuk_button_link_to 'Add a second referee', candidate_interface_references_start_path %>
+    <%= govuk_link_to 'Add a second referee', candidate_interface_references_start_path, button: true %>
   <% else %>
     <p class="govuk-body">You can add more referees to increase the chances of getting 2 references quickly.</p>
     <p class="govuk-body">We’ll cancel any remaining requests when you’ve received 2 references.</p>
-    <%= govuk_button_link_to 'Add another referee', candidate_interface_references_start_path, class: 'govuk-button--secondary' %>
+    <%= govuk_link_to 'Add another referee', candidate_interface_references_start_path, button: true, class: 'govuk-button--secondary' %>
   <% end %>
 </div>

--- a/app/components/provider_interface/activity_log_event_component.html.erb
+++ b/app/components/provider_interface/activity_log_event_component.html.erb
@@ -23,7 +23,7 @@
           </p>
         <% end %>
         <% if link.present? && link[:url].present? %>
-          <p class="app-timeline__event_link"><a class="govuk-link" href="<%= link[:url] %>"><%= link[:text] %></a></p>
+          <p class="app-timeline__event_link"><%= govuk_link_to link[:text], link[:url] %></p>
         <% end %>
       </div>
     </div>

--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -25,11 +25,11 @@
 
           <% if FeatureFlag.active?(:interviews) %>
             <div class="govuk-button-group">
-              <%= govuk_button_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice), class: 'govuk-!-margin-bottom-0 govuk-!-margin-right-2' %>
-              <%= govuk_button_link_to 'Make decision', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-button--secondary govuk-!-margin-bottom-0 govuk-!-margin-right-2' %>
+              <%= govuk_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice), button: true, class: 'govuk-!-margin-bottom-0 govuk-!-margin-right-2' %>
+              <%= govuk_link_to 'Make decision', provider_interface_application_choice_respond_path(application_choice), button: true, class: 'govuk-button--secondary govuk-!-margin-bottom-0 govuk-!-margin-right-2' %>
             </div>
           <% else %>
-            <%= govuk_button_link_to 'Make decision', provider_interface_application_choice_respond_path(application_choice) %>
+            <%= govuk_link_to 'Make decision', provider_interface_application_choice_respond_path(application_choice), button: true %>
           <% end %>
         <% elsif waiting_for_interview? %>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
@@ -43,7 +43,7 @@
             <% end -%>
           </p>
 
-          <%= govuk_button_link_to 'Make decision', provider_interface_application_choice_respond_path(application_choice) %>
+          <%= govuk_link_to 'Make decision', provider_interface_application_choice_respond_path(application_choice), button: true %>
 
         <% elsif awaiting_decision_but_cannot_respond? -%>
           <p class="govuk-body">
@@ -76,7 +76,7 @@
             </p>
           <% end %>
 
-          <%= govuk_button_link_to 'Review deferred offer', provider_interface_reconfirm_deferred_offer_path(application_choice) %>
+          <%= govuk_link_to 'Review deferred offer', provider_interface_reconfirm_deferred_offer_path(application_choice), button: true %>
         <% elsif rejection_reason_required? -%>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
             Give feedback
@@ -85,7 +85,7 @@
           <p class="govuk-body">
             You did not make a decision about the application within <%= application_choice.reject_by_default_days %> working days. Tell the candidate why their application was unsuccessful.
           </p>
-            <%= govuk_button_link_to 'Give feedback', provider_interface_reasons_for_rejection_initial_questions_path(application_choice) %>
+          <%= govuk_link_to 'Give feedback', provider_interface_reasons_for_rejection_initial_questions_path(application_choice), button: true %>
         <% end -%>
       </div>
     </div>

--- a/app/components/provider_interface/application_choice_interviews_list_component.html.erb
+++ b/app/components/provider_interface/application_choice_interviews_list_component.html.erb
@@ -1,6 +1,6 @@
 <div class="app-interviews">
   <% if user_can_create_or_change_interviews %>
-    <%= govuk_button_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice), class: 'govuk-button--secondary' %>
+    <%= govuk_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice), button: true, class: 'govuk-button--secondary' %>
   <% end %>
 
   <% if upcoming_interviews.any? %>

--- a/app/components/provider_interface/personal_details_component.rb
+++ b/app/components/provider_interface/personal_details_component.rb
@@ -54,7 +54,7 @@ module ProviderInterface
     def email_row
       {
         key: 'Email address',
-        value: mail_to(email_address, email_address, class: 'govuk-link'),
+        value: govuk_mail_to(email_address, email_address),
       }
     end
 

--- a/app/components/provider_interface/reference_with_feedback_component.rb
+++ b/app/components/provider_interface/reference_with_feedback_component.rb
@@ -42,7 +42,7 @@ module ProviderInterface
     def email_address_row
       {
         key: 'Email address',
-        value: mail_to(email_address, email_address, class: 'govuk-link'),
+        value: govuk_mail_to(email_address, email_address),
       }
     end
 

--- a/app/components/provider_interface/safeguarding_declaration_component.html.erb
+++ b/app/components/provider_interface/safeguarding_declaration_component.html.erb
@@ -54,19 +54,13 @@
           This is because organisational permissions have not been set up. Contact
           <% if others.one? %>
             <% user = others.first %>
-            <%= user.full_name %> at
-            <a class="govuk-link" href="mailto:<%= user.email_address %>">
-              <%= user.email_address %>
-            </a>.
+            <%= user.full_name %> at <%= govuk_mail_to user.email_address, user.email_address %>.
           <% else %>
             one of the following people:
             <ul class="govuk-list govuk-list--bullet">
             <% others.each do |user| %>
               <li>
-                <%= user.full_name %> at
-                <a class="govuk-link" href="mailto:<%= user.email_address %>">
-                  <%= user.email_address %>
-                </a>
+                <%= user.full_name %> at <%= govuk_mail_to user.email_address, user.email_address %>
               </li>
             <% end %>
             </ul>

--- a/app/components/provider_interface/status_box_components/awaiting_provider_decision_component.html.erb
+++ b/app/components/provider_interface/status_box_components/awaiting_provider_decision_component.html.erb
@@ -1,3 +1,3 @@
 <%= render SummaryListComponent.new(rows: rows) %>
 
-<%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-!-margin-bottom-0 govuk-!-display-none-print' %>
+<%= govuk_link_to 'Respond to application', provider_interface_application_choice_respond_path(application_choice), button: true, class: 'govuk-!-margin-bottom-0 govuk-!-display-none-print' %>

--- a/app/components/provider_interface/status_box_components/interviewing_component.html.erb
+++ b/app/components/provider_interface/status_box_components/interviewing_component.html.erb
@@ -1,3 +1,3 @@
 <%= render SummaryListComponent.new(rows: rows) %>
 
-<%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-!-margin-bottom-0 govuk-!-display-none-print' %>
+<%= govuk_link_to 'Respond to application', provider_interface_application_choice_respond_path(application_choice), button: true, class: 'govuk-!-margin-bottom-0 govuk-!-display-none-print' %>

--- a/app/components/support_interface/application_add_course_component.html.erb
+++ b/app/components/support_interface/application_add_course_component.html.erb
@@ -1,11 +1,11 @@
 <% if !application_form.submitted? %>
-  <p class='govuk-body'>
+  <p class="govuk-body">
     This candidate can add <%= application_form.maximum_number_of_course_choices %> course choices to this application.
   </p>
 <% elsif application_form.support_cannot_add_course_choice? %>
-  <p class='govuk-body'>
+  <p class="govuk-body">
     This application already has the maximum number of active course choices (<%= application_form.maximum_number_of_course_choices %>), so we can't add any more until the candidate withdraws one or more course choices.
   </p>
 <% else %>
-  <%= govuk_button_link_to 'Add a course', support_interface_application_form_search_course_new_path(application_form_id: application_form.id), form_class: 'govuk-!-display-inline-block' %>
+  <%= govuk_link_to 'Add a course', support_interface_application_form_search_course_new_path(application_form_id: application_form.id), button: true %>
 <% end %>

--- a/app/components/support_interface/feature_toggle_component.html.erb
+++ b/app/components/support_interface/feature_toggle_component.html.erb
@@ -1,0 +1,8 @@
+<%= govuk_button_to(
+  toggle_label,
+  toggle_link,
+  class: 'app-button--tertiary govuk-!-margin-bottom-0',
+  aria: {
+    label: toggle_aria_label,
+  },
+) %>

--- a/app/components/support_interface/feature_toggle_component.rb
+++ b/app/components/support_interface/feature_toggle_component.rb
@@ -1,0 +1,23 @@
+module SupportInterface
+  class FeatureToggleComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :feature_name
+
+    def initialize(feature_name:)
+      @feature_name = feature_name
+    end
+
+    def toggle_label
+      FeatureFlag.active?(feature_name) ? 'Deactivate' : 'Activate'
+    end
+
+    def toggle_link
+      FeatureFlag.active?(feature_name) ? support_interface_deactivate_feature_flag_path(feature_name) : support_interface_activate_feature_flag_path(feature_name)
+    end
+
+    def toggle_aria_label
+      "#{toggle_label} ‘#{feature_name.humanize}’ feature"
+    end
+  end
+end

--- a/app/components/support_interface/personal_details_component.rb
+++ b/app/components/support_interface/personal_details_component.rb
@@ -59,7 +59,7 @@ module SupportInterface
     def email_row
       {
         key: 'Email address',
-        value: mail_to(email_address, email_address, class: 'govuk-link'),
+        value: govuk_mail_to(email_address, email_address),
         action: 'email address',
         change_path: support_interface_application_form_edit_applicant_details_path(application_form),
       }

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,19 +1,4 @@
 module ViewHelper
-  def govuk_link_to(body = nil, url = nil, html_options = nil, &block)
-    if block_given?
-      html_options = url
-      url = body
-      body = block
-    end
-    html_options ||= {}
-
-    html_options[:class] = prepend_css_class('govuk-link', html_options[:class])
-
-    return link_to(url, html_options) { yield } if block_given?
-
-    link_to(body, url, html_options)
-  end
-
   def govuk_back_link_to(url = :back, body = 'Back')
     classes = 'govuk-!-display-none-print'
 

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -34,9 +34,7 @@ module ViewHelper
   end
 
   def bat_contact_mail_to(name = 'becomingateacher<wbr>@digital.education.gov.uk', html_options: {})
-    html_options[:class] = prepend_css_class('govuk-link', html_options[:class])
-
-    mail_to('becomingateacher@digital.education.gov.uk', name.html_safe, html_options)
+    govuk_mail_to('becomingateacher@digital.education.gov.uk', name.html_safe, html_options)
   end
 
   def submitted_at_date
@@ -127,16 +125,6 @@ module ViewHelper
       yield
     else
       govuk_link_to 'Confirm environment to make changes', support_interface_confirm_environment_path(from: request.fullpath)
-    end
-  end
-
-private
-
-  def prepend_css_class(css_class, current_class)
-    if current_class
-      current_class.prepend("#{css_class} ")
-    else
-      css_class
     end
   end
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -29,44 +29,6 @@ module ViewHelper
     )
   end
 
-  def govuk_button_link_to(body = nil, url = nil, html_options = nil, &block)
-    if block_given?
-      html_options = url
-      url = body
-      body = block
-    end
-    html_options ||= {}
-
-    html_options = {
-      class: prepend_css_class('govuk-button', html_options[:class]),
-      role: 'button',
-      data: { module: 'govuk-button' },
-      draggable: false,
-    }.merge(html_options)
-
-    return link_to(url, html_options) { yield } if block_given?
-
-    link_to(body, url, html_options)
-  end
-
-  def govuk_button_to(name, options = {}, html_options = {}, &_block)
-    if block_given?
-      html_options = options
-      options = name
-    end
-
-    html_options = {
-      class: prepend_css_class('govuk-button', html_options[:class]),
-      role: 'button',
-      data: { module: 'govuk-button' },
-      draggable: false,
-    }.merge(html_options)
-
-    return button_to(options, html_options) { yield } if block_given?
-
-    button_to(name, options, html_options)
-  end
-
   def break_email_address(email_address)
     email_address.gsub(/@/, '<wbr>@').html_safe
   end

--- a/app/views/candidate_interface/application_choices/index.html.erb
+++ b/app/views/candidate_interface/application_choices/index.html.erb
@@ -11,6 +11,6 @@
     <% else %>
       <%= render 'guidance' %>
     <% end %>
-    <%= govuk_button_link_to t('continue'), candidate_interface_course_choices_choose_path, class: 'govuk-!-margin-bottom-9' %>
+    <%= govuk_link_to t('continue'), candidate_interface_course_choices_choose_path, button: true, class: 'govuk-!-margin-bottom-9' %>
   </div>
 </div>

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -14,7 +14,7 @@
     <% if @application_choices.present? && @application_form.can_add_more_choices? %>
       <div class="govuk-inset-text">
         <p class="govuk-body">You can choose <%= pluralize(current_application.choices_left_to_make, 'more course') %>.</p>
-        <%= govuk_button_link_to t('application_form.courses.another.button'), candidate_interface_course_choices_choose_path, class: 'govuk-button--secondary' %>
+        <%= govuk_link_to t('application_form.courses.another.button'), candidate_interface_course_choices_choose_path, button: true, class: 'govuk-button--secondary' %>
       </div>
     <% end %>
   </div>

--- a/app/views/candidate_interface/course_choices/ucas/no_courses.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas/no_courses.html.erb
@@ -22,11 +22,8 @@
       For more information, see our <%= govuk_link_to "#{t('service_name.get_into_teaching')} guidance on applying for teacher training", t('get_into_teaching.url_applying') %>
     </p>
 
-    <p class="govuk-body govuk-!-margin-bottom-0">
-      <%= govuk_button_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url %>
-    </p>
+    <p class="govuk-body govuk-!-margin-bottom-0"><%= govuk_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url, button: true %></p>
     <p class="govuk-body">or</p>
+    <p class="govuk-body"><%= govuk_link_to 'Return to your application', candidate_interface_application_form_path %></p>
   </div>
 </div>
-
-<p class="govuk-body"><%= govuk_link_to 'Return to your application', candidate_interface_application_form_path %></p>

--- a/app/views/candidate_interface/course_choices/ucas/with_course.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas/with_course.html.erb
@@ -34,9 +34,7 @@
       </h2>
     </div>
 
-    <p class="govuk-body govuk-!-margin-bottom-0">
-      <%= govuk_button_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url %>
-    </p>
+    <p class="govuk-body govuk-!-margin-bottom-0"><%= govuk_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url, button: true %></p>
     <p class="govuk-body">or</p>
     <p class="govuk-body"><%= govuk_link_to 'Return to your application', candidate_interface_application_form_path %></p>
   </div>

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -7,7 +7,7 @@
       <%= t('page_titles.degree') %>
     </h1>
 
-    <%= govuk_button_link_to t('application_form.degree.another.button'), candidate_interface_new_degree_path, class: 'govuk-button--secondary' %>
+    <%= govuk_link_to t('application_form.degree.another.button'), candidate_interface_new_degree_path, button: true, class: 'govuk-button--secondary' %>
   </div>
 </div>
 

--- a/app/views/candidate_interface/equality_and_diversity/review.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/review.html.erb
@@ -11,7 +11,7 @@
     <%= render(CandidateInterface::EqualityAndDiversityReviewComponent.new(application_form: @current_application)) %>
 
     <p class="govuk-body">
-      <%= govuk_button_link_to t('continue'), candidate_interface_application_submit_show_path %>
+      <%= govuk_link_to t('continue'), candidate_interface_application_submit_show_path, button: true %>
     </p>
   </div>
 </div>

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -7,7 +7,7 @@
       <%= other_qualifications_title(@application_form) %>
     </h1>
 
-    <%= govuk_button_link_to t('application_form.other_qualification.another.button'), candidate_interface_other_qualification_type_path, class: 'govuk-button--secondary' %>
+    <%= govuk_link_to t('application_form.other_qualification.another.button'), candidate_interface_other_qualification_type_path, button: true, class: 'govuk-button--secondary' %>
   </div>
 </div>
 

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
@@ -15,9 +15,7 @@
   sponsor student visas for courses without a salary.
 </p>
 <p class="govuk-body">
-  <a href="https://www.gov.uk/government/publications/register-of-licensed-sponsors-students" class="govuk-link">
-    Check if a provider has a student visa sponsor licence.
-  </a>
+  <%= govuk_link_to 'Check if a provider has a student visa sponsor licence', 'https://www.gov.uk/government/publications/register-of-licensed-sponsors-students' %>.
 </p>
 <p class="govuk-body">
   You may be eligible for another type of visa that does not need your training provider to act as sponsor.

--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -10,9 +10,9 @@
   </div>
 
   <% if @application_form.application_work_experiences.blank? %>
-    <%= govuk_button_link_to 'Add a job', candidate_interface_new_restructured_work_history_path %>
+    <%= govuk_link_to 'Add a job', candidate_interface_new_restructured_work_history_path, button: true %>
   <% else %>
-    <%= govuk_button_link_to candidate_interface_new_restructured_work_history_path, class: 'govuk-button--secondary' do %>
+    <%= govuk_link_to candidate_interface_new_restructured_work_history_path, button: true, class: 'govuk-button--secondary' do %>
       <%= @application_form.application_work_experiences.any? ? t('application_form.work_history.another.button') : t('application_form.work_history.add.button') %>
     <% end %>
   <% end %>

--- a/app/views/candidate_interface/shared/pilot_holding_page.html.erb
+++ b/app/views/candidate_interface/shared/pilot_holding_page.html.erb
@@ -11,9 +11,9 @@
     <p class="govuk-body-l"><%= service_name %> is a new GOV.UK service being trialled with a small number of training providers in England.</p>
 
     <div class="govuk-inset-text">
-        Learn more about teacher training in <a href="https://www.discoverteaching.wales/routes-into-teaching/" class="govuk-link">Wales</a>,
-        <a href="https://teachinscotland.scot/" class="govuk-link">Scotland</a> and
-        <a href="https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland" class="govuk-link">Northern Ireland</a>
+      Learn more about teacher training in <a href="https://www.discoverteaching.wales/routes-into-teaching/" class="govuk-link">Wales</a>,
+      <a href="https://teachinscotland.scot/" class="govuk-link">Scotland</a> and
+      <a href="https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland" class="govuk-link">Northern Ireland</a>
     </div>
 
     <h2 class="govuk-heading-m">Already have a <%= service_name %> account with us?</h2>
@@ -24,6 +24,6 @@
     <p class="govuk-body">We’re sorry, but this service is not ready for any more new candidates at the moment.</p>
     <p class="govuk-body">You can still apply to all teacher training courses and training providers through UCAS.</p>
 
-    <%= govuk_button_link_to 'Apply through UCAS', UCAS.apply_url %>
+    <%= govuk_link_to 'Apply through UCAS', UCAS.apply_url, button: true %>
   </div>
 </div>

--- a/app/views/candidate_interface/shared/pilot_holding_page.html.erb
+++ b/app/views/candidate_interface/shared/pilot_holding_page.html.erb
@@ -11,9 +11,9 @@
     <p class="govuk-body-l"><%= service_name %> is a new GOV.UK service being trialled with a small number of training providers in England.</p>
 
     <div class="govuk-inset-text">
-      Learn more about teacher training in <a href="https://www.discoverteaching.wales/routes-into-teaching/" class="govuk-link">Wales</a>,
-      <a href="https://teachinscotland.scot/" class="govuk-link">Scotland</a> and
-      <a href="https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland" class="govuk-link">Northern Ireland</a>
+      Learn more about teacher training in <%= govuk_link_to 'Wales', 'https://www.discoverteaching.wales/routes-into-teaching/' %>,
+      <%= govuk_link_to 'Scotland', 'https://teachinscotland.scot/' %> and
+      <%= govuk_link_to 'Northern Ireland', 'https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland' %>.
     </div>
 
     <h2 class="govuk-heading-m">Already have a <%= service_name %> account with us?</h2>

--- a/app/views/candidate_interface/submitted_application_form/complete.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/complete.html.erb
@@ -21,9 +21,9 @@
     <aside class="app-related" role="complementary">
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Updating your contact details</h2>
 
-      <div class="govuk-body-s">
-        You can update your contact details at any point during the application process. To do this, email us at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher<wbr>@digital.education.gov.uk</a>.
-      </div>
+      <p class="govuk-body-s">
+        You can update your contact details at any point during the application process. To do this, email us at <%= bat_contact_mail_to %>.
+      </p>
     </aside>
   </div>
 </div>

--- a/app/views/candidate_interface/unsubmitted_application_form/before_you_start.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/before_you_start.html.erb
@@ -9,7 +9,7 @@
 
     <hr class="govuk-section-break govuk-section-break--m">
 
-    <%= govuk_button_link_to 'Choose a course', candidate_interface_course_choices_choose_path, class: 'govuk-!-margin-bottom-5' %>
+    <%= govuk_link_to 'Choose a course', candidate_interface_course_choices_choose_path, button: true, class: 'govuk-!-margin-bottom-5' %>
     <p class="govuk-body">or</p>
     <%= govuk_link_to 'Go to your application form', candidate_interface_application_form_path, class: 'govuk-body' %>
   </div>

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -33,5 +33,5 @@
 <%= render partial: 'candidate_interface/application_form/review', locals: { application_form: @application_form, editable: true } %>
 
 <% unless EndOfCycleTimetable.between_cycles?(@application_form.phase) %>
-  <%= govuk_button_link_to t('continue'), candidate_interface_start_equality_and_diversity_path %>
+  <%= govuk_link_to t('continue'), candidate_interface_start_equality_and_diversity_path, button: true %>
 <% end %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -217,10 +217,10 @@
       <% if EndOfCycleTimetable.between_cycles?(@application_form.phase) %>
         <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.review') %></h2>
         <p class="govuk-body">You cannot submit your application until <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.</p>
-        <%= govuk_button_link_to 'Review your application', candidate_interface_application_review_path %>
+        <%= govuk_link_to 'Review your application', candidate_interface_application_review_path, button: true %>
       <% elsif CandidateInterface::EndOfCyclePolicy.can_submit?(@application_form) %>
         <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.check_and_submit') %></h2>
-        <%= govuk_button_link_to t('section_items.check_and_submit'), candidate_interface_application_review_path %>
+        <%= govuk_link_to t('section_items.check_and_submit'), candidate_interface_application_review_path, button: true %>
       <% end %>
     </section>
   </div>

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -7,7 +7,7 @@
       <%= t('page_titles.volunteering.short') %>
     </h1>
 
-    <%= govuk_button_link_to candidate_interface_new_volunteering_role_path, class: 'govuk-button--secondary' do %>
+    <%= govuk_link_to candidate_interface_new_volunteering_role_path, button: true, class: 'govuk-button--secondary' do %>
       <%= @application_form.application_volunteering_experiences.any? ? t('application_form.volunteering.another.button') : t('application_form.volunteering.add.button') %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/work_history/review/show.html.erb
+++ b/app/views/candidate_interface/work_history/review/show.html.erb
@@ -7,7 +7,7 @@
       <%= t('page_titles.work_history') %>
     </h1>
 
-    <%= govuk_button_link_to candidate_interface_new_work_history_path, class: 'govuk-button--secondary' do %>
+    <%= govuk_link_to candidate_interface_new_work_history_path, button: true, class: 'govuk-button--secondary' do %>
       <%= @application_form.application_work_experiences.any? ? t('application_form.work_history.another.button') : t('application_form.work_history.add.button') %>
     <% end %>
   </div>

--- a/app/views/provider_interface/notes/index.html.erb
+++ b/app/views/provider_interface/notes/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: @provider_can_respond) %>
 
-<%= govuk_button_link_to 'Add note', new_provider_interface_application_choice_note_path(@application_choice), class: 'govuk-button--secondary' %>
+<%= govuk_link_to 'Add note', new_provider_interface_application_choice_note_path(@application_choice), button: true, class: 'govuk-button--secondary' %>
 
 <% unless @notes.empty? %>
   <div class="govuk-grid-row">

--- a/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
+++ b/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
@@ -19,97 +19,97 @@
     <h2 class="govuk-heading-m">Contents</h2>
     <ol class="app-contents-list__list">
       <li class="app-contents-list__list-item app-contents-list__list-item--parent">
-        <a class="govuk-link app-contents-list__link" href="#section-1">Section 1: Introduction</a>
+        <%= govuk_link_to 'Section 1: Introduction', '#section-1', class: 'app-contents-list__link' %>
         <ol class="app-contents-list__nested-list">
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-1-1">Background</a>
+            <%= govuk_link_to 'Background', '#section-1-1', class: 'app-contents-list__link' %>
           </li>
         </ol>
       </li>
       <li class="app-contents-list__list-item app-contents-list__list-item--parent">
-        <a class="govuk-link app-contents-list__link" href="#section-2">Section 2: What personal data DfE and the provider process/share and why</a>
+        <%= govuk_link_to 'Section 2: What personal data DfE and the provider process/share and why', '#section-2', class: 'app-contents-list__link' %>
         <ol class="app-contents-list__nested-list">
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-2-1">What data DfE and the provider will process/share</a>
+            <%= govuk_link_to 'What data DfE and the provider will process/share', '#section-2-1', class: 'app-contents-list__link' %>
           </li>
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-2-2">What the provider can use personal data for</a>
+            <%= govuk_link_to 'What the provider can use personal data for', '#section-2-2', class: 'app-contents-list__link' %>
           </li>
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-2-3">What DfE can use personal data for</a>
+            <%= govuk_link_to 'What DfE can use personal data for', '#section-2-3', class: 'app-contents-list__link' %>
           </li>
         </ol>
       </li>
       <li class="app-contents-list__list-item app-contents-list__list-item--parent">
-        <a class="govuk-link app-contents-list__link" href="#section-3">Section 3: DfE’s legal basis for sharing/processing personal</a>
+        <%= govuk_link_to 'Section 3: DfE’s legal basis for sharing/processing personal', '#section-3', class: 'app-contents-list__link' %>
         <ol class="app-contents-list__nested-list">
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-3-1">Lawful conditions for sharing/processing personal data</a>
+            <%= govuk_link_to 'Lawful conditions for sharing/processing personal data', '#section-3-1', class: 'app-contents-list__link' %>
           </li>
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-3-2">The right to respect for private and family life</a>
+            <%= govuk_link_to 'The right to respect for private and family life', '#section-3-2', class: 'app-contents-list__link' %>
           </li>
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-3-3">Privacy notices</a>
+            <%= govuk_link_to 'Privacy notices', '#section-3-3', class: 'app-contents-list__link' %>
           </li>
         </ol>
       </li>
       <li class="app-contents-list__list-item app-contents-list__list-item--parent">
-        <a class="govuk-link app-contents-list__link" href="#section-4">Section 4: Data handling</a>
+        <%= govuk_link_to 'Section 4: Data handling', '#section-4', class: 'app-contents-list__link' %>
         <ol class="app-contents-list__nested-list">
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-4-1">Process and systems used for sharing data</a>
+            <%= govuk_link_to 'Process and systems used for sharing data', '#section-4-1', class: 'app-contents-list__link' %>
           </li>
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-4-2">Accuracy of the shared data</a>
+            <%= govuk_link_to 'Accuracy of the shared data', '#section-4-2', class: 'app-contents-list__link' %>
           </li>
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-4-3">Assurance of compliance</a>
+            <%= govuk_link_to 'Assurance of compliance', '#section-4-3', class: 'app-contents-list__link' %>
           </li>
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-4-4">Third party disclosure</a>
+            <%= govuk_link_to 'Third party disclosure', '#section-4-4', class: 'app-contents-list__link' %>
           </li>
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-4-5">Handling subject access requests (SARs)</a>
+            <%= govuk_link_to 'Handling subject access requests (SARs)', '#section-4-5', class: 'app-contents-list__link' %>
           </li>
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-4-6">Handling Freedom of Information Act Requests</a>
+            <%= govuk_link_to 'Handling Freedom of Information Act Requests', '#section-4-6', class: 'app-contents-list__link' %>
           </li>
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-4-7">Data storage</a>
+            <%= govuk_link_to 'Data storage', '#section-4-7', class: 'app-contents-list__link' %>
           </li>
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-4-8">Retention schedule</a>
+            <%= govuk_link_to 'Retention schedule', '#section-4-8', class: 'app-contents-list__link' %>
           </li>
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-4-9">Destruction schedule</a>
+            <%= govuk_link_to 'Destruction schedule', '#section-4-9', class: 'app-contents-list__link' %>
           </li>
         </ol>
       </li>
       <li class="app-contents-list__list-item app-contents-list__list-item--parent">
-        <a class="govuk-link app-contents-list__link" href="#section-5">Section 5: Security breaches</a>
+        <%= govuk_link_to 'Section 5: Security breaches', '#section-5', class: 'app-contents-list__link' %>
         <ol class="app-contents-list__nested-list">
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-5-1">Security incidents</a>
+            <%= govuk_link_to 'Security incidents', '#section-5-1', class: 'app-contents-list__link' %>
           </li>
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-5-2">Consequences of security incident</a>
-          </li>
-        </ol>
-      </li>
-      <li class="app-contents-list__list-item app-contents-list__list-item--parent">
-        <a class="govuk-link app-contents-list__link" href="#section-6">Section 6: Issues, disputes and resolution between participants</a>
-        <ol class="app-contents-list__nested-list">
-          <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-6-1">Resolving disputes</a>
+            <%= govuk_link_to 'Consequences of security incident', '#section-5-2', class: 'app-contents-list__link' %>
           </li>
         </ol>
       </li>
       <li class="app-contents-list__list-item app-contents-list__list-item--parent">
-        <a class="govuk-link app-contents-list__link" href="#section-7">Section 7: Termination</a>
+        <%= govuk_link_to 'Section 6: Issues, disputes and resolution between participants', '#section-6', class: 'app-contents-list__link' %>
         <ol class="app-contents-list__nested-list">
           <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-            <a class="govuk-link app-contents-list__link" href="#section-7-1">When to terminate this agreement</a>
+            <%= govuk_link_to 'Resolving disputes', '#section-6-1', class: 'app-contents-list__link' %>
+          </li>
+        </ol>
+      </li>
+      <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+        <%= govuk_link_to 'Section 7: Termination', '#section-7', class: 'app-contents-list__link' %>
+        <ol class="app-contents-list__nested-list">
+          <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+            <%= govuk_link_to 'When to terminate this agreement', '#section-7-1', class: 'app-contents-list__link' %>
           </li>
         </ol>
       </li>

--- a/app/views/provider_interface/provider_agreements/success.html.erb
+++ b/app/views/provider_interface/provider_agreements/success.html.erb
@@ -12,7 +12,7 @@
       </p>
 
       <p class="govuk-body">
-        <%= govuk_button_link_to 'Set up permissions', provider_interface_provider_relationship_permissions_organisations_path %>
+        <%= govuk_link_to 'Set up permissions', provider_interface_provider_relationship_permissions_organisations_path, button: true %>
       </p>
     <% else %>
       <% if current_provider_user.authorisation.can_manage_users_for_at_least_one_provider? %>
@@ -34,7 +34,7 @@
       </p>
 
       <p class="govuk-body">
-        <%= govuk_button_link_to t('continue'), provider_interface_applications_path %>
+        <%= govuk_link_to t('continue'), provider_interface_applications_path, button: true %>
       </p>
     <% end %>
   </div>

--- a/app/views/provider_interface/provider_users/index.html.erb
+++ b/app/views/provider_interface/provider_users/index.html.erb
@@ -9,10 +9,7 @@
 
 <h1 class="govuk-heading-xl"><%= t('page_titles.provider.users') %></h1>
 
-<%= govuk_button_link_to(
-  'Invite user',
-  provider_interface_edit_invitation_basic_details_path,
-) %>
+<%= govuk_link_to 'Invite user', provider_interface_edit_invitation_basic_details_path, button: true %>
 
 <div class="govuk-body">
 <% @provider_users_with_providers.each do |provider_user, providers| %>

--- a/app/views/provider_interface/provider_users/show.html.erb
+++ b/app/views/provider_interface/provider_users/show.html.erb
@@ -17,6 +17,6 @@
       possible_permissions: @possible_permissions,
     ) %>
 
-    <%= govuk_button_link_to 'Delete user', provider_interface_provider_user_remove_provider_user_path(@provider_user), class: 'govuk-button--warning' %>
+    <%= govuk_link_to 'Delete user', provider_interface_provider_user_remove_provider_user_path(@provider_user), button: true, class: 'govuk-button--warning' %>
   </div>
 </div>

--- a/app/views/provider_interface/reconfirm_deferred_offers/start.html.erb
+++ b/app/views/provider_interface/reconfirm_deferred_offers/start.html.erb
@@ -27,8 +27,7 @@
 
       <% unless @wizard.applicable? %>
         <p class="govuk-body-m govuk-!-margin-top-5">
-          To change the details of this offer, contact us at
-          <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.
+          To change the details of this offer, contact us at <%= bat_contact_mail_to %>.
         </p>
         <p class="govuk-body-m">Tell us which of the following details you’d like to change:</p>
         <ul class="govuk-list govuk-list--bullet">

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -127,7 +127,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <h2 class="govuk-heading-m app-section__title--with-top-border">The team</h2>
-        <p class="govuk-body">Our team is constantly making improvements based on feedback from users. To get involved so you can shape the service, email us at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher<wbr>@digital.education.gov.uk</a></p>
+        <p class="govuk-body">Our team is constantly making improvements based on feedback from users. To get involved so you can shape the service, email us at <%= bat_contact_mail_to %></p>
       </div>
       <div class="govuk-grid-column-one-half">
         <img src="/provider/team.jpg" alt="The Apply team sat round a desk.">

--- a/app/views/support_interface/application_forms/audit.html.erb
+++ b/app/views/support_interface/application_forms/audit.html.erb
@@ -2,6 +2,6 @@
 
 <%= render 'application_navigation', title: 'History' %>
 
-<%= govuk_button_link_to 'Add comment', support_interface_application_form_new_comment_path %>
+<%= govuk_link_to 'Add comment', support_interface_application_form_new_comment_path, button: true %>
 
 <%= render SupportInterface::AuditTrailComponent.new(audited_thing: @application_form) %>

--- a/app/views/support_interface/data_exports/show.html.erb
+++ b/app/views/support_interface/data_exports/show.html.erb
@@ -17,7 +17,7 @@
 <% if @data_export.completed_at %>
   <p class="govuk-body">Export generation completed in <%= @data_export.generation_time %> <%= 'second'.pluralize(@data_export.generation_time) %>.</p>
 
-  <%= govuk_button_link_to 'Download export (CSV)', download_support_interface_data_export_path(@data_export), { type: 'text/csv' } %>
+  <%= govuk_link_to 'Download export (CSV)', download_support_interface_data_export_path(@data_export), button: true, type: 'text/csv' %>
 <% else %>
   <p class="govuk-body">This export is being generated. Refresh the page to see if it completed.</p>
 <% end %>

--- a/app/views/support_interface/provider_users/_provider_user_impersonation.html.erb
+++ b/app/views/support_interface/provider_users/_provider_user_impersonation.html.erb
@@ -5,7 +5,7 @@
     to see what they see. Any changes made will be linked to you.
   </p>
 
-  <%= govuk_button_link_to 'Stop impersonating this user', support_interface_end_impersonation_path, class: 'govuk-button--secondary' %>
+  <%= govuk_link_to 'Stop impersonating this user', support_interface_end_impersonation_path, button: true, class: 'govuk-button--secondary' %>
 <% else %>
   <%= govuk_button_to 'Sign in as this provider user', support_interface_provider_user_impersonate_path(provider_user), form_class: 'govuk-!-display-inline-block' %>
 <% end %>

--- a/app/views/support_interface/provider_users/index.html.erb
+++ b/app/views/support_interface/provider_users/index.html.erb
@@ -1,8 +1,8 @@
 <%= render 'support_interface/providers/providers_navigation', title: 'Provider users' %>
 
 <div class="govuk-button-group">
-  <%= govuk_button_link_to 'Add provider user', new_support_interface_provider_user_path %>
-  <%= govuk_button_link_to 'Download active provider users (CSV)', "#{new_support_interface_data_export_path}#providers_export", class: 'govuk-button--secondary' %>
+  <%= govuk_link_to 'Add provider user', new_support_interface_provider_user_path, button: true %>
+  <%= govuk_link_to 'Download active provider users (CSV)', "#{new_support_interface_data_export_path}#providers_export", button: true, class: 'govuk-button--secondary' %>
 </div>
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @provider_users) do %>

--- a/app/views/support_interface/providers/users.html.erb
+++ b/app/views/support_interface/providers/users.html.erb
@@ -1,6 +1,6 @@
 <%= render 'provider_navigation', title: 'Provider users' %>
 
-<%= govuk_button_link_to 'Add provider user', new_support_interface_provider_user_path %>
+<%= govuk_link_to 'Add provider user', new_support_interface_provider_user_path, button: true %>
 
 <%= render(SupportInterface::ProviderUsersTableComponent.new(provider_users: @provider.provider_users)) %>
 

--- a/app/views/support_interface/settings/feature_flags.html.erb
+++ b/app/views/support_interface/settings/feature_flags.html.erb
@@ -26,17 +26,7 @@
   ].compact) do %>
     <%= render SummaryCardHeaderComponent.new(title: feature_name.humanize, heading_level: 2) do %>
       <% protect_against_mistakes do %>
-        <% if FeatureFlag.active?(feature_name) %>
-          <%= govuk_button_to support_interface_deactivate_feature_flag_path(feature_name),
-                 class: 'app-button--tertiary govuk-!-margin-bottom-0' do %>
-            Deactivate<span class="govuk-visually-hidden"> ‘<%= feature_name.humanize %>’ feature</span>
-          <% end %>
-        <% else %>
-          <%= govuk_button_to support_interface_activate_feature_flag_path(feature_name),
-                 class: 'app-button--tertiary govuk-!-margin-bottom-0' do %>
-            Activate<span class="govuk-visually-hidden"> ‘<%= feature_name.humanize %>’ feature</span>
-          <% end %>
-        <% end %>
+        <%= render SupportInterface::FeatureToggleComponent.new(feature_name: feature_name) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -1,6 +1,6 @@
 <%= render 'support_interface/settings/settings_navigation', title: 'Support users' %>
 
-<%= govuk_button_link_to 'Add support user', new_support_interface_support_user_path %>
+<%= govuk_link_to 'Add support user', new_support_interface_support_user_path, button: true %>
 
 <table class="govuk-table">
   <thead class="govuk-table__head">

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -45,7 +45,7 @@
       <p class="govuk-body">It should be run shortly after the Apply 2 deadline closes at midnight on <%= EndOfCycleTimetable.date(:apply_2_deadline).to_s(:govuk_date) %>.</p>
     </div>
     <div class="govuk-grid-column-one-third">
-      <%= govuk_button_link_to 'Cancel applications', support_interface_confirm_cancel_applications_at_end_of_cycle_path, class: 'govuk-button--warning' %>
+      <%= govuk_link_to 'Cancel applications', support_interface_confirm_cancel_applications_at_end_of_cycle_path, button: true, class: 'govuk-button--warning' %>
     </div>
   </div>
 </section>
@@ -58,7 +58,7 @@
         <p class="govuk-body">This task deletes all candidates with emails that end in <code>@example.com</code>, their applications and associated data.</p>
       </div>
       <div class="govuk-grid-column-one-third">
-        <%= govuk_button_link_to 'Delete test applications', support_interface_confirm_delete_test_applications_path, class: 'govuk-button--warning' %>
+        <%= govuk_link_to 'Delete test applications', support_interface_confirm_delete_test_applications_path, button: true, class: 'govuk-button--warning' %>
       </div>
     </div>
   </section>

--- a/lib/rubocop/cop/govuk/govuk_link_to.rb
+++ b/lib/rubocop/cop/govuk/govuk_link_to.rb
@@ -5,7 +5,7 @@ module RuboCop
         def on_send(node)
           return unless node.method_name == :link_to
 
-          add_offense(node, message: 'Use govuk_link_to, govuk_back_link_to or govuk_button_link_to instead of link_to')
+          add_offense(node, message: 'Use govuk_link_to or govuk_back_link_to instead of link_to')
         end
       end
     end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -1,33 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ViewHelper, type: :helper do
-  describe '#govuk_link_to' do
-    it 'returns an anchor tag with the govuk-link class' do
-      anchor_tag = helper.govuk_link_to('Woof', 'https://localhost:0103/dog/woof')
-
-      expect(anchor_tag).to eq('<a class="govuk-link" href="https://localhost:0103/dog/woof">Woof</a>')
-    end
-
-    it 'returns an anchor tag with the govuk-link class and target="_blank"' do
-      anchor_tag = helper.govuk_link_to('Meow', 'https://localhost:0103/cat/meow', target: :_blank)
-
-      expect(anchor_tag).to eq('<a target="_blank" class="govuk-link" href="https://localhost:0103/cat/meow">Meow</a>')
-    end
-
-    it 'returns an anchor tag with additional HTML options' do
-      anchor_tag = helper.govuk_link_to('Baaa', 'https://localhost:0103/sheep/baaa', class: 'govuk-link--no-visited-state', target: :_blank)
-
-      expect(anchor_tag).to eq('<a class="govuk-link govuk-link--no-visited-state" target="_blank" href="https://localhost:0103/sheep/baaa">Baaa</a>')
-    end
-
-    it 'accepts a block' do
-      anchor_tag = helper.govuk_link_to('https://localhost:0103/bee/buzz') do
-        'Buzz'
-      end
-      expect(anchor_tag).to eq('<a class="govuk-link" href="https://localhost:0103/bee/buzz">Buzz</a>')
-    end
-  end
-
   describe '#govuk_back_link_to' do
     it 'returns an anchor tag with the govuk-back-link class and defaults to "Back"' do
       anchor_tag = helper.govuk_back_link_to('https://localhost:0103/snek/ssss')

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -41,35 +41,6 @@ RSpec.describe ViewHelper, type: :helper do
     end
   end
 
-  describe '#govuk_button_link_to' do
-    it 'returns an anchor tag with the govuk-button class, button role and data-module="govuk-button"' do
-      anchor_tag = helper.govuk_button_link_to('Hoot', 'https://localhost:0103/owl/hoot')
-
-      expect(anchor_tag).to eq('<a class="govuk-button" role="button" data-module="govuk-button" draggable="false" href="https://localhost:0103/owl/hoot">Hoot</a>')
-    end
-
-    it 'returns an anchor tag with additional HTML options' do
-      anchor_tag = helper.govuk_button_link_to('Cluck', 'https://localhost:0103/chicken/cluck', class: 'govuk-button--start')
-
-      expect(anchor_tag).to eq('<a class="govuk-button govuk-button--start" role="button" data-module="govuk-button" draggable="false" href="https://localhost:0103/chicken/cluck">Cluck</a>')
-    end
-
-    it 'accepts a block' do
-      anchor_tag = helper.govuk_button_link_to('https://localhost:0103/bee/buzz') do
-        'Buzz'
-      end
-      expect(anchor_tag).to eq('<a class="govuk-button" role="button" data-module="govuk-button" draggable="false" href="https://localhost:0103/bee/buzz">Buzz</a>')
-    end
-  end
-
-  describe '#govuk_button_to' do
-    it 'returns a form and button using the govuk-button class and data module' do
-      button_to_result = helper.govuk_button_to('Hoot', 'https://localhost:0103/owl/hoot')
-
-      expect(button_to_result).to eq('<form class="button_to" method="post" action="https://localhost:0103/owl/hoot"><input class="govuk-button" role="button" data-module="govuk-button" draggable="false" type="submit" value="Hoot" /></form>')
-    end
-  end
-
   describe 'application date helpers' do
     before do
       @application_dates = instance_double(


### PR DESCRIPTION
## Context

The `govuk-components` gem provides the following helpers:

* `govuk_link_to`
* `govuk_mail_to`
* `govuk_button_to`

We have our own helpers that replicate this functionality. In addition, we have a `govuk_button_link_to` helper which styles links as buttons. The same can be achieved by using the `govuk_link_to` helper from `govuk-components`, with the `button` parameter set to `true`.

## Changes proposed in this pull request

* Remove `govuk_link_to` helper and tests
* Remove `govuk_button_to` helper and tests
* Refactor `bat_contact_mail_to` helper to call `govuk_mail_to`
* Refactor the feature flag button toggles into a component – this is because the `govuk_button_to` helper in `govuk-components` does not accept block content. Hopefully this is a bit drier as a result.

I also reviewed the usage of these link helpers:

* Ensure we are always using the `bat_contact_mail_to` helper
* Ensure we are always using the `govuk_link_to` helper
* Ensure we are always using the `govuk_mail_to` helper

This means that there are no places in the application where `.govuk-link` is manually set. Actually, that’s not true… it still appears in the phase banner text, but can review this when refactor the phase banner to use the respective component from `govuk-components`.

## Guidance to review

* Could the `FeatureToggleComponent` be simplified or improved?
* Should I add new tests for `FeatureToggleComponent`, or move existing tests for the view into component tests?
* Are we happy to use `govuk_link_to` with `button: true` as opposed to a dedicated helper?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
