### PR TITLE
Fix export history bug 2

### DIFF
--- a/app/services/data_migrations/backfill_export_type.rb
+++ b/app/services/data_migrations/backfill_export_type.rb
@@ -24,7 +24,7 @@ module DataMigrations
       when 'Candidate survey', 'Daily export of applications for TAD', 'Daily export of notifications breakdown', 'RejectedCandidatesExport'
         nil
       else
-        export.name.parameterize.underscore
+        DataExport::EXPORT_TYPES.select { |_key, value| value[:name] == export.name }.values[0][:export_type]
       end
     end
   end

--- a/app/services/data_migrations/backfill_export_type.rb
+++ b/app/services/data_migrations/backfill_export_type.rb
@@ -6,10 +6,25 @@ module DataMigrations
     def change
       data_exports = DataExport.all.where(export_type: nil)
 
-      data_exports.each do |export|
-        export_type = export.name == 'Unexplained breaks in work history' ? 'work_history_break' : export.name.parameterize.underscore
+      data_exports.each { |export| export.update!(export_type: export_type(export)) }
+    end
 
-        export.update!(export_type: export_type)
+  private
+
+    def export_type(export)
+      case export.name
+      when 'Unexplained breaks in work history'
+        'work_history_break'
+      when 'Locations', 'Locations export'
+        'persona_export'
+      when 'Applications for TAD'
+        'tad_applications'
+      when 'Provider performance for TAD'
+        'tad_provider_performance'
+      when 'Candidate survey', 'Daily export of applications for TAD', 'Daily export of notifications breakdown', 'RejectedCandidatesExport'
+        nil
+      else
+        export.name.parameterize.underscore
       end
     end
   end

--- a/spec/services/data_migrations/backfill_export_type_spec.rb
+++ b/spec/services/data_migrations/backfill_export_type_spec.rb
@@ -2,16 +2,25 @@ require 'rails_helper'
 
 RSpec.describe DataMigrations::BackfillExportType do
   it 'backfills the export_type column in Data Exports' do
-    data_export = create(:data_export, export_type: nil)
+    data_export = create(:data_export, name: 'Active provider user permissions', export_type: nil)
 
     described_class.new.change
     expect(data_export.reload.export_type).to eq 'active_provider_user_permissions'
   end
 
-  it 'correctly backfills old work_history_break exports' do
-    data_export = create(:data_export, name: 'Unexplained breaks in work history', export_type: nil)
+  it 'correctly backfills for old and renamed exports' do
+    work_history_export = create(:data_export, name: 'Unexplained breaks in work history', export_type: nil)
+    persona_export = create(:data_export, name: 'Locations', export_type: nil)
+    tad_export = create(:data_export, name: 'Applications for TAD', export_type: nil)
+    tad_provider_performance_export = create(:data_export, name: 'Provider performance for TAD', export_type: nil)
+    candidate_survey_export = create(:data_export, name: 'Candidate survey', export_type: nil)
 
     described_class.new.change
-    expect(data_export.reload.export_type).to eq 'work_history_break'
+
+    expect(work_history_export.reload.export_type).to eq 'work_history_break'
+    expect(persona_export.reload.export_type).to eq 'persona_export'
+    expect(tad_export.reload.export_type).to eq 'tad_applications'
+    expect(tad_provider_performance_export.reload.export_type).to eq 'tad_provider_performance'
+    expect(candidate_survey_export.reload.export_type).to eq nil
   end
 end


### PR DESCRIPTION
## Context

Only a small subset of export history records are being shown.

Only data_export records with an export_type are shown. This field is automatically filled for all new export downloads. We wrote a migration to backfill the old data_export records but this migration failed for a couple of reasons.

1. Some of the exports have been renamed or removed. Eg. `Unexplained breaks in work history` was renamed `Work history break`. `RejectedCandidatesExport` was removed.
2. The `export_type` is not equal to `export.name.parameterize.underscore` in all cases so that caused the migration to fail. Eg. 

```
    sites_export: {
      name: 'Sites',
      export_type: 'sites_export',
      description: 'A list of sites that are being synced from Find, along with distances to their respective providers.',
      class: SupportInterface::SitesExport,
    }
```

This follows on from [this PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/4448). The previous PR solved one instance of the first problem above but didn't catch them all.

## Changes proposed in this pull request

For this PR, I started by getting all the export names from the `data_exports` table on prod by running `SELECT DISTINCT "name" FROM "data_exports";` in Blazer.

```
Active provider user permissions
Active provider users
Application references
Application timings
Applications for TAD
Candidate application feedback
Candidate autosuggest usage
Candidate course choice withdrawal survey
Candidate email send counts
Candidate feedback
Candidate journey tracking
Candidate survey
Daily export of applications for TAD
Daily export of notifications breakdown
Equality and diversity data
Interview changes
Locations
Locations export
Notes
Notifications
Offer conditions
Organisation permissions
Persona data
Provider Access Controls
Provider performance for TAD
Providers
Qualifications
Referee survey
RejectedCandidatesExport
Sites
Structured reasons for rejection
Submitted application choices
Unexplained   breaks in work history
User permissions
Work history break
```

I was then able to work through the git history to identify which exports still exist, but have been renamed and which exports no longer exist. I have added a `case` statement to handle these accordingly.

To solve the second problem, I updated the logic so that it looks up the `export_type` from `DataExport::EXPORT_TYPES` rather than assuming it can be calculated from the `name`.

In order to test that all the cases are handled I added some tests, but also manually added a record in to my local DB for each of the names seen on the prod db. I was then able to run the migration locally and check that all cases have been handled.

![image](https://user-images.githubusercontent.com/33458055/114046633-e929d200-9880-11eb-8f8a-45260548d8de.png)

## Guidance to review



## Link to Trello card

https://trello.com/c/K5o3HiH8/3258-fix-export-history-bug

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
