### PR TITLE
Use GovukComponent::InsetText

### DIFF
--- a/app/components/candidate_interface/add_reference_component.html.erb
+++ b/app/components/candidate_interface/add_reference_component.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-inset-text">
+<%= govuk_inset_text do %>
   <% if no_viable_references? %>
     <p class="govuk-body">You need 2 references before you can submit your application.</p>
     <%= govuk_link_to 'Add a referee', candidate_interface_references_start_path, button: true %>
@@ -10,4 +10,4 @@
     <p class="govuk-body">We’ll cancel any remaining requests when you’ve received 2 references.</p>
     <%= govuk_link_to 'Add another referee', candidate_interface_references_start_path, button: true, class: 'govuk-button--secondary' %>
   <% end %>
-</div>
+<% end %>

--- a/app/components/candidate_interface/apply_again_call_to_action_component.html.erb
+++ b/app/components/candidate_interface/apply_again_call_to_action_component.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-inset-text govuk-!-margin-top-0">
+<%= govuk_inset_text(classes: 'govuk-!-margin-top-0') do %>
   <h2 class="govuk-heading-m"><%= title %></h2>
 
   <p class="govuk-body">If now’s the right time, you can still apply for courses that start this academic year.</p>
@@ -13,4 +13,4 @@
     candidate_interface_apply_again_path,
     class: 'govuk-!-margin-bottom-0',
   ) %>
-</div>
+<% end %>

--- a/app/components/candidate_interface/incomplete_section_component.html.erb
+++ b/app/components/candidate_interface/incomplete_section_component.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-inset-text app-inset-text--narrow-border app-inset-text--<%= @error ? 'error' : 'important' %>" id="incomplete-<%= section %>-error">
+<%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--#{@error ? 'error' : 'important'}", html_attributes: { id: "incomplete-#{section}-error" }) do %>
   <p class="app-inset-text__title"><%= @text %></p>
   <p class="govuk-body"><%= govuk_link_to link_text, @section_path, class: 'govuk-link--no-visited-state', 'data-qa': "incomplete-#{section}" %></p>
-</div>
+<% end %>

--- a/app/components/candidate_interface/offers_call_to_action_component.html.erb
+++ b/app/components/candidate_interface/offers_call_to_action_component.html.erb
@@ -1,5 +1,5 @@
-<div class="govuk-inset-text govuk-!-margin-top-0">
+<%= govuk_inset_text(classes: 'govuk-!-margin-top-0') do %>
   <h2 class="govuk-heading-m"><%= title %></h2>
 
   <p class="govuk-body"><%= message %></p>
-</div>
+<% end %>

--- a/app/components/candidate_interface/restructured_work_history/gap_component.html.erb
+++ b/app/components/candidate_interface/restructured_work_history/gap_component.html.erb
@@ -1,6 +1,6 @@
-<div class="govuk-inset-text app-inset-text--important govuk-!-margin-top-0 govuk-!-margin-bottom-0">
+<%= govuk_inset_text(classes: 'app-inset-text--important govuk-!-margin-top-0 govuk-!-margin-bottom-0') do %>
   You have a break in your work history (<%= format_months_to_years_and_months(@break_period.length) %>)
   <br>
   <%= govuk_link_to 'Add another job', candidate_interface_new_restructured_work_history_path %> or
   <%= govuk_link_to 'add a reason for this break', candidate_interface_new_restructured_work_history_break_path(start_date: @break_period.start_date, end_date: @break_period.end_date) %>
-</div>
+<% end %>

--- a/app/components/interview_bookings_item_component.html.erb
+++ b/app/components/interview_bookings_item_component.html.erb
@@ -3,9 +3,9 @@
 <% else %>
   <p class="govuk-body">You have an interview scheduled for <%= formatted_time(interview) %></p>
   <p class="govuk-body govuk-!-margin-bottom-0">Information from provider:</p>
-  <div class="govuk-inset-text govuk-!-margin-top-1 govuk-!-margin-bottom-1">
+  <%= govuk_inset_text(classes: 'govuk-!-margin-top-1 govuk-!-margin-bottom-1') do %>
     <%= location(interview) %>
     <%= additional_details(interview) %>
