### PR TITLE
Restoring the business day logic for dbd specs

### DIFF
--- a/spec/services/set_decline_by_default_spec.rb
+++ b/spec/services/set_decline_by_default_spec.rb
@@ -182,7 +182,8 @@ RSpec.describe SetDeclineByDefault do
         )
 
         call_service
-        new_dbd_date = 1.business_days.after(old_dbd_date).end_of_day
+        # adding 1 day to a time _after business hours_ takes you 2.business_days fwd
+        new_dbd_date = 1.business_days.after(old_dbd_date - 12.hours).end_of_day
 
         expect_all_relevant_decline_by_default_at_values_to_be new_dbd_date
       end
@@ -192,7 +193,9 @@ RSpec.describe SetDeclineByDefault do
 
         call_service
 
-        new_dbd_date = 1.business_days.after(old_dbd_date).end_of_day
+        # adding 1 day to a time _after business hours_ takes you 2.business_days fwd
+        new_dbd_date = 1.business_days.after(old_dbd_date - 12.hours).end_of_day
+
         expect_all_relevant_decline_by_default_at_values_to_be new_dbd_date
       end
 
@@ -201,7 +204,9 @@ RSpec.describe SetDeclineByDefault do
 
         call_service
 
-        new_dbd_date = 1.business_days.after(old_dbd_date).end_of_day
+        # adding 1 day to a time _after business hours_ takes you 2.business_days fwd
+        new_dbd_date = 1.business_days.after(old_dbd_date - 12.hours).end_of_day
+
         expect_all_relevant_decline_by_default_at_values_to_be new_dbd_date
       end
     end


### PR DESCRIPTION
## Context

Business days rely on business hours, and anything running outside those rolls over to the next day

## Changes proposed in this pull request

Reinstate DBD workaround in specs removed here: https://github.com/DFE-Digital/apply-for-teacher-training/pull/4536

## Guidance to review

It seems that the logic for calculating dbd business days changes if it is outside hours. Substracting 12 hours was instated to ensure we don't roll over to next day.

I removed this initially as it was failing, however I've tested again and now it seems ok with subtracting hours and adding hours to replicate outside hours beginning of day and end of day and I couldn't get any failures. 


## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
