### PR TITLE
Update Unpaid Experience (volunteering) review page

### DIFF
--- a/app/components/candidate_interface/volunteering_review_component.html.erb
+++ b/app/components/candidate_interface/volunteering_review_component.html.erb
@@ -15,13 +15,12 @@
 <% if show_missing_banner? %>
   <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :volunteering, section_path: candidate_interface_volunteering_experience_path, error: @missing_error)) %>
 <% elsif @application_form.application_volunteering_experiences.empty? %>
-  <section class="app-summary-card govuk-!-margin-bottom-6">
-    <%= render(SummaryCardHeaderComponent.new(title: t('application_form.volunteering.no_experience.summary_card_title'), heading_level: @heading_level)) %>
+  <%= govuk_inset_text(classes: 'govuk-!-margin-top-0 govuk-!-width-two-thirds') do %>
+    <p>The Department for Education have made it easier for teacher training applicants to gain experience in school.</p>
+    <p>
+      <%= govuk_link_to t('application_form.volunteering.no_experience.get_experience'), 'https://schoolexperience.education.gov.uk', target: :_blank, rel: 'noopener' %>
+    </p>
+  <% end %>
 
-    <div class="app-summary-card__body">
-      The Department for Education have made it easier for teacher training
-      applicants to gain experience in school. Learn more at
-      <%= govuk_link_to 'Get school experience', 'https://schoolexperience.education.gov.uk/', target: :_blank, rel: 'noopener' %>.
-    </div>
-  </section>
+  <%= render(SummaryCardComponent.new(rows: no_experience_row, editable: @editable)) %>
 <% end %>

--- a/app/components/candidate_interface/volunteering_review_component.html.erb
+++ b/app/components/candidate_interface/volunteering_review_component.html.erb
@@ -15,11 +15,13 @@
 <% if show_missing_banner? %>
   <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :volunteering, section_path: candidate_interface_volunteering_experience_path, error: @missing_error)) %>
 <% elsif @application_form.application_volunteering_experiences.empty? %>
-  <%= govuk_inset_text(classes: 'govuk-!-margin-top-0 govuk-!-width-two-thirds') do %>
-    <p>The Department for Education have made it easier for teacher training applicants to gain experience in school.</p>
-    <p>
-      <%= govuk_link_to t('application_form.volunteering.no_experience.get_experience'), 'https://schoolexperience.education.gov.uk', target: :_blank, rel: 'noopener' %>
-    </p>
+  <% if show_experience_advice %>
+    <%= govuk_inset_text(classes: 'govuk-!-margin-top-0 govuk-!-width-two-thirds') do %>
+      <p>The Department for Education have made it easier for teacher training applicants to gain experience in school.</p>
+      <p>
+        <%= govuk_link_to t('application_form.volunteering.no_experience.get_experience'), 'https://schoolexperience.education.gov.uk', target: :_blank, rel: 'noopener' %>
+      </p>
+    <% end %>
   <% end %>
 
   <%= render(SummaryCardComponent.new(rows: no_experience_row, editable: @editable)) %>

--- a/app/components/candidate_interface/volunteering_review_component.rb
+++ b/app/components/candidate_interface/volunteering_review_component.rb
@@ -24,6 +24,17 @@ module CandidateInterface
       ]
     end
 
+    def no_experience_row
+      [
+        {
+          key: t('application_form.volunteering.experience.label'),
+          value: 'No',
+          action: t('application_form.volunteering.experience.change_action'),
+          change_path: candidate_interface_volunteering_experience_path,
+        },
+      ]
+    end
+
     def show_missing_banner?
       @show_incomplete && !@application_form.volunteering_completed && @editable
     end

--- a/app/components/candidate_interface/volunteering_review_component.rb
+++ b/app/components/candidate_interface/volunteering_review_component.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     include ViewHelper
     include DateValidationHelper
 
