### PR TITLE
Use radio buttons to complete individual sections instead of checkboxes

### DIFF
--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -1,9 +1,7 @@
 <%= form_with model: section_complete_form, url: path, method: request_method do |f| %>
   <%= f.govuk_error_summary %>
 
-  <% if summary_component %>
-    <%= render(summary_component) %>
-  <% end %>
+  <%= render(review_component) %>
 
   <%= f.govuk_radio_buttons_fieldset :completed, classes: 'govuk-!-width-two-thirds ', legend: { text: t('application_form.completed_question'), size: 'm' } do %>
     <% if hint_text %>

--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -7,7 +7,7 @@
     <% if hint_text %>
       <div class="govuk-hint"><%= hint_text %></div>
     <% end %>
-    <%= f.govuk_radio_button :completed, true, label: { text: radio_button_label }, link_errors: true %>
+    <%= f.govuk_radio_button :completed, true, label: { text: complete_or_reviewed_radio_button_label }, link_errors: true %>
     <%= f.govuk_radio_button :completed, false, label: { text: t('application_form.incomplete_radio') } %>
   <% end %>
 

--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -1,8 +1,12 @@
-<%= form_with model: @application_form, url: @path, method: @request_method do |f| %>
-  <div class='govuk-form-group'>
-    <%= f.hidden_field @field_name, value: false %>
-    <%= f.govuk_check_box @field_name, true, multiple: false, label: { text: t(checkbox_label) } %>
-  </div>
+<%= form_with model: section_complete_form, url: path, method: request_method do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= render(summary_component) %>
+
+  <%= f.govuk_radio_buttons_fieldset :completed, legend: { text: t('application_form.completed_question'), size: 'm' } do %>
+    <%= f.govuk_radio_button :completed, true, label: { text: radio_button_label }, link_errors: true%>
+    <%= f.govuk_radio_button :completed, false, label: { text: t('application_form.incomplete_radio') } %>
+  <% end %>
 
   <%= f.govuk_submit t('continue') %>
 <% end %>

--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -1,7 +1,9 @@
 <%= form_with model: section_complete_form, url: path, method: request_method do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= render(summary_component) %>
+  <% if summary_component %>
+    <%= render(summary_component) %>
+  <% end %>
 
   <%= f.govuk_radio_buttons_fieldset :completed, classes: 'govuk-!-width-two-thirds ', legend: { text: t('application_form.completed_question'), size: 'm' } do %>
     <% if complete_hint_text %>

--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -6,8 +6,8 @@
   <% end %>
 
   <%= f.govuk_radio_buttons_fieldset :completed, classes: 'govuk-!-width-two-thirds ', legend: { text: t('application_form.completed_question'), size: 'm' } do %>
-    <% if complete_hint_text %>
-      <div class="govuk-hint"><%= complete_hint_text %></div>
+    <% if hint_text %>
+      <div class="govuk-hint"><%= hint_text %></div>
     <% end %>
     <%= f.govuk_radio_button :completed, true, label: { text: radio_button_label }, link_errors: true %>
     <%= f.govuk_radio_button :completed, false, label: { text: t('application_form.incomplete_radio') } %>

--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -3,8 +3,11 @@
 
   <%= render(summary_component) %>
 
-  <%= f.govuk_radio_buttons_fieldset :completed, legend: { text: t('application_form.completed_question'), size: 'm' } do %>
-    <%= f.govuk_radio_button :completed, true, label: { text: radio_button_label }, link_errors: true%>
+  <%= f.govuk_radio_buttons_fieldset :completed, classes: 'govuk-!-width-two-thirds ', legend: { text: t('application_form.completed_question'), size: 'm' } do %>
+    <% if complete_hint_text %>
+      <div class="govuk-hint"><%= complete_hint_text %></div>
+    <% end %>
+    <%= f.govuk_radio_button :completed, true, label: { text: radio_button_label }, link_errors: true %>
     <%= f.govuk_radio_button :completed, false, label: { text: t('application_form.incomplete_radio') } %>
   <% end %>
 

--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -5,7 +5,13 @@
 
   <%= f.govuk_radio_buttons_fieldset :completed, classes: 'govuk-!-width-two-thirds ', legend: { text: t('application_form.completed_question'), size: 'm' } do %>
     <% if hint_text %>
-      <div class="govuk-hint"><%= hint_text %></div>
+      <% if hint_text.is_a?(Array) %>
+        <% hint_text.each do |paragraph| %>
+          <div class="govuk-hint"><%= paragraph %></div>
+        <% end %>
+      <% else %>
+        <div class="govuk-hint"><%= hint_text %></div>
+      <% end %>
     <% end %>
     <%= f.govuk_radio_button :completed, true, label: { text: complete_or_reviewed_radio_button_label }, link_errors: true %>
     <%= f.govuk_radio_button :completed, false, label: { text: t('application_form.incomplete_radio') } %>

--- a/app/components/candidate_interface/complete_section_component.rb
+++ b/app/components/candidate_interface/complete_section_component.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   class CompleteSectionComponent < ViewComponent::Base
     attr_reader :section_complete_form, :path, :request_method, :summary_component, :complete_hint_text, :section_review
 
-    def initialize(section_complete_form:, path:, request_method:, summary_component:, section_review: false, complete_hint_text: false)
+    def initialize(section_complete_form:, path:, request_method:, summary_component: nil, section_review: false, complete_hint_text: false)
       @section_complete_form = section_complete_form
       @path = path
       @request_method = request_method
@@ -13,9 +13,9 @@ module CandidateInterface
 
     def radio_button_label
       if section_review
-        'application_form.reviewed_radio'
+        t('application_form.reviewed_radio')
       else
-        'application_form.completed_radio'
+        t('application_form.completed_radio')
       end
     end
   end

--- a/app/components/candidate_interface/complete_section_component.rb
+++ b/app/components/candidate_interface/complete_section_component.rb
@@ -11,7 +11,7 @@ module CandidateInterface
       @hint_text = hint_text
     end
 
-    def radio_button_label
+    def complete_or_reviewed_radio_button_label
       if section_review
         t('application_form.reviewed_radio')
       else

--- a/app/components/candidate_interface/complete_section_component.rb
+++ b/app/components/candidate_interface/complete_section_component.rb
@@ -1,18 +1,20 @@
 module CandidateInterface
   class CompleteSectionComponent < ViewComponent::Base
-    def initialize(application_form:, path:, request_method:, field_name:, section_review: false)
-      @application_form = application_form
+    attr_reader :section_complete_form, :path, :request_method, :summary_component, :section_review
+
+    def initialize(section_complete_form:, path:, request_method:, summary_component:, section_review: false)
+      @section_complete_form = section_complete_form
       @path = path
       @request_method = request_method
-      @field_name = field_name
+      @summary_component = summary_component
       @section_review = section_review
     end
 
-    def checkbox_label
-      if @section_review
-        'application_form.reviewed_checkbox'
+    def radio_button_label
+      if section_review
+        'application_form.reviewed_radio'
       else
-        'application_form.completed_checkbox'
+        'application_form.completed_radio'
       end
     end
   end

--- a/app/components/candidate_interface/complete_section_component.rb
+++ b/app/components/candidate_interface/complete_section_component.rb
@@ -1,14 +1,14 @@
 module CandidateInterface
   class CompleteSectionComponent < ViewComponent::Base
-    attr_reader :section_complete_form, :path, :request_method, :summary_component, :complete_hint_text, :section_review
+    attr_reader :section_complete_form, :path, :request_method, :summary_component, :hint_text, :section_review
 
-    def initialize(section_complete_form:, path:, request_method:, summary_component: nil, section_review: false, complete_hint_text: false)
+    def initialize(section_complete_form:, path:, request_method:, summary_component: nil, section_review: false, hint_text: false)
       @section_complete_form = section_complete_form
       @path = path
       @request_method = request_method
       @summary_component = summary_component
       @section_review = section_review
-      @complete_hint_text = complete_hint_text
+      @hint_text = hint_text
     end
 
     def radio_button_label

--- a/app/components/candidate_interface/complete_section_component.rb
+++ b/app/components/candidate_interface/complete_section_component.rb
@@ -1,12 +1,12 @@
 module CandidateInterface
   class CompleteSectionComponent < ViewComponent::Base
-    attr_reader :section_complete_form, :path, :request_method, :summary_component, :hint_text, :section_review
+    attr_reader :section_complete_form, :path, :request_method, :review_component, :hint_text, :section_review
 
-    def initialize(section_complete_form:, path:, request_method:, summary_component: nil, section_review: false, hint_text: false)
+    def initialize(section_complete_form:, path:, request_method:, review_component:, section_review: false, hint_text: false)
       @section_complete_form = section_complete_form
       @path = path
       @request_method = request_method
-      @summary_component = summary_component
+      @review_component = review_component
       @section_review = section_review
       @hint_text = hint_text
     end

--- a/app/components/candidate_interface/complete_section_component.rb
+++ b/app/components/candidate_interface/complete_section_component.rb
@@ -1,13 +1,14 @@
 module CandidateInterface
   class CompleteSectionComponent < ViewComponent::Base
-    attr_reader :section_complete_form, :path, :request_method, :summary_component, :section_review
+    attr_reader :section_complete_form, :path, :request_method, :summary_component, :complete_hint_text, :section_review
 
-    def initialize(section_complete_form:, path:, request_method:, summary_component:, section_review: false)
+    def initialize(section_complete_form:, path:, request_method:, summary_component:, section_review: false, complete_hint_text: false)
       @section_complete_form = section_complete_form
       @path = path
       @request_method = request_method
       @summary_component = summary_component
       @section_review = section_review
+      @complete_hint_text = complete_hint_text
     end
 
     def radio_button_label

--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -30,20 +30,20 @@ module CandidateInterface
     def review
       @application_form = current_application
       @application_choices = current_candidate.current_application.application_choices
+      @section_complete_form = SectionCompleteForm.new(completed: current_application.course_choices_completed)
     end
 
     def complete
       @application_form = current_application
+      @section_complete_form = SectionCompleteForm.new(form_params)
 
       render :index and return if @application_form.application_choices.count.zero?
 
-      if @application_form.update(application_form_params)
+      if @section_complete_form.save(current_application, :course_choices_completed)
         redirect_to candidate_interface_application_form_path
       else
-        @application_choices = current_candidate.current_application.application_choices
-        track_validation_error(@application_form)
-
-        render :review
+        track_validation_error(@section_complete_form)
+        render :show
       end
     end
 
@@ -53,8 +53,8 @@ module CandidateInterface
       params.permit(:id)[:id]
     end
 
-    def application_form_params
-      params.require(:application_form).permit(:course_choices_completed)
+    def form_params
+      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -54,7 +54,7 @@ module CandidateInterface
     end
 
     def form_params
-      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
+      strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -23,7 +23,7 @@ module CandidateInterface
   private
 
     def application_form_params
-      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
+      strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -4,18 +4,26 @@ module CandidateInterface
 
     def show
       @application_form = current_application
+      @section_complete_form = SectionCompleteForm.new(
+        completed: current_application.contact_details_completed,
+      )
     end
 
     def complete
-      current_application.update!(application_form_params)
+      @section_complete_form = SectionCompleteForm.new(completed: application_form_params[:completed])
 
-      redirect_to candidate_interface_application_form_path
+      if @section_complete_form.save(current_application, :contact_details_completed)
+        redirect_to candidate_interface_application_form_path
+      else
+        track_validation_error(@section_complete_form)
+        render :show
+      end
     end
 
   private
 
     def application_form_params
