### PR TITLE
Start writing current_course_option_id

### DIFF
--- a/app/forms/candidate_interface/pick_site_form.rb
+++ b/app/forms/candidate_interface/pick_site_form.rb
@@ -20,13 +20,17 @@ module CandidateInterface
 
       application_form.application_choices.create!(
         course_option: course_option,
+        current_course_option_id: course_option.id,
       )
     end
 
     def update(application_choice)
       return unless valid?
 
-      application_choice.update!(course_option: course_option)
+      application_choice.update!(
+        course_option: course_option,
+        current_course_option_id: course_option.id,
+      )
     end
 
   private

--- a/app/services/change_an_offer.rb
+++ b/app/services/change_an_offer.rb
@@ -28,6 +28,7 @@ class ChangeAnOffer
         now = Time.zone.now
         attributes = {
           offered_course_option: @course_option,
+          current_course_option_id: @course_option.id,
           offer_changed_at: now,
         }
         attributes[:offer] = { 'conditions' => @offer_conditions } if @offer_conditions

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -43,6 +43,7 @@ class MakeAnOffer
         ActiveRecord::Base.transaction do
           application_choice.status = 'offer'
           application_choice.offered_course_option = course_option
+          application_choice.current_course_option_id = course_option.id
           application_choice.offer = { 'conditions' => offer_conditions }
           application_choice.offered_at = Time.zone.now
           application_choice.save!

--- a/spec/forms/candidate_interface/pick_site_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_site_form_spec.rb
@@ -36,6 +36,22 @@ RSpec.describe CandidateInterface::PickSiteForm, type: :model do
     end
   end
 
+  describe '#save' do
+    it 'updates the course_option for an existing course choice' do
+      application_form = create(:application_form)
+      course_option = create(:course_option)
+
+      CandidateInterface::PickSiteForm.new(
+        application_form: application_form,
+        course_option_id: course_option.id,
+      ).save
+
+      application_choice = application_form.reload.application_choices.first
+      expect(application_choice.course_option.id).to eq(course_option.id)
+      expect(application_choice.current_course_option_id).to eq(course_option.id)
+    end
+  end
+
   describe '#update' do
     it 'updates the course_option for an existing course choice' do
       application_choice = create(:application_choice)
@@ -49,6 +65,7 @@ RSpec.describe CandidateInterface::PickSiteForm, type: :model do
       ).update(application_choice)
 
       expect(application_choice.course_option.id).to eq(new_course_option.id)
+      expect(application_choice.current_course_option_id).to eq(new_course_option.id)
     end
   end
 end

--- a/spec/services/change_an_offer_spec.rb
+++ b/spec/services/change_an_offer_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe ChangeAnOffer do
     expect { service.save }.to change(application_choice, :offered_course_option_id)
   end
 
+  it 'changes current_course_option_id' do
+    expect { service.save }.to change(application_choice, :current_course_option_id)
+  end
+
   it 'does not change offered_at' do
     expect { service.save }.not_to change(application_choice, :offered_at)
   end

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -96,6 +96,14 @@ RSpec.describe MakeAnOffer, sidekiq: true do
       expect(application_choice.offered_course_option_id).to eq valid_course_option.id
     end
 
+    it 'sets current_course_option_id' do
+      offer = MakeAnOffer.new(actor: user, application_choice: application_choice, course_option: valid_course_option)
+
+      offer.save
+
+      expect(application_choice.current_course_option_id).to eq valid_course_option.id
+    end
+
     it 'sets the decline_by_default_at date' do
       MakeAnOffer.new(actor: user, application_choice: application_choice, course_option: valid_course_option).save
       application_choice.reload


### PR DESCRIPTION
## Context

To reduce the risk of nil `current_course_option_id` values when we deploy https://github.com/DFE-Digital/apply-for-teacher-training/pull/4499 here is some temporary code to start populating this field when new course choices are made (candidate interface) or when course details change as part of making an offer (provider interface).

## Changes proposed in this pull request

Start setting `current_course_option_id`.

## Guidance to review

We're setting `current_course_option_id` instead of `current_course_option` in the create/update statements because no ActiveRecord associations have been defined yet.

## Link to Trello card

https://trello.com/c/oYjeu4Hh

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
