### PR TITLE
Make unique courses per application invariant check more lenient

### DIFF
--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -122,6 +122,7 @@ class DetectInvariants
     applications_with_the_same_choice = ApplicationForm
       .joins(application_choices: [:course_option])
       .where.not(submitted_at: nil)
+      .where.not("application_choices.status": %w[withdrawn rejected])
       .group('application_forms.id', 'course_options.course_id')
       .having('COUNT(DISTINCT course_options.course_id) < COUNT(application_choices.id)')
 

--- a/spec/workers/detect_invariants_spec.rb
+++ b/spec/workers/detect_invariants_spec.rb
@@ -147,5 +147,21 @@ RSpec.describe DetectInvariants do
         ),
       )
     end
+
+    it 'ignores withdrawn and rejected application choices submitted with the same course' do
+      course = create(:course)
+      course_option1 = create(:course_option, course: course)
+      course_option2 = create(:course_option, course: course)
+      course_option3 = create(:course_option, course: course)
+      application_form = create(:completed_application_form)
+
+      create(:submitted_application_choice, status: :withdrawn, application_form: application_form, course_option: course_option1)
+      create(:submitted_application_choice, status: :rejected, application_form: application_form, course_option: course_option2)
+      create(:submitted_application_choice, application_form: application_form, course_option: course_option3)
+
+      DetectInvariants.new.perform
+
+      expect(Raven).not_to have_received(:capture_exception)
+    end
   end
 end


### PR DESCRIPTION
## Context
There are some applications which do not pass the check, even though they should really be valid. We want to allow multiple applications to the same course if the application choices have reached a non-success state.

## Changes proposed in this pull request
Ignore application choices that have been withdrawn or rejected when checking if a candidate has applied to the same course multiple times

## Guidance to review
Withdrawn is actually an end state, it's not possible to go back without support help.
Rejected is not actually an end state, since it's possible to make an offer on a rejected application. I don't think we need to worry about this until it happens, especially since we'll be notified by the checks if they break.

## Slack thread
https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1618063976394000

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
