### PR TITLE
Add course type parameters to test data generate endpoint

### DIFF
--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -13,12 +13,14 @@ module VendorAPI
     end
 
     def generate
-      GenerateTestApplicationsForProvider.new.call(
+      GenerateTestApplicationsForProvider.new(
         provider: current_provider,
         courses_per_application: courses_per_application_param,
         count: count_param,
+        for_training_courses: for_training_courses_param,
         for_ratified_courses: for_ratified_courses_param,
-      )
+        for_test_provider_courses: for_test_provider_courses_param,
+      ).call
 
       render json: { data: { message: 'Request submitted. Applications will appear once they have been generated' } }
     rescue ParameterInvalid => e
@@ -53,8 +55,16 @@ module VendorAPI
       [(params[:courses_per_application] || DEFAULT_COURSES_COUNT).to_i, MAX_COURSES_COUNT].min
     end
 
+    def for_training_courses_param
+      params[:for_training_courses] == 'true'
+    end
+
     def for_ratified_courses_param
       params[:for_ratified_courses] == 'true'
+    end
+
+    def for_test_provider_courses_param
+      params[:for_test_provider_courses] == 'true'
     end
   end
 end

--- a/app/services/generate_fake_provider.rb
+++ b/app/services/generate_fake_provider.rb
@@ -25,7 +25,7 @@ class GenerateFakeProvider
   end
 
   def self.generate_ratified_courses_for(ratifying_provider)
