### PR TITLE
Add trailing text to indicate approximate dates for work experiences

### DIFF
--- a/app/components/work_history_item_component.rb
+++ b/app/components/work_history_item_component.rb
@@ -42,11 +42,19 @@ private
   attr_accessor :item
 
   def formatted_start_date
+    if item.is_a?(ApplicationWorkExperience) && item.start_date_unknown
+      return "#{item.start_date.to_s(:month_and_year)} (approximate)"
+    end
+
     item.start_date.to_s(:month_and_year)
   end
 
   def formatted_end_date
     return 'Present' if item.end_date.nil?
+
+    if item.is_a?(ApplicationWorkExperience) && item.end_date_unknown
+      return "#{item.end_date.to_s(:month_and_year)} (approximate)"
+    end
 
     item.end_date.to_s(:month_and_year)
   end

--- a/spec/components/work_history_component_spec.rb
+++ b/spec/components/work_history_component_spec.rb
@@ -191,4 +191,53 @@ RSpec.describe WorkHistoryComponent do
       expect(rendered.text).to include 'Pig herder - Part time'
     end
   end
+
+  context 'with work experiences with approximate start and end dates' do
+    it 'renders work experience details, explained break and approximate dates' do
+      application_form = instance_double(ApplicationForm, submitted_at: Time.zone.local(2020, 2, 1))
+      breaks = [
+        build(
+          :application_work_history_break,
+          start_date: Date.new(2018, 2, 1),
+          end_date: Date.new(2019, 12, 1),
+          reason: 'I found sheep farming very stressful and needed to take time off work',
+        ),
+      ]
+      experiences = [
+        build(
+          :application_work_experience,
+          start_date: Date.new(2014, 10, 1),
+          end_date: Date.new(2018, 2, 1),
+          start_date_unknown: true,
+          end_date_unknown: true,
+          role: 'Sheep herder',
+          commitment: 'full_time',
+          working_pattern: '',
+          organisation: 'Bobs Farm',
+          details: 'Livestock management',
+        ),
+        build(
+          :application_work_experience,
+          start_date: Date.new(2020, 1, 1),
+          end_date: nil,
+          start_date_unknown: true,
+          role: 'Pig herder',
+          commitment: 'part_time',
+          working_pattern: '',
+          organisation: 'Alices Farm',
+          details: 'Livestock management',
+        ),
+      ]
+      allow(application_form).to receive(:application_work_experiences).and_return(experiences)
+      allow(application_form).to receive(:application_work_history_breaks).and_return(breaks)
+
+      rendered = render_inline(described_class.new(application_form: application_form))
+      expect(rendered.text).to include 'October 2014 (approximate) - February 2018 (approximate)'
+      expect(rendered.text).to include 'Sheep herder - Full time'
+      expect(rendered.text).to include 'Break (1 year and 10 months)'
+      expect(rendered.text).to include 'I found sheep farming very stressful and needed to take time off work'
+      expect(rendered.text).to include 'January 2020 (approximate) - Present'
+      expect(rendered.text).to include 'Pig herder - Part time'
+    end
+  end
 end


### PR DESCRIPTION
## Context

Update manage interface to indicate if work experience start/end dates have been flagged as 'approximate' by candidate. 

## Link to Trello card

https://trello.com/c/p5bxyt7C/3567-work-history-mark-approximate-dates-in-manage

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
