### PR TITLE
Content changes for automatically declined rejected applications

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -25,6 +25,9 @@
         <% if days_to_respond_text %>
           <dt class="govuk-visually-hidden">Days left to respond</dt>
           <dd class="govuk-body-s"><%= days_to_respond_text %></dd>
+        <% elsif candidate_days_to_respond_text %>
+          <dt class="govuk-visually-hidden">Days left for candidate to respond</dt>
+          <dd class="govuk-body-s"><%= candidate_days_to_respond_text %></dd>
         <% end %>
         <dt class="govuk-visually-hidden">Cycle</dt>
         <dd class="govuk-hint govuk-!-font-size-16"><%= recruitment_cycle_text %></dd>

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -18,7 +18,21 @@ module ProviderInterface
 
     def days_to_respond_text
       if (days_left_to_respond = application_choice.days_left_to_respond)
-        "#{days_until(Date.current + days_left_to_respond).capitalize} to respond"
+        if days_left_to_respond.zero?
+          'Last day to make decision'
+        else
+          "#{days_until(Date.current + days_left_to_respond).capitalize} to make decision"
+        end
+      end
+    end
+
+    def candidate_days_to_respond_text
+      if (days_left_to_respond = application_choice.days_until_decline_by_default)
+        if days_left_to_respond.positive?
+          "#{days_until(Date.current + days_left_to_respond).capitalize} for candidate to respond"
+        else
+          'Last day for candidate to respond'
+        end
       end
     end
 

--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -17,9 +17,9 @@
           </h2>
           <p class="govuk-body">
             <% if time_is_today_or_tomorrow?(application_choice.reject_by_default_at) -%>
-              You have until <%= time_today_or_tomorrow(application_choice.reject_by_default_at) %> to respond to this application. Otherwise it will be automatically rejected.
+              This application will be automatically rejected at the end of <%= date_and_time_today_or_tomorrow(application_choice.reject_by_default_at) %> if you do not make a decision.
             <% else -%>
-              You have <%= days_until(application_choice.reject_by_default_at.to_date) %> to make a decision - this application will be automatically rejected on <%= application_choice.reject_by_default_at.to_s(:govuk_date) %>.
+              This application will be automatically rejected in <%= days_until(application_choice.reject_by_default_at.to_date) %> (<%= application_choice.reject_by_default_at.to_s(:govuk_date_and_time) %>) if you do not make a decision.
             <% end -%>
           </p>
 
@@ -37,9 +37,9 @@
           </h2>
           <p class="govuk-body">
             <% if time_is_today_or_tomorrow?(application_choice.reject_by_default_at) -%>
-              You have until <%= time_today_or_tomorrow(application_choice.reject_by_default_at) %> to respond to this application. Otherwise it will be automatically rejected.
+              This application will be automatically rejected at the end of <%= date_and_time_today_or_tomorrow(application_choice.reject_by_default_at) %> if you do not make a decision.
             <% else -%>
-              You have <%= days_until(application_choice.reject_by_default_at.to_date) %> to make a decision - this application will be automatically rejected on <%= application_choice.reject_by_default_at.to_s(:govuk_date) %>.
+              This application will be automatically rejected in <%= days_until(application_choice.reject_by_default_at.to_date) %> (<%= application_choice.reject_by_default_at.to_s(:govuk_date_and_time) %>) if you do not make a decision.
             <% end -%>
           </p>
 

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -21,13 +21,13 @@
 
   .govuk-grid-column-one-third {
     @include govuk-media-query($from: tablet) {
-      width: 37%;
+      width: 40%;
     }
   }
 
   .govuk-grid-column-two-thirds {
     @include govuk-media-query($from: tablet) {
-      width: 63%;
+      width: 60%;
     }
   }
 

--- a/app/helpers/task_view_helper.rb
+++ b/app/helpers/task_view_helper.rb
@@ -7,7 +7,7 @@ module TaskViewHelper
     when 4 then 'Ready for review'
     when 5 then 'Interviewing'
     when 6 then 'Offers pending conditions (previous cycle)'
-    when 7 then 'Waiting for candidate action'
+    when 7 then 'Waiting for candidate to respond to offer'
     when 8 then 'Offers pending conditions (current cycle)'
     when 9 then 'Successful candidates'
     when 10 then 'Deferred offers'

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -82,9 +82,9 @@ class ApplicationChoice < ApplicationRecord
   end
 
   def days_until_decline_by_default
-    if status == 'offer'
-      dbd = decline_by_default_at
-      ((dbd - Time.zone.now) / 1.day).floor if dbd && dbd > Time.zone.now
+    dbd = decline_by_default_at
+    if offer? && dbd && dbd > Time.zone.now
+      ((dbd - Time.zone.now) / 1.day).floor
     end
   end
 

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -81,6 +81,13 @@ class ApplicationChoice < ApplicationRecord
     end
   end
 
+  def days_until_decline_by_default
+    if status == 'offer'
+      dbd = decline_by_default_at
+      ((dbd - Time.zone.now) / 1.day).floor if dbd && dbd > Time.zone.now
+    end
+  end
+
   delegate :course_not_available?, to: :course_option
   delegate :withdrawn?, to: :course, prefix: true
 

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -127,7 +127,6 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
       create(
         :application_choice,
         :awaiting_provider_decision,
-        updated_at: Time.zone.parse('2020-06-01T09:05:00+01:00'),
       )
     end
 
