### PR TITLE
Slack course notification improvement

### DIFF
--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -356,17 +356,22 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
     end
 
     describe 'Slack notification' do
+      let(:accredited_body_code) { nil }
+
+      let!(:provider) do
+        create(:provider, code: 'ABC', name: 'University of Life', sync_courses: true)
+      end
+
       before do
         stub_teacher_training_api_course_with_site(provider_code: 'ABC',
                                                    course_code: 'ABC1',
                                                    recruitment_cycle_year: RecruitmentCycle.current_year,
-                                                   course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
+                                                   course_attributes: [{
+                                                     accredited_body_code: accredited_body_code,
+                                                     study_mode: 'full_time',
+                                                   }],
                                                    site_code: 'A',
                                                    vacancy_status: 'full_time_vacancies')
-      end
-
-      let!(:provider) do
-        create(:provider, code: 'ABC', name: 'University of Life', sync_courses: true)
       end
 
       it 'notifies Slack when the provider already has open courses on Apply in this cycle', sidekiq: true do
@@ -374,7 +379,29 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
 
         described_class.new.perform(provider.id, RecruitmentCycle.current_year)
 
-        expect_slack_message_with_text('University of Life, which has courses open on Apply, added a new course')
+        expect_slack_message_with_text('University of Life, which has courses open on Apply, added a new course. There’s no separate accredited body for this course.')
+      end
+
+      context 'the course from TTAPI has an accredited_body_code' do
+        let(:accredited_body_code) { 'DEF' }
+
+        it 'includes the accredited provider details when DSA is signed' do
+          accredited_provider = create(:provider, :with_signed_agreement, code: 'DEF', name: 'Canterbury')
+          create(:course, :open_on_apply, provider: provider, accredited_provider: accredited_provider) # existing course
+
+          described_class.new.perform(provider.id, RecruitmentCycle.current_year)
+
+          expect_slack_message_with_text('University of Life, which has courses open on Apply, added a new course. It’s ratified by Canterbury, who have signed the DSA.')
+        end
+
+        it 'includes the accredited provider details when DSA is not signed' do
+          accredited_provider = create(:provider, code: 'DEF', name: 'Canterbury')
+          create(:course, :open_on_apply, provider: provider, accredited_provider: accredited_provider) # existing course
+
+          described_class.new.perform(provider.id, RecruitmentCycle.current_year)
+
+          expect_slack_message_with_text('University of Life, which has courses open on Apply, added a new course. It’s ratified by Canterbury, who have NOT signed the DSA.')
+        end
       end
 
       it 'does not notify Slack when the provider does not have open courses on Apply in this cycle', sidekiq: true do


### PR DESCRIPTION
## Context

https://ukgovernmentdfe.slack.com/archives/CQA64BETU/p1619177647262900

We now notify Slack when a provider opens a course that might need opening on Apply. To enable quicker triage by the transition team we want to include the Accredited body in the message.

## Changes proposed in this pull request

Include the AB and whether or not it's been onboarded (ie signed the DSA).

Before: `One Sixth Form College, which has courses open on Apply, added a new course`
After: `One Sixth Form College, which has courses open on Apply, added a new course. It’s ratified by Canterbury, who have signed the DSA.`

## Guidance to review

Ignore whitespace, start with the tests

## Link to Trello card

https://trello.com/b/5IiPW0Ok/provendor-team-board

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
