### PR TITLE
Prompt candidates with GCSE fail grades about how they are going to achieve passes

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -21,7 +21,7 @@ module CandidateInterface
           enic_reference_row,
           comparable_uk_qualification_row,
           grade_row,
-          grade_explanation_row,
+          failing_grade_explanation_row,
           award_year_row,
         ].compact
       end
@@ -76,7 +76,7 @@ module CandidateInterface
       }
     end
 
-    def grade_explanation_row
+    def failing_grade_explanation_row
       return nil unless application_qualification.failed_required_gcse? && application_qualification.missing_explanation.present?
 
       {

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -21,6 +21,7 @@ module CandidateInterface
           enic_reference_row,
           comparable_uk_qualification_row,
           grade_row,
+          grade_explanation_row,
           award_year_row,
         ].compact
       end
@@ -72,6 +73,17 @@ module CandidateInterface
         value: present_grades || t('gcse_summary.not_specified'),
         action: "grade for #{gcse_qualification_types[application_qualification.qualification_type.to_sym]}, #{subject}",
         change_path: grade_edit_path,
+      }
+    end
+
+    def grade_explanation_row
+      return nil unless application_qualification.failed_required_gcse? && application_qualification.missing_explanation.present?
+
+      {
+        key: 'How I expect to gain this qualification',
+        value: application_qualification.missing_explanation,
+        action: 'if you are working towards this qualification at grade 4 (C) or above, give us details',
+        change_path: candidate_interface_gcse_details_edit_grade_explanation_path(subject: subject),
       }
     end
 

--- a/app/controllers/candidate_interface/gcse/english/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/english/grade_controller.rb
@@ -48,7 +48,9 @@ module CandidateInterface
     end
 
     def next_gcse_path
-      if english_gcse_grade_form.award_year.nil?
+      if current_qualification.failed_required_gcse?
+        candidate_interface_gcse_details_edit_grade_explanation_path(subject: @subject)
+      elsif english_gcse_grade_form.award_year.nil?
         candidate_interface_gcse_details_edit_year_path(subject: @subject)
       else
         candidate_interface_gcse_review_path(subject: @subject)

--- a/app/controllers/candidate_interface/gcse/grade_explanation_controller.rb
+++ b/app/controllers/candidate_interface/gcse/grade_explanation_controller.rb
@@ -1,0 +1,33 @@
+module CandidateInterface
+  class Gcse::GradeExplanationController < Gcse::BaseController
+    def edit
+      @form = CandidateInterface::GcseGradeExplanationForm.build_from_qualification(current_qualification)
+    end
+
+    def update
+      @form = CandidateInterface::GcseGradeExplanationForm.new(update_params)
+
+      if @form.save(current_qualification)
+        update_gcse_completed(false)
+
+        if current_qualification.award_year.nil?
+          redirect_to candidate_interface_gcse_details_edit_year_path(subject: params[:subject])
+        else
+          redirect_to candidate_interface_gcse_review_path
+        end
+      else
+        track_validation_error(@form)
+
+        render :edit
+      end
+    end
+
+  private
+
+    def update_params
+      strip_whitespace params
+        .require(:candidate_interface_gcse_grade_explanation_form)
+        .permit(:missing_explanation)
+    end
+  end
+end

--- a/app/controllers/candidate_interface/gcse/maths/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/maths/grade_controller.rb
@@ -27,7 +27,9 @@ module CandidateInterface
     end
 
     def next_gcse_path
-      if current_qualification.award_year.nil?
+      if current_qualification.failed_required_gcse?
+        candidate_interface_gcse_details_edit_grade_explanation_path(subject: @subject)
+      elsif current_qualification.award_year.nil?
         candidate_interface_gcse_details_edit_year_path(subject: @subject)
       else
         candidate_interface_gcse_review_path(subject: @subject)

--- a/app/controllers/candidate_interface/gcse/science/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/science/grade_controller.rb
@@ -30,7 +30,9 @@ module CandidateInterface
     end
 
     def next_path
-      if current_qualification.award_year.nil?
+      if current_qualification.failed_required_gcse?
+        candidate_interface_gcse_details_edit_grade_explanation_path(subject: @subject)
+      elsif current_qualification.award_year.nil?
         candidate_interface_gcse_details_edit_year_path(subject: @subject)
       else
         candidate_interface_gcse_review_path(subject: @subject)

