### PR TITLE
Add the candidate ID to application choices export

### DIFF
--- a/app/services/provider_interface/application_data_export.rb
+++ b/app/services/provider_interface/application_data_export.rb
@@ -9,6 +9,7 @@ module ProviderInterface
 
         rows << {
           'application_choice_id' => application.id,
+          'candidate_id' => application.application_form.candidate.public_id,
           'support_reference' => application.application_form.support_reference,
           'status' => application.status,
           'submitted_at' => application.application_form.submitted_at,

--- a/spec/services/provider_interface/application_data_export_spec.rb
+++ b/spec/services/provider_interface/application_data_export_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
 
       expected = {
         'application_choice_id' => application_choice.id.to_s,
+        'candidate_id' => application_choice.application_form.candidate.public_id,
         'support_reference' => application_choice.application_form.support_reference,
         'status' => application_choice.status,
         'submitted_at' => application_choice.application_form.submitted_at&.to_s,


### PR DESCRIPTION
## Context

We do not surface the candidate ID in the application choice export on the applications list page.

## Changes proposed in this pull request

Add a new column for candidate ID as requested by providers.

## Guidance to review

Is this a breaking change for providers consuming the export?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
