### PR TITLE
Move course sync check into an invariant check

### DIFF
--- a/app/models/teacher_training_public_api/sync_check.rb
+++ b/app/models/teacher_training_public_api/sync_check.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingPublicAPI
-  class SyncCheck < OkComputer::Check
+  class SyncCheck
     LAST_SUCCESSFUL_SYNC = 'last-successful-sync-with-teacher-training-api'.freeze
 
     def self.set_last_sync(date)
@@ -14,17 +14,11 @@ module TeacherTrainingPublicAPI
       Redis.current.get(LAST_SUCCESSFUL_SYNC)
     end
 
-    def check
-      last_date = self.class.last_sync
-
-      if last_date.nil?
-        mark_failure
-        mark_message 'Problem finding the time when the Teacher training API sync last succeeded'
-      elsif Time.zone.parse(last_date) < (Time.zone.now - 1.hour)
-        mark_failure
-        mark_message 'The sync with the Teacher training API has not succeeded in an hour'
+    def self.check
+      if last_sync.nil?
+        false
       else
-        mark_message 'The sync with the Teacher training API has succeeded in the last hour'
+        Time.zone.parse(last_sync) >= (Time.zone.now - 1.hour)
       end
     end
   end

--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -9,6 +9,7 @@ class DetectInvariants
     detect_applications_with_course_choices_in_previous_cycle
     detect_submitted_applications_with_more_than_three_course_choices
     detect_applications_submitted_with_the_same_course
+    detect_course_sync_not_succeeded_for_an_hour
   end
 
   def detect_application_choices_in_old_states
@@ -139,12 +140,23 @@ class DetectInvariants
     end
   end
 
+  def detect_course_sync_not_succeeded_for_an_hour
+    unless TeacherTrainingPublicAPI::SyncCheck.check
+      Raven.capture_exception(
+        CourseSyncNotSucceededForAnHour.new(
+          'The course sync via the Teacher training public API has not succeeded for an hour',
+        ),
+      )
+    end
+  end
+
   class ApplicationInRemovedState < StandardError; end
   class OutstandingReferencesOnSubmittedApplication < StandardError; end
   class ApplicationEditedByWrongCandidate < StandardError; end
   class ApplicationHasCourseChoiceInPreviousCycle < StandardError; end
   class SubmittedApplicationHasMoreThanThreeChoices < StandardError; end
   class ApplicationSubmittedWithTheSameCourse < StandardError; end
+  class CourseSyncNotSucceededForAnHour < StandardError; end
 
 private
 

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -32,7 +32,6 @@ OkComputer::Registry.register 'sidekiq_default_queue', OkComputer::SidekiqLatenc
 OkComputer::Registry.register 'sidekiq_mailers_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'mailers', threshold: 100) # threshold in seconds
 OkComputer::Registry.register 'sidekiq_retries_count', SidekiqRetriesCheck.new
 OkComputer::Registry.register 'simulated_failure', SimulatedFailureCheck.new
-OkComputer::Registry.register 'ttapi_sync', TeacherTrainingPublicAPI::SyncCheck.new
 OkComputer::Registry.register 'version', OkComputer::AppVersionCheck.new
 
 OkComputer.make_optional %w[version]

--- a/spec/workers/detect_invariants_spec.rb
+++ b/spec/workers/detect_invariants_spec.rb
@@ -1,7 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe DetectInvariants do
-  before { allow(Raven).to receive(:capture_exception) }
+  before do
+    allow(Raven).to receive(:capture_exception)
+
+    # or unwanted exceptions will be thrown by this check
+    TeacherTrainingPublicAPI::SyncCheck.set_last_sync(Time.zone.now)
+  end
 
   describe '#perform' do
     it 'detects application choices in deprecated states' do
@@ -159,6 +164,24 @@ RSpec.describe DetectInvariants do
       create(:submitted_application_choice, status: :rejected, application_form: application_form, course_option: course_option2)
       create(:submitted_application_choice, application_form: application_form, course_option: course_option3)
 
+      DetectInvariants.new.perform
+
+      expect(Raven).not_to have_received(:capture_exception)
+    end
+
+    it 'detects when the course sync hasn’t succeeded for an hour' do
+      TeacherTrainingPublicAPI::SyncCheck.clear_last_sync
+
+      DetectInvariants.new.perform
+
+      expect(Raven).to have_received(:capture_exception).with(
+        DetectInvariants::CourseSyncNotSucceededForAnHour.new(
+          'The course sync via the Teacher training public API has not succeeded for an hour',
+        ),
+      )
+    end
+
+    it 'doesn’t alert when the course sync has succeeded recently' do
       DetectInvariants.new.perform
 
       expect(Raven).not_to have_received(:capture_exception)


### PR DESCRIPTION
## Context

Having this check in `OkComputer` causes StatusCake and Azure to declare the site down when the sync hasn't succeeded. A Sentry error via invariant check is a less alarming way to alert us about this.

## Changes proposed in this pull request

Turn `TeacherTrainingPublicAPI::SyncCheck` into a plain Ruby object and use it in a new invariant check.

## Link to Trello card

https://trello.com/c/M67Wp16p/451-move-ttapi-sync-check-from-the-monitoring-endpoint-to-an-invariant-check

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
