### PR TITLE
Sync course subject names from ttapi [2/3]

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -137,4 +137,8 @@ class Course < ApplicationRecord
       .where(application_choices: { course_options: { course: self } })
       .distinct
   end
+
+  def subject_codes
+    @subject_codes ||= subjects.includes(:course_subjects).map(&:code)
+  end
 end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,4 +1,5 @@
 class Subject < ApplicationRecord
+  has_many :course_subjects
   has_many :courses, through: :course_subjects
 
   validates :code, uniqueness: true

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -12,8 +12,8 @@ FactoryBot.define do
     age_range { '4 to 8' }
     withdrawn { false }
 
-    subject_codes { [Faker::Alphanumeric.alphanumeric(number: 2, min_alpha: 1).upcase] }
     funding_type { %w[fee salary apprenticeship].sample }
+    course_subjects { [association(:course_subject, course: instance)] }
 
     trait :open_on_apply do
       open_on_apply { true }

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :subject do
     name { Faker::Educator.subject }
-    code { Faker::Alphanumeric.alphanumeric(number: 2) }
+    code { Faker::Alphanumeric.alphanumeric(number: 4) }
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -111,4 +111,12 @@ RSpec.describe Course, type: :model do
       expect(course.in_previous_cycle).to eq course_in_previous_cycle
     end
   end
+
+  describe '#subject_codes' do
+    let(:course) { create(:course, subjects: [create(:subject, code: '01'), create(:subject, code: '9X')]) }
+
+    it 'returns an array with all the codes of the course subjects' do
+      expect(course.subject_codes).to contain_exactly('01', '9X')
+    end
+  end
 end

--- a/spec/services/open_provider_courses_spec.rb
+++ b/spec/services/open_provider_courses_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe OpenProviderCourses do
     course = create(:course, exposed_in_find: true, provider: provider)
 
     expect { described_class.new(provider: provider).call }
-      .to(change { course.audits.count }.from(1).to(2))
+      .to(change { course.audits.count }.from(2).to(3))
 
     expect(course.audits.last.audited_changes.keys).to include('open_on_apply')
   end

--- a/spec/services/provider_interface/hesa_data_export_spec.rb
+++ b/spec/services/provider_interface/hesa_data_export_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe ProviderInterface::HesaDataExport do
     end
 
     before do
-      @course = create(:course, study_mode: 'full_time', subject_codes: %w[F3 X9], provider: training_provider, accredited_provider: accredited_provider)
+      subjects = [create(:subject, code: 'F3'), create(:subject, code: 'X9')]
+      @course = create(:course, study_mode: 'full_time', subjects: subjects, provider: training_provider, accredited_provider: accredited_provider)
       application_qualification = create(
         :application_qualification,
         level: 'degree',

--- a/spec/system/find_sync/syncing_providers_spec.rb
+++ b/spec/system/find_sync/syncing_providers_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Syncing providers', sidekiq: true do
 
   def given_there_is_an_existing_provider_and_course_in_apply
     @existing_provider = create :provider, code: 'ABC', sync_courses: true
-    create :course, code: 'ABC1', provider: @existing_provider, subject_codes: %w[]
+    create :course, code: 'ABC1', provider: @existing_provider, subjects: %w[]
   end
 
   def and_there_is_a_provider_with_a_course_in_find


### PR DESCRIPTION
## Context

Use new subjects association to map course subject codes to exports

## Link to Trello card

https://trello.com/c/nkoWKwIn/3582-sync-course-subject-names-from-ttapi-2

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
