### PR TITLE
Add ContentSecurityPolicy header

### DIFF
--- a/app/middlewares/apply/content_security_policy_middleware.rb
+++ b/app/middlewares/apply/content_security_policy_middleware.rb
@@ -1,0 +1,15 @@
+module Apply
+  class ContentSecurityPolicyMiddleware < ActionDispatch::ContentSecurityPolicy::Middleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      if FeatureFlag.active?(:content_security_policy)
+        super
+      else
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -29,6 +29,7 @@ class FeatureFlag
     [:updated_offer_flow, 'Activates the new make offer flow for providers', 'Despo Pentara'],
     [:unconditional_offers_via_api, 'Activates the ability to accept unconditional offers via the API', 'Steve Laing'],
     [:configurable_provider_notifications, 'Providers can manage individual email notifications', 'Aga Dufrat'],
+    [:content_security_policy, 'Enables the content security policy declared in `config/initializers/content_security_policy.rb`', 'Steve Hook'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
@@ -4,8 +4,6 @@
   <%= other_qualifications_title(current_application) %>
 </h1>
 
-<%= render 'candidate_interface/other_qualifications/shared/instructions' %>
-
 <%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { text: 'What type of qualification do you want to add?', size: 'm' } do %>
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::GCSE_TYPE, label: { text: 'GCSE' }, link_errors: true %>
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::A_LEVEL_TYPE, label: { text: 'A level' } %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -37,7 +37,7 @@
   </head>
 
   <body class="govuk-template__body <%= yield :body_class %>">
-    <script>
+    <script nonce="<%= request.content_security_policy_nonce %>">
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 

--- a/app/views/shared/_analytics.html.erb
+++ b/app/views/shared/_analytics.html.erb
@@ -1,6 +1,6 @@
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=<%= @google_analytics_id %>"></script>
-<script>
+<script nonce="<%= request.content_security_policy_nonce %>">
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());

--- a/app/views/shared/_zendesk_snippet.html.erb
+++ b/app/views/shared/_zendesk_snippet.html.erb
@@ -1,1 +1,5 @@
-<script id="ze-snippet" src=https://static.zdassets.com/ekr/snippet.js?key=904d04ae-8027-4ebb-ad39-d0e9f68d6ab1> </script>
+<script
+  id="ze-snippet"
+  nonce="<%= request.content_security_policy_nonce %>"
+  src=https://static.zdassets.com/ekr/snippet.js?key=904d04ae-8027-4ebb-ad39-d0e9f68d6ab1>
+</script>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,19 +4,19 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
-#   # If you are using webpack-dev-server then specify webpack-dev-server host
-#   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self, :https
+  policy.font_src    :self, :https, :data
+  policy.img_src     :self, :https, :data
+  policy.object_src  :none
+  policy.script_src  :self, :https
+  policy.style_src   :self, :https
+  # If you are using webpack-dev-server then specify webpack-dev-server host
+  policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  # Specify URI for violation reports
+  # policy.report_uri "/csp-violation-report-endpoint"
+end
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -5,24 +5,27 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 Rails.application.config.content_security_policy do |policy|
-  policy.default_src :self, :https
+  connect_src = ['wss://widget-mediator.zopim.com']
+  connect_src << 'http://localhost:3035' << 'ws://localhost:3035' if Rails.env.development?
+
+  policy.default_src :self, :https, 'www.googletagmanager.com', 'static.zdassets.com'
   policy.font_src    :self, :https, :data
   policy.img_src     :self, :https, :data
   policy.object_src  :none
   policy.script_src  :self, :https
-  policy.style_src   :self, :https
+  policy.style_src   :self, :https, :unsafe_inline
   # If you are using webpack-dev-server then specify webpack-dev-server host
-  policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
 
+  policy.connect_src :self, :https, *connect_src
   # Specify URI for violation reports
   # policy.report_uri "/csp-violation-report-endpoint"
 end
 
 # If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
 
 # Set the nonce only to specific directives
-# Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
+Rails.application.config.content_security_policy_nonce_directives = %w[script-src]
 
 # Report CSP violations to a specified URI
 # For further information see the following documentation:

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -5,18 +5,17 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 Rails.application.config.content_security_policy do |policy|
-  connect_src = ['wss://widget-mediator.zopim.com']
-  connect_src << 'http://localhost:3035' << 'ws://localhost:3035' if Rails.env.development?
-
+  # Include sources for Google Analytics and ZenDesk integration
   policy.default_src :self, :https, 'www.googletagmanager.com', 'static.zdassets.com'
   policy.font_src    :self, :https, :data
   policy.img_src     :self, :https, :data
   policy.object_src  :none
   policy.script_src  :self, :https, 'www.googletagmanager.com', 'static.zdassets.com', :unsafe_inline, :unsafe_eval
   policy.style_src   :self, :https, :unsafe_inline
