### PR TITLE
Make commands to view and edit Key Vault secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ jmeter.log
 # Terraform files
 *.tfstate
 .terraform
+
+# Key Vault secrets management script used in Makefile
+bin/fetch_config.rb


### PR DESCRIPTION
## Context

Enable devs to view/edit app secrets from the console.

## Changes proposed in this pull request

make commands to view, edit and save back secrets to Azure Key Vault.

```
make qa view-app-secrets
make staging edit-app-secrets
```

## Guidance to review

## Link to Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
