### PR TITLE
SPIKE - Trim trail/leading whitespace autosuggest inputs

### DIFF
--- a/app/frontend/packs/autosuggests/init-autosuggest.js
+++ b/app/frontend/packs/autosuggests/init-autosuggest.js
@@ -16,7 +16,12 @@ export const initAutosuggest = ({ inputIds, containerId, templates = {}, styles 
           templates: {
             inputValue: templates.inputTemplate,
             suggestion: templates.suggestionTemplate
-          }
+          },
+          source: (query, populateResults) => {
+            const source = JSON.parse(container.dataset.source)
+            const matches = source.filter(r => r.toLowerCase().indexOf(query.toLowerCase().trim()) !== -1)
+            populateResults(matches);
+          },
         }
       )
 


### PR DESCRIPTION
## Context

Currently when you enter a leading or trailing space in any of the auto-completes it filters out any entries that don't match the pattern of characters and spaces input. We want to ignore trailing and leading spaces for auto-complete purposes as well as trim them from values that end up in the database.

## Changes proposed in this pull request

This can be done by providing a custom `source` option.

## Guidance to review

- We probably would want to make this an option for our own wrapper. So this would need to be generalised. Ideas on how to do that?
- Also would want to avoid the `JSON.parse` every time we suggest.

## Link to Trello card

https://trello.com/c/f2yaj7CF/3318-strip-away-white-space-degree-autofill

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
