### PR TITLE
Use http health check type for web app

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -17,7 +17,7 @@ provider "cloudfoundry" {
 resource "cloudfoundry_app" "web_app" {
   name                       = local.web_app_name
   docker_image               = var.app_docker_image
-  health_check_type          = "process"
+  health_check_type          = "http"
   health_check_http_endpoint = "/check"
   health_check_timeout       = 180
   instances                  = var.web_app_instances


### PR DESCRIPTION
## Context

Now that HostAuthorisation is removed, we can use the http health check type without any additional changes.

## Changes proposed in this pull request

Use `http` `health_check_type`

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
