### PR TITLE
Make missing section messaging consistent on review screen

### DIFF
--- a/config/locales/candidate_interface/review_application.yml
+++ b/config/locales/candidate_interface/review_application.yml
@@ -3,63 +3,65 @@ en:
     title: Review your application
     heading: Review your application
     course_choices:
-      incomplete: Course choices are not marked as completed
+      incomplete: Course choices not marked as complete
       complete_section: Complete your course choices
     personal_details:
-      incomplete: Personal details not entered
-      complete_section: Enter your personal details
+      incomplete: Personal details not marked as complete
+      not_marked_complete: Personal details not marked as completed
+      complete_section: Complete your personal details
+      mark_as_complete: Mark as complete
     contact_details:
-      incomplete: Contact details not entered
-      complete_section: Enter your contact details
+      incomplete: Contact details not marked as complete
+      complete_section: Complete your contact details
     training_with_a_disability:
-      incomplete: Any disability or other needs not entered
+      incomplete: Any disability or other needs not marked as complete
       complete_section: Do you want to ask for help to become a teacher?
     safeguarding:
-      incomplete: Safeguarding information not entered
+      incomplete: Safeguarding information not marked as complete
       complete_section: Do you need to declare any safeguarding issues?
     work_experience:
-      incomplete: Work history is not marked as completed
+      incomplete: Work history not marked as complete
       complete_section: Complete your work history
     volunteering:
-      incomplete: Volunteering with children and young people is not marked as completed
+      incomplete: Volunteering with children and young people not marked as complete
       complete_section: Do you have any experience working with children and young people?
     degrees:
-      incomplete: Degree section not marked as completed
-      complete_section: Enter your degrees
+      incomplete: Degree section not marked as complete
+      complete_section: Complete degrees section
     maths_gcse:
-      incomplete: Maths GCSE or equivalent not entered
-      complete_section: Enter your Maths GCSE or equivalent
+      incomplete: Maths GCSE or equivalent not marked as complete
+      complete_section: Complete Maths GCSE or equivalent
       missing: Maths GCSE not complete
       enter_missing: Enter all values for Maths GCSE or equivalent
     english_gcse:
-      incomplete: English GCSE or equivalent not entered
-      complete_section: Enter your English GCSE or equivalent
+      incomplete: English GCSE or equivalent not marked as complete
+      complete_section: Complete English GCSE or equivalent
       missing: English GCSE not complete
       enter_missing: Enter all values for English GCSE or equivalent
     science_gcse:
-      incomplete: Science GCSE or equivalent not entered
-      complete_section: Enter your Science GCSE or equivalent
+      incomplete: Science GCSE or equivalent not marked as complete
+      complete_section: Complete Science GCSE or equivalent
       missing: Science GCSE not complete
       enter_missing: Enter all values for Science GCSE or equivalent
     other_qualifications:
       incomplete: A levels and other qualifications not marked as complete
       complete_section: Complete your other qualifications
     other_qualifications_international:
-      incomplete: The other qualifications section is not marked as complete
+      incomplete: Other qualifications section not marked as complete
       complete_section: Complete your other qualifications
     efl:
       incomplete: English as a foreign language not marked as complete
       complete_section: Have you done an English as a foreign language assessment?
     becoming_a_teacher:
-      incomplete: Personal statement not entered
+      incomplete: Personal statement not marked as complete
       not_reviewed: Personal statement not marked as reviewed
       complete_section: Why do you want to be a teacher?
     subject_knowledge:
-      incomplete: Subject knowledge not entered
+      incomplete: Subject knowledge not marked as complete
       not_reviewed: Subject knowledge not marked as reviewed
       complete_section: What do you know about the subject you want to teach?
     interview_preferences:
-      incomplete: Interview needs not entered
+      incomplete: Interview needs not marked as complete
       complete_section: Do you have any interview needs?
     references:
       incomplete: Add %{minimum_references} referees to your application

--- a/spec/components/candidate_interface/incomplete_section_component_spec.rb
+++ b/spec/components/candidate_interface/incomplete_section_component_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 RSpec.describe CandidateInterface::IncompleteSectionComponent do
   it 'renders a section incomplete banner component' do
     result = render_inline(described_class.new(section: 'degrees', section_path: '#'))
-    expect(result.css('.app-inset-text__title').text).to include('Degree section not marked as completed')
+    expect(result.css('.app-inset-text__title').text).to include('Degree section not marked as complete')
     expect(result.css('.app-inset-text--important .govuk-link')).to be_present
-    expect(result.css('.app-inset-text--important .govuk-link').text).to include('Enter your degrees')
+    expect(result.css('.app-inset-text--important .govuk-link').text).to include('Complete degrees section')
   end
 
   it 'renders custom link text if given' do
     result = render_inline(described_class.new(section: 'degrees', section_path: '#', link_text: 'Click here to win'))
-    expect(result.css('.app-inset-text__title').text).to include('Degree section not marked as completed')
+    expect(result.css('.app-inset-text__title').text).to include('Degree section not marked as complete')
     expect(result.css('.app-inset-text--important .govuk-link')).to be_present
     expect(result.css('.app-inset-text--important .govuk-link').text).to include('Click here to win')
   end

--- a/spec/components/candidate_interface/personal_details_review_component_spec.rb
+++ b/spec/components/candidate_interface/personal_details_review_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewComponent do
       application_form = build_stubbed(:application_form)
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include('Personal details not entered')
+      expect(result.text).to include('Personal details not marked as complete')
     end
   end
 


### PR DESCRIPTION

## Context
When reviewing the application just prior to submit, we show info
banners for each section that hasn't been marked as complete. The
messaging in these banners is inconsistent, with some referring to
details that haven't been "entered".



<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
This PR makes the messaging consistently refer to the section as
having not been "marked as complete".

eg —
<!-- If there are UI changes, please include Before and After screenshots. -->
![Screenshot_20210426_214649](https://user-images.githubusercontent.com/519250/116217450-8de15600-a741-11eb-91b8-308d552fa8e5.png)

## Guidance to review
- Manual testing: Start a brand new application and then check and submit without filling anything in.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/xSCHq14t
## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
