### PR TITLE
Add rejection reasons review to subject knowledge section

### DIFF
--- a/app/components/candidate_interface/becoming_a_teacher_review_component.rb
+++ b/app/components/candidate_interface/becoming_a_teacher_review_component.rb
@@ -19,7 +19,7 @@ module CandidateInterface
     end
 
     def review_needed?
-      @application_form.becoming_a_teacher_review_pending?
+      @application_form.review_pending?(:becoming_a_teacher)
     end
 
   private

--- a/app/components/candidate_interface/subject_knowledge_review_component.html.erb
+++ b/app/components/candidate_interface/subject_knowledge_review_component.html.erb
@@ -1,5 +1,12 @@
 <% if show_missing_banner? %>
-  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :subject_knowledge, section_path: candidate_interface_edit_subject_knowledge_path, error: @missing_error)) %>
+  <%= render(
+    CandidateInterface::IncompleteSectionComponent.new(
+      section: :subject_knowledge,
+      section_path: candidate_interface_edit_subject_knowledge_path,
+      error: @missing_error,
+      review_needed: review_needed?,
+    ),
+  ) %>
 <% else %>
   <%= render(SummaryCardComponent.new(rows: subject_knowledge_form_rows, editable: @editable)) %>
 <% end %>

--- a/app/components/candidate_interface/subject_knowledge_review_component.rb
+++ b/app/components/candidate_interface/subject_knowledge_review_component.rb
@@ -18,6 +18,10 @@ module CandidateInterface
       !@application_form.subject_knowledge_completed && @editable if @submitting_application
     end
 
+    def review_needed?
+      @application_form.subject_knowledge_review_pending?
+    end
+
   private
 
     attr_reader :application_form

--- a/app/components/candidate_interface/subject_knowledge_review_component.rb
+++ b/app/components/candidate_interface/subject_knowledge_review_component.rb
@@ -19,7 +19,7 @@ module CandidateInterface
     end
 
     def review_needed?
-      @application_form.subject_knowledge_review_pending?
+      @application_form.review_pending?(:subject_knowledge)
     end
 
   private

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -357,45 +357,29 @@ class ApplicationForm < ApplicationRecord
   end
 
   def mark_sections_incomplete_if_review_needed!
-    if becoming_a_teacher_reviewable?
+    if reviewable?(:becoming_a_teacher)
       update!(becoming_a_teacher_completed: false)
     end
 
-    if subject_knowledge_reviewable?
+    if reviewable?(:subject_knowledge)
       update!(subject_knowledge_completed: false)
     end
   end
 
-  def becoming_a_teacher_rejection_reasons
-    CandidateInterface::RejectionReasonsHistory.all_previous_applications(self, :becoming_a_teacher)
+  def rejection_reasons(section)
+    CandidateInterface::RejectionReasonsHistory.all_previous_applications(self, section)
   end
 
-  def becoming_a_teacher_previous_application_rejection_reason
-    CandidateInterface::RejectionReasonsHistory.previous_application(self, :becoming_a_teacher)
+  def previous_application_rejection_reason(section)
+    CandidateInterface::RejectionReasonsHistory.previous_application(self, section)
   end
 
-  def becoming_a_teacher_review_pending?
-    !becoming_a_teacher_completed? && becoming_a_teacher_reviewable?
+  def review_pending?(section)
+    !send("#{section}_completed?") && reviewable?(section)
   end
 
-  def becoming_a_teacher_reviewable?
-    apply_2? && becoming_a_teacher_previous_application_rejection_reason.present?
-  end
-
-  def subject_knowledge_review_pending?
-    !subject_knowledge_completed? && subject_knowledge_reviewable?
-  end
-
-  def subject_knowledge_reviewable?
-    apply_2? && subject_knowledge_previous_application_rejection_reason.present?
-  end
-
-  def subject_knowledge_previous_application_rejection_reason
-    CandidateInterface::RejectionReasonsHistory.previous_application(self, :subject_knowledge)
-  end
-
-  def subject_knowledge_rejection_reasons
-    CandidateInterface::RejectionReasonsHistory.all_previous_applications(self, :subject_knowledge)
+  def reviewable?(section)
+    apply_2? && previous_application_rejection_reason(section).present?
   end
 
 private

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -360,6 +360,10 @@ class ApplicationForm < ApplicationRecord
     if becoming_a_teacher_reviewable?
       update!(becoming_a_teacher_completed: false)
     end