--- a/app/forms/candidate_interface/english_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/english_gcse_grade_form.rb
@@ -145,7 +145,11 @@ module CandidateInterface
     end
 
     def save
-      is_multiple_gcse? ? save_grades : save_grade
+      result = is_multiple_gcse? ? save_grades : save_grade
+      return false unless result
+
+      reset_missing_explanation!(qualification)
+      result
     end
 
   private
@@ -156,6 +160,12 @@ module CandidateInterface
         return false
       end
       qualification.update(grade: set_grade, constituent_grades: nil)
+    end
+
+    def reset_missing_explanation!(qualification)
+      return true unless qualification.pass_gcse?
+
+      qualification.update(missing_explanation: nil)
     end
 
     def save_grades

--- a/app/forms/candidate_interface/gcse_grade_explanation_form.rb
+++ b/app/forms/candidate_interface/gcse_grade_explanation_form.rb
@@ -1,0 +1,19 @@
+module CandidateInterface
+  class GcseGradeExplanationForm
+    include ActiveModel::Model
+
+    attr_accessor :missing_explanation
+
+    def self.build_from_qualification(qualification)
+      new(
+        missing_explanation: qualification.missing_explanation,
+      )
+    end
+
+    def save(qualification)
+      return false unless valid?
+
+      qualification.update!(missing_explanation: missing_explanation)
+    end
+  end
+end

--- a/app/forms/candidate_interface/maths_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/maths_gcse_grade_form.rb
@@ -31,6 +31,7 @@ module CandidateInterface
     def save(qualification)
       if valid?
         qualification.update!(grade: set_grade)
+        reset_missing_explanation!(qualification)
       else
         log_validation_errors(:grade)
         false
@@ -90,6 +91,12 @@ module CandidateInterface
       else
         sanitize(grade)
       end
+    end
+
+    def reset_missing_explanation!(qualification)
+      return true unless qualification.pass_gcse?
+
+      qualification.update(missing_explanation: nil)
     end
   end
 end

--- a/app/forms/candidate_interface/science_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/science_gcse_grade_form.rb
@@ -68,11 +68,13 @@ module CandidateInterface
         return false
       end
 
-      qualification.update(
+      return false unless qualification.update(
         grade: set_grade,
         constituent_grades: set_triple_award_grades,
         subject: subject,
       )
+
+      reset_missing_explanation!(qualification)
     end
 
     def assign_values(params)
@@ -230,6 +232,12 @@ module CandidateInterface
 
     def gsce_qualification_type?
       qualification.qualification_type == 'gcse'
+    end
+
+    def reset_missing_explanation!(qualification)
+      return true unless qualification.pass_gcse?
+
+      qualification.update(missing_explanation: nil)
     end
   end
 end

--- a/app/helpers/gcse_qualification_helper.rb
+++ b/app/helpers/gcse_qualification_helper.rb
@@ -12,6 +12,14 @@ module GcseQualificationHelper
     end
   end
 
+  def grade_explanation_step_title(subject)
+    t("gcse_edit_grade_explanation.page_titles.#{subject}")
+  end
+
+  def grade_explanation_subject_title(subject)
+    t("gcse_edit_grade_explanation.subject_titles.#{subject}")
+  end
+
   def grade_step_title(subject, qualification_type)
     subject = subject.capitalize if subject == 'english'
     t('gcse_edit_grade.page_title', subject: subject, qualification_type: get_qualification_type_name(qualification_type))

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -156,11 +156,13 @@ class ApplicationQualification < ApplicationRecord
 
   GCSE_PASS_GRADES = %w[A* A B C A*A* A*A AA AB BB BC CC CD 9 8 7 6 5 4 99 98 88 87 77 76 66 65 55 54 44 43].freeze
   def failed_required_gcse?
-    return true if required_gcse? &&
-      all_grades.present? &&
-      all_grades.none? { |grade| GCSE_PASS_GRADES.include?(grade.upcase) }
+    return true if required_gcse? && all_grades.present? && !pass_gcse?
 
     false
+  end
+
+  def pass_gcse?
+    gcse? && all_grades.any? { |grade| GCSE_PASS_GRADES.include?(grade.upcase) }
   end
 
   def all_grades

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -156,13 +156,23 @@ class ApplicationQualification < ApplicationRecord
 
   GCSE_PASS_GRADES = %w[A* A B C A*A* A*A AA AB BB BC CC CD 9 8 7 6 5 4 99 98 88 87 77 76 66 65 55 54 44 43].freeze
   def failed_required_gcse?
-    return true if required_gcse? && grade.present? && !GCSE_PASS_GRADES.include?(grade.upcase)
+    return true if required_gcse? &&
+      all_grades.present? &&
+      all_grades.none? { |grade| GCSE_PASS_GRADES.include?(grade.upcase) }
 
     false
   end
 
+  def all_grades
+    return [grade] if grade.present?
+
+    constituent_grades.map { |_key, value| value['grade'] }
+  end
+
   def required_gcse?
-    gcse? && qualification_type.to_s.downcase == 'gcse' && REQUIRED_GCSE_SUBJECTS.include?(subject)
+    gcse? &&
+      qualification_type.to_s.downcase == 'gcse' &&
+      REQUIRED_GCSE_SUBJECTS.include?(subject)
   end
 
 private

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -35,6 +35,16 @@ class ApplicationQualification < ApplicationRecord
   SCIENCE_SINGLE_AWARD = 'science single award'.freeze
   SCIENCE_DOUBLE_AWARD = 'science double award'.freeze
   SCIENCE_TRIPLE_AWARD = 'science triple award'.freeze
+  ENGLISH = 'english'.freeze
+  MATHS = 'maths'.freeze
+  REQUIRED_GCSE_SUBJECTS = [
+    SCIENCE,
+    SCIENCE_SINGLE_AWARD,
+    SCIENCE_DOUBLE_AWARD,
+    SCIENCE_TRIPLE_AWARD,
+    ENGLISH,
+    MATHS,
+  ].freeze
 
   belongs_to :application_form, touch: true
 
@@ -142,6 +152,17 @@ class ApplicationQualification < ApplicationRecord
     ].compact.join(' - ')
 
     details.strip if details.present?
