### PR TITLE
Reordered qualification type radio buttons for 'A levels and other qualifications'

### DIFF
--- a/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
@@ -5,9 +5,9 @@
 </h1>
 
 <%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { text: 'What type of qualification do you want to add?', size: 'm' } do %>
-  <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::GCSE_TYPE, label: { text: 'GCSE' }, link_errors: true %>
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::A_LEVEL_TYPE, label: { text: 'A level' } %>
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::AS_LEVEL_TYPE, label: { text: 'AS level' } %>
+  <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::GCSE_TYPE, label: { text: 'GCSE' }, link_errors: true %>
 
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::OTHER_TYPE, label: { text: 'Other UK qualification' } do %>
     <%= f.govuk_text_field :other_uk_qualification_type, label: { text: 'Qualification name', size: 's' } %>


### PR DESCRIPTION
## Context

As part of the work on the 'A levels and other qualifications' section, the `qualification_type` radio buttons need to be reordered on the selection page to match the prototype.

## Changes proposed in this pull request

|Before|After|
|---|---|
|![Screenshot 2021-04-26 at 17 55 45](https://user-images.githubusercontent.com/47917431/116122830-2df39c80-a6ba-11eb-9149-7b512a0a70e6.png)|![Screenshot 2021-04-26 at 17 56 04](https://user-images.githubusercontent.com/47917431/116122857-34821400-a6ba-11eb-9cf3-3edaea7350ba.png)|



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/lruaJM0Y/3331-reorder-the-a-levels-and-other-qualifications-section-choices

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
