### PR TITLE
Fix bugs relating to not accounting for the interviewing state

### DIFF
--- a/app/components/candidate_interface/application_dashboard_course_choices_component.rb
+++ b/app/components/candidate_interface/application_dashboard_course_choices_component.rb
@@ -99,7 +99,7 @@ module CandidateInterface
 
     def interview_row(application_choice)
       return unless application_choice.interviews.kept.any? ||
-        application_choice.awaiting_provider_decision?
+        application_choice.decision_pending?
 
       {
         key: 'Interview'.pluralize(application_choice.interviews.size),

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -55,7 +55,7 @@ module ProviderInterface
     end
 
     def awaiting_decision_but_cannot_respond?
-      !provider_can_respond && application_choice.awaiting_provider_decision?
+      !provider_can_respond && application_choice.decision_pending?
     end
 
     def waiting_for_interview?

--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -38,7 +38,7 @@ module SupportInterface
       end
 
       rows << { key: 'Sent to provider at', value: application_choice.sent_to_provider_at.to_s(:govuk_date_and_time) } if application_choice.sent_to_provider_at
-      rows << { key: 'Reject by default at', value: application_choice.reject_by_default_at.to_s(:govuk_date_and_time) } if application_choice.reject_by_default_at && application_choice.awaiting_provider_decision?
+      rows << { key: 'Reject by default at', value: application_choice.reject_by_default_at.to_s(:govuk_date_and_time) } if application_choice.reject_by_default_at && application_choice.decision_pending?
       rows << { key: 'Decline by default at', value: application_choice.decline_by_default_at.to_s(:govuk_date_and_time) } if application_choice.decline_by_default_at && application_choice.offer?
 
       if visible_over_vendor_api?

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -161,7 +161,7 @@ module ProviderInterface
     end
 
     def confirm_application_is_in_decision_pending_state
-      return if ApplicationStateChange::DECISION_PENDING_STATUSES.include?(@application_choice.status.to_sym)
+      return if @application_choice.decision_pending?
 
       redirect_to(provider_interface_application_choice_path(@application_choice))
     end

--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -158,7 +158,7 @@ module ProviderInterface
     end
 
     def confirm_application_is_in_decision_pending_state
-      return if ApplicationStateChange::DECISION_PENDING_STATUSES.include?(@application_choice.status.to_sym)
+      return if @application_choice.decision_pending?
 
       redirect_back(fallback_location: provider_interface_application_choice_path(@application_choice))
     end

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -74,7 +74,7 @@ module ProviderInterface
     end
 
     def confirm_application_is_in_decision_pending_state
-      return if ApplicationStateChange::DECISION_PENDING_STATUSES.include?(@application_choice.status.to_sym)
+      return if @application_choice.decision_pending?
 
       redirect_to(provider_interface_application_choice_path(@application_choice))
     end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -95,7 +95,7 @@ class CandidateMailer < ApplicationMailer
     @course = application_choice.course_option.course
     @application_choice = RejectedApplicationChoicePresenter.new(application_choice)
     @offer = application_choice.self_and_siblings.find(&:offer?)
-    @awaiting_decision = application_choice.self_and_siblings.find(&:awaiting_provider_decision?)
+    @awaiting_decision = application_choice.self_and_siblings.find(&:decision_pending?)
     @awaiting_decision_by = @awaiting_decision.reject_by_default_at.to_s(:govuk_date)
     @candidate_magic_link = candidate_magic_link(@application_choice.application_form.candidate)
 
@@ -105,7 +105,7 @@ class CandidateMailer < ApplicationMailer
   def application_rejected_awaiting_decision_only(application_choice)
     @course = application_choice.course_option.course
     @application_choice = RejectedApplicationChoicePresenter.new(application_choice)
-    @awaiting_decision = application_choice.self_and_siblings.select(&:awaiting_provider_decision?)
+    @awaiting_decision = application_choice.self_and_siblings.select(&:decision_pending?)
     @awaiting_decisions_by = @awaiting_decision.sort_by(&:reject_by_default_at).map(&:reject_by_default_at).last.to_s(:govuk_date)
 
     email_for_candidate(application_choice.application_form)
@@ -221,7 +221,7 @@ class CandidateMailer < ApplicationMailer
 
     @course_option = @application_choice.course_option
     @offered_course_option = @application_choice.offered_course_option
-    @is_awaiting_decision = application_choice.self_and_siblings.any?(&:awaiting_provider_decision?)
+    @is_awaiting_decision = application_choice.self_and_siblings.decision_pending.any?
     @offers = @application_choice.self_and_siblings.select(&:offer?).map do |offer|
       "#{offer.course_option.course.name_and_code} at #{offer.course_option.course.provider.name}"
     end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -39,6 +39,12 @@ class ApplicationChoice < ApplicationRecord
     offer_deferred: 'offer_deferred',
   }
 