+
+    if subject_knowledge_reviewable?
+      update!(subject_knowledge_completed: false)
+    end
   end
 
   def becoming_a_teacher_rejection_reasons
@@ -376,6 +380,22 @@ class ApplicationForm < ApplicationRecord
 
   def becoming_a_teacher_reviewable?
     apply_2? && becoming_a_teacher_previous_application_rejection_reason.present?
+  end
+
+  def subject_knowledge_review_pending?
+    !subject_knowledge_completed? && subject_knowledge_reviewable?
+  end
+
+  def subject_knowledge_reviewable?
+    apply_2? && subject_knowledge_previous_application_rejection_reason.present?
+  end
+
+  def subject_knowledge_previous_application_rejection_reason
+    CandidateInterface::RejectionReasonsHistory.previous_application(self, :subject_knowledge)
+  end
+
+  def subject_knowledge_rejection_reasons
+    CandidateInterface::RejectionReasonsHistory.all_previous_applications(self, :subject_knowledge)
   end
 
 private

--- a/app/models/candidate_interface/rejection_reasons_history.rb
+++ b/app/models/candidate_interface/rejection_reasons_history.rb
@@ -66,6 +66,8 @@ module CandidateInterface
       case section
       when :becoming_a_teacher
         :quality_of_application_personal_statement_what_to_improve
+      when :subject_knowledge
+        :quality_of_application_subject_knowledge_what_to_improve
       else
         raise UnsupportedSectionError
       end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -31,7 +31,7 @@ module CandidateInterface
 
         # "Personal statement and interview" section
         [:becoming_a_teacher, becoming_a_teacher_completed?, becoming_a_teacher_review_pending?],
-        [:subject_knowledge, subject_knowledge_completed?],
+        [:subject_knowledge, subject_knowledge_completed?, subject_knowledge_review_pending?],
         [:interview_preferences, interview_preferences_completed?],
 
         # "References" section
@@ -264,6 +264,10 @@ module CandidateInterface
 
     def subject_knowledge_valid?
       SubjectKnowledgeForm.build_from_application(@application_form).valid?
+    end
+
+    def subject_knowledge_review_pending?
+      @application_form.subject_knowledge_review_pending?
     end
 
     def interview_preferences_completed?

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -255,7 +255,7 @@ module CandidateInterface
     end
 
     def becoming_a_teacher_review_pending?
-      @application_form.becoming_a_teacher_review_pending?
+      @application_form.review_pending?(:becoming_a_teacher)
     end
 
     def subject_knowledge_completed?
@@ -275,7 +275,7 @@ module CandidateInterface
     end
 
     def subject_knowledge_review_pending?
-      @application_form.subject_knowledge_review_pending?
+      @application_form.review_pending?(:subject_knowledge)
     end
 
     def interview_preferences_completed?

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -266,6 +266,14 @@ module CandidateInterface
       SubjectKnowledgeForm.build_from_application(@application_form).valid?
     end
 
+    def subject_knowledge_path
+      if subject_knowledge_valid?
+        Rails.application.routes.url_helpers.candidate_interface_subject_knowledge_show_path
+      else
+        Rails.application.routes.url_helpers.candidate_interface_edit_subject_knowledge_path
+      end
+    end
+
     def subject_knowledge_review_pending?
       @application_form.subject_knowledge_review_pending?
     end

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -6,8 +6,9 @@
 </h1>
 
 <% if @application_form.review_pending?(:becoming_a_teacher) %>
-  <div class='govuk-inset-text govuk-!-width-two-thirds govuk-!-margin-top-0'>
-    <h2 class="govuk-heading-m">Feedback from previous applications</h2>
+  <%= govuk_inset_text do %>
+    <% rejection_reasons = @application_form.rejection_reasons(:becoming_a_teacher) %>
+    <h2 class="govuk-heading-m">Feedback from previous <%= 'application'.pluralize(rejection_reasons.size) %></h2>
 
     <% @application_form.rejection_reasons(:becoming_a_teacher).each do |rejection_reason| %>
       <h3 class="govuk-heading-s govuk-!-margin-bottom-2"><%= rejection_reason.provider_name %></h3>
@@ -15,7 +16,7 @@
         <p class="govuk-body">“<%= rejection_reason.feedback %>”</p>
       </blockquote>
     <% end %>
