### PR TITLE
Add Candidate ID in manage

### DIFF
--- a/app/components/provider_interface/personal_details_component.rb
+++ b/app/components/provider_interface/personal_details_component.rb
@@ -32,6 +32,7 @@ module ProviderInterface
         phone_number_row,
         email_row,
         address_row,
+        candidate_id_row,
       ].compact
     end
 
@@ -101,6 +102,13 @@ module ProviderInterface
       {
         key: 'Address',
         value: application_form.full_address,
+      }
+    end
+
+    def candidate_id_row
+      {
+        key: 'Candidate ID',
+        value: candidate.public_id,
       }
     end
 

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -36,6 +36,10 @@ class Candidate < ApplicationRecord
     Encryptor.encrypt(id)
   end
 
+  def public_id
+    "C#{id}"
+  end
+
 private
 
   def downcase_email

--- a/app/presenters/register_api/single_application_presenter.rb
+++ b/app/presenters/register_api/single_application_presenter.rb
@@ -21,7 +21,7 @@ module RegisterAPI
           submitted_at: application_form.submitted_at.iso8601,
           recruited_at: application_choice.recruited_at.iso8601,
           candidate: {
-            id: "C#{application_form.candidate.id}",
+            id: application_form.candidate.public_id,
             first_name: application_form.first_name,
             last_name: application_form.last_name,
             date_of_birth: application_form.date_of_birth,

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -27,7 +27,7 @@ module VendorAPI
           reject_by_default_at: application_choice.reject_by_default_at&.iso8601,
           recruited_at: application_choice.recruited_at,
           candidate: {
-            id: "C#{application_form.candidate.id}",
+            id: application_form.candidate.public_id,
             first_name: application_form.first_name,
             last_name: application_form.last_name,
             date_of_birth: application_form.date_of_birth,

--- a/spec/components/provider_interface/personal_details_component_spec.rb
+++ b/spec/components/provider_interface/personal_details_component_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe ProviderInterface::PersonalDetailsComponent do
     expect(result.css('.govuk-summary-list__value').text).to include(application_form.candidate.email_address)
   end
 
+  it 'renders the candidate’s public ID' do
+    expect(result.css('.govuk-summary-list__value').text).to include("C#{application_form.candidate.id}")
+  end
+
   it 'does not render right to work fields if nationality is British or Irish' do
     expect(result.text).not_to include('Has the right to work or study in the UK?')
     expect(result.text).not_to include('Residency details')


### PR DESCRIPTION
## Context

Providers with student record systems aren't able to cross-reference the Candidate ID we send them with the IDs they see in Manage. It could be that through duplicate matching they've attached that ID to an existing candidate, whether from a previous cycle or from a UCAS application.

## Changes proposed in this pull request

Add the Candidate ID in Manage.

<img width="733" alt="Screenshot 2021-04-09 at 15 26 49" src="https://user-images.githubusercontent.com/642279/114195117-15f4ec80-9948-11eb-9448-e61f19a08e08.png">

## Link to Trello card

https://ukgovernmentdfe.slack.com/archives/C01EZFNUPLP/p1616678101044700?thread_ts=1616678080.044400&cid=C01EZFNUPLP