### PR TITLE
Use nationality to determine international candidates in other qualifications

### DIFF
--- a/app/components/candidate_interface/other_qualifications_review_component.html.erb
+++ b/app/components/candidate_interface/other_qualifications_review_component.html.erb
@@ -1,7 +1,7 @@
 <% if @qualifications.present? %>
   <% if @submitting_application && !@application_form.other_qualifications_completed %>
     <%= render CandidateInterface::IncompleteSectionComponent.new(
-      section: application_form.international_address? ? :other_qualifications_international : :other_qualifications,
+      section: application_form.international_applicant? ? :other_qualifications_international : :other_qualifications,
       section_path: candidate_interface_review_other_qualifications_path,
       error: @missing_error,
     ) %>
@@ -30,7 +30,7 @@
 <% else %>
   <% if @submitting_application && !application_form.other_qualifications_completed %>
     <%= render CandidateInterface::IncompleteSectionComponent.new(
-      section: application_form.international_address? ? :other_qualifications_international : :other_qualifications,
+      section: application_form.international_applicant? ? :other_qualifications_international : :other_qualifications,
       section_path: candidate_interface_other_qualification_type_path,
       error: @missing_error,
     ) %>

--- a/app/components/candidate_interface/other_qualifications_review_component.html.erb
+++ b/app/components/candidate_interface/other_qualifications_review_component.html.erb
@@ -1,7 +1,7 @@
 <% if @qualifications.present? %>
   <% if @submitting_application && !@application_form.other_qualifications_completed %>
     <%= render CandidateInterface::IncompleteSectionComponent.new(
-      section: application_form.international? ? :other_qualifications_international : :other_qualifications,
+      section: application_form.international_address? ? :other_qualifications_international : :other_qualifications,
       section_path: candidate_interface_review_other_qualifications_path,
       error: @missing_error,
     ) %>
@@ -30,7 +30,7 @@
 <% else %>
   <% if @submitting_application && !application_form.other_qualifications_completed %>
     <%= render CandidateInterface::IncompleteSectionComponent.new(
-      section: application_form.international? ? :other_qualifications_international : :other_qualifications,
+      section: application_form.international_address? ? :other_qualifications_international : :other_qualifications,
       section_path: candidate_interface_other_qualification_type_path,
       error: @missing_error,
     ) %>

--- a/app/components/efl_qualification_card_component.rb
+++ b/app/components/efl_qualification_card_component.rb
@@ -7,7 +7,7 @@ class EflQualificationCardComponent < ViewComponent::Base
   end
 
   def render?
-    !application_form.english_speaking_nationality? && english_proficiency.present?
+    !application_form.british_or_irish? && english_proficiency.present?
   end
 
   def english_proficiency

--- a/app/helpers/other_qualifications_helper.rb
+++ b/app/helpers/other_qualifications_helper.rb
@@ -1,6 +1,6 @@
 module OtherQualificationsHelper
   def other_qualifications_title(application_form)
-    if application_form.international?
+    if application_form.international_address?
       I18n.t('page_titles.other_qualifications_international')
     else
       I18n.t('page_titles.other_qualifications')

--- a/app/helpers/other_qualifications_helper.rb
+++ b/app/helpers/other_qualifications_helper.rb
@@ -1,6 +1,6 @@
 module OtherQualificationsHelper
   def other_qualifications_title(application_form)
-    if application_form.international_address?
+    if application_form.international_applicant?
       I18n.t('page_titles.other_qualifications_international')
     else
       I18n.t('page_titles.other_qualifications')

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -28,7 +28,7 @@ class ApplicationForm < ApplicationRecord
   MINIMUM_COMPLETE_REFERENCES = 2
   MAXIMUM_REFERENCES = 10
   EQUALITY_AND_DIVERSITY_MINIMAL_ATTR = %w[sex disabilities ethnic_group].freeze
