### PR TITLE
Add summary of application and candidate identifiers to API docs

### DIFF
--- a/app/views/api_docs/vendor_api_docs/pages/home.md
+++ b/app/views/api_docs/vendor_api_docs/pages/home.md
@@ -45,6 +45,14 @@ Grades for GCSEs and A/AS levels are strictly validated since the ITT 2021 recru
 - `/reference-data/gcse-grades`
 - `/reference-data/a-and-as-level-grades`
 
+### How candidates and applications are identified
+
+Applications on the API have three identifiers associated with them:
+
+- `Application.id`, eg `1234`. This identifies an application to a single course. Candidates can have up to three course applications for one application form.
+-  `ApplicationAttributes.support_reference`, eg `AB1234`. This identifies the application form carrying this application choice. We show it to candidates when they submit their form.
+- `Candidate.id`, eg `C7890`. This identifies a candidate. Candidates can have multiple applications.
+
 ## How do I connect to this API?
 
 ### Authentication and authorisation

--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,7 @@
+## 26th April
+
+Add [documentation](/api-docs#how-candidates-and-applications-are-identified) about application and candidate IDs
+
 ## 16th April
 
 `Qualification` now includes an optional `subject_code` field. This contains the HECoS code for the subject if it is available


### PR DESCRIPTION
## Context

We don't document this for providers/vendors but it's useful to know

https://ukgovernmentdfe.slack.com/archives/C01EZFNUPLP/p1619188542020400

## Changes proposed in this pull request

Add to the docs