-      strip_whitespace params.require(:application_form).permit(:contact_details_completed)
+      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/degrees/review_controller.rb
+++ b/app/controllers/candidate_interface/degrees/review_controller.rb
@@ -24,7 +24,7 @@ module CandidateInterface
     private
 
       def application_form_params
-        strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
+        strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
       end
     end
   end

--- a/app/controllers/candidate_interface/degrees/review_controller.rb
+++ b/app/controllers/candidate_interface/degrees/review_controller.rb
@@ -3,25 +3,28 @@ module CandidateInterface
     class ReviewController < BaseController
       def show
         @application_form = current_application
+        @section_complete_form = SectionCompleteForm.new(completed: current_application.degrees_completed)
       end
 
       def complete
         @application_form = current_application
+        @section_complete_form = SectionCompleteForm.new(application_form_params)
 
         if @application_form.incomplete_degree_information?
           flash[:warning] = 'You cannot mark this section complete with incomplete degree information.'
           render :show
-        else
-          @application_form.update!(application_form_params)
-
+        elsif @section_complete_form.save(current_application, :degrees_completed)
           redirect_to candidate_interface_application_form_path
+        else
+          track_validation_error(@section_complete_form)
+          render :show
         end
       end
 
     private
 
       def application_form_params
-        strip_whitespace params.require(:application_form).permit(:degrees_completed)
+        strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
       end
     end
   end

--- a/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
@@ -7,11 +7,21 @@ module CandidateInterface
 
       def show
         @component_instance = ChooseEflReviewComponent.call(english_proficiency)
+        @section_complete_form = SectionCompleteForm.new(
+          completed: current_application.efl_completed,
+        )
       end
 
       def complete
-        current_application.update!(completion_params)
-        redirect_to candidate_interface_application_form_path
+        @component_instance = ChooseEflReviewComponent.call(english_proficiency)
+        @section_complete_form = SectionCompleteForm.new(completion_params)
+
+        if @section_complete_form.save(current_application, :efl_completed)
+          redirect_to candidate_interface_application_form_path
+        else
+          track_validation_error(@section_complete_form)
+          render :show
+        end
       end
 
     private
@@ -28,8 +38,8 @@ module CandidateInterface
 
       def completion_params
         strip_whitespace params
-          .require(:application_form)
-          .permit(:efl_completed)
+          .require(:candidate_interface_section_complete_form)
+          .permit(:completed)
       end
     end
   end

--- a/app/controllers/candidate_interface/gcse/review_controller.rb
+++ b/app/controllers/candidate_interface/gcse/review_controller.rb
@@ -6,19 +6,24 @@ module CandidateInterface
     def show
       @application_form = current_application
       @application_qualification = current_qualification
+      @section_complete_form = SectionCompleteForm.new(
+        completed: current_application.send(@field_name),
+      )
     end
 
     def complete
       @application_form = current_application
       @application_qualification = current_qualification
+      @section_complete_form = SectionCompleteForm.new(completed: application_form_params[:completed])
 
       if @application_qualification.incomplete_gcse_information? && !@application_qualification.missing_qualification?
         flash[:warning] = 'You cannot mark this section complete with incomplete GCSE information.'
         render :show
-      else
-        current_application.update!(application_form_params)
-
+      elsif @section_complete_form.save(current_application, @field_name.to_sym)
         redirect_to candidate_interface_application_form_path
+      else
+        track_validation_error(@section_complete_form)
+        render :show
       end
     end
 
@@ -29,7 +34,7 @@ module CandidateInterface
     end
 
     def application_form_params
-      strip_whitespace params.require(:application_form).permit(@field_name)
+      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/review_controller.rb
+++ b/app/controllers/candidate_interface/gcse/review_controller.rb
@@ -34,7 +34,7 @@ module CandidateInterface
     end
 
     def application_form_params
-      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
+      strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/interview_needs_controller.rb
+++ b/app/controllers/candidate_interface/interview_needs_controller.rb
@@ -46,7 +46,7 @@ module CandidateInterface
     end
 
     def form_params
-      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
+      strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/interview_needs_controller.rb
+++ b/app/controllers/candidate_interface/interview_needs_controller.rb
@@ -23,12 +23,18 @@ module CandidateInterface
 
     def show
       @application_form = current_application
+      @section_complete_form = SectionCompleteForm.new(completed: current_application.interview_preferences_completed)
     end
 
     def complete
-      current_application.update!(application_form_params)
+      @section_complete_form = SectionCompleteForm.new(form_params)
 
-      redirect_to candidate_interface_application_form_path
+      if @section_complete_form.save(current_application, :interview_preferences_completed)
+        redirect_to candidate_interface_application_form_path
+      else
+        track_validation_error(@section_complete_form)
+        render :show
+      end
     end
 
   private
@@ -39,8 +45,8 @@ module CandidateInterface
       )
     end
 
-    def application_form_params
-      strip_whitespace params.require(:application_form).permit(:interview_preferences_completed)
+    def form_params
+      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -4,26 +4,31 @@ module CandidateInterface
       redirect_to candidate_interface_other_qualification_type_path and return if current_application.application_qualifications.other.blank? && !current_application.no_other_qualifications
 
       @application_form = current_application
+      @section_complete_form = SectionCompleteForm.new(
+        completed: current_application.other_qualifications_completed,
+      )
     end
 
     def complete
       @application_form = current_candidate.current_application
+      @section_complete_form = SectionCompleteForm.new(application_form_params)
 
       if section_marked_as_complete? && there_are_incomplete_qualifications?
         flash[:warning] = 'You must fill in all your qualifications to complete this section'
 
         render :show
-      else
-        @application_form.update!(application_form_params)
-
+      elsif @section_complete_form.save(current_application, :other_qualifications_completed)
         redirect_to candidate_interface_application_form_path
+      else
+        track_validation_error(@section_complete_form)
+        render :show
       end
     end
 
   private
 
     def application_form_params
-      strip_whitespace params.require(:application_form).permit(:other_qualifications_completed)
+      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
     end
 
     def there_are_incomplete_qualifications?

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -36,7 +36,7 @@ module CandidateInterface
     end
 
     def section_marked_as_complete?
-      application_form_params[:other_qualifications_completed] == 'true'
+      application_form_params[:completed] == 'true'
     end
   end
 end

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -28,7 +28,7 @@ module CandidateInterface
   private
 
     def application_form_params
-      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
+      strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
     end
 
     def there_are_incomplete_qualifications?

--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -5,6 +5,9 @@ module CandidateInterface
 
       def show
         @application_form = current_application
+        @section_complete_form = SectionCompleteForm.new(
+          completed: current_application.personal_details_completed,
+        )
         @personal_details_form = PersonalDetailsForm.build_from_application(current_application)
         @nationalities_form = NationalitiesForm.build_from_application(current_application)
         @languages_form = LanguagesForm.build_from_application(current_application)
@@ -18,31 +21,37 @@ module CandidateInterface
         @nationalities_form = NationalitiesForm.build_from_application(current_application)
         @languages_form = LanguagesForm.build_from_application(current_application)
         @right_to_work_or_study_form = RightToWorkOrStudyForm.build_from_application(current_application)
+        @section_complete_form = SectionCompleteForm.new(completed: application_form_params[:completed])
+        @personal_details_review = PersonalDetailsReviewComponent.new(application_form: current_application)
 
-        if @personal_details_form.valid? &&
-            @nationalities_form.valid? &&
-            @right_to_work_or_study_form.valid? &&
-            @languages_form.valid?
-          current_application.update!(application_form_params)
-          redirect_to candidate_interface_application_form_path
-        elsif @personal_details_form.valid? &&
-            @nationalities_form.valid? &&
-            (hiding_languages_section? || @languages_form.valid?)
-
-          current_application.update!(application_form_params)
-          redirect_to candidate_interface_application_form_path
+        if all_sections_valid? || hiding_languages?
+          save_section_complete_form
         else
-          @personal_details_review = PersonalDetailsReviewComponent.new(
-            application_form: current_application,
-          )
           render :show
         end
       end
 
     private
 
+      def all_sections_valid?
+        @personal_details_form.valid? && @nationalities_form.valid? && @right_to_work_or_study_form.valid? && @languages_form.valid?
+      end
+
+      def hiding_languages?
+        @personal_details_form.valid? && @nationalities_form.valid? && (hiding_languages_section? || @languages_form.valid?)
+      end
+
+      def save_section_complete_form
+        if @section_complete_form.save(current_application, :personal_details_completed)
+          redirect_to candidate_interface_application_form_path
+        else
+          track_validation_error(@section_complete_form)
+          render :show
+        end
+      end
+
       def application_form_params
-        strip_whitespace params.require(:application_form).permit(:personal_details_completed)
+        strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
       end
 
       def hiding_languages_section?

--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -51,7 +51,7 @@ module CandidateInterface
       end
 
       def application_form_params
-        strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
+        strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
       end
 
       def hiding_languages_section?

--- a/app/controllers/candidate_interface/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement_controller.rb
@@ -46,7 +46,7 @@ module CandidateInterface
     end
 
     def form_params
-      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
+      strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement_controller.rb
@@ -23,12 +23,18 @@ module CandidateInterface
 
     def show
       @application_form = current_application
+      @section_complete_form = SectionCompleteForm.new(completed: current_application.becoming_a_teacher_completed)
     end
 
     def complete
-      current_application.update!(application_form_params)
+      @section_complete_form = SectionCompleteForm.new(form_params)
 
-      redirect_to candidate_interface_application_form_path
+      if @section_complete_form.save(current_application, :becoming_a_teacher_completed)
+        redirect_to candidate_interface_application_form_path
+      else
+        track_validation_error(@section_complete_form)
+        render :show
+      end
     end
 
   private
@@ -39,8 +45,8 @@ module CandidateInterface
       )
     end
 
-    def application_form_params
-      strip_whitespace params.require(:application_form).permit(:becoming_a_teacher_completed)
+    def form_params
+      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
@@ -19,7 +19,7 @@ module CandidateInterface
   private
 
     def form_params
-      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
+      strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
@@ -2,18 +2,24 @@ module CandidateInterface
   class RestructuredWorkHistory::ReviewController < RestructuredWorkHistory::BaseController
     def show
       @application_form = current_application
+      @section_complete_form = SectionCompleteForm.new(completed: current_application.work_history_completed)
     end
 
     def complete
-      current_application.update!(application_form_params)
+      @section_complete_form = SectionCompleteForm.new(form_params)
 
-      redirect_to candidate_interface_application_form_path
+      if @section_complete_form.save(current_application, :work_history_completed)
+        redirect_to candidate_interface_application_form_path
+      else
+        track_validation_error(@section_complete_form)
+        render :show
+      end
     end
 
   private
 
-    def application_form_params
-      strip_whitespace params.require(:application_form).permit(:work_history_completed)
+    def form_params
+      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/safeguarding_controller.rb
+++ b/app/controllers/candidate_interface/safeguarding_controller.rb
@@ -44,7 +44,7 @@ module CandidateInterface
     end
 
     def form_params
-      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
+      strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/safeguarding_controller.rb
+++ b/app/controllers/candidate_interface/safeguarding_controller.rb
@@ -4,6 +4,7 @@ module CandidateInterface
 
     def show
       @application_form = current_application
+      @section_complete_form = SectionCompleteForm.new(completed: current_application.safeguarding_issues_completed)
     end
 
     def edit
@@ -24,9 +25,14 @@ module CandidateInterface
     end
 
     def complete
-      current_application.update!(application_form_params)
+      @section_complete_form = SectionCompleteForm.new(form_params)
 
