### PR TITLE
Add review functionality to personal statement section

### DIFF
--- a/app/components/candidate_interface/becoming_a_teacher_review_component.html.erb
+++ b/app/components/candidate_interface/becoming_a_teacher_review_component.html.erb
@@ -1,5 +1,12 @@
 <% if show_missing_banner? %>
-  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :becoming_a_teacher, section_path: candidate_interface_edit_becoming_a_teacher_path, error: @missing_error)) %>
+  <%= render(
+    CandidateInterface::IncompleteSectionComponent.new(
+      section: :becoming_a_teacher,
+      section_path: candidate_interface_edit_becoming_a_teacher_path,
+      error: @missing_error,
+      review_needed: review_needed?,
+    ),
+  ) %>
 <% else %>
   <%= render(SummaryCardComponent.new(rows: becoming_a_teacher_form_rows, editable: @editable)) %>
 <% end %>

--- a/app/components/candidate_interface/becoming_a_teacher_review_component.rb
+++ b/app/components/candidate_interface/becoming_a_teacher_review_component.rb
@@ -18,6 +18,10 @@ module CandidateInterface
       !@application_form.becoming_a_teacher_completed && @editable if @submitting_application
     end
 
+    def review_needed?
+      @application_form.becoming_a_teacher_review_pending?
+    end
+
   private
 
     attr_reader :application_form

--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: @application_form, url: @path, method: @request_method do |f| %>
   <div class='govuk-form-group'>
     <%= f.hidden_field @field_name, value: false %>
-    <%= f.govuk_check_box @field_name, true, multiple: false, label: { text: t('application_form.completed_checkbox') } %>
+    <%= f.govuk_check_box @field_name, true, multiple: false, label: { text: t(checkbox_label) } %>
   </div>
 
   <%= f.govuk_submit t('continue') %>

--- a/app/components/candidate_interface/complete_section_component.rb
+++ b/app/components/candidate_interface/complete_section_component.rb
@@ -1,10 +1,19 @@
 module CandidateInterface
   class CompleteSectionComponent < ViewComponent::Base
-    def initialize(application_form:, path:, request_method:, field_name:)
+    def initialize(application_form:, path:, request_method:, field_name:, section_review: false)
       @application_form = application_form
       @path = path
       @request_method = request_method
       @field_name = field_name
+      @section_review = section_review
+    end
+
+    def checkbox_label
+      if @section_review
+        'application_form.reviewed_checkbox'
+      else
+        'application_form.completed_checkbox'
+      end
     end
   end
 end

--- a/app/components/candidate_interface/incomplete_section_component.html.erb
+++ b/app/components/candidate_interface/incomplete_section_component.html.erb
@@ -1,4 +1,4 @@
 <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--#{@error ? 'error' : 'important'}", html_attributes: { id: "incomplete-#{section}-error" }) do %>
-  <p class="app-inset-text__title"><%= @text %></p>
+  <p class="app-inset-text__title"><%= message %></p>
   <p class="govuk-body"><%= govuk_link_to link_text, @section_path, class: 'govuk-link--no-visited-state', 'data-qa': "incomplete-#{section}" %></p>
 <% end %>

--- a/app/components/candidate_interface/incomplete_section_component.rb
+++ b/app/components/candidate_interface/incomplete_section_component.rb
@@ -7,15 +7,25 @@ module CandidateInterface
       section_path:,
       text: t("review_application.#{section}.incomplete"),
       link_text: t("review_application.#{section}.complete_section"),
-      error: false
+      error: false,
+      review_needed: false
     )
       @section = section
       @section_path = section_path
       @text = text
       @error = error
       @link_text = link_text
+      @review_needed = review_needed
     end
 
     attr_reader :section, :section_path, :text, :link_text
+
+    def message
+      if @review_needed
+        t("review_application.#{section}.not_reviewed")
+      else
+        text
+      end
+    end
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -356,6 +356,28 @@ class ApplicationForm < ApplicationRecord
     end
   end
 
