### PR TITLE
Ensure R4R controller redirects unless the application choice can be rejected

### DIFF
--- a/app/controllers/provider_interface/reasons_for_rejection_controller.rb
+++ b/app/controllers/provider_interface/reasons_for_rejection_controller.rb
@@ -2,6 +2,7 @@ module ProviderInterface
   class ReasonsForRejectionController < ProviderInterfaceController
     before_action :set_application_choice
     before_action :redirect_if_application_rejected_and_feedback_provided
+    before_action :check_application_is_rejectable
 
     def edit_initial_questions
       @wizard = ReasonsForRejectionWizard.new(store, current_step: 'initial_questions')
@@ -133,6 +134,13 @@ module ProviderInterface
     def offer_store
       key = "offer_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
       WizardStateStores::RedisStore.new(key: key)
+    end
+
+    def check_application_is_rejectable
+      return if ApplicationStateChange.new(@application_choice).can_reject?
+      return if @application_choice.rejected_by_default?
+
+      render_404
     end
   end
 end

--- a/spec/requests/provider_interface/reasons_for_rejection_controller_spec.rb
+++ b/spec/requests/provider_interface/reasons_for_rejection_controller_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ReasonsForRejectionController, type: :request do
+  include DfESignInHelpers
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions) }
+  let(:provider) { provider_user.providers.first }
+  let(:course_option) { build(:course_option, course: build(:course, :open_on_apply, provider: provider)) }
+  let(:application_choice) do
+    create(:application_choice,
+           status: status,
+           application_form: build(:application_form, :minimum_info),
+           course_option: course_option)
+  end
+
+  before do
+    allow(DfESignInUser).to receive(:load_from_session)
+      .and_return(
+        DfESignInUser.new(
+          email_address: provider_user.email_address,
+          dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+          first_name: provider_user.first_name,
+          last_name: provider_user.last_name,
+        ),
+      )
+  end
+
+  describe 'if application choice is in a rejectable state' do
+    let(:status) { 'awaiting_provider_decision' }
+
+    it 'responds with 200' do
+      get provider_interface_reasons_for_rejection_initial_questions_path(application_choice)
+
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe 'if application choice is not in a rejectable state' do
+    let(:status) { (ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - ApplicationStateChange::DECISION_PENDING_STATUSES).sample }
+
+    context 'GET initial_questions' do
+      it 'responds with 404' do
+        get provider_interface_reasons_for_rejection_initial_questions_path(application_choice)
+
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'POST update_initial_questions' do
+      it 'responds with 404' do
+        post provider_interface_reasons_for_rejection_update_initial_questions_path(application_choice)
+
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'GET other_reasons' do
+      it 'responds with 404' do
+        get provider_interface_reasons_for_rejection_other_reasons_path(application_choice)
+
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'POST update_other_reasons' do
+      it 'responds with 404' do
+        post provider_interface_reasons_for_rejection_update_other_reasons_path(application_choice)
+
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'GET check' do
+      it 'responds with 404' do
+        get provider_interface_reasons_for_rejection_check_path(application_choice)
+
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'POST commit' do
+      it 'responds with 404' do
+        post provider_interface_reasons_for_rejection_commit_path(application_choice)
+
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

It's possible to access the reasons for rejection wizard flow by URL for an application which ultimately cannot transition to a rejected state.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds a before_action filter to prevent access to any R4R controller actions unless the application is rejectable.
 
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/yqm6ZWTd/3578-only-applications-in-the-awaiting-decision-or-interviewing-state-can-be-rejected
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