-      redirect_to candidate_interface_application_form_path
+      if @section_complete_form.save(current_application, :safeguarding_issues_completed)
+        redirect_to candidate_interface_application_form_path
+      else
+        track_validation_error(@section_complete_form)
+        render :show
+      end
     end
 
   private
@@ -37,8 +43,8 @@ module CandidateInterface
         .permit(:share_safeguarding_issues, :safeguarding_issues)
     end
 
-    def application_form_params
-      strip_whitespace params.require(:application_form).permit(:safeguarding_issues_completed)
+    def form_params
+      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/subject_knowledge_controller.rb
@@ -52,7 +52,7 @@ module CandidateInterface
     end
 
     def section_complete_form_params
-      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
+      strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/subject_knowledge_controller.rb
@@ -25,12 +25,18 @@ module CandidateInterface
 
     def show
       @application_form = current_application
+      @section_complete_form = SectionCompleteForm.new(completed: current_application.subject_knowledge_completed)
     end
 
     def complete
-      current_application.update!(application_form_params)
+      @section_complete_form = SectionCompleteForm.new(section_complete_form_params)
 
-      redirect_to candidate_interface_application_form_path
+      if @section_complete_form.save(current_application, :subject_knowledge_completed)
+        redirect_to candidate_interface_application_form_path
+      else
+        track_validation_error(@section_complete_form)
+        render :show
+      end
     end
 
   private
@@ -45,8 +51,8 @@ module CandidateInterface
       current_application.application_choices.map(&:course).map(&:name_and_code)
     end
 
-    def application_form_params
-      strip_whitespace params.require(:application_form).permit(:subject_knowledge_completed)
+    def section_complete_form_params
+      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -4,6 +4,7 @@ module CandidateInterface
 
     def show
       @application_form = current_application
+      @section_complete_form = SectionCompleteForm.new(completed: current_application.training_with_a_disability_completed)
     end
 
     def edit
@@ -24,9 +25,14 @@ module CandidateInterface
     end
 
     def complete
-      current_application.update!(application_form_params)
+      @section_complete_form = SectionCompleteForm.new(section_complete_form_params)
 
-      redirect_to candidate_interface_application_form_path
+      if @section_complete_form.save(current_application, :training_with_a_disability_completed)
+        redirect_to candidate_interface_application_form_path
+      else
+        track_validation_error(@section_complete_form)
+        render :show
+      end
     end
 
   private
@@ -37,8 +43,8 @@ module CandidateInterface
         .permit(:disclose_disability, :disability_disclosure)
     end
 
-    def application_form_params
-      strip_whitespace params.require(:application_form).permit(:training_with_a_disability_completed)
+    def section_complete_form_params
+      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -44,7 +44,7 @@ module CandidateInterface
     end
 
     def section_complete_form_params
-      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
+      strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/volunteering/review_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/review_controller.rb
@@ -4,18 +4,24 @@ module CandidateInterface
 
     def show
       @application_form = current_application
+      @section_complete_form = SectionCompleteForm.new(completed: current_application.volunteering_completed)
     end
 
     def complete
-      current_application.update!(application_form_params)
+      @section_complete_form = SectionCompleteForm.new(form_params)
 
-      redirect_to candidate_interface_application_form_path
+      if @section_complete_form.save(current_application, :volunteering_completed)
+        redirect_to candidate_interface_application_form_path
+      else
+        track_validation_error(@section_complete_form)
+        render :show
+      end
     end
 
   private
 
-    def application_form_params
-      strip_whitespace params.require(:application_form).permit(:volunteering_completed)
+    def form_params
+      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/volunteering/review_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/review_controller.rb
@@ -21,7 +21,7 @@ module CandidateInterface
   private
 
     def form_params
-      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
+      strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/work_history/review_controller.rb
@@ -5,7 +5,6 @@ module CandidateInterface
         current_application.work_history_explanation.nil?
 
       @application_form = current_application
-
       @section_complete_form = SectionCompleteForm.new(completed: current_application.work_history_completed)
     end
 

--- a/app/controllers/candidate_interface/work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/work_history/review_controller.rb
@@ -5,18 +5,25 @@ module CandidateInterface
         current_application.work_history_explanation.nil?
 
       @application_form = current_application
+
+      @section_complete_form = SectionCompleteForm.new(completed: current_application.work_history_completed)
     end
 
     def complete
-      current_application.update!(application_form_params)
+      @section_complete_form = SectionCompleteForm.new(form_params)
 
-      redirect_to candidate_interface_application_form_path
+      if @section_complete_form.save(current_application, :work_history_completed)
+        redirect_to candidate_interface_application_form_path
+      else
+        track_validation_error(@section_complete_form)
+        render :show
+      end
     end
 
   private
 
-    def application_form_params
-      strip_whitespace params.require(:application_form).permit(:work_history_completed)
+    def form_params
+      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/work_history/review_controller.rb
@@ -22,7 +22,7 @@ module CandidateInterface
   private
 
     def form_params
-      strip_whitespace params.require(:candidate_interface_section_complete_form).permit(:completed)
+      strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
     end
   end
 end

--- a/app/forms/candidate_interface/section_complete_form.rb
+++ b/app/forms/candidate_interface/section_complete_form.rb
@@ -1,0 +1,14 @@
+module CandidateInterface
+  class SectionCompleteForm
+    include ActiveModel::Model
+
+    attr_accessor :completed
+    validates :completed, presence: true
+
+    def save(application_form, attr)
+      return false unless valid?
+
+      application_form.update!(attr => completed)
+    end
+  end
+end

--- a/app/forms/candidate_interface/section_complete_form.rb
+++ b/app/forms/candidate_interface/section_complete_form.rb
@@ -4,6 +4,7 @@ module CandidateInterface
 
     attr_accessor :completed
     validates :completed, presence: true
+    validates :completed, inclusion: { in: %w[true false] }
 
     def save(application_form, attr)
       return false unless valid?

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -28,11 +28,9 @@
         path: candidate_interface_course_choices_complete_path,
         request_method: :patch,
         review_component: CandidateInterface::CourseChoicesReviewComponent.new(application_form: @application_form),
-        hint_text: if @application_choices.count == 1
-                              t('application_form.courses.complete.hint_text_two_courses')
-                            elsif @application_choices.count == 2
-                              t('application_form.courses.complete.hint_text_one_course')
-                            end,
+        hint_text: if current_application.choices_left_to_make.positive?
+                     t('application_form.courses.complete.hint_text', count: current_application.choices_left_to_make)
+                   end,
       )) %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -12,10 +12,7 @@
     </h1>
 
     <% if @application_choices.present? && @application_form.can_add_more_choices? %>
-      <%= govuk_inset_text do %>
-        <p class="govuk-body">You can choose <%= pluralize(current_application.choices_left_to_make, 'more course') %>.</p>
-        <%= govuk_link_to t('application_form.courses.another.button'), candidate_interface_course_choices_choose_path, button: true, class: 'govuk-button--secondary' %>
-      <% end %>
+      <%= govuk_link_to t('application_form.courses.another.button'), candidate_interface_course_choices_choose_path, button: true, class: 'govuk-button--secondary' %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -27,7 +27,7 @@
         section_complete_form: @section_complete_form,
         path: candidate_interface_course_choices_complete_path,
         request_method: :patch,
-        summary_component: CandidateInterface::CourseChoicesReviewComponent.new(application_form: @application_form),
+        review_component: CandidateInterface::CourseChoicesReviewComponent.new(application_form: @application_form),
         hint_text: if @application_choices.count == 1
                               t('application_form.courses.complete.hint_text_two_courses')
                             elsif @application_choices.count == 2

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -28,7 +28,7 @@
         path: candidate_interface_course_choices_complete_path,
         request_method: :patch,
         summary_component: CandidateInterface::CourseChoicesReviewComponent.new(application_form: @application_form),
-        complete_hint_text: if @application_choices.count == 1
+        hint_text: if @application_choices.count == 1
                               t('application_form.courses.complete.hint_text_two_courses')
                             elsif @application_choices.count == 2
                               t('application_form.courses.complete.hint_text_one_course')

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -32,7 +32,7 @@
                               t('application_form.courses.complete.hint_text_two_courses')
                             elsif @application_choices.count == 2
                               t('application_form.courses.complete.hint_text_one_course')
-                            end
+                            end,
       )) %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -20,31 +20,20 @@
   </div>
 </div>
 
-<%= form_with model: @application_form, url: candidate_interface_course_choices_complete_path do |f| %>
-  <%= f.govuk_error_summary %>
-
-  <%= render(CandidateInterface::CourseChoicesReviewComponent.new(application_form: @application_form)) %>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <% if @application_choices.present? %>
-        <% if @application_choices.count >= 1 %>
-          <%= f.govuk_check_boxes_fieldset :course_choices_completed, legend: nil do %>
-            <%= f.hidden_field :course_choices_completed, value: false %>
-            <%= f.govuk_check_box(
-              :course_choices_completed,
-              true,
-              multiple: false,
-              label: {
-                text: t('application_form.courses.complete.completed_checkbox'),
-              },
-              link_errors: true,
-            ) %>
-          <% end %>
-
-          <%= f.govuk_submit t('continue') %>
-        <% end %>
-      </div>
-    </div>
-  <% end %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @application_choices.present? &&  @application_choices.count >= 1 %>
+      <%= render(CandidateInterface::CompleteSectionComponent.new(
+        section_complete_form: @section_complete_form,
+        path: candidate_interface_course_choices_complete_path,
+        request_method: :patch,
+        summary_component: CandidateInterface::CourseChoicesReviewComponent.new(application_form: @application_form),
+        complete_hint_text: if @application_choices.count == 1
+                              t('application_form.courses.complete.hint_text_two_courses')
+                            elsif @application_choices.count == 2
+                              t('application_form.courses.complete.hint_text_one_course')
+                            end
+      )) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -9,5 +9,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_contact_information_complete_path,
   request_method: :patch,
-  summary_component: CandidateInterface::ContactDetailsReviewComponent.new(application_form: @application_form),
+  review_component: CandidateInterface::ContactDetailsReviewComponent.new(application_form: @application_form),
 )) %>

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -9,5 +9,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_contact_information_complete_path,
   request_method: :patch,
-  summary_component: CandidateInterface::ContactDetailsReviewComponent.new(application_form: @application_form)
+  summary_component: CandidateInterface::ContactDetailsReviewComponent.new(application_form: @application_form),
 )) %>

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -5,11 +5,9 @@
   <%= t('page_titles.contact_information') %>
 </h1>
 
-<%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: @application_form)) %>
-
 <%= render(CandidateInterface::CompleteSectionComponent.new(
-  application_form: @application_form,
+  section_complete_form: @section_complete_form,
   path: candidate_interface_contact_information_complete_path,
   request_method: :patch,
-  field_name: :contact_details_completed,
+  summary_component: CandidateInterface::ContactDetailsReviewComponent.new(application_form: @application_form)
 )) %>

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -15,6 +15,6 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_degrees_complete_path,
   request_method: :patch,
-  summary_component: CandidateInterface::DegreesReviewComponent.new(application_form: @application_form),
+  review_component: CandidateInterface::DegreesReviewComponent.new(application_form: @application_form),
   hint_text: t('application_form.degree.review.complete_hint_text'),
 )) %>

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -15,5 +15,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_degrees_complete_path,
   request_method: :patch,
-  summary_component: CandidateInterface::DegreesReviewComponent.new(application_form: @application_form)
-)) %>
+  summary_component: CandidateInterface::DegreesReviewComponent.new(application_form: @application_form),
+  complete_hint_text: t('application_form.degree.review.complete_hint_text') )) %>

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -11,13 +11,9 @@
   </div>
 </div>
 