-  </div>
+  <% end %>
   <p class="govuk-body">The provider will send more details about the interview by email.</p>
 <% end %>

--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -6,7 +6,7 @@
 <% if show_inset_text? -%>
   <div class="govuk-grid-row govuk-!-display-none-print">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <div class="govuk-inset-text govuk-!-margin-top-0">
+      <%= govuk_inset_text(classes: 'govuk-!-margin-top-0') do %>
         <% if respond_to_application? -%>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
             <% if FeatureFlag.active?(:interviews) %>
@@ -87,7 +87,7 @@
           </p>
           <%= govuk_link_to 'Give feedback', provider_interface_reasons_for_rejection_initial_questions_path(application_choice), button: true %>
         <% end -%>
-      </div>
+      <% end %>
     </div>
   </div>
 <% end -%>

--- a/app/components/provider_interface/application_offer_withdrawn_feedback_component.html.erb
+++ b/app/components/provider_interface/application_offer_withdrawn_feedback_component.html.erb
@@ -1,6 +1,4 @@
 <p class="govuk-body">
   The offer was withdrawn on <%= application_choice.offer_withdrawn_at.to_s(:govuk_date) %>. The following feedback was sent to the candidate.
 </p>
-<div class="govuk-inset-text">
-  <%= application_choice.offer_withdrawal_reason %>
-</div>
+<%= govuk_inset_text(text: application_choice.offer_withdrawal_reason) %>

--- a/app/components/provider_interface/application_rejection_feedback_component.html.erb
+++ b/app/components/provider_interface/application_rejection_feedback_component.html.erb
@@ -7,12 +7,12 @@
       The following feedback was sent to the candidate.
     <% end -%>
   </p>
-  <div class="govuk-inset-text">
+  <%= govuk_inset_text do %>
     <%= render ReasonsForRejectionComponent.new(
       application_choice: application_choice,
       reasons_for_rejection: ReasonsForRejection.new(application_choice.structured_rejection_reasons),
     ) %>
-  </div>
+  <% end %>
 <% else %>
   <%= render SummaryListComponent.new(rows: rejected_rows) %>
 <% end %>

--- a/app/components/support_interface/application_navigation_component.html.erb
+++ b/app/components/support_interface/application_navigation_component.html.erb
@@ -1,8 +1,8 @@
-<div class="govuk-inset-text app-inset-text--important app-inset-text--narrow-border govuk-!-margin-top-0">
+<%= govuk_inset_text(classes: 'app-inset-text--important app-inset-text--narrow-border govuk-!-margin-top-0') do %>
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Useful links for this application</h2>
   <ul class="govuk-list govuk-!-font-size-16">
     <% links.each do |link| %>
       <li><%= govuk_link_to link[:title], link[:href], class: 'govuk-link--no-visited-state' %></li>
     <% end %>
   </ul>
-</div>
+<% end %>

--- a/app/components/support_interface/ucas_match_action_component.html.erb
+++ b/app/components/support_interface/ucas_match_action_component.html.erb
@@ -1,17 +1,14 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop">
-    <div class="govuk-inset-text govuk-!-margin-top-0">
-      <h2 class="govuk-heading-s">
-        <%= inset_text_header %>
-      </h2>
-      <% if action_details.present? %>
-        <%= action_details %>
-      <% end %>
-      <% if @match.action_needed? && @match.requires_manual_action? %>
-        <%= form_with url: button[:path], method: :post do |f| %>
-          <%= f.govuk_submit button[:text] %>
-        <% end %>
-      <% end %>
-    </div>
-  </div>
-</div>
+
+<%= govuk_inset_text(classes: 'govuk-!-margin-top-0 govuk-!-width-two-thirds') do %>
+  <h2 class="govuk-heading-s">
+    <%= inset_text_header %>
+  </h2>
+  <% if action_details.present? %>
+    <%= action_details %>
+  <% end %>
+  <% if @match.action_needed? && @match.requires_manual_action? %>
+    <%= form_with url: button[:path], method: :post do |f| %>
+      <%= f.govuk_submit button[:text] %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/support_interface/ucas_match_action_component.rb
+++ b/app/components/support_interface/ucas_match_action_component.rb
@@ -68,7 +68,7 @@ module SupportInterface
     def required_action_details
       capture do
         concat tag.p(ACTIONS[@match.next_action][:instructions])
