### PR TITLE
Add new option to other qualifications section & make it mandatory

### DIFF
--- a/app/components/candidate_interface/other_qualifications_review_component.html.erb
+++ b/app/components/candidate_interface/other_qualifications_review_component.html.erb
@@ -1,26 +1,33 @@
-<% if !@submitting_application && !@qualifications.empty? %>
-  <%= govuk_link_to t('application_form.other_qualification.another.button'),
-    candidate_interface_other_qualification_type_path,
-    button: true,
-    class: 'govuk-button--secondary'
-  %>
-<% end %>
+<% if @qualifications.present? %>
+  <% if @submitting_application && !@application_form.other_qualifications_completed %>
+    <%= render CandidateInterface::IncompleteSectionComponent.new(
+      section: application_form.international? ? :other_qualifications_international : :other_qualifications,
+      section_path: candidate_interface_review_other_qualifications_path,
+      error: @missing_error,
+    ) %>
+  <% end %>
 
-<% @qualifications.each do |qualification| %>
-  <%= render(SummaryCardComponent.new(rows: other_qualifications_rows(qualification), editable: @editable)) do %>
-    <%= render(SummaryCardHeaderComponent.new(title: qualification.title, heading_level: @heading_level)) do %>
-      <% if @editable %>
-        <div class="app-summary-card__actions">
-          <%= govuk_link_to candidate_interface_confirm_destroy_other_qualification_path(qualification.id) do %>
-            <%= t('application_form.other_qualification.delete') %><span class="govuk-visually-hidden"><%= generate_action(qualification: qualification) %></span>
-          <% end %>
-        </div>
+  <% if !@submitting_application %>
+    <%= govuk_link_to t('application_form.other_qualification.another.button'),
+      candidate_interface_other_qualification_type_path,
+      button: true,
+      class: 'govuk-button--secondary' %>
+  <% end %>
+
+  <% @qualifications.each do |qualification| %>
+    <%= render(SummaryCardComponent.new(rows: other_qualifications_rows(qualification), editable: @editable)) do %>
+      <%= render(SummaryCardHeaderComponent.new(title: qualification.title, heading_level: @heading_level)) do %>
+        <% if @editable %>
+          <div class="app-summary-card__actions">
+            <%= govuk_link_to candidate_interface_confirm_destroy_other_qualification_path(qualification.id) do %>
+              <%= t('application_form.other_qualification.delete') %><span class="govuk-visually-hidden"><%= generate_action(qualification: qualification) %></span>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>
-<% end %>
-
-<% if @qualifications.empty? %>
+<% else %>
   <% if @submitting_application && !application_form.other_qualifications_completed %>
     <%= render CandidateInterface::IncompleteSectionComponent.new(
       section: application_form.international? ? :other_qualifications_international : :other_qualifications,
@@ -37,8 +44,7 @@
       <%= govuk_link_to t('application_form.other_qualification.first.button'),
         candidate_interface_other_qualification_type_path,
         button: true,
-        class: 'govuk-button--secondary govuk-!-margin-bottom-0'
-      %>
+        class: 'govuk-button--secondary govuk-!-margin-bottom-0' %>
     </div>
 
     <%= render(SummaryCardComponent.new(rows: no_qualification_row, editable: @editable)) %>

--- a/app/components/candidate_interface/other_qualifications_review_component.html.erb
+++ b/app/components/candidate_interface/other_qualifications_review_component.html.erb
@@ -1,6 +1,11 @@
-<% if show_missing_banner? %>
-  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :other_qualifications, section_path: candidate_interface_review_other_qualifications_path, error: @missing_error)) %>
+<% if !@submitting_application && !@qualifications.empty? %>
+  <%= govuk_link_to t('application_form.other_qualification.another.button'),
+    candidate_interface_other_qualification_type_path,
+    button: true,
+    class: 'govuk-button--secondary'
+  %>
 <% end %>
+
 <% @qualifications.each do |qualification| %>
   <%= render(SummaryCardComponent.new(rows: other_qualifications_rows(qualification), editable: @editable)) do %>
     <%= render(SummaryCardHeaderComponent.new(title: qualification.title, heading_level: @heading_level)) do %>
@@ -16,5 +21,26 @@
 <% end %>
 
 <% if @qualifications.empty? %>
