### PR TITLE
 Support browser back button in Make offer flow

### DIFF
--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -17,7 +17,7 @@ module ProviderInterface
     end
 
     def create
-      @wizard = OfferWizard.new(offer_store, { decision: selected_decision })
+      @wizard = OfferWizard.new(offer_store, { decision: selected_decision, current_step: 'select_option' })
 
       if @wizard.valid_for_current_step?
 

--- a/app/controllers/provider_interface/offer/conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/conditions_controller.rb
@@ -7,7 +7,7 @@ module ProviderInterface
       end
 
       def create
-        @wizard = OfferWizard.new(offer_store, conditions_attributes_for_wizard)
+        @wizard = OfferWizard.new(offer_store, conditions_attributes_for_wizard.merge!(current_step: 'conditions'))
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!
@@ -24,7 +24,7 @@ module ProviderInterface
       end
 
       def update
-        @wizard = OfferWizard.new(offer_store, conditions_attributes_for_wizard)
+        @wizard = OfferWizard.new(offer_store, conditions_attributes_for_wizard.merge!(current_step: 'conditions'))
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!

--- a/app/controllers/provider_interface/offer/conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/conditions_controller.rb
@@ -7,7 +7,7 @@ module ProviderInterface
       end
 
       def create
-        @wizard = OfferWizard.new(offer_store, conditions_attributes_for_wizard.merge!(current_step: 'conditions'))
+        @wizard = OfferWizard.new(offer_store, attributes_for_wizard)
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!
@@ -24,7 +24,7 @@ module ProviderInterface
       end
 
       def update
-        @wizard = OfferWizard.new(offer_store, conditions_attributes_for_wizard.merge!(current_step: 'conditions'))
+        @wizard = OfferWizard.new(offer_store, attributes_for_wizard)
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!
@@ -42,14 +42,12 @@ module ProviderInterface
               .permit(further_conditions: {}, standard_conditions: [])
       end
 
-      def conditions_attributes_for_wizard
-        params = conditions_params.to_h
+      def attributes_for_wizard
+        attributes = conditions_params
 
-        params['further_conditions'] = params['further_conditions'].values.map do |hash|
-          hash['text']
-        end
+        further_conditions = conditions_params.to_h['further_conditions'].values.map { |hash| hash['text'] }
 
-        params
+        attributes.merge!(further_conditions: further_conditions, current_step: 'conditions')
       end
     end
   end

--- a/app/controllers/provider_interface/offer/courses_controller.rb
+++ b/app/controllers/provider_interface/offer/courses_controller.rb
@@ -9,7 +9,7 @@ module ProviderInterface
       end
 
       def create
-        @wizard = OfferWizard.new(offer_store)
+        @wizard = OfferWizard.new(offer_store, { decision: 'change_offer', current_step: 'courses' })
         reset_study_mode_if_course_has_changed_and_update_course
 
         if @wizard.valid_for_current_step?
@@ -31,7 +31,7 @@ module ProviderInterface
       end
 
       def update
-        @wizard = OfferWizard.new(offer_store)
+        @wizard = OfferWizard.new(offer_store, { current_step: 'courses' })
         reset_study_mode_if_course_has_changed_and_update_course
 
         if @wizard.valid_for_current_step?

--- a/app/controllers/provider_interface/offer/locations_controller.rb
+++ b/app/controllers/provider_interface/offer/locations_controller.rb
@@ -9,7 +9,7 @@ module ProviderInterface
       end
 
       def create
-        @wizard = OfferWizard.new(offer_store, course_option_params.to_h.merge(decision: 'change_offer', current_step: 'locations'))
+        @wizard = OfferWizard.new(offer_store, attributes_for_wizard)
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!
@@ -30,7 +30,7 @@ module ProviderInterface
       end
 
       def update
