### PR TITLE
Don’t render organisation change link for interview with one provider

### DIFF
--- a/app/components/provider_interface/interview_details_component.rb
+++ b/app/components/provider_interface/interview_details_component.rb
@@ -28,7 +28,7 @@ module ProviderInterface
     end
 
     def organisation_row
-      build_row(:provider_id, @interview_form.provider.name)
+      build_row(:provider_id, @interview_form.provider.name, editable: @interview_form.multiple_application_providers?)
     end
 
     def location_row
@@ -39,13 +39,13 @@ module ProviderInterface
       build_row(:additional_details, @interview_form.additional_details.presence || 'None')
     end
 
-    def build_row(field, value)
+    def build_row(field, value, editable: true)
       key = key_for_field(field)
       {
         key: key,
         value: value,
         action: key.downcase,
-        change_path: change_path(field),
+        change_path: editable ? change_path(field) : nil,
       }
     end
 

--- a/app/forms/provider_interface/interview_wizard.rb
+++ b/app/forms/provider_interface/interview_wizard.rb
@@ -76,6 +76,10 @@ module ProviderInterface
       wizard
     end
 
+    def multiple_application_providers?
+      @_multiple_application_providers ||= application_providers.count > 1
+    end
+
   private
 
     def date_and_time_in_future
@@ -107,10 +111,6 @@ module ProviderInterface
       return if time_in_correct_format?
 
       errors.add(:time, :invalid)
-    end
-
-    def multiple_application_providers?
-      @_multiple_application_providers ||= application_providers.count > 1
     end
 
     def application_providers

--- a/spec/components/provider_interface/interview_details_component_spec.rb
+++ b/spec/components/provider_interface/interview_details_component_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ProviderInterface::InterviewDetailsComponent do
   let(:application_choice) { build_stubbed(:application_choice, id: 1) }
   let(:location) { 'Zoom' }
   let(:additional_details) { 'Do not be late' }
+  let(:multiple_application_providers) { false }
   let(:interview_form) do
     instance_double(
       ProviderInterface::InterviewWizard,
@@ -14,6 +15,7 @@ RSpec.describe ProviderInterface::InterviewDetailsComponent do
       location: location,
       additional_details: additional_details,
       application_choice: application_choice,
+      multiple_application_providers?: multiple_application_providers,
     )
   end
   let(:render) { render_inline(described_class.new(interview_form)) }
@@ -63,9 +65,13 @@ RSpec.describe ProviderInterface::InterviewDetailsComponent do
       expect(time_row.css('a').attr('href').value).to eq('/provider/applications/1/interviews/new#provider-interface-interview-wizard-time-field')
     end
 
-    it 'provider' do
-      provider_row = find_table_row('Organisation carrying out interview')
-      expect(provider_row.css('a').attr('href').value).to eq("/provider/applications/1/interviews/new#provider-interface-interview-wizard-provider-id-#{provider.id}-field")
+    context 'provider' do
+      let(:multiple_application_providers) { true }
+
+      it 'when multiple providers' do
+        provider_row = find_table_row('Organisation carrying out interview')
+        expect(provider_row.css('a').attr('href').value).to eq("/provider/applications/1/interviews/new#provider-interface-interview-wizard-provider-id-#{provider.id}-field")
+      end
     end
 
     it 'location' do
@@ -76,6 +82,17 @@ RSpec.describe ProviderInterface::InterviewDetailsComponent do
     it 'additional_details' do
       additional_details_row = find_table_row('Additional details')
       expect(additional_details_row.css('a').attr('href').value).to eq('/provider/applications/1/interviews/new#provider-interface-interview-wizard-additional-details-field')
+    end
+  end
+
+  describe 'renders no change change link' do
+    context 'provider' do
+      let(:multiple_application_providers) { false }
+
+      it 'when single provider' do
+        provider_row = find_table_row('Organisation carrying out interview')
+        expect(provider_row.css('a')).to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
## Context

Currently the change organisation link is rendered even when there is only one application  provider. 

## Changes proposed in this pull request

Only render the change link when the application has multiple providers.

## Link to Trello card

https://trello.com/c/bMoEEAK1/3496-change-link-for-interview-with-one-organisation

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