-  <p class="govuk-body">No other qualifications entered.</p>
+  <% if @submitting_application && !application_form.other_qualifications_completed %>
+    <%= render CandidateInterface::IncompleteSectionComponent.new(
+      section: application_form.international? ? :other_qualifications_international : :other_qualifications,
+      section_path: candidate_interface_other_qualification_type_path,
+      error: @missing_error,
+    ) %>
+  <% elsif @submitting_application && application_form.other_qualifications_completed %>
+    <%= render(SummaryCardComponent.new(rows: no_qualification_row, editable: @editable)) %>
+  <% else %>
+    <div class="govuk-inset-text govuk-!-width-two-thirds govuk-!-margin-top-0">
+      <p class="govuk-body">Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.</p>
+      <p class="govuk-body">Training providers usually ask you for them later in the process.</p>
+
+      <%= govuk_link_to t('application_form.other_qualification.first.button'),
+        candidate_interface_other_qualification_type_path,
+        button: true,
+        class: 'govuk-button--secondary govuk-!-margin-bottom-0'
+      %>
+    </div>
+
+    <%= render(SummaryCardComponent.new(rows: no_qualification_row, editable: @editable)) %>
+  <% end %>
 <% end %>

--- a/app/components/candidate_interface/other_qualifications_review_component.html.erb
+++ b/app/components/candidate_interface/other_qualifications_review_component.html.erb
@@ -37,7 +37,7 @@
   <% elsif @submitting_application && application_form.other_qualifications_completed %>
     <%= render(SummaryCardComponent.new(rows: no_qualification_row, editable: @editable)) %>
   <% else %>
-    <div class="govuk-inset-text govuk-!-width-two-thirds govuk-!-margin-top-0">
+    <%= govuk_inset_text(classes: 'govuk-!-width-two-thirds govuk-!-margin-top-0') do %>
       <p class="govuk-body">Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.</p>
       <p class="govuk-body">Training providers usually ask you for them later in the process.</p>
 
@@ -45,7 +45,7 @@
         candidate_interface_other_qualification_type_path,
         button: true,
         class: 'govuk-button--secondary govuk-!-margin-bottom-0' %>
-    </div>
+    <% end %>
 
     <%= render(SummaryCardComponent.new(rows: no_qualification_row, editable: @editable)) %>
   <% end %>

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -35,7 +35,7 @@ module CandidateInterface
       [{
         key: 'Do you want to add any A levels and other qualifications',
         value: 'No',
-        change_path: candidate_interface_other_qualification_type_path,
+        change_path: candidate_interface_other_qualification_type_path(change: true),
       }]
     end
 

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -31,8 +31,12 @@ module CandidateInterface
       end
     end
 
-    def show_missing_banner?
-      @submitting_application && @application_form.application_qualifications.other.any?(&:incomplete_other_qualification?)
+    def no_qualification_row
+      [{
+        key: 'Do you want to add any A levels and other qualifications',
+        value: 'No',
+        change_path: candidate_interface_other_qualification_type_path,
+      }]
     end
 
   private

--- a/app/controllers/candidate_interface/other_qualifications/destroy_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/destroy_controller.rb
@@ -10,7 +10,13 @@ module CandidateInterface
       current_qualification.destroy!
       current_application.update!(other_qualifications_completed: false)
 
-      redirect_to candidate_interface_review_other_qualifications_path
+      if current_application.application_qualifications.other.count.zero?
+
+        redirect_to candidate_interface_other_qualification_type_path
+      else
+
+        redirect_to candidate_interface_review_other_qualifications_path
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class OtherQualifications::ReviewController < OtherQualifications::BaseController
     def show
-      redirect_to candidate_interface_other_qualification_type_path and return if current_application.application_qualifications.other.blank?
+      redirect_to candidate_interface_other_qualification_type_path and return if current_application.application_qualifications.other.blank? && !current_application.no_other_qualifications
 
       @application_form = current_application
     end

--- a/app/controllers/candidate_interface/other_qualifications/type_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/type_controller.rb
@@ -8,7 +8,7 @@ module CandidateInterface
       @form = OtherQualificationTypeForm.new(
         current_application,
         intermediate_data_service,
-        current_step: :type,
+        { current_step: :type }.merge!(qualification_type: current_application.no_other_qualifications ? 'no_other_qualifications' : nil),
       )
     end
 
@@ -19,7 +19,9 @@ module CandidateInterface
         other_qualification_type_params.merge(current_step: :type),
       )
 
-      if @form.save_intermediate
+      if @form.no_other_qualification? && @form.save_no_other_qualifications
+        redirect_to candidate_interface_review_other_qualifications_path
+      elsif @form.save_intermediate
         redirect_to candidate_interface_other_qualification_details_path
       else
         track_validation_error(@form)
@@ -80,7 +82,7 @@ module CandidateInterface
     def other_qualification_type_params
       strip_whitespace params
         .fetch(:candidate_interface_other_qualification_type_form, {})
-        .permit(:qualification_type, :other_uk_qualification_type, :non_uk_qualification_type)
+        .permit(:qualification_type, :other_uk_qualification_type, :non_uk_qualification_type, :no_other_qualification)
     end
   end
 end