-    test_provider = Provider.default_scoped.find_or_create_by(name: 'Test Provider', code: 'TEST')
+    test_provider = TestProvider.find_or_create
 
     unique_course_codes(3).each do |code|
       generate_course_options_for FactoryBot.create(

--- a/app/services/test_provider.rb
+++ b/app/services/test_provider.rb
@@ -1,0 +1,31 @@
+class TestProvider
+  def self.find_or_create
+    Provider.default_scoped.find_or_create_by(code: 'TEST') do |provider|
+      provider.name = 'Test Provider'
+    end
+  end
+
+  def self.training_courses
+    test_provider = find_or_create
+
+    existing_courses = test_provider.courses.where(
+      open_on_apply: true,
+      recruitment_cycle_year: RecruitmentCycle.current_year,
+    )
+
+    return existing_courses if existing_courses.count >= 3
+
+    new_test_courses = FactoryBot.create_list(:course, 3, :open_on_apply, provider: test_provider)
+    new_test_courses.each do |course|
+      create_course_option_for(course)
+    end
+
+    existing_courses.reload
+  end
+
+  def self.create_course_option_for(course)
+    FactoryBot.create(:course_option, course: course)
+  end
+
+  private_class_method :create_course_option_for
+end

--- a/app/services/vendor_api/generate_test_applications_for_provider.rb
+++ b/app/services/vendor_api/generate_test_applications_for_provider.rb
@@ -1,27 +1,72 @@
 module VendorAPI
   class GenerateTestApplicationsForProvider
-    def call(provider:, courses_per_application:, count:, for_ratified_courses: false)
+    def initialize(provider:, courses_per_application:, count:, for_training_courses: false, for_ratified_courses: false, for_test_provider_courses: false)
+      @provider = provider
+      @courses_per_application = courses_per_application
+      @application_count = count
+
+      if [for_training_courses, for_ratified_courses, for_test_provider_courses].none?
+        for_training_courses = true
+      end
+      @for_training_courses = for_training_courses
+      @for_ratified_courses = for_ratified_courses
+      @for_test_provider_courses = for_test_provider_courses
+    end
+
+    def call
       raise ParameterInvalid, 'Parameter is invalid (cannot be zero): courses_per_application' if courses_per_application.zero?
 
-      course_ids = course_list_for_provider(provider, for_ratified_courses).pluck(:id)
+      application_count.times do
+        course_ids = random_course_ids_to_apply_for
 
-      raise ParameterInvalid, 'Parameter is invalid (cannot be greater than number of available courses): courses_per_application' if course_ids.count < courses_per_application
+        raise ParameterInvalid, 'Parameter is invalid (cannot be greater than number of available courses): courses_per_application' if course_ids.count < courses_per_application
 
-      GenerateTestApplicationsForCourses.perform_async(course_ids, courses_per_application, count)
+        GenerateTestApplicationsForCourses.perform_async(course_ids, courses_per_application)
+      end
     end
 
   private
 
-    def course_list_for_provider(provider, for_ratified_courses)
-      if for_ratified_courses
-        GetCoursesRatifiedByProvider.call(provider: provider)
-      else
-        Course.current_cycle
-              .open_on_apply
-              .joins(:course_options)
-              .distinct
-              .where(provider: provider)
+    attr_reader :provider, :courses_per_application, :application_count, :for_training_courses, :for_ratified_courses, :for_test_provider_courses
+
+    def random_course_ids_to_apply_for
+      even_split = even_split_for_number_of_course_types
+
+      courses = []
+
+      if for_training_courses
+        courses += courses_run_by_provider.sample(even_split.pop)
       end
+      if for_ratified_courses
+        courses += courses_ratified_by_provider.sample(even_split.pop)
+      end
+      if for_test_provider_courses
+        courses += courses_run_by_test_provider.sample(even_split.pop)
+      end
+
+      courses.pluck(:id)
+    end
+
+    def even_split_for_number_of_course_types
+      course_types_count = [for_training_courses, for_ratified_courses, for_test_provider_courses].count(true)
+
+      3.times.to_a.in_groups(course_types_count, false).map(&:count).shuffle
+    end
+
+    def courses_ratified_by_provider
+      @_courses_ratified_by_provider ||= GetCoursesRatifiedByProvider.call(provider: provider)
+    end
+
+    def courses_run_by_provider
+      @_courses_run_by_provider ||= Course.current_cycle
+                                          .open_on_apply
+                                          .joins(:course_options)
+                                          .distinct
+                                          .where(provider: provider)
+    end
+
+    def courses_run_by_test_provider
+      @_courses_run_by_test_provider ||= TestProvider.training_courses
     end
   end
 end

--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,14 @@
+## 5th May
+
+The following experimental/sandbox endpoint has been updated:
+
+`/test-data/generate` now accepts optional `for_training_courses` and `for_test_provider_courses` query params.
+
+Supplying `for_training_courses=true` will ensure that applications are generated for courses run by the organisation.
+Supplying `for_test_provider_courses=true` will ensure that applications are generated for courses run by a separate, sandbox only, test provider.
+Supplying none of `for_ratified_courses`, `for_training_courses` or `for_test_provider_courses` as `true`, will result in applications being generated to courses run by the organisation (the same effect as just `for_training_courses=true`)
+
+
 ## 26th April
 
 Add [documentation](/api-docs#how-candidates-and-applications-are-identified) about application and candidate IDs

--- a/app/workers/generate_test_applications_for_courses.rb
+++ b/app/workers/generate_test_applications_for_courses.rb
@@ -1,7 +1,28 @@
 class GenerateTestApplicationsForCourses
   include Sidekiq::Worker
 
-  def perform(course_ids, courses_per_application, count)
+  def perform(course_ids, courses_per_application, count = nil)
+    if count.present?
+      generate_multiple(course_ids, courses_per_application, count)
+    else
+      generate_single(course_ids, courses_per_application)
+    end
+  end
+
+private
+
+  def generate_single(course_ids, courses_per_application)
+    courses_to_apply_to = Course.where(id: course_ids)
+
+    TestApplications.new.create_application(
+      recruitment_cycle_year: RecruitmentCycle.current_year,
+      states: [:awaiting_provider_decision] * courses_per_application,
+      courses_to_apply_to: courses_to_apply_to,
+    )
+  end
+
+  # Included for backwards compatibility, since at deployment time old jobs with outdated parameters may not have been picked up yet.
+  def generate_multiple(course_ids, courses_per_application, count)
     courses_to_apply_to = Course.where(id: course_ids)
 
     1.upto(count).flat_map do

--- a/config/vendor-api-experimental.yml
+++ b/config/vendor-api-experimental.yml
@@ -25,8 +25,18 @@ paths:
           default: 1
           minimum: 1
           maximum: 3
+      - name: for_training_courses
+        description: Generate applications for courses your organisation runs. Please specify 'true', for example for_training_courses=true. Will be set to true if neither for_ratified_courses or for_test_provider_courses are true
+        in: query
+        schema:
+          type: string
       - name: for_ratified_courses
         description: Generate applications for courses your organisation awards Qualified Teacher Status (QTS) for but does not run. For example, your organisation may be a Higher Education Institution ratifying School Direct courses. Please specify 'true', for example for_ratified_courses=true
+        in: query
+        schema:
+          type: string
+      - name: for_test_provider_courses
+        description: Generate applications for courses run by a test provider, separate to your organisation. Please specify 'true', for example for_test_provider_courses=true
         in: query
         schema:
           type: string

--- a/spec/requests/vendor_api/post_test_data_generate_spec.rb
+++ b/spec/requests/vendor_api/post_test_data_generate_spec.rb
@@ -34,6 +34,38 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request, s
     expect(ApplicationChoice.count).to eq(3)
   end
 
+  it 'generates applications only to courses that the provider ratifies when for_training_courses=true' do
+    create(:course_option, course: create(:course, :open_on_apply, accredited_provider: currently_authenticated_provider))
+    expected_option = create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
+
+    post_api_request '/api/v1/test-data/generate?count=1&courses_per_application=1&for_training_courses=true'
+
+    expect(Candidate.count).to eq(1)
+    expect(ApplicationChoice.count).to eq(1)
+    expect(ApplicationChoice.all.map(&:course_option).uniq).to contain_exactly(expected_option)
+  end
+
+  it 'generates applications only to courses that the provider ratifies when for_ratified_courses=true' do
+    create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
+    expected_option = create(:course_option, course: create(:course, :open_on_apply, accredited_provider: currently_authenticated_provider))
+
+    post_api_request '/api/v1/test-data/generate?count=1&courses_per_application=1&for_ratified_courses=true'
+
+    expect(Candidate.count).to eq(1)
+    expect(ApplicationChoice.count).to eq(1)
+    expect(ApplicationChoice.all.map(&:course_option).uniq).to contain_exactly(expected_option)
+  end
+
+  it 'generates applications only to courses that the provider ratifies when for_test_provider_courses=true' do
+    create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
+    create(:course_option, course: create(:course, :open_on_apply, accredited_provider: currently_authenticated_provider))
+
+    post_api_request '/api/v1/test-data/generate?count=1&for_test_provider_courses=true'
+
+    expect(Candidate.count).to eq(1)
+    expect(ApplicationChoice.all.map(&:course_option).map(&:provider).map(&:code).compact).to contain_exactly('TEST')
+  end
+
   it 'returns responses conforming to the schema' do
     create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
 

--- a/spec/services/test_provider_spec.rb
+++ b/spec/services/test_provider_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe TestProvider do
+  describe '.find_or_create' do
+    context 'when the provider does not exist' do
+      it 'creates and returns a provider with code TEST' do
+        existing_test_provider = Provider.find_by(code: 'TEST')
+        test_provider = described_class.find_or_create
+
+        expect(existing_test_provider).to be_nil
+        expect(test_provider.code).to eq('TEST')
+        expect(test_provider.name).to eq('Test Provider')
+      end
+    end
+
+    context 'when the provider exists' do
+      let!(:test_provider) { create(:provider, code: 'TEST') }
+
+      it 'returns the provider with code TEST' do
+        expect(described_class.find_or_create).to eq(test_provider)
+      end
+    end
+  end
+
+  describe '.training_courses' do
+    let!(:test_provider) { create(:provider, code: 'TEST') }
+
+    context 'when there are 3 or more existing open courses' do
+      let!(:test_provider_courses) do
+        create_list(:course, 3, :open_on_apply, provider: test_provider)
+      end
+
+      it 'returns the list of courses run by the training provider' do
+        expect(described_class.training_courses).to match_array(test_provider_courses)
+      end
+    end
+
+    context 'when there are fewer than 3 existing open courses' do
+      let!(:test_provider_courses) do
+        create(:course, :open_on_apply, provider: test_provider)
+        create_list(:course, 3, :open_on_apply, :previous_year, provider: test_provider)
+        create_list(:course, 3, provider: test_provider)
+      end
+
+      it 'creates and returns open courses for the current year' do
+        courses = described_class.training_courses
+
+        expect(courses.count).to be >= 3
+        expect(courses.where(open_on_apply: false)).to be_empty
+        expect(courses.previous_cycle).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/vendor_api/generate_test_applications_for_provider_spec.rb
+++ b/spec/services/vendor_api/generate_test_applications_for_provider_spec.rb
@@ -1,70 +1,139 @@
 require 'rails_helper'
 
 RSpec.describe VendorAPI::GenerateTestApplicationsForProvider, sidekiq: true do
+  let(:provider) { create(:provider) }
+  let(:courses_per_application) { 3 }
+  let(:application_count) { 1 }
+  let(:for_training_courses) { false }
+  let(:for_ratified_courses) { false }
+  let(:for_test_provider_courses) { false }
+  let(:service_params) do
+    {
+      provider: provider,
+      courses_per_application: courses_per_application,
+      count: application_count,
+      for_training_courses: for_training_courses,
+      for_ratified_courses: for_ratified_courses,
+      for_test_provider_courses: for_test_provider_courses,
+    }
+  end
+
+  before do
+    create(:course_option)
+    # rubocop:disable FactoryBot/CreateList
+    3.times do
+      create(:course_option, course: create(:course, :open_on_apply, provider: provider))
+    end
+    3.times do
+      create(:course_option, course: create(:course, accredited_provider: provider))
+    end
+    # rubocop:enable FactoryBot/CreateList
+  end
+
   describe '#call' do
-    it 'generates applications to courses the provider runs' do
-      provider = create(:provider)
-      create(:course_option)
-      # rubocop:disable FactoryBot/CreateList
-      3.times do
-        create(:course_option, course: create(:course, :open_on_apply, provider: provider))
+    context 'when count is more than 1' do
+      let(:application_count) { 2 }
+
+      it 'generates the correct number of application forms to the correct courses' do
+        described_class.new(service_params).call
+
+        choices = provider.application_choices
+        expect(choices.map(&:application_form).uniq.count).to eq(2)
+        expect(choices.map(&:course).map(&:provider).uniq).to eq([provider])
       end
-      # rubocop:enable FactoryBot/CreateList
-
-      described_class.new.call(
-        provider: provider,
-        courses_per_application: 3,
-        count: 2,
-      )
-
-      choices = provider.application_choices
-      expect(choices.map(&:application_form).uniq.count).to eq(2)
-      expect(choices.map(&:course).map(&:provider).uniq).to eq([provider])
     end
 
-    it 'can generate applications to courses the provider ratifies' do
-      provider = create(:provider)
-      create(:course_option)
-      create(:course_option, course: create(:course, provider: provider))
-      # rubocop:disable FactoryBot/CreateList
-      3.times do
-        create(:course_option, course: create(:course, accredited_provider: provider))
+    context 'when all of for_training_courses, for_ratifying_courses and for_test_provider_courses are false' do
+      it 'generates applications to courses run by the provider' do
+        described_class.new(service_params).call
+
+        choices = provider.application_choices.last.application_form.application_choices
+        training_providers = choices.map(&:provider).compact.uniq
+
+        expect(choices.count).to eq(3)
+        expect(training_providers).to contain_exactly(provider)
       end
-      # rubocop:enable FactoryBot/CreateList
+    end
 
-      described_class.new.call(
-        provider: provider,
-        courses_per_application: 3,
-        count: 2,
-        for_ratified_courses: true,
-      )
+    context 'when all of for_training_courses, for_ratifying_courses and for_test_provider_courses are true' do
+      let(:for_training_courses) { true }
+      let(:for_ratified_courses) { true }
+      let(:for_test_provider_courses) { true }
 
-      choices = provider.accredited_courses.flat_map(&:application_choices)
-      expect(choices.map(&:application_form).uniq.count).to eq(2)
-      expect(choices.map(&:course).map(&:accredited_provider).uniq).to eq([provider])
+      it 'generates applications to a test provider course, and courses run and ratified by the provider' do
+        described_class.new(service_params).call
+
+        choices = provider.application_choices.last.application_form.application_choices
+        training_providers = choices.map(&:provider).compact
+        accredited_providers = choices.map(&:accredited_provider).compact
+
+        expect(choices.count).to eq(3)
+        expect(training_providers.map(&:code)).to include(provider.code, 'TEST')
+        expect(accredited_providers).to include(provider)
+      end
+    end
+
+    context 'when for_training_courses is true' do
+      let(:for_training_courses) { true }
+
+      it 'generates applications to courses run by the provider' do
+        described_class.new(service_params).call
+
+        choices = provider.application_choices.last.application_form.application_choices
+        training_providers = choices.map(&:provider).compact.uniq
+
+        expect(choices.count).to eq(3)
+        expect(training_providers).to contain_exactly(provider)
+      end
+    end
+
+    context 'when for_ratified_courses is true' do
+      let(:for_ratified_courses) { true }
+
+      it 'generates applications to courses ratified by the provider' do
+        described_class.new(service_params).call
+
+        choices = provider.accredited_courses.flat_map(&:application_choices).last.application_form.application_choices
+        accredited_providers = choices.map(&:accredited_provider).compact.uniq
+
+        expect(choices.count).to eq(3)
+        expect(accredited_providers).to contain_exactly(provider)
+      end
+    end
+
+    context 'when for_test_provider_courses is true' do
+      let(:for_test_provider_courses) { true }
+
+      it 'generates applications to courses run by the test provider' do
+        described_class.new(service_params).call
+
+        test_provider = Provider.find_by(code: 'TEST')
+        choices = test_provider.application_choices.last.application_form.application_choices
+        providers = choices.map(&:provider).compact.uniq
+
+        expect(choices.count).to eq(3)
+        expect(providers).to contain_exactly(test_provider)
+      end
     end
 
     describe 'raises an error' do
       it 'when a request is made for zero courses per application' do
         expect {
-          described_class.new.call(
+          described_class.new(
             provider: create(:provider),
             courses_per_application: 0,
             count: 1,
-          )
+          ).call
         }.to raise_error ParameterInvalid, 'Parameter is invalid (cannot be zero): courses_per_application'
       end
 
       it 'when a request is made for more courses than exist' do
-        provider = create(:provider)
-        create(:course_option, course: create(:course, :open_on_apply, provider: provider))
-
         expect {
-          described_class.new.call(
-            provider: provider,
+          described_class.new(
+            provider: create(:provider),
             courses_per_application: 2,
             count: 1,
-          )
+          ).call
         }.to raise_error ParameterInvalid, 'Parameter is invalid (cannot be greater than number of available courses): courses_per_application'
       end
     end


### PR DESCRIPTION
## Context
Providers have asked to be able to generate more realistic applications on Sandbox. The requirement is to be able to generate applications that apply to a mixture of courses: run by the org, ratified by the org, and run by a separate unrelated org.

## Changes proposed in this pull request
Add a mixed param to the endpoint which forces the application that s generated to be to the required organisations.
We use the TEST provider that's available on Sandbox, to put the external applications in, to avoid clashing with other testing.

## Link to Trello card
https://trello.com/c/flCTHBtA/3560-support-generating-test-applications-to-both-the-accredited-body-and-their-sds-over-the-api

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
