### PR TITLE
Fix `govuk_button` not rendering correctly

### DIFF
--- a/app/views/provider_interface/interviews/check.html.erb
+++ b/app/views/provider_interface/interviews/check.html.erb
@@ -13,7 +13,7 @@
     <% if @interview.present? %>
       <%= govuk_button_to t('.update.confirm'), { action: 'update', id: @interview.id }, method: :put %>
     <% else %>
-      <%= govuk_button_to t('.confirm'), action: 'commit' %>
+      <%= govuk_button_to t('.confirm'), { action: 'commit' }, method: :post %>
     <% end %>
 
     <p class="govuk-body">


### PR DESCRIPTION
## Context

The current button isn't rendering correctly  and without any styles
![Screenshot 2021-04-16 at 11 42 20](https://user-images.githubusercontent.com/2732945/115009908-7b4f5d00-9eb5-11eb-8d5c-5a104e3715b2.png)


## Changes proposed in this pull request

Add a method which ensures the correct styles are rendered

## Guidance to review

I've checked other occurrences and this is the only one.

## Link to Trello card

trello-ticket: https://trello.com/c/t0D1R5m9/3624-change-link-for-interview-with-one-organisation

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
