### PR TITLE
Terraform config for statuscake alerts

### DIFF
--- a/terraform/modules/statuscake/main.tf
+++ b/terraform/modules/statuscake/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    statuscake = {
+      source  = "StatusCakeDev/statuscake"
+      version = "1.0.1"
+    }
+  }
+}
+
+provider "statuscake" {
+  username = var.username
+  apikey   = var.password
+}
+
+resource "statuscake_test" "alert" {
+  for_each = var.alerts
+
+  website_name   = each.value.website_name
+  website_url    = each.value.website_url
+  test_type      = each.value.test_type
+  check_rate     = each.value.check_rate
+  contact_group  = each.value.contact_group
+  trigger_rate   = each.value.trigger_rate
+  node_locations = each.value.node_locations
+  confirmations  = each.value.confirmations
+}

--- a/terraform/modules/statuscake/variables.tf
+++ b/terraform/modules/statuscake/variables.tf
@@ -1,0 +1,5 @@
+variable "username" {}
+
+variable "password" {}
+
+variable "alerts" { type = map(any) }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -49,3 +49,11 @@ module "paas" {
   clock_app_instances       = var.paas_clock_app_instances
   worker_app_instances      = var.paas_worker_app_instances
 }
+
+module "statuscake" {
+  source = "./modules/statuscake"
+
+  username = local.infra_secrets.STATUSCAKE_USERNAME
+  password = local.infra_secrets.STATUSCAKE_PASSWORD
+  alerts   = var.statuscake_alerts
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -34,6 +34,9 @@ variable "key_vault_infra_secret_name" {}
 
 variable "key_vault_app_secret_name" {}
 
+# StatusCake variables
+variable "statuscake_alerts" { type = map(any) }
+
 locals {
   cf_api_url        = "https://api.london.cloud.service.gov.uk"
   azure_credentials = try(jsondecode(var.azure_credentials), null)

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -14,22 +14,74 @@ key_vault_infra_secret_name = "BAT-INFRA-SECRETS-PRODUCTION"
 
 # StatusCake
 statuscake_alerts = {
-  apply-staging = {
+  apply-prod = {
     website_name   = "Apply-Teacher-Training-Prod"
-    website_url    = "https://www.apply-for-teacher-training.service.gov.uk/integrations/monitoring/all"
+    website_url    = "https://www.apply-for-teacher-training.service.gov.uk/check"
     test_type      = "HTTP"
     check_rate     = 30
     contact_group  = [188603]
     trigger_rate   = 0
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+    confirmations  = 2
   }
-  apply-cloudapps-qa = {
+  apply-prod-sidekiq-retries = {
+    website_name   = "Apply-Teacher-Training-Check-Prod"
+    website_url    = "https://www.apply-for-teacher-training.service.gov.uk/integrations/monitoring/sidekiq_retries_count"
+    test_type      = "HTTP"
+    check_rate     = 60
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+    confirmations  = 2
+  }
+  apply-prod-sidekiq-mailer = {
+    website_name   = "Apply-Teacher-Training-Sidekiq-Mailers-Queue-Prod"
+    website_url    = "https://www.apply-for-teacher-training.service.gov.uk/integrations/monitoring/sidekiq_mailers_queue"
+    test_type      = "HTTP"
+    check_rate     = 60
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+    confirmations  = 2
+  }
+  apply-prod-sidekiq-default = {
+    website_name   = "Apply-Teacher-Training-Sidekiq-Default-Queue-Prod"
+    website_url    = "https://www.apply-for-teacher-training.service.gov.uk/integrations/monitoring/sidekiq_default_queue"
+    test_type      = "HTTP"
+    check_rate     = 60
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+    confirmations  = 2
+  }
+  apply-prod-redis = {
+    website_name   = "Apply-Teacher-Training-Redis-Prod"
+    website_url    = "https://www.apply-for-teacher-training.service.gov.uk/integrations/monitoring/redis"
+    test_type      = "HTTP"
+    check_rate     = 60
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+    confirmations  = 2
+  }
+  apply-prod-postgres = {
+    website_name   = "Apply-Teacher-Training-Redis-Prod"
+    website_url    = "https://www.apply-for-teacher-training.service.gov.uk/integrations/monitoring/postgres"
+    test_type      = "HTTP"
+    check_rate     = 60
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+    confirmations  = 2
+  }
+  apply-cloudapps-prod = {
     website_name   = "Apply-Teacher-Training-Cloudapps-Prod"
-    website_url    = "https://apply-prod.london.cloudapps.digital/integrations/monitoring/all"
+    website_url    = "https://apply-prod.london.cloudapps.digital/check"
     test_type      = "HTTP"
     check_rate     = 30
     contact_group  = [188603]
     trigger_rate   = 0
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+    confirmations  = 1
   }
 }

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -11,3 +11,25 @@ key_vault_resource_group    = "s121p01-shared-rg"
 key_vault_name              = "s121p01-shared-kv-01"
 key_vault_app_secret_name   = "APPLY-APP-SECRETS-PRODUCTION"
 key_vault_infra_secret_name = "BAT-INFRA-SECRETS-PRODUCTION"
+
+# StatusCake
+statuscake_alerts = {
+  apply-staging = {
+    website_name   = "Apply-Teacher-Training-Prod"
+    website_url    = "https://www.apply-for-teacher-training.service.gov.uk/integrations/monitoring/all"
+    test_type      = "HTTP"
+    check_rate     = 30
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+  }
+  apply-cloudapps-qa = {
+    website_name   = "Apply-Teacher-Training-Cloudapps-Prod"
+    website_url    = "https://apply-prod.london.cloudapps.digital/integrations/monitoring/all"
+    test_type      = "HTTP"
+    check_rate     = 30
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+  }
+}

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -22,14 +22,26 @@ statuscake_alerts = {
     contact_group  = [188603]
     trigger_rate   = 0
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+    confirmations  = 2
   }
-  apply-cloudapps-qa = {
-    website_name   = "Apply-Teacher-Training-Cloudapps-QA"
-    website_url    = "https://apply-qa.london.cloudapps.digital/integrations/monitoring/all"
+  apply-qa-check = {
+    website_name   = "Apply-Teacher-Training-Check-QA"
+    website_url    = "https://qa.apply-for-teacher-training.service.gov.uk/check"
     test_type      = "HTTP"
     check_rate     = 30
     contact_group  = [188603]
     trigger_rate   = 0
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+    confirmations  = 2
+  }
+  apply-cloudapps-qa = {
+    website_name   = "Apply-Teacher-Training-Cloudapps-QA"
+    website_url    = "https://apply-qa.london.cloudapps.digital/check"
+    test_type      = "HTTP"
+    check_rate     = 30
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+    confirmations  = 1
   }
 }

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -11,3 +11,25 @@ key_vault_resource_group    = "s121d01-shared-rg"
 key_vault_name              = "s121d01-shared-kv-01"
 key_vault_app_secret_name   = "APPLY-APP-SECRETS-QA"
 key_vault_infra_secret_name = "BAT-INFRA-SECRETS-QA"
+
+# StatusCake
+statuscake_alerts = {
+  apply-qa = {
+    website_name   = "Apply-Teacher-Training-QA"
+    website_url    = "https://qa.apply-for-teacher-training.service.gov.uk/integrations/monitoring/all"
+    test_type      = "HTTP"
+    check_rate     = 30
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+  }
+  apply-cloudapps-qa = {
+    website_name   = "Apply-Teacher-Training-Cloudapps-QA"
+    website_url    = "https://apply-qa.london.cloudapps.digital/integrations/monitoring/all"
+    test_type      = "HTTP"
+    check_rate     = 30
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+  }
+}

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -11,3 +11,25 @@ key_vault_resource_group    = "s121p01-shared-rg"
 key_vault_name              = "s121p01-shared-kv-01"
 key_vault_app_secret_name   = "APPLY-APP-SECRETS-SANDBOX"
 key_vault_infra_secret_name = "BAT-INFRA-SECRETS-SANDBOX"
+
+# StatusCake
+statuscake_alerts = {
+  apply-qa = {
+    website_name   = "Apply-Teacher-Training-Sandbox"
+    website_url    = "https://sandbox.apply-for-teacher-training.service.gov.uk/integrations/monitoring/all"
+    test_type      = "HTTP"
+    check_rate     = 30
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+  }
+  apply-cloudapps-qa = {
+    website_name   = "Apply-Teacher-Training-Cloudapps-Sandbox"
+    website_url    = "https://apply-sandbox.london.cloudapps.digital/integrations/monitoring/all"
+    test_type      = "HTTP"
+    check_rate     = 30
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+  }
+}

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -14,7 +14,7 @@ key_vault_infra_secret_name = "BAT-INFRA-SECRETS-SANDBOX"
 
 # StatusCake
 statuscake_alerts = {
-  apply-qa = {
+  apply-sandbox = {
     website_name   = "Apply-Teacher-Training-Sandbox"
     website_url    = "https://sandbox.apply-for-teacher-training.service.gov.uk/integrations/monitoring/all"
     test_type      = "HTTP"
@@ -22,14 +22,26 @@ statuscake_alerts = {
     contact_group  = [188603]
     trigger_rate   = 0
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+    confirmations  = 2
   }
-  apply-cloudapps-qa = {
-    website_name   = "Apply-Teacher-Training-Cloudapps-Sandbox"
-    website_url    = "https://apply-sandbox.london.cloudapps.digital/integrations/monitoring/all"
+  apply-sandbox-check = {
+    website_name   = "Apply-Teacher-Training-Check-Sandbox"
+    website_url    = "https://sandbox.apply-for-teacher-training.service.gov.uk/check"
     test_type      = "HTTP"
     check_rate     = 30
     contact_group  = [188603]
     trigger_rate   = 0
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+    confirmations  = 2
+  }
+  apply-cloudapps-qa = {
+    website_name   = "Apply-Teacher-Training-Cloudapps-Sandbox"
+    website_url    = "https://apply-sandbox.london.cloudapps.digital/check"
+    test_type      = "HTTP"
+    check_rate     = 30
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+    confirmations  = 1
   }
 }

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -22,14 +22,26 @@ statuscake_alerts = {
     contact_group  = [188603]
     trigger_rate   = 0
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+    confirmations  = 2
   }
-  apply-cloudapps-qa = {
-    website_name   = "Apply-Teacher-Training-Cloudapps-Staging"
-    website_url    = "https://apply-staging.london.cloudapps.digital/integrations/monitoring/all"
+  apply-staging-check = {
+    website_name   = "Apply-Teacher-Training-Check-Staging"
+    website_url    = "https://staging.apply-for-teacher-training.service.gov.uk/check"
     test_type      = "HTTP"
     check_rate     = 30
     contact_group  = [188603]
     trigger_rate   = 0
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+    confirmations  = 2
+  }
+  apply-cloudapps-qa = {
+    website_name   = "Apply-Teacher-Training-Cloudapps-Staging"
+    website_url    = "https://apply-staging.london.cloudapps.digital/check"
+    test_type      = "HTTP"
+    check_rate     = 30
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+    confirmations  = 1
   }
 }

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -11,3 +11,25 @@ key_vault_resource_group    = "s121t01-shared-rg"
 key_vault_name              = "s121t01-shared-kv-01"
 key_vault_app_secret_name   = "APPLY-APP-SECRETS-STAGING"
 key_vault_infra_secret_name = "BAT-INFRA-SECRETS-STAGING"
+
+# StatusCake
+statuscake_alerts = {
+  apply-staging = {
+    website_name   = "Apply-Teacher-Training-Staging"
+    website_url    = "https://staging.apply-for-teacher-training.service.gov.uk/integrations/monitoring/all"
+    test_type      = "HTTP"
+    check_rate     = 30
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+  }
+  apply-cloudapps-qa = {
+    website_name   = "Apply-Teacher-Training-Cloudapps-Staging"
+    website_url    = "https://apply-staging.london.cloudapps.digital/integrations/monitoring/all"
+    test_type      = "HTTP"
+    check_rate     = 30
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+  }
+}


### PR DESCRIPTION
## Context

Bring statuscake alerts inside Terraform configuration

## Changes proposed in this pull request

Terraform StatusCake alert configuration.
Setup availability alerts for service and cloudapps domains.

## Link to Trello card

https://trello.com/c/sR1kUvH8/439-statuscake-monitoring

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
