### PR TITLE
Amend provider content on offer summary card

### DIFF
--- a/app/components/provider_interface/completed_offer_summary_component.rb
+++ b/app/components/provider_interface/completed_offer_summary_component.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     include ViewHelper
 
     def rows
-      [
+      rows = [
         { key: 'Training provider',
           value: course_option.provider.name_and_code,
           action: 'Change',
@@ -20,10 +20,10 @@ module ProviderInterface
           value: course_option.site.name_and_address,
           action: 'Change',
           change_path: change_location_path },
-        { key: 'Accredited body',
-          value: course_option.course&.accredited_provider&.name_and_code || course_option.provider.name_and_code,
-          change_path: nil },
       ]
+      return rows if course_option.course.accredited_provider.blank?
+
+      rows << accredited_body_details(course_option)
     end
 
     def change_provider_path

--- a/app/components/provider_interface/completed_offer_summary_component.rb
+++ b/app/components/provider_interface/completed_offer_summary_component.rb
@@ -4,7 +4,7 @@ module ProviderInterface
 
     def rows
       [
-        { key: 'Training Provider',
+        { key: 'Training provider',
           value: course_option.provider.name_and_code,
           action: 'Change',
           change_path: change_provider_path },

--- a/app/components/provider_interface/course_summary_component.rb
+++ b/app/components/provider_interface/course_summary_component.rb
@@ -12,7 +12,7 @@ module ProviderInterface
     end
 
     def rows
-      [
+      rows = [
         {
           key: 'Provider',
           value: provider_name,
@@ -30,6 +30,17 @@ module ProviderInterface
           value: study_mode,
         },
       ]
+      return rows if course_option.course.accredited_provider.blank?
+
+      rows << accredited_body_details(course_option)
+    end
+
+  private
+
+    def accredited_body_details(course_option)
+      { key: 'Accredited body',
+        value: course_option.course.accredited_provider.name_and_code,
+        change_path: nil }
     end
   end
 end

--- a/app/components/provider_interface/course_summary_component.rb
+++ b/app/components/provider_interface/course_summary_component.rb
@@ -14,7 +14,7 @@ module ProviderInterface
     def rows
       rows = [
         {
-          key: 'Provider',
+          key: 'Training provider',
           value: provider_name,
         },
         {

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -19,7 +19,7 @@ module ProviderInterface
 
     def rows
       [
-        { key: 'Provider',
+        { key: 'Training provider',
           value: course_option.provider.name_and_code,
           action: 'Change',
           change_path: change_provider_path },

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -18,7 +18,7 @@ module ProviderInterface
     end
 
     def rows
-      [
+      rows = [
         { key: 'Training provider',
           value: course_option.provider.name_and_code,
           action: 'Change',
@@ -36,6 +36,9 @@ module ProviderInterface
           action: 'Change',
           change_path: change_study_mode_path },
       ]
+      return rows if course_option.course.accredited_provider.blank?
+
+      rows << accredited_body_details(course_option)
     end
 
     def change_provider_path
@@ -63,6 +66,12 @@ module ProviderInterface
     delegate :conditions_not_met?, to: :application_state
 
   private
+
+    def accredited_body_details(course_option)
+      { key: 'Accredited body',
+        value: course_option.course.accredited_provider.name_and_code,
+        change_path: nil }
+    end
 
     def application_state
       @application_state ||= ApplicationStateChange.new(application_choice)

--- a/app/components/provider_interface/read_only_completed_offer_summary_component.rb
+++ b/app/components/provider_interface/read_only_completed_offer_summary_component.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     include ViewHelper
 
     def rows
-      [
+      rows = [
         { key: 'Training provider',
           value: course_option.provider.name_and_code },
         { key: 'Course',
@@ -12,9 +12,10 @@ module ProviderInterface
           value: course_option.study_mode.humanize },
         { key: 'Location',
           value: course_option.site.name_and_address },
-        { key: 'Accredited body',
-          value: course_option.course&.accredited_provider&.name_and_code || course_option.provider.name_and_code },
       ]
+      return rows if course_option.course.accredited_provider.blank?
+
+      rows << accredited_body_details(course_option)
     end
   end
 end

--- a/app/components/provider_interface/read_only_completed_offer_summary_component.rb
+++ b/app/components/provider_interface/read_only_completed_offer_summary_component.rb
@@ -4,7 +4,7 @@ module ProviderInterface
 
     def rows
       [
-        { key: 'Training Provider',
+        { key: 'Training provider',
           value: course_option.provider.name_and_code },
         { key: 'Course',
           value: course_option.course.name_and_code },

--- a/app/views/provider_interface/offer/checks/new.html.erb
+++ b/app/views/provider_interface/offer/checks/new.html.erb
@@ -19,14 +19,6 @@
                                                               available_course_options: @course_options,
                                                               show_conditions_link: true) %>
 
-      <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-          <span class="govuk-warning-text__assistive"></span>
-          When you send this offer, you guarantee a place on this course as long as the candidate meets the conditions.
-        </strong>
-      </div>
-
       <%= f.govuk_submit t('.submit') %>
 
       <p class="govuk-body">

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -7,7 +7,7 @@ en:
     offer:
       providers:
         new:
-          title: Select provider
+          title: Select training provider
         edit:
           title: Select training provider
       courses:

--- a/spec/components/provider_interface/course_summary_component_spec.rb
+++ b/spec/components/provider_interface/course_summary_component_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe ProviderInterface::CourseSummaryComponent do
   it 'renders the provider name' do
     render_text = row_text_selector(:provider, render)
 
-    expect(render_text).to include('Provider')
+    expect(render_text).to include('Training provider')
     expect(render_text).to include('Best Training')
   end
 

--- a/spec/components/provider_interface/course_summary_component_spec.rb
+++ b/spec/components/provider_interface/course_summary_component_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe ProviderInterface::CourseSummaryComponent do
       course: 1,
       location: 2,
       full_or_part_time: 3,
+      accredited_body: 4,
     }
 
     render.css('.govuk-summary-list__row')[rows[row_name]].text
@@ -74,5 +75,16 @@ RSpec.describe ProviderInterface::CourseSummaryComponent do
 
     expect(render_text).to include('Full time or part time')
     expect(render_text).to include('Full time')
+  end
+
+  context 'renders the accredited body' do
+    let(:course) { build(:course, :with_accredited_provider) }
+
+    it 'when one is set' do
+      render_text = row_text_selector(:accredited_body, render)
+
+      expect(render_text).to include('Accredited body')
+      expect(render_text).to include(course.accredited_provider.name_and_code)
+    end
   end
 end

--- a/spec/components/provider_interface/offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/offer_summary_component_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
       course: 1,
       location: 2,
       full_or_part_time: 3,
+      accredited_provider: 4,
     }
 
     render.css('.govuk-summary-list__row')[rows[row_name]].text
@@ -108,6 +109,15 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
     expect(row_text_selector(:course, render)).to include(course_option.course.name_and_code)
     expect(row_text_selector(:location, render)).to include(course_option.site.name_and_address)
     expect(row_text_selector(:full_or_part_time, render)).to include(course_option.study_mode.humanize)
+  end
+
+  context 'when the accredited provider is not the same as the training provider' do
+    let(:course) { build_stubbed(:course, :with_accredited_provider) }
+    let(:course_option) { build_stubbed(:course_option, course: course) }
+
+    it 'renders an extra row with the accredited provider details' do
+      expect(row_text_selector(:accredited_provider, render)).to include(course.accredited_provider.name_and_code)
+    end
   end
 
   context 'when conditions are set' do

--- a/spec/components/provider_interface/read_only_completed_offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/read_only_completed_offer_summary_component_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ReadOnlyCompletedOfferSummaryComponent do
+  include Rails.application.routes.url_helpers
+
+  let(:application_choice) { build_stubbed(:application_choice) }
+  let(:course_option) { build_stubbed(:course_option) }
+  let(:providers) { [] }
+  let(:course) { build_stubbed(:course) }
+  let(:courses) { [] }
+  let(:course_options) { [] }
+  let(:editable) { false }
+  let(:render) do
+    render_inline(described_class.new(application_choice: application_choice, course_option: course_option,
+                                      conditions: ['condition 1'],
+                                      available_providers: providers,
+                                      available_courses: courses,
+                                      available_course_options: course_options,
+                                      course: course,
+                                      editable: false))
+  end
+
+  def row_text_selector(row_name, render)
+    rows = {
+      provider: 0,
+      course: 1,
+      full_or_part_time: 2,
+      location: 3,
+      accredited_provider: 4,
+    }
+
+    render.css('.govuk-summary-list__row')[rows[row_name]].text
+  end
+
+  it 'renders the new course option details' do
+    expect(row_text_selector(:provider, render)).to include(course_option.provider.name)
+    expect(row_text_selector(:course, render)).to include(course_option.course.name_and_code)
+    expect(row_text_selector(:location, render)).to include(course_option.site.name_and_address)
+    expect(row_text_selector(:full_or_part_time, render)).to include(course_option.study_mode.humanize)
+  end
+
+  context 'when the accredited provider is not the same as the training provider' do
+    let(:course) { build_stubbed(:course, :with_accredited_provider) }
+    let(:course_option) { build_stubbed(:course_option, course: course) }
+
+    it 'renders an extra row with the accredited provider details' do
+      expect(row_text_selector(:accredited_provider, render)).to include(course.accredited_provider.name_and_code)
+    end
+  end
+end

--- a/spec/system/provider_interface/change_make_offer_spec.rb
+++ b/spec/system/provider_interface/change_make_offer_spec.rb
@@ -174,7 +174,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def then_i_am_taken_to_the_change_provider_page
-    expect(page).to have_content('Select provider')
+    expect(page).to have_content('Select training provider')
   end
 
   def when_i_select_a_different_provider

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -238,7 +238,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def then_i_am_taken_to_the_change_provider_page
-    expect(page).to have_content('Select provider')
+    expect(page).to have_content('Select training provider')
   end
 
   def when_i_select_a_different_provider


### PR DESCRIPTION
## Context

Small fixes of issues identified as part of Make offer design review

## Guidance to review

Walk through Make Offer, Change Make offer and Change offer flows. For the first two you need an application choice in the received or interviewing state. To change an offer you need to acess the Offer tab of an application in the Offered state.

## Link to Trello card

https://trello.com/c/dNexzE9h/3616-amend-provider-content-on-offer-summary-card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