+  scope :decision_pending, -> { where(status: ApplicationStateChange::DECISION_PENDING_STATUSES) }
+
+  def decision_pending?
+    ApplicationStateChange::DECISION_PENDING_STATUSES.include? status.to_sym
+  end
+
   def different_offer?
     offered_course_option_id && offered_course_option_id != course_option_id
   end
@@ -69,7 +75,7 @@ class ApplicationChoice < ApplicationRecord
       return pg_days_left_to_respond
     end
 
-    if status == 'awaiting_provider_decision'
+    if decision_pending?
       rbd = reject_by_default_at
       ((rbd - Time.zone.now) / 1.day).floor if rbd && rbd > Time.zone.now
     end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -104,7 +104,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def awaiting_provider_decisions?
-    application_choices.where(status: ApplicationStateChange::DECISION_PENDING_STATUSES).any?
+    application_choices.decision_pending.any?
   end
 
   def first_not_declined_application_choice
@@ -155,16 +155,12 @@ class ApplicationForm < ApplicationRecord
   end
 
   def all_provider_decisions_made?
-    application_choices.any? && (application_choices.map(&:status).map(&:to_sym) & ApplicationStateChange::DECISION_PENDING_STATUSES).empty?
+    application_choices.decision_pending.none?
   end
 
   def all_choices_withdrawn?
     application_choices.any? &&
       application_choices.all? { |application_choice| application_choice.status == 'withdrawn' }
-  end
-
-  def any_awaiting_provider_decision?
-    application_choices.map.any?(&:awaiting_provider_decision?)
   end
 
   def any_offers?

--- a/app/queries/get_application_choices_ready_to_reject_by_default.rb
+++ b/app/queries/get_application_choices_ready_to_reject_by_default.rb
@@ -1,6 +1,6 @@
 class GetApplicationChoicesReadyToRejectByDefault
   def self.call
-    scope = ApplicationChoice.where(status: :awaiting_provider_decision).order(:application_form_id)
+    scope = ApplicationChoice.decision_pending.order(:application_form_id)
     application_choices_past_reject_by_default_at(scope)
   end
 

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -42,7 +42,7 @@ private
   def application_choices_awaiting_provider_decision
     @application_choice
       .self_and_siblings
-      .where(status: ApplicationStateChange::DECISION_PENDING_STATUSES)
+      .decision_pending
   end
 
   def unconditional_offer?

--- a/app/services/send_candidate_rejection_email.rb
+++ b/app/services/send_candidate_rejection_email.rb
@@ -32,7 +32,7 @@ private
   end
 
   def applications_awaiting_decision_count
-    @applications_pending_decision_count ||= candidate_applications.awaiting_provider_decision.count
+    @applications_pending_decision_count ||= candidate_applications.decision_pending.count
   end
 
   def applications_with_offer_count

--- a/app/services/send_new_offer_email_to_candidate.rb
+++ b/app/services/send_new_offer_email_to_candidate.rb
@@ -16,7 +16,7 @@ private
 
   def mail_type(application_choice)
     candidate_application_choices = application_choice.self_and_siblings
-    number_of_pending_decisions = candidate_application_choices.select(&:awaiting_provider_decision?).count
+    number_of_pending_decisions = candidate_application_choices.decision_pending.count
     number_of_offers = candidate_application_choices.select(&:offer?).count
 
     if number_of_pending_decisions.positive?

--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -43,7 +43,7 @@ module SupportInterface
         :rejected_by_default
       elsif choice.rejected_at.present?
         :rejected
-      elsif choice.awaiting_provider_decision?
+      elsif choice.decision_pending?
         :awaiting_provider
       end
     end