-    def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
+    def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false, show_experience_advice: false)
       @application_form = application_form
       @volunteering_roles = CandidateInterface::VolunteeringRoleForm.build_all_from_application(
         @application_form,
@@ -12,6 +12,7 @@ module CandidateInterface
       @heading_level = heading_level
       @show_incomplete = show_incomplete
       @missing_error = missing_error
+      @show_experience_advice = show_experience_advice
     end
 
     def volunteering_role_rows(volunteering_role)
@@ -41,7 +42,7 @@ module CandidateInterface
 
   private
 
-    attr_reader :application_form
+    attr_reader :application_form, :show_experience_advice
 
     def role_row(volunteering_role)
       {

--- a/app/controllers/candidate_interface/volunteering/start_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/start_controller.rb
@@ -3,13 +3,17 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_submitted
 
     def show
-      @volunteering_experience_form = VolunteeringExperienceForm.new
+      @volunteering_experience_form = VolunteeringExperienceForm.new(
+        experience: current_application.volunteering_experience,
+      )
     end
 
     def submit
       @volunteering_experience_form = VolunteeringExperienceForm.new(volunteering_experience_form_params)
 
       if @volunteering_experience_form.valid?
+        @volunteering_experience_form.save(current_application)
+
         if @volunteering_experience_form.experience == 'false'
           redirect_to candidate_interface_review_volunteering_path
         else

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -309,9 +309,9 @@ module CandidateInterface
   private
 
     def show_review_volunteering?
-      volunteering_experience_is_set = @application_form.volunteering_experience == true
+      no_volunteering_confirmed = @application_form.volunteering_experience == false && @application_form.application_volunteering_experiences.empty?
 
-      volunteering_completed? || volunteering_added? || volunteering_experience_is_set
+      volunteering_completed? || volunteering_added? || no_volunteering_confirmed
     end
 
     def gcse_completed?(gcse)

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -1,25 +1,16 @@
 <% content_for :title, t('page_titles.volunteering.short') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <%= t('page_titles.volunteering.short') %>
-    </h1>
-
-    <%= govuk_link_to candidate_interface_new_volunteering_role_path, button: true, class: 'govuk-button--secondary' do %>
-      <%= @application_form.application_volunteering_experiences.any? ? t('application_form.volunteering.another.button') : t('application_form.volunteering.add.button') %>
-    <% end %>
-  </div>
-</div>
+<h1 class="govuk-heading-xl"><%= t('page_titles.volunteering.short') %></h1>
+<% if @application_form.application_volunteering_experiences.any? %>
+  <%= govuk_link_to(t('application_form.volunteering.another.button'), candidate_interface_new_volunteering_role_path, button: true, class: 'govuk-button--secondary') %>
+<% end %>
 
 <%= render(CandidateInterface::VolunteeringReviewComponent.new(application_form: @application_form)) %>
 
-<%= form_with model: @application_form, url: candidate_interface_complete_volunteering_path do |f| %>
-  <div class="govuk-form-group">
-    <%= f.hidden_field :volunteering_completed, value: false %>
-    <%= f.govuk_check_box :volunteering_completed, true, multiple: false, label: { text: t('application_form.volunteering.review.completed_checkbox') } %>
-  </div>
-
-  <%= f.govuk_submit t('continue') %>
-<% end %>
+<%= render(CandidateInterface::CompleteSectionComponent.new(
+  application_form: @application_form,
+  path: candidate_interface_complete_volunteering_path,
+  request_method: :patch,
+  field_name: :volunteering_completed,
+)) %>

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -6,7 +6,7 @@
   <%= govuk_link_to(t('application_form.volunteering.another.button'), candidate_interface_new_volunteering_role_path, button: true, class: 'govuk-button--secondary') %>
 <% end %>
 
-<%= render(CandidateInterface::VolunteeringReviewComponent.new(application_form: @application_form)) %>
+<%= render(CandidateInterface::VolunteeringReviewComponent.new(application_form: @application_form, show_experience_advice: true)) %>
 
 <%= render(CandidateInterface::CompleteSectionComponent.new(
   application_form: @application_form,

--- a/app/views/candidate_interface/volunteering/start/show.html.erb
+++ b/app/views/candidate_interface/volunteering/start/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.volunteering.long'), @volunteering_experience_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(:back) %>
 
 <div class="govuk-grid-row">
   <%= form_with model: @volunteering_experience_form, url: candidate_interface_volunteering_experience_path do |f| %>

--- a/config/locales/candidate_interface/volunteering.yml
+++ b/config/locales/candidate_interface/volunteering.yml
@@ -3,8 +3,10 @@ en:
     volunteering:
       experience:
         label: Do you have any relevant unpaid experience?
+        change_action: Change
       no_experience:
         summary_card_title: 'Children and young people: no volunteering or experience in school roles entered'
+        get_experience: Learn more at Get school experience
       role:
         label: Your role
         review_label: Role

--- a/spec/components/candidate_interface/volunteering_review_component_spec.rb
+++ b/spec/components/candidate_interface/volunteering_review_component_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe CandidateInterface::VolunteeringReviewComponent do
 
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.css('.app-summary-card__title').text).to include(
-        t('application_form.volunteering.no_experience.summary_card_title'),
+      expect(result.css('.app-summary-card__body').text).to include(
+        t('application_form.volunteering.experience.label'),
       )
     end
 

--- a/spec/components/candidate_interface/volunteering_review_component_spec.rb
+++ b/spec/components/candidate_interface/volunteering_review_component_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::VolunteeringReviewComponent do
   context 'when they have no experience in volunteering' do
-    it 'shows how to get school experience' do
+    it 'confirms that they have no volunteering experience' do
       application_form = build_stubbed(:application_form)
 
       result = render_inline(described_class.new(application_form: application_form))
@@ -12,13 +12,33 @@ RSpec.describe CandidateInterface::VolunteeringReviewComponent do
       )
     end
 
-    it 'does not show how to get school experience if volunteering experience' do
+    it 'does not confirm that they have no volunteering experience' do
       application_form = create(:completed_application_form, volunteering_experiences_count: 1)
 
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.css('.app-summary-card__title').text).not_to include(
         t('application_form.volunteering.no_experience.summary_card_title'),
+      )
+    end
+
+    it 'shows how to get school experience' do
+      application_form = build_stubbed(:application_form)
+
+      result = render_inline(described_class.new(application_form: application_form, show_experience_advice: true))
+
+      expect(result.css('.govuk-inset-text').text).to include(
+        t('application_form.volunteering.no_experience.get_experience'),
+      )
+    end
+
+    it 'does not show how to get school experience' do
+      application_form = build_stubbed(:application_form)
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-inset-text').text).not_to include(
+        t('application_form.volunteering.no_experience.get_experience'),
       )
     end
   end

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -452,7 +452,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
   describe '#volunteering_path' do
     it 'returns the experience path if volunteering experience is not set' do
-      application_form = build(:completed_application_form, volunteering_completed: false, volunteering_experience: nil, volunteering_experiences_count: 0)
+      application_form = build(:completed_application_form, volunteering_completed: false, volunteering_experience: nil)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter.volunteering_path).to eq(
@@ -460,17 +460,17 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
       )
     end
 
