### PR TITLE
Create an 'undo' action for support agents to reinstate a declined offer

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -10,9 +10,16 @@ module SupportInterface
     end
 
     def rows
-      rows = [
-        { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent.new(status: application_choice.status)) },
-      ]
+      rows = if FeatureFlag.active?(:support_user_reinstate_offer) && application_choice.declined? && !application_choice.declined_by_default
+               [
+                 { key: 'Status',
+                   value: render(SupportInterface::ApplicationStatusTagComponent.new(status: application_choice.status)),
+                   action: 'Reinstate offer',
+                   action_path: support_interface_application_form_reinstate_offer_path(application_form_id: @application_choice.application_form.id, application_choice_id: @application_choice.id) },
+               ]
+             else
+               [{ key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent.new(status: application_choice.status)) }]
+             end
 
       if application_choice.offer?
         rows << { key: 'Offer made at', value: application_choice.offered_at.to_s(:govuk_date_and_time) }

--- a/app/controllers/support_interface/application_forms/application_choices_controller.rb
+++ b/app/controllers/support_interface/application_forms/application_choices_controller.rb
@@ -1,0 +1,40 @@
+module SupportInterface
+  module ApplicationForms
+    class ApplicationChoicesController < SupportInterfaceController
+      before_action :build_application_form, :build_application_choice, :redirect_to_application_form_unless_declined_and_flag_active
+
+      def confirm_reinstate_offer
+        @declined_course_choice = ReinstateDeclinedOfferForm.new
+      end
+
+      def reinstate_offer
+        @declined_course_choice = ReinstateDeclinedOfferForm.new(reinstate_offer_params)
+
+        if @declined_course_choice.save(@application_choice)
+          flash[:success] = 'Offer was reinstated'
+          redirect_to support_interface_application_form_path(@application_form.id)
+        else
+          render :confirm_reinstate_offer
+        end
+      end
+
+    private
+
+      def reinstate_offer_params
+        params.require(:support_interface_application_forms_reinstate_declined_offer_form).permit(:status, :audit_comment_ticket, :accept_guidance)
+      end
+
+      def build_application_form
+        @application_form = ApplicationForm.find(params[:application_form_id])
+      end
+
+      def build_application_choice
+        @application_choice = @application_form.application_choices.find(params[:application_choice_id])
+      end
+
+      def redirect_to_application_form_unless_declined_and_flag_active
+        redirect_to support_interface_application_form_path(@application_form.id) unless FeatureFlag.active?(:support_user_reinstate_offer) && @application_choice.declined?
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/application_forms/reinstate_declined_offer_form.rb
+++ b/app/forms/support_interface/application_forms/reinstate_declined_offer_form.rb
@@ -1,0 +1,20 @@
+module SupportInterface
+  module ApplicationForms
+    class ReinstateDeclinedOfferForm
+      include ActiveModel::Model
+
+      attr_accessor :accept_guidance, :status, :audit_comment_ticket
+
+      validates :accept_guidance, :audit_comment_ticket, presence: true
+      validates :audit_comment_ticket, format: { with: /\A((http|https):\/\/)?(www.)?becomingateacher.zendesk.com\/agent\/tickets\// }
+
+      def save(course_choice)
+        self.accept_guidance = ActiveModel::Type::Boolean.new.cast(accept_guidance)
+
+        return false unless valid?
+
+        ReinstateDeclinedOffer.new(course_choice: course_choice, zendesk_ticket: audit_comment_ticket).save!
+      end
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -30,6 +30,7 @@ class FeatureFlag
     [:unconditional_offers_via_api, 'Activates the ability to accept unconditional offers via the API', 'Steve Laing'],
     [:configurable_provider_notifications, 'Providers can manage individual email notifications', 'Aga Dufrat'],
     [:content_security_policy, 'Enables the content security policy declared in `config/initializers/content_security_policy.rb`', 'Steve Hook'],
+    [:support_user_reinstate_offer, 'Allows a support users to reinstate a declined course choice offer', 'James Glenn'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/services/reinstate_declined_offer.rb
+++ b/app/services/reinstate_declined_offer.rb
@@ -1,0 +1,36 @@
+class ReinstateDeclinedOffer
+  def initialize(course_choice:, zendesk_ticket:)
+    @course_choice = course_choice
+    @zendesk_ticket = zendesk_ticket
+  end
+
+  def save!
+    reset_all_dbd
+
+    @course_choice.update!(
+      status: 'offer',
+      declined_at: nil,
+      decline_by_default_at: set_dbd_value,
+      audit_comment: "Reinstate offer Zendesk request: #{@zendesk_ticket}",
+    )
+  end
+
+private
+
+  def reset_all_dbd
+    choices_to_reset.each do |choice|
+      choice.update!(
+        decline_by_default_at: set_dbd_value,
+        audit_comment: "DBD reset due to a reinstated offer on application choice #{@course_choice.id} from ticket: #{@zendesk_ticket}",
+      )
+    end
+  end
+
+  def choices_to_reset
+    @course_choice.self_and_siblings.where(status: 'offer').where.not(id: @course_choice.id)
+  end
+
+  def set_dbd_value
+    TimeLimitCalculator.new(rule: :decline_by_default, effective_date: Time.zone.now).call[:time_in_future]
+  end
+end

--- a/app/views/support_interface/application_forms/application_choices/confirm_reinstate_offer.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/confirm_reinstate_offer.html.erb
@@ -1,0 +1,47 @@
+<% content_for :browser_title, title_with_error_prefix('Reinstate offer', @declined_course_choice.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(application_form_id: params[:application_form_id]), 'Back to application') %>
+
+<%= form_with(
+  model: @declined_course_choice,
+  url: support_interface_application_form_reinstate_offer_path(application_form_id: params[:application_form_id], application_choice_id: params[:application_choice_id]),
+  method: :patch
+  )do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        Are you sure you want to reinstate this offer?
+      </h1>
+
+      <p class="govuk-body">An offer can only be reinstated if:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>it was declined within 5 working days of the request to reinstate and,</li>
+        <li>the candidate has not accepted any other offers</li>
+      </ul>
+      <p class="govuk-body">In order to reinstate the offer you must first contact the provider to confirm that they agree to this.</p>
+      <p class="govuk-body">By reinstating the offer, the DBD deadline for this offer (and any other offers) will be reset to 10 working days.</p>
+      <p class="govuk-body">Once the offer has been reinstated, please email the candidate using the macro.</p>
+      <p class="govuk-body">There are separate macros if the request was made after 5 working days or if the candidate has already accepted another offer.</p>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_text_field(
+              :audit_comment_ticket,
+              label: {
+                text: 'Zendesk ticket URL',
+                size: 'm',
+              },
+              rows: 1,
+              hint: { text: 'For example https://becomingateacher.zendesk.com/agent/tickets/12345' },
+            ) %>
+    </div>
+  </div>
+
+  <%= f.govuk_check_boxes_fieldset :accept_guidance, legend: nil do %>
+    <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
+  <% end %>
+
+  <%= f.govuk_submit t('continue') %>
+<% end %>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -134,3 +134,10 @@ en:
               invalid: Enter a real postcode (for example, BN1 1AA)
             audit_comment:
               blank: You must provide an audit comment
+        support_interface/application_forms/reinstate_declined_offer_form:
+          attributes:
+            accept_guidance:
+              blank: Select that you have read the guidance
+            audit_comment_ticket:
+              blank: Enter a Zendesk ticket URL
+              invalid: Enter a valid Zendesk ticket URL

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -816,6 +816,9 @@ Rails.application.routes.draw do
       patch '/nationalities' => 'application_forms/nationalities#update'
       get '/right-to-work-or-study' => 'application_forms/right_to_work_or_study#edit', as: :application_form_edit_right_to_work_or_study
       patch '/right-to-work-or-study' => 'application_forms/right_to_work_or_study#update'
+
+      get '/reinstate-offer/:application_choice_id' => 'application_forms/application_choices#confirm_reinstate_offer', as: :application_form_reinstate_offer
+      patch '/reinstate-offer/:application_choice_id' => 'application_forms/application_choices#reinstate_offer'
     end
 
     get '/ucas-matches' => 'ucas_matches#index'

--- a/spec/forms/support_interface/application_forms/reinstate_declined_offer_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/reinstate_declined_offer_form_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationForms::ReinstateDeclinedOfferForm, type: :model, with_audited: true do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:accept_guidance) }
+    it { is_expected.to validate_presence_of(:audit_comment_ticket) }
+
+    context 'for an invalid zendesk link' do
+      invalid_link = 'nonsense'
+      it { is_expected.not_to allow_value(invalid_link).for(:audit_comment_ticket) }
+    end
+
+    context 'for an valid zendesk link' do
+      valid_link = 'www.becomingateacher.zendesk.com/agent/tickets/example'
+      it { is_expected.to allow_value(valid_link).for(:audit_comment_ticket) }
+    end
+  end
+
+  describe '.build_from_course_choice' do
+    it 'creates an object based on the provided ApplicationChoice' do
+    end
+  end
+
+  describe '#save' do
+    let(:zendesk_ticket) { 'www.becomingateacher.zendesk.com/agent/tickets/example' }
+
+    it 'returns false if not valid' do
+      course_choice = create(:application_choice, status: :offer)
+      declined_offer_form = SupportInterface::ApplicationForms::ReinstateDeclinedOfferForm.new
+
+      expect(declined_offer_form.save(course_choice)).to eq(false)
+    end
+
+    it 'updates the provided ApplicationChoice with the "offer made" status if valid' do
+      Timecop.freeze do
+        course_choice = create(:application_choice, :with_declined_offer)
+
+        declined_offer_form = SupportInterface::ApplicationForms::ReinstateDeclinedOfferForm.new(
+          { status: :declined,
+            audit_comment_ticket: zendesk_ticket,
+            accept_guidance: true },
+        )
+
+        expect(declined_offer_form.save(course_choice)).to eq(true)
+
+        expect(course_choice).to have_attributes({
+          status: 'offer',
+          declined_at: nil,
+          declined_by_default: false,
+          decline_by_default_at: 10.business_days.from_now.end_of_day,
+        })
+
+        expect(course_choice.audits.last.comment).to include(zendesk_ticket)
+      end
+    end
+  end
+end