+  def mark_sections_incomplete_if_review_needed!
+    if becoming_a_teacher_reviewable?
+      update!(becoming_a_teacher_completed: false)
+    end
+  end
+
+  def becoming_a_teacher_rejection_reasons
+    CandidateInterface::RejectionReasonsHistory.all_previous_applications(self, :becoming_a_teacher)
+  end
+
+  def becoming_a_teacher_most_recent_rejection_reason
+    CandidateInterface::RejectionReasonsHistory.most_recent(self, :becoming_a_teacher)
+  end
+
+  def becoming_a_teacher_review_pending?
+    !becoming_a_teacher_completed? && becoming_a_teacher_reviewable?
+  end
+
+  def becoming_a_teacher_reviewable?
+    apply_2? && becoming_a_teacher_most_recent_rejection_reason.present?
+  end
+
 private
 
   def geocode_address_if_required

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -366,8 +366,8 @@ class ApplicationForm < ApplicationRecord
     CandidateInterface::RejectionReasonsHistory.all_previous_applications(self, :becoming_a_teacher)
   end
 
-  def becoming_a_teacher_most_recent_rejection_reason
-    CandidateInterface::RejectionReasonsHistory.most_recent(self, :becoming_a_teacher)
+  def becoming_a_teacher_previous_application_rejection_reason
+    CandidateInterface::RejectionReasonsHistory.previous_application(self, :becoming_a_teacher)
   end
 
   def becoming_a_teacher_review_pending?
@@ -375,7 +375,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def becoming_a_teacher_reviewable?
-    apply_2? && becoming_a_teacher_most_recent_rejection_reason.present?
+    apply_2? && becoming_a_teacher_previous_application_rejection_reason.present?
   end
 
 private

--- a/app/models/candidate_interface/rejection_reasons_history.rb
+++ b/app/models/candidate_interface/rejection_reasons_history.rb
@@ -7,8 +7,8 @@ module CandidateInterface
       new(application_form, section).all_previous_applications
     end
 
-    def self.most_recent(application_form, section)
-      new(application_form, section).most_recent
+    def self.previous_application(application_form, section)
+      new(application_form, section).previous_application
     end
 
     attr_reader :application_form, :section, :reasons_for_rejection_method
@@ -28,7 +28,7 @@ module CandidateInterface
       end
     end
 
-    def most_recent
+    def previous_application
       previous_application = application_form.previous_application_form
       return [] if previous_application.blank?
 

--- a/app/models/candidate_interface/rejection_reasons_history.rb
+++ b/app/models/candidate_interface/rejection_reasons_history.rb
@@ -1,0 +1,74 @@
+module CandidateInterface
+  class RejectionReasonsHistory
+    class UnsupportedSectionError < StandardError; end
+    HistoryItem = Struct.new(:provider_name, :section, :feedback)
+
+    def self.all_previous_applications(application_form, section)
+      new(application_form, section).all_previous_applications
+    end
+
+    def self.most_recent(application_form, section)
+      new(application_form, section).most_recent
+    end
+
+    attr_reader :application_form, :section, :reasons_for_rejection_method
+
+    def initialize(application_form, section)
+      @application_form = application_form
+      @section = section
+      @reasons_for_rejection_method = map_section_to_method
+    end
+
+    def all_previous_applications
+      previous_applications = collect_previous_applications(application_form)
+      return [] if previous_applications.blank?
+
+      previous_applications.flat_map do |application|
+        extract_history(application.application_choices)
+      end
+    end
+
+    def most_recent
+      previous_application = application_form.previous_application_form
+      return [] if previous_application.blank?
+
+      extract_history(previous_application.application_choices)
+    end
+
+  private
+
+    def collect_previous_applications(application_form)
+      previous = application_form.previous_application_form
+      [].tap do |collection|
+        while previous.present?
+          collection << previous
+          previous = previous.previous_application_form
+        end
+      end
+    end
+
+    def extract_history(application_choices)
+      application_choices.includes(:provider).filter_map do |choice|
+        reasons_for_rejection = ReasonsForRejection.new choice.structured_rejection_reasons
+        feedback = reasons_for_rejection.send reasons_for_rejection_method
+
+        if feedback.present?
+          HistoryItem.new(
+            choice.provider.name,
+            section,
+            feedback,
+          )
+        end
+      end
+    end
+
+    def map_section_to_method
+      case section
+      when :becoming_a_teacher
+        :quality_of_application_personal_statement_what_to_improve
+      else
+        raise UnsupportedSectionError
+      end
+    end
+  end
+end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -250,6 +250,10 @@ module CandidateInterface
       end
     end
 
