### PR TITLE
Apply the discussed fixes to the application dashboard

### DIFF
--- a/app/components/candidate_interface/application_dashboard_guidance_component.html.erb
+++ b/app/components/candidate_interface/application_dashboard_guidance_component.html.erb
@@ -10,7 +10,7 @@
 
 <% elsif has_multiple_offers_but_awaiting_decisions? %>
 
-  <p class="govuk-body"><%= number_of_offers_in_words %> of your training providers have made a decision on your application.</p>
+  <p class="govuk-body">2 of your training providers have made a decision on your application.</p>
   <p class="govuk-body">Our <%= govuk_link_to('teacher training advisers', 'https://beta-adviser-getintoteaching.education.gov.uk/') %> can help you prepare for any interviews.</p>
 
 <% elsif has_single_offer_but_awaiting_decisions? %>
@@ -27,7 +27,6 @@
 <% elsif offer_deferred? %>
 
   <p class="govuk-body">You’ve chosen to defer your course.</p>
-  <p class="govuk-body">Before your offer is confirmed, there are some final conditions to meet.</p>
 
 <% elsif conditions_met? %>
 

--- a/app/components/candidate_interface/application_dashboard_guidance_component.rb
+++ b/app/components/candidate_interface/application_dashboard_guidance_component.rb
@@ -4,12 +4,6 @@ module CandidateInterface
 
     attr_reader :application_form
 
-    NUMBER_IN_WORDS = {
-      1 => 'One',
-      2 => 'Two',
-      3 => 'Three',
-    }.freeze
-
     def initialize(application_form:)
       @application_form = application_form
     end
@@ -48,11 +42,6 @@ module CandidateInterface
 
     def has_multiple_offers?
       multiple_choices_with_status?('offer')
-    end
-
-    def number_of_offers_in_words
-      count = statuses.select { |s| s == 'offer' }.count
-      NUMBER_IN_WORDS[count] || count.to_s
     end
 
     def accepted_offer_provider_name

--- a/app/components/candidate_interface/apply_again_call_to_action_component.rb
+++ b/app/components/candidate_interface/apply_again_call_to_action_component.rb
@@ -9,7 +9,7 @@ module CandidateInterface
 
     def title
       if offers_declined?
-        "You’ve declined #{multiple_offers_declined? ? 'all of your offers' : 'your offer'}."
+        "You’ve declined #{multiple_offers_declined? ? 'all of your offers' : 'your offer'}"
       elsif applications_withdrawn?
         "You’ve withdrawn your #{multiple_offers_withdrawn? ? 'applications' : 'application'}"
       else

--- a/spec/components/candidate_interface/application_dashboard_guidance_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_guidance_component_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CandidateInterface::ApplicationDashboardGuidanceComponent do
       statuses: %w[offer offer awaiting_provider_decision],
     )
     result = render_inline(described_class.new(application_form: application_form))
-    expect(result.text).to include('Two of your training providers have made a decision on your application')
+    expect(result.text).to include('2 of your training providers have made a decision on your application')
   end
 
   it 'displays correct message when an offer has been accepted' do


### PR DESCRIPTION
## Context

After reviewing the recent changes to the dashboard there were a few minor bugs that needed fixing.

## Changes proposed in this pull request

- Remove `Before your offer is confirmed, there are some final conditions to meet.` for deferred offers
- `Two of your training providers have made a decision on your application.` should be `2 of your training providers have made a decision on your application.`
- Remove the full stop from `You’ve declined your offer. `

## Link to Trello card

https://trello.com/c/xpNnuh0R/3302-dashboard-walkthrough-changes

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
