### PR TITLE
Fix the WhoRanWhichExportExport

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -66,12 +66,6 @@ class DataExport < ApplicationRecord
       description: 'Anonymised candidate equality and diversity data.',
       class: SupportInterface::EqualityAndDiversityExport,
     },
-    who_ran_which_export: {
-      name: 'Who ran which export',
-      export_type: 'who_ran_which_export',
-      description: 'A list of all the exports that have been generated and who initiated them.',
-      class: SupportInterface::WhoRanWhichExportExport,
-    },
     interviews_export: {
       name: 'Interview changes',
       export_type: 'interview_export',
@@ -168,6 +162,12 @@ class DataExport < ApplicationRecord
       description: 'A list of changes to user permissions and audit information about the changes.',
       class: SupportInterface::UserPermissionsExport,
     },
+    who_ran_which_export: {
+      name: 'Who ran which export',
+      export_type: 'who_ran_which_export',
+      description: 'A list of all the exports that have been generated and who initiated them.',
+      class: SupportInterface::WhoRanWhichExportExport,
+    },
     work_history_break: {
       name: 'Work history break',
       export_type: 'work_history_break',
@@ -207,7 +207,6 @@ class DataExport < ApplicationRecord
     candidate_journey_tracking: 'candidate_journey_tracking',
     candidate_course_choice_withdrawal_survey: 'candidate_course_choice_withdrawal_survey',
     equality_and_diversity: 'equality_and_diversity',
-    export_initiators: 'export_initiators',
     interviews_export: 'interview_export',
     notifications_export: 'notifications_export',
     notes_export: 'notes_export',
@@ -224,6 +223,7 @@ class DataExport < ApplicationRecord
     tad_applications: 'tad_applications',
     tad_provider_performance: 'tad_provider_performance',
     user_permissions: 'user_permissions',
+    who_ran_which_export: 'who_ran_which_export',
     work_history_break: 'work_history_break',
   }
 end


### PR DESCRIPTION
## Context

I forgot to update the export type enum when I refactored the name of the export

## Changes proposed in this pull request

- Add the correct name to the export_type enum and alphabetise it

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
