### PR TITLE
Fix bug around withdrawing from interviewing choices when accepting an offer

### DIFF
--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -42,7 +42,7 @@ private
   def application_choices_awaiting_provider_decision
     @application_choice
       .self_and_siblings
-      .awaiting_provider_decision
+      .where(status: ApplicationStateChange::DECISION_PENDING_STATUSES)
   end
 
   def unconditional_offer?


### PR DESCRIPTION
## Context
If a candidate accepts an offer, we want to withdraw from any in progress applications and decline any other offers. Since adding the interviewing state, we do not withdraw interviewing applications when an offer is accepted

## Changes proposed in this pull request
Look for and withdraw interviewing application choices when offers are accepted