-  </div>
+  <% end %>
 <% else %>
   <p class="govuk-body govuk-!-font-weight-bold">This section is important to your application. Before continuing:</p>
   <ul class="govuk-list govuk-list--bullet">

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -5,11 +5,11 @@
   <%= t('page_titles.becoming_a_teacher') %>
 </h1>
 
-<% if @application_form.becoming_a_teacher_review_pending? %>
+<% if @application_form.review_pending?(:becoming_a_teacher) %>
   <div class='govuk-inset-text govuk-!-width-two-thirds govuk-!-margin-top-0'>
     <h2 class="govuk-heading-m">Feedback from previous applications</h2>
 
-    <% @application_form.becoming_a_teacher_rejection_reasons.each do |rejection_reason| %>
+    <% @application_form.rejection_reasons(:becoming_a_teacher).each do |rejection_reason| %>
       <h3 class="govuk-heading-s govuk-!-margin-bottom-2"><%= rejection_reason.provider_name %></h3>
       <blockquote class="govuk-!-margin-left-0 govuk-!-margin-top-0">
         <p class="govuk-body">“<%= rejection_reason.feedback %>”</p>
@@ -33,5 +33,5 @@
   path: candidate_interface_becoming_a_teacher_complete_path,
   request_method: :patch,
   field_name: :becoming_a_teacher_completed,
-  section_review: @application_form.becoming_a_teacher_reviewable?,
+  section_review: @application_form.reviewable?(:becoming_a_teacher),
 )) %>

--- a/app/views/candidate_interface/subject_knowledge/show.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/show.html.erb
@@ -5,6 +5,19 @@
   <%= t('page_titles.subject_knowledge') %>
 </h1>
 
+<% if @application_form.subject_knowledge_review_pending? %>
+  <div class='govuk-inset-text govuk-!-width-two-thirds govuk-!-margin-top-0'>
+    <h2 class="govuk-heading-m">Feedback from previous applications</h2>
+
+    <% @application_form.subject_knowledge_rejection_reasons.each do |rejection_reason| %>
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-2"><%= rejection_reason.provider_name %></h3>
+      <blockquote class="govuk-!-margin-left-0 govuk-!-margin-top-0">
+        <p class="govuk-body">“<%= rejection_reason.feedback %>”</p>
+      </blockquote>
+    <% end %>
+  </div>
+<% end %>
+
 <%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: @application_form)) %>
 
 <%= render(CandidateInterface::CompleteSectionComponent.new(
@@ -12,4 +25,5 @@
   path: candidate_interface_subject_knowledge_complete_path,
   request_method: :patch,
   field_name: :subject_knowledge_completed,
+  section_review: @application_form.subject_knowledge_reviewable?,
 )) %>

--- a/app/views/candidate_interface/subject_knowledge/show.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/show.html.erb
@@ -5,11 +5,11 @@
   <%= t('page_titles.subject_knowledge') %>
 </h1>
 
-<% if @application_form.subject_knowledge_review_pending? %>
+<% if @application_form.review_pending?(:subject_knowledge) %>
   <div class='govuk-inset-text govuk-!-width-two-thirds govuk-!-margin-top-0'>
     <h2 class="govuk-heading-m">Feedback from previous applications</h2>
 
-    <% @application_form.subject_knowledge_rejection_reasons.each do |rejection_reason| %>
+    <% @application_form.rejection_reasons(:subject_knowledge).each do |rejection_reason| %>
       <h3 class="govuk-heading-s govuk-!-margin-bottom-2"><%= rejection_reason.provider_name %></h3>
       <blockquote class="govuk-!-margin-left-0 govuk-!-margin-top-0">
         <p class="govuk-body">“<%= rejection_reason.feedback %>”</p>
@@ -25,5 +25,5 @@
   path: candidate_interface_subject_knowledge_complete_path,
   request_method: :patch,
   field_name: :subject_knowledge_completed,
-  section_review: @application_form.subject_knowledge_reviewable?,
+  section_review: @application_form.reviewable?(:subject_knowledge),
 )) %>

--- a/app/views/candidate_interface/subject_knowledge/show.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/show.html.erb
@@ -6,16 +6,17 @@
 </h1>
 
 <% if @application_form.review_pending?(:subject_knowledge) %>
