### PR TITLE
Create data export which shows who has initiated each export

### DIFF
--- a/app/exports/who_ran_which_export_export.yml
+++ b/app/exports/who_ran_which_export_export.yml
@@ -1,0 +1,11 @@
+custom_columns:
+  export_type:
+    type: string
+  created_at:
+    type: string
+    format: date-time
+    example: 2020-11-01T00:00:00+00:00
+  initiated_by:
+    type: string
+    description: The email address of the support user that initated the export
+    example: joe.bloggs@digital.education.gov.uk

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -66,6 +66,12 @@ class DataExport < ApplicationRecord
       description: 'Anonymised candidate equality and diversity data.',
       class: SupportInterface::EqualityAndDiversityExport,
     },
+    who_ran_which_export: {
+      name: 'Who ran which export',
+      export_type: 'who_ran_which_export',
+      description: 'A list of all the exports that have been generated and who initiated them.',
+      class: SupportInterface::WhoRanWhichExportExport,
+    },
     interviews_export: {
       name: 'Interview changes',
       export_type: 'interview_export',
@@ -201,6 +207,7 @@ class DataExport < ApplicationRecord
     candidate_journey_tracking: 'candidate_journey_tracking',
     candidate_course_choice_withdrawal_survey: 'candidate_course_choice_withdrawal_survey',
     equality_and_diversity: 'equality_and_diversity',
+    export_initiators: 'export_initiators',
     interviews_export: 'interview_export',
     notifications_export: 'notifications_export',
     notes_export: 'notes_export',

--- a/app/services/support_interface/who_ran_which_export_export.rb
+++ b/app/services/support_interface/who_ran_which_export_export.rb
@@ -1,0 +1,18 @@
+module SupportInterface
+  class WhoRanWhichExportExport
+    def data_for_export
+      DataExport
+      .where
+      .not(export_type: nil)
+      .order(%i[export_type created_at])
+      .find_each(batch_size: 100)
+      .map do |export|
+        {
+          export_type: export.export_type,
+          created_at: export.created_at,
+          initiated_by: export.initiator.email_address,
+        }
+      end
+    end
+  end
+end

--- a/spec/services/support_interface/who_ran_which_export_export_spec.rb
+++ b/spec/services/support_interface/who_ran_which_export_export_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::WhoRanWhichExportExport do
+  describe 'documentation' do
+    before do
+      support_user = create(:support_user)
+      create(:data_export, initiator: support_user)
+    end
+
+    it_behaves_like 'a data export'
+  end
+
+  describe '#data_for_export' do
+    it 'returns an array of hashes constaining generated data exports and who initiated them ordered by type and created_at' do
+      support_user1 = create(:support_user)
+      support_user2 = create(:support_user)
+      latest_provider_user_export = create(:data_export, initiator: support_user2)
+      earliest_provider_user_export = create(:data_export, initiator: support_user1, created_at: 3.days.ago)
+      work_history_export = create(:data_export, initiator: support_user1, created_at: 1.day.ago, export_type: 'work_history_break', name: 'Work history break')
+
+      expect(described_class.new.data_for_export).to contain_exactly(
+        {
+          export_type: earliest_provider_user_export.export_type,
+          created_at: earliest_provider_user_export.created_at,
+          initiated_by: support_user1.email_address,
+        },
+        {
+          export_type: latest_provider_user_export.export_type,
+          created_at: latest_provider_user_export.created_at,
+          initiated_by: support_user2.email_address,
+        },
+        {
+          export_type: work_history_export.export_type,
+          created_at: work_history_export.created_at,
+          initiated_by: support_user1.email_address,
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to be able to identify who the users of our exports are so that we can assign the primary user ownership of the export.

This export provides the export_type, created_at and email address of the initiator.

## Changes proposed in this pull request

- Add export 
- Add yml file for docs 

## Guidance to review


Can anyone think of a better name for this export?

## Link to Trello card

https://trello.com/c/loC6hQ4V/3320-dev-build-export-which-captures-each-exports-users

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