--- a/app/services/support_interface/notifications_export.rb
+++ b/app/services/support_interface/notifications_export.rb
@@ -35,9 +35,7 @@ module SupportInterface
     end
 
     def awaiting_decisions_count(applications)
-      applications.count do |application|
-        ApplicationStateChange::DECISION_PENDING_STATUSES.include?(application.status.to_sym)
-      end
+      applications.count(&:decision_pending?)
     end
 
     def receiving_decisions_count(applications)

--- a/spec/components/provider_interface/application_choice_header_component_spec.rb
+++ b/spec/components/provider_interface/application_choice_header_component_spec.rb
@@ -42,6 +42,18 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
       it 'presents content without a heading or button' do
         expect(result.css('.govuk-inset-text').text).to include('There are 10 days to respond.')
       end
+
+      context 'when the interviews FeatureFlag is enabled' do
+        let(:status) { 'interviewing' }
+
+        before do
+          FeatureFlag.activate(:interviews)
+        end
+
+        it 'presents content without a heading or button' do
+          expect(result.css('.govuk-inset-text').text).to include('There are 10 days to respond.')
+        end
+      end
     end
 
     context 'when the application has had an offer' do

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
   let(:offer) { build_stubbed(:application_choice, :with_offer, course_option: course_option) }
   let(:awaiting_decision) { build_stubbed(:application_choice, :awaiting_provider_decision, course_option: other_option, offered_course_option: other_option) }
+  let(:interviewing) { build_stubbed(:application_choice, :awaiting_provider_decision, status: :interviewing, course_option: other_option, offered_course_option: other_option) }
 
   let(:application_choices) { [] }
 
@@ -147,26 +148,47 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     describe '.application_rejected_one_offer_one_awaiting_decision' do
       let(:email) { mailer.application_rejected_one_offer_one_awaiting_decision(application_choices.first) }
-      let(:application_choices) { [rejected, offer, awaiting_decision] }
 
-      it_behaves_like(
-        'a mail with subject and content',
-        I18n.t!('candidate_mailer.application_rejected_one_offer_one_awaiting_decision.subject',
-                provider_name: 'Brighthurst Technical College'),
-        'heading' => 'Dear Bob',
-        'course name and code' => 'Applied Science (Psychology)',
-        'qualifications rejection heading' => 'Qualifications',
-        'qualifications rejection content' => 'Bad qualifications',
-        'other application details' => 'You have an offer and are waiting for a decision about another course',
-        'application with offer' => 'You have an offer from Brighthurst Technical College to study Applied Science (Psychology)',
-        'application awaiting decision' => 'to make a decision about your application to study Forensic Science',
-        'decision day' => 'has until 22 June 2020 to make a decision',
-      )
+      context 'with an awaiting decision application' do
+        let(:application_choices) { [rejected, offer, awaiting_decision] }
+
+        it_behaves_like(
+          'a mail with subject and content',
+          I18n.t!('candidate_mailer.application_rejected_one_offer_one_awaiting_decision.subject',
+                  provider_name: 'Brighthurst Technical College'),
+          'heading' => 'Dear Bob',
+          'course name and code' => 'Applied Science (Psychology)',
+          'qualifications rejection heading' => 'Qualifications',
+          'qualifications rejection content' => 'Bad qualifications',
+          'other application details' => 'You have an offer and are waiting for a decision about another course',
+          'application with offer' => 'You have an offer from Brighthurst Technical College to study Applied Science (Psychology)',
+          'application awaiting decision' => 'to make a decision about your application to study Forensic Science',
+          'decision day' => 'has until 22 June 2020 to make a decision',
+        )
+      end
+
+      context 'with an interviewing application' do
+        let(:application_choices) { [rejected, offer, interviewing] }
+
+        it_behaves_like(
+          'a mail with subject and content',
+          I18n.t!('candidate_mailer.application_rejected_one_offer_one_awaiting_decision.subject',
+                  provider_name: 'Brighthurst Technical College'),
+          'heading' => 'Dear Bob',
+          'course name and code' => 'Applied Science (Psychology)',
+          'qualifications rejection heading' => 'Qualifications',
+          'qualifications rejection content' => 'Bad qualifications',
+          'other application details' => 'You have an offer and are waiting for a decision about another course',
+          'application with offer' => 'You have an offer from Brighthurst Technical College to study Applied Science (Psychology)',
+          'application awaiting decision' => 'to make a decision about your application to study Forensic Science',
+          'decision day' => 'has until 22 June 2020 to make a decision',
+        )
+      end
     end
 
     describe '.application_rejected_awaiting_decision_only' do
       let(:email) { mailer.application_rejected_awaiting_decision_only(application_choices.first) }
