### PR TITLE
Reverse study mode with locations on offer summary cards

### DIFF
--- a/app/components/provider_interface/course_summary_component.rb
+++ b/app/components/provider_interface/course_summary_component.rb
@@ -22,12 +22,12 @@ module ProviderInterface
           value: course_name_and_code,
         },
         {
-          key: 'Location',
-          value: location_name_and_address,
-        },
-        {
           key: 'Full time or part time',
           value: study_mode,
+        },
+        {
+          key: 'Location',
+          value: location_name_and_address,
         },
       ]
       return rows if course_option.course.accredited_provider.blank?

--- a/app/components/provider_interface/deferred_offer_details_component.rb
+++ b/app/components/provider_interface/deferred_offer_details_component.rb
@@ -21,12 +21,12 @@ module ProviderInterface
           value: course_option.course.name_and_code,
         },
         {
-          key: 'Location',
-          value: course_option.site.name_and_address,
-        },
-        {
           key: 'Full time or part time',
           value: course_option.study_mode.humanize,
+        },
+        {
+          key: 'Location',
+          value: course_option.site.name_and_address,
         },
       ]
     end

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -27,14 +27,14 @@ module ProviderInterface
           value: course_option.course.name_and_code,
           action: 'Change',
           change_path: change_course_path },
-        { key: 'Location',
-          value: course_option.site.name_and_address,
-          action: 'Change',
-          change_path: change_location_path },
         { key: 'Full time or part time',
           value: course_option.study_mode.humanize,
           action: 'Change',
           change_path: change_study_mode_path },
+        { key: 'Location',
+          value: course_option.site.name_and_address,
+          action: 'Change',
+          change_path: change_location_path },
       ]
       return rows if course_option.course.accredited_provider.blank?
 

--- a/app/components/provider_interface/status_box_components/course_rows.rb
+++ b/app/components/provider_interface/status_box_components/course_rows.rb
@@ -12,12 +12,12 @@ module ProviderInterface
             value: course_option.course.name_and_code,
           },
           {
-            key: 'Location',
-            value: course_option.site.name_and_address,
-          },
-          {
             key: 'Full time or part time',
             value: course_option.study_mode.humanize,
+          },
+          {
+            key: 'Location',
+            value: course_option.site.name_and_address,
           },
         ]
 

--- a/spec/components/provider_interface/course_summary_component_spec.rb
+++ b/spec/components/provider_interface/course_summary_component_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe ProviderInterface::CourseSummaryComponent do
     rows = {
       provider: 0,
       course: 1,
-      location: 2,
-      full_or_part_time: 3,
+      full_or_part_time: 2,
+      location: 3,
       accredited_body: 4,
     }
 

--- a/spec/components/provider_interface/deferred_offer_details_component_spec.rb
+++ b/spec/components/provider_interface/deferred_offer_details_component_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::DeferredOfferDetailsComponent do
+  let(:application_choice) { instance_double(ApplicationChoice, offer: false) }
+  let(:provider) { build(:provider, name: 'Best Training') }
+  let(:course_option) { build(:course_option) }
+
+  let(:render) { render_inline(described_class.new(application_choice: application_choice, course_option: course_option)) }
+
+  def row_text_selector(row_name, render)
+    rows = {
+      provider: 0,
+      course: 1,
+      full_or_part_time: 2,
+      location: 3,
+    }
+
+    render.css('.govuk-summary-list__row')[rows[row_name]].text
+  end
+
+  it 'renders the provider name' do
+    render_text = row_text_selector(:provider, render)
+
+    expect(render_text).to include('Provider')
+    expect(render_text).to include(course_option.course.provider.name)
+  end
+
+  it 'renders the course name and code' do
+    render_text = row_text_selector(:course, render)
+
+    expect(render_text).to include('Course')
+    expect(render_text).to include(course_option.course.name_and_code)
+  end
+
+  it 'renders the study mode' do
+    render_text = row_text_selector(:full_or_part_time, render)
+
+    expect(render_text).to include('Full time or part time')
+    expect(render_text).to include(course_option.study_mode.humanize)
+  end
+
+  it 'renders the location' do
+    render_text = row_text_selector(:location, render)
+
+    expect(render_text).to include('Location')
+    expect(render_text).to include(course_option.site.name_and_address)
+  end
+end

--- a/spec/components/provider_interface/offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/offer_summary_component_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
     rows = {
       provider: 0,
       course: 1,
-      location: 2,
-      full_or_part_time: 3,
+      full_or_part_time: 2,
+      location: 3,
       accredited_provider: 4,
     }
 
@@ -75,7 +75,7 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
 
     it 'renders a change link' do
       course_options_change_link = Rails.application.routes.url_helpers.new_provider_interface_application_choice_offer_locations_path(application_choice)
-      expect(row_link_selector(2)).to eq(course_options_change_link)
+      expect(row_link_selector(3)).to eq(course_options_change_link)
     end
   end
 
@@ -83,7 +83,7 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
     let(:course_options) { [build_stubbed(:course_option)] }
 
     it 'renders no change link' do
-      expect(row_link_selector(2)).to eq(nil)
+      expect(row_link_selector(3)).to eq(nil)
     end
   end
 
@@ -92,7 +92,7 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
 
     it 'renders a change link' do
       study_mode_change_link = Rails.application.routes.url_helpers.new_provider_interface_application_choice_offer_study_modes_path(application_choice)
-      expect(row_link_selector(3)).to eq(study_mode_change_link)
+      expect(row_link_selector(2)).to eq(study_mode_change_link)
     end
   end
 
@@ -100,7 +100,7 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
     let(:course) { build_stubbed(:course, study_mode: :full_time) }
 
     it 'renders no change link' do
-      expect(row_link_selector(3)).to eq(nil)
+      expect(row_link_selector(2)).to eq(nil)
     end
   end
 

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -148,7 +148,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_i_can_confirm_the_new_location_selection
-    within(:xpath, "////div[@class='govuk-summary-list__row'][3]") do
+    within(:xpath, "////div[@class='govuk-summary-list__row'][4]") do
       expect(page).to have_content(@selected_course_option.site.name_and_address)
     end
   end
@@ -158,7 +158,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_i_can_confirm_the_new_study_mode_selection
-    within(:xpath, "////div[@class='govuk-summary-list__row'][4]") do
+    within(:xpath, "////div[@class='govuk-summary-list__row'][3]") do
       expect(page).to have_content(@selected_course_option.study_mode.humanize)
     end
   end


### PR DESCRIPTION
## Context
Update components displaying requested of offered course details in the order displayed in the make offer flow.

## Changes proposed in this pull request

Update offer summary, course summary and old make offer components to first display the study mode and then the location of a course.

## Guidance to review

Changes should be reflected on
1. Make offer decision page
2. Offer summary page (at the end of make or change offer flow)
3. Offer tab
4. Defer & withdraw offer (can be accessed via offer tab when application choice is in correct state)
4. Reconfirm offer (end of defer offer flow)

## Link to Trello card

https://trello.com/c/F9HCtsg2/3618-reverse-study-mode-with-locations-on-offer-summary-cards

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