-        @wizard = OfferWizard.new(offer_store, course_option_params.to_h.merge(current_step: 'locations'))
+        @wizard = OfferWizard.new(offer_store, attributes_for_wizard)
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!
@@ -47,6 +47,10 @@ module ProviderInterface
 
       def course_option_params
         params.require(:provider_interface_offer_wizard).permit(:course_option_id)
+      end
+
+      def attributes_for_wizard
+        course_option_params.to_h.merge!(current_step: 'locations')
       end
     end
   end

--- a/app/controllers/provider_interface/offer/locations_controller.rb
+++ b/app/controllers/provider_interface/offer/locations_controller.rb
@@ -9,7 +9,7 @@ module ProviderInterface
       end
 
       def create
-        @wizard = OfferWizard.new(offer_store, course_option_params.to_h)
+        @wizard = OfferWizard.new(offer_store, course_option_params.to_h.merge(decision: 'change_offer', current_step: 'locations'))
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!
@@ -30,7 +30,7 @@ module ProviderInterface
       end
 
       def update
-        @wizard = OfferWizard.new(offer_store, course_option_params.to_h)
+        @wizard = OfferWizard.new(offer_store, course_option_params.to_h.merge(current_step: 'locations'))
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!

--- a/app/controllers/provider_interface/offer/providers_controller.rb
+++ b/app/controllers/provider_interface/offer/providers_controller.rb
@@ -9,7 +9,7 @@ module ProviderInterface
       end
 
       def create
-        @wizard = OfferWizard.new(offer_store, provider_params.to_h.merge!(decision: 'change_offer', current_step: 'providers'))
+        @wizard = OfferWizard.new(offer_store, attributes_for_wizard)
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!
@@ -30,7 +30,7 @@ module ProviderInterface
       end
 
       def update
-        @wizard = OfferWizard.new(offer_store, provider_params.to_h.merge!(current_step: 'providers'))
+        @wizard = OfferWizard.new(offer_store, attributes_for_wizard)
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!
@@ -47,6 +47,10 @@ module ProviderInterface
 
       def provider_params
         params.require(:provider_interface_offer_wizard).permit(:provider_id)
+      end
+
+      def attributes_for_wizard
+        provider_params.to_h.merge!(current_step: 'providers')
       end
     end
   end

--- a/app/controllers/provider_interface/offer/providers_controller.rb
+++ b/app/controllers/provider_interface/offer/providers_controller.rb
@@ -9,7 +9,7 @@ module ProviderInterface
       end
 
       def create
-        @wizard = OfferWizard.new(offer_store, provider_params.to_h)
+        @wizard = OfferWizard.new(offer_store, provider_params.to_h.merge!(decision: 'change_offer', current_step: 'providers'))
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!
@@ -30,7 +30,7 @@ module ProviderInterface
       end
 
       def update
-        @wizard = OfferWizard.new(offer_store, provider_params.to_h)
+        @wizard = OfferWizard.new(offer_store, provider_params.to_h.merge!(current_step: 'providers'))
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!

--- a/app/controllers/provider_interface/offer/study_modes_controller.rb
+++ b/app/controllers/provider_interface/offer/study_modes_controller.rb
@@ -10,7 +10,7 @@ module ProviderInterface
       end
 
       def create
-        @wizard = OfferWizard.new(offer_store, study_mode_params.to_h)
+        @wizard = OfferWizard.new(offer_store, study_mode_params.to_h.merge!(decision: 'change_offer', current_step: 'study_modes'))
         @wizard.course_option_id = nil if @wizard.course_option_id && @wizard.course_option.study_mode != @wizard.study_mode
 
         if @wizard.valid_for_current_step?
@@ -34,7 +34,7 @@ module ProviderInterface
       end
 
       def update
-        @wizard = OfferWizard.new(offer_store, study_mode_params.to_h)
+        @wizard = OfferWizard.new(offer_store, study_mode_params.to_h.merge!(current_step: 'study_modes'))
         @wizard.course_option_id = nil if @wizard.course_option_id && @wizard.course_option.study_mode != @wizard.study_mode
 
         if @wizard.valid_for_current_step?

