### PR TITLE
Offer direct links to email log emails in Support

### DIFF
--- a/app/components/support_interface/email_log_row_component.html.erb
+++ b/app/components/support_interface/email_log_row_component.html.erb
@@ -1,6 +1,11 @@
-<tr class="govuk-table__row">
+<tr class="govuk-table__row" id="email-<%= email.id %>">
   <td class="govuk-table__cell">
     <%= email.created_at.to_s(:govuk_date_and_time) %>
+    <p class="govuk-body">
+      <%= govuk_link_to url_for(anchor: "email-#{email.id}") do %>
+        Link to this <span class="govuk-visually-hidden">email to <%= email.to %> of type <%= email.humanised_email_type %> on <%= email.created_at.to_s(:govuk_date_and_time) %></span>
+      <% end %>
+    </p>
   </td>
   <td class="govuk-table__cell govuk-!-padding-top-0">
     <%= render SummaryListComponent.new(rows: summary_list_rows) %>


### PR DESCRIPTION
## Context

It's useful to be able to link to individual emails when discussing support tickets

## Changes proposed in this pull request

<img width="667" alt="Screenshot 2021-04-09 at 16 46 47" src="https://user-images.githubusercontent.com/642279/114206436-41310900-9953-11eb-84cd-fc18c04c5296.png">
