### PR TITLE
Offer links to individual application choices in Support

### DIFF
--- a/app/components/summary_card_header_component.html.erb
+++ b/app/components/summary_card_header_component.html.erb
@@ -1,4 +1,4 @@
-<header class="app-summary-card__header">
+<header class="app-summary-card__header" <%= @anchor ? "id=#{@anchor}" : nil %>>
   <h<%= @heading_level %> class="app-summary-card__title">
     <%= @title %>
   </h<%= @heading_level %>>

--- a/app/components/summary_card_header_component.rb
+++ b/app/components/summary_card_header_component.rb
@@ -1,6 +1,7 @@
 class SummaryCardHeaderComponent < ViewComponent::Base
-  def initialize(title:, heading_level: 2)
+  def initialize(title:, heading_level: 2, anchor: nil)
     @title = title
     @heading_level = heading_level
+    @anchor = anchor
   end
 end

--- a/app/components/support_interface/application_choice_component.html.erb
+++ b/app/components/support_interface/application_choice_component.html.erb
@@ -1,3 +1,3 @@
 <%= render SummaryCardComponent.new(rows: rows) do %>
-  <%= render SummaryCardHeaderComponent.new(title: "Application choice ##{application_choice.id}", heading_level: 3) %>
+  <%= render SummaryCardHeaderComponent.new(title: title, heading_level: 3, anchor: anchor) %>
 <% end %>

--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -57,6 +57,17 @@ module SupportInterface
       rows
     end
 
+    def title
+      link_text = "<span class='govuk-visually-hidden'>Application choice ID</span> ##{application_choice.id}".html_safe
+      href = support_interface_application_form_path(application_choice.application_form_id, anchor: anchor)
+
+      "Application choice #{govuk_link_to(link_text, href)}".html_safe
+    end
+
+    def anchor
+      "application-choice-#{application_choice.id}"
+    end
+
   private
 
     def rejection_reasons_text


### PR DESCRIPTION
## Context

It's annoying not to be able to pass around links to individual application choices in support

## Changes proposed in this pull request

Turn the ID part of the heading into a hyperlink

<img width="750" alt="Screenshot 2021-04-09 at 16 35 52" src="https://user-images.githubusercontent.com/642279/114204952-ae439f00-9951-11eb-98cc-c3fcc1502f32.png">

