### PR TITLE
Add data migration to cleanup qualification types

### DIFF
--- a/app/services/data_migrations/trim_qualification_degree_types.rb
+++ b/app/services/data_migrations/trim_qualification_degree_types.rb
@@ -1,0 +1,17 @@
+module DataMigrations
+  class TrimQualificationDegreeTypes
+    TIMESTAMP = 20210426215031
+    MANUAL_RUN = false
+
+    def change
+      ApplicationQualification.where(level: 'degree').find_each do |application_qualification|
+        if /^\s+/ =~ application_qualification.qualification_type ||
+            /\s+$/ =~ application_qualification.qualification_type
+          application_qualification.update!(
+            qualification_type: application_qualification.qualification_type.strip,
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::TrimQualificationDegreeTypes',
   'DataMigrations::BackfillCurrentCourseOptionId',
   'DataMigrations::BackfillExportType',
   'DataMigrations::FixLatLongFlipFlops',

--- a/spec/services/data_migrations/trim_qualification_degree_types_spec.rb
+++ b/spec/services/data_migrations/trim_qualification_degree_types_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::TrimQualificationDegreeTypes do
+  it 'removes leading whitespace' do
+    degree_qualification = create(:degree_qualification, qualification_type: '  Bachelor of Life')
+    described_class.new.change
+    expect(degree_qualification.reload.qualification_type).to eq 'Bachelor of Life'
+  end
+
+  it 'removes trailing whitespace' do
+    degree_qualification = create(:degree_qualification, qualification_type: 'Bachelor of Life   ')
+    described_class.new.change
+    expect(degree_qualification.reload.qualification_type).to eq 'Bachelor of Life'
+  end
+
+  it 'leaves values without any leading/trailing whitespace as they are' do
+    degree_qualification = create(:degree_qualification, qualification_type: 'Bachelor of Life')
+    described_class.new.change
+    expect(degree_qualification.reload.qualification_type).to eq 'Bachelor of Life'
+  end
+end


### PR DESCRIPTION
## Context

Candidates can enter degree types as free text (as well as by selecting from the auto-suggest). This sometimes leads to values for the same type differing only by trailing or leading whitespace. We want to remove this so that degree qualifications are easier to analyse.

## Changes proposed in this pull request

This PR is a follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/4594. It adds a data migration to correct any `ApplicationForm#qualification_type` values (for degrees) that contain trailing or leading whitespace.

OPENING IN DRAFT BECAUSE THIS MIGRATION NEEDS TO BE DEPLOYED AFTER THE ABOVE PR.

## Guidance to review

Does this migration make sense? Does it do what is needed to clean up the data?

## Link to Trello card

https://trello.com/c/rvoXuX31/3317-strip-away-trailing-space-degree-autofills

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
