### PR TITLE
Change how references are retrieved in CandidateJourneyTracker

### DIFF
--- a/app/services/support_interface/candidate_journey_tracker.rb
+++ b/app/services/support_interface/candidate_journey_tracker.rb
@@ -143,7 +143,16 @@ module SupportInterface
     end
 
     def received_references
-      @received_references ||= all_references.select(&:feedback_provided?)
+      @received_references ||=
+        begin
+          references = all_references.unscoped.feedback_provided
+
+          if references.any? { |ref| ref.feedback_provided_at.blank? } # an error state caused by bad data
+            [] # show nothing about references in the export so that the application can be easily ignored/filtered out
+          else
+            references.order(feedback_provided_at: :asc)
+          end
+        end
     end
 
     def earliest_update_audit_for(model, attributes)


### PR DESCRIPTION


## Context
The "completed references" fields of this export are supposed to show
timestamps for the first and second reference received for a given
application. Currently the export retrieves these references ordered by
id, irrespective of when they were actually received.

Further, some references in the production database have blank
feedback_provided_at timestamps, leading to blank fields in the export.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Address both of these issues as follows:

- Update the reference retrieval logic so that all `feedback_provided`
  references are returned ordered by their `feedback_provided_at`
  timestamp
- If a `feedback_provided` reference has a missing
  `feedback_provided_at` timestamp, rather than show an incomplete and
  potentially confusing/misleading picture in the export, opt instead
  to not display any reference data for that application. This allows
  the application to be easily filtered out of any reference-related analysis.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Can just review the diff, although the spec changes are probably best reviewed in split mode.



<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/ls2bG8KZ
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