-        concat tag.p("Please refer to #{govuk_link_to('Dual-running user support manual', 'https://docs.google.com/document/d/1XvZiD8_ng_aG_7nvDGuJ9JIdPu6pFdCO2ujfKeFDOk4')} for more information about the current process.".html_safe)
+        concat tag.p("Please refer to the #{govuk_link_to('dual-running user support manual', 'https://docs.google.com/document/d/1XvZiD8_ng_aG_7nvDGuJ9JIdPu6pFdCO2ujfKeFDOk4')} for more information about the current process.".html_safe)
       end
     end
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -65,9 +65,10 @@ class Provider < ApplicationRecord
     accredited_providers.all?(&:onboarded?)
   end
 
-  def no_admin_users?
-    !(provider_permissions.exists?(manage_users: true) &&
-      provider_permissions.exists?(manage_organisations: true))
+  def lacks_admin_users?
+    sync_courses &&
+      !(provider_permissions.exists?(manage_users: true) &&
+        provider_permissions.exists?(manage_organisations: true))
   end
 
   def not_accepting_appplications_on_ucas?

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -12,10 +12,10 @@
     </h1>
 
     <% if @application_choices.present? && @application_form.can_add_more_choices? %>
-      <div class="govuk-inset-text">
+      <%= govuk_inset_text do %>
         <p class="govuk-body">You can choose <%= pluralize(current_application.choices_left_to_make, 'more course') %>.</p>
         <%= govuk_link_to t('application_form.courses.another.button'), candidate_interface_course_choices_choose_path, button: true, class: 'govuk-button--secondary' %>
-      </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/apply_from_find/_apply_using_ucas.html.erb
+++ b/app/views/candidate_interface/apply_from_find/_apply_using_ucas.html.erb
@@ -16,7 +16,7 @@
       When you apply you’ll need these codes for the Choices section of your application form:
     </p>
 
-    <div class="govuk-inset-text">
+    <%= govuk_inset_text do %>
       <ul class="govuk-list">
         <li class="govuk-!-margin-bottom-2">
           Training provider code:
@@ -55,7 +55,7 @@
           <% end %>
         </tbody>
       </table>
-    </div>
+    <% end %>
 
     <%= govuk_start_now_button(
       text: t('apply_from_find.ucas_apply_button'),

--- a/app/views/candidate_interface/course_choices/ucas/with_course.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas/with_course.html.erb
@@ -23,16 +23,16 @@
     <h2 class="govuk-heading-m">Make a note of your choice</h2>
     <p class="govuk-body">When you apply through UCAS, you’ll need these details for the course choices section of your application:</p>
 
-    <div class="govuk-inset-text govuk-!-margin-top-0 govuk-body">
+    <%= govuk_inset_text do %>
       Training provider:
-      <h2 class="govuk-header-l">
+      <h2 class="govuk-header-l govuk-!-margin-top-0">
         <%= @provider.name_and_code %>
       </h2>
       Training programme:
       <h2 class="govuk-header-l govuk-!-margin-top-0">
         <%= @course.name_and_code %>
       </h2>
-    </div>
+    <% end %>
 
     <p class="govuk-body govuk-!-margin-bottom-0"><%= govuk_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url, button: true %></p>
     <p class="govuk-body">or</p>

--- a/app/views/candidate_interface/degrees/grade/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/grade/_form_fields.html.erb
@@ -20,9 +20,7 @@
 <% else %>
 
   <% if degree.predicted_grade? %>
-    <div class="govuk-inset-text">
-      You must give an academic referee who can agree that you’re aiming for this grade.
-    </div>
+    <%= govuk_inset_text(text: 'You must give an academic referee who can agree that you’re aiming for this grade.') %>
   <% end %>
 
   <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: @page_title, size: 'xl', tag: 'h1' } do %>