-<%= render(CandidateInterface::DegreesReviewComponent.new(application_form: @application_form)) %>
-
-<%= form_with model: @application_form, url: candidate_interface_degrees_complete_path do |f| %>
-  <div class="govuk-form-group">
-    <%= f.hidden_field :degrees_completed, value: false %>
-    <%= f.govuk_check_box :degrees_completed, true, multiple: false, label: { text: t('application_form.degree.review.completed_checkbox') } %>
-  </div>
-
-  <%= f.govuk_submit t('continue') %>
-<% end %>
+<%= render(CandidateInterface::CompleteSectionComponent.new(
+  section_complete_form: @section_complete_form,
+  path: candidate_interface_degrees_complete_path,
+  request_method: :patch,
+  summary_component: CandidateInterface::DegreesReviewComponent.new(application_form: @application_form)
+)) %>

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -16,4 +16,5 @@
   path: candidate_interface_degrees_complete_path,
   request_method: :patch,
   summary_component: CandidateInterface::DegreesReviewComponent.new(application_form: @application_form),
-  complete_hint_text: t('application_form.degree.review.complete_hint_text') )) %>
+  complete_hint_text: t('application_form.degree.review.complete_hint_text'),
+)) %>

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -16,5 +16,5 @@
   path: candidate_interface_degrees_complete_path,
   request_method: :patch,
   summary_component: CandidateInterface::DegreesReviewComponent.new(application_form: @application_form),
-  complete_hint_text: t('application_form.degree.review.complete_hint_text'),
+  hint_text: t('application_form.degree.review.complete_hint_text'),
 )) %>

--- a/app/views/candidate_interface/english_foreign_language/review/show.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/review/show.html.erb
@@ -7,5 +7,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_english_foreign_language_complete_path,
   request_method: :patch,
-  summary_component: @component_instance
+  summary_component: @component_instance,
 )) %>

--- a/app/views/candidate_interface/english_foreign_language/review/show.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/review/show.html.erb
@@ -7,5 +7,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_english_foreign_language_complete_path,
   request_method: :patch,
-  summary_component: @component_instance,
+  review_component: @component_instance,
 )) %>

--- a/app/views/candidate_interface/english_foreign_language/review/show.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/review/show.html.erb
@@ -1,17 +1,11 @@
 <% content_for :title, t('page_titles.efl.review') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
-<h1 class="govuk-heading-xl">
-  <%= t('page_titles.efl.review') %>
-</h1>
+<h1 class="govuk-heading-xl"><%= t('page_titles.efl.review') %></h1>
 
-<%= render(@component_instance) %>
-
-<%= form_with model: current_application, url: candidate_interface_english_foreign_language_complete_path do |f| %>
-  <div class='govuk-form-group'>
-    <%= f.hidden_field :efl_completed, value: false %>
-    <%= f.govuk_check_box :efl_completed, true, multiple: false, label: { text: t('application_form.degree.review.completed_checkbox') } %>
-  </div>
-
-  <%= f.govuk_submit t('continue') %>
-<% end %>
+<%= render(CandidateInterface::CompleteSectionComponent.new(
+  section_complete_form: @section_complete_form,
+  path: candidate_interface_english_foreign_language_complete_path,
+  request_method: :patch,
+  summary_component: @component_instance
+)) %>

--- a/app/views/candidate_interface/gcse/review/show.html.erb
+++ b/app/views/candidate_interface/gcse/review/show.html.erb
@@ -10,6 +10,6 @@
   summary_component: CandidateInterface::GcseQualificationReviewComponent.new(
     application_form: @application_form,
     application_qualification: @application_qualification,
-    subject: @subject
-  )
+    subject: @subject,
+  ),
 )) %>

--- a/app/views/candidate_interface/gcse/review/show.html.erb
+++ b/app/views/candidate_interface/gcse/review/show.html.erb
@@ -7,7 +7,7 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_gcse_complete_path,
   request_method: :patch,
-  summary_component: CandidateInterface::GcseQualificationReviewComponent.new(
+  review_component: CandidateInterface::GcseQualificationReviewComponent.new(
     application_form: @application_form,
     application_qualification: @application_qualification,
     subject: @subject,

--- a/app/views/candidate_interface/gcse/review/show.html.erb
+++ b/app/views/candidate_interface/gcse/review/show.html.erb
@@ -3,11 +3,13 @@
 
 <h1 class="govuk-heading-xl"><%= t("gcse_summary.page_titles.#{@subject}") %></h1>
 
-<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_qualification, subject: @subject)) %>
-
 <%= render(CandidateInterface::CompleteSectionComponent.new(
-  application_form: @application_form,
+  section_complete_form: @section_complete_form,
   path: candidate_interface_gcse_complete_path,
   request_method: :patch,
-  field_name: @field_name,
+  summary_component: CandidateInterface::GcseQualificationReviewComponent.new(
+    application_form: @application_form,
+    application_qualification: @application_qualification,
+    subject: @subject
+  )
 )) %>

--- a/app/views/candidate_interface/interview_needs/show.html.erb
+++ b/app/views/candidate_interface/interview_needs/show.html.erb
@@ -5,11 +5,9 @@
   <%= t('page_titles.interview_preferences') %>
 </h1>
 
-<%= render(CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: @application_form)) %>
-
 <%= render(CandidateInterface::CompleteSectionComponent.new(
-  application_form: @application_form,
+  section_complete_form: @section_complete_form,
   path: candidate_interface_interview_preferences_complete_path,
   request_method: :patch,
-  field_name: :interview_preferences_completed,
+  summary_component: CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: @application_form)
 )) %>

--- a/app/views/candidate_interface/interview_needs/show.html.erb
+++ b/app/views/candidate_interface/interview_needs/show.html.erb
@@ -9,5 +9,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_interview_preferences_complete_path,
   request_method: :patch,
-  summary_component: CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: @application_form),
+  review_component: CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: @application_form),
 )) %>

--- a/app/views/candidate_interface/interview_needs/show.html.erb
+++ b/app/views/candidate_interface/interview_needs/show.html.erb
@@ -9,5 +9,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_interview_preferences_complete_path,
   request_method: :patch,
-  summary_component: CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: @application_form)
+  summary_component: CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: @application_form),
 )) %>

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -5,13 +5,9 @@
   <%= other_qualifications_title(@application_form) %>
 </h1>
 
-<%= render(CandidateInterface::OtherQualificationsReviewComponent.new(application_form: @application_form)) %>
-
-<%= form_with model: @application_form, url: candidate_interface_complete_other_qualifications_path do |f| %>
-  <div class="govuk-form-group">
-    <%= f.hidden_field :other_qualifications_completed, value: false %>
-    <%= f.govuk_check_box :other_qualifications_completed, true, multiple: false, label: { text: t('application_form.other_qualification.review.completed_checkbox') } %>
-  </div>
-
-  <%= f.govuk_submit t('continue') %>
-<% end %>
+<%= render(CandidateInterface::CompleteSectionComponent.new(
+  section_complete_form: @section_complete_form,
+  path: candidate_interface_complete_other_qualifications_path,
+  request_method: :patch,
+  summary_component: CandidateInterface::OtherQualificationsReviewComponent.new(application_form: @application_form)
+)) %>

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -9,5 +9,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_complete_other_qualifications_path,
   request_method: :patch,
-  summary_component: CandidateInterface::OtherQualificationsReviewComponent.new(application_form: @application_form)
+  summary_component: CandidateInterface::OtherQualificationsReviewComponent.new(application_form: @application_form),
 )) %>

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -9,5 +9,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_complete_other_qualifications_path,
   request_method: :patch,
-  summary_component: CandidateInterface::OtherQualificationsReviewComponent.new(application_form: @application_form),
+  review_component: CandidateInterface::OtherQualificationsReviewComponent.new(application_form: @application_form),
 )) %>

--- a/app/views/candidate_interface/personal_details/review/show.html.erb
+++ b/app/views/candidate_interface/personal_details/review/show.html.erb
@@ -2,7 +2,7 @@
                                                 @personal_details_form.errors.any? ||
                                                  @nationalities_form.errors.any? ||
                                                  @languages_form.errors.any? ||
-                                                  @section_complete_form.errors.any? ) %>
+                                                  @section_complete_form.errors.any?) %>
 
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
@@ -14,5 +14,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_personal_details_complete_path,
   request_method: :patch,
-  summary_component: SummaryCardComponent.new(rows: @personal_details_review.rows)
+  summary_component: SummaryCardComponent.new(rows: @personal_details_review.rows),
 )) %>

--- a/app/views/candidate_interface/personal_details/review/show.html.erb
+++ b/app/views/candidate_interface/personal_details/review/show.html.erb
@@ -1,7 +1,8 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.personal_information'),
                                                 @personal_details_form.errors.any? ||
                                                  @nationalities_form.errors.any? ||
-                                                 @languages_form.errors.any?) %>
+                                                 @languages_form.errors.any? ||
+                                                  @section_complete_form.errors.any? ) %>
 
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
@@ -9,11 +10,9 @@
   <%= t('page_titles.personal_information') %>
 </h1>
 
-<%= render(SummaryCardComponent.new(rows: @personal_details_review.rows)) %>
-
 <%= render(CandidateInterface::CompleteSectionComponent.new(
-  application_form: @application_form,
+  section_complete_form: @section_complete_form,
   path: candidate_interface_personal_details_complete_path,
   request_method: :patch,
-  field_name: :personal_details_completed,
+  summary_component: SummaryCardComponent.new(rows: @personal_details_review.rows)
 )) %>

--- a/app/views/candidate_interface/personal_details/review/show.html.erb
+++ b/app/views/candidate_interface/personal_details/review/show.html.erb
@@ -14,5 +14,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_personal_details_complete_path,
   request_method: :patch,
-  summary_component: SummaryCardComponent.new(rows: @personal_details_review.rows),
+  review_component: SummaryCardComponent.new(rows: @personal_details_review.rows),
 )) %>

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -31,7 +31,7 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_becoming_a_teacher_complete_path,
   request_method: :patch,
-  summary_component: CandidateInterface::BecomingATeacherReviewComponent.new(application_form: @application_form),
+  review_component: CandidateInterface::BecomingATeacherReviewComponent.new(application_form: @application_form),
   hint_text: t('application_form.personal_statement.becoming_a_teacher.complete_hint_text_html'),
   section_review: @application_form.reviewable?(:becoming_a_teacher),
 )) %>

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -32,6 +32,6 @@
   path: candidate_interface_becoming_a_teacher_complete_path,
   request_method: :patch,
   summary_component: CandidateInterface::BecomingATeacherReviewComponent.new(application_form: @application_form),
-  complete_hint_text: t('application_form.personal_statement.becoming_a_teacher.complete_hint_text_html'),
+  hint_text: t('application_form.personal_statement.becoming_a_teacher.complete_hint_text_html'),
   section_review: @application_form.reviewable?(:becoming_a_teacher),
 )) %>

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -32,6 +32,9 @@
   path: candidate_interface_becoming_a_teacher_complete_path,
   request_method: :patch,
   review_component: CandidateInterface::BecomingATeacherReviewComponent.new(application_form: @application_form),
-  hint_text: t('application_form.personal_statement.becoming_a_teacher.complete_hint_text_html'),
+  hint_text: [
+    t('application_form.personal_statement.becoming_a_teacher.complete_hint_text_one'),
+    t('application_form.personal_statement.becoming_a_teacher.complete_hint_text_two'),
+  ],
   section_review: @application_form.reviewable?(:becoming_a_teacher),
 )) %>

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -27,12 +27,11 @@
   <p class="govuk-body govuk-!-font-weight-bold">You’ll be able to review it again before you submit your application.</p>
 <% end %>
 
