### PR TITLE
Fix layout for Activity log component previews

### DIFF
--- a/app/views/layouts/previews/provider.html.erb
+++ b/app/views/layouts/previews/provider.html.erb
@@ -1,16 +1,5 @@
-<!DOCTYPE html>
-<html lang="en" class="govuk-template">
-  <head>
-    <meta charset="utf-8">
-    <title><%= try(:browser_title) %></title>
-    <%= stylesheet_pack_tag 'application-provider', media: 'all' %>
-  </head>
+<% content_for :before_content do %>
+  <%= stylesheet_pack_tag 'application-provider', media: 'all' %>
+<% end %>
 
-  <body class="govuk-template__body">
-    <div class="govuk-!-margin-top-5">
-      <%= content_for?(:body) ? yield(:body) : yield %>
-    </div>
-
-    <%= javascript_pack_tag 'application' %>
-  </body>
-</html>
+<%= render template: 'layouts/application' %>

--- a/spec/components/previews/provider_interface/application_status_tag_component_preview.rb
+++ b/spec/components/previews/provider_interface/application_status_tag_component_preview.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class ApplicationStatusTagComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
     ApplicationStateChange.valid_states.each do |state_name|
       define_method state_name do
         render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: FactoryBot.build_stubbed(:application_choice, status: state_name))

--- a/spec/components/previews/provider_interface/application_timeline_component_preview.rb
+++ b/spec/components/previews/provider_interface/application_timeline_component_preview.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class ApplicationTimelineComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
     def rejected
       application_choice = ApplicationChoice.where(status: 'rejected').sample
       render_component_for application_choice: application_choice

--- a/spec/components/previews/provider_interface/change_offer_preview.rb
+++ b/spec/components/previews/provider_interface/change_offer_preview.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class ChangeOfferPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
     def existing_offer_start_at_1_provider(provider_interface_change_offer_form: nil)
       initial_step :provider
       set_application_choice application_choice_with_offer

--- a/spec/components/previews/provider_interface/course_summary_component_preview.rb
+++ b/spec/components/previews/provider_interface/course_summary_component_preview.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class CourseSummaryComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
     def course_details
       render CourseSummaryComponent.new(course_option: CourseOption.limit(10).sample)
     end

--- a/spec/components/previews/provider_interface/filter_component_preview.rb
+++ b/spec/components/previews/provider_interface/filter_component_preview.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class FilterComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
     def default_view
       render_component_for(filter: filter_mock(filters: with_name_status_provider_and_accredited_provider))
     end

--- a/spec/components/previews/provider_interface/interview_form_component_preview.rb
+++ b/spec/components/previews/provider_interface/interview_form_component_preview.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class InterviewFormComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
     class FormModel
       include ActiveModel::Model
       attr_accessor :time, :date, :location, :additional_details, :provider_id

--- a/spec/components/previews/provider_interface/offer_summary_component_preview.rb
+++ b/spec/components/previews/provider_interface/offer_summary_component_preview.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class OfferSummaryComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
     def offer_summary
       application_choice = ApplicationChoice.limit(5).sample
       course_option = CourseOption.limit(10).sample

--- a/spec/components/previews/provider_interface/offer_summary_list_component_preview.rb
+++ b/spec/components/previews/provider_interface/offer_summary_list_component_preview.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class OfferSummaryListComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
     def application_choice_with_offer
       render_component_for choices: ApplicationChoice.where(status: :offer)
     end

--- a/spec/components/previews/provider_interface/safeguarding_declaration_component_preview.rb
+++ b/spec/components/previews/provider_interface/safeguarding_declaration_component_preview.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class SafeguardingDeclarationComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
     def can_view__with_safeguarding_issues_never_asked
       find_user_and_course safeguarding_access: true
       build_application_choice :with_safeguarding_issues_never_asked

--- a/spec/components/previews/provider_interface/status_box_component_preview.rb
+++ b/spec/components/previews/provider_interface/status_box_component_preview.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class StatusBoxComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
     def awaiting_provider_decision
       render_component_for choices: ApplicationChoice.where(status: :awaiting_provider_decision)
     end

--- a/spec/components/previews/provider_interface/volunteering_history_component_preview.rb
+++ b/spec/components/previews/provider_interface/volunteering_history_component_preview.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class VolunteeringHistoryComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
     def application
       render_component_for application_form: application_form
     end

--- a/spec/components/previews/provider_interface/work_history_component_preview.rb
+++ b/spec/components/previews/provider_interface/work_history_component_preview.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class WorkHistoryComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
     def application
       render_component_for application_form: application_form
     end

--- a/spec/components/previews/provider_user_notification_preferences_component_preview.rb
+++ b/spec/components/previews/provider_user_notification_preferences_component_preview.rb
@@ -1,4 +1,6 @@
 class ProviderUserNotificationPreferencesComponentPreview < ViewComponent::Preview
+  layout 'previews/provider'
+
   def notification_preferences
     render ProviderUserNotificationPreferencesComponent.new(
       FactoryBot.build(:provider_user_notification_preferences),


### PR DESCRIPTION
## Context

Activity log component previews didn't render consistently with the rest of the previews. Other Manage components like the Timeline appeared unstyled.

## Changes proposed in this pull request

Have all Mange component previews use a layout which inherits from the standard layout but injects the correct CSS.

### Activity log before

<img width="1047" alt="Screenshot 2021-04-08 at 00 24 17" src="https://user-images.githubusercontent.com/642279/114033151-e7f2a800-9874-11eb-8097-58e2f7082e4e.png">

### Activity log after

<img width="1018" alt="Screenshot 2021-04-08 at 00 23 52" src="https://user-images.githubusercontent.com/642279/114033168-eb862f00-9874-11eb-8bee-264fcc10ea8e.png">

### Timeline before

<img width="1048" alt="Screenshot 2021-04-08 at 00 23 45" src="https://user-images.githubusercontent.com/642279/114033182-f04ae300-9874-11eb-9456-6a7fe0dbeb7b.png">

### Timeline after

<img width="1053" alt="Screenshot 2021-04-08 at 00 23 38" src="https://user-images.githubusercontent.com/642279/114033203-f3de6a00-9874-11eb-81d1-4eb6ab9e71c7.png">

## Link to Trello card

https://trello.com/c/5ieRfH2r/3307-fix-layout-of-the-activity-log-component-previews

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
