### PR TITLE
Add `iso8601` to timestamp in notes export to avoid flakey specs

### DIFF
--- a/app/services/support_interface/notes_export.rb
+++ b/app/services/support_interface/notes_export.rb
@@ -25,7 +25,7 @@ module SupportInterface
         {
           note_subject: note.subject,
           note_message: note.message,
-          note_created_at: note.created_at,
+          note_created_at: note.created_at.iso8601,
           candidate_id: note.application_choice.application_form.candidate.id,
           provider_code: provider&.code,
           provider_name: provider&.name,

--- a/spec/services/support_interface/notes_export_spec.rb
+++ b/spec/services/support_interface/notes_export_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe SupportInterface::NotesExport do
         {
           note_subject: note1.subject,
           note_message: note1.message,
-          note_created_at: note1.created_at,
+          note_created_at: note1.created_at.iso8601,
           candidate_id: candidate.id,
           provider_code: training_provider.code,
           provider_name: training_provider.name,
@@ -47,7 +47,7 @@ RSpec.describe SupportInterface::NotesExport do
         {
           note_subject: note2.subject,
           note_message: note2.message,
-          note_created_at: note2.created_at,
+          note_created_at: note2.created_at.iso8601,
           candidate_id: candidate.id,
           provider_code: ratifying_provider.code,
           provider_name: ratifying_provider.name,
@@ -84,7 +84,7 @@ RSpec.describe SupportInterface::NotesExport do
         {
           note_subject: note1.subject,
           note_message: note1.message,
-          note_created_at: note1.created_at,
+          note_created_at: note1.created_at.iso8601,
           candidate_id: candidate.id,
           provider_code: nil,
           provider_name: nil,
@@ -95,7 +95,7 @@ RSpec.describe SupportInterface::NotesExport do
         {
           note_subject: note2.subject,
           note_message: note2.message,
-          note_created_at: note2.created_at,
+          note_created_at: note2.created_at.iso8601,
           candidate_id: candidate.id,
           provider_code: training_provider2.code,
           provider_name: training_provider2.name,


### PR DESCRIPTION
## Context

We're getting spec failures due to date precision in the notes export

## Changes proposed in this pull request

use `iso8601` to avoid any random failures

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