-<%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: @application_form)) %>
-
 <%= render(CandidateInterface::CompleteSectionComponent.new(
-  application_form: @application_form,
+  section_complete_form: @section_complete_form,
   path: candidate_interface_becoming_a_teacher_complete_path,
   request_method: :patch,
-  field_name: :becoming_a_teacher_completed,
+  summary_component: CandidateInterface::BecomingATeacherReviewComponent.new(application_form: @application_form),
+  complete_hint_text: t('application_form.personal_statement.becoming_a_teacher.complete_hint_text_html'),
   section_review: @application_form.reviewable?(:becoming_a_teacher),
 )) %>

--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -19,14 +19,11 @@
 <% end %>
 
 <% unless @application_form.can_complete? && @application_form.application_work_experiences.blank? %>
-  <%= render(CandidateInterface::RestructuredWorkHistory::ReviewComponent.new(application_form: @application_form)) %>
-
-  <%= form_with model: @application_form, url: candidate_interface_restructured_work_history_complete_path do |f| %>
-    <div class="govuk-form-group">
-      <%= f.hidden_field :work_history_completed, value: false %>
-      <%= f.govuk_check_box :work_history_completed, true, multiple: false, label: { text: t('application_form.work_history.review.completed_checkbox') } %>
-    </div>
-
-    <%= f.govuk_submit t('save_and_continue') %>
-  <% end %>
+  <%= render(CandidateInterface::CompleteSectionComponent.new(
+    section_complete_form: @section_complete_form,
+    path: candidate_interface_restructured_work_history_complete_path,
+    request_method: :patch,
+    summary_component: CandidateInterface::RestructuredWorkHistory::ReviewComponent.new(application_form: @application_form),
+    complete_hint_text: t('application_form.work_history.complete.hint_text')
+  )) %>
 <% end %>

--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -24,6 +24,6 @@
     path: candidate_interface_restructured_work_history_complete_path,
     request_method: :patch,
     summary_component: CandidateInterface::RestructuredWorkHistory::ReviewComponent.new(application_form: @application_form),
-    complete_hint_text: t('application_form.work_history.complete.hint_text')
+    complete_hint_text: t('application_form.work_history.complete.hint_text'),
   )) %>
 <% end %>

--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -23,7 +23,7 @@
     section_complete_form: @section_complete_form,
     path: candidate_interface_restructured_work_history_complete_path,
     request_method: :patch,
-    summary_component: CandidateInterface::RestructuredWorkHistory::ReviewComponent.new(application_form: @application_form),
+    review_component: CandidateInterface::RestructuredWorkHistory::ReviewComponent.new(application_form: @application_form),
     hint_text: t('application_form.work_history.complete.hint_text'),
   )) %>
 <% end %>

--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -24,6 +24,6 @@
     path: candidate_interface_restructured_work_history_complete_path,
     request_method: :patch,
     summary_component: CandidateInterface::RestructuredWorkHistory::ReviewComponent.new(application_form: @application_form),
-    complete_hint_text: t('application_form.work_history.complete.hint_text'),
+    hint_text: t('application_form.work_history.complete.hint_text'),
   )) %>
 <% end %>

--- a/app/views/candidate_interface/safeguarding/show.html.erb
+++ b/app/views/candidate_interface/safeguarding/show.html.erb
@@ -9,5 +9,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_complete_safeguarding_path,
   request_method: :post,
-  summary_component: CandidateInterface::SafeguardingReviewComponent.new(application_form: @current_application),
+  review_component: CandidateInterface::SafeguardingReviewComponent.new(application_form: @current_application),
 )) %>

--- a/app/views/candidate_interface/safeguarding/show.html.erb
+++ b/app/views/candidate_interface/safeguarding/show.html.erb
@@ -9,5 +9,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_complete_safeguarding_path,
   request_method: :post,
-  summary_component: CandidateInterface::SafeguardingReviewComponent.new(application_form: @current_application)
+  summary_component: CandidateInterface::SafeguardingReviewComponent.new(application_form: @current_application),
 )) %>

--- a/app/views/candidate_interface/safeguarding/show.html.erb
+++ b/app/views/candidate_interface/safeguarding/show.html.erb
@@ -5,11 +5,9 @@
   <%= t('page_titles.suitability_to_work_with_children') %>
 </h1>
 
-<%= render(CandidateInterface::SafeguardingReviewComponent.new(application_form: @current_application)) %>
-
 <%= render(CandidateInterface::CompleteSectionComponent.new(
-  application_form: @application_form,
+  section_complete_form: @section_complete_form,
   path: candidate_interface_complete_safeguarding_path,
   request_method: :post,
-  field_name: :safeguarding_issues_completed,
+  summary_component: CandidateInterface::SafeguardingReviewComponent.new(application_form: @current_application)
 )) %>

--- a/app/views/candidate_interface/subject_knowledge/show.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/show.html.erb
@@ -24,6 +24,6 @@
   path: candidate_interface_subject_knowledge_complete_path,
   request_method: :patch,
   section_review: @application_form.reviewable?(:subject_knowledge),
-  summary_component: CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: @application_form),
+  review_component: CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: @application_form),
   hint_text: t('application_form.personal_statement.subject_knowledge.complete_hint_text_html'),
 )) %>

--- a/app/views/candidate_interface/subject_knowledge/show.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/show.html.erb
@@ -25,5 +25,8 @@
   request_method: :patch,
   section_review: @application_form.reviewable?(:subject_knowledge),
   review_component: CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: @application_form),
-  hint_text: t('application_form.personal_statement.subject_knowledge.complete_hint_text_html'),
+  hint_text: [
+    t('application_form.personal_statement.subject_knowledge.complete_hint_text_one'),
+    t('application_form.personal_statement.subject_knowledge.complete_hint_text_two'),
+  ],
 )) %>

--- a/app/views/candidate_interface/subject_knowledge/show.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/show.html.erb
@@ -19,12 +19,11 @@
   <% end %>
 <% end %>
 
-<%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: @application_form)) %>
-
 <%= render(CandidateInterface::CompleteSectionComponent.new(
-  application_form: @application_form,
+  section_complete_form: @section_complete_form,
   path: candidate_interface_subject_knowledge_complete_path,
   request_method: :patch,
-  field_name: :subject_knowledge_completed,
   section_review: @application_form.reviewable?(:subject_knowledge),
+  summary_component: CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: @application_form),
+  complete_hint_text: t('application_form.personal_statement.subject_knowledge.complete_hint_text_html'),
 )) %>

--- a/app/views/candidate_interface/subject_knowledge/show.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/show.html.erb
@@ -25,5 +25,5 @@
   request_method: :patch,
   section_review: @application_form.reviewable?(:subject_knowledge),
   summary_component: CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: @application_form),
-  complete_hint_text: t('application_form.personal_statement.subject_knowledge.complete_hint_text_html'),
+  hint_text: t('application_form.personal_statement.subject_knowledge.complete_hint_text_html'),
 )) %>

--- a/app/views/candidate_interface/training_with_a_disability/show.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/show.html.erb
@@ -9,5 +9,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_training_with_a_disability_complete_path,
   request_method: :patch,
-  summary_component: CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form)
+  summary_component: CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form),
 )) %>

--- a/app/views/candidate_interface/training_with_a_disability/show.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/show.html.erb
@@ -5,11 +5,9 @@
   <%= t('page_titles.training_with_a_disability') %>
 </h1>
 
-<%= render(CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form)) %>
-
 <%= render(CandidateInterface::CompleteSectionComponent.new(
-  application_form: @application_form,
+  section_complete_form: @section_complete_form,
   path: candidate_interface_training_with_a_disability_complete_path,
   request_method: :patch,
-  field_name: :training_with_a_disability_completed,
+  summary_component: CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form)
 )) %>

--- a/app/views/candidate_interface/training_with_a_disability/show.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/show.html.erb
@@ -9,5 +9,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_training_with_a_disability_complete_path,
   request_method: :patch,
-  summary_component: CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form),
+  review_component: CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form),
 )) %>

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -6,11 +6,9 @@
   <%= govuk_link_to(t('application_form.volunteering.another.button'), candidate_interface_new_volunteering_role_path, button: true, class: 'govuk-button--secondary') %>
 <% end %>
 
-<%= render(CandidateInterface::VolunteeringReviewComponent.new(application_form: @application_form, show_experience_advice: true)) %>
-
 <%= render(CandidateInterface::CompleteSectionComponent.new(
-  application_form: @application_form,
+  section_complete_form: @section_complete_form,
   path: candidate_interface_complete_volunteering_path,
   request_method: :patch,
-  field_name: :volunteering_completed,
+  summary_component: CandidateInterface::VolunteeringReviewComponent.new(application_form: @application_form),
 )) %>

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -10,5 +10,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_complete_volunteering_path,
   request_method: :patch,
-  summary_component: CandidateInterface::VolunteeringReviewComponent.new(application_form: @application_form, show_experience_advice: true),
+  review_component: CandidateInterface::VolunteeringReviewComponent.new(application_form: @application_form, show_experience_advice: true),
 )) %>

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -10,5 +10,5 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_complete_volunteering_path,
   request_method: :patch,
-  summary_component: CandidateInterface::VolunteeringReviewComponent.new(application_form: @application_form),
+  summary_component: CandidateInterface::VolunteeringReviewComponent.new(application_form: @application_form, show_experience_advice: true),
 )) %>

--- a/app/views/candidate_interface/work_history/review/show.html.erb
+++ b/app/views/candidate_interface/work_history/review/show.html.erb
@@ -13,13 +13,10 @@
   </div>
 </div>
 
-<%= render(CandidateInterface::WorkHistoryReviewComponent.new(application_form: @application_form)) %>
-
-<%= form_with model: @application_form, url: candidate_interface_work_history_complete_path do |f| %>
-  <div class="govuk-form-group">
-    <%= f.hidden_field :work_history_completed, value: false %>
-    <%= f.govuk_check_box :work_history_completed, true, multiple: false, label: { text: t('application_form.work_history.review.completed_checkbox') } %>
-  </div>
-
-  <%= f.govuk_submit t('continue') %>
-<% end %>
+<%= render(CandidateInterface::CompleteSectionComponent.new(
+  section_complete_form: @section_complete_form,
+  path: candidate_interface_work_history_complete_path,
+  request_method: :patch,
+  summary_component: CandidateInterface::WorkHistoryReviewComponent.new(application_form: @application_form),
+  complete_hint_text: t('application_form.work_history.complete.hint_text')
+)) %>

--- a/app/views/candidate_interface/work_history/review/show.html.erb
+++ b/app/views/candidate_interface/work_history/review/show.html.erb
@@ -17,6 +17,6 @@
   section_complete_form: @section_complete_form,
   path: candidate_interface_work_history_complete_path,
   request_method: :patch,
-  summary_component: CandidateInterface::WorkHistoryReviewComponent.new(application_form: @application_form),
+  review_component: CandidateInterface::WorkHistoryReviewComponent.new(application_form: @application_form),
   hint_text: t('application_form.work_history.complete.hint_text'),
 )) %>

--- a/app/views/candidate_interface/work_history/review/show.html.erb
+++ b/app/views/candidate_interface/work_history/review/show.html.erb
@@ -18,5 +18,5 @@
   path: candidate_interface_work_history_complete_path,
   request_method: :patch,
   summary_component: CandidateInterface::WorkHistoryReviewComponent.new(application_form: @application_form),
