### PR TITLE
Configure education.gov.uk as custom hostname for PaaS

### DIFF
--- a/terraform/modules/paas/data.tf
+++ b/terraform/modules/paas/data.tf
@@ -15,6 +15,10 @@ data "cloudfoundry_domain" "apply_service_gov_uk" {
   name = "apply-for-teacher-training.service.gov.uk"
 }
 
+data "cloudfoundry_domain" "apply_education_gov_uk" {
+  name = "apply-for-teacher-training.education.gov.uk"
+}
+
 data "cloudfoundry_service" "postgres" {
   name = "postgres"
 }

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -92,6 +92,12 @@ resource "cloudfoundry_route" "web_app_service_gov_uk_route" {
   hostname = local.service_gov_uk_host_names[var.app_environment]
 }
 
+resource "cloudfoundry_route" "web_app_education_gov_uk_route" {
+  domain   = data.cloudfoundry_domain.apply_education_gov_uk.id
+  space    = data.cloudfoundry_space.space.id
+  hostname = local.service_gov_uk_host_names[var.app_environment]
+}
+
 resource "cloudfoundry_service_instance" "postgres" {
   name         = local.postgres_service_name
   space        = data.cloudfoundry_space.space.id

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -48,7 +48,7 @@ locals {
     sandbox = "sandbox"
     prod    = "www"
   }
-  web_app_routes = [cloudfoundry_route.web_app_service_gov_uk_route, cloudfoundry_route.web_app_cloudapps_digital_route]
+  web_app_routes = [cloudfoundry_route.web_app_service_gov_uk_route, cloudfoundry_route.web_app_cloudapps_digital_route, cloudfoundry_route.web_app_education_gov_uk_route]
   app_environment_variables = merge(var.app_environment_variables,
     {
       BLAZER_DATABASE_URL = cloudfoundry_service_key.postgres-readonly-key.credentials.uri


### PR DESCRIPTION
## Context

The `apply-for-teacher-training.education.gov.uk` domain redirects to `apply-for-teacher-training.service.gov.uk` 
The 301 redirect is managed in app code, so the `education.gov.uk` needs to be configured as a http route for the app on PaaS.

## Changes proposed in this pull request

add `education.gov.uk` as a custom route for redirecting to service.gov.uk

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
