### PR TITLE
Report and ignore UCASMatch records with no applications

### DIFF
--- a/app/components/support_interface/ucas_matches_statistics_component.html.erb
+++ b/app/components/support_interface/ucas_matches_statistics_component.html.erb
@@ -30,6 +30,14 @@
   </div>
 </div>
 
+<% if action_taken_count['no_application_choice'].present? %>
+  <div class="govuk-grid-row app-grid-row--flex govuk-!-margin-bottom-6">
+    <div class="govuk-grid-column-one-quarter">
+      <%= render SupportInterface::TileComponent.new(count: action_taken_count['no_application_choice'] || '0', label: 'bad data') %>
+    </div>
+  </div>
+<% end %>
+
 <p class='govuk-body'>For the matches which have not been resolved yet, we have taken the following actions</p>
 
 <div class="govuk-grid-row app-grid-row--flex govuk-!-margin-bottom-6">

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -10,6 +10,7 @@ class UCASMatch < ApplicationRecord
     resolved_on_apply: 'resolved_on_apply',
     resolved_on_ucas: 'resolved_on_ucas',
     manually_resolved: 'manually_resolved',
+    no_application_choice: 'no_application_choice',
   }
 
   def ready_to_resolve?
@@ -17,7 +18,7 @@ class UCASMatch < ApplicationRecord
   end
 
   def resolved?
-    %w[resolved_on_apply resolved_on_ucas manually_resolved].include?(action_taken)
+    %w[resolved_on_apply resolved_on_ucas manually_resolved no_application_choice].include?(action_taken)
   end
 
   def trackable_applicant_key

--- a/app/services/ucas_matches/send_ucas_match_initial_emails_duplicate_applications.rb
+++ b/app/services/ucas_matches/send_ucas_match_initial_emails_duplicate_applications.rb
@@ -10,13 +10,18 @@ module UCASMatches
       raise "Initial emails for UCAS match ##{ucas_match.id} were already sent" if ucas_match.initial_emails_sent?
 
       application_choice = ucas_match.application_choices_for_same_course_on_both_services.first
-      raise "No application choices found for UCAS match ##{ucas_match.id}" unless application_choice
+      report_bad_data!(ucas_match) if application_choice.blank?
 
       CandidateMailer.ucas_match_initial_email_duplicate_applications(application_choice).deliver_later
 
       application_choice.provider.provider_users.each do |provider_user|
         ProviderMailer.ucas_match_initial_email_duplicate_applications(provider_user, application_choice).deliver_later
       end
+    end
+
+    def report_bad_data!(ucas_match)
+      ucas_match.update!(action_taken: :no_application_choice)
+      raise "No application choices found for UCAS match ##{ucas_match.id}"
     end
   end
 end

--- a/app/services/ucas_matches/send_ucas_match_initial_emails_duplicate_applications.rb
+++ b/app/services/ucas_matches/send_ucas_match_initial_emails_duplicate_applications.rb
@@ -10,6 +10,7 @@ module UCASMatches
       raise "Initial emails for UCAS match ##{ucas_match.id} were already sent" if ucas_match.initial_emails_sent?
 
       application_choice = ucas_match.application_choices_for_same_course_on_both_services.first
+      raise "No application choices found for UCAS match ##{ucas_match.id}" unless application_choice
 
       CandidateMailer.ucas_match_initial_email_duplicate_applications(application_choice).deliver_later
 

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -73,8 +73,20 @@ RSpec.describe UCASMatch do
   end
 
   describe '#resolved?' do
-    it 'returns true if action_taken is resolved_on_apply or resolved_on_ucas' do
+    it 'returns true if action_taken is resolved_on_apply' do
+      ucas_match = build_stubbed(:ucas_match, action_taken: 'resolved_on_apply')
+
+      expect(ucas_match.resolved?).to eq(true)
+    end
+
+    it 'returns true if action_taken is resolved_on_ucas' do
       ucas_match = build_stubbed(:ucas_match, action_taken: 'resolved_on_ucas')