-  <div class='govuk-inset-text govuk-!-width-two-thirds govuk-!-margin-top-0'>
-    <h2 class="govuk-heading-m">Feedback from previous applications</h2>
+  <%= govuk_inset_text do %>
+    <% rejection_reasons = @application_form.rejection_reasons(:subject_knowledge) %>
+    <h2 class="govuk-heading-m">Feedback from previous <%= 'application'.pluralize(rejection_reasons.size) %></h2>
 
-    <% @application_form.rejection_reasons(:subject_knowledge).each do |rejection_reason| %>
+    <% rejection_reasons.each do |rejection_reason| %>
       <h3 class="govuk-heading-s govuk-!-margin-bottom-2"><%= rejection_reason.provider_name %></h3>
       <blockquote class="govuk-!-margin-left-0 govuk-!-margin-top-0">
         <p class="govuk-body">“<%= rejection_reason.feedback %>”</p>
       </blockquote>
     <% end %>
-  </div>
+  <% end %>
 <% end %>
 
 <%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: @application_form)) %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -162,38 +162,22 @@
 
       <ol class="app-task-list">
         <li class="app-task-list__item govuk-hint">
-          <% if @application_form_presenter.becoming_a_teacher_review_pending? %>
-            <%= render(TaskListItemComponent.new(
-              text: t('page_titles.becoming_a_teacher'),
-              completed: false,
-              path: @application_form_presenter.becoming_a_teacher_path,
-              custom_status: 'Review',
-              custom_color: 'pink',
-            )) %>
-          <% else %>
-            <%= render(TaskListItemComponent.new(
-              text: t('page_titles.becoming_a_teacher'),
-              completed: @application_form_presenter.becoming_a_teacher_completed?,
-              path: @application_form_presenter.becoming_a_teacher_path,
-            )) %>
-          <% end %>
+          <%= render(TaskListItemComponent.new(
+            text: t('page_titles.becoming_a_teacher'),
+            completed: @application_form_presenter.becoming_a_teacher_completed?,
+            path: @application_form_presenter.becoming_a_teacher_path,
+            custom_status: @application_form_presenter.becoming_a_teacher_review_pending? ? 'Review' : nil,
+            custom_color: @application_form_presenter.becoming_a_teacher_review_pending? ? 'pink' : nil,
+          )) %>
         </li>
         <li class="app-task-list__item govuk-hint">
-          <% if @application_form_presenter.subject_knowledge_review_pending? %>
-            <%= render(TaskListItemComponent.new(
-              text: t('page_titles.subject_knowledge'),
-              completed: false,
-              path: @application_form_presenter.subject_knowledge_valid? ? candidate_interface_subject_knowledge_show_path : candidate_interface_edit_subject_knowledge_path,
-              custom_status: 'Review',
-              custom_color: 'pink',
-            )) %>
-          <% else %>
-            <%= render(TaskListItemComponent.new(
-              text: t('page_titles.subject_knowledge'),
-              completed: @application_form_presenter.subject_knowledge_completed?,
-              path: @application_form_presenter.subject_knowledge_valid? ? candidate_interface_subject_knowledge_show_path : candidate_interface_edit_subject_knowledge_path,
-            )) %>
-          <% end %>
+          <%= render(TaskListItemComponent.new(
+            text: t('page_titles.subject_knowledge'),
+            completed: @application_form_presenter.subject_knowledge_completed?,
+            path: @application_form_presenter.subject_knowledge_valid? ? candidate_interface_subject_knowledge_show_path : candidate_interface_edit_subject_knowledge_path,
+            custom_status: @application_form_presenter.subject_knowledge_review_pending? ? 'Review' : nil,
+            custom_color: @application_form_presenter.subject_knowledge_review_pending? ? 'pink' : nil,
+          )) %>
         </li>
       </ol>
     </section>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -179,11 +179,21 @@
           <% end %>
         </li>
         <li class="app-task-list__item govuk-hint">
