### PR TITLE
Add Feature-Policy response header

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -69,5 +69,9 @@ module ApplyForPostgraduateTeacherTraining
     config.after_initialize do |app|
       app.routes.append { get '*path', to: 'errors#not_found' }
     end
+
+    config.action_dispatch.default_headers = {
+      'Feature-Policy' => "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'",
+    }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -71,7 +71,7 @@ module ApplyForPostgraduateTeacherTraining
     end
 
     config.action_dispatch.default_headers = {
-      'Feature-Policy' => "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'",
+      'Feature-Policy' => "accelerometer 'none'; ambient-light-sensor: 'none', autoplay: 'none', battery: 'none', camera 'none'; display-capture: 'none', document-domain: 'none', fullscreen: 'none', geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; midi: 'none', payment 'none'; publickey-credentials-get: 'none', usb 'none', wake-lock: 'none', screen-wake-lock: 'none', web-share: 'none'",
     }
   end
 end


### PR DESCRIPTION
## Context

This PR configures the `Feature-Policy` HTTP response header to declare the set of browser features that the application is permitted (or not permitted in our case) to use. For example, Apply does not need to use the users computers camera.

This is a follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/4496 (though it's independent).

## Changes proposed in this pull request

- [x] Add the `Feature-Policy` header and disable browser features that we don't use

## Guidance to review

- Is there some feature on this list (that I've missed) that we do actually use?

There are a couple of other headers that came up in pen-testing that we were encouraged to consider:
- I've skipped `Referer-Policy` because we use redirect_to :back in our application that uses the `Referer` header.
- Also skipping `Expect-CT` as it's likely to be obsolete in a couple of months (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect-CT)

## Link to Trello card

https://trello.com/c/ApkZRgMC/3259-pentest-416-were-missing-application-security-headers-low-🚧

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