--- a/spec/services/reinstate_declined_offer_spec.rb
+++ b/spec/services/reinstate_declined_offer_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe ReinstateDeclinedOffer, with_audited: true do
+  describe '#save!' do
+    it 'updates the application course choice status back to "offer made" and resets the DBD days back to 10' do
+      Timecop.freeze do
+        course_choice = create(:application_choice, status: :offer)
+        original_course_choice = course_choice.clone
+        zendesk_ticket = 'www.becomingateacher.zendesk.com/agent/tickets/example'
+
+        DeclineOffer.new(application_choice: course_choice).save!
+        ReinstateDeclinedOffer.new(course_choice: course_choice, zendesk_ticket: zendesk_ticket).save!
+
+        expect(course_choice).to eq original_course_choice
+        expect(course_choice.audits.last.comment).to include(zendesk_ticket)
+      end
+    end
+
+    it 'resets the DBD of the other application choices with an offer status and ignores any without' do
+      Timecop.freeze do
+        zendesk_ticket = 'www.becomingateacher.zendesk.com/agent/tickets/example'
+        application_form = create(:completed_application_form)
+
+        declined_course_choice = create(:application_choice, :with_declined_offer, application_form: application_form)
+        offered_course_choice = create(:application_choice, :with_offer, application_form: application_form)
+        course_choice_awaiting_decision = create(:application_choice, status: :awaiting_provider_decision, application_form: application_form)
+
+        ReinstateDeclinedOffer.new(course_choice: declined_course_choice, zendesk_ticket: zendesk_ticket).save!
+
+        expect(declined_course_choice).to have_attributes({
+          status: 'offer',
+          declined_at: nil,
+          decline_by_default_at: 10.business_days.from_now.end_of_day,
+        })
+
+        expect(declined_course_choice.audits.last.comment).to eq "Reinstate offer Zendesk request: #{zendesk_ticket}"
+
+        expect(offered_course_choice.reload.decline_by_default_at.round).to be_within(1.second).of 10.business_days.from_now.end_of_day
+
+        expect(offered_course_choice.audits.last.comment).to eq "DBD reset due to a reinstated offer on application choice #{declined_course_choice.id} from ticket: #{zendesk_ticket}"
+
+        expect(course_choice_awaiting_decision.reload).to eq course_choice_awaiting_decision
+      end
+    end
+  end
+end