-  complete_hint_text: t('application_form.work_history.complete.hint_text'),
+  hint_text: t('application_form.work_history.complete.hint_text'),
 )) %>

--- a/app/views/candidate_interface/work_history/review/show.html.erb
+++ b/app/views/candidate_interface/work_history/review/show.html.erb
@@ -18,5 +18,5 @@
   path: candidate_interface_work_history_complete_path,
   request_method: :patch,
   summary_component: CandidateInterface::WorkHistoryReviewComponent.new(application_form: @application_form),
-  complete_hint_text: t('application_form.work_history.complete.hint_text')
+  complete_hint_text: t('application_form.work_history.complete.hint_text'),
 )) %>

--- a/config/locales/candidate_interface/application_form.yml
+++ b/config/locales/candidate_interface/application_form.yml
@@ -1,8 +1,10 @@
 en:
   application_form:
     begin_button: Start now
-    completed_checkbox: I have completed this section
-    reviewed_checkbox: I have reviewed this section
+    completed_question: Have you completed this section?
+    completed_radio: Yes, I have completed this section
+    reviewed_radio: I have reviewed this section
+    incomplete_radio: No, I'll come back to it later
 
   activemodel:
     errors:

--- a/config/locales/candidate_interface/courses.yml
+++ b/config/locales/candidate_interface/courses.yml
@@ -8,8 +8,9 @@ en:
         button: Add another course
       withdraw: Withdraw
       complete:
-        hint_text_one_course: You can add one more course
-        hint_text_two_courses: You can add two more courses
+        hint_text:
+          one: You can add one more course
+          other: You can add %{count} more courses
       view_and_respond_to_offer: View and respond to offer
     confirm_selection:
       heading: You selected a course

--- a/config/locales/candidate_interface/courses.yml
+++ b/config/locales/candidate_interface/courses.yml
@@ -8,7 +8,8 @@ en:
         button: Add another course
       withdraw: Withdraw
       complete:
-        completed_checkbox: I have completed this section
+        hint_text_one_course: You can add one more course
+        hint_text_two_courses: You can add two more courses
       view_and_respond_to_offer: View and respond to offer
     confirm_selection:
       heading: You selected a course

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -59,7 +59,7 @@ en:
         review_label: Graduation year
         change_action: year
       review:
-        completed_checkbox: I have completed this section
+        complete_hint_text: Check the entry requirements for your chosen course. Providers usually ask for a degree at 2:2 or above. Contact the training provider if you do not have the right degree level.
       another:
         button: Add another degree
       delete: Delete degree

--- a/config/locales/candidate_interface/other_qualification.yml
+++ b/config/locales/candidate_interface/other_qualification.yml
@@ -32,8 +32,6 @@ en:
         button: Add another qualification
       first:
         button: Add a qualification
-      review:
-        completed_checkbox: I have completed this section
       delete: Delete qualification
       confirm_delete: Yes I’m sure - delete this qualification
 

--- a/config/locales/candidate_interface/personal_statement.yml
+++ b/config/locales/candidate_interface/personal_statement.yml
@@ -4,6 +4,9 @@ en:
       becoming_a_teacher:
         change_action: why do you want to be a teacher?
         label: Why do you want to be a teacher?
+        complete_hint_text_html: |
+          Proofread this section carefully for spelling and grammar. Ask someone you trust for their opinion.
+          <p>Ensure this is all your own work as plagiarism will be penalised.</p>
       subject_knowledge:
         key: Your knowledge about the subject you want to teach
         change_action: evidence of subject knowledge

--- a/config/locales/candidate_interface/personal_statement.yml
+++ b/config/locales/candidate_interface/personal_statement.yml
@@ -4,16 +4,14 @@ en:
       becoming_a_teacher:
         change_action: why do you want to be a teacher?
         label: Why do you want to be a teacher?
-        complete_hint_text_html: |
-          <p>Proofread this section carefully for spelling and grammar. Ask someone you trust for their opinion.</p>
-          <p>Ensure this is all your own work as plagiarism will be penalised.</p>
+        complete_hint_text_one: Proofread this section carefully for spelling and grammar. Ask someone you trust for their opinion.
+        complete_hint_text_two: Ensure this is all your own work as plagiarism will be penalised.
       subject_knowledge:
         key: Your knowledge about the subject you want to teach
         change_action: evidence of subject knowledge
         label: Tell us what you know about the subject you want to teach
-        complete_hint_text_html: |
-          <p>Proofread this section carefully for spelling and grammar. Ask someone you trust for their opinion.</p>
-          <p>Ensure this is all your own work as plagiarism will be penalised.</p>
+        complete_hint_text_one: Proofread this section carefully for spelling and grammar. Ask someone you trust for their opinion.
+        complete_hint_text_two: Ensure this is all your own work as plagiarism will be penalised.
       interview_preferences:
         key: Interview needs
         change_action: interview needs

--- a/config/locales/candidate_interface/personal_statement.yml
+++ b/config/locales/candidate_interface/personal_statement.yml
@@ -11,6 +11,9 @@ en:
         key: Your knowledge about the subject you want to teach
         change_action: evidence of subject knowledge
         label: Tell us what you know about the subject you want to teach
+        complete_hint_text_html: |
+          Proofread this section carefully for spelling and grammar. Ask someone you trust for their opinion.
+          <p>Ensure this is all your own work as plagiarism will be penalised.</p>
       interview_preferences:
         key: Interview needs
         change_action: interview needs

--- a/config/locales/candidate_interface/personal_statement.yml
+++ b/config/locales/candidate_interface/personal_statement.yml
@@ -5,14 +5,14 @@ en:
         change_action: why do you want to be a teacher?
         label: Why do you want to be a teacher?
         complete_hint_text_html: |
-          Proofread this section carefully for spelling and grammar. Ask someone you trust for their opinion.
+          <p>Proofread this section carefully for spelling and grammar. Ask someone you trust for their opinion.</p>
           <p>Ensure this is all your own work as plagiarism will be penalised.</p>
       subject_knowledge:
         key: Your knowledge about the subject you want to teach
         change_action: evidence of subject knowledge
         label: Tell us what you know about the subject you want to teach
         complete_hint_text_html: |
-          Proofread this section carefully for spelling and grammar. Ask someone you trust for their opinion.
+          <p>Proofread this section carefully for spelling and grammar. Ask someone you trust for their opinion.</p>
           <p>Ensure this is all your own work as plagiarism will be penalised.</p>
       interview_preferences:
         key: Interview needs

--- a/config/locales/candidate_interface/section_complete.yml
+++ b/config/locales/candidate_interface/section_complete.yml
@@ -6,3 +6,4 @@ en:
           attributes:
             completed:
               blank: Select whether you have completed this section
+              inclusion: Select ‘true’ or ‘false’

--- a/config/locales/candidate_interface/section_complete.yml
+++ b/config/locales/candidate_interface/section_complete.yml
@@ -1,0 +1,8 @@
+en:
+  activemodel:
+    errors:
+      models:
+        candidate_interface/section_complete_form:
+          attributes:
+            completed:
+              blank: Select whether you have completed this section

--- a/config/locales/candidate_interface/volunteering.yml
+++ b/config/locales/candidate_interface/volunteering.yml
@@ -44,8 +44,6 @@ en:
         button: Add a role
       another:
         button: Add another role
-      review:
-        completed_checkbox: I have completed this section
       start_date_restructured_work_history:
         label: When did you start this role?
         hint_text: For example, 5 2018. If you cannot remember the exact month or year, enter an estimate.

--- a/config/locales/candidate_interface/work_history.yml
+++ b/config/locales/candidate_interface/work_history.yml
@@ -68,7 +68,7 @@ en:
       another:
         button: Add another job
       review:
-        completed_checkbox: I have completed this section
+        complete_hint_text: Ensure you’ve added all the jobs you’ve had since you left school. Remember to explain any gaps in your work history.
 
   activemodel:
     errors:

--- a/spec/components/candidate_interface/complete_section_component_spec.rb
+++ b/spec/components/candidate_interface/complete_section_component_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::CompleteSectionComponent do
   let(:section_complete_form) { CandidateInterface::SectionCompleteForm.new }
-  let(:summary_component) { ViewComponent::Base.new }
-  let(:application_form) { create(:application_form) }
+  let(:application_form) { build_stubbed(:application_form, :minimum_info) }
+  let(:review_component) { CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: application_form) }
   let(:path) { Rails.application.routes.url_helpers.candidate_interface_application_form_path }
   let(:field_name) { 'completed' }
   let(:request_method) { 'post' }
@@ -15,10 +15,13 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
         section_complete_form: section_complete_form,
         path: path,
         request_method: request_method,
+        review_component: review_component,
       ),
     )
 
-    expect(result.css('.govuk-form-group').text).to include 'I have completed this section'
+    expect(result.css('.govuk-form-group').text).to include t('application_form.completed_radio')
+    expect(result.css('.govuk-form-group').text).to include t('application_form.incomplete_radio')
+    expect(result.css('.app-summary-card').text).to include 'Interview needs'
     expect(result.to_html).to include path
     expect(result.to_html).to include request_method
     expect(result.to_html).to include field_name
@@ -31,10 +34,11 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
         path: path,
         request_method: request_method,
         hint_text: hint_text,
+        review_component: review_component,
       ),
     )
 
-    expect(result.to_html).to include complete_hint_text
+    expect(result.to_html).to include hint_text
   end
 
   it 'renders a review radio button label if specified' do
@@ -44,9 +48,10 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
         path: path,
         request_method: request_method,
         section_review: true,
+        review_component: review_component,
       ),
     )
 
-    expect(result.css('.govuk-form-group').text).to include 'I have reviewed this section'
+    expect(result.css('.govuk-form-group').text).to include t('application_form.reviewed_radio')
   end
 end

--- a/spec/components/candidate_interface/complete_section_component_spec.rb
+++ b/spec/components/candidate_interface/complete_section_component_spec.rb
@@ -41,6 +41,23 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
     expect(result.to_html).to include hint_text
   end
 
