### PR TITLE
Add strong_migrations gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,9 @@ gem 'geocoder'
 
 gem 'strip_attributes'
 
+# Automate checks for potentially unsafe migrations
+gem 'strong_migrations'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -477,6 +477,8 @@ GEM
       sprockets (>= 3.0.0)
     strip_attributes (1.11.0)
       activemodel (>= 3.0, < 7.0)
+    strong_migrations (0.7.6)
+      activerecord (>= 5)
     super_diff (0.6.2)
       attr_extras (>= 6.2.4)
       diff-lcs
@@ -611,6 +613,7 @@ DEPENDENCIES
   skylight
   sprockets-rails
   strip_attributes
+  strong_migrations
   super_diff
   timecop
   tzinfo-data

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,26 @@
+# Mark existing migrations as safe
+StrongMigrations.start_after = 20210423111709
+
+# Set timeouts for migrations
+# If you use PgBouncer in transaction mode, delete these lines and set timeouts on the database user
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour
+
+# Analyze tables after indexes are added
+# Outdated statistics can sometimes hurt performance
+StrongMigrations.auto_analyze = true
+
+# Set the version of the production database
+# so the right checks are run in development
+# StrongMigrations.target_version = 10
+
+# Add custom checks
+# StrongMigrations.add_check do |method, args|
+#   if method == :add_index && args[0].to_s == "users"
+#     stop! "No more indexes on the users table"
+#   end
+# end
+
+# Make some operations safe by default
+# See https://github.com/ankane/strong_migrations#safe-by-default
+# StrongMigrations.safe_by_default = true


### PR DESCRIPTION

## Context
This automatically detects potentially unsafe schema migrations and
provides guidance around how to complete these operations with zero
downtime and/or better performance.

Any migration code that triggers an error can be reviewed and then
marked as safe by wrapping it in a block, eg -

```
safety_assured {
  # migration code
}
```
Benefits:
- Detecting unsafe schema migrations becomes an automated process rather than an entirely manual one driven by code reviews.
- Encourages good migration practice via its error messages and documentation.
- Easily removed/disabled if it starts causing any issues with migrations.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Add the gem and some default config.

### Example

**Operation:**
```ruby
add_column :application_forms, :testing_strong_migrations, :boolean, default: true
```
**Output:**
```ruby
Migrating to TestStrongMigrationsGem (20210423113024)
== 20210423113024 TestStrongMigrationsGem: migrating ==========================
  TRANSACTION (0.1ms)  BEGIN
   (0.1ms)  SET statement_timeout TO 3600000
   (0.1ms)  SET lock_timeout TO 10000
   (0.1ms)  SHOW server_version_num
  TRANSACTION (0.1ms)  ROLLBACK
   (0.1ms)  SELECT pg_advisory_unlock(1548636341943550335)
An error has occurred, this and all later migrations canceled:


=== Dangerous operation detected #strong_migrations ===

Adding a column with a non-null default blocks reads and writes while the entire table is rewritten.
Instead, add the column without a default value, then change the default.

class TestStrongMigrationsGem < ActiveRecord::Migration[6.1]
  def up
    add_column :application_forms, :testing_strong_migrations, :boolean
    change_column_default :application_forms, :testing_strong_migrations, true
  end

  def down
    remove_column :application_forms, :testing_strong_migrations
  end
end

Then backfill the existing rows in the Rails console or a separate migration with disable_ddl_transaction!.

class BackfillTestStrongMigrationsGem < ActiveRecord::Migration[6.1]
  disable_ddl_transaction!

  def up
    ApplicationForm.unscoped.in_batches do |relation|
      relation.update_all testing_strong_migrations: true
      sleep(0.01)
    end
  end
end
```
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
