### PR TITLE
Health check timeout to 180 seconds

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -19,6 +19,7 @@ resource "cloudfoundry_app" "web_app" {
   docker_image               = var.app_docker_image
   health_check_type          = "process"
   health_check_http_endpoint = "/check"
+  health_check_timeout       = 180
   instances                  = var.web_app_instances
   memory                     = var.web_app_memory
   space                      = data.cloudfoundry_space.space.id
@@ -41,16 +42,17 @@ resource "cloudfoundry_app" "web_app" {
 }
 
 resource "cloudfoundry_app" "clock" {
-  name               = local.clock_app_name
-  docker_image       = var.app_docker_image
-  health_check_type  = "process"
-  command            = "bundle exec clockwork config/clock.rb"
-  instances          = var.clock_app_instances
-  memory             = var.clock_app_memory
-  space              = data.cloudfoundry_space.space.id
-  timeout            = 180
-  environment        = local.clock_app_env_variables
-  docker_credentials = var.docker_credentials
+  name                 = local.clock_app_name
+  docker_image         = var.app_docker_image
+  health_check_type    = "process"
+  health_check_timeout = 180
+  command              = "bundle exec clockwork config/clock.rb"
+  instances            = var.clock_app_instances
+  memory               = var.clock_app_memory
+  space                = data.cloudfoundry_space.space.id
+  timeout              = 180
+  environment          = local.clock_app_env_variables
+  docker_credentials   = var.docker_credentials
   dynamic "service_binding" {
     for_each = local.app_service_bindings
     content {
@@ -60,16 +62,17 @@ resource "cloudfoundry_app" "clock" {
 }
 
 resource "cloudfoundry_app" "worker" {
-  name               = local.worker_app_name
-  docker_image       = var.app_docker_image
-  health_check_type  = "process"
-  command            = "bundle exec sidekiq -c 5 -C config/sidekiq.yml"
-  instances          = var.worker_app_instances
-  memory             = var.worker_app_memory
-  space              = data.cloudfoundry_space.space.id
-  timeout            = 180
-  environment        = local.worker_app_env_variables
-  docker_credentials = var.docker_credentials
+  name                 = local.worker_app_name
+  docker_image         = var.app_docker_image
+  health_check_type    = "process"
+  health_check_timeout = 180
+  command              = "bundle exec sidekiq -c 5 -C config/sidekiq.yml"
+  instances            = var.worker_app_instances
+  memory               = var.worker_app_memory
+  space                = data.cloudfoundry_space.space.id
+  timeout              = 180
+  environment          = local.worker_app_env_variables
+  docker_credentials   = var.docker_credentials
   dynamic "service_binding" {
     for_each = local.app_service_bindings
     content {


### PR DESCRIPTION
## Context

Few deployments are failing with the worker apps failing to complete staging.

## Changes proposed in this pull request

Set health check timeout at 180 seconds.


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