+  it 'renders more than one hint' do
+    another_hint_text = 'Another hint text'
+
+    result = render_inline(
+      described_class.new(
+        section_complete_form: section_complete_form,
+        path: path,
+        request_method: request_method,
+        hint_text: [hint_text, another_hint_text],
+        review_component: review_component,
+      ),
+    )
+
+    expect(result.to_html).to include hint_text
+    expect(result.to_html).to include another_hint_text
+  end
+
   it 'renders a review radio button label if specified' do
     result = render_inline(
       described_class.new(

--- a/spec/components/candidate_interface/complete_section_component_spec.rb
+++ b/spec/components/candidate_interface/complete_section_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
   let(:path) { Rails.application.routes.url_helpers.candidate_interface_application_form_path }
   let(:field_name) { 'completed' }
   let(:request_method) { 'post' }
-  let(:complete_hint_text) { 'hints' }
+  let(:hint_text) { 'hints' }
 
   it 'renders successfully' do
     result = render_inline(
@@ -30,7 +30,7 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
         section_complete_form: section_complete_form,
         path: path,
         request_method: request_method,
-        complete_hint_text: complete_hint_text,
+        hint_text: hint_text,
       ),
     )
 

--- a/spec/components/candidate_interface/complete_section_component_spec.rb
+++ b/spec/components/candidate_interface/complete_section_component_spec.rb
@@ -1,18 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::CompleteSectionComponent do
+  let(:section_complete_form) { CandidateInterface::SectionCompleteForm.new }
+  let(:summary_component) { ViewComponent::Base.new }
   let(:application_form) { create(:application_form) }
   let(:path) { Rails.application.routes.url_helpers.candidate_interface_application_form_path }
-  let(:field_name) { 'field_name' }
+  let(:field_name) { 'completed' }
   let(:request_method) { 'post' }
+  let(:complete_hint_text) { 'hints' }
 
   it 'renders successfully' do
     result = render_inline(
       described_class.new(
-        application_form: application_form,
+        section_complete_form: section_complete_form,
         path: path,
         request_method: request_method,
-        field_name: field_name,
       ),
     )
 
@@ -22,20 +24,29 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
     expect(result.to_html).to include field_name
   end
 
-  it 'renders a review checkbox label if specified' do
+  it 'renders a hint if specified' do
     result = render_inline(
       described_class.new(
-        application_form: application_form,
+        section_complete_form: section_complete_form,
         path: path,
         request_method: request_method,
-        field_name: field_name,
+        complete_hint_text: complete_hint_text,
+      ),
+    )
+
+    expect(result.to_html).to include complete_hint_text
+  end
+
+  it 'renders a review radio button label if specified' do
+    result = render_inline(
+      described_class.new(
+        section_complete_form: section_complete_form,
+        path: path,
+        request_method: request_method,
         section_review: true,
       ),
     )
 
     expect(result.css('.govuk-form-group').text).to include 'I have reviewed this section'
-    expect(result.to_html).to include path
-    expect(result.to_html).to include request_method
-    expect(result.to_html).to include field_name
   end
 end

--- a/spec/forms/candidate_interface/section_complete_form_spec.rb
+++ b/spec/forms/candidate_interface/section_complete_form_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::SectionCompleteForm, type: :model do
+  it "validates presence of 'completed'" do
+    degree_form = described_class.new(completed: nil)
+    error_message = t('activemodel.errors.models.candidate_interface/section_complete_form.attributes.completed.blank')
+
+    degree_form.validate
+
+    expect(degree_form.errors.full_messages_for(:completed)).to eq(
+      ["Completed #{error_message}"],
+    )
+  end
+
+  describe '#new' do
+    it "sets the 'completed' attribute" do
+      section_complete_form = described_class.new(completed: true)
+
+      expect(section_complete_form.completed).to eq(true)
+    end
+  end
+
+  describe '#save' do
+    let(:application_form) { create(:application_form, :minimum_info, personal_details_completed: nil) }
+
+    it 'returns false if not valid' do
+      section_complete_form = described_class.new(completed: nil)
+
+      expect(section_complete_form.save(application_form, :personal_details_completed)).to eq(false)
+    end
+
+    it "updates 'section completed' if valid" do
+      section_complete_form = described_class.new(completed: true)
+
+      expect(section_complete_form.save(application_form, :personal_details_completed)).to eq(true)
+      expect(application_form.personal_details_completed).to eq(true)
+    end
+  end
+end

--- a/spec/forms/candidate_interface/section_complete_form_spec.rb
+++ b/spec/forms/candidate_interface/section_complete_form_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::SectionCompleteForm, type: :model do
   describe 'validations' do
-    it "validates presence of 'completed'" do
+    it "validates 'completed'" do
       degree_form = described_class.new(completed: nil)
       error_message_blank = t('activemodel.errors.models.candidate_interface/section_complete_form.attributes.completed.blank')
       error_message_inclusion = t('activemodel.errors.models.candidate_interface/section_complete_form.attributes.completed.inclusion')
@@ -36,7 +36,7 @@ RSpec.describe CandidateInterface::SectionCompleteForm, type: :model do
     end
 
     it "updates 'section completed' if valid" do
-      section_complete_form = described_class.new(completed: true)
+      section_complete_form = described_class.new(completed: 'true')
 
       expect(section_complete_form.save(application_form, :personal_details_completed)).to eq(true)
       expect(application_form.personal_details_completed).to eq(true)

--- a/spec/forms/candidate_interface/section_complete_form_spec.rb
+++ b/spec/forms/candidate_interface/section_complete_form_spec.rb
@@ -1,15 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::SectionCompleteForm, type: :model do
-  it "validates presence of 'completed'" do
-    degree_form = described_class.new(completed: nil)
-    error_message = t('activemodel.errors.models.candidate_interface/section_complete_form.attributes.completed.blank')
+  describe 'validations' do
+    it "validates presence of 'completed'" do
+      degree_form = described_class.new(completed: nil)
+      error_message_blank = t('activemodel.errors.models.candidate_interface/section_complete_form.attributes.completed.blank')
+      error_message_inclusion = t('activemodel.errors.models.candidate_interface/section_complete_form.attributes.completed.inclusion')
 
-    degree_form.validate
+      degree_form.validate
 
-    expect(degree_form.errors.full_messages_for(:completed)).to eq(
-      ["Completed #{error_message}"],
-    )
+      expect(degree_form.errors.full_messages_for(:completed)).to eq(
+        [
+          "Completed #{error_message_blank}",
+          "Completed #{error_message_inclusion}",
+        ],
+      )
+    end
   end
 
   describe '#new' do

--- a/spec/forms/support_interface/provider_user_form_spec.rb
+++ b/spec/forms/support_interface/provider_user_form_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SupportInterface::ProviderUserForm do
     }
   end
 
-  subject(:provider_user_form) { described_class.new(form_params) }
+  subject(:provider_user_form) { described_class.new(section_complete_form_params) }
 
   describe 'validations' do
     context 'email address exists' do

--- a/spec/forms/support_interface/provider_user_form_spec.rb
+++ b/spec/forms/support_interface/provider_user_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SupportInterface::ProviderUserForm do
       },
     }
   end
