### PR TITLE
Sync course subject names from ttapi [3/3]

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -60,7 +60,6 @@ module TeacherTrainingPublicAPI
         subject = ::Subject.find_or_initialize_by(code: code)
         course.subjects << subject unless course.course_subjects.exists?(subject_id: subject.id)
       end
-      course.subject_codes = course_from_api.subject_codes
     end
 
     def study_mode(course_from_api)

--- a/db/migrate/20210412143252_remove_subject_codes_from_course.rb
+++ b/db/migrate/20210412143252_remove_subject_codes_from_course.rb
@@ -1,0 +1,5 @@
+class RemoveSubjectCodesFromCourse < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :courses, :subject_codes, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -403,7 +403,6 @@ ActiveRecord::Schema.define(version: 2021_04_15_141658) do
     t.string "course_length"
     t.string "description"
     t.integer "accredited_provider_id"
-    t.jsonb "subject_codes"
     t.string "funding_type"
     t.string "age_range"
     t.jsonb "qualifications"

--- a/spec/system/find_sync/syncing_providers_spec.rb
+++ b/spec/system/find_sync/syncing_providers_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Syncing providers', sidekiq: true do
     and_there_is_a_provider_with_a_course_in_find
 
     when_the_sync_runs
-    then_it_updates_the_course_subject_codes
+    then_it_updates_the_course_subjects
     and_it_sets_the_last_synced_timestamp
   end
 
@@ -42,10 +42,10 @@ RSpec.describe 'Syncing providers', sidekiq: true do
     TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async
   end
 
-  def then_it_updates_the_course_subject_codes
+  def then_it_updates_the_course_subjects
     course = Course.find_by(code: 'ABC1')
 
-    expect(course.subject_codes).to eq(%w[08])
+    expect(course.subjects.map(&:code)).to eq(%w[08])
   end
 
   def and_it_sets_the_last_synced_timestamp


### PR DESCRIPTION
## Context

Removes `subject_codes` field from `courses` table

## Link to Trello card

https://trello.com/c/81C0pJrz/3583-sync-course-subject-names-from-ttapi-3

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
