### PR TITLE
Resolve ActiveModel::Errors deprecation warnings

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,11 +2,11 @@ class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def not_found
-    render 'not_found.html', status: :not_found
+    render 'not_found', status: :not_found, formats: %i[html]
   end
 
   def unprocessable_entity
-    render 'unprocessable_entity.html', status: :unprocessable_entity
+    render 'unprocessable_entity', status: :unprocessable_entity, formats: %i[html]
   end
 
   def not_acceptable
@@ -31,7 +31,7 @@ class ErrorsController < ApplicationController
       end
 
       format.any do
-        render 'internal_server_error.html', status: :internal_server_error
+        render 'internal_server_error', status: :internal_server_error, formats: %i[html]
       end
     end
   end

--- a/app/forms/candidate_interface/pick_site_form.rb
+++ b/app/forms/candidate_interface/pick_site_form.rb
@@ -44,7 +44,7 @@ module CandidateInterface
                     'errors.messages.too_many_course_choices'
                   end
 
-      errors[:base] << I18n.t!(error_key, course_name_and_code: course_option.course.name_and_code)
+      errors.add(:base, I18n.t!(error_key, course_name_and_code: course_option.course.name_and_code))
     end
   end
 end

--- a/app/forms/provider_interface/application_data_export_form.rb
+++ b/app/forms/provider_interface/application_data_export_form.rb
@@ -37,13 +37,13 @@ module ProviderInterface
 
     def at_least_one_recruitment_cycle_year_is_selected
       if recruitment_cycle_years.all?(&:blank?)
-        errors[:recruitment_cycle_years] << 'Select at least one year'
+        errors.add(:recruitment_cycle_years, 'Select at least one year')
       end
     end
 
     def at_least_one_status_is_selected
       if statuses.all?(&:blank?)
-        errors[:statuses] << 'Select at least one status'
+        errors.add(:statuses, 'Select at least one status')
       end
     end
 

--- a/app/forms/provider_interface/fields_for_provider_user_permissions_form.rb
+++ b/app/forms/provider_interface/fields_for_provider_user_permissions_form.rb
@@ -25,7 +25,7 @@ module ProviderInterface
 
     def at_least_one_extra_permission_is_set
       if permissions.reject(&:blank?).none?
-        errors[:permissions] << 'Select extra permissions'
+        errors.add(:permissions, 'Select extra permissions')
       end
     end
   end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -196,8 +196,8 @@ module ProviderInterface
       condition_models.map(&:valid?).all?
 
       condition_models.each do |model|
-        model.errors.each do |key, message|
-          errors.add("further_conditions[#{model.id}][#{key}]", message)
+        model.errors.each do |error|
+          errors.add("further_conditions[#{model.id}][#{error.attribute}]", error.message)
         end
       end
     end

--- a/app/forms/provider_interface/provider_relationship_permissions_setup_wizard.rb
+++ b/app/forms/provider_interface/provider_relationship_permissions_setup_wizard.rb
@@ -152,8 +152,8 @@ module ProviderInterface
     def validate_permissions_form
       return if current_permissions_form.valid?
 
-      current_permissions_form.errors.map do |key, message|
-        errors.add("provider_relationship_permissions[#{current_provider_relationship_id}][#{key}]", message)
+      current_permissions_form.errors.map do |error|
+        errors.add("provider_relationship_permissions[#{current_provider_relationship_id}][#{error.attribute}]", error.message)
       end
     end
   end

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -122,8 +122,8 @@ module ProviderInterface
     def permission_form_is_valid
       return if permissions_form.valid?
 
-      permissions_form.errors.map do |key, message|
-        errors.add("provider_permissions[#{permissions_form.id}][#{key}]", message)
+      permissions_form.errors.each do |error|
+        errors.add("provider_permissions[#{permissions_form.id}][#{error.attribute}]", error.message)
       end
     end
 

--- a/app/forms/provider_interface/provider_user_providers_form.rb
+++ b/app/forms/provider_interface/provider_user_providers_form.rb
@@ -40,7 +40,7 @@ module ProviderInterface
 
     def at_least_one_provider_is_selected
       if selected_providers.none?
-        errors[:provider_ids] << 'Select which organisations this user will have access to'
+        errors.add(:provider_ids, 'Select which organisations this user will have access to')
       end
     end
 

--- a/app/forms/support_interface/provider_relationships_form.rb
+++ b/app/forms/support_interface/provider_relationships_form.rb
@@ -46,8 +46,8 @@ module SupportInterface
     def all_relationships_valid?
       @relationships.each do |relationship|
         relationship.valid?
-        relationship.errors.map do |key, message|
-          errors.add("relationships[#{relationship.id}][#{key}]", message)
+        relationship.errors.each do |error|
+          errors.add("relationships[#{relationship.id}][#{error.attribute}]", error.message)
         end
       end
     end

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -5,7 +5,7 @@ class PostcodeValidator < ActiveModel::EachValidator
     postcode = UKPostcode.parse(value)
 
     unless postcode.full_valid?
-      record.errors[attribute] << I18n.t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.postcode.invalid')
+      record.errors.add(attribute, I18n.t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.postcode.invalid'))
     end
   end
 end

--- a/app/validators/valid_for_notify_validator.rb
+++ b/app/validators/valid_for_notify_validator.rb
@@ -10,7 +10,7 @@ class ValidForNotifyValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, value)
     if value.blank? || !value.match?(EMAIL_REGEX)
-      record.errors[attribute] << I18n.t('validation_errors.email_address_format')
+      record.errors.add(attribute, I18n.t('validation_errors.email_address_format'))
     end
   end
 end


### PR DESCRIPTION
Resolves deprecation warnings listed below

1. DEPRECATION WARNING: Rendering actions with '.' in the name is deprecated
2. DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. 
3. DEPRECATION WARNING: Enumerating ActiveModel::Errors as a hash has been deprecated
