### PR TITLE
Set current_course_option_id for existing application choices

### DIFF
--- a/app/services/data_migrations/backfill_current_course_option_id.rb
+++ b/app/services/data_migrations/backfill_current_course_option_id.rb
@@ -1,0 +1,17 @@
+module DataMigrations
+  class BackfillCurrentCourseOptionId
+    TIMESTAMP = 20210419154319
+    MANUAL_RUN = false
+
+    def change
+      sql = <<~POPULATE_CURRENT_OPTION_ID_SQL.squish
+        UPDATE application_choices
+           SET current_course_option_id = COALESCE(offered_course_option_id, course_option_id)
+      POPULATE_CURRENT_OPTION_ID_SQL
+
+      ActiveRecord::Base.connection.execute(sql)
+
+      raise 'setting current_course_option_id failed' if ApplicationChoice.where(current_course_option_id: nil).any?
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillCurrentCourseOptionId',
   'DataMigrations::BackfillExportType',
   'DataMigrations::FixLatLongFlipFlops',
 ].freeze

--- a/spec/services/data_migrations/backfill_current_course_option_id_spec.rb
+++ b/spec/services/data_migrations/backfill_current_course_option_id_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillCurrentCourseOptionId do
+  it 'uses offered_course_option_id, if present' do
+    course_option = create(:course_option)
+    application_choice = create(:application_choice, offered_course_option_id: course_option.id)
+
+    described_class.new.change
+
+    expect(application_choice.reload.current_course_option_id).to eq(course_option.id)
+  end
+
+  it 'falls back to course_option_id, if offered_course_option_id is blank' do
+    application_choice = create(:application_choice, offered_course_option_id: nil)
+    application_choice.update_columns(current_course_option_id: nil)
+
+    described_class.new.change
+
+    expect(application_choice.reload.current_course_option_id).to eq(application_choice.course_option.id)
+  end
+end


### PR DESCRIPTION
## Context

After deploying https://github.com/DFE-Digital/apply-for-teacher-training/pull/4546, which will start setting `current_course_option_id` for all new applications, we need to deal with existing application choices and populate `current_course_option_id` for them, before starting to read from this field (see https://github.com/DFE-Digital/apply-for-teacher-training/pull/4499).

## Changes proposed in this pull request

Extract the data migration from https://github.com/DFE-Digital/apply-for-teacher-training/pull/4499 and deploy this first, to avoid any race conditions.

## Guidance to review

See the spec.

## Link to Trello card

https://trello.com/c/oYjeu4Hh

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