--- a/app/controllers/candidate_interface/other_qualifications/type_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/type_controller.rb
@@ -8,7 +8,7 @@ module CandidateInterface
       @form = OtherQualificationTypeForm.new(
         current_application,
         intermediate_data_service,
-        { current_step: :type }.merge!(qualification_type: current_application.no_other_qualifications ? 'no_other_qualifications' : nil),
+        current_step: :type,
       )
     end
 

--- a/app/controllers/candidate_interface/other_qualifications/type_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/type_controller.rb
@@ -19,8 +19,13 @@ module CandidateInterface
         other_qualification_type_params.merge(current_step: :type),
       )
 
-      if @form.no_other_qualification? && @form.save_no_other_qualifications
-        redirect_to candidate_interface_review_other_qualifications_path
+      if @form.no_other_qualification?
+        if @form.save_no_other_qualifications
+          redirect_to candidate_interface_review_other_qualifications_path
+        else
+          track_validation_error(@form)
+          render :new
+        end
       elsif @form.save_intermediate
         redirect_to candidate_interface_other_qualification_details_path
       else

--- a/app/controllers/candidate_interface/other_qualifications/type_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/type_controller.rb
@@ -8,7 +8,7 @@ module CandidateInterface
       @form = OtherQualificationTypeForm.new(
         current_application,
         intermediate_data_service,
-        current_step: :type,
+        { current_step: :type }.merge!(qualification_type: params[:change] == 'true' ? 'no_other_qualifications' : nil),
       )
     end
 

--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -70,6 +70,7 @@ module CandidateInterface
         )
 
       application_qualification.assign_attributes(attributes_for_persistence)
+      @current_application.update!(no_other_qualifications: false)
       application_qualification.save
     end
 

--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -46,6 +46,7 @@ module CandidateInterface
       @current_application = current_application
       @intermediate_data_service = intermediate_data_service
       options = @intermediate_data_service.read.merge(options) if @intermediate_data_service
+      self.choice = 'no'
 
       self.id ||= options[:id] || options['id']
 

--- a/app/forms/candidate_interface/other_qualification_type_form.rb
+++ b/app/forms/candidate_interface/other_qualification_type_form.rb
@@ -23,9 +23,10 @@ module CandidateInterface
     attr_accessor :qualification_type
     attr_accessor :other_uk_qualification_type
     attr_accessor :non_uk_qualification_type
+    attr_accessor :no_other_qualification
 
-    validates :qualification_type, presence: true
-    validates :qualification_type, inclusion: { in: ALL_VALID_TYPES, allow_blank: false }
+    validates :qualification_type, presence: true, unless: :no_other_qualification
+    validates :qualification_type, inclusion: { in: ALL_VALID_TYPES, allow_blank: false }, unless: :no_other_qualification
     validates :other_uk_qualification_type, presence: true, if: -> { qualification_type == OTHER_TYPE }
     validates :other_uk_qualification_type, length: { maximum: 100 }
     validates :non_uk_qualification_type, presence: true, if: -> { qualification_type == NON_UK_TYPE }

--- a/app/forms/candidate_interface/other_qualification_type_form.rb
+++ b/app/forms/candidate_interface/other_qualification_type_form.rb
@@ -24,8 +24,8 @@ module CandidateInterface
     attr_accessor :other_uk_qualification_type
     attr_accessor :non_uk_qualification_type
 
-    validates :qualification_type, presence: true, unless: :no_other_qualification?
-    validates :qualification_type, inclusion: { in: ALL_VALID_TYPES, allow_blank: false }, unless: :no_other_qualification?
+    validates :qualification_type, presence: true
+    validates :qualification_type, inclusion: { in: ALL_VALID_TYPES + %w[no_other_qualifications], allow_blank: false }
     validates :other_uk_qualification_type, presence: true, if: -> { qualification_type == OTHER_TYPE }
     validates :other_uk_qualification_type, length: { maximum: 100 }
     validates :non_uk_qualification_type, presence: true, if: -> { qualification_type == NON_UK_TYPE }

--- a/app/forms/candidate_interface/other_qualification_type_form.rb
+++ b/app/forms/candidate_interface/other_qualification_type_form.rb
@@ -23,10 +23,9 @@ module CandidateInterface
     attr_accessor :qualification_type
     attr_accessor :other_uk_qualification_type
     attr_accessor :non_uk_qualification_type
-    attr_accessor :no_other_qualification
 