-          <%= render(TaskListItemComponent.new(
-            text: t('page_titles.subject_knowledge'),
-            completed: @application_form_presenter.subject_knowledge_completed?,
-            path: @application_form_presenter.subject_knowledge_valid? ? candidate_interface_subject_knowledge_show_path : candidate_interface_edit_subject_knowledge_path,
-          )) %>
+          <% if @application_form_presenter.subject_knowledge_review_pending? %>
+            <%= render(TaskListItemComponent.new(
+              text: t('page_titles.subject_knowledge'),
+              completed: false,
+              path: @application_form_presenter.subject_knowledge_valid? ? candidate_interface_subject_knowledge_show_path : candidate_interface_edit_subject_knowledge_path,
+              custom_status: 'Review',
+              custom_color: 'pink',
+            )) %>
+          <% else %>
+            <%= render(TaskListItemComponent.new(
+              text: t('page_titles.subject_knowledge'),
+              completed: @application_form_presenter.subject_knowledge_completed?,
+              path: @application_form_presenter.subject_knowledge_valid? ? candidate_interface_subject_knowledge_show_path : candidate_interface_edit_subject_knowledge_path,
+            )) %>
+          <% end %>
         </li>
       </ol>
     </section>

--- a/config/locales/candidate_interface/review_application.yml
+++ b/config/locales/candidate_interface/review_application.yml
@@ -56,7 +56,8 @@ en:
       complete_section: Why do you want to be a teacher?
     subject_knowledge:
       incomplete: Subject knowledge not entered
-      complete_section: What you know about the subject you want to teach?
+      not_reviewed: Subject knowledge not marked as reviewed
+      complete_section: What do you know about the subject you want to teach?
     interview_preferences:
       incomplete: Interview needs not entered
       complete_section: Do you have any interview needs?

--- a/spec/components/candidate_interface/becoming_a_teacher_review_component_spec.rb
+++ b/spec/components/candidate_interface/becoming_a_teacher_review_component_spec.rb
@@ -19,4 +19,28 @@ RSpec.describe CandidateInterface::BecomingATeacherReviewComponent do
       expect(result.css('.govuk-summary-list__actions').text).not_to include("Change #{t('application_form.personal_statement.becoming_a_teacher.change_action')}")
     end
   end
+
+  describe 'submitting app' do
+    let(:result) { render_inline(described_class.new(application_form: application_form, submitting_application: true)) }
+
+    context 'section not complete' do
+      before { application_form.becoming_a_teacher_completed = false }
+
+      context 'when review is pending' do
+        before { allow(application_form).to receive(:review_pending?).with(:becoming_a_teacher).and_return(true) }
+
+        it 'shows review-related messaging' do
+          expect(result.text).to include(t('review_application.becoming_a_teacher.not_reviewed'))
+        end
+      end
+
+      context 'when review is not pending' do
+        before { allow(application_form).to receive(:review_pending?).with(:becoming_a_teacher).and_return(false) }
+
+        it 'shows section missing messaging' do
+          expect(result.text).to include(t('review_application.becoming_a_teacher.incomplete'))
+        end
+      end
+    end
+  end
 end

--- a/spec/components/candidate_interface/subject_knowledge_review_component_spec.rb
+++ b/spec/components/candidate_interface/subject_knowledge_review_component_spec.rb
@@ -19,4 +19,28 @@ RSpec.describe CandidateInterface::SubjectKnowledgeReviewComponent do
       expect(result.css('.govuk-summary-list__actions').text).not_to include("Change #{t('application_form.personal_statement.subject_knowledge.change_action')}")
     end
   end
+
+  describe 'submitting app' do
+    let(:result) { render_inline(described_class.new(application_form: application_form, submitting_application: true)) }
+
+    context 'section not complete' do
+      before { application_form.subject_knowledge_completed = false }
+
+      context 'when review is pending' do
+        before { allow(application_form).to receive(:review_pending?).with(:subject_knowledge).and_return(true) }
+
+        it 'shows review-related messaging' do
+          expect(result.text).to include(t('review_application.subject_knowledge.not_reviewed'))
+        end
+      end
+
+      context 'when review is not pending' do
+        before { allow(application_form).to receive(:review_pending?).with(:subject_knowledge).and_return(false) }
+
+        it 'shows section missing messaging' do
+          expect(result.text).to include(t('review_application.subject_knowledge.incomplete'))
+        end
+      end
+    end
+  end
 end

--- a/spec/system/candidate_interface/apply_again/candidate_reviews_rejection_reasons_from_previous_applications_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_reviews_rejection_reasons_from_previous_applications_spec.rb
@@ -7,15 +7,17 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
     given_i_am_signed_in_as_a_candidate
     and_i_have_an_unsuccessful_application_with_rejection_reasons
     when_i_apply_again
+    then_subject_knowledge_needs_review
     then_becoming_a_teacher_needs_review