-  ENGLISH_SPEAKING_NATIONALITIES = %w[GB IE].freeze
+  BRITISH_OR_IRISH_NATIONALITIES = %w[GB IE].freeze
   MAXIMUM_PHASE_ONE_COURSE_CHOICES = 3
   MAXIMUM_PHASE_TWO_COURSE_CHOICES = 1
 
@@ -243,16 +243,16 @@ class ApplicationForm < ApplicationRecord
     application_qualifications.degree.any?(&:incomplete_degree_information?)
   end
 
-  def english_speaking_nationality?
+  def british_or_irish?
     nationality_codes = nationalities.map { |n| NATIONALITIES_BY_NAME[n] }.compact
 
     nationality_codes.any? do |code|
-      code.in? ENGLISH_SPEAKING_NATIONALITIES
+      code.in? BRITISH_OR_IRISH_NATIONALITIES
     end
   end
 
   def international_applicant?
-    nationalities.present? && !english_speaking_nationality?
+    nationalities.present? && !british_or_irish?
   end
 
   def build_nationalities_hash
@@ -319,7 +319,7 @@ class ApplicationForm < ApplicationRecord
     return self[:english_main_language] if fetch_database_value
 
     if self[:english_main_language].nil?
-      return true if english_speaking_nationality?
+      return true if british_or_irish?
       return true if english_proficiency&.qualification_not_needed?
 
       false

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -251,9 +251,10 @@ class ApplicationForm < ApplicationRecord
     end
   end
 
-  def efl_section_required?
+  def international_applicant?
     nationalities.present? && !english_speaking_nationality?
   end
