### PR TITLE
Fix DBD bug with interviewing state

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -104,7 +104,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def awaiting_provider_decisions?
-    application_choices.where(status: :awaiting_provider_decision).any?
+    application_choices.where(status: ApplicationStateChange::DECISION_PENDING_STATUSES).any?
   end
 
   def first_not_declined_application_choice

--- a/spec/services/set_decline_by_default_spec.rb
+++ b/spec/services/set_decline_by_default_spec.rb
@@ -69,6 +69,18 @@ RSpec.describe SetDeclineByDefault do
       end
     end
 
+    context 'when one offer was made, and the rest are in the interviewing state' do
+      it 'the DBD is not set for any of the application_choices' do
+        choices[0].update(status: :offer, offered_at: 1.business_days.before(now))
+        choices[1].update(status: :interviewing)
+        choices[2].update(status: :interviewing)
+
+        call_service
+
+        expect_all_relevant_decline_by_default_at_values_to_be nil
+      end
+    end
+
     context 'when one offer was made, and two decisions are rejected' do
       it 'the DBD is set to 10 business days from the date of the most recent decision' do
         choices[0].update(status: :offer, offered_at: 1.business_days.before(now))


### PR DESCRIPTION
## Context
If an application has an offer and the rest of the choices are interviewing, then DBD is mistakenly set.

## Changes proposed in this pull request
Check for application choices in the decisions pending statuses, which include interviewing