+    and_i_can_review_subject_knowledge
     and_i_can_review_becoming_a_teacher
 
-    when_i_confirm_i_have_reviewed_this_section
+    when_i_confirm_i_have_reviewed_becoming_a_teacher
     then_becoming_a_teacher_no_longer_needs_review
     and_i_can_set_it_back_to_unreviewed
 
     when_i_submit_my_application
-    then_i_am_informed_that_i_have_not_reviewed_becoming_a_teacher
+    then_i_am_informed_that_i_have_not_reviewed_these_sections
     and_i_can_submit_once_i_have_reviewed
   end
 
@@ -32,7 +34,14 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
       references_count: 2,
       candidate: @candidate,
     )
-    create(:application_choice, :with_structured_rejection_reasons, application_form: application)
+    choice = create(:application_choice, :with_structured_rejection_reasons, application_form: application)
+
+    choice.update!(
+      structured_rejection_reasons: {
+        quality_of_application_subject_knowledge_what_to_improve: 'Subject knowledge needs improving',
+        quality_of_application_personal_statement_what_to_improve: 'Personal statement needs improving',
+      },
+    )
   end
 
   def when_i_apply_again
@@ -45,20 +54,34 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
     candidate_fills_in_apply_again_course_choice
   end
 
+  def then_subject_knowledge_needs_review
+    within_task_list_item('Your suitability to teach a subject or age group') do
+      expect(page).to have_css('.govuk-tag', text: 'Review')
+    end
+  end
+
   def then_becoming_a_teacher_needs_review
     within_task_list_item('Why do you want to teach') do
       expect(page).to have_css('.govuk-tag', text: 'Review')
     end
   end
 
-  def and_i_can_review_becoming_a_teacher
-    click_link 'Why do you want to teach'
-    expect(page).to have_content 'Use a spellchecker'
+  def and_i_can_review_subject_knowledge
+    click_link 'Your suitability to teach a subject or age group'
+    expect(page).to have_content 'Subject knowledge needs improving'
+    visit candidate_interface_application_form_path
   end
 
-  def when_i_confirm_i_have_reviewed_this_section
+  def and_i_can_review_becoming_a_teacher
+    click_link 'Why do you want to teach'
+    expect(page).to have_content 'Personal statement needs improving'
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_confirm_i_have_reviewed_becoming_a_teacher
+    click_link 'Why do you want to teach'
     check t('application_form.reviewed_checkbox')
-    click_button t('continue')
+    click_on t('continue')
   end
 
   def then_becoming_a_teacher_no_longer_needs_review
@@ -70,33 +93,44 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
   def and_i_can_set_it_back_to_unreviewed
     click_link 'Why do you want to teach'
     uncheck t('application_form.reviewed_checkbox')
-    click_button t('continue')
+    click_on t('continue')
     then_becoming_a_teacher_needs_review
   end
 
   def when_i_submit_my_application
     click_on 'Check and submit your application'
-    click_on 'Continue'
+    click_on t('continue')
   end
 
-  def then_i_am_informed_that_i_have_not_reviewed_becoming_a_teacher
+  def then_i_am_informed_that_i_have_not_reviewed_these_sections
     within becoming_a_teacher_error_container do
       expect(page).to have_content 'Personal statement not marked as reviewed'
+    end
+
+    within subject_knowledge_error_container do
+      expect(page).to have_content 'Subject knowledge not marked as reviewed'
     end
   end
 
   def and_i_can_submit_once_i_have_reviewed
-    click_link 'Why do you want to be a teacher?'
-    click_on 'Continue'
-    when_i_confirm_i_have_reviewed_this_section
+    click_link 'Why do you want to be a teacher'
+    click_on t('continue')
+    check t('application_form.reviewed_checkbox')
+    click_on t('continue')
+    click_link 'Your suitability to teach a subject or age group'
+    check t('application_form.reviewed_checkbox')
+    click_on t('continue')
+
     click_on 'Check and submit'
     expect(page).not_to have_css becoming_a_teacher_error_container
-    click_on 'Continue'
+    expect(page).not_to have_css subject_knowledge_error_container
+    click_on t('continue')
     choose 'No'
-    click_on 'Continue'
+    click_on t('continue')
     choose 'No'
-    click_button 'Send application'
-    click_on 'Continue'
+    click_on 'Send application'
+    click_on t('continue')
+
     expect(page).to have_content 'Application successfully submitted'
   end
 
