### PR TITLE
Whitelist host machine's IP address for HostAuthorization and use http health check for web app

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -116,6 +116,11 @@ Rails.application.configure do
     config.hosts << host
   end
 
+  # Whitelist the ip address on the machine/docker instance
+  Socket.ip_address_list.each do |ip|
+    config.hosts << ip.ip_address
+  end
+
   class FixAzureXForwardedForMiddleware
     def initialize(app)
       @app = app

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -17,8 +17,9 @@ provider "cloudfoundry" {
 resource "cloudfoundry_app" "web_app" {
   name                       = local.web_app_name
   docker_image               = var.app_docker_image
-  health_check_type          = "process"
+  health_check_type          = "http"
   health_check_http_endpoint = "/check"
+  health_check_timeout       = 180
   instances                  = var.web_app_instances
   memory                     = var.web_app_memory
   space                      = data.cloudfoundry_space.space.id


### PR DESCRIPTION
## Context

cf http healthcheck runs on each instance of the app and the hostname used is the local IP address of the instance.
So using a http health check while using HostAuthorization on the web app fails without whitelisting this IP address of the app instance.

## Changes proposed in this pull request

Add the IP address of the host instance to `config.hosts`

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
