### PR TITLE
Fix bug where predicted_grade is not set when entering degree

### DIFF
--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -161,6 +161,8 @@ module CandidateInterface
     end
 
     def formatted_completion_status(degree)
+      return if degree.predicted_grade.nil?
+
       degree.completed? ? 'Yes' : 'No'
     end
 

--- a/app/forms/candidate_interface/degree_completion_status_form.rb
+++ b/app/forms/candidate_interface/degree_completion_status_form.rb
@@ -13,7 +13,9 @@ module CandidateInterface
     end
 
     def assign_form_values(degree)
-      self.degree_completed = degree.predicted_grade? ? 'no' : 'yes'
+      unless degree.predicted_grade.nil?
+        self.degree_completed = degree.predicted_grade? ? 'no' : 'yes'
+      end
       self
     end
 

--- a/spec/components/candidate_interface/degrees_review_component_spec.rb
+++ b/spec/components/candidate_interface/degrees_review_component_spec.rb
@@ -189,6 +189,33 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
     end
   end
 
+  context 'when the degree has been saved without setting the value of predicted_grade' do
+    let(:degree1) do
+      build_stubbed(
+        :degree_qualification,
+        qualification_type: 'Bachelor of Arts in Architecture',
+        subject: 'Woof',
+        institution_name: 'University of Doge',
+        grade: 'Upper second',
+        predicted_grade: nil,
+        start_year: '2005',
+        award_year: '2008',
+      )
+    end
+
+    it 'renders component with correct values for the completion status row' do
+      allow(application_form).to receive(:application_qualifications).and_return(
+        ActiveRecordRelationStub.new(ApplicationQualification, [degree1], scopes: [:degrees]),
+      )
+
+      result = render_inline(described_class.new(application_form: application_form))
+      completed_degree_summary = result.css('.app-summary-card').first
+      completion_status_row = completed_degree_summary.css('.govuk-summary-list__row').find { |e| e.text.include?('Have you completed this degree?') }
+
+      expect(completion_status_row.css('.govuk-summary-list__value').text).to be_blank
+    end
+  end
+
   context 'when degrees are editable and first degree is international' do
     let(:degree1) do
       build_stubbed(

--- a/spec/forms/candidate_interface/degree_completion_status_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_completion_status_form_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CandidateInterface::DegreeCompletionStatusForm, type: :model do
 
   describe '#assign_form_values(degree)' do
     it 'sets degree_completed to "no" if degree.predicted_grade? is true' do
-      degree = instance_double(ApplicationQualification, predicted_grade?: true)
+      degree = build_stubbed(:degree_qualification, predicted_grade: true)
       form = described_class.new
       form.assign_form_values(degree)
 
@@ -37,11 +37,19 @@ RSpec.describe CandidateInterface::DegreeCompletionStatusForm, type: :model do
     end
 
     it 'sets degree_completed to "yes" if degree.predicted_grade? is false' do
-      degree = instance_double(ApplicationQualification, predicted_grade?: false)
+      degree = build_stubbed(:degree_qualification, predicted_grade: false)
       form = described_class.new
       form.assign_form_values(degree)
 
       expect(form.degree_completed).to eq 'yes'
+    end
+
+    it 'does not set degree_completed if degree.predicted_grade is nil' do
+      degree = build_stubbed(:degree_qualification, predicted_grade: nil)
+      form = described_class.new
+      form.assign_form_values(degree)
+
+      expect(form.degree_completed).to be_nil
     end
   end
 end


### PR DESCRIPTION
## Context
From a support request, a candidate has entered a degree and from what they can see it is complete. However, they get a validation error when trying to mark it as complete. See https://becomingateacher.zendesk.com/agent/tickets/19044

This occurs because they filled out the degree until the "Have you completed this degree?" page and then left the flow. They then re-entered the flow to see a review page that looks as though that section has been filled in, and never filled it in.

## Changes proposed in this pull request
Handle the case where `predicted_grade` is `nil` in the db in the form and review pages

## Guidance to review
Have I missed anything?
