### PR TITLE
Remove warning text from check page on change an offer

### DIFF
--- a/app/views/provider_interface/offer/checks/edit.html.erb
+++ b/app/views/provider_interface/offer/checks/edit.html.erb
@@ -18,14 +18,6 @@
                                                                        available_courses: @courses,
                                                                        available_course_options: @course_options) %>
 
-      <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-          <span class="govuk-warning-text__assistive"></span>
-          When you send this offer, you guarantee a place on this course as long as the candidate meets the conditions.
-        </strong>
-      </div>
-
       <%= f.govuk_submit t('.submit') %>
 
       <p class="govuk-body">


### PR DESCRIPTION
## Context

Dev/Design review outcomes include removing this text

## Changes proposed in this pull request

Remove warning text from check changing an offer summary page

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
