### PR TITLE
Set application form created date in the past

### DIFF
--- a/spec/services/support_interface/application_references_export_spec.rb
+++ b/spec/services/support_interface/application_references_export_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SupportInterface::ApplicationReferencesExport do
 
   describe '#data_for_export' do
     it 'returns an array of hashes containing non duplicate reference types' do
-      application_form_one = create(:application_form)
+      application_form_one = create(:application_form, created_at: 1.day.ago)
 
       create(:reference, feedback_status: 'feedback_refused', referee_type: 'academic', application_form: application_form_one)
       create(:reference, feedback_status: 'feedback_refused', referee_type: 'professional', application_form: application_form_one)


### PR DESCRIPTION
## Context

Spec used to flake when occasionally created_at field != updated_at field. This issue has been fixed by specifying that created_at != updated_at under all circumstances. This is more reflective of the real behaviour of an application (which is created and then references are added later).
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
