### PR TITLE
Force study_mode selection after course changes in the wizard

### DIFF
--- a/app/controllers/provider_interface/offer/courses_controller.rb
+++ b/app/controllers/provider_interface/offer/courses_controller.rb
@@ -9,7 +9,8 @@ module ProviderInterface
       end
 
       def create
-        @wizard = OfferWizard.new(offer_store, course_params.to_h)
+        @wizard = OfferWizard.new(offer_store)
+        reset_study_mode_if_course_has_changed_and_update_course
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!
@@ -30,7 +31,8 @@ module ProviderInterface
       end
 
       def update
-        @wizard = OfferWizard.new(offer_store, course_params.to_h)
+        @wizard = OfferWizard.new(offer_store)
+        reset_study_mode_if_course_has_changed_and_update_course
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!
@@ -44,6 +46,12 @@ module ProviderInterface
       end
 
     private
+
+      def reset_study_mode_if_course_has_changed_and_update_course
+        course_id = course_params['course_id']
+        @wizard.study_mode = nil if course_id != @wizard.course_id
+        @wizard.course_id = course_id
+      end
 
       def course_params
         params.require(:provider_interface_offer_wizard).permit(:course_id)

--- a/spec/system/provider_interface/change_existing_offer_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_spec.rb
@@ -43,8 +43,9 @@ RSpec.feature 'Provider changes an existing offer' do
 
     when_i_select_a_different_course
     and_i_click_continue
+    then_no_study_mode_is_pre_selected
 
-    when_i_select_a_different_study_mode
+    when_i_select_a_study_mode
     and_i_click_continue
 
     when_i_select_a_new_location
@@ -142,7 +143,12 @@ RSpec.feature 'Provider changes an existing offer' do
     choose @selected_course.name_and_code
   end
 
-  def when_i_select_a_different_study_mode
+  def then_no_study_mode_is_pre_selected
+    expect(find_field('Full time')).not_to be_checked
+    expect(find_field('Part time')).not_to be_checked
+  end
+
+  def when_i_select_a_study_mode
     choose @selected_course_option.study_mode.humanize
   end
 

--- a/spec/system/provider_interface/change_make_offer_spec.rb
+++ b/spec/system/provider_interface/change_make_offer_spec.rb
@@ -42,8 +42,9 @@ RSpec.feature 'Provider makes an offer' do
 
     when_i_select_a_different_course
     and_i_click_continue
+    then_no_study_mode_is_pre_selected
 
-    when_i_select_a_different_study_mode
+    when_i_select_a_study_mode
     and_i_click_continue
 
     when_i_select_a_new_location
@@ -132,12 +133,17 @@ RSpec.feature 'Provider makes an offer' do
     expect(page).to have_content('Select study mode')
   end
 
-  def when_i_select_a_different_study_mode
+  def when_i_select_a_study_mode
     choose @selected_course_option.study_mode.humanize
   end
 
   def when_i_select_a_different_course
     choose @selected_course.name_and_code
+  end
+
+  def then_no_study_mode_is_pre_selected
+    expect(find_field('Full time')).not_to be_checked
+    expect(find_field('Part time')).not_to be_checked
   end
 
   def then_i_am_taken_to_the_change_course_page


### PR DESCRIPTION
## Context

In the new offer flow, after changing a course the wizard pre-selects the same `study_mode` (full-time/part-time) as the last user choice, on the relevant step.

## Changes proposed in this pull request

Change the course selection step to reset the `study_mode` value to `nil`, so that no study_mode is pre-selected when the user lands on the full-time/part-time step.

## Guidance to review

Note: The study mode step is skipped if the selected course is only available as full-time or part-time.

## Link to Trello card

https://trello.com/c/VUDzbeAw

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
