### PR TITLE
Show section title in ‘Providers‘ breadcrumb

### DIFF
--- a/app/views/support_interface/application_forms/_application_navigation.html.erb
+++ b/app/views/support_interface/application_forms/_application_navigation.html.erb
@@ -3,7 +3,7 @@
     'Candidates': support_interface_applications_path,
     @application_form.candidate.email_address => support_interface_candidate_path(@application_form.candidate),
     @application_form.support_reference => support_interface_application_form_path(@application_form),
-  }.merge(title != 'Details' ? { title: nil } : {})) %>
+  }.merge(title != 'Details' ? { title => nil } : {})) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/support_interface/course/_course_navigation.html.erb
+++ b/app/views/support_interface/course/_course_navigation.html.erb
@@ -6,7 +6,7 @@
     @course.provider.name => support_interface_provider_path(@course.provider),
     'Courses': support_interface_provider_courses_path(@course.provider),
     @course.name => support_interface_course_path(@course),
-  }.merge(title != 'Details' ? { title: nil } : {})) %>
+  }.merge(title != 'Details' ? { title => nil } : {})) %>
 <% end %>
 
 <%= render TabNavigationComponent.new(items: [

--- a/app/views/support_interface/data_exports/_data_export_navigation.html.erb
+++ b/app/views/support_interface/data_exports/_data_export_navigation.html.erb
@@ -6,7 +6,7 @@
     'Performance': support_interface_performance_path,
     'Data directory': support_interface_data_directory_path,
     params[:data_export_type].humanize => support_interface_view_export_information_path,
-  }.merge(title != 'Details' ? { title: nil } : {})) %>
+  }.merge(title != 'Details' ? { title => nil } : {})) %>
 <% end %>
 
 <%= render TabNavigationComponent.new(items: [

--- a/app/views/support_interface/provider_users/_provider_user_navigation.html.erb
+++ b/app/views/support_interface/provider_users/_provider_user_navigation.html.erb
@@ -5,7 +5,7 @@
     'Providers': support_interface_providers_path,
     'Provider users': support_interface_provider_users_path,
     provider_user.display_name => support_interface_provider_user_path(provider_user),
-  }.merge(title != 'Details' ? { title: nil } : {})) %>
+  }.merge(title != 'Details' ? { title => nil } : {})) %>
 <% end %>
 
 <%= render TabNavigationComponent.new(items: [

--- a/app/views/support_interface/providers/_provider_navigation.html.erb
+++ b/app/views/support_interface/providers/_provider_navigation.html.erb
@@ -4,7 +4,7 @@
   <%= breadcrumbs({
     'Providers': support_interface_providers_path(onboarding_stages: %w[synced dsa_signed]),
     @provider.name => support_interface_provider_path(@provider),
-  }.merge(title != 'Details' ? { title: nil } : {})) %>
+  }.merge(title != 'Details' ? { title => nil } : {})) %>
 <% end %>
 
 <%= render 'no_admin_users_warning' %>

--- a/app/views/support_interface/ucas_matches/_ucas_match_navigation.html.erb
+++ b/app/views/support_interface/ucas_matches/_ucas_match_navigation.html.erb
@@ -6,7 +6,7 @@
     'Candidates': support_interface_candidates_path,
     'UCAS matches': support_interface_ucas_matches_path,
     @match.candidate.email_address => support_interface_ucas_match_path(@match),
-  }.merge(title != 'Details' ? { title: nil } : {})) %>
+  }.merge(title != 'Details' ? { title => nil } : {})) %>
 <% end %>
 
 <%= render TabNavigationComponent.new(items: [


### PR DESCRIPTION
## Context

Fixes ‘title’ appearing in ‘Providers’ breadcrumb in support.

## Changes proposed in this pull request

| Before | After |
| - | - |
| <img width="500" alt="Screenshot 2021-04-12 at 19 19 40" src="https://user-images.githubusercontent.com/813383/114442169-2ca77780-9bc4-11eb-948f-e493e9f00cb1.png"> | <img width="510" alt="Screenshot 2021-04-12 at 19 19 30" src="https://user-images.githubusercontent.com/813383/114442167-2b764a80-9bc4-11eb-8c82-e2d191d93f31.png"> |

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