-    validates :qualification_type, presence: true, unless: :no_other_qualification
-    validates :qualification_type, inclusion: { in: ALL_VALID_TYPES, allow_blank: false }, unless: :no_other_qualification
+    validates :qualification_type, presence: true, unless: :no_other_qualification?
+    validates :qualification_type, inclusion: { in: ALL_VALID_TYPES, allow_blank: false }, unless: :no_other_qualification?
     validates :other_uk_qualification_type, presence: true, if: -> { qualification_type == OTHER_TYPE }
     validates :other_uk_qualification_type, length: { maximum: 100 }
     validates :non_uk_qualification_type, presence: true, if: -> { qualification_type == NON_UK_TYPE }
@@ -46,6 +45,16 @@ module CandidateInterface
 
     def save_intermediate
       valid? && save_intermediate!
+    end
+
+    def save_no_other_qualifications
+      return false unless valid?
+
+      @current_application.update!(no_other_qualifications: true)
+    end
+
+    def no_other_qualification?
+      qualification_type == 'no_other_qualifications'
     end
 
     def save_intermediate!

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -26,7 +26,7 @@ module CandidateInterface
         [:maths_gcse, maths_gcse_completed?],
         [:english_gcse, english_gcse_completed?],
         ([:science_gcse, science_gcse_completed?] if @application_form.science_gcse_needed?),
-        [:other_qualifications, no_incomplete_qualifications?],
+        [:other_qualifications, other_qualifications_completed?],
         ([:efl, english_as_a_foreign_language_completed?] if display_efl_link?),
 
         # "Personal statement and interview" section
@@ -223,7 +223,7 @@ module CandidateInterface
     end
 
     def other_qualifications_completed?
-      @application_form.other_qualifications_completed
+      @application_form.other_qualifications_completed && no_incomplete_qualifications?
     end
 
     def other_qualifications_added?

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -167,7 +167,7 @@ module CandidateInterface
     end
 
     def other_qualification_path
-      if other_qualifications_completed? || other_qualifications_added?
+      if other_qualifications_completed? || other_qualifications_added? || @application_form.no_other_qualifications
         Rails.application.routes.url_helpers.candidate_interface_review_other_qualifications_path
       else
         Rails.application.routes.url_helpers.candidate_interface_other_qualification_type_path

--- a/app/views/candidate_interface/other_qualifications/details/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/new.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.qualification_details'), @form.errors.any?) %>
-<% if current_application.application_qualifications.other.blank? %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
-<% else %>
-  <% content_for :before_content, govuk_back_link_to %>
-<% end %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -1,15 +1,9 @@
 <% content_for :title, other_qualifications_title(@application_form) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <%= other_qualifications_title(@application_form) %>
-    </h1>
-
-    <%= govuk_link_to t('application_form.other_qualification.another.button'), candidate_interface_other_qualification_type_path, button: true, class: 'govuk-button--secondary' %>
-  </div>
-</div>
+<h1 class="govuk-heading-xl">
+  <%= other_qualifications_title(@application_form) %>
+</h1>
 
 <%= render(CandidateInterface::OtherQualificationsReviewComponent.new(application_form: @application_form)) %>
 

--- a/app/views/candidate_interface/other_qualifications/shared/_instructions.html.erb
+++ b/app/views/candidate_interface/other_qualifications/shared/_instructions.html.erb
@@ -1,6 +1,0 @@
-<p class="govuk-body">
-  Enter your qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.
-</p>
-<p class="govuk-body">
-  Undergraduate and postgraduate degrees should be included in the ‘Degree’ section.
-</p>

--- a/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
@@ -4,8 +4,6 @@
   <%= other_qualifications_title(current_application) %>
 </h1>
 
-<%= render 'candidate_interface/other_qualifications/shared/instructions' %>
-
 <%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { text: 'What type of qualification do you want to add?', size: 'm' } do %>
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::GCSE_TYPE, label: { text: 'GCSE' }, link_errors: true %>
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::A_LEVEL_TYPE, label: { text: 'A level' } %>
@@ -17,6 +15,13 @@
   <% end %>
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::NON_UK_TYPE, label: { text: 'Non-UK qualification' } do %>
     <%= f.govuk_text_field :non_uk_qualification_type, label: { text: 'Qualification name', size: 's' }, hint: { text: t('application_form.other_qualification.qualification_type.non_uk.hint_text') } %>
+  <% end %>
+  <% if current_application.application_qualifications.other.blank? && !current_application.no_other_qualifications %>
+    <%= f.govuk_radio_divider %>
+    <%= f.govuk_radio_button :qualification_type,
+      'no_other_qualifications',
+      label: { text: current_application.international? ? 'I do not want to add any other qualifications' : 'I do not want to add any A levels and other qualifications' },
+      hint: -> { 'Providers look at A levels and other qualifications for evidence of subject knowledge not covered in your degree or work history' } %>
   <% end %>
 <% end %>
 

