### PR TITLE
Trim degree type values before they are saved

### DIFF
--- a/app/forms/candidate_interface/degree_type_form.rb
+++ b/app/forms/candidate_interface/degree_type_form.rb
@@ -14,6 +14,7 @@ module CandidateInterface
     validates :international_type_description, length: { maximum: 255 }
 
     def save
+      sanitize!
       return false unless valid?
       return false unless application_form_present?
 
@@ -25,6 +26,7 @@ module CandidateInterface
     end
 
     def update
+      sanitize!
       return false unless valid?
       return false unless degree_present?
 
@@ -72,6 +74,11 @@ module CandidateInterface
 
     def uk?
       uk_degree == 'yes'
+    end
+
+    def sanitize!
+      self.type_description = self.type_description.strip if self.type_description
+      self.international_type_description = self.international_type_description.strip if self.international_type_description
     end
   end
 end

--- a/spec/forms/candidate_interface/degree_type_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_type_form_spec.rb
@@ -56,6 +56,23 @@ RSpec.describe CandidateInterface::DegreeTypeForm do
         expect(form.errors.full_messages).to eq ['Application form is missing']
       end
     end
+
+    context 'when type description has trailing whitespace' do
+      let(:form) do
+        described_class.new(
+          type_description: ' BSc  ',
+          uk_degree: 'yes',
+          application_form: create(:application_form),
+        )
+      end
+
+      it 'persists the qualification and strips the trailing and leading whitespace from qualification_type' do
+        form.save
+
+        degree = form.application_form.application_qualifications.degree.first
+        expect(degree.qualification_type).to eq 'BSc'
+      end
+    end
   end
 
   describe '#update' do


### PR DESCRIPTION
## Context

Candidates can enter degree types as free text (as well as by selecting from the auto-suggest). This sometimes leads to values for the same type differing only by trailing or leading whitespace. We want to remove this so that degree qualifications are easier to analyse.

## Changes proposed in this pull request

This PR attempts to stop values with trailing or leading whitespace getting into the database in future by trimming them before save.
A separate migration will be needed to fix up any values that are already in the database and should be deployed separately after this one.

## Guidance to review

- Are there other ways to input this attribute that I've missed?

## Link to Trello card

https://trello.com/c/rvoXuX31/3317-strip-away-trailing-space-degree-autofills

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
