### PR TITLE
Add export for feedback provided on Find

### DIFF
--- a/app/exports/find_feedback_export.yml
+++ b/app/exports/find_feedback_export.yml
@@ -1,0 +1,16 @@
+common_columns:
+  - email
+
+custom_columns:
+  feedback_provided_at:
+    type: string
+    format: date-time
+    example: 2020-11-01T00:00:00+00:00
+  find_url:
+    type: string
+    format: link
+    description: A link to the page that the candidate was on when they chose to provide feedback.
+    example: https://www.find-postgraduate-teacher-training.service.gov.uk/course/2AT/2T84
+  feedback:
+    type: string
+    description: Feedback left by the user

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -66,6 +66,12 @@ class DataExport < ApplicationRecord
       description: 'Anonymised candidate equality and diversity data.',
       class: SupportInterface::EqualityAndDiversityExport,
     },
+    find_feedback: {
+      name: 'Find feedback',
+      export_type: 'find_feedback',
+      description: 'Feedback provided from the Find service results and course pages',
+      class: SupportInterface::FindFeedbackExport,
+    },
     interviews_export: {
       name: 'Interview changes',
       export_type: 'interview_export',
@@ -207,6 +213,7 @@ class DataExport < ApplicationRecord
     candidate_journey_tracking: 'candidate_journey_tracking',
     candidate_course_choice_withdrawal_survey: 'candidate_course_choice_withdrawal_survey',
     equality_and_diversity: 'equality_and_diversity',
+    find_feedback: 'find_feedback',
     interviews_export: 'interview_export',
     notifications_export: 'notifications_export',
     notes_export: 'notes_export',

--- a/app/services/support_interface/find_feedback_export.rb
+++ b/app/services/support_interface/find_feedback_export.rb
@@ -1,0 +1,20 @@
+module SupportInterface
+  class FindFeedbackExport
+    def data_for_export
+      FindFeedback.all.order(:created_at).find_each(batch_size: 100).map do |find_feedback|
+        {
+          feedback_provided_at: find_feedback.created_at,
+          find_url: find_url(find_feedback),
+          email: find_feedback.email_address,
+          feedback: find_feedback.feedback,
+        }
+      end
+    end
+
+  private
+
+    def find_url(find_feedback)
+      'https://www.find-postgraduate-teacher-training.service.gov.uk' + find_feedback.path
+    end
+  end
+end

--- a/spec/factories/find_feedback.rb
+++ b/spec/factories/find_feedback.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :find_feedback do
+    find_controller { 'results' }
+    path { '/results' }
+    feedback { Faker::Lorem.paragraph(sentence_count: 3) }
+    email_address { "#{SecureRandom.hex(5)}@example.com" }
+  end
+end

--- a/spec/services/support_interface/find_feedback_export_spec.rb
+++ b/spec/services/support_interface/find_feedback_export_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::FindFeedbackExport do
+  describe 'documentation' do
+    before { create(:find_feedback) }
+
+    it_behaves_like 'a data export'
+  end
+
+  describe '#data_for_export' do
+    it 'returns an array of hashes containing feedback from Find' do
+      feedback1 = create(:find_feedback)
+      feedback2 = create(:find_feedback, find_controller: 'courses', path: '/course/L24/2CCR', created_at: 1.day.ago)
+
+      expect(described_class.new.data_for_export).to contain_exactly(
+        {
+          feedback_provided_at: feedback2.created_at,
+          find_url: 'https://www.find-postgraduate-teacher-training.service.gov.uk/course/L24/2CCR',
+          email: feedback2.email_address,
+          feedback: feedback2.feedback,
+        },
+        {
+          feedback_provided_at: feedback1.created_at,
+          find_url: 'https://www.find-postgraduate-teacher-training.service.gov.uk/results',
+          email: feedback1.email_address,
+          feedback: feedback1.feedback,
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

On the course and results page on Find, we give users the option to provide feedback. This is persisted to the Apply db, but we currently aren't exposing it via an export.


## Changes proposed in this pull request

- Add an export to for feedback provided on Find
- Add docs 

## Guidance to review

Does linking to the page they were on seem reasonable? I could just expose the path/find_controller

## Link to Trello card

https://trello.com/c/aIl3Z8AB/3329-add-an-export-for-findfeedback

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