--- a/spec/system/support_interface/reinstate_offer_to_declined_course_choice_spec.rb
+++ b/spec/system/support_interface/reinstate_offer_to_declined_course_choice_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+RSpec.feature 'Reinstate offer to a declined course choice' do
+  include DfESignInHelpers
+
+  scenario 'Support user can reverse a course choice that has accidently been declined' do
+    given_i_am_a_support_user
+    and_the_reinstate_offer_feature_flag_is_on
+    and_there_is_a_submitted_application_in_the_system_with_a_declined_offer
+    and_i_visit_the_support_page
+
+    when_i_click_on_an_application
+    and_i_am_on_the_correct_application_page
+    then_i_see_the_declined_course_choice
+
+    when_i_click_on_the_reinstate_offer_link
+    then_i_see_the_reinstate_offer_page
+    when_i_click_continue
+    then_i_am_told_to_confirm_i_have_followed_the_guidance
+
+    when_i_confirm_reinstating_an_offer
+    and_i_click_continue
+    then_i_am_told_that_i_need_to_provide_a_zendesk_ticket
+    when_i_provide_an_invalid_zendesk_ticket_link
+    and_i_click_continue
+    then_i_am_told_that_i_need_to_provide_a_valid_zendesk_ticket_link
+
+    when_i_provide_a_valid_zendesk_ticket
+    and_i_confirm_reinstating_an_offer
+    and_i_click_continue
+    then_i_am_redirected_to_the_application_form_page
+    and_i_see_the_offer_has_been_reinstated
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_the_reinstate_offer_feature_flag_is_on
+    FeatureFlag.activate(:support_user_reinstate_offer)
+  end
+
+  def and_there_is_a_submitted_application_in_the_system_with_a_declined_offer
+    @application_form = create :completed_application_form
+
+    @application_choice = create(
+      :application_choice,
+      :with_declined_offer,
+      application_form: @application_form,
+    )
+  end
+
+  def and_i_visit_the_support_page
+    visit support_interface_path
+  end
+
+  def when_i_click_on_an_application
+    click_on @application_form.full_name
+  end
+
+  def and_i_am_on_the_correct_application_page
+    expect(page).to have_current_path support_interface_application_form_path(application_form_id: @application_form.id)
+  end
+
+  def then_i_see_the_declined_course_choice
+    within(all('.app-summary-card__body')[0]) do
+      expect(page).to have_content('Offer declined')
+    end
+  end
+
+  def when_i_click_on_the_reinstate_offer_link
+    within(all('.app-summary-card__body')[0]) do
+      within(all('.govuk-summary-list__row')[0]) do
+        all('.govuk-summary-list__actions')[0].click_link
+      end
+    end
+  end
+
+  def then_i_see_the_reinstate_offer_page
+    expect(page).to have_current_path support_interface_application_form_reinstate_offer_path(@application_form.id, @application_choice.id)
+  end
+
+  def and_i_click_continue
+    click_button 'Continue'
+  end
+  alias_method :when_i_click_continue, :and_i_click_continue
+
+  def then_i_am_told_to_confirm_i_have_followed_the_guidance
+    expect(page).to have_content 'Select that you have read the guidance'
+  end
+
+  def when_i_confirm_reinstating_an_offer
+    check 'I have read the guidance'
+  end
+  alias_method :and_i_confirm_reinstating_an_offer, :when_i_confirm_reinstating_an_offer
+
+  def then_i_am_told_that_i_need_to_provide_a_zendesk_ticket
+    expect(page).to have_content 'Enter a Zendesk ticket URL'
+  end
+
+  def when_i_provide_an_invalid_zendesk_ticket_link
+    fill_in('Zendesk ticket URL', with: 'This wont work')
+  end
+
+  def then_i_am_told_that_i_need_to_provide_a_valid_zendesk_ticket_link
+    expect(page).to have_content 'Enter a valid Zendesk ticket URL'
+  end
+
+  def when_i_provide_a_valid_zendesk_ticket
+    fill_in('Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/example')
+  end
+
+  def then_i_am_redirected_to_the_application_form_page
+    expect(page).to have_current_path support_interface_application_form_path(application_form_id: @application_form.id)
+  end
+
+  def and_i_see_the_offer_has_been_reinstated
+    within(all('.app-summary-card__body')[0]) do
+      expect(page).to have_content('Offer made')
+    end
+  end
+end