-    it 'returns the experience path if no volunteering experience' do
-      application_form = build(:completed_application_form, volunteering_completed: false, volunteering_experience: false, volunteering_experiences_count: 0)
+    it 'returns the review path if candidate has no volunteering experience' do
+      application_form = build(:completed_application_form, volunteering_completed: false, volunteering_experience: false)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter.volunteering_path).to eq(
-        Rails.application.routes.url_helpers.candidate_interface_volunteering_experience_path,
+        Rails.application.routes.url_helpers.candidate_interface_review_volunteering_path,
       )
     end
 
-    it 'returns the review path if volunteering experience' do
-      application_form = build(:completed_application_form, volunteering_completed: false, volunteering_experience: true, volunteering_experiences_count: 1)
+    it 'returns the review path if candidate has volunteering experience' do
+      application_form = create(:completed_application_form, volunteering_completed: false, volunteering_experience: true, volunteering_experiences_count: 1)
 
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 

--- a/spec/system/candidate_interface/entering_details/candidate_choosing_no_volunteering_and_school_experience_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_choosing_no_volunteering_and_school_experience_spec.rb
@@ -53,6 +53,6 @@ RSpec.feature 'Choosing no volunteering and school experience' do
   end
 
   def then_i_see_how_to_get_school_experience
-    expect(page).to have_content('Learn more at Get school experience.')
+    expect(page).to have_content(t('application_form.volunteering.no_experience.get_experience'))
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
     then_the_volunteering_section_should_be_marked_as_incomplete
 
     when_i_click_the_volunteering_section_link
