### PR TITLE
WIP - Use radio buttons to complete individual sections instead of checkboxes

### DIFF
--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -1,8 +1,12 @@
-<%= form_with model: @application_form, url: @path, method: @request_method do |f| %>
-  <div class='govuk-form-group'>
-    <%= f.hidden_field @field_name, value: false %>
-    <%= f.govuk_check_box @field_name, true, multiple: false, label: { text: t('application_form.completed_checkbox') } %>
-  </div>
+<%= form_with model: completion_form, url: path, method: request_method do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= render(summary) %>
+
+  <%= f.govuk_radio_buttons_fieldset field_name, legend: { text: 'Have you completed this section?', size: 'm' } do %>
+    <%= f.govuk_radio_button field_name, true, label: { text: t('application_form.completed_radio') }, link_errors: true%>
+    <%= f.govuk_radio_button field_name, false, label: { text: t('application_form.incomplete_radio') } %>
+  <% end %>
 
   <%= f.govuk_submit t('continue') %>
 <% end %>

--- a/app/components/candidate_interface/complete_section_component.rb
+++ b/app/components/candidate_interface/complete_section_component.rb
@@ -1,10 +1,13 @@
 module CandidateInterface
   class CompleteSectionComponent < ViewComponent::Base
-    def initialize(application_form:, path:, request_method:, field_name:)
-      @application_form = application_form
+    attr_reader :completion_form, :path, :request_method, :field_name, :summary
+
+    def initialize(completion_form:, path:, request_method:, field_name:, summary:)
+      @completion_form = completion_form
       @path = path
       @request_method = request_method
       @field_name = field_name
+      @summary = summary
     end
   end
 end

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -31,6 +31,7 @@ module CandidateInterface
         user: current_candidate,
         details: form.errors.messages.map { |field, messages| [field, { messages: messages, value: form.public_send(field) }] }.to_h,
       )
+
     rescue StandardError => e
       # Never crash validation error tracking
       Raven.capture_exception(e)

--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -5,6 +5,9 @@ module CandidateInterface
 
       def show
         @application_form = current_application
+        @completion_form = CompletionForm.build_from_application(
+          personal_details_completed: current_application.personal_details_completed,
+        )
         @personal_details_form = PersonalDetailsForm.build_from_application(current_application)
         @nationalities_form = NationalitiesForm.build_from_application(current_application)
         @languages_form = LanguagesForm.build_from_application(current_application)
@@ -18,31 +21,31 @@ module CandidateInterface
         @nationalities_form = NationalitiesForm.build_from_application(current_application)
         @languages_form = LanguagesForm.build_from_application(current_application)
         @right_to_work_or_study_form = RightToWorkOrStudyForm.build_from_application(current_application)
+        @completion_form = CompletionForm.build_from_application(application_form_params)
+        @personal_details_review = PersonalDetailsReviewComponent.new(application_form: current_application)
 
-        if @personal_details_form.valid? &&
-            @nationalities_form.valid? &&
-            @right_to_work_or_study_form.valid? &&
-            @languages_form.valid?
-          current_application.update!(application_form_params)
-          redirect_to candidate_interface_application_form_path
-        elsif @personal_details_form.valid? &&
-            @nationalities_form.valid? &&
-            (hiding_languages_section? || @languages_form.valid?)
-
-          current_application.update!(application_form_params)
-          redirect_to candidate_interface_application_form_path
+        if @personal_details_form.valid? && @nationalities_form.valid? && @right_to_work_or_study_form.valid? && @languages_form.valid?
+          save_completion_form
+        elsif @personal_details_form.valid? && @nationalities_form.valid? && (hiding_languages_section? || @languages_form.valid?)
+          save_completion_form
         else
-          @personal_details_review = PersonalDetailsReviewComponent.new(
-            application_form: current_application,
-          )
           render :show
         end
       end
 
     private
 
+      def save_completion_form
+        if @completion_form.save(current_application, :personal_details_completed)
+          redirect_to candidate_interface_application_form_path
+        else
+          track_validation_error(@completion_form)
+          render :show
+        end
+      end
+
       def application_form_params
