### PR TITLE
Fix copy-paste error in performance_statistics_spec

### DIFF
--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe PerformanceStatistics, type: :model do
 
       apply_again_form = create(:application_form, phase: 'apply_2')
       create(:application_choice, status: 'unsubmitted', application_form: apply_again_form)
-      apply_again_form.update_column(:updated_at, form.created_at)
+      apply_again_form.update_column(:updated_at, apply_again_form.created_at)
 
       expect(ProcessState.new(form).state).to be :unsubmitted_not_started_form
 


### PR DESCRIPTION
This spec passed by accident because the `form` was usually created at the same time as the `apply_again_form`, but this wasn't always true, especially in (relatively slow) CI environments
