### PR TITLE
Tweaks to interview changes export

### DIFF
--- a/app/exports/interview_changes_export.yml
+++ b/app/exports/interview_changes_export.yml
@@ -2,7 +2,7 @@ common_columns:
 - provider_code
 - course_code
 - candidate_id
-- application_form_id
+- application_choice_id
 - provider_id
 
 custom_columns:
@@ -24,12 +24,6 @@ custom_columns:
   provider_user:
     type: string
     description: Email address of the user who made the change, or 'Support' if done by support
-  interview_status:
-    type: string
-    description: Whether the interview was upcoming or past when the change was made
-    enum:
-      - upcoming
-      - past
   date_and_time:
     type: datetime
     description: |

--- a/app/services/support_interface/interview_changes_export.rb
+++ b/app/services/support_interface/interview_changes_export.rb
@@ -21,10 +21,9 @@ module SupportInterface
         audit_type: audit.action,
         interview_id: interview.id,
         candidate_id: application_choice.candidate.id,
-        application_form_id: application_choice.application_form.id,
+        application_choice_id: application_choice.id,
         provider_code: application_choice.provider.code,
         provider_user: audit_user(audit),
-        interview_status: interview_status(interview, audit),
         interview_preferences: application_choice.application_form.interview_preferences,
         application_submitted_at: application_choice.application_form.submitted_at,
         course_code: application_choice.course.code,
@@ -41,31 +40,6 @@ module SupportInterface
           application_choice: %i[application_form course site candidate provider],
         },
       )
-    end
-
-    def interview_status(interview, audit)
-      if audit.created_at < interview_time_when_change_made(interview, audit)
-        'upcoming'
-      else
-        'past'
-      end
-    end
-
-    def interview_time_when_change_made(interview, audit)
-      # We want to return the time the interview was scheduled for at the time of the audit.
-      # If the time was changed, then return the original time from the audited_changes.
-      # If the time was not changed, then it is either an upcoming interview (since the validation means you can't make it in the past)
-      # or it is a cancellation and the interview time on the interview model is representative.
-      interview_time_from_audit(audit).presence || interview.date_and_time
-    end
-
-    def interview_time_from_audit(audit)
-      audited_time = audit.audited_changes['date_and_time']
-      if audited_time.is_a?(Array)
-        Time.zone.parse(audited_time.first)
-      elsif audited_time.present?
-        Time.zone.parse(audited_time)
-      end
     end
 
     def interview_change(audit)

--- a/spec/services/support_interface/interview_changes_export_spec.rb
+++ b/spec/services/support_interface/interview_changes_export_spec.rb
@@ -58,10 +58,9 @@ RSpec.describe SupportInterface::InterviewChangesExport do
           audit_type: 'create',
           interview_id: interview.id,
           candidate_id: interview.application_choice.candidate.id,
-          application_form_id: interview.application_choice.application_form.id,
+          application_choice_id: interview.application_choice.id,
           provider_code: interview.application_choice.provider.code,
           provider_user: create_interview_audit.user.email_address,
-          interview_status: 'upcoming',
           interview_preferences: interview.application_choice.application_form.interview_preferences,
           application_submitted_at: interview.application_choice.application_form.submitted_at,
           course_code: interview.application_choice.course.code,
@@ -79,10 +78,9 @@ RSpec.describe SupportInterface::InterviewChangesExport do
           audit_type: 'update',
           interview_id: interview.id,
           candidate_id: interview.application_choice.candidate.id,
-          application_form_id: interview.application_choice.application_form.id,
+          application_choice_id: interview.application_choice.id,
           provider_code: interview.application_choice.provider.code,
           provider_user: edit_interview_audit.user.email_address,
-          interview_status: 'upcoming',
           interview_preferences: interview.application_choice.application_form.interview_preferences,
           application_submitted_at: interview.application_choice.application_form.submitted_at,
           course_code: interview.application_choice.course.code,
@@ -156,10 +154,6 @@ RSpec.describe SupportInterface::InterviewChangesExport do
         expect(row[:audit_type]).to eq('update')
       end
 
-      it 'sets the interview status to upcoming' do
-        expect(row[:interview_status]).to eq('upcoming')
-      end
-
       it 'sets correct interview attributes' do
         expect(row[:provider_id]).to be_blank
         expect(row[:date_and_time]).to eq(2.days.from_now.to_s)
@@ -207,16 +201,12 @@ RSpec.describe SupportInterface::InterviewChangesExport do
         expect(row[:location]).to eq('New Zoom link')
         expect(row[:additional_details]).to be_blank
       end
-
-      it 'sets the interview status to past' do
-        expect(row[:interview_status]).to eq('past')
-      end
     end
 
     describe 'application related columns' do
       it 'returns columns relating to the application' do
         expect(row[:candidate_id]).to eq(interview.application_choice.candidate.id)
-        expect(row[:application_form_id]).to eq(interview.application_choice.application_form_id)
+        expect(row[:application_choice_id]).to eq(interview.application_choice_id)
         expect(row[:provider_code]).to eq(interview.application_choice.provider.code)
         expect(row[:interview_preferences]).to eq(interview.application_choice.application_form.interview_preferences)
         expect(row[:application_submitted_at]).to eq(interview.application_choice.application_form.submitted_at)


### PR DESCRIPTION
## Context
The interview_status column was not useful, and it will be more useful for analysis to have the choice id rather than the form id

## Changes proposed in this pull request
Delete interview_status column
Return application choice id rather than form id

## Link to Trello card
https://trello.com/c/foWQBJeP/3598-updates-to-the-interview-changes-extract-in-support

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