+  end
+
+  GCSE_PASS_GRADES = %w[A* A B C A*A* A*A AA AB BB BC CC CD 9 8 7 6 5 4 99 98 88 87 77 76 66 65 55 54 44 43].freeze
+  def failed_required_gcse?
+    return true if required_gcse? && grade.present? && !GCSE_PASS_GRADES.include?(grade.upcase)
+
+    false
+  end
+
+  def required_gcse?
+    gcse? && qualification_type.to_s.downcase == 'gcse' && REQUIRED_GCSE_SUBJECTS.include?(subject)
   end
 
 private

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -164,6 +164,8 @@ class ApplicationQualification < ApplicationRecord
   end
 
   def all_grades
+    return [] unless grade.present? || constituent_grades.present?
+
     return [grade] if grade.present?
 
     constituent_grades.map { |_key, value| value['grade'] }

--- a/app/views/candidate_interface/gcse/grade_explanation/edit.html.erb
+++ b/app/views/candidate_interface/gcse/grade_explanation/edit.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title, title_with_error_prefix(grade_explanation_step_title(@subject), @form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: candidate_interface_gcse_details_edit_grade_explanation_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+          <h1 class="govuk-fieldset__heading">
+            You need <%= grade_explanation_subject_title(@subject) %> GCSE at grade 4 (C) or above, or equivalent
+          </h1>
+        </legend>
+        <p class="govuk-body">You can still apply for teacher training if you do not have this. However, it will need to be in place by the start of your course.</p>
+        <p class="govuk-body">For advice, contact your chosen training provider or <a href="https://getintoteaching.education.gov.uk/">Get Into Teaching</a>.</p>
+        <%= f.govuk_text_area(
+          :missing_explanation,
+          label: { text: 'If you are working towards this qualification at grade 4 (C) or above, give us details (optional)', size: 'm' },
+          rows: 6,
+          max_words: 200,
+        ) do %>
+        <% end %>
+      </fieldset>
+
+      <%= f.govuk_submit t('save_and_continue') %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/candidate_interface/gcse_details.yml
+++ b/config/locales/candidate_interface/gcse_details.yml
@@ -4,6 +4,15 @@ en:
       maths: Add maths GCSE grade 4 (C) or above, or equivalent
       english: Add English GCSE grade 4 (C) or above, or equivalent
       science: Add science GCSE grade 4 (C) or above, or equivalent
+  gcse_edit_grade_explanation:
+    subject_titles:
+      maths: a maths
+      english: an English
+      science: a science
+    page_titles:
+      maths: You need a maths GCSE at grade 4 (C) or above, or equivalent
+      english: You need an English GCSE at grade 4 (C) or above, or equivalent
+      science: You need a science GCSE at grade 4 (C) or above, or equivalent
   gcse_edit_grade:
     page_title: What grade is your %{subject} %{qualification_type}?
     guidance:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -205,6 +205,9 @@ Rails.application.routes.draw do
         get '/year' => 'gcse/year#edit', as: :gcse_details_edit_year
         patch '/year' => 'gcse/year#update'
 
+        get '/grade-explanation' => 'gcse/grade_explanation#edit', as: :gcse_details_edit_grade_explanation
+        patch '/grade-explanation' => 'gcse/grade_explanation#update'
+
         get '/review' => 'gcse/review#show', as: :gcse_review
         patch '/complete' => 'gcse/review#complete', as: :gcse_complete
       end

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -82,6 +82,30 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
     end
   end
 
+  context 'a uk qualification with failure grade and explanation' do
+    it 'displays award year, qualification type and grade' do
+      application_form = build :application_form
+      @qualification = application_qualification = build(
+        :application_qualification,
+        application_form: application_form,
+        qualification_type: 'gcse',
+        level: 'gcse',
+        grade: 'D',
+        subject: 'maths',
+        missing_explanation: 'I am going to work harder',
+      )
+      result = render_inline(
+        described_class.new(application_form: application_form, application_qualification: application_qualification, subject: 'maths'),
+      )
+
+      expect(result.text).to match(/Qualification\s+GCSE/)
+      expect(result.text).to match(/Year awarded\s+#{@qualification.award_year}/)
+      expect(result.text).to match(/Grade\s+#{@qualification.grade}/)
+      expect(result.text).to match(/How I expect to gain this qualification\s+#{@qualification.missing_explanation}/)
+      expect(result.text).not_to match(/Country\s+#{@qualification.institution_country}/)
+    end
+  end
+
   context 'when the candidate has entered a triple science GCSE award' do
     it 'displays each science subject and associated grade' do
       application_form = build :application_form

--- a/spec/factories/application_qualification.rb
+++ b/spec/factories/application_qualification.rb
@@ -32,6 +32,12 @@ FactoryBot.define do
         grade { nil }
         missing_explanation { 'I will be taking an equivalency test in a few weeks' }
       end
+
+      trait :multiple_english_gcses do
+        grade { nil }
+        subject { 'english' }
+        constituent_grades { { english_language: { grade: 'A', public_id: 120282 }, english_literature: { grade: 'D', public_id: 120283 } } }
+      end
     end
 
     factory :degree_qualification do

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -272,4 +272,26 @@ RSpec.describe ApplicationQualification, type: :model do
       expect(qualification.constituent_grades['Cockney Rhyming Slang']['public_id']).not_to be_nil
     end
   end
+
+  describe '#failed_required_gcse?' do
+    it 'returns false if the qualification is not GCSE level' do
+      expect(build(:degree_qualification).failed_required_gcse?).to be false
+    end
+
+    it 'returns false if the qualification is GCSE level but is a non-uk equivalant' do
+      expect(build(:gcse_qualification, :non_uk).failed_required_gcse?).to be false
+    end
+
+    it 'returns false if the qualification is GCSE and has a pass grade' do
+      expect(build(:gcse_qualification, grade: 'B').failed_required_gcse?).to be false
+    end
+
+    it 'returns false if the qualification is not for maths, english or science' do
+      expect(build(:gcse_qualification, grade: 'E', subject: 'history').failed_required_gcse?).to be false
+    end
+
+    it 'returns true if the qualification is GCSE and has a fail grade' do
+      expect(build(:gcse_qualification, grade: 'E').failed_required_gcse?).to be true
+    end
+  end
 end

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -293,5 +293,14 @@ RSpec.describe ApplicationQualification, type: :model do
     it 'returns true if the qualification is GCSE and has a fail grade' do
       expect(build(:gcse_qualification, grade: 'E').failed_required_gcse?).to be true
     end
+
+    it 'returns false if the qualification is GCSE with multiple awards and one is a pass grade' do
+      expect(build(:gcse_qualification, :multiple_english_gcses).failed_required_gcse?).to be false
+    end
+
+    it 'returns true if the qualification is GCSE with multiple awards and all are fail grades' do
+      grades = { english_language: { grade: 'E', public_id: 120282 }, english_literature: { grade: 'D', public_id: 120283 } }
+      expect(build(:gcse_qualification, :multiple_english_gcses, constituent_grades: grades).failed_required_gcse?).to be true
+    end
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
@@ -71,14 +71,14 @@ RSpec.feature 'Candidate entering GCSE details but without a pass grade' do
   def when_i_fill_in_the_fail_grade
     fill_in 'Please specify your grade', with: 'D'
   end
-  
+
   def then_i_am_prompted_to_explain_how_i_can_improve_this_grade
-    expect(page).to have_content 'You need a Maths GCSE at grade 4 (C) or above, or equivalent'
+    expect(page).to have_content 'You need a maths GCSE at grade 4 (C) or above, or equivalent'
     expect(page).to have_content 'If you are working towards this qualification at grade 4 (C) or above, give us details (optional)'
   end
 
   def when_i_fill_in_the_explanation
-    fill_in 'missing_explanation', with: 'Hard work and dedication'
+    fill_in 'If you are working towards this qualification at grade 4 (C) or above, give us details (optional)', with: 'Hard work and dedication'
   end
 
   def and_i_fill_in_the_year

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate entering GCSE details but without a pass grade' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their maths GCSE details' do
+    given_i_am_signed_in
+
+    when_i_visit_the_candidate_application_page
+    and_i_click_on_the_maths_gcse_link
+    then_i_see_the_add_gcse_maths_page
+
+    when_i_select_gcse_option
+    and_i_click_save_and_continue
+    then_i_see_add_grade_page
+
+    when_i_fill_in_the_fail_grade
+    and_i_click_save_and_continue
+    then_i_am_prompted_to_explain_how_i_can_improve_this_grade
+
+    when_i_fill_in_the_explanation
+    and_i_click_save_and_continue
+    and_i_fill_in_the_year
+    and_i_click_save_and_continue
+    then_i_see_the_review_page_with_correct_details
+
+    # TODO: change grade
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_click_on_the_maths_gcse_link
+    click_on 'Maths GCSE or equivalent'
+  end
+
+  def when_i_select_gcse_option
+    choose('GCSE')
+  end
+
+  def and_i_select_gcse_option
+    when_i_select_gcse_option
+  end
+
+  def and_i_click_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def when_i_visit_the_candidate_application_page
+    visit '/candidate/application'
+  end
+
+  def then_i_see_the_add_gcse_maths_page
+    expect(page).to have_content 'Add maths GCSE grade 4 (C) or above, or equivalent'
+  end
+
+  def then_i_see_the_review_page_with_correct_details
+    expect(page).to have_content 'Maths GCSE or equivalent'
+
+    expect(page).to have_content 'GCSE'
+    expect(page).to have_content 'D'
+    expect(page).to have_content 'Hard work and dedication'
+    expect(page).to have_content '1990'
+  end
+
+  def then_i_see_add_grade_page
+    expect(page).to have_content t('gcse_edit_grade.page_title', subject: 'maths', qualification_type: 'GCSE')
+  end
+
+  def when_i_fill_in_the_fail_grade
+    fill_in 'Please specify your grade', with: 'D'
+  end
+  
+  def then_i_am_prompted_to_explain_how_i_can_improve_this_grade
+    expect(page).to have_content 'You need a Maths GCSE at grade 4 (C) or above, or equivalent'
+    expect(page).to have_content 'If you are working towards this qualification at grade 4 (C) or above, give us details (optional)'
+  end
+
+  def when_i_fill_in_the_explanation
+    fill_in 'missing_explanation', with: 'Hard work and dedication'
+  end
+
+  def and_i_fill_in_the_year
+    fill_in 'Enter year', with: '1990'
+  end
+end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
@@ -27,6 +27,7 @@ RSpec.feature 'Candidate entering GCSE details but without a pass grade' do
     when_i_click_to_change_grade
     and_i_change_to_a_pass_grade
     then_i_see_the_review_page_with_new_details
+    and_the_missing_explanation_has_been_reset
 
     when_i_click_to_change_grade
     and_i_change_to_a_fail_grade
@@ -111,5 +112,10 @@ RSpec.feature 'Candidate entering GCSE details but without a pass grade' do
 
   def then_i_see_the_review_page_with_new_details
     expect(page).to have_content "Grade\nB"
+  end
+
+  def and_the_missing_explanation_has_been_reset
+    expect(page).not_to have_content 'Hard work and dedication'
+    expect(ApplicationQualification.last.missing_explanation).to be_nil
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
@@ -24,7 +24,13 @@ RSpec.feature 'Candidate entering GCSE details but without a pass grade' do
     and_i_click_save_and_continue
     then_i_see_the_review_page_with_correct_details
 
-    # TODO: change grade
+    when_i_click_to_change_grade
+    and_i_change_to_a_pass_grade
+    then_i_see_the_review_page_with_new_details
+
+    when_i_click_to_change_grade
+    and_i_change_to_a_fail_grade
+    then_i_am_prompted_to_explain_how_i_can_improve_this_grade
   end
 
   def given_i_am_signed_in
@@ -59,7 +65,7 @@ RSpec.feature 'Candidate entering GCSE details but without a pass grade' do
     expect(page).to have_content 'Maths GCSE or equivalent'
 
     expect(page).to have_content 'GCSE'
-    expect(page).to have_content 'D'
+    expect(page).to have_content "Grade\nD"
     expect(page).to have_content 'Hard work and dedication'
     expect(page).to have_content '1990'
   end
@@ -70,6 +76,10 @@ RSpec.feature 'Candidate entering GCSE details but without a pass grade' do
 
   def when_i_fill_in_the_fail_grade
     fill_in 'Please specify your grade', with: 'D'
+  end
+
+  def when_i_fill_in_the_pass_grade
+    fill_in 'Please specify your grade', with: 'B'
   end
 
   def then_i_am_prompted_to_explain_how_i_can_improve_this_grade
@@ -83,5 +93,23 @@ RSpec.feature 'Candidate entering GCSE details but without a pass grade' do
 
   def and_i_fill_in_the_year
     fill_in 'Enter year', with: '1990'
+  end
+
+  def when_i_click_to_change_grade
+    click_change_link('grade')
+  end
+
+  def and_i_change_to_a_pass_grade
+    when_i_fill_in_the_pass_grade
+    and_i_click_save_and_continue
+  end
+
+  def and_i_change_to_a_fail_grade
+    when_i_fill_in_the_fail_grade
+    and_i_click_save_and_continue
+  end
+
+  def then_i_see_the_review_page_with_new_details
+    expect(page).to have_content "Grade\nB"
   end
 end


### PR DESCRIPTION
## Context

As a candidate who does not have a pass grade for English or maths (or science) GCSE I need to say how I plan to meet the requirement so that I can improve my chances of having a successful application.

## Changes proposed in this pull request

- [x] If a candidate does not enter a pass grade, we show an additional page in the flow: ‘You need a [subject] GCSE grade 4 (C) or above, or equivalent’, which gives candidates an opportunity to say how the expect to meet this requirement.
<img width="747" alt="image" src="https://user-images.githubusercontent.com/450843/115524053-9f2feb80-a285-11eb-9999-0c86d02829d2.png">

- [x] Show the response to the above question on the review page if applicable
<img width="861" alt="image" src="https://user-images.githubusercontent.com/450843/115543030-d6f45e80-a298-11eb-849c-7ae12153d65f.png">

- [x] Only for Maths, English and Science
- [x] Fix tests
- [x] Handle multi-grade awards

## Guidance to review

- I've not added a feature flag for this change. Is one needed?
- Can you see any issues with reusing the existing `ApplicationQualification#missing_explanation` attribute to store the new value? (Up to now it's only been used in cases where there is no qualification or grade).
- I've tried to handle single/multiple grade qualifications by taking the `grade` or extracting the individual grades from `constituent_grades`. Does this make sense? A pass is defined as a qualification with at least one pass grade.

## Link to Trello card

https://trello.com/c/ONl9m9RD/3307-ask-additional-question-if-candidate-does-not-enter-a-gcse-pass-grade

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
