### PR TITLE
Include accredited providers as part of check for candidate masquerading

### DIFF
--- a/app/controllers/provider_interface/candidates_controller.rb
+++ b/app/controllers/provider_interface/candidates_controller.rb
@@ -21,11 +21,9 @@ module ProviderInterface
   private
 
     def verify_provider_association(candidate:, providers:)
-      provider_ids_from_candidate = candidate.application_forms
-                                              .map(&:application_choices).flatten
-                                              .map(&:provider).map(&:id).uniq
+      application_choices = candidate.application_forms.map(&:application_choices).flatten
 
-      providers.any? { |provider| provider_ids_from_candidate.include? provider.id }
+      (application_choices.map(&:associated_providers).flatten & providers).any?
     end
 
     def disable_on_production

--- a/spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb
+++ b/spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe 'A Provider can sign in as a candidate' do
     then_i_am_redirected_to_the_candidate_interface
     and_i_see_a_flash_message
     and_i_am_logged_in_as_that_candidate
+
+    when_my_organisation_ratifies_a_course_for_an_application
+    and_i_visit_the_ratified_application_in_the_provider_interface
+    and_i_click_on_the_sign_in_button
+
+    then_i_am_redirected_to_the_candidate_interface
+    and_i_see_a_flash_message
+    and_i_am_logged_in_as_the_ratified_application_candidate
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -24,7 +32,7 @@ RSpec.describe 'A Provider can sign in as a candidate' do
 
   def and_i_am_permitted_to_see_applications_for_my_provider
     @provider = create(:provider, :with_signed_agreement)
-    create(:provider_user, providers: [@provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    @provider_user = create(:provider_user, providers: [@provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
   end
 
   def and_my_organisation_has_received_an_application
@@ -51,5 +59,19 @@ RSpec.describe 'A Provider can sign in as a candidate' do
 
   def and_i_am_logged_in_as_that_candidate
     expect(page).to have_content(@candidate.email_address)
+  end
+
+  def when_my_organisation_ratifies_a_course_for_an_application
+    training_provider = create(:provider)
+    course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: @provider)
+    @ratified_application_choice = create(:submitted_application_choice, :with_completed_application_form, course_option: course_option)
+  end
+
+  def and_i_visit_the_ratified_application_in_the_provider_interface
+    visit provider_interface_application_choice_path(@ratified_application_choice)
+  end
+
+  def and_i_am_logged_in_as_the_ratified_application_candidate
+    expect(page).to have_content(@ratified_application_choice.application_form.candidate.email_address)
   end
 end


### PR DESCRIPTION
## Context

If a provider user belongs to an org which ratifies a course a candidate has applied for, they should be able to masquerade as the candidate assuming they have the correct user and org permissions.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Widen the check to verify that the provider user may also belong to an accrediting org with the correct user and org permissions.
<!-- If there are UI changes, please include Before and After screenshots. -->

Paired with @benswannack on this

## Guidance to review

To test you need an application where the course is ratified by your provider user's org and the training provider for the course is not one of your orgs.
You also need to make sure the ratifying provider org has permissions to make decisions on the relationship between the course provider and the ratifying (accredited) provider.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

Is the permissions check for make decisions necessary? We've erred on the side of being more restrictive but maybe this isn't necessary.

## Link to Trello card

https://trello.com/c/hYXKo0OV/3528-provider-is-unable-to-masquerade-as-candidate-in-sandbox
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
