### PR TITLE
Add custom colors to TaskListItemComponent

### DIFF
--- a/app/components/task_list_item_component.html.erb
+++ b/app/components/task_list_item_component.html.erb
@@ -1,8 +1,6 @@
 <div class="app-task-list__content">
   <%= govuk_link_to text, path, class: 'app-task-list__task-name', 'aria-describedby': tag_id %>
-  <% if submitted %>
-    <%= govuk_tag(text: 'Submitted', colour: 'grey', html_attributes: { id: tag_id }) %>
-  <% elsif custom_status %>
+  <% if custom_status %>
     <%= govuk_tag(text: custom_status, colour: 'purple', html_attributes: { id: tag_id }) %>
   <% elsif completed %>
     <%= govuk_tag(text: 'Completed', html_attributes: { id: tag_id }) %>

--- a/app/components/task_list_item_component.html.erb
+++ b/app/components/task_list_item_component.html.erb
@@ -1,7 +1,7 @@
 <div class="app-task-list__content">
   <%= govuk_link_to text, path, class: 'app-task-list__task-name', 'aria-describedby': tag_id %>
   <% if custom_status %>
-    <%= govuk_tag(text: custom_status, colour: 'purple', html_attributes: { id: tag_id }) %>
+    <%= govuk_tag(text: custom_status, colour: custom_color || 'purple', html_attributes: { id: tag_id }) %>
   <% elsif completed %>
     <%= govuk_tag(text: 'Completed', html_attributes: { id: tag_id }) %>
   <% elsif show_incomplete %>

--- a/app/components/task_list_item_component.rb
+++ b/app/components/task_list_item_component.rb
@@ -6,14 +6,12 @@ class TaskListItemComponent < ViewComponent::Base
     path:,
     text:,
     show_incomplete: true,
-    submitted: false,
     custom_status: nil
   )
     @completed = completed
     @path = path
     @text = text
     @show_incomplete = show_incomplete
-    @submitted = submitted
     @custom_status = custom_status
   end
 
@@ -23,5 +21,5 @@ class TaskListItemComponent < ViewComponent::Base
 
 private
 
-  attr_reader :completed, :path, :text, :show_incomplete, :submitted, :custom_status
+  attr_reader :completed, :path, :text, :show_incomplete, :custom_status
 end

--- a/app/components/task_list_item_component.rb
+++ b/app/components/task_list_item_component.rb
@@ -6,13 +6,15 @@ class TaskListItemComponent < ViewComponent::Base
     path:,
     text:,
     show_incomplete: true,
-    custom_status: nil
+    custom_status: nil,
+    custom_color: nil
   )
     @completed = completed
     @path = path
     @text = text
     @show_incomplete = show_incomplete
     @custom_status = custom_status
+    @custom_color = custom_color
   end
 
   def tag_id
@@ -21,5 +23,5 @@ class TaskListItemComponent < ViewComponent::Base
 
 private
 
-  attr_reader :completed, :path, :text, :show_incomplete, :custom_status
+  attr_reader :completed, :path, :text, :show_incomplete, :custom_status, :custom_color
 end

--- a/spec/components/task_list_item_component_spec.rb
+++ b/spec/components/task_list_item_component_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe TaskListItemComponent do
-  def render_component(completed:, custom_status: nil)
-    render_inline(TaskListItemComponent.new(text: 'Personal details', path: '/personal-details', completed: completed, custom_status: custom_status))
+  def render_component(completed:, custom_status: nil, custom_color: nil)
+    render_inline(TaskListItemComponent.new(text: 'Personal details', path: '/personal-details', completed: completed, custom_status: custom_status, custom_color: custom_color))
   end
 
   it 'renders the correct text, href' do
@@ -21,9 +21,23 @@ RSpec.describe TaskListItemComponent do
     expect(result.css('#personal-details-badge-id').text).to include('Incomplete')
   end
 
-  it 'renders with a custom status badge' do
-    result = render_component(completed: false, custom_status: 'In progress')
-    expect(result.css('#personal-details-badge-id').text).to include('In progress')
-    expect(result.css('#personal-details-badge-id').first[:class]).to include('govuk-tag--purple')
+  context 'when given a custom status' do
+    it 'renders with a custom status badge' do
+      result = render_component(completed: false, custom_status: 'In progress')
+      expect(result.css('#personal-details-badge-id').text).to include('In progress')
+      expect(result.css('#personal-details-badge-id').first[:class]).to include('govuk-tag--purple')
+    end
+
+    it 'prioritises the custom status over the completed status' do
+      result = render_component(completed: true, custom_status: 'In progress')
+      expect(result.css('#personal-details-badge-id').text).to include('In progress')
+      expect(result.css('#personal-details-badge-id').first[:class]).to include('govuk-tag--purple')
+    end
+
+    it 'renders custom colors' do
+      result = render_component(completed: false, custom_status: 'In progress', custom_color: 'pink')
+      expect(result.css('#personal-details-badge-id').text).to include('In progress')
+      expect(result.css('#personal-details-badge-id').first[:class]).to include('govuk-tag--pink')
+    end
   end
 end


### PR DESCRIPTION
## Context

We're adding 'Review' badges to certain sections of the application when a candidate applied again. Just as we currently allow for custom statuses to be rendered by this component, we also need to ability to specify colors that aren't supported by default.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Add a `custom_color` argument to the component.
<!-- If there are UI changes, please include Before and After screenshots. -->

With `custom_color: green` —

![Screenshot_20210419_083612](https://user-images.githubusercontent.com/519250/115198730-4e37c000-a0ea-11eb-9a27-3efd46b9a235.png)


## Guidance to review
Per commit would be useful if only because there's also a small cleanup commit that removes an unused argument.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
