### PR TITLE
Remove deprecated `html_options` from `govuk_collection_select`

### DIFF
--- a/app/views/support_interface/validation_errors/summary.html.erb
+++ b/app/views/support_interface/validation_errors/summary.html.erb
@@ -25,12 +25,10 @@
                 options: {
                   selected: params['sortby'] || 'all_time',
                 },
-                html_options: {
-                  class: 'sortedby-label',
-                  selected: 2,
-                  onchange: 'this.form.submit()',
-                  role: 'listbox',
-                },
+                class: 'sortedby-label',
+                selected: 2,
+                onchange: 'this.form.submit()',
+                role: 'listbox',
               ) %>
         </div>
         <%= f.govuk_submit('Update') %>


### PR DESCRIPTION

## Context

The latest bump to the gem `govuk_design_system_formbuilder` deprecated `html_options` on `govuk_collection_select`. This only appears in one instance in our app

## Changes proposed in this pull request

Remove the `html_options` kwarg and move the custom attributes to the method call

## Guidance to review

check `/support/performance/validation-errors/summary?sortby=all_time` still functions as expected

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