+    def becoming_a_teacher_review_pending?
+      @application_form.becoming_a_teacher_review_pending?
+    end
+
     def subject_knowledge_completed?
       @application_form.subject_knowledge_completed
     end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -30,7 +30,7 @@ module CandidateInterface
         ([:efl, english_as_a_foreign_language_completed?] if display_efl_link?),
 
         # "Personal statement and interview" section
-        [:becoming_a_teacher, becoming_a_teacher_completed?],
+        [:becoming_a_teacher, becoming_a_teacher_completed?, becoming_a_teacher_review_pending?],
         [:subject_knowledge, subject_knowledge_completed?],
         [:interview_preferences, interview_preferences_completed?],
 
@@ -42,7 +42,11 @@ module CandidateInterface
     def incomplete_sections
       sections_with_completion
         .reject(&:second)
-        .map(&:first)
+        .map { |sections_with_completion| OpenStruct.new(name: sections_with_completion.first, needs_review?: sections_with_completion.third) }
+        .map do |section|
+          message = section.needs_review? ? "review_application.#{section.name}.not_reviewed" : "review_application.#{section.name}.incomplete"
+          OpenStruct.new(name: section.name, message: message)
+        end
     end
 
     ApplicationChoiceError = Struct.new(:message, :course_choice_id) do

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -242,6 +242,14 @@ module CandidateInterface
       BecomingATeacherForm.build_from_application(@application_form).valid?
     end
 
+    def becoming_a_teacher_path
+      if becoming_a_teacher_valid?
+        Rails.application.routes.url_helpers.candidate_interface_becoming_a_teacher_show_path
+      else
+        Rails.application.routes.url_helpers.candidate_interface_edit_becoming_a_teacher_path
+      end
+    end
+
     def subject_knowledge_completed?
       @application_form.subject_knowledge_completed
     end

--- a/app/services/apply_again.rb
+++ b/app/services/apply_again.rb
@@ -5,7 +5,9 @@ class ApplyAgain
 
   def call
     if @application_form.ended_without_success?
-      DuplicateApplication.new(@application_form, target_phase: 'apply_2').duplicate
+      DuplicateApplication.new(@application_form, target_phase: 'apply_2')
+        .duplicate
+        .tap(&:mark_sections_incomplete_if_review_needed!)
     else
       false
     end

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -5,13 +5,26 @@
   <%= t('page_titles.becoming_a_teacher') %>
 </h1>
 
-<p class="govuk-body govuk-!-font-weight-bold">This section is important to your application. Before continuing:</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>proofread your answer carefully for spelling and grammar</li>
-  <li>ask someone you trust for their opinion</li>
-  <li>ensure this piece of writing is all your own work – plagiarism will be penalised</li>
-</ul>
-<p class="govuk-body govuk-!-font-weight-bold">You’ll be able to review it again before you submit your application.</p>
+<% if @application_form.becoming_a_teacher_review_pending? %>
+  <div class='govuk-inset-text govuk-!-width-two-thirds govuk-!-margin-top-0'>
+    <h2 class="govuk-heading-m">Feedback from previous applications</h2>
+
+    <% @application_form.becoming_a_teacher_rejection_reasons.each do |rejection_reason| %>
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-2"><%= rejection_reason.provider_name %></h3>
+      <blockquote class="govuk-!-margin-left-0 govuk-!-margin-top-0">
+        <p class="govuk-body">“<%= rejection_reason.feedback %>”</p>
+      </blockquote>
+    <% end %>
+  </div>
+<% else %>
+  <p class="govuk-body govuk-!-font-weight-bold">This section is important to your application. Before continuing:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>proofread your answer carefully for spelling and grammar</li>
+    <li>ask someone you trust for their opinion</li>
+    <li>ensure this piece of writing is all your own work – plagiarism will be penalised</li>
+  </ul>
+  <p class="govuk-body govuk-!-font-weight-bold">You’ll be able to review it again before you submit your application.</p>
+<% end %>
 
 <%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: @application_form)) %>
 
