### PR TITLE
Rework BackfillExportType data migration

### DIFF
--- a/app/services/data_migrations/backfill_export_type.rb
+++ b/app/services/data_migrations/backfill_export_type.rb
@@ -4,28 +4,56 @@ module DataMigrations
     MANUAL_RUN = false
 
     def change
-      data_exports = DataExport.all.where(export_type: nil)
+      data_exports = DataExport.select(:id, :name, :export_type).where(export_type: nil)
 
-      data_exports.each { |export| export.update!(export_type: export_type(export)) }
+      data_exports.find_in_batches(batch_size: 10).with_index do |batch, batch_number|
+        Rails.logger.info("Updating DataExport export_types, batch no. #{batch_number}...")
+        batch.each { |export| export.update!(export_type: export_type_lookup.fetch(export.name)) }
+      end
     end
 
   private
 
-    def export_type(export)
-      case export.name
-      when 'Unexplained breaks in work history'
-        'work_history_break'
-      when 'Locations', 'Locations export'
-        'persona_export'
-      when 'Applications for TAD'
-        'tad_applications'
-      when 'Provider performance for TAD'
-        'tad_provider_performance'
-      when 'Candidate survey', 'Daily export of applications for TAD', 'Daily export of notifications breakdown', 'RejectedCandidatesExport'
-        nil
-      else
-        DataExport::EXPORT_TYPES.select { |_key, value| value[:name] == export.name }.values[0][:export_type]
-      end
+    def export_type_lookup
+      @export_type_lookup ||= {
+        'Unexplained breaks in work history' => 'work_history_break',
+        'Locations' => 'persona_export',
+        'Locations export' => 'persona_export',
+        'Applications for TAD' => 'tad_applications',
+        'Provider performance for TAD' => 'tad_provider_performance',
+        'Candidate survey' => nil,
+        'Daily export of applications for TAD' => nil,
+        'Daily export of notifications breakdown' => nil,
+        'RejectedCandidatesExport' => nil,
+        'Active provider user permissions' => 'active_provider_user_permissions',
+        'Active provider users' => 'active_provider_users',
+        'Application references' => 'application_references',
+        'Application timings' => 'application_timings',
+        'Candidate application feedback' => 'candidate_application_feedback',
+        'Candidate autosuggest usage' => 'candidate_autosuggest_usage',
+        'Candidate email send counts' => 'candidate_email_send_counts',
+        'Candidate feedback' => 'candidate_feedback',
+        'Candidate journey tracking' => 'candidate_journey_tracking',
+        'Candidate course choice withdrawal survey' => 'candidate_course_choice_withdrawal_survey',
+        'Equality and diversity data' => 'equality_and_diversity',
+        'Interview changes' => 'interview_export',
+        'Notes' => 'notes_export',
+        'Notifications' => 'notifications_export',
+        'Offer conditions' => 'offer_conditions',
+        'Organisation permissions' => 'organisation_permissions',
+        'Provider Access Controls' => 'provider_access_controls',
+        'Providers' => 'providers_export',
+        'Persona data' => 'persona_export',
+        'Qualifications' => 'qualifications',
+        'Referee survey' => 'referee_survey',
+        'Sites' => 'sites_export',
+        'Structured reasons for rejection' => 'structured_reasons_for_rejection',
+        'Submitted application choices' => 'submitted_application_choices',
+        'TAD applications' => 'tad_applications',
+        'TAD provider performance' => 'tad_provider_performance',
+        'User permissions' => 'user_permissions',
+        'Work history break' => 'work_history_break',
+      }
     end
   end
 end


### PR DESCRIPTION


## Context
Seeing some issues with this in production. It appears to be related to
either memory usage or a SQL timeout.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Change as follows:

- Use a simple hash lookup for the export_type values
- Use a small batch size of 10
- Set statement_timeout to 0 before execution
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Review of the diff should be sufficient, including a onceover of the lookup hash.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
