### PR TITLE
Indicate this candidate has used relevant skills for work experience

### DIFF
--- a/app/components/work_history_item_component.html.erb
+++ b/app/components/work_history_item_component.html.erb
@@ -10,7 +10,14 @@
   </p>
   <p class="govuk-body">
     <%= details %>
-    <% if working_with_children? %>
+    <% if relevant_skills? %>
+      <p class="govuk-body govuk-!-font-size-16">
+        <svg class="app-icon govuk-!-margin-right-1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 200 200" focusable="false" fill="currentColor" aria-hidden="true">
+          <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"></path>
+        </svg>
+        This role used skills relevant to teaching
+      </p>
+    <% elsif working_with_children? %>
       <p class="govuk-body govuk-!-font-size-16">
         <svg class="app-icon govuk-!-margin-right-1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 200 200" focusable="false" fill="currentColor" aria-hidden="true">
           <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"></path>

--- a/app/components/work_history_item_component.rb
+++ b/app/components/work_history_item_component.rb
@@ -26,7 +26,11 @@ class WorkHistoryItemComponent < ViewComponent::Base
   end
 
   def working_with_children?
-    item.respond_to?(:working_with_children?) && item.working_with_children?
+    item.try(:working_with_children?)
+  end
+
+  def relevant_skills?
+    item.try(:relevant_skills?)
   end
 
   def organisation

--- a/spec/components/work_history_component_spec.rb
+++ b/spec/components/work_history_component_spec.rb
@@ -84,6 +84,33 @@ RSpec.describe WorkHistoryComponent do
     end
   end
 
+  context 'with work experiences with relevant skills' do
+    it 'renders work experience details and relevant skills flag' do
+      experiences = [
+        build(
+          :application_work_experience,
+          start_date: 6.years.ago,
+          end_date: nil,
+          role: 'Nursery manager',
+          commitment: 'part_time',
+          working_pattern: '',
+          organisation: 'Bobs Farm',
+          details: 'I run the staff nursery',
+          relevant_skills: true,
+          working_with_children: true,
+        ),
+      ]
+      allow(application_form).to receive(:application_work_experiences).and_return(experiences)
+      allow(application_form).to receive(:application_work_history_breaks).and_return([])
+
+      rendered = render_inline(described_class.new(application_form: application_form))
+      expect(rendered.text).to include "#{6.years.ago.to_s(:month_and_year)} - Present"
+      expect(rendered.text).to include 'Nursery manager - Part time'
+      expect(rendered.text).to include 'This role used skills relevant to teaching'
+      expect(rendered.text).not_to include 'Worked with children'
+    end
+  end
+
   context 'with work experiences and unexplained work break' do
     it 'renders work experience details and unexplained break' do
       experiences = [


### PR DESCRIPTION
## Context

If the candidate has indicated that work experience has been relevant to their application by answering a new question as part of the application then prefer this over the older 'working with children' flag.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

If the restructured work history feature flag is active and the candidate has indicated their work experience used relevant skills then rendering this.

![image](https://user-images.githubusercontent.com/93511/115258135-9fff3b00-a128-11eb-940e-f5a2b6950b7e.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Enable the `restructured_work_history` feature flag and update a work experience item so that `relevant_skills: true`.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/oxeICHx0/3571-work-history-marking-roles-that-are-relevant-to-teaching-on-a-candidates-application-in-manage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
