### PR TITLE
Clarify meaning of "invited" in Slack notification

### DIFF
--- a/app/services/invite_provider_user.rb
+++ b/app/services/invite_provider_user.rb
@@ -45,7 +45,7 @@ private
 
   def send_slack_notification
     providers = @provider_user.providers.map(&:name).to_sentence
-    message = "#{@provider_user.first_name} has been invited to join #{providers}"
+    message = ":technologist: Provider user #{@provider_user.first_name} has been invited to join #{providers}"
     url = Rails.application.routes.url_helpers.edit_support_interface_provider_user_url(@provider_user)
 
     SlackNotificationWorker.perform_async(message, url)

--- a/spec/services/invite_provider_user_spec.rb
+++ b/spec/services/invite_provider_user_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe InviteProviderUser, sidekiq: true do
       url = Rails.application.routes.url_helpers.edit_support_interface_provider_user_url(provider_user)
 
       expect(SlackNotificationWorker).to have_received(:perform_async)
-        .with("Firstname has been invited to join #{provider.name}", url)
+        .with(":technologist: Provider user Firstname has been invited to join #{provider.name}", url)
     end
   end
 


### PR DESCRIPTION
## Context

It's a bit confusing when we say "invited to join" in Slack. It's about a provider user, not a candidate.

<img width="404" alt="Screenshot 2021-04-20 at 14 48 40" src="https://user-images.githubusercontent.com/642279/115407038-9ee11300-a1e7-11eb-9d5a-528d61101d01.png">

## Changes proposed in this pull request

Add a 👩‍💻 emoji and the words "Provider user" to the notification.

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