+
+      expect(ucas_match.resolved?).to eq(true)
+    end
+
+    it 'returns true if action_taken is no_application_choice' do
+      ucas_match = build_stubbed(:ucas_match, action_taken: 'no_application_choice')
 
       expect(ucas_match.resolved?).to eq(true)
     end

--- a/spec/services/ucas_matches/send_ucas_match_initial_emails_duplicate_applications_spec.rb
+++ b/spec/services/ucas_matches/send_ucas_match_initial_emails_duplicate_applications_spec.rb
@@ -19,11 +19,13 @@ RSpec.describe UCASMatches::SendUCASMatchInitialEmailsDuplicateApplications do
           expect { described_class.new(ucas_match).call }.to raise_error("Initial emails for UCAS match ##{ucas_match.id} were already sent")
         end
 
-        it 'when no application_choices_for_same_course_on_both_services are present' do
-          weird_match = build_stubbed(:ucas_match)
+        it 'and no application_choices_for_same_course_on_both_services are present' do
+          weird_match = create(:ucas_match)
           allow(weird_match).to receive(:application_choices_for_same_course_on_both_services).and_return([])
 
           expect { described_class.new(weird_match).call }.to raise_error("No application choices found for UCAS match ##{weird_match.id}")
+          expect(weird_match.reload.action_taken).to eq('no_application_choice')
+          expect(weird_match).to be_resolved
         end
       end
 

--- a/spec/services/ucas_matches/send_ucas_match_initial_emails_duplicate_applications_spec.rb
+++ b/spec/services/ucas_matches/send_ucas_match_initial_emails_duplicate_applications_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe UCASMatches::SendUCASMatchInitialEmailsDuplicateApplications do
         it 'when the emails have already been sent it throws an exception' do
           expect { described_class.new(ucas_match).call }.to raise_error("Initial emails for UCAS match ##{ucas_match.id} were already sent")
         end
+
+        it 'when no application_choices_for_same_course_on_both_services are present' do
+          weird_match = build_stubbed(:ucas_match)
+          allow(weird_match).to receive(:application_choices_for_same_course_on_both_services).and_return([])
+
+          expect { described_class.new(weird_match).call }.to raise_error("No application choices found for UCAS match ##{weird_match.id}")
+        end
       end
 
       describe 'when the initial emails have not been sent already' do


### PR DESCRIPTION
## Context

We are getting many sidekiq failures on QA related to bad UCASMatch data. Many tasks still enqueued in Retries, which will never succeed because they have `nil` arguments.

![image](https://user-images.githubusercontent.com/107591/115782303-6db53e00-a3b3-11eb-97b5-3bfd82985624.png)

Obviously, we could clear the Retries queue, but the moment we switch on ucas matching again, other similar tasks will probably be enqueued. I haven't got to the bottom of the data issue, but the failures are caused by UCASMatch records with next_action of initial_emails_sent which return no `application_for_the_same_course_in_progress_on_both_services?` records. These UCASMatch records are not actionable, but will always be considered during ucas matching, which is not ideal. Maybe we need an additional enum/action_taken along the lines of :no_application_choice which is set so that the process forgets about them. But we should also raise an error, lest this masks data issues on production. 

## Changes proposed in this pull request

Introduce a `no_application_choice` enum/action_taken, and include it in the `resolved?` states.
Set this as `action_taken` for UCASMatch records that return no application choices.
Raise a meaningful error so that we hear about such cases from Sentry.

Add a counter for problematic UCAS matches to the relevant dashboard:

![image](https://user-images.githubusercontent.com/107591/117118722-091dba00-ad89-11eb-8da5-713ee542b8f8.png)

Individual UCAS matches with `no_application_choice` are also visible in the usual list:

![image](https://user-images.githubusercontent.com/107591/117121446-81d24580-ad8c-11eb-9e90-fc4350d2b9fd.png)

## Guidance to review

Should be easy. Does the approach make sense?

## Link to Trello card

No Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