--- a/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
@@ -16,7 +16,7 @@
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::NON_UK_TYPE, label: { text: 'Non-UK qualification' } do %>
     <%= f.govuk_text_field :non_uk_qualification_type, label: { text: 'Qualification name', size: 's' }, hint: { text: t('application_form.other_qualification.qualification_type.non_uk.hint_text') } %>
   <% end %>
-  <% if current_application.application_qualifications.other.blank? && !current_application.no_other_qualifications %>
+  <% if (current_application.application_qualifications.other.blank? && params[:change] == 'true') || (current_application.application_qualifications.other.blank? && !current_application.no_other_qualifications) %>
     <%= f.govuk_radio_divider %>
     <%= f.govuk_radio_button :qualification_type,
       'no_other_qualifications',

--- a/app/views/candidate_interface/other_qualifications/type/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(other_qualifications_title(current_application), @form.errors.any?) %>
-<% if current_application.application_qualifications.other.blank? %>
+<% if current_application.application_qualifications.other.blank? && !current_application.no_other_qualifications %>
   <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 <% else %>
   <% content_for :before_content, govuk_back_link_to(candidate_interface_review_other_qualifications_path, 'Back') %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -123,7 +123,7 @@
           <%= render(TaskListItemComponent.new(
             text: other_qualifications_title(@application_form),
             completed: @application_form_presenter.other_qualifications_completed?,
-            path: @application_form_presenter.other_qualification_path, show_incomplete: false
+            path: @application_form_presenter.other_qualification_path,
           )) %>
         </li>
         <li class="app-task-list__item">

--- a/config/locales/candidate_interface/other_qualification.yml
+++ b/config/locales/candidate_interface/other_qualification.yml
@@ -30,6 +30,8 @@ en:
         change_action: year
       another:
         button: Add another qualification
+      first:
+        button: Add a qualification
       review:
         completed_checkbox: I have completed this section
       delete: Delete qualification

--- a/config/locales/candidate_interface/review_application.yml
+++ b/config/locales/candidate_interface/review_application.yml
@@ -42,8 +42,11 @@ en:
       missing: Science GCSE not complete
       enter_missing: Enter all values for Science GCSE or equivalent
     other_qualifications:
-      incomplete: The academic and other relevant qualifications section has an incomplete qualification
-      complete_section: Complete your academic and other relevant qualifications
+      incomplete: A levels and other qualifications not marked as complete
+      complete_section: Complete your other qualifications
+    other_qualifications_international:
+      incomplete: The other qualifications section is not marked as complete
+      complete_section: Complete your other qualifications
     efl:
       incomplete: English as a foreign language not marked as complete
       complete_section: Have you done an English as a foreign language assessment?

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -187,27 +187,39 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
     end
   end
 
-  describe '#show_missing_banner?' do
-    let(:application_form) { create(:application_form) }
+  context 'when the candidate selects not to provide other qualifications' do
+    it 'is submitted and the section is completed' do
+      application_form = create(:application_form, other_qualifications_completed: true)
+      result = render_inline(described_class.new(application_form: application_form, submitting_application: true))
 
-    context 'when they have not added an other qualification and are submitting the application' do
-      it 'returns false' do
-        expect(described_class.new(application_form: application_form, submitting_application: true).show_missing_banner?).to eq false
-      end
+      expect(page).not_to have_content('Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.')
+      expect(result.css('.govuk-summary-list__key').text).to include('Do you want to add any A levels and other qualifications')
+      expect(result.css('.govuk-summary-list__value').text).to include('No')
+      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
+        Rails.application.routes.url_helpers.candidate_interface_other_qualification_type_path,
+      )
     end
 
-    context 'when they have fully completed their other qualifications and are submitting their application' do
-      it 'returns false' do
-        create(:other_qualification, application_form: application_form)
-        expect(described_class.new(application_form: application_form, submitting_application: true).show_missing_banner?).to eq false
-      end
+    it 'is submitted and the section is not completed' do
+      application_form = create(:application_form, other_qualifications_completed: false)
+      result = render_inline(described_class.new(application_form: application_form, submitting_application: true))
+
+      expect(page).to have_content('A levels and other qualifications not marked as complete')
+      expect(result.css('.govuk-inset-text a')[0].attr('href')).to include(
+        Rails.application.routes.url_helpers.candidate_interface_other_qualification_type_path,
+      )
     end
 