-  # If you are using webpack-dev-server then specify webpack-dev-server host
 
-  policy.connect_src :self, :https, *connect_src
+  # For ZenDesk chat
+  policy.connect_src :self, :https, 'wss://widget-mediator.zopim.com'
+
   # Specify URI for violation reports
   # policy.report_uri "/csp-violation-report-endpoint"
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,3 +1,5 @@
+require_relative '../../app/middlewares/apply/content_security_policy_middleware'
+
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy
@@ -30,3 +32,10 @@ Rails.application.config.content_security_policy_nonce_directives = %w[script-sr
 # For further information see the following documentation:
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
 # Rails.application.config.content_security_policy_report_only = true
+
+# Subclass the built-in CSP middleware so that we can feature flag it.
+# Delete this when retiring the :content_security_policy feature flag.
+Rails.application.configure do
+  config.middleware.insert_after ActionDispatch::ContentSecurityPolicy::Middleware, Apply::ContentSecurityPolicyMiddleware
+  config.middleware.delete ActionDispatch::ContentSecurityPolicy::Middleware
+end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,7 +12,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.font_src    :self, :https, :data
   policy.img_src     :self, :https, :data
   policy.object_src  :none
-  policy.script_src  :self, :https
+  policy.script_src  :self, :https, 'www.googletagmanager.com', 'static.zdassets.com', :unsafe_inline, :unsafe_eval
   policy.style_src   :self, :https, :unsafe_inline
   # If you are using webpack-dev-server then specify webpack-dev-server host
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "env": [
       "jest"
     ],
-    "globals": ["$", "history"]
+    "globals": [
+      "$",
+      "history"
+    ]
   }
 }

--- a/spec/mailers/previews/rails/mailers/email.html.erb
+++ b/spec/mailers/previews/rails/mailers/email.html.erb
@@ -108,7 +108,7 @@
   </p>
 <% end %>
 
-<script>
+<script nonce="<%= request.content_security_policy_nonce %>">
   function refreshBody(reload) {
     var part_select = document.querySelector('select#part');
     var locale_select = document.querySelector('select#locale');

--- a/spec/middlewares/apply/content_security_policy_middleware_spec.rb
+++ b/spec/middlewares/apply/content_security_policy_middleware_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Apply::ContentSecurityPolicyMiddleware, type: :request do
+  let(:status) { 200 }
+  let(:headers) { { 'HEADER' => 'Yeah!' } }
+  let(:mock_response) { ['Hellowwworlds!'] }
+
+  def mock_app
+    main_app = lambda { |env|
+      @env = env
+      [status, headers, @body || mock_response]
+    }
+
+    builder = Rack::Builder.new
+    builder.use Apply::ContentSecurityPolicyMiddleware
+    builder.run main_app
+    @app = builder.to_app
+  end
+
+  before do
+    mock_app
+  end
+
+  describe 'with content_security_policy feature flag active' do
+    it 'sets the CSP header' do
+      FeatureFlag.activate(:content_security_policy)
+      get '/foo'
+
+      expect(response.header).to have_key('Content-Security-Policy')
+    end
+  end
+
+  describe 'with content_security_policy feature flag inactive' do
+    it 'does NOT set the CSP header' do
+      FeatureFlag.deactivate(:content_security_policy)
+      get '/foo'
+
+      expect(response.header).not_to have_key('Content-Security-Policy')
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR configures our application to set the ContentSecurityPolicy response header. This limits the kind of content that browsers will run in our service. For example, we only allow JavaScript to run from our own site or a short whitelist of trusted providers. This helps to mitigate the risk of XSS.

## Changes proposed in this pull request

- Uncomment the default CSP config in `config/initializers/content_security_policy.rb`.
- We pull in a handful of scripts from external sites (for ZenDesk and Google Analytics). We need to whitelist these.
- We have a few inline JavaScripts. We can use a nonce to validate these.
- We have a few inline CSS `style` elements. There doesn't seem to be a way to use a nonce to validate these in the same way as JavaScript so we permit unsafe_inline for styles. See https://github.com/omniauth/omniauth/blob/a62d36b3f847e0e55b077790112e96950c35085a/lib/omniauth/form.rb
- ZenDesk integration also uses Web sockets (for live chat I guess) and this too needs to be whitelisted.

## Guidance to review

- Is anything missing?
- I would have liked to have feature-flagged this change because it potentially breaks significant pieces of functionality. But given that the config is loaded in an initialiser I don't think it would be an effective way to switch it off (you need to restart the application servers). Is there another way that we can de-risk this change?
- Is it reasonable to allow `unsafe-inline` CSS?

## Link to Trello card

https://trello.com/c/ApkZRgMC/3259-pentest-416-were-missing-application-security-headers-low-🚧

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
