### PR TITLE
Limit autofill extract to application forms submitted after 1st December 2020

### DIFF
--- a/app/services/support_interface/candidate_autofill_usage_export.rb
+++ b/app/services/support_interface/candidate_autofill_usage_export.rb
@@ -108,13 +108,11 @@ module SupportInterface
             recruitment_cycle_year: RecruitmentCycle.current_year,
           },
         )
-        .where.not(
-          qualification_type: 'non_uk',
+        .where(
+          'application_forms.submitted_at > ?', Date.new(2020, 12, 1)
         )
         .where.not(
-          application_forms: {
-            submitted_at: nil,
-          },
+          qualification_type: 'non_uk',
         )
         .all
     end

--- a/spec/services/support_interface/candidate_autofill_usage_export_spec.rb
+++ b/spec/services/support_interface/candidate_autofill_usage_export_spec.rb
@@ -50,6 +50,15 @@ RSpec.describe SupportInterface::CandidateAutofillUsageExport do
       end
     end
 
+    context 'Applications submitted before Dec 1, 2020' do
+      it "does not return a hash of candidates' autofill usage" do
+        application_form = create(:application_form, :minimum_info, phase: 'apply_1', submitted_at: Date.new(2020, 11, 1))
+        create(:degree_qualification, application_form: application_form)
+
+        expect(described_class.new.data_for_export).to be_empty
+      end
+    end
+
     context 'Non UK qualifications' do
       it "does not return a hash of candidates' autofill usage" do
         application_form = create(:application_form, :minimum_info, phase: 'apply_1')


### PR DESCRIPTION
## Context

```
As a... candy analyst
I need to... know what the autofill usage particularly related to degrees after structured quals had been launched
So that... we can understand what other amendments are required for register data sharing
```

## Changes proposed in this pull request

- The Candidate autosuggest usage extract scoped to submitted application forms after 1st December 2020

## Link to Trello card

https://trello.com/c/5vIUeyr7/3312-limit-autofill-extract-to-entries-after-1st-december-2020

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