--- a/app/views/candidate_interface/find_course_selections/confirm_selection.html.erb
+++ b/app/views/candidate_interface/find_course_selections/confirm_selection.html.erb
@@ -7,18 +7,16 @@
         <%= t('application_form.confirm_selection.heading') %>
       </h1>
 
-      <div class="govuk-inset-text govuk-!-margin-top-0">
-        <%= govuk_link_to @course_selection_form.course.find_url,
-                    class: 'govuk-!-font-weight-bold',
-                    style: 'text-decoration: none' do %>
-        <span class="govuk-!-font-size-19">
-          <%= @course_selection_form.course.provider.name %>
-        </span><br>
-        <span class="search-result-link-name govuk-!-font-size-24" style="text-decoration: underline">
-          <%= @course_selection_form.course.name_and_code %>
-        </span>
+      <%= govuk_inset_text(classes: 'govuk-!-margin-top-0') do %>
+        <%= govuk_link_to(@course_selection_form.course.find_url, class: 'govuk-!-font-weight-bold', style: 'text-decoration: none') do %>
+          <span class="govuk-!-font-size-19">
+            <%= @course_selection_form.course.provider.name %>
+          </span><br>
+          <span class="search-result-link-name govuk-!-font-size-24" style="text-decoration: underline">
+            <%= @course_selection_form.course.name_and_code %>
+          </span>
         <% end %>
-      </div>
+      <% end %>
 
       <%= f.govuk_radio_buttons_fieldset :confirm, legend: { text: t('application_form.confirm_selection.question'), size: 'm' } do %>
         <%= f.govuk_radio_button :confirm, true, label: { text: 'Yes' }, link_errors: true %>

--- a/app/views/candidate_interface/references/reminder/new.html.erb
+++ b/app/views/candidate_interface/references/reminder/new.html.erb
@@ -13,9 +13,7 @@
         <%= t('page_titles.references_send_reminder') %>
       </h1>
 
-      <p class="govuk-inset-text">
-        You can only send one reminder to this referee.
-      </p>
+      <%= govuk_inset_text(text: 'You can only send one reminder to this referee.') %>
 
       <% if @reference.next_automated_chase_at.present? %>
         <p class="govuk-body">

--- a/app/views/candidate_interface/shared/pilot_holding_page.html.erb
+++ b/app/views/candidate_interface/shared/pilot_holding_page.html.erb
@@ -10,11 +10,11 @@
 
     <p class="govuk-body-l"><%= service_name %> is a new GOV.UK service being trialled with a small number of training providers in England.</p>
 
-    <div class="govuk-inset-text">
+    <%= govuk_inset_text do %>
       Learn more about teacher training in <%= govuk_link_to 'Wales', 'https://www.discoverteaching.wales/routes-into-teaching/' %>,
       <%= govuk_link_to 'Scotland', 'https://teachinscotland.scot/' %> and
       <%= govuk_link_to 'Northern Ireland', 'https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland' %>.
-    </div>
+    <% end %>
 
     <h2 class="govuk-heading-m">Already have a <%= service_name %> account with us?</h2>
     <p class="govuk-body">Please <%= govuk_link_to 'sign in and continue your application', candidate_interface_sign_in_path %>.</p>

--- a/app/views/candidate_interface/unsubmitted_application_form/submit_show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/submit_show.html.erb
@@ -16,7 +16,7 @@
         as part of my application.
       </p>
 
-      <div class="govuk-inset-text">
+      <%= govuk_inset_text do %>
         <p class="govuk-body">
           As prospective teachers, all candidates must consent to an enhanced
           DBS check. This will show up any past criminal convictions, both
@@ -31,7 +31,7 @@
         <p class="govuk-body">
           <%= govuk_link_to t('application_form.submit_application.conviction_link'), 'https://www.gov.uk/exoffenders-and-employment' %>.
         </p>
-      </div>
+      <% end %>
 
       <%= f.govuk_radio_buttons_fieldset :further_information, legend: { text: t('application_form.further_information.further_information.label'), size: 'm' } do %>
         <%= f.govuk_radio_button :further_information, true, label: { text: 'Yes' }, link_errors: true do %>