### PR DESCRIPTION
## Context

There has been a reoccurring request for developers, who are on support, to reinstate an offer that has been accidentally declined by the candidate. This requires the dev to go into the support console, find the application and update it there.

This PR adds functionality for support agents to be able to reinstate the offer from the support UI, without the need for a developer to be involved.

## Changes proposed in this pull request

- Add a feature flag that is then used on the `ApplicationChoiceComponent` to conditionally render a 'Reinstate offer' link
- Add a new view that the user is directed to after clicking the link, that will contain guidance on when this feature should/can be used, a mandatory text box for the Zendesk request link and a confirmation checkbox
- A new form and controller to handle this logic and validate that there is a Zendesk ticket - in the correct format - and that the support user has confirmed that they've read the guidance
- A new `ReinstateDeclinedOffer` service that is used to update the course choice status, reset the DBD days (currently 10) and also add an audit comment

## Guidance to review

- The reinstate offer page is still quite rough and needs a bit of cleaning up. Even though the support user has clicked through from the application choice, would it be helpful to also list the application choice they are about to update on this page as well - just for another visual sense check? Or rather than having the title as a generic _"Are you sure you want to reinstate the offer for this course choice?"_, be specific about which course choice is going to be reinstated?
- **Policy guidance still needs to be confirmed**
- Is there enough "friction" to reinstating the offer?
- How are the tests - what can I do to improve these and is there anything I haven't covered?

## Link to Trello card

https://trello.com/c/1k17OycL/3265-create-undo-actions-for-applicationchoice-states

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
