### PR TITLE
Fix slack link for new-course-to-open notification

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -33,7 +33,7 @@ module TeacherTrainingPublicAPI
         if provider.any_open_courses_in_current_cycle?
           SlackNotificationWorker.perform_async(
             "#{provider.name}, which has courses open on Apply, added a new course",
-            support_interface_provider_courses_path(provider),
+            support_interface_provider_courses_url(provider),
           )
         end
       end


### PR DESCRIPTION
## Context

#4543 and then

<img width="522" alt="Screenshot 2021-04-21 at 10 15 16" src="https://user-images.githubusercontent.com/642279/115529115-88d85e80-a28a-11eb-92fb-78e66d917029.png">

The link needs to be a proper URL for it to work in Slack