-    context 'when they have an incomplete qualification and are submitting their application' do
-      it 'returns true' do
-        create(:other_qualification, application_form: application_form, award_year: nil)
-        expect(described_class.new(application_form: application_form, submitting_application: true).show_missing_banner?).to eq true
-      end
+    it 'is not being submitted' do
+      application_form = create(:application_form)
+      result = render_inline(described_class.new(application_form: application_form, submitting_application: false))
+
+      expect(page).to have_content('Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.')
+      expect(result.css('.govuk-summary-list__key').text).to include('Do you want to add any A levels and other qualifications')
+      expect(result.css('.govuk-summary-list__value').text).to include('No')
+      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
+        Rails.application.routes.url_helpers.candidate_interface_other_qualification_type_path,
+      )
     end
   end
 end

--- a/spec/forms/candidate_interface/other_qualification_type_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_type_form_spec.rb
@@ -8,6 +8,54 @@ RSpec.describe CandidateInterface::OtherQualificationTypeForm do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:qualification_type) }
     it { is_expected.to validate_length_of(:other_uk_qualification_type).is_at_most(100) }
+
+    context 'when a candidate has provided qualifications' do
+      it 'returns true when qualification_type is in the `ALL_VALID_TYPES` constant' do
+        described_class::ALL_VALID_TYPES.each do |valid_qualification_type|
+          form = case valid_qualification_type
+                 when 'Other'
+                   described_class.new(nil, nil, 'qualification_type' => valid_qualification_type, other_uk_qualification_type: 'BTEC')
+                 when 'non_uk'
+                   described_class.new(nil, nil, 'qualification_type' => valid_qualification_type, non_uk_qualification_type: 'ZTEC')
+                 else
+                   described_class.new(nil, nil, 'qualification_type' => valid_qualification_type)
+                 end
+
+          expect(form.valid?).to eq true
+        end
+      end
+
+      it 'returns false when the qualification_type is not in the `ALL_VALID_TYPES` constant' do
+        form = described_class.new(nil, nil, 'qualification_type' => 'Invalid qual')
+
+        expect(form.valid?).to eq false
+      end
+
+      it 'validates presence of `other_uk_qualification_type` when the candidate has selected other uk qualificaiton' do
+        invalid_form = described_class.new(nil, nil, 'qualification_type' => 'Other')
+
+        valid_form = described_class.new(nil, nil, 'qualification_type' => 'Other', 'other_uk_qualification_type' => 'BTEC')
+
+        expect(invalid_form.valid?).to eq false
+        expect(valid_form.valid?).to eq true
+      end
+
+      it 'validates presence of `non_uk_qualification_type` when the candidate has selected non uk qualificaiton' do
+        invalid_form = described_class.new(nil, nil, 'qualification_type' => 'non_uk')
+
+        valid_form = described_class.new(nil, nil, 'qualification_type' => 'non_uk', 'non_uk_qualification_type' => 'ZTEC')
+        expect(invalid_form.valid?).to eq false
+        expect(valid_form.valid?).to eq true
+      end
+    end
+
+    context 'when a candidate has no other qualifications to add' do
+      it 'does not validate that qualification_type is in the `ALL_VALID_TYPES`' do
+        form = described_class.new(nil, nil, 'qualification_type' => 'no_other_qualifications')
+
+        expect(form.valid?).to eq true
+      end
+    end
   end
 
   describe '#initialize' do

--- a/spec/forms/candidate_interface/other_qualification_type_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_type_form_spec.rb
@@ -5,6 +5,19 @@ RSpec.describe CandidateInterface::OtherQualificationTypeForm do
     'activemodel.errors.models.candidate_interface/other_qualification_type_form.attributes.'
   end
 
+  let(:current_application) { create(:application_form) }
+  let(:intermediate_data_service) do
+    Class.new {
+      def read
+        {
+          'qualification_type' => 'non_uk',
+          'institution_country' => 'New Zealand',
+          'non_uk_qualification_type' => 'German diploma',
+        }
+      end
+    }.new
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:qualification_type) }
     it { is_expected.to validate_length_of(:other_uk_qualification_type).is_at_most(100) }
@@ -59,19 +72,6 @@ RSpec.describe CandidateInterface::OtherQualificationTypeForm do
   end
 
   describe '#initialize' do
