### PR TITLE
Fix syntax error in GA custom dimension setup

### DIFF
--- a/app/views/shared/_analytics.html.erb
+++ b/app/views/shared/_analytics.html.erb
@@ -6,7 +6,7 @@
   gtag('js', new Date());
   gtag('config', '<%= @google_analytics_id %>');
   <% if @provider_type.present? %>
-    gtag('config', '<%= @google_analytics_id %>', { 'custom_map': { 'dimension2': 'Provider type' });
+    gtag('config', '<%= @google_analytics_id %>', { 'custom_map': { 'dimension2': 'Provider type' } });
     gtag('event', 'provider_type_dimension', { 'Provider type': '<%= @provider_type %>' });
   <% end %>
 </script>


### PR DESCRIPTION
## Context

There's a missing closing brace in the `provider_type` custom dimension setup code for GA.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds missing closing brace.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
