### PR TITLE
Remove duplicate references from the ApplicationReferences export

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -15,7 +15,7 @@ class DataExport < ApplicationRecord
     application_references: {
       name: 'Application references',
       export_type: 'application_references',
-      description: 'A list of all application references which have been selected by candidates to date.',
+      description: 'A list of all application references which have been selected by candidates to date. All duplicate references caused by duplication of a candidates application form caused by Applying Again or carrying over their application between cycles have been removed.',
       class: SupportInterface::ApplicationReferencesExport,
     },
     application_timings: {

--- a/app/services/support_interface/application_references_export.rb
+++ b/app/services/support_interface/application_references_export.rb
@@ -11,7 +11,7 @@ module SupportInterface
           application_state: ProcessState.new(application_form).state,
         }
 
-        application_form.application_references.map.with_index(1) do |reference, index|
+        application_form.application_references.reject(&:duplicate).map.with_index(1) do |reference, index|
           output[:"ref_#{index}_type"] = reference.referee_type
           output[:"ref_#{index}_state"] = reference.feedback_status
           output[:"ref_#{index}_requested_at"] = reference.requested_at


### PR DESCRIPTION
## Context

At the moment, duplicate references are exposed in the ApplicationReference export. This causes issues with automation of the export analysis purposes as specific columns are used to calculate average response time etc. which is skewed when you have duplicate values.

## Changes proposed in this pull request

- Reject duplicate references from the ApplicationReference export

## Guidance to review

Does this seem reasonable?

There's definitely a trade-off as this is now only showing *new* references which could be slightly misleading if you don't know that is the behaviour.

## Link to Trello card

https://trello.com/c/hXZDSy12/3264-remove-duplicate-references-from-the-applicationreferenceexport

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
