### PR TITLE
Trigger deployment to qa and staging after build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,3 +138,17 @@ jobs:
           INCLUDE_PATTERN: ${{ matrix.include-pattern }}
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern }}
           DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
+
+  trigger-deployment:
+    name: Trigger Deployment
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    if: github.ref == 'ref/heads/master'
+    steps:
+      - name: Trigger Deployment to QA and Staging
+        if: success()
+        uses: benc-uk/workflow-dispatch@v1.1
+        with:
+          workflow: Deploy
+          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          inputs: '{"qa": "true", "staging": "true", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Context

Deploy to `qa` and `staging` when build completes.

## Changes proposed in this pull request

Deploy to `qa` and `staging` when build completes on `master`

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