--- a/app/controllers/provider_interface/offer/study_modes_controller.rb
+++ b/app/controllers/provider_interface/offer/study_modes_controller.rb
@@ -10,7 +10,7 @@ module ProviderInterface
       end
 
       def create
-        @wizard = OfferWizard.new(offer_store, study_mode_params.to_h.merge!(decision: 'change_offer', current_step: 'study_modes'))
+        @wizard = OfferWizard.new(offer_store, attributes_for_wizard)
         @wizard.course_option_id = nil if @wizard.course_option_id && @wizard.course_option.study_mode != @wizard.study_mode
 
         if @wizard.valid_for_current_step?
@@ -34,7 +34,7 @@ module ProviderInterface
       end
 
       def update
-        @wizard = OfferWizard.new(offer_store, study_mode_params.to_h.merge!(current_step: 'study_modes'))
+        @wizard = OfferWizard.new(offer_store, attributes_for_wizard)
         @wizard.course_option_id = nil if @wizard.course_option_id && @wizard.course_option.study_mode != @wizard.study_mode
 
         if @wizard.valid_for_current_step?
@@ -60,6 +60,10 @@ module ProviderInterface
           user: current_provider_user,
           current_course: @application_choice.offered_course,
         ).available_study_modes(course: course)
+      end
+
+      def attributes_for_wizard
+        study_mode_params.to_h.merge!(current_step: 'study_modes')
       end
     end
   end

--- a/app/services/wizard_path_history.rb
+++ b/app/services/wizard_path_history.rb
@@ -24,7 +24,6 @@ class WizardPathHistory
   end
 
   def previous_step
-    return path_history[PREVIOUS_STEP_INDEX] if step.nil?
     raise NoSuchStepError unless path_history.rindex(step)
 
     path_history[path_history.rindex(step) - 1]

--- a/app/services/wizard_path_history.rb
+++ b/app/services/wizard_path_history.rb
@@ -18,7 +18,7 @@ class WizardPathHistory
   def update
     if action == 'back'
       path_history.pop
-    elsif step
+    elsif step && !path_history.last.eql?(step)
       path_history << step
     end
   end

--- a/spec/services/wizard_path_history_spec.rb
+++ b/spec/services/wizard_path_history_spec.rb
@@ -36,6 +36,17 @@ RSpec.describe WizardPathHistory do
         expect(service.path_history).to eq(%i[step1 step2 step3])
       end
     end
+
+    context 'when action is not `back` and the same as the last step is provided' do
+      let(:action) { nil }
+      let(:step) { :step2 }
+
+      it 'the path_history is not updated' do
+        service.update
+
+        expect(service.path_history).to eq(%i[step1 step2])
+      end
+    end
   end
 
   describe '#previous_step' do

--- a/spec/services/wizard_path_history_spec.rb
+++ b/spec/services/wizard_path_history_spec.rb
@@ -56,13 +56,5 @@ RSpec.describe WizardPathHistory do
         expect(service.previous_step).to eq(:step3)
       end
     end
-
-    context 'when no step is specified' do
-      let(:step) {}
-
-      it 'returns the step before the last' do
-        expect(service.previous_step).to eq(:step3)
-      end
-    end
   end
 end


### PR DESCRIPTION
## Context
Currently when a user goes to the previous Make offer step using the browser back button, it causes the flow to break, as it only has knowledge of what the current step is through the `new` and `edit` offer controller actions.

I tried adding some system specs but I was getting some unrelated errors when enabling javascript. Any suggestions on how to approach this? Do we need to test this?

## Changes proposed in this pull request

Ensure that current step is also set as part of submit actions (`create` and `update`). This should enable the wizard to always return the correct next step and avoid any errors.

## Link to Trello card
https://trello.com/c/MjEArmnE/3617-investigate-supporting-browser-back-button-in-make-offer-flow

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