--- a/app/views/provider_interface/reasons_for_rejection/check.html.erb
+++ b/app/views/provider_interface/reasons_for_rejection/check.html.erb
@@ -16,13 +16,13 @@
         Your feedback will be given to the candidate in the format below.
       </p>
 
-      <div class="govuk-inset-text">
+      <%= govuk_inset_text do %>
         <%= render ReasonsForRejectionComponent.new(
           application_choice: @application_choice,
           reasons_for_rejection: @wizard.to_model,
           editable: true,
         ) %>
-      </div>
+      <% end %>
 
       <% if @application_choice.rejected_by_default? %>
         <%= f.govuk_submit 'Send feedback' %>

--- a/app/views/referee_interface/reference/relationship.html.erb
+++ b/app/views/referee_interface/reference/relationship.html.erb
@@ -16,7 +16,7 @@
 
       <p class="govuk-body"><%= @application.full_name %> describes your relationship as follows:</p>
 
-      <p class="govuk-inset-text"><%= @relationship %></p>
+      <%= govuk_inset_text(text: @relationship) %>
 
       <%= f.govuk_radio_buttons_fieldset :relationship_confirmation, legend: { text: t('referee.relationship_confirmation.legend') } do %>
         <%= f.govuk_radio_button :relationship_confirmation, :yes, label: { text: t('referee.relationship_confirmation.yes.label') }, link_errors: true %>

--- a/app/views/support_interface/providers/_lacks_admin_users_warning.html.erb
+++ b/app/views/support_interface/providers/_lacks_admin_users_warning.html.erb
@@ -1,6 +1,6 @@
-<% if @provider.no_admin_users? %>
-  <div class="govuk-inset-text govuk-!-margin-bottom-4">
+<% if @provider.lacks_admin_users? %>
+  <%= govuk_inset_text do %>
     <h2 class="govuk-heading-m">No admin user</h2>
     <p class="govuk-body">This provider has no users with the ability to manage organisations and users.</p>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/support_interface/providers/_no_admin_users_warning.html.erb
+++ b/app/views/support_interface/providers/_no_admin_users_warning.html.erb
@@ -1,4 +1,4 @@
-<% if @provider.sync_courses? && @provider.no_admin_users? %>
+<% if @provider.no_admin_users? %>
   <div class="govuk-inset-text govuk-!-margin-bottom-4">
     <h2 class="govuk-heading-m">No admin user</h2>
     <p class="govuk-body">This provider has no users with the ability to manage organisations and users.</p>

--- a/app/views/support_interface/providers/_provider_navigation.html.erb
+++ b/app/views/support_interface/providers/_provider_navigation.html.erb
@@ -7,7 +7,7 @@
   }.merge(title != 'Details' ? { title => nil } : {})) %>
 <% end %>
 
-<%= render 'no_admin_users_warning' %>
+<%= render 'lacks_admin_users_warning' %>
 
 <%= render TabNavigationComponent.new(items: [
   { name: 'Details', url: support_interface_provider_path },

--- a/app/views/support_interface/providers/index.html.erb
+++ b/app/views/support_interface/providers/index.html.erb
@@ -23,7 +23,7 @@
             <span class="govuk-!-display-block govuk-!-margin-bottom-1">
               <%= govuk_link_to provider.name_and_code, support_interface_provider_path(provider) %>
             </span>
-            <% if provider.no_admin_users? %>
+            <% if provider.lacks_admin_users? %>
               <span class="govuk-caption-m">No admin user</span>
             <% end %>
           </td>


### PR DESCRIPTION
## Context

Use `GovukComponent::InsetText` to render inset text (via `govuk-components` `govuk_inset_text` helper method).

## Changes proposed in this pull request

* Essentially replaces HTML markup with equivalent method from the gem and its params
* Also fixes apparent bug with when ‘No admin users’ warning is shown in support

## Guidance to review

* Is this bug fix correct (see inline comment)? Am using the same test as used in the view that lists all provider users

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
