### PR TITLE
Fix bug in CandidateJourneyTracker

### DIFF
--- a/app/services/support_interface/candidate_journey_tracker.rb
+++ b/app/services/support_interface/candidate_journey_tracker.rb
@@ -134,18 +134,10 @@ module SupportInterface
       )
     end
 
-  private
-
-    def all_references
-      @all_references ||= @application_choice
-        .application_form
-        .application_references
-    end
-
     def received_references
       @received_references ||=
         begin
-          references = all_references.unscoped.feedback_provided
+          references = all_references.unscope(:order).feedback_provided
 
           if references.any? { |ref| ref.feedback_provided_at.blank? } # an error state caused by bad data
             [] # show nothing about references in the export so that the application can be easily ignored/filtered out
@@ -153,6 +145,14 @@ module SupportInterface
             references.order(feedback_provided_at: :asc)
           end
         end
+    end
+
+  private
+
+    def all_references
+      @all_references ||= @application_choice
+        .application_form
+        .application_references
     end
 
     def earliest_update_audit_for(model, attributes)

--- a/spec/services/support_interface/candidate_journey_tracker_spec.rb
+++ b/spec/services/support_interface/candidate_journey_tracker_spec.rb
@@ -130,6 +130,15 @@ RSpec.describe SupportInterface::CandidateJourneyTracker, with_audited: true do
         expect(described_class.new(application_choice).completed_reference_2_received_at).to eq(nil)
       end
     end
+
+    describe '#received_references' do
+      it 'returns only references related to the application choice' do
+        create(:reference, :feedback_provided, requested_at: 4.days.ago, feedback_provided_at: 3.days.ago)
+        application_form.application_references = [reference_1, reference_2, reference_3]
+
+        expect(described_class.new(application_choice).received_references).to eq([reference_3, reference_2, reference_1])
+      end
+    end
   end
 
   describe '#reference_reminder_email_sent' do


### PR DESCRIPTION
When retrieving references from the database, rather than unscoping the
entire query, just unscope the order so that a new order can be applied
without returning every reference.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
