### PR TITLE
Correction - Cookie banners and printing applications

### DIFF
--- a/app/components/cookie_banners_component.html.erb
+++ b/app/components/cookie_banners_component.html.erb
@@ -1,65 +1,66 @@
-<div class="govuk-!-display-none-print">
-  <%= govuk_cookie_banner(
-        title: "Cookies on #{service_name}",
-        html_attributes: {
-          hidden: false,
-          aria: {
-            label: "Cookies on #{service_name}",
-          },
-          data: {
-            module: 'govuk-fallback-cookie-banner',
-            qa: 'fallback-cookie-banner',
-          },
+<%= govuk_cookie_banner(
+      title: "Cookies on #{service_name}",
+      classes: 'govuk-!-display-none-print',
+      html_attributes: {
+        hidden: false,
+        aria: {
+          label: "Cookies on #{service_name}",
         },
-      ) do |cookie_banner| %>
-    <%= cookie_banner.with(:body) do %>
-      <p class="govuk-body">We use cookies to make this service work and collect analytics information. To accept or
-        reject cookies, turn on JavaScript in your browser settings or reload this page.</p>
-    <% end %>
+        data: {
+          module: 'govuk-fallback-cookie-banner',
+          qa: 'fallback-cookie-banner',
+        },
+      },
+    ) do |cookie_banner| %>
+  <%= cookie_banner.with(:body) do %>
+    <p class="govuk-body">We use cookies to make this service work and collect analytics information. To accept or
+      reject cookies, turn on JavaScript in your browser settings or reload this page.</p>
   <% end %>
+<% end %>
 
-  <%= govuk_cookie_banner(
-        title: "Cookies on #{service_name}",
-        html_attributes: {
-          hidden: true,
-          data: {
-            module: 'govuk-cookie-banner',
-            service: service_name_short,
-          },
-          aria: {
-            label: "Cookies on #{service_name}",
-          },
+<%= govuk_cookie_banner(
+      title: "Cookies on #{service_name}",
+      classes: 'govuk-!-display-none-print',
+      html_attributes: {
+        hidden: true,
+        data: {
+          module: 'govuk-cookie-banner',
+          service: service_name_short,
         },
-      ) do |cookie_banner| %>
-    <%= cookie_banner.with(:body) do %>
-      <p class="govuk-body">We use some essential cookies to make this service work.</p>
-      <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and
-        make improvements.</p>
-    <% end %>
-    <%= cookie_banner.with(:actions) do %>
-      <button type="button" class="govuk-button" data-accept-cookie="true">Accept analytics cookies</button>
-      <button type="button" class="govuk-button" data-accept-cookie="false">Reject analytics cookies</button>
-      <%= govuk_link_to('View cookies', namespace_cookies_path) %>
-    <% end %>
+        aria: {
+          label: "Cookies on #{service_name}",
+        },
+      },
+    ) do |cookie_banner| %>
+  <%= cookie_banner.with(:body) do %>
+    <p class="govuk-body">We use some essential cookies to make this service work.</p>
+    <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and
+      make improvements.</p>
   <% end %>
+  <%= cookie_banner.with(:actions) do %>
+    <button type="button" class="govuk-button" data-accept-cookie="true">Accept analytics cookies</button>
+    <button type="button" class="govuk-button" data-accept-cookie="false">Reject analytics cookies</button>
+    <%= govuk_link_to('View cookies', namespace_cookies_path) %>
+  <% end %>
+<% end %>
 
-  <%= govuk_cookie_banner(
-        html_attributes: {
-          hidden: true,
-          data: {
-            module: 'govuk-cookie-confirmation-banner',
-          },
-          aria: {
-            label: "Cookies on #{service_name}",
-          },
+<%= govuk_cookie_banner(
+      classes: 'govuk-!-display-none-print',
+      html_attributes: {
+        hidden: true,
+        data: {
+          module: 'govuk-cookie-confirmation-banner',
         },
-      ) do |cookie_banner| %>
-    <%= cookie_banner.with(:body) do %>
-      <p>You’ve <span id="user-answer"></span> analytics cookies. You
-        can <%= govuk_link_to('change your cookie settings', namespace_cookies_path) %> at any time.</p>
-    <% end %>
-    <%= cookie_banner.with(:actions) do %>
-      <button type="button" class="govuk-button">Hide this message</button>
-    <% end %>
+        aria: {
+          label: "Cookies on #{service_name}",
+        },
+      },
+    ) do |cookie_banner| %>
+  <%= cookie_banner.with(:body) do %>
+    <p>You’ve <span id="user-answer"></span> analytics cookies. You
+      can <%= govuk_link_to('change your cookie settings', namespace_cookies_path) %> at any time.</p>
   <% end %>
-</div>
+  <%= cookie_banner.with(:actions) do %>
+    <button type="button" class="govuk-button">Hide this message</button>
+  <% end %>
+<% end %>


### PR DESCRIPTION
## Context
https://github.com/DFE-Digital/apply-for-teacher-training/pull/4581

## Changes proposed in this pull request

Correction added - uses the `classes` attribute to hide banners when printing applications

## Link to Trello card

https://trello.com/c/eHPVAjGu/3328-do-not-display-accept-cookies-prompt-when-you-download-a-pdf-of-an-application

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