-        strip_whitespace params.require(:application_form).permit(:personal_details_completed)
+        strip_whitespace params.require(:candidate_interface_completion_form).permit(:personal_details_completed)
       end
 
       def hiding_languages_section?

--- a/app/forms/candidate_interface/completion_form.rb
+++ b/app/forms/candidate_interface/completion_form.rb
@@ -1,0 +1,32 @@
+module CandidateInterface
+  class CompletionForm
+    include ActiveModel::Model
+
+    def self.build_from_application(attr_hash)
+      attr = attr_hash.keys.first
+
+      create_attr_accessor_from(attr)
+      create_validation_from(attr)
+
+      new(attr_hash)
+    end
+
+    def self.create_attr_accessor_from(attr)
+      instance_eval do
+        attr_accessor attr
+      end
+    end
+
+    def self.create_validation_from(attr)
+      instance_eval do
+        validates attr, presence: true
+      end
+    end
+
+    def save(application_form, attr)
+      return false unless valid?
+
+      application_form.update!(attr => send(attr))
+    end
+  end
+end

--- a/app/views/candidate_interface/personal_details/review/show.html.erb
+++ b/app/views/candidate_interface/personal_details/review/show.html.erb
@@ -1,7 +1,8 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.personal_information'),
                                                 @personal_details_form.errors.any? ||
                                                  @nationalities_form.errors.any? ||
-                                                 @languages_form.errors.any?) %>
+                                                 @languages_form.errors.any? ||
+                                                  @completion_form.errors.any? ) %>
 
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
@@ -9,11 +10,10 @@
   <%= t('page_titles.personal_information') %>
 </h1>
 
-<%= render(SummaryCardComponent.new(rows: @personal_details_review.rows)) %>
-
 <%= render(CandidateInterface::CompleteSectionComponent.new(
-  application_form: @application_form,
+  completion_form: @completion_form,
   path: candidate_interface_personal_details_complete_path,
   request_method: :patch,
   field_name: :personal_details_completed,
+  summary: SummaryCardComponent.new(rows: @personal_details_review.rows)
 )) %>

--- a/config/locales/candidate_interface/application_form.yml
+++ b/config/locales/candidate_interface/application_form.yml
@@ -2,6 +2,8 @@ en:
   application_form:
     begin_button: Start now
     completed_checkbox: I have completed this section
+    completed_radio: Yes, I have completed this section
+    incomplete_radio: No, I'll come back to it later
 
   activemodel:
     errors:

--- a/config/locales/candidate_interface/section_complete.yml
+++ b/config/locales/candidate_interface/section_complete.yml
@@ -1,0 +1,8 @@
+en:
+  activemodel:
+    errors:
+      models:
+        candidate_interface/completion_form:
+          attributes:
+            personal_details_completed:
+              blank: Select whether you have completed this section

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_spec.rb
@@ -114,7 +114,7 @@ RSpec.feature 'Entering their personal details' do
   end
 
   def when_i_mark_the_section_as_completed
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_submit_my_details

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_languages_hidden_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_languages_hidden_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Entering personal details' do
   end
 
   def and_i_can_mark_the_section_complete
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
 
     expect(page).to have_css('#personal-information-badge-id', text: 'Completed')


### PR DESCRIPTION
## Context

```
As a... candidate completing my application
I need to... mark sections as complete
So that... I know which parts of my application still need to be completed
```

Rather than use a check box we want to now use radio buttons to indicate whether a section is complete

https://apply-beta-prototype.herokuapp.com/application/12345



## Changes proposed in this pull request

Seeking some early feedback on this!

I have tried to create a generic form object that be used everywhere. The challenge however is that the state of each section that is completed is stored as a separate column in the db. I've had to use some potentially horrible meta programming to create the corresponding `attr_accessor` and validator in the form object.

What do people think?



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/MgPkClPi/3303-use-radio-buttons-to-complete-individual-sections-instead-of-checkboxes


## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
