### PR TITLE
Fix RBD date calculation in specs

### DIFF
--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -157,13 +157,13 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
     end
 
     context 'when 1 day is left to respond' do
-      let(:rbd) { 2.days.from_now.midday }
+      let(:rbd) { 1.day.from_now.end_of_day }
 
       it { is_expected.to eq('1 day to make decision') }
     end
 
     context 'when 2 days are left to respond' do
-      let(:rbd) { 3.days.from_now.midday }
+      let(:rbd) { 2.days.from_now.end_of_day }
 
       it { is_expected.to eq('2 days to make decision') }
     end

--- a/spec/services/set_decline_by_default_spec.rb
+++ b/spec/services/set_decline_by_default_spec.rb
@@ -33,11 +33,11 @@ RSpec.describe SetDeclineByDefault do
 
     context 'when all the application choices have an offer' do
       it 'the DBD is set to 10 business days from the date of the most recent offer' do
-        choices[0].update(status: :offer, offered_at: 1.business_days.before(now).end_of_day)
+        most_recent_offer_date = 1.business_days.before(now).end_of_day
+        choices[0].update(status: :offer, offered_at: most_recent_offer_date)
         choices[1].update(status: :offer, offered_at: 2.business_days.before(now).end_of_day)
         choices[2].destroy # this tests that we can handle fewer than 3 choices
-
-        expected_dbd_date = 9.business_days.after(now).end_of_day
+        expected_dbd_date = 10.business_days.after(most_recent_offer_date).end_of_day
 
         call_service
 
@@ -83,11 +83,12 @@ RSpec.describe SetDeclineByDefault do
 
     context 'when one offer was made, and two decisions are rejected' do
       it 'the DBD is set to 10 business days from the date of the most recent decision' do
-        choices[0].update(status: :offer, offered_at: 1.business_days.before(now).end_of_day)
+        most_recent_offer_date = 1.business_days.before(now).end_of_day
+        choices[0].update(status: :offer, offered_at: most_recent_offer_date)
         choices[1].update(status: :rejected, rejected_at: 2.business_days.before(now).end_of_day)
         choices[2].update(status: :rejected, rejected_at: 3.business_days.before(now).end_of_day)
 
-        expected_dbd_date = 9.business_days.after(now).end_of_day
+        expected_dbd_date = 10.business_days.after(most_recent_offer_date).end_of_day
 
         call_service
 
@@ -97,11 +98,12 @@ RSpec.describe SetDeclineByDefault do
 
     context 'when the most recent decision is a rejection' do
       it 'the DBD is set to 10 business days from the date of this rejection' do
+        most_recent_rejection_date = 1.business_days.before(now).end_of_day
         choices[0].update(status: :rejected, rejected_at: 3.business_days.before(now).end_of_day)
         choices[1].update(status: :offer, offered_at: 2.business_days.before(now).end_of_day)
-        choices[2].update(status: :rejected, rejected_at: 1.business_days.before(now).end_of_day)
+        choices[2].update(status: :rejected, rejected_at: most_recent_rejection_date)
 
-        expected_dbd_date = 9.business_days.after(now).end_of_day
+        expected_dbd_date = 10.business_days.after(most_recent_rejection_date).end_of_day
 
         call_service
 
@@ -180,9 +182,7 @@ RSpec.describe SetDeclineByDefault do
         )
 
         call_service
-
-        # adding 1 day to a time _after business hours_ takes you 2.business_days fwd
-        new_dbd_date = 1.business_days.after(old_dbd_date - 12.hours).end_of_day
+        new_dbd_date = 1.business_days.after(old_dbd_date).end_of_day
 
         expect_all_relevant_decline_by_default_at_values_to_be new_dbd_date
       end
@@ -192,8 +192,7 @@ RSpec.describe SetDeclineByDefault do
 
         call_service
 
-        # adding 1 day to a time _after business hours_ takes you 2.business_days fwd
-        new_dbd_date = 1.business_days.after(old_dbd_date - 12.hours).end_of_day
+        new_dbd_date = 1.business_days.after(old_dbd_date).end_of_day
         expect_all_relevant_decline_by_default_at_values_to_be new_dbd_date
       end
 
@@ -202,8 +201,7 @@ RSpec.describe SetDeclineByDefault do
 
         call_service
 
-        # adding 1 day to a time _after business hours_ takes you 2.business_days fwd
-        new_dbd_date = 1.business_days.after(old_dbd_date - 12.hours).end_of_day
+        new_dbd_date = 1.business_days.after(old_dbd_date).end_of_day
         expect_all_relevant_decline_by_default_at_values_to_be new_dbd_date
       end
     end


### PR DESCRIPTION
## Context

RBD is always set to EOD, the current spec is setting it to midday, skewing the calculation of when the RBD date should be displayed

## Changes proposed in this pull request

Change the RBD to end of day and fix the specs accordingly.
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