+  alias_method :efl_section_required?, :international_applicant?
 
   def build_nationalities_hash
     CandidateInterface::GetNationalitiesFormHash.new(application_form: self).call

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -58,7 +58,7 @@ class ApplicationForm < ApplicationRecord
   enum address_type: {
     uk: 'uk',
     international: 'international',
-  }
+  }, _suffix: :address
   attribute :address_type, :string, default: 'uk'
 
   enum feedback_satisfaction_level: {
@@ -264,7 +264,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def full_address
-    if international?
+    if international_address?
       [
         address_line1,
         address_line2,
@@ -349,7 +349,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def domicile
-    if international?
+    if international_address?
       DomicileResolver.hesa_code_for_country country
     else
       DomicileResolver.hesa_code_for_postcode postcode
@@ -387,7 +387,7 @@ private
   def geocode_address_if_required
     return unless address_changed?
 
-    if international?
+    if international_address?
       update!(latitude: nil, longitude: nil)
     else
       GeocodeApplicationAddressWorker.perform_async(id)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -254,7 +254,6 @@ class ApplicationForm < ApplicationRecord
   def international_applicant?
     nationalities.present? && !english_speaking_nationality?
   end
-  alias_method :efl_section_required?, :international_applicant?
 
   def build_nationalities_hash
     CandidateInterface::GetNationalitiesFormHash.new(application_form: self).call

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -333,7 +333,7 @@ module CandidateInterface
     end
 
     def display_efl_link?
-      @application_form.efl_section_required?
+      @application_form.international_applicant?
     end
 
     def references

--- a/app/presenters/register_api/single_application_presenter.rb
+++ b/app/presenters/register_api/single_application_presenter.rb
@@ -84,7 +84,7 @@ module RegisterAPI
 
       (EU_EEA_SWISS_COUNTRY_CODES & application_choice.nationalities).any? &&
         application_form.right_to_work_or_study_yes? &&
-        application_form.uk?
+        application_form.uk_address?
     end
 
     def course_info_for(course_option)
@@ -182,7 +182,7 @@ module RegisterAPI
     end
 
     def contact_details
-      if application_form.international?
+      if application_form.international_address?
         address_line1 = application_form.address_line1 || application_form.international_address
 
         {

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -141,7 +141,7 @@ module VendorAPI
 
       (EU_EEA_SWISS_COUNTRY_CODES & application_choice.nationalities).any? &&
         application_form.right_to_work_or_study_yes? &&
-        application_form.uk?
+        application_form.uk_address?
     end
 
     def course_info_for(course_option)
@@ -319,7 +319,7 @@ module VendorAPI
     end
 
     def contact_details
-      if application_form.international?
+      if application_form.international_address?
         address_line1 = application_form.address_line1 || application_form.international_address
 
         {

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -55,7 +55,7 @@
   <h3 class="govuk-heading-m"><%= t('page_titles.english_gcse') %></h3>
   <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.english_gcse, subject: 'english', editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
 
-  <% if @application_form.efl_section_required? %>
+  <% if @application_form.international_applicant? %>
     <h3 class="govuk-heading-m"><%= t('page_titles.efl.start') %></h3>
     <% if @application_form.english_proficiency.present? %>
       <%= render(CandidateInterface::ChooseEflReviewComponent.call(@application_form.english_proficiency)) %>

--- a/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
@@ -20,7 +20,7 @@
     <%= f.govuk_radio_divider %>
     <%= f.govuk_radio_button :qualification_type,
       'no_other_qualifications',
-      label: { text: current_application.international_address? ? 'I do not want to add any other qualifications' : 'I do not want to add any A levels and other qualifications' },
+      label: { text: current_application.international_applicant? ? 'I do not want to add any other qualifications' : 'I do not want to add any A levels and other qualifications' },
       hint: -> { 'Providers look at A levels and other qualifications for evidence of subject knowledge not covered in your degree or work history' } %>
   <% end %>
 <% end %>

--- a/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
@@ -20,7 +20,7 @@
     <%= f.govuk_radio_divider %>
     <%= f.govuk_radio_button :qualification_type,
       'no_other_qualifications',
-      label: { text: current_application.international? ? 'I do not want to add any other qualifications' : 'I do not want to add any A levels and other qualifications' },
+      label: { text: current_application.international_address? ? 'I do not want to add any other qualifications' : 'I do not want to add any A levels and other qualifications' },
       hint: -> { 'Providers look at A levels and other qualifications for evidence of subject knowledge not covered in your degree or work history' } %>
   <% end %>
 <% end %>

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -297,7 +297,7 @@ RSpec.describe ApplicationForm do
     end
   end
 
-  describe '#english_speaking_nationality?' do
+  describe '#british_or_irish?' do
     context 'when any applicant nationality is identified as "English-speaking"' do
       let(:nationality_permutations) do
         [
@@ -314,7 +314,7 @@ RSpec.describe ApplicationForm do
       it 'returns true' do
         nationality_permutations.each do |permutation|
           application_form = build(:application_form, permutation)
-          expect(application_form.english_speaking_nationality?).to eq true
+          expect(application_form.british_or_irish?).to eq true
         end
       end
     end
@@ -331,7 +331,7 @@ RSpec.describe ApplicationForm do
       it 'return false' do
         nationality_permutations.each do |permutation|
           application_form = build(:application_form, permutation)
-          expect(application_form.english_speaking_nationality?).to eq false
+          expect(application_form.british_or_irish?).to eq false
         end
       end
     end
@@ -369,7 +369,7 @@ RSpec.describe ApplicationForm do
         expect(application_form.english_main_language).to eq false
       end
 
-      context 'when english_speaking_nationality? is true' do
+      context 'when british_or_irish? is true' do
         it 'returns true' do
           application_form.first_nationality = 'British'
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -404,7 +404,7 @@ RSpec.describe ApplicationForm do
     end
   end
 
-  describe '#efl_section_required?' do
+  describe '#international_applicant?' do
     let(:application_with_english_speaking_nationality) do
       build_stubbed :application_form, first_nationality: 'British', second_nationality: 'French'
     end
@@ -417,7 +417,7 @@ RSpec.describe ApplicationForm do
       let(:application_form) { application_with_english_speaking_nationality }
 
       it 'returns false' do
-        expect(application_form.efl_section_required?).to be false
+        expect(application_form.international_applicant?).to be false
       end
     end
 
@@ -425,7 +425,7 @@ RSpec.describe ApplicationForm do
       let(:application_form) { application_with_no_english_speaking_nationalities }
 
       it 'returns true' do
-        expect(application_form.efl_section_required?).to be true
+        expect(application_form.international_applicant?).to be true
       end
     end
 
@@ -433,7 +433,7 @@ RSpec.describe ApplicationForm do
       let(:application_form) { build_stubbed :application_form }
 
       it 'returns false' do
-        expect(application_form.efl_section_required?).to be false
+        expect(application_form.international_applicant?).to be false
       end
     end
   end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -159,7 +159,7 @@ module CandidateHelper
     click_button t('continue')
   end
 
-  def candidate_fills_in_personal_details
+  def candidate_fills_in_personal_details(international: false)
     scope = 'application_form.personal_details'
     fill_in t('first_name.label', scope: scope), with: 'Lando'
     fill_in t('last_name.label', scope: scope), with: 'Calrissian'
@@ -169,12 +169,26 @@ module CandidateHelper
     fill_in 'Year', with: '1937'
     click_button t('save_and_continue')
 
-    check 'British'
-    check 'Citizen of a different country'
-    within('#candidate-interface-nationalities-form-other-nationality1-field') do
-      select 'American'
+    if international
+      check 'Citizen of a different country'
+      within('#candidate-interface-nationalities-form-other-nationality1-field') do
+        select 'Indian'
+      end
+      click_button t('save_and_continue')
+      choose 'Yes'
+      fill_in(
+        'What is your immigration status?',
+        with: 'I have settled status',
+      )
+      click_button t('save_and_continue')
+    else
+      check 'British'
+      check 'Citizen of a different country'
+      within('#candidate-interface-nationalities-form-other-nationality1-field') do
+        select 'American'
+      end
+      click_button t('save_and_continue')
     end
-    click_button t('save_and_continue')
 
     check t('application_form.completed_checkbox')
     click_button t('continue')

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -180,15 +180,14 @@ module CandidateHelper
         'What is your immigration status?',
         with: 'I have settled status',
       )
-      click_button t('save_and_continue')
     else
       check 'British'
       check 'Citizen of a different country'
       within('#candidate-interface-nationalities-form-other-nationality1-field') do
         select 'American'
       end
-      click_button t('save_and_continue')
     end
+    click_button t('save_and_continue')
 
     check t('application_form.completed_checkbox')
     click_button t('continue')

--- a/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
@@ -78,8 +78,8 @@ RSpec.feature 'Non-uk Other qualifications' do
   end
 
   def and_i_am_an_international_candidate
-    click_link 'Contact information'
-    candidate_fills_in_international_contact_details
+    click_link t('page_titles.personal_information')
+    candidate_fills_in_personal_details(international: true)
   end
 
   def when_i_click_on_other_qualifications


### PR DESCRIPTION
## Context

Currently the _A levels and other qualifications_ section uses `international?` (based on `address_type` enum) to determine if the candidate is an international student and if they are it will then render the section titles, and other pieces of copy, as 'Other qualifications' rather an 'A levels and other qualifications'. We want to use nationality instead so it's consistent with the EFL feature.

## Changes proposed in this pull request

- [x] Add `_address` suffix to the `ApplicationForm#address_type` enum. So helpers like `ApplicationForm#uk?` now become `ApplicationForm#uk_address` etc.
- [x] Add an `ApplicationForm#international_applicant?` method that uses the same logic as the existing `efl_section_required?` method. Use this in the other qualifications front end to switch the content between UK (including term _A level_) and more generic international variants.
- [x] Drop the `efl_section_required?` method and just use `international_applicant?`
- [x] Rename `ApplicationForm#english_speaking_nationality?` to simply `british_or_irish?`
- [x] Update system specs

## Guidance to review

- Per commit is probably easier.
- The card says that we should change the enum values - I'm a bit reluctant to do that unless there is a strong need due to the effort needed to migrate the existing values in the DB. Does this make sense?

## Link to Trello card

https://trello.com/c/5AxBkwIz/3319-update-the-criteria-for-classifying-international-candidates-on-the-a-levels-and-other-qualifications-section

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
