### PR TITLE
Send a Slack notification to remind us to open a new course

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -52,6 +52,10 @@ class Provider < ApplicationRecord
     accredited_courses.or(courses).current_cycle.exposed_in_find.all?(&:open_on_apply?)
   end
 
+  def any_open_courses_in_current_cycle?
+    accredited_courses.or(courses).current_cycle.exposed_in_find.any?(&:open_on_apply?)
+  end
+
   def application_forms
     ApplicationForm.where(id: application_choices.select(:application_form_id))
   end

--- a/spec/support/slack_notifications.rb
+++ b/spec/support/slack_notifications.rb
@@ -10,4 +10,8 @@ RSpec.configure do |config|
       sent_message.include?(expected_message)
     }
   end
+
+  def expect_no_slack_message
+    expect(WebMock).not_to have_requested(:post, 'https://example.com/slack-webhook')
+  end
 end


### PR DESCRIPTION
If a provider with any open courses adds a new course, that course must
be opened manually on Apply. Let the team know via Slack.

## Context

eg https://ukgovernmentdfe.slack.com/archives/C01EZFNUPLP/p1618840191022000

## Changes proposed in this pull request

Send a Slack notification when a provider with any open courses in this cycle creates a new course on Publish and it shows up in the API

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
