### PR TITLE
Change interview date hint text and error message to include RBD

### DIFF
--- a/app/components/provider_interface/interview_form_component.html.erb
+++ b/app/components/provider_interface/interview_form_component.html.erb
@@ -16,7 +16,16 @@
     </div>
   <% end %>
 
-  <%= f.govuk_date_field :date, hint: { text: t('helpers.hint.provider_interface_interview_wizard.date', example_date: example_date) } %>
+  <%= f.govuk_date_field(
+        :date,
+        hint: {
+          text: t(
+            'helpers.hint.provider_interface_interview_wizard.date',
+            rbd_date: application_choice.reject_by_default_at.to_s(:govuk_date),
+            example_date: example_date,
+          ),
+        },
+      ) %>
 
   <%= f.govuk_text_field :time, width: 5, label: { size: 'm' } %>
 

--- a/app/forms/provider_interface/interview_wizard.rb
+++ b/app/forms/provider_interface/interview_wizard.rb
@@ -94,7 +94,8 @@ module ProviderInterface
     end
 
     def date_after_rbd_date
-      errors.add(:date, :after_rdb) if date > application_choice.reject_by_default_at
+      rbd_date = application_choice.reject_by_default_at
+      errors.add(:date, :after_rdb, rbd_date: rbd_date.to_s(:govuk_date)) if date > rbd_date
     end
 
     def time_in_correct_format?

--- a/config/locales/interview.yml
+++ b/config/locales/interview.yml
@@ -39,7 +39,7 @@ en:
         additional_details: Additional details
     hint:
       provider_interface_interview_wizard:
-        date: For example, %{example_date}
+        date: No later than %{rbd_date}, after which the application will be automatically rejected - enter numbers, for example, %{example_date}
         time: For example, 9am or 2:30pm - enter 12pm for midday
     legend:
       provider_interface_interview_wizard:
@@ -52,7 +52,7 @@ en:
           attributes:
             date:
               past: Interview date must be today or in the future
-              after_rdb: Interview date must be before the application closing date
+              after_rdb: Interview date must be no later than %{rbd_date}
               invalid_date: Interview date must be a real date
               blank_date_fields: Interview date must include a %{fields}
               blank_date: Enter interview date

--- a/spec/components/provider_interface/interview_form_component_spec.rb
+++ b/spec/components/provider_interface/interview_form_component_spec.rb
@@ -72,7 +72,8 @@ RSpec.describe ProviderInterface::InterviewFormComponent do
     end
 
     it 'renders the hint text correctly' do
-      expect(render.css('.govuk-hint').first.text).to eq("For example, #{1.day.from_now.strftime('%-d %-m %Y')}")
+      expected = "No later than #{application_choice.reject_by_default_at.to_s(:govuk_date)}, after which the application will be automatically rejected - enter numbers, for example, #{1.day.from_now.strftime('%-d %-m %Y')}"
+      expect(render.css('.govuk-hint').first.text).to eq(expected)
     end
   end
 

--- a/spec/forms/provider_interface/interview_wizard_spec.rb
+++ b/spec/forms/provider_interface/interview_wizard_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe ProviderInterface::InterviewWizard do
         it 'is invalid with the correct error' do
           Timecop.freeze(2021, 1, 13) do
             expect(wizard).to be_invalid
-            expect(wizard.errors[:date]).to contain_exactly('Interview date must be before the application closing date')
+            expect(wizard.errors[:date]).to contain_exactly('Interview date must be no later than 14 February 2021')
           end
         end
       end


### PR DESCRIPTION
## Context
It previously wasn't clear that the RBD date of the application was part of the form validation

## Changes proposed in this pull request
Add text about restrictions on interview date to do with RBD date, and update error message to match

## Guidance to review
Here's what it looks like now:
<img width="699" alt="Screenshot 2021-04-22 at 09 07 46" src="https://user-images.githubusercontent.com/30071178/115679188-365e7700-a34a-11eb-95e6-e9153b6a49f0.png">


## Link to Trello card
https://trello.com/c/w641x9Gp/3615-help-users-set-up-an-interview-before-the-automatic-rejection-date

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