-    then_i_should_be_prompted_to_add_new_experience
+    then_i_should_be_see_the_volunteering_review_page
   end
 
   def given_i_am_signed_in
@@ -95,7 +95,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
     click_button t('application_form.volunteering.delete.confirm')
   end
 
-  def then_i_should_be_prompted_to_add_new_experience
-    expect(page).to have_current_path(candidate_interface_volunteering_experience_path)
+  def then_i_should_be_see_the_volunteering_review_page
+    expect(page).to have_current_path(candidate_interface_review_volunteering_path)
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_with_restructured_work_history_active_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_with_restructured_work_history_active_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
     then_the_volunteering_section_should_be_marked_as_incomplete
 
     when_i_click_the_volunteering_section_link
-    then_i_should_be_prompted_to_add_new_experience
+    then_i_should_be_see_the_volunteering_review_page
   end
 
   def given_i_am_signed_in
@@ -101,7 +101,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
     click_button t('application_form.volunteering.delete.confirm')
   end
 
-  def then_i_should_be_prompted_to_add_new_experience
-    expect(page).to have_current_path(candidate_interface_volunteering_experience_path)
+  def then_i_should_be_see_the_volunteering_review_page
+    expect(page).to have_current_path(candidate_interface_review_volunteering_path)
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_and_school_experience_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_and_school_experience_spec.rb
@@ -42,7 +42,11 @@ RSpec.feature 'Entering volunteering and school experience' do
     and_i_submit_the_volunteering_experience_form
     then_i_can_see_a_link_to_get_school_experience
 
-    when_i_click_on_add_a_role
+    when_i_click_on_change
+    then_i_see_the_unpaid_experience_page
+
+    when_i_choose_yes_experience
+    and_i_submit_the_volunteering_experience_form
     then_i_see_the_add_volunteering_role_form
 
     when_i_fill_in_another_volunteering_role
@@ -224,6 +228,10 @@ RSpec.feature 'Entering volunteering and school experience' do
     click_link t('application_form.volunteering.another.button')
   end
 
+  def then_i_see_the_unpaid_experience_page
+    expect(page).to have_content(t('page_titles.volunteering.long'))
+  end
+
   def then_i_see_the_add_volunteering_role_form
     expect(page).to have_content(t('page_titles.add_volunteering_role'))
   end
@@ -237,10 +245,10 @@ RSpec.feature 'Entering volunteering and school experience' do
   end
 
   def then_i_can_see_a_link_to_get_school_experience
-    expect(page).to have_link('Get school experience', href: 'https://schoolexperience.education.gov.uk/')
+    expect(page).to have_link(t('application_form.volunteering.no_experience.get_experience'), href: 'https://schoolexperience.education.gov.uk')
   end
 
-  def when_i_click_on_add_a_role
-    click_link t('application_form.volunteering.add.button')
+  def when_i_click_on_change
+    click_link t('application_form.volunteering.experience.change_action')
   end
 end


### PR DESCRIPTION
## Context

```
As a... candidate with no unpaid experience
I need to... know that I can get school experience
So that... I can improve my application
```

Currently, if you answer ‘No’ to the question ‘Do you have any relevant unpaid experience?’, we show a summary card with information about getting school experience. We’ve since changed how we show such guidance, and should be consistent in how we replay answers.

[Prototype design](https://apply-beta-prototype.herokuapp.com/application/12345/unpaid-experience/review)

## Changes proposed in this pull request

- Update replaying answer for no unpaid experience to use same design as that used for other sections.
- use CompleteSectionComponent

### Before 

<img width="1021" alt="unpaid_before" src="https://user-images.githubusercontent.com/5256922/114890300-cbb9b280-9e02-11eb-9363-6f2ce3d5e307.png">

### After

<img width="1068" alt="unpaid_after" src="https://user-images.githubusercontent.com/5256922/114889906-741b4700-9e02-11eb-88b1-8ad8f6d77d4f.png">


## Guidance to review

- Visit `/candidate/application/unpaid-experience` and select 'no' to `Do you have any relevant unpaid experience?`. 

## Link to Trello card

https://trello.com/c/pEGX8x9w/3290-update-replaying-answer-to-having-no-unpaid-experience-to-use-same-design-as-that-used-for-other-sections

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