@@ -156,19 +155,63 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
     context 'when less than a day is left to respond' do
       let(:rbd) { Time.zone.parse('2020-06-02T09:05:00+01:00') }
 
-      it { is_expected.to eq('Less than 1 day to respond') }
+      it { is_expected.to eq('Last day to make decision') }
     end
 
     context 'when 1 day is left to respond' do
       let(:rbd) { Time.zone.parse('2020-06-03T09:05:00+01:00') }
 
-      it { is_expected.to eq('1 day to respond') }
+      it { is_expected.to eq('1 day to make decision') }
     end
 
     context 'when 2 days are left to respond' do
       let(:rbd) { Time.zone.parse('2020-06-04T09:05:00+01:00') }
 
-      it { is_expected.to eq('2 days to respond') }
+      it { is_expected.to eq('2 days to make decision') }
+    end
+  end
+
+  describe '#decision_by_date_text' do
+    around do |example|
+      Timecop.freeze(Time.zone.local(2020, 6, 1, 12, 30, 0)) { example.run }
+    end
+
+    let(:application_choice) do
+      create(
+        :application_choice,
+        :with_offer,
+        decline_by_default_at: dbd,
+      )
+    end
+
+    before { application_choice.decline_by_default_at = dbd }
+
+    subject(:candidate_days_to_respond_text) do
+      described_class.new(application_choice: application_choice).candidate_days_to_respond_text
+    end
+
+    context 'when decision_by_date is in the past' do
+      let(:dbd) { Time.zone.parse('2020-05-02T09:05:00+01:00') }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when less than a day is left to respond' do
+      let(:dbd) { Time.zone.parse('2020-06-02T09:05:00+01:00') }
+
+      it { is_expected.to eq('Last day for candidate to respond') }
+    end
+
+    context 'when 1 day is left to respond' do
+      let(:dbd) { Time.zone.parse('2020-06-03T09:05:00+01:00') }
+
+      it { is_expected.to eq('1 day for candidate to respond') }
+    end
+
+    context 'when 2 days are left to respond' do
+      let(:dbd) { Time.zone.parse('2020-06-04T09:05:00+01:00') }
+
+      it { is_expected.to eq('2 days for candidate to respond') }
     end
   end
 

--- a/spec/components/provider_interface/application_choice_header_component_spec.rb
+++ b/spec/components/provider_interface/application_choice_header_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
           expect(result.css('.govuk-button').first.text).to eq('Set up interview')
           expect(result.css('.govuk-button').last.text).to eq('Make decision')
           expect(result.css('.govuk-inset-text').text).to include(
-            'You have until 12pm (midday) tomorrow to respond to this application. Otherwise it will be automatically rejected.',
+            'This application will be automatically rejected at the end of tomorrow (2 November 2021 at 12pm (midday)) if you do not make a decision.',
           )
         end
       end
@@ -30,7 +30,7 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
         it 'the Make decision button is available and RDB info is presented ' do
           expect(result.css('.govuk-button').last.text).to eq('Make decision')
           expect(result.css('.govuk-inset-text').text).to include(
-            'You have until 12pm (midday) tomorrow to respond to this application. Otherwise it will be automatically rejected.',
+            'This application will be automatically rejected at the end of tomorrow (2 November 2021 at 12pm (midday)) if you do not make a decision.',
           )
         end
       end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -99,8 +99,8 @@ RSpec.describe ViewHelper, type: :helper do
       expect(helper.time_is_today_or_tomorrow?(Time.zone.now - 24.hours)).to be false
     end
 
-    it 'is not true for a time in 49 hours' do
-      expect(helper.time_is_today_or_tomorrow?(Time.zone.now - 49.hours)).to be false
+    it 'is not true for a time after tomorrow' do
+      expect(helper.time_is_today_or_tomorrow?(Time.zone.now + 49.hours)).to be false
     end
   end
 

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def then_i_should_see_a_prompt_to_respond_to_the_application
-    expect(page).to have_content(/You have \d+ days to make a decision/)
+    expect(page).to have_content(/This application will be automatically rejected in \d+ days/)
   end
 
   def when_i_click_to_respond_to_the_application


### PR DESCRIPTION
## Context

Changes that implement the design requirements set out here - https://bat-design-history.netlify.app/manage-teacher-training-applications/showing-when-an-offer-will-be-automatically-declined/

Some of the changes requested have been completed in another [PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/4394)

## Changes proposed in this pull request

- Added declined by default to application card for offered state
- Update rejected by default display for application list
- Change rejected by default text to application choice header

## Guidance to review

For the application list, look at the text next to applications in the offered and received/interviewing states
![image](https://user-images.githubusercontent.com/25597009/114425620-29ef5700-9bb1-11eb-8c2c-e7a861bd0f70.png)

![image](https://user-images.githubusercontent.com/25597009/114425861-61f69a00-9bb1-11eb-8787-d0291560ee25.png)

For the application choice header, select a candidate in the offered state

![image](https://user-images.githubusercontent.com/25597009/114426090-9c603700-9bb1-11eb-8a45-9a7cf3c05908.png)

## Link to Trello card

https://trello.com/c/gPo8FHgx/3580-content-changes-for-automatically-declined-rejected-applications

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