@@ -20,4 +33,5 @@
   path: candidate_interface_becoming_a_teacher_complete_path,
   request_method: :patch,
   field_name: :becoming_a_teacher_completed,
+  section_review: @application_form.becoming_a_teacher_reviewable?,
 )) %>

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -10,7 +10,9 @@
       <ul class="govuk-list govuk-error-summary__list">
         <% @incomplete_sections.each do |section| %>
           <li>
-            <a href="<%= "#incomplete-#{section}-error" %>"><%= t("review_application.#{section}.incomplete", minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES) %></a>
+            <a href="<%= "#incomplete-#{section.name}-error" %>">
+              <%= t(section.message, minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES) %>
+            </a>
           </li>
         <% end %>
 

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -165,8 +165,8 @@
           <%= render(TaskListItemComponent.new(
             text: t('page_titles.becoming_a_teacher'),
             completed: @application_form_presenter.becoming_a_teacher_completed?,
-            path: @application_form_presenter.becoming_a_teacher_valid? ? candidate_interface_becoming_a_teacher_show_path : candidate_interface_edit_becoming_a_teacher_path,
-          )) %>
+              path: @application_form_presenter.becoming_a_teacher_path,
+            )) %>
         </li>
         <li class="app-task-list__item govuk-hint">
           <%= render(TaskListItemComponent.new(

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -162,11 +162,21 @@
 
       <ol class="app-task-list">
         <li class="app-task-list__item govuk-hint">
-          <%= render(TaskListItemComponent.new(
-            text: t('page_titles.becoming_a_teacher'),
-            completed: @application_form_presenter.becoming_a_teacher_completed?,
+          <% if @application_form_presenter.becoming_a_teacher_review_pending? %>
+            <%= render(TaskListItemComponent.new(
+              text: t('page_titles.becoming_a_teacher'),
+              completed: false,
+              path: @application_form_presenter.becoming_a_teacher_path,
+              custom_status: 'Review',
+              custom_color: 'pink',
+            )) %>
+          <% else %>
+            <%= render(TaskListItemComponent.new(
+              text: t('page_titles.becoming_a_teacher'),
+              completed: @application_form_presenter.becoming_a_teacher_completed?,
               path: @application_form_presenter.becoming_a_teacher_path,
             )) %>
+          <% end %>
         </li>
         <li class="app-task-list__item govuk-hint">
           <%= render(TaskListItemComponent.new(

--- a/config/locales/candidate_interface/application_form.yml
+++ b/config/locales/candidate_interface/application_form.yml
@@ -2,6 +2,7 @@ en:
   application_form:
     begin_button: Start now
     completed_checkbox: I have completed this section
+    reviewed_checkbox: I have reviewed this section
 
   activemodel:
     errors:

--- a/config/locales/candidate_interface/review_application.yml
+++ b/config/locales/candidate_interface/review_application.yml
@@ -52,6 +52,7 @@ en:
       complete_section: Have you done an English as a foreign language assessment?
     becoming_a_teacher:
       incomplete: Personal statement not entered
+      not_reviewed: Personal statement not marked as reviewed
       complete_section: Why do you want to be a teacher?
     subject_knowledge:
       incomplete: Subject knowledge not entered

--- a/spec/components/candidate_interface/complete_section_component_spec.rb
+++ b/spec/components/candidate_interface/complete_section_component_spec.rb
@@ -8,13 +8,32 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
 
   it 'renders successfully' do
     result = render_inline(
-      described_class.new(application_form: application_form,
-                          path: path,
-                          request_method: request_method,
-                          field_name: field_name),
+      described_class.new(
+        application_form: application_form,
+        path: path,
+        request_method: request_method,
+        field_name: field_name,
+      ),
     )
 
     expect(result.css('.govuk-form-group').text).to include 'I have completed this section'
+    expect(result.to_html).to include path
+    expect(result.to_html).to include request_method
+    expect(result.to_html).to include field_name
+  end
+
+  it 'renders a review checkbox label if specified' do
+    result = render_inline(
+      described_class.new(
+        application_form: application_form,
+        path: path,
+        request_method: request_method,
+        field_name: field_name,
+        section_review: true,
+      ),
+    )
+
+    expect(result.css('.govuk-form-group').text).to include 'I have reviewed this section'
     expect(result.to_html).to include path
     expect(result.to_html).to include request_method
     expect(result.to_html).to include field_name

--- a/spec/models/candidate_interface/rejection_reasons_history_spec.rb
+++ b/spec/models/candidate_interface/rejection_reasons_history_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::RejectionReasonsHistory do
+  describe '.all_previous_applications' do
+    context 'when given an unsupported section' do
+      it 'raises an error' do
+        application_form = build(:application_form)
+
+        expect {
+          described_class.all_previous_applications(application_form, :juggling_skills)
+        }.to raise_error(described_class::UnsupportedSectionError)
+      end
+    end
+
+    context 'when no previous application' do
+      it 'returns an empty array' do
+        application_form = create(:application_form)
+        expect(
+          described_class.all_previous_applications(application_form, :becoming_a_teacher),
+        ).to eq []
+      end
+    end
+
+    it 'returns a history of rejection reasons from previous applications' do
+      previous_application_form1 = create(:application_form)
+      choice1 = create(:application_choice, :with_structured_rejection_reasons, application_form: previous_application_form1)
+      choice2 = create(:application_choice, :with_structured_rejection_reasons, application_form: previous_application_form1)
+      previous_application_form2 = apply_again!(previous_application_form1)
+      choice3 = create(:application_choice, :with_structured_rejection_reasons, application_form: previous_application_form2)
+      %w[Bad Good Amazing].zip([choice1, choice2, choice3]).each do |feedback, choice|
+        choice.update!(structured_rejection_reasons: choice.structured_rejection_reasons.merge(quality_of_application_personal_statement_what_to_improve: feedback))
+      end
+      current_application_form = apply_again!(previous_application_form2)
+
+      feedback = described_class.all_previous_applications(current_application_form, :becoming_a_teacher)
+
+      expect(feedback).to match_array [
+        described_class::HistoryItem.new(choice3.provider.name, :becoming_a_teacher, 'Amazing'),
+        described_class::HistoryItem.new(choice2.provider.name, :becoming_a_teacher, 'Good'),
+        described_class::HistoryItem.new(choice1.provider.name, :becoming_a_teacher, 'Bad'),
+      ]
+    end
+
+    it 'ignores application choices with no relevant feedback' do
+      previous_application_form = create(:application_form)
+      choice = create(:application_choice, :with_structured_rejection_reasons, application_form: previous_application_form)
+      create(:application_choice, structured_rejection_reasons: { 'safeguarding_y_n' => 'No' }, application_form: previous_application_form)
+      create(:application_choice, application_form: previous_application_form)
+      current_application_form = apply_again!(previous_application_form)
+
+      feedback = described_class.all_previous_applications(current_application_form, :becoming_a_teacher)
+
+      expect(feedback).to match_array [
+        described_class::HistoryItem.new(choice.provider.name, :becoming_a_teacher, 'Use a spellchecker'),
+      ]
+    end
+
+  private
+
+    def apply_again!(application_form)
+      DuplicateApplication.new(application_form, target_phase: :apply_2).duplicate
+    end
+  end
+end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -144,6 +144,21 @@ module CandidateHelper
     click_button t('continue')
   end
 
+  def candidate_fills_in_apply_again_course_choice
+    click_link t('continue')
+    choose 'Yes, I know where I want to apply'
+    click_button t('continue')
+
+    select 'Gorse SCITT (1N1)'
+    click_button t('continue')
+
+    choose 'Primary (2XT2)'
+    click_button t('continue')
+
+    check t('application_form.courses.complete.completed_checkbox')
+    click_button t('continue')
+  end
+
   def candidate_fills_in_personal_details
     scope = 'application_form.personal_details'
     fill_in t('first_name.label', scope: scope), with: 'Lando'

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -424,6 +424,12 @@ module CandidateHelper
     end
   end
 
+  def within_task_list_item(title, &block)
+    within(page.find('.app-task-list__item', text: title)) do
+      block.call
+    end
+  end
+
   def expect_validation_error(message)
     errors = all('.govuk-error-message')
     expect(errors.map(&:text).one? { |e| e.include? message }).to eq true

--- a/spec/system/candidate_interface/apply_again/candidate_reviews_rejection_reasons_from_previous_applications_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_reviews_rejection_reasons_from_previous_applications_spec.rb
@@ -7,12 +7,16 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
     given_i_am_signed_in_as_a_candidate
     and_i_have_an_unsuccessful_application_with_rejection_reasons
     when_i_apply_again
-    then_personal_statement_needs_review
-    and_i_can_review_personal_statement
+    then_become_a_teacher_needs_review
+    and_i_can_review_become_a_teacher
 
     when_i_confirm_i_have_reviewed_this_section
-    then_personal_statement_no_longer_needs_review
+    then_become_a_teacher_no_longer_needs_review
     and_i_can_set_it_back_to_unreviewed
+
+    when_i_submit_my_application
+    then_i_am_informed_that_i_have_not_reviewed_become_a_teacher
+    and_i_can_submit_once_i_have_reviewed
   end
 
   def given_i_am_signed_in_as_a_candidate
@@ -21,22 +25,33 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
   end
 
   def and_i_have_an_unsuccessful_application_with_rejection_reasons
-    application = create(:completed_application_form, candidate: @candidate)
+    application = create(
+      :completed_application_form,
+      :with_gcses,
+      :with_completed_references,
+      references_count: 2,
+      candidate: @candidate,
+    )
     create(:application_choice, :with_structured_rejection_reasons, application_form: application)
   end
 
   def when_i_apply_again
+    given_courses_exist
+
     visit candidate_interface_application_complete_path
     click_on 'Apply again'
+
+    click_link 'Choose your course'
+    candidate_fills_in_apply_again_course_choice
   end
 
-  def then_personal_statement_needs_review
+  def then_become_a_teacher_needs_review
     within_task_list_item('Why do you want to teach') do
       expect(page).to have_css('.govuk-tag', text: 'Review')
     end
   end
 
-  def and_i_can_review_personal_statement
+  def and_i_can_review_become_a_teacher
     click_link 'Why do you want to teach'
     expect(page).to have_content 'Use a spellchecker'
   end
@@ -46,7 +61,7 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
     click_button t('continue')
   end
 
-  def then_personal_statement_no_longer_needs_review
+  def then_become_a_teacher_no_longer_needs_review
     within_task_list_item('Why do you want to teach') do
       expect(page).to have_css('.govuk-tag', text: 'Completed')
     end
@@ -56,6 +71,38 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
     click_link 'Why do you want to teach'
     uncheck t('application_form.reviewed_checkbox')
     click_button t('continue')
-    then_personal_statement_needs_review
+    then_become_a_teacher_needs_review
+  end
+
+  def when_i_submit_my_application
+    click_on 'Check and submit your application'
+    click_on 'Continue'
+  end
+
+  def then_i_am_informed_that_i_have_not_reviewed_become_a_teacher
+    within become_a_teacher_error_container do
+      expect(page).to have_content 'Personal statement not marked as reviewed'
+    end
+  end
+
+  def and_i_can_submit_once_i_have_reviewed
+    click_link 'Why do you want to be a teacher?'
+    click_on 'Continue'
+    when_i_confirm_i_have_reviewed_this_section
+    click_on 'Check and submit'
+    expect(page).not_to have_css become_a_teacher_error_container
+    click_on 'Continue'
+    choose 'No'
+    click_on 'Continue'
+    choose 'No'
+    click_button 'Send application'
+    click_on 'Continue'
+    expect(page).to have_content 'Application successfully submitted'
+  end
+
+private
+
+  def become_a_teacher_error_container
+    '#incomplete-becoming_a_teacher-error'
   end
 end

--- a/spec/system/candidate_interface/apply_again/candidate_reviews_rejection_reasons_from_previous_applications_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_reviews_rejection_reasons_from_previous_applications_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate with unsuccessful application can review rejection reasons when applying again' do
+  include CandidateHelper
+
+  scenario 'Apply again and review rejection reasons' do
+    given_i_am_signed_in_as_a_candidate
+    and_i_have_an_unsuccessful_application_with_rejection_reasons
+    when_i_apply_again
+    then_personal_statement_needs_review
+    and_i_can_review_personal_statement
+
+    when_i_confirm_i_have_reviewed_this_section
+    then_personal_statement_no_longer_needs_review
+    and_i_can_set_it_back_to_unreviewed
+  end
+
+  def given_i_am_signed_in_as_a_candidate
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_an_unsuccessful_application_with_rejection_reasons
+    application = create(:completed_application_form, candidate: @candidate)
+    create(:application_choice, :with_structured_rejection_reasons, application_form: application)
+  end
+
+  def when_i_apply_again
+    visit candidate_interface_application_complete_path
+    click_on 'Apply again'
+  end
+
+  def then_personal_statement_needs_review
+    within_task_list_item('Why do you want to teach') do
+      expect(page).to have_css('.govuk-tag', text: 'Review')
+    end
+  end
+
+  def and_i_can_review_personal_statement
+    click_link 'Why do you want to teach'
+    expect(page).to have_content 'Use a spellchecker'
+  end
+
+  def when_i_confirm_i_have_reviewed_this_section
+    check t('application_form.reviewed_checkbox')
+    click_button t('continue')
+  end
+
+  def then_personal_statement_no_longer_needs_review
+    within_task_list_item('Why do you want to teach') do
+      expect(page).to have_css('.govuk-tag', text: 'Completed')
+    end
+  end
+
+  def and_i_can_set_it_back_to_unreviewed
+    click_link 'Why do you want to teach'
+    uncheck t('application_form.reviewed_checkbox')
+    click_button t('continue')
+    then_personal_statement_needs_review
+  end
+end


### PR DESCRIPTION
## Context

As a.... candidate
In order to... improve my chance of success when applying again
I want to... review the sections of my application that providers said needed improvement.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
We want to encourage candidates to review feedback from past,
unsuccessful applications. This commit adds a review workflow to the
'Why do you want to teach' section of the personal statement.

This new workflow is implemented as a set of cosmetic changes on top of
the existing 'completed' flags we have for each section. This means we
can use the existing database column and preserve the same validation
behaviour while changing only the messaging the candidate sees.

Broadly, this change does the following:

- Mark the 'becoming_a_teacher' section as incomplete when applying
  again if there is structured feedback for this section in the
  previous application form.
- Show a 'Review' badge for this section on the application form page.
- Add a RejectionReasonsHistory class that handles retrieval of past
  rejection reasons, providing methods to return the entire rejection
  history of a section or just the most recent one.
- Summarize the rejection history of the section when reviewing it.

Finally, we also add updated error messaging for this section on app submit.

**Review badge on application form page**:

![Screenshot_20210420_122710](https://user-images.githubusercontent.com/519250/115388404-bf06d700-a1d3-11eb-99d9-bff27dd1ea56.png)


**Inline rejection reasons for the section**:

![Screenshot_20210420_122627](https://user-images.githubusercontent.com/519250/115388361-ae566100-a1d3-11eb-8ecd-d0c1956b48d4.png)


**Error on app submit**:

![Screenshot_20210420_122427-1](https://user-images.githubusercontent.com/519250/115388191-7cdd9580-a1d3-11eb-876d-293c746b22a8.png)


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Per commit highly recommended. There are a couple of precursor commits and the system spec has been added on its own to outline the expected behaviour.
- Manual testing will need an unsuccessful application with structured feedback in `quality_of_application_personal_statement_what_to_improve`. The review workflow can then be tested by applying again.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/BkHTZAJE
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