-    let(:current_application) { create(:application_form) }
-    let(:intermediate_data_service) do
-      Class.new {
-        def read
-          {
-            'qualification_type' => 'non_uk',
-            'institution_country' => 'New Zealand',
-            'non_uk_qualification_type' => 'German diploma',
-          }
-        end
-      }.new
-    end
-
     context 'the qualification type is being updated from a non-uk qualification to a uk qualification' do
       it 'assigns an empty string to the non_uk attributes' do
         form = CandidateInterface::OtherQualificationTypeForm.new(
@@ -85,6 +85,25 @@ RSpec.describe CandidateInterface::OtherQualificationTypeForm do
         expect(form.non_uk_qualification_type).to be_nil
         expect(form.institution_country).to be_nil
       end
+    end
+  end
+
+  describe '#save_no_other_qualifications' do
+    it 'does not update no_other_qualifications when invalid' do
+      form = described_class.new
+      expect(form.save_no_other_qualifications).to eq false
+      expect(current_application.reload.no_other_qualifications).to eq false
+    end
+
+    it 'updates the application forms no_other_qualifications to true' do
+      form = CandidateInterface::OtherQualificationTypeForm.new(
+        current_application,
+        intermediate_data_service,
+        'qualification_type' => 'no_other_qualifications',
+      )
+
+      expect(form.save_no_other_qualifications).to eq true
+      expect(current_application.reload.no_other_qualifications).to eq true
     end
   end
 end

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   end
 
   describe '#other_qualifications_completed?' do
-    it 'returns true if other qualifications section is completed' do
+    it 'returns true if other qualifications section is completed and there are no incompleted qualifications' do
       application_form = FactoryBot.build(:application_form, other_qualifications_completed: true)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
@@ -197,6 +197,18 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
     it 'returns false if other qualifications section is incomplete' do
       application_form = FactoryBot.build(:application_form, other_qualifications_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).not_to be_other_qualifications_completed
+    end
+
+    it 'returns false if other qualifications is completed but there is an incomplete qualification' do
+      application_form = FactoryBot.build(:application_form, other_qualifications_completed: true)
+      create(:other_qualification,
+             subject: nil,
+             grade: nil,
+             application_form: application_form)
+
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).not_to be_other_qualifications_completed

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_no_qualification_option_choice_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_no_qualification_option_choice_spec.rb
@@ -1,0 +1,157 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering their other qualifications' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their other qualifications after choosing not to provide any' do
+    given_i_am_signed_in
+    and_i_visit_the_site
+    then_i_see_the_other_qualifications_section_is_incomplete
+
+    when_i_click_on_other_qualifications
+    then_i_see_the_select_qualification_type_page
+
+    when_i_do_not_select_any_type_option
+    and_i_click_continue
+    then_i_see_the_qualification_type_error
+
+    when_i_select_i_do_not_want_to_add_any_a_levels
+    and_i_click_continue
+    then_i_see_a_level_advice
+    and_i_see_my_no_other_qualification_selection
+
+    when_i_select_add_another_qualification
+    and_i_choose_other
+    and_i_click_continue
+    and_i_fill_in_my_other_qualifications_details
+    and_i_choose_not_to_add_additional_qualifications
+    and_click_save_and_continue
+    then_i_see_the_other_qualification_review_page
+    and_i_dont_see_my_no_other_qualification_selected
+    and_see_my_other_uk_qualification_has_the_correct_format
+
+    when_i_click_on_delete_my_first_qualification
+    and_i_confirm_that_i_want_to_delete_my_additional_qualification
+    then_i_see_the_select_qualification_type_page
+    and_i_select_i_do_not_want_to_add_any_a_levels
+    and_i_click_continue
+    then_i_see_a_level_advice
+    and_i_see_my_no_other_qualification_selection
+
+    when_i_mark_this_section_as_completed
+    and_i_click_on_continue
+    then_i_see_that_the_section_is_completed
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def then_i_see_the_other_qualifications_section_is_incomplete
+    expect(page).to have_css('#a-levels-and-other-qualifications-badge-id', text: 'Incomplete')
+  end
+
+  def when_i_click_on_other_qualifications
+    click_link t('page_titles.other_qualifications')
+  end
+
+  def then_i_see_the_select_qualification_type_page
+    expect(page).to have_current_path(candidate_interface_other_qualification_type_path)
+  end
+
+  def when_i_select_i_do_not_want_to_add_any_a_levels
+    choose 'I do not want to add any A levels and other qualifications'
+  end
+  alias_method :and_i_select_i_do_not_want_to_add_any_a_levels, :when_i_select_i_do_not_want_to_add_any_a_levels
+
+  def then_i_see_a_level_advice
+    expect(page).to have_content('Adding A levels and other qualifications makes your application stronger.')
+  end
+
+  def and_i_see_my_no_other_qualification_selection
+    expect(page).to have_content('Do you want to add any A levels and other qualifications')
+  end
+
+  def and_i_click_continue
+    click_button t('continue')
+  end
+  alias_method :when_i_click_continue, :and_i_click_continue
+
+  def and_click_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def when_i_choose_other
+    choose 'Other'
+    within('#candidate-interface-other-qualification-type-form-qualification-type-other-conditional') do
+      fill_in 'Qualification name', with: 'Access Course'
+    end
+  end
+  alias_method :and_i_choose_other, :when_i_choose_other
+
+  def when_i_fill_in_my_other_qualifications_details
+    fill_in t('application_form.other_qualification.subject.label'), with: 'History, English and Psychology'
+    fill_in t('application_form.other_qualification.grade.label'), with: 'Distinction'
+    fill_in t('application_form.other_qualification.award_year.label'), with: '2012'
+  end
+  alias_method :and_i_fill_in_my_other_qualifications_details, :when_i_fill_in_my_other_qualifications_details
+
+  def and_i_choose_not_to_add_additional_qualifications
+    choose 'No, not at the moment'
+  end
+
+  def then_i_see_the_other_qualification_review_page
+    expect(page).to have_current_path(candidate_interface_review_other_qualifications_path)
+  end
+
+  def and_i_dont_see_my_no_other_qualification_selected
+    expect(page).not_to have_content('Do you want to add any A levels and other qualifications')
+  end
+
+  def and_see_my_other_uk_qualification_has_the_correct_format
+    @application = current_candidate.current_application
+    expect(@application.application_qualifications.last.qualification_type).to eq 'Other'
+    expect(@application.application_qualifications.last.other_uk_qualification_type).to eq 'Access Course'
+    expect(@application.application_qualifications.last.subject).to eq 'History, English and Psychology'
+  end
+
+  def when_i_select_add_another_qualification
+    click_link 'Add a qualification'
+  end
+
+  def when_i_click_on_delete_my_first_qualification
+    within(all('.app-summary-card')[0]) do
+      click_link(t('application_form.other_qualification.delete'))
+    end
+  end
+
+  def and_i_confirm_that_i_want_to_delete_my_additional_qualification
+    click_button t('application_form.other_qualification.confirm_delete')
+  end
+
+  def when_i_click_on_continue
+    click_button t('continue')
+  end
+
+  def when_i_mark_this_section_as_completed
+    check t('application_form.other_qualification.review.completed_checkbox')
+  end
+
+  def and_i_click_on_continue
+    when_i_click_on_continue
+  end
+
+  def then_i_see_that_the_section_is_completed
+    expect(page).to have_css('#a-levels-and-other-qualifications-badge-id', text: 'Completed')
+  end
+
+  def when_i_do_not_select_any_type_option; end
+
+  def then_i_see_the_qualification_type_error
+    expect(page).to have_content 'Enter the type of qualification'
+  end
+end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature 'Entering their other qualifications' do
     then_i_see_the_select_qualification_type_page
 
     when_i_click_back_to_application_form
