### PR TITLE
Remove config.hosts setting from production.rb

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,11 +111,6 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
-  # Whitelist the production domains for HostAuthorization
-  HostingEnvironment.authorised_hosts.each do |host|
-    config.hosts << host
-  end
-
   class FixAzureXForwardedForMiddleware
     def initialize(app)
       @app = app


### PR DESCRIPTION
DNS rebinding is only exploitable in Rails via webconsole, which is only available in development.

The idea is that if an attacker causes the user's browser to visit `malicious-domain.com` and then a) runs JS from that domain and b) causes `malicious-domain.com` to resolve to `127.0.0.1` then their JS can make requests against the local network (or others!) that would otherwise be blocked by the Same-Origin policy (ie `malicious-domain.com` scripts can't make requests to domains with different hostnames). The attacker might then, for example try to POST via the REPL in the webconsole screen by sending formdata to `POST malicious-domain.com/webconsole` or wherever legit input to that REPL gets POSTed.

## Context

@vigneshmsft pointed out we didn't need it: https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1618578258054500?thread_ts=1618569242.045800&cid=CN1MCQCHZ

## Changes proposed in this pull request

Remove the setting in prod. Follow-up PR will set a new `HOSTNAME` ENV var prior to dispensing with `AUTHORIZED_HOSTS` altogether

Further reading:

https://bigbinary.com/blog/rails-6-adds-guard-against-dns-rebinding-attacks
https://medium.com/@brannondorsey/attacking-private-networks-from-the-internet-with-dns-rebinding-ea7098a2d325
http://benmmurphy.github.io/blog/2016/07/11/rails-webconsole-dns-rebinding/

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
