### PR TITLE
Export googleAnalyticsManage env var in QA

### DIFF
--- a/azure/pipelines/build.yml
+++ b/azure/pipelines/build.yml
@@ -318,6 +318,7 @@ stages:
       sandbox: '$(sandbox)'
       skylightAuthToken: '$(skylightAuthToken)'
       skylightEnable: '$(skylightEnable)'
+      googleAnalyticsManage: '$(googleAnalyticsManage)'
 
 
 - stage: deploy_devops


### PR DESCRIPTION
## Context

We'd like to integrate Tag Manager with Google Analytics, having a
working test account will allow us to try out various triggers without
skewing production analytics data.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Expose `googleAnalyticsManage` in the QA environment. This will use the test account ID.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/88FPUaKz/3515-add-google-tag-manager-to-manage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