-    and_that_the_section_is_not_marked_as_complete_or_incomplete
+    and_that_the_section_is_not_marked_as_complete
   end
 
   def given_i_am_signed_in
@@ -368,7 +368,7 @@ RSpec.feature 'Entering their other qualifications' do
     click_link 'Back to application'
   end
 
-  def and_that_the_section_is_not_marked_as_complete_or_incomplete
-    expect(page).not_to have_css('#a-levels-and-other-qualifications-badge-id')
+  def and_that_the_section_is_not_marked_as_complete
+    expect(page).not_to have_css('#a-levels-and-other-qualifications-badge-id', text: 'Completed')
   end
 end


### PR DESCRIPTION
## Context

A levels are not part of the teacher training entry requirements so candidates do not have to enter them. A levels help providers build a more detailed picture of the person applying, allowing candidates to demonstrate qualifications in a wider range of subjects. This is significant if they do not have a degree or work experience in a subject that they’re applying for.

If a person has not entered their A levels, providers are likely to ask for them later, potentially slowing down the application process. We also know, from analysis, that candidates who add 2 or more A levels have lower levels of rejection.

## Changes proposed in this pull request

The following aspects of the application have been updated:

* The other qualifications section becomes mandatory.

  In order to complete the section without any qualifications, a candidate needs to select the ‘I do not want to add A levels or other qualifications’ option (or ‘I do not want to add any other qualifications’ if an international candidate).

  This applies to new and unsubmitted applications – but not those that have already been submitted.

  If qualifications have already been added, this option is no longer shown.

* Reviewing this section when a candidate has decided not to add any qualifications replays this answer, and allows them to change it. Additional guidance is also shown reminding a candidate why adding other qualification(s) can improve their application.

* Make ‘No’ the default for adding another qualification question.


## Guidance to review

[Prototype](https://apply-beta-prototype.herokuapp.com/application/12345)

## Link to Trello card

https://trello.com/c/YYoOD2vT/3244-dev-reorder-qualification-sections-rename-other-qualifications-section-and-make-it-mandatory

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
