### PR TITLE
Revert "Temporary removal of mapping subjects to a course"

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -56,6 +56,10 @@ module TeacherTrainingPublicAPI
       course.age_range = age_range_in_years(course_from_api)
       course.withdrawn = course_from_api.state == 'withdrawn'
       course.qualifications = course_from_api.qualifications
+      course_from_api.subject_codes.each do |code|
+        subject = ::Subject.find_or_initialize_by(code: code)
+        course.subjects << subject unless course.course_subjects.exists?(subject_id: subject.id)
+      end
       course.subject_codes = course_from_api.subject_codes
     end
 

--- a/app/workers/teacher_training_public_api/sync_all_providers_and_courses_worker.rb
+++ b/app/workers/teacher_training_public_api/sync_all_providers_and_courses_worker.rb
@@ -4,6 +4,7 @@ module TeacherTrainingPublicAPI
     sidekiq_options retry: 3, queue: :low_priority
 
     def perform
+      SyncSubjects.new.perform
       SyncAllProvidersAndCourses.call
     end
   end

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -66,6 +66,34 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
         expect(course_option.vacancy_status).to eq 'vacancies'
       end
 
+      context 'mapping subjects to a course' do
+        before do
+          stub_teacher_training_api_courses(provider_code: 'ABC',
+                                            specified_attributes: [{ code: 'ABC1', accredited_body_code: nil }])
+
+          stub_teacher_training_api_sites(provider_code: 'ABC', course_code: 'ABC1',
+                                          specified_attributes: [{}])
+        end
+
+        it 'when there is no entry for the subject it creates a new one' do
+          expect {
+            described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
+          }.to change(Subject, :count).by(1)
+
+          expect(Subject.exists?(code: '00')).to be true
+        end
+
+        it 'when the subject exists it associates the existing entry' do
+          subject = create(:subject, code: '00')
+          expect {
+            described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
+          }.to change(Subject, :count).by(0)
+
+          course = Course.last
+          expect(course.subjects).to contain_exactly(subject)
+        end
+      end
+
       it 'correctly handles missing address info' do
         stub_teacher_training_api_courses(
           provider_code: 'ABC',

--- a/spec/workers/teacher_training_public_api/sync_all_providers_and_courses_worker_spec.rb
+++ b/spec/workers/teacher_training_public_api/sync_all_providers_and_courses_worker_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker do
+  describe '#perform' do
+    it 'calls the SyncSubjects service' do
+      allow(TeacherTrainingPublicAPI::SyncAllProvidersAndCourses).to receive(:call)
+
+      sync_subjects_service = instance_double(TeacherTrainingPublicAPI::SyncSubjects, perform: nil)
+      allow(TeacherTrainingPublicAPI::SyncSubjects).to receive(:new).and_return(sync_subjects_service)
+
+      described_class.new.perform
+
+      expect(sync_subjects_service).to have_received(:perform)
+    end
+  end
+end


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-teacher-training#4507 and reintroduced Subjects on courses and subject syncing as part of TTAPI Sync worker.