### PR TITLE
Remove international degrees from the autocomplete export

### DIFF
--- a/app/services/support_interface/candidate_autofill_usage_export.rb
+++ b/app/services/support_interface/candidate_autofill_usage_export.rb
@@ -114,6 +114,9 @@ module SupportInterface
         .where.not(
           qualification_type: 'non_uk',
         )
+        .where.not(
+          international: true,
+        )
         .all
     end
 

--- a/spec/services/support_interface/candidate_autofill_usage_export_spec.rb
+++ b/spec/services/support_interface/candidate_autofill_usage_export_spec.rb
@@ -68,6 +68,15 @@ RSpec.describe SupportInterface::CandidateAutofillUsageExport do
       end
     end
 
+    context 'International degrees' do
+      it "does not return a hash of candidates' autofill usage" do
+        application_form = create(:application_form, :minimum_info, phase: 'apply_1')
+        create(:degree_qualification, application_form: application_form, international: true)
+
+        expect(described_class.new.data_for_export).to be_empty
+      end
+    end
+
     context 'Candidate free text inputs' do
       it "returns true for 'free_text?' row" do
         application_form = create(:application_form, :minimum_info, phase: 'apply_1')


### PR DESCRIPTION
## Context

We use two different mechanisms to identify international qualifications. One of which is `qualification_type: 'non_uk'` for GCSEs and OtherQuals and `international: true` for degrees.

We should be using one mechanism going forward. I'll card something up, but for now let's exclude them from the export 

## Changes proposed in this pull request

- Remove international degrees from the autofill export 

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