-      let(:application_choices) { [rejected, awaiting_decision, awaiting_decision] }
+      let(:application_choices) { [rejected, awaiting_decision, interviewing] }
 
       it_behaves_like(
         'a mail with subject and content',

--- a/spec/services/send_candidate_rejection_email_spec.rb
+++ b/spec/services/send_candidate_rejection_email_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe SendCandidateRejectionEmail do
     let(:application_choice) { create(:application_choice, status: :rejected, application_form: application_form) }
     let(:application_choice_with_offer) { create(:application_choice, :with_offer, application_form: application_form) }
     let(:application_choice_awaiting_decision) { create(:application_choice, status: :awaiting_provider_decision, application_form: application_form) }
+    let(:application_choice_with_interview) { create(:application_choice, status: :interviewing, application_form: application_form) }
     let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
 
     context 'when an application choice is rejected' do
@@ -24,6 +25,20 @@ RSpec.describe SendCandidateRejectionEmail do
         before do
           application_choice_with_offer
           application_choice_awaiting_decision
+
+          allow(CandidateMailer).to receive(:application_rejected_one_offer_one_awaiting_decision).and_return(mail)
+          described_class.new(application_choice: application_choice).call
+        end
+
+        it 'the application_rejected_one_offer_one_awaiting_decision email is sent to the candidate' do
+          expect(CandidateMailer).to have_received(:application_rejected_one_offer_one_awaiting_decision).with(application_choice)
+        end
+      end
+
+      describe 'when there are applications both with offer and interviews' do
+        before do
+          application_choice_with_offer
+          application_choice_with_interview
 
           allow(CandidateMailer).to receive(:application_rejected_one_offer_one_awaiting_decision).and_return(mail)
           described_class.new(application_choice: application_choice).call

--- a/spec/services/send_new_offer_email_to_candidate_spec.rb
+++ b/spec/services/send_new_offer_email_to_candidate_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SendNewOfferEmailToCandidate do
         allow(CandidateMailer).to receive(:new_offer_multiple_offers).and_return(mail)
         setup_application
         other_course_option = create(:course_option)
-        @other_application_choice = @application_form.application_choices.create(
+        @application_form.application_choices.create(
           application_form: @application_form,
           course_option: other_course_option,
           status: :offer,
@@ -48,16 +48,35 @@ RSpec.describe SendNewOfferEmailToCandidate do
       end
     end
 
-    context 'when there are decisions pending' do
+    context 'when there are other choices in the awaiting_provider_decision state' do
       before do
         mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
         allow(CandidateMailer).to receive(:new_offer_decisions_pending).and_return(mail)
         setup_application
         other_course_option = create(:course_option)
-        @other_application_choice = @application_form.application_choices.create(
+        @application_form.application_choices.create(
           application_form: @application_form,
           course_option: other_course_option,
           status: :awaiting_provider_decision,
+        )
+      end
+
+      it 'sends new offer email for pending decision case' do
+        described_class.new(application_choice: @application_choice).call
+        expect(CandidateMailer).to have_received(:new_offer_decisions_pending).with(@application_choice)
+      end
+    end
+
+    context 'when there are other choices in the interviewing state' do
+      before do
+        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+        allow(CandidateMailer).to receive(:new_offer_decisions_pending).and_return(mail)
+        setup_application
+        other_course_option = create(:course_option)
+        @application_form.application_choices.create(
+          application_form: @application_form,
+          course_option: other_course_option,
+          status: :interviewing,
         )
       end
 


### PR DESCRIPTION
## Context
There are a few issues around not accounting for the interviewing state.

## Changes proposed in this pull request
Main fix is to send candidates the correct email when they get an offer. At the moment, we send a 'single_offer' email, where we should send a 'decisions_pending' email.

## Guidance to review
I've put some specs in that failed before the changes. Do we want to cover any other cases here too?