@@ -104,5 +138,9 @@ private
 
   def becoming_a_teacher_error_container
     '#incomplete-becoming_a_teacher-error'
+  end
+
+  def subject_knowledge_error_container
+    '#incomplete-subject_knowledge-error'
   end
 end

--- a/spec/system/candidate_interface/apply_again/candidate_reviews_rejection_reasons_from_previous_applications_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_reviews_rejection_reasons_from_previous_applications_spec.rb
@@ -7,15 +7,15 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
     given_i_am_signed_in_as_a_candidate
     and_i_have_an_unsuccessful_application_with_rejection_reasons
     when_i_apply_again
-    then_become_a_teacher_needs_review
-    and_i_can_review_become_a_teacher
+    then_becoming_a_teacher_needs_review
+    and_i_can_review_becoming_a_teacher
 
     when_i_confirm_i_have_reviewed_this_section
-    then_become_a_teacher_no_longer_needs_review
+    then_becoming_a_teacher_no_longer_needs_review
     and_i_can_set_it_back_to_unreviewed
 
     when_i_submit_my_application
-    then_i_am_informed_that_i_have_not_reviewed_become_a_teacher
+    then_i_am_informed_that_i_have_not_reviewed_becoming_a_teacher
     and_i_can_submit_once_i_have_reviewed
   end
 
@@ -45,13 +45,13 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
     candidate_fills_in_apply_again_course_choice
   end
 
-  def then_become_a_teacher_needs_review
+  def then_becoming_a_teacher_needs_review
     within_task_list_item('Why do you want to teach') do
       expect(page).to have_css('.govuk-tag', text: 'Review')
     end
   end
 
-  def and_i_can_review_become_a_teacher
+  def and_i_can_review_becoming_a_teacher
     click_link 'Why do you want to teach'
     expect(page).to have_content 'Use a spellchecker'
   end
@@ -61,7 +61,7 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
     click_button t('continue')
   end
 
-  def then_become_a_teacher_no_longer_needs_review
+  def then_becoming_a_teacher_no_longer_needs_review
     within_task_list_item('Why do you want to teach') do
       expect(page).to have_css('.govuk-tag', text: 'Completed')
     end
@@ -71,7 +71,7 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
     click_link 'Why do you want to teach'
     uncheck t('application_form.reviewed_checkbox')
     click_button t('continue')
-    then_become_a_teacher_needs_review
+    then_becoming_a_teacher_needs_review
   end
 
   def when_i_submit_my_application
@@ -79,8 +79,8 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
     click_on 'Continue'
   end
 
-  def then_i_am_informed_that_i_have_not_reviewed_become_a_teacher
-    within become_a_teacher_error_container do
+  def then_i_am_informed_that_i_have_not_reviewed_becoming_a_teacher
+    within becoming_a_teacher_error_container do
       expect(page).to have_content 'Personal statement not marked as reviewed'
     end
   end
@@ -90,7 +90,7 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
     click_on 'Continue'
     when_i_confirm_i_have_reviewed_this_section
     click_on 'Check and submit'
-    expect(page).not_to have_css become_a_teacher_error_container
+    expect(page).not_to have_css becoming_a_teacher_error_container
     click_on 'Continue'
     choose 'No'
     click_on 'Continue'
@@ -102,7 +102,7 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
 
 private
 
-  def become_a_teacher_error_container
+  def becoming_a_teacher_error_container
     '#incomplete-becoming_a_teacher-error'
   end
 end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
As a.... candidate
In order to... improve my chance of success when applying again
I want to... review the sections of my application that providers said needed improvement.


## Changes proposed in this pull request
Building on https://github.com/DFE-Digital/apply-for-teacher-training/pull/4551, add to the 'subject_knowledge' section the same review workflow that we've implemented for 'becoming_a_teacher'. To summarize, this will:

- Show a review badge against this section if the candidate is applying
  again and they have subject knowledge rejection reasons from their
  previous application.
- Show past rejection reasons inline when they're reviewing
  subject knowledge.
- Update validations on application submit to refer to 'reviewing' the
  section rather than completing it.

This PR also includes several refactoring/housekeeping commits. 

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Per commit recommended.
- Manual testing will need an unsuccessful application with structured feedback in `quality_of_application_subject_knowledge_what_to_improve`. The review workflow can then be tested by applying again.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/BkHTZAJE
## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
