### PR TITLE
Add batch sizes for our exports

### DIFF
--- a/app/services/support_interface/active_provider_user_permissions_export.rb
+++ b/app/services/support_interface/active_provider_user_permissions_export.rb
@@ -3,7 +3,7 @@ module SupportInterface
     def data_for_export
       active_provider_users = ProviderUser.includes(:providers).where.not(last_signed_in_at: nil)
 
-      active_provider_users.flat_map { |provider_user| data_for_user(provider_user) }
+      active_provider_users.find_each(batch_size: 100).flat_map { |provider_user| data_for_user(provider_user) }
     end
 
   private

--- a/app/services/support_interface/active_provider_users_export.rb
+++ b/app/services/support_interface/active_provider_users_export.rb
@@ -3,7 +3,7 @@ module SupportInterface
     def data_for_export
       active_provider_users = ProviderUser.includes(:providers).where.not(last_signed_in_at: nil)
 
-      active_provider_users.map do |provider_user|
+      active_provider_users.find_each(batch_size: 100).map do |provider_user|
         {
           provider_full_name: provider_user.full_name,
           provider_email_address: provider_user.email_address,

--- a/app/services/support_interface/application_references_export.rb
+++ b/app/services/support_interface/application_references_export.rb
@@ -3,7 +3,7 @@ module SupportInterface
     def data_for_export
       application_forms = ApplicationForm.includes(:application_choices, application_references: :audits)
 
-      data_for_export = application_forms.map do |application_form|
+      data_for_export = application_forms.find_each(batch_size: 100).map do |application_form|
         output = {
           recruitment_cycle_year: application_form.recruitment_cycle_year,
           support_reference: application_form.support_reference,

--- a/app/services/support_interface/candidate_feedback_export.rb
+++ b/app/services/support_interface/candidate_feedback_export.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class CandidateFeedbackExport
     def data_for_export
-      application_forms.find_each.map do |application_form|
+      application_forms.find_each(batch_size: 100).map do |application_form|
         {
           full_name: application_form.full_name,
           recruitment_cycle_year: application_form.recruitment_cycle_year,

--- a/app/services/support_interface/candidate_journey_tracking_export.rb
+++ b/app/services/support_interface/candidate_journey_tracking_export.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class CandidateJourneyTrackingExport
     def application_choices
-      all_application_choices.find_each.map do |choice|
+      all_application_choices.find_each(batch_size: 100).map do |choice|
         {
           application_choice_id: choice.id,
           choice_status: choice.status,

--- a/app/services/support_interface/course_choice_withdrawal_survey_export.rb
+++ b/app/services/support_interface/course_choice_withdrawal_survey_export.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class CourseChoiceWithdrawalSurveyExport
     def data_for_export
-      application_choices.map do |application_choice|
+      application_choices.find_each(batch_size: 100).map do |application_choice|
         survey = application_choice.withdrawal_feedback
         {
           full_name: application_choice.application_form.full_name,

--- a/app/services/support_interface/equality_and_diversity_export.rb
+++ b/app/services/support_interface/equality_and_diversity_export.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class EqualityAndDiversityExport
     def data_for_export
-      data_for_export = application_forms.includes(:application_choices).map do |application_form|
+      data_for_export = application_forms.includes(:application_choices).find_each(batch_size: 100).map do |application_form|
         rejected_application_choices = application_form.application_choices.rejected
 
         output = {

--- a/app/services/support_interface/notifications_export.rb
+++ b/app/services/support_interface/notifications_export.rb
@@ -3,7 +3,7 @@ module SupportInterface
     def data_for_export
       courses = Course.where(recruitment_cycle_year: RecruitmentCycle.current_year, open_on_apply: true)
       providers = Provider.includes(:provider_users, :application_choices).joins(:courses).merge(courses).group('providers.id')
-      providers.flat_map do |provider|
+      providers.find_each(batch_size: 100).flat_map do |provider|
         data_for_provider(provider, provider_users_with_make_decisions(provider), visible_applications(provider))
       end
     end

--- a/app/services/support_interface/offer_conditions_export.rb
+++ b/app/services/support_interface/offer_conditions_export.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class OfferConditionsExport
     def offers
-      relevant_choices.flat_map do |choice|
+      relevant_choices.find_each(batch_size: 100).flat_map do |choice|
         {
           support_reference: choice.application_form.support_reference,
           phase: choice.application_form.phase,

--- a/app/services/support_interface/persona_export.rb
+++ b/app/services/support_interface/persona_export.rb
@@ -3,7 +3,7 @@ module SupportInterface
     include GeocodeHelper
 
     def data_for_export
-      application_choices.find_each.map do |application_choice|
+      application_choices.find_each(batch_size: 100).map do |application_choice|
         application_form = application_choice.application_form
 
         {

--- a/app/services/support_interface/provider_access_controls_export.rb
+++ b/app/services/support_interface/provider_access_controls_export.rb
@@ -3,7 +3,7 @@ module SupportInterface
     def data_for_export
       providers = Provider.where(sync_courses: true)
 
-      providers.map do |provider|
+      providers.find_each(batch_size: 100).map do |provider|
         access_controls = ProviderAccessControlsStats.new(provider)
         {
           provider_name: provider.name,

--- a/app/services/support_interface/providers_export.rb
+++ b/app/services/support_interface/providers_export.rb
@@ -3,7 +3,7 @@ module SupportInterface
     include GeocodeHelper
 
     def providers
-      relevant_providers.map do |provider|
+      relevant_providers.find_each(batch_size: 100).map do |provider|
         {
           provider_name: provider.name,
           provider_code: provider.code,

--- a/app/services/support_interface/referee_survey_export.rb
+++ b/app/services/support_interface/referee_survey_export.rb
@@ -5,7 +5,7 @@ module SupportInterface
                                   .includes(:application_form)
                                   .where.not(questionnaire: nil)
                                   .where.not(duplicate: true)
-      references_with_feedback = non_duplicate_references.reject do |reference|
+      references_with_feedback = non_duplicate_references.find_each(batch_size: 100).reject do |reference|
         reference.questionnaire.values.all? { |response| response == ' | ' }
       end
 

--- a/app/services/support_interface/sites_export.rb
+++ b/app/services/support_interface/sites_export.rb
@@ -3,7 +3,7 @@ module SupportInterface
     include GeocodeHelper
 
     def sites
-      relevant_sites.map do |site|
+      relevant_sites.find_each(batch_size: 100).map do |site|
         {
           site_id: site.id,
           site_code: site.code,

--- a/app/services/support_interface/structured_reasons_for_rejection_export.rb
+++ b/app/services/support_interface/structured_reasons_for_rejection_export.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class StructuredReasonsForRejectionExport
     def data_for_export
-      data_for_export = application_choices.order(:id).map do |application_choice|
+      data_for_export = application_choices.order(:id).find_each(batch_size: 100).map do |application_choice|
         output = {
           candidate_id: application_choice.application_form_id,
           application_choice_id: application_choice.id,

--- a/app/services/support_interface/tad_provider_stats_export.rb
+++ b/app/services/support_interface/tad_provider_stats_export.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class TADProviderStatsExport
     def call
-      data_for_export = courses.map do |course|
+      data_for_export = courses.find_each(batch_size: 100).map do |course|
         choice_statuses = choice_statuses(course)
 
         {


### PR DESCRIPTION
## Context

A bunch of exports have been hanging. Some for sure due to SQL timeouts. We're holding a large number of objects in memory while mapping them. Hopefully using find_each will solve this issue.

## Changes proposed in this pull request

- Use batch sizes of 100 in our exports

## Link to Trello card

https://trello.com/c/jpVqOvY3/3315-hanging-exports

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
