### PR TITLE
Fix bug where candidate can submit their application with a site that has been deleted by the provider

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -45,8 +45,12 @@
           to see if the course will re-open or discuss alternatives
         </li>
       </ul>
-    <% elsif application_choice.site_full? %>
-      <p class="app-inset-text__title"><%= application_choice.site_full_error %>.</p>
+    <% elsif application_choice.site_full? || application_choice.site_invalid? %>
+       <% if application_choice.site_full? %>
+         <p class="app-inset-text__title"><%= application_choice.site_full_error %>.</p>
+       <% else %>
+         <p class="app-inset-text__title"><%= application_choice.site_invalid_error %>.</p>
+       <% end %>
       <p class="govuk-body">You can:</p>
       <ul class="govuk-list govuk-list--bullet">
         <% if site_change_path(application_choice) %>

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -119,6 +119,14 @@ class ApplicationChoice < ApplicationRecord
     I18n.t('errors.application_choices.site_full', descriptor: course.provider_and_name_code)
   end
 
+  def site_invalid?
+    !course_option.site_still_valid
+  end
+
+  def site_invalid_error
+    I18n.t('errors.application_choices.site_invalid', descriptor: course.provider_and_name_code)
+  end
+
   def study_mode_full?
     course_option.no_vacancies?
   end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -81,6 +81,12 @@ module CandidateInterface
             )
             next
           end
+          if choice.site_invalid?
+            error_list << ApplicationChoiceError.new(
+              choice.site_invalid_error, choice.id
+            )
+            next
+          end
 
           next unless choice.study_mode_full?
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -436,6 +436,7 @@ en:
       course_not_available: You cannot apply to ‘%{descriptor}’ because it is not running
       course_full: You cannot apply to ‘%{descriptor}’ because it has no vacancies
       site_full: Your chosen location for ‘%{descriptor}’ has no vacancies
+      site_invalid: The location you’ve chosen for ‘%{descriptor}’ has been removed by the provider. Choose a different location.
       study_mode_full: Your chosen location for ‘%{descriptor}’ has no %{study_mode} vacancies
       course_closed_on_apply: ‘%{course_name_and_code}’ at %{provider_name} is not available on Apply for teacher training anymore
       already_added: You have already added %{course_name_and_code}

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -111,6 +111,24 @@ RSpec.describe ApplicationChoice, type: :model do
     end
   end
 
+  describe '#site_invalid?' do
+    context 'a course option has been removed by the provider' do
+      it 'returns true' do
+        course_option = build(:course_option, site_still_valid: false)
+        application_choice = create(:application_choice, course_option: course_option)
+        expect(application_choice.site_invalid?).to be true
+      end
+    end
+
+    context 'a course option is still valid' do
+      it 'returns false' do
+        course_option = build(:course_option, site_still_valid: true)
+        application_choice = create(:application_choice, course_option: course_option)
+        expect(application_choice.site_invalid?).to be false
+      end
+    end
+  end
+
   describe '#course_study_mode_full?' do
     context 'with option that has vacancies' do
       it 'returns false' do

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -500,6 +500,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
         site_full?: false,
         study_mode_full?: false,
         course_closed_on_apply?: false,
+        site_invalid?: false,
       )
     end
 
@@ -512,6 +513,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
         site_full?: false,
         study_mode_full?: false,
         course_closed_on_apply?: false,
+        site_invalid?: false,
       )
     end
 
@@ -576,6 +578,18 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
       it 'returns the appropriate error' do
         expect(presenter.application_choice_errors.map(&:message)).to eq %w[site_full]
+        expect(presenter.application_choice_errors.map(&:anchor)).to eq(['#course-choice-999'])
+      end
+    end
+
+    context 'a course option has been removed by the provider' do
+      before do
+        allow(application_choice_2).to receive(:site_invalid?).and_return true
+        allow(application_choice_2).to receive(:site_invalid_error).and_return 'site_invalid'
+      end
+
+      it 'returns the appropriate error' do
+        expect(presenter.application_choice_errors.map(&:message)).to eq %w[site_invalid]
         expect(presenter.application_choice_errors.map(&:anchor)).to eq(['#course-choice-999'])
       end
     end

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_a_removed_site_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_a_removed_site_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate attempts to submit their application with a removed site' do
+  include CandidateHelper
+
+  scenario 'The location that the candidate picked has been removed by the provider' do
+    given_i_complete_my_application
+    and_the_selected_courses_site_has_been_removed_by_the_provider
+    when_i_submit_my_application
+    then_i_cannot_proceed
+  end
+
+  def given_i_complete_my_application
+    candidate_completes_application_form
+  end
+
+  def and_the_selected_courses_site_has_been_removed_by_the_provider
+    current_candidate.current_application.application_choices.first.course_option.update!(site_still_valid: false)
+  end
+
+  def when_i_submit_my_application
+    click_link 'Check and submit your application'
+    click_link t('continue')
+  end
+
+  def then_i_cannot_proceed
+    expect(page).to have_content('There is a problem')
+    expect(page).to have_content("The location you’ve chosen for ‘#{current_candidate.current_application.application_choices.first.course.provider_and_name_code}’ has been removed by the provider. Choose a different location.")
+  end
+end


### PR DESCRIPTION
## Context

At the moment, we do a bunch of checks to see if a course is full before submitting an application.

One thing that's slipped through the net is sites that have been removed from Publish by a provider.

## Changes proposed in this pull request

- Check whether `site_still_valid` is true for the course choice on the review application form page

## Guidance to review

- Set site_still_valid to false on a course_option and attempt to submit the application 

## Link to Trello card

https://trello.com/c/QP7UjRAc/3325-bug-candidate-can-submit-a-course-choice-where-the-site-has-been-deleted-on-publish

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
