### PR TITLE
Fix Rejection by default applications in the API

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -95,6 +95,11 @@ module VendorAPI
           reason: application_choice.offer_withdrawal_reason,
           date: application_choice.offer_withdrawn_at.iso8601,
         }
+      elsif application_choice.rejected_by_default?
+        {
+          reason: 'Not entered',
+          date: application_choice.rejected_at.iso8601,
+        }
       end
     end
 

--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+## 15th April
+
+Changes to existing attributes:
+
+- Update the return values of the `rejection` object `reason` field to return `Not entered` if there is no rejection reason yet provided on an application rejected by default.
+
 ## 31st March
 
 `Qualification.grade` now has a value of `Not entered` when the candidate did not provide a value. This used to be `null`, though we promised a string.

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -969,7 +969,7 @@ components:
       properties:
         reason:
           type: string
-          description: The reason for rejection or offer withdrawal
+          description: The reason for rejection or offer withdrawal. If none are yet provided for an application rejected by default, the value `Not entered` is returned
           maxLength: 65535
           example: Does not meet minimum GCSE requirements
         date:

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     end
   end
 
+  describe 'attributes.rejection with a rejected application with no feedback' do
+    it 'returns a rejection object' do
+      rejected_at = Time.zone.local(2019, 1, 1, 0, 0, 0)
+      application_form = create(:application_form,
+                                :minimum_info)
+      application_choice = create(:application_choice, :with_rejection_by_default, application_form: application_form, rejected_at: rejected_at)
+
+      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+
+      expect(response.to_json).to be_valid_against_openapi_schema('Application')
+      expect(response[:attributes][:rejection]).to eq(reason: 'Not entered', date: rejected_at.iso8601)
+    end
+  end
+
   describe 'attributes.hesa_itt_data' do
     context 'when an application choice has had an accepted offer' do
       let(:application_choice) do


### PR DESCRIPTION
## Context

If an application RDB'd, we are not returning the rejection object in the API correctly as we only check for the presence of rejection reasons or withdrawal reasons .

## Changes proposed in this pull request

Return the rejection date and a default reason if an application was rejected by default, but no feedback has been supplied yet.

## Guidance to review

anything I missed?
## Link to Trello card

trello ticket: https://trello.com/c/qhj5L5Mm/3595-rbdd-applications-dont-always-have-a-rejection-object-in-the-api

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
