### PR TITLE
Reorder the degree type autocomplete order to mimic registers

### DIFF
--- a/config/initializers/qualifications/hesa_degree_types.rb
+++ b/config/initializers/qualifications/hesa_degree_types.rb
@@ -1,10 +1,4 @@
 HESA_DEGREE_TYPES = [
-  ['1', nil, 'BEd', :bachelor],
-  ['3', nil, 'BSc/Education', :bachelor],
-  ['5', nil, 'BTech/Education', :bachelor],
-  ['7', nil, 'BA/Education', :bachelor],
-  ['9', nil, 'BA Combined Studies/Education of the Deaf', :bachelor],
-  ['12', nil, 'BA with intercalated PGCE', :bachelor],
   ['51', 'BA', 'Bachelor of Arts', :bachelor],
   ['52', 'BAEcon', 'Bachelor of Arts Economics', :bachelor],
   ['53', 'BAArch', 'Bachelor of Arts in Architecture', :bachelor],
@@ -53,6 +47,13 @@ HESA_DEGREE_TYPES = [
   ['96', 'BVsc', 'Bachelor of Veterinary Science', :bachelor],
   ['97', 'BEd', 'Bachelor of Education Scotland and Northern Ireland', :bachelor],
   ['98', 'BPhil', 'Bachelor of Philosophy', :bachelor],
+
+  ['1', nil, 'BEd', :bachelor],
+  ['3', nil, 'BSc/Education', :bachelor],
+  ['5', nil, 'BTech/Education', :bachelor],
+  ['7', nil, 'BA/Education', :bachelor],
+  ['9', nil, 'BA Combined Studies/Education of the Deaf', :bachelor],
+  ['12', nil, 'BA with intercalated PGCE', :bachelor],
 
   ['200', 'MA', 'Master of Arts', :master],
   ['201', 'MLib', 'Master of Librarianship', :master],

--- a/spec/lib/hesa/degree_type_spec.rb
+++ b/spec/lib/hesa/degree_type_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Hesa::DegreeType do
     it 'returns a list of concatenated abbreviations and names' do
       abbreviations_and_names = described_class.abbreviations_and_names
 
-      expect(abbreviations_and_names.first).to eq '|BEd'
+      expect(abbreviations_and_names.first).to eq 'BA|Bachelor of Arts'
       expect(abbreviations_and_names[60]).to eq 'MTheol|Master of Theology'
     end
 


### PR DESCRIPTION
## Context

At the moment the ordering of the degree type autocomplete isn't particularly ideal. if you type ba you see 'BA/Education' before 'BA Bachelor of Arts'.

We've been asked to replicate the listing order Register use (see here https://github.com/DFE-Digital/register-trainee-teachers/blob/4639a524d563276d62d809de5a6f361c61c213ce/app/lib/dttp/code_sets/degree_types.rb)

## Changes proposed in this pull request

- Reorder the degree type in the initialiser
- Update the tests

## Guidance to review

Does altering the ordering in the initialiser cause any issues that i haven't thought of?
You can test this by adding a degree and typing 'ba' into the degree type autocomplete

## Link to Trello card

https://trello.com/c/Bq9BScNy/3310-alphabetically-order-degree-types-to-prevent-ba-education-appearing-first-in-the-autocomplete

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
