### PR TITLE
Fix incorrect error message in the add course Apply Again journey

### DIFF
--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -14,7 +14,9 @@ module CandidateInterface
         flash[:warning] = "You have already selected #{course.name_and_code}."
         redirect_to candidate_interface_course_choices_review_path
       elsif current_application.has_the_maximum_number_of_course_choices?
-        flash[:warning] = I18n.t('errors.messages.too_many_course_choices', course_name_and_code: course.name_and_code)
+        error_message_key = current_application.apply_1? ? 'errors.messages.too_many_course_choices' : 'errors.messages.apply_again_course_already_chosen'
+        flash[:warning] = I18n.t(error_message_key, course_name_and_code: course.name_and_code)
+
         redirect_to candidate_interface_course_choices_review_path
       else
         redirect_to candidate_interface_course_confirm_selection_path(course.id)

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     when_i_arrive_at_the_apply_from_find_page_with_course_params_with_one_site
     then_i_should_see_the_courses_review_page
     and_i_should_be_informed_i_already_have_3_courses
+
+    given_the_course_i_selected_has_multiple_sites
+    and_i_am_an_existing_candidate_on_apply
+    and_i_am_signed_in
+    and_i_am_applying_again
+    and_i_have_1_application_choice
+
+    when_i_arrive_at_the_apply_from_find_page_with_course_params_with_one_site
+    then_i_should_see_the_courses_review_page
+    and_i_should_be_informed_i_can_only_have_1_course_choice
   end
 
   def given_the_pilot_is_open
@@ -170,6 +180,18 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
 
   def and_i_should_be_informed_i_have_already_selected_that_course
     expect(page).to have_content "You have already selected #{@course.name_and_code}."
+  end
+
+  def and_i_am_applying_again
+    @candidate.current_application.apply_2!
+  end
+
+  def and_i_have_1_application_choice
+    create(:application_choice, application_form: @candidate.current_application)
+  end
+
+  def and_i_should_be_informed_i_can_only_have_1_course_choice
+    expect(page).to have_content t('errors.messages.apply_again_course_already_chosen', course_name_and_code: @course.name_and_code)
   end
 
 private


### PR DESCRIPTION
## Context

At the moment, if a candidate has an apply_2 application form with an application choice, when they arrive from Find with course params then they are told that they cannot have more than 3 courses associated with their application form.

This commit checks to see if the application form is apply_1 or apply_2 before rendering the correct error message.

## Changes proposed in this pull request

- Ensure that the `apply_again_course_already_chosen` error is rendered when a candidate already has a course choice on their application form and arrives from Find with course params in the query string.

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/114585127-3a6c0400-9c7b-11eb-8736-2a7c75dd9832.png)|![image](https://user-images.githubusercontent.com/42515961/114584833-eeb95a80-9c7a-11eb-96cc-3b71a340fb8e.png)|

## Link to Trello card

https://trello.com/c/Z1ySPc8g/3292-bug-fix-incorrect-add-course-choice-error-message-for-apply-again-applications

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
