### PR TITLE
Don't use blue-green deployment strategy for clock/web containers 

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -48,7 +48,6 @@ resource "cloudfoundry_app" "clock" {
   instances          = var.clock_app_instances
   memory             = var.clock_app_memory
   space              = data.cloudfoundry_space.space.id
-  strategy           = "blue-green-v2"
   timeout            = 180
   environment        = local.clock_app_env_variables
   docker_credentials = var.docker_credentials
@@ -68,7 +67,6 @@ resource "cloudfoundry_app" "worker" {
   instances          = var.worker_app_instances
   memory             = var.worker_app_memory
   space              = data.cloudfoundry_space.space.id
-  strategy           = "blue-green-v2"
   timeout            = 180
   environment        = local.worker_app_env_variables
   docker_credentials = var.docker_credentials


### PR DESCRIPTION
## Context

When a deployment of a new version is underway, the jobs on the worker app are still running.
The worker container might still run a job on the old schema while the version is being updated and causing the job to error.

## Changes proposed in this pull request

Use standard deployment strategy, so the worker container is updated and restarted.


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