-  let(:form_params) do
+  let(:section_complete_form_params) do
     {
       first_name: 'Jane',
       last_name: 'Smith',

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -155,7 +155,7 @@ module CandidateHelper
     choose 'Primary (2XT2)'
     click_button t('continue')
 
-    check t('application_form.courses.complete.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -140,7 +140,7 @@ module CandidateHelper
     choose 'No, not at the moment'
     click_button t('continue')
 
-    check t('application_form.courses.complete.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 
@@ -189,7 +189,7 @@ module CandidateHelper
     end
     click_button t('save_and_continue')
 
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 
@@ -204,7 +204,7 @@ module CandidateHelper
     fill_in t('application_form.contact_details.postcode.uk.label'), with: 'SW1P 3BT'
     click_button t('save_and_continue')
 
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 
@@ -250,7 +250,7 @@ module CandidateHelper
     fill_in 'Year started course', with: year_with_trailing_space
     fill_in 'Graduation year', with: year_with_preceding_space
     click_button t('save_and_continue')
-    check t('application_form.degree.review.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 
@@ -262,7 +262,7 @@ module CandidateHelper
     fill_in t('application_form.other_qualification.award_year.label'), with: '2015'
     choose 'No, not at the moment'
     click_button t('save_and_continue')
-    check t('application_form.other_qualification.review.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 
@@ -270,7 +270,7 @@ module CandidateHelper
     choose t('application_form.training_with_a_disability.disclose_disability.yes')
     fill_in t('application_form.training_with_a_disability.disability_disclosure.label'), with: 'I have difficulty climbing stairs'
     click_button t('continue')
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 
@@ -278,7 +278,7 @@ module CandidateHelper
     choose 'Yes'
     fill_in 'Give any relevant information', with: 'I have a criminal conviction.'
     click_button t('continue')
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 
@@ -305,7 +305,7 @@ module CandidateHelper
     end
 
     click_button t('save_and_continue')
-    check t('application_form.work_history.review.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 
@@ -333,7 +333,7 @@ module CandidateHelper
     end
 
     click_button t('save_and_continue')
-    check t('application_form.volunteering.review.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 
@@ -378,7 +378,7 @@ module CandidateHelper
     click_button t('save_and_continue')
     fill_in 'Enter year', with: '1990'
     click_button t('save_and_continue')
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 
@@ -390,7 +390,7 @@ module CandidateHelper
     click_button t('save_and_continue')
     fill_in 'Enter year', with: '1990'
     click_button t('save_and_continue')
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 
@@ -398,7 +398,7 @@ module CandidateHelper
     choose('I do not have this qualification yet')
     fill_in t('application_form.gcse.missing_explanation.label'), with: 'I will sit the exam at my local college this summer.'
     click_button t('save_and_continue')
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 
@@ -406,7 +406,7 @@ module CandidateHelper
     fill_in t('application_form.personal_statement.becoming_a_teacher.label'), with: 'I believe I would be a first-rate teacher'
     click_button t('continue')
     # Confirmation page
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 
@@ -414,7 +414,7 @@ module CandidateHelper
     fill_in t('application_form.personal_statement.subject_knowledge.label'), with: 'Everything'
     click_button t('continue')
     # Confirmation page
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 
@@ -423,7 +423,7 @@ module CandidateHelper
     fill_in t('application_form.personal_statement.interview_preferences.yes_label'), with: 'Not on a Wednesday'
     click_button t('save_and_continue')
     # Confirmation page
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -221,7 +221,7 @@ module CandidateHelper
     fill_in 'candidate_interface_contact_details_form[address_line4]', with: '110018'
     click_button t('save_and_continue')
 
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 

--- a/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_to_new_cycle_spec.rb
@@ -175,7 +175,7 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
   def and_i_complete_the_section
     choose 'No, not at the moment'
     click_button t('continue')
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 

--- a/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
@@ -140,7 +140,7 @@ RSpec.feature 'Manually carry over unsubmitted applications that do not have cou
   def and_i_complete_the_section
     choose 'No, not at the moment'
     click_button t('continue')
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 

--- a/spec/system/candidate_interface/apply_again/candidate_reviews_rejection_reasons_from_previous_applications_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_reviews_rejection_reasons_from_previous_applications_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
 
   def when_i_confirm_i_have_reviewed_becoming_a_teacher
     click_link 'Why do you want to teach'
-    check t('application_form.reviewed_checkbox')
+    choose t('application_form.reviewed_radio')
     click_on t('continue')
   end
 
@@ -92,9 +92,8 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
 
   def and_i_can_set_it_back_to_unreviewed
     click_link 'Why do you want to teach'
-    uncheck t('application_form.reviewed_checkbox')
-    click_on t('continue')
-    then_becoming_a_teacher_needs_review
+    choose t('application_form.incomplete_radio')
+    click_button t('continue')
   end
 
   def when_i_submit_my_application
@@ -115,10 +114,10 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
   def and_i_can_submit_once_i_have_reviewed
     click_link 'Why do you want to be a teacher'
     click_on t('continue')
-    check t('application_form.reviewed_checkbox')
+    choose t('application_form.reviewed_radio')
     click_on t('continue')
     click_link 'Your suitability to teach a subject or age group'
-    check t('application_form.reviewed_checkbox')
+    choose t('application_form.reviewed_radio')
     click_on t('continue')
 
     click_on 'Check and submit'

--- a/spec/system/candidate_interface/apply_again/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -114,7 +114,7 @@ RSpec.feature 'Candidate with unsuccessful application' do
   end
 
   def when_i_complete_my_application
-    check t('application_form.courses.complete.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
     candidate_submits_application
   end

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
@@ -194,7 +194,7 @@ RSpec.feature 'Selecting a course' do
 
   def when_i_mark_this_section_as_completed
     visit candidate_interface_course_choices_index_path
-    check t('application_form.courses.complete.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def then_i_see_that_the_section_is_completed

--- a/spec/system/candidate_interface/entering_details/add_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/add_other_qualification_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'Add Other qualification' do
     click_button t('continue')
     expect(page).to have_css('#english-as-a-foreign-language-assessment-badge-id', text: 'Incomplete')
     click_link efl_link_text
-    check 'I have completed this section'
+    choose t('application_form.completed_radio')
     click_button t('continue')
     expect(page).to have_css('#english-as-a-foreign-language-assessment-badge-id', text: 'Completed')
   end

--- a/spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
   end
 
   def when_i_mark_the_section_as_completed
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def then_i_should_see_the_form

--- a/spec/system/candidate_interface/entering_details/candidate_deletes_and_adds_other_qualifications_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_deletes_and_adds_other_qualifications_after_completing_the_section_spec.rb
@@ -85,10 +85,6 @@ RSpec.feature 'Candidates academic and other relevant qualifications' do
     click_button t('application_form.degree.confirm_delete')
   end
 
-  def and_i_mark_this_section_as_completed
-    check t('application_form.degree.review.completed_checkbox')
-  end
-
   def and_i_click_on_continue
     click_button t('continue')
   end

--- a/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
   end
 
   def and_i_mark_this_section_as_completed
-    check t('application_form.volunteering.review.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_click_on_continue

--- a/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_with_restructured_work_history_active_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_with_restructured_work_history_active_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
   end
 
   def and_i_mark_this_section_as_completed
-    check t('application_form.volunteering.review.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_click_on_continue

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
@@ -175,7 +175,7 @@ RSpec.feature 'Entering their contact information' do
   end
 
   def when_i_mark_the_section_as_completed
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_submit_my_details

--- a/spec/system/candidate_interface/entering_details/candidate_entering_disability_info_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_disability_info_spec.rb
@@ -107,7 +107,7 @@ RSpec.feature 'Entering their disability information' do
   end
 
   def when_i_mark_the_section_as_completed
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_submit_my_details

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
@@ -192,7 +192,7 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def when_i_mark_the_section_as_completed
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
   alias_method :and_i_mark_the_section_as_completed, :when_i_mark_the_section_as_completed
 

--- a/spec/system/candidate_interface/entering_details/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_international_gcse_spec.rb
@@ -166,7 +166,7 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
   end
 
   def when_i_mark_the_section_as_completed
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def then_i_see_the_maths_gcse_is_completed

--- a/spec/system/candidate_interface/entering_details/candidate_entering_interview_preferences_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_interview_preferences_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature 'Entering interview preferences' do
   end
 
   def when_i_mark_the_section_as_completed
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_submit_my_interview_preferences

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_no_qualification_option_choice_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_no_qualification_option_choice_spec.rb
@@ -138,7 +138,7 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def when_i_mark_this_section_as_completed
-    check t('application_form.other_qualification.review.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_click_on_continue

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
@@ -319,7 +319,7 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def when_i_mark_this_section_as_completed
-    check t('application_form.other_qualification.review.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_have_an_incomplete_qualification

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_spec.rb
@@ -114,7 +114,7 @@ RSpec.feature 'Entering their personal details' do
   end
 
   def when_i_mark_the_section_as_completed
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_submit_my_details

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_languages_hidden_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_languages_hidden_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Entering personal details' do
   end
 
   def and_i_can_mark_the_section_complete
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
 
     expect(page).to have_css('#personal-information-badge-id', text: 'Completed')

--- a/spec/system/candidate_interface/entering_details/candidate_entering_subject_knowledge_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_subject_knowledge_spec.rb
@@ -87,7 +87,7 @@ RSpec.feature 'Entering subject knowledge' do
   end
 
   def when_i_mark_the_section_as_completed
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_submit_my_subject_knowledge

--- a/spec/system/candidate_interface/entering_details/candidate_entering_suitability_to_work_with_children_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_suitability_to_work_with_children_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature 'Entering their suitability to work with children' do
   end
 
   def when_i_mark_the_section_as_completed
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def when_i_click_on_continue

--- a/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_and_school_experience_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_and_school_experience_spec.rb
@@ -205,7 +205,7 @@ RSpec.feature 'Entering volunteering and school experience' do
   end
 
   def when_i_mark_this_section_as_completed
-    check t('application_form.volunteering.review.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_click_on_continue

--- a/spec/system/candidate_interface/entering_details/declare_no_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/declare_no_qualification_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature 'Declare no EFL qualification' do
     click_button t('continue')
     expect(page).to have_css('#english-as-a-foreign-language-assessment-badge-id', text: 'Incomplete')
     click_link efl_link_text
-    check 'I have completed this section'
+    choose t('application_form.completed_radio')
     click_button t('continue')
     expect(page).to have_css('#english-as-a-foreign-language-assessment-badge-id', text: 'Completed')
   end

--- a/spec/system/candidate_interface/entering_details/declare_qualification_not_needed_spec.rb
+++ b/spec/system/candidate_interface/entering_details/declare_qualification_not_needed_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Declare EFL qualification not required' do
     click_button t('continue')
     expect(page).to have_css('#english-as-a-foreign-language-assessment-badge-id', text: 'Incomplete')
     click_link efl_link_text
-    check 'I have completed this section'
+    choose t('application_form.completed_radio')
     click_button t('continue')
     expect(page).to have_css('#english-as-a-foreign-language-assessment-badge-id', text: 'Completed')
   end

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degree_with_missing_information_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degree_with_missing_information_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature 'Entering degree with missing info' do
   end
 
   def then_i_cannot_mark_this_section_complete
-    check t('application_form.degree.review.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
     expect(page).to have_content 'You cannot mark this section complete with incomplete degree information.'
     expect(current_candidate.current_application).not_to be_degrees_completed

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degrees_spec.rb
@@ -164,7 +164,7 @@ RSpec.feature 'Entering a degree' do
   end
 
   def when_i_mark_this_section_as_completed
-    check t('application_form.degree.review.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_click_on_continue

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degrees_spec.rb
@@ -280,7 +280,7 @@ RSpec.feature 'Entering their degrees' do
   end
 
   def when_i_mark_this_section_as_completed
-    check t('application_form.degree.review.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_click_on_continue

--- a/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
@@ -206,7 +206,7 @@ RSpec.feature 'Non-uk Other qualifications' do
   def and_leave_grade_and_subject_blank; end
 
   def when_i_mark_this_section_as_completed
-    check t('application_form.other_qualification.review.completed_checkbox')
+    choose t('application_form.completed_checkbox')
   end
 
   def and_i_mark_this_section_as_completed

--- a/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
@@ -206,11 +206,7 @@ RSpec.feature 'Non-uk Other qualifications' do
   def and_leave_grade_and_subject_blank; end
 
   def when_i_mark_this_section_as_completed
-    choose t('application_form.completed_checkbox')
-  end
-
-  def and_i_mark_this_section_as_completed
-    when_i_mark_this_section_as_completed
+    choose t('application_form.completed_radio')
   end
 
   def then_i_do_not_see_the_incomplete_application

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_breaks_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_breaks_spec.rb
@@ -173,8 +173,8 @@ RSpec.feature 'Entering reasons for their work history breaks' do
   end
 
   def when_i_mark_this_section_as_completed
-    check t('application_form.work_history.review.completed_checkbox')
-    click_button t('save_and_continue')
+    choose t('application_form.completed_radio')
+    click_button t('continue')
     expect(page).to have_content(t('page_titles.application_form'))
   end
 

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_full_time_education_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_full_time_education_spec.rb
@@ -53,11 +53,11 @@ RSpec.feature 'Entering their work history' do
   end
 
   def when_i_mark_this_section_as_completed
-    check t('application_form.work_history.review.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_click_on_continue
-    click_button t('save_and_continue')
+    click_button t('continue')
   end
 
   def then_i_should_see_the_form

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_not_worked_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_not_worked_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature 'Entering their work history' do
   end
 
   def when_i_mark_this_section_as_completed
-    check t('application_form.work_history.review.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_click_on_continue

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_not_worked_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_not_worked_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature 'Entering their work history' do
   end
 
   def and_i_click_on_continue
-    click_button t('save_and_continue')
+    click_button t('continue')
   end
 
   def then_i_should_see_the_form

--- a/spec/system/candidate_interface/entering_details/work_history/candidate_edits_work_history_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/entering_details/work_history/candidate_edits_work_history_after_completing_the_section_spec.rb
@@ -118,7 +118,7 @@ RSpec.feature 'Candidate deletes their work history' do
   end
 
   def and_i_mark_this_section_as_completed
-    check t('application_form.work_history.review.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_click_on_continue

--- a/spec/system/candidate_interface/entering_details/work_history/candidate_entering_work_history_not_worked_spec.rb
+++ b/spec/system/candidate_interface/entering_details/work_history/candidate_entering_work_history_not_worked_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature 'Entering their work history' do
   end
 
   def when_i_mark_this_section_as_completed
-    check t('application_form.work_history.review.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_click_on_continue

--- a/spec/system/candidate_interface/entering_details/work_history/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/entering_details/work_history/candidate_entering_work_history_spec.rb
@@ -190,7 +190,7 @@ RSpec.feature 'Entering their work history' do
   end
 
   def when_i_mark_this_section_as_completed
-    check t('application_form.work_history.review.completed_checkbox')
+    choose t('application_form.completed_radio')
   end
 
   def and_i_click_on_continue

--- a/spec/system/candidate_interface/entering_details/your_ielts_results_spec.rb
+++ b/spec/system/candidate_interface/entering_details/your_ielts_results_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'Your IELTS result' do
     click_button t('continue')
     expect(page).to have_css('#english-as-a-foreign-language-assessment-badge-id', text: 'Incomplete')
     click_link efl_link_text
-    check 'I have completed this section'
+    choose t('application_form.completed_radio')
     click_button t('continue')
     expect(page).to have_css('#english-as-a-foreign-language-assessment-badge-id', text: 'Completed')
   end

--- a/spec/system/candidate_interface/entering_details/your_toefl_result_spec.rb
+++ b/spec/system/candidate_interface/entering_details/your_toefl_result_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature 'Your TOEFL result' do
     click_button t('continue')
     expect(page).to have_css('#english-as-a-foreign-language-assessment-badge-id', text: 'Incomplete')
     click_link efl_link_text
-    check 'I have completed this section'
+    choose t('application_form.completed_radio')
     click_button t('continue')
     expect(page).to have_css('#english-as-a-foreign-language-assessment-badge-id', text: 'Completed')
   end

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'International candidate submits the application' do
     click_button t('save_and_continue')
 
     # Mark Personal Details complete
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
 
     click_link t('page_titles.contact_information')
@@ -134,7 +134,7 @@ RSpec.feature 'International candidate submits the application' do
 
     choose 'No, English is not a foreign language to me'
     click_button t('continue')
-    check t('application_form.completed_checkbox')
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 


### PR DESCRIPTION
## Context

```
As a... candidate completing my application
I need to... mark sections as complete
So that... I know which parts of my application still need to be completed
```

## Changes proposed in this pull request

- The current ‘I have completed this section’ checkboxes on section review pages have been updated to use radio buttons. 
- Additionally, some sections show an additional contextual hint text, which encourage candidates to review certain aspects before marking a section as complete.

## Guidance to review

- There is little complexity here, just a lot of file changes here (sorry) . The `CompleteSection` component was updated to match the design. This uses a standard field (`:completed`) and form object (for validation). As a result all the controllers required updating along with specs. I've tried to break up into small / reviewable commits. 

<img width="400" alt="complete-radio-buttons" src="https://user-images.githubusercontent.com/5256922/115748724-56178e80-a38e-11eb-8b5e-01940797d950.png">

## Link to Trello card

https://trello.com/c/MgPkClPi/3303-use-radio-buttons-to-complete-individual-sections-instead-of-checkboxes

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
