### PR TITLE
Add CSP nonce to GTM script tag

### DIFF
--- a/app/views/shared/_tag_manager.html.erb
+++ b/app/views/shared/_tag_manager.html.erb
@@ -1,5 +1,5 @@
 <!-- Google Tag Manager -->
-<script>
+<script nonce="<%= request.content_security_policy_nonce %>">
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','<%= @google_tag_manager_id %>');
 </script>
 <!-- End Google Tag Manager -->


### PR DESCRIPTION
## Context

The tag manager script will be blocked in production-like environments because of cross site scripting security policy. 
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Add the same nonce attribute we use for GA. See https://developers.google.com/tag-manager/web/csp and
https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/views/shared/_analytics.html.erb#L3

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
