### PR TITLE
Introduce ValidationException and update provider authorisation

### DIFF
--- a/app/errors/validation_exception.rb
+++ b/app/errors/validation_exception.rb
@@ -1,0 +1,22 @@
+class ValidationException < StandardError
+  attr_accessor :error_messages
+
+  def initialize(error_messages)
+    @error_messages = error_messages
+  end
+
+  def as_json
+    errors = error_messages.map do |error_message|
+      {
+        error: 'ValidationError',
+        message: error_message,
+      }
+    end
+
+    { errors: errors }
+  end
+
+  def message
+    error_messages.join(', ')
+  end
+end

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -73,7 +73,12 @@ class ProviderAuthorisation
     full_authorisation? permission: :view_diversity_information, course: course
   end
 
-  def can_make_decisions?(application_choice:, course_option_id:)
+  def can_make_decisions?(application_choice:, course_option_id: nil, course_option: nil)
+    if course_option_id.blank? && course_option.blank?
+      raise ValidationException, ['Please provide a course_option or course_option_id']
+    end
+
+    course_option_id ||= course_option.id
     course = CourseOption.find(course_option_id).course
 
     add_error(:make_decisions, :requires_application_choice_visibility) unless
@@ -87,7 +92,12 @@ class ProviderAuthorisation
     errors.blank?
   end
 
-  def assert_can_make_decisions!(application_choice:, course_option_id:)
+  def assert_can_make_decisions!(application_choice:, course_option_id: nil, course_option: nil)
+    if course_option_id.blank? && course_option.blank?
+      raise ValidationException, ['Please provide a course_option or course_option_id']
+    end
+
+    course_option_id ||= course_option.id
     return if can_make_decisions?(application_choice: application_choice, course_option_id: course_option_id)
 
     raise NotAuthorisedError, full_error_messages.join(' ')

--- a/spec/errors/validation_exception_spec.rb
+++ b/spec/errors/validation_exception_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe ValidationException do
+  let(:test_validation_exception) do
+    Class.new do
+      include ActiveModel::Model
+
+      attr_accessor :name, :surname
+
+      validates :name, :surname, presence: true
+
+      def execute
+        raise ValidationException, errors.full_messages unless valid?
+      end
+    end
+  end
+
+  let(:name) { nil }
+  let(:surname) { nil }
+
+  before do
+    stub_const('TestValidationException', test_validation_exception)
+  end
+
+  it 'contains the correct error messages' do
+    model = TestValidationException.new(name: name, surname: surname)
+
+    expect { model.execute }.to raise_error(ValidationException, 'Name can\'t be blank, Surname can\'t be blank')
+  end
+
+  it 'can return the error messages in json format' do
+    TestValidationException.new(name: name, surname: surname).execute
+  rescue ValidationException => e
+    expect(e.as_json).to eq(errors: [{ error: 'ValidationError', message: 'Name can\'t be blank' },
+                                     { error: 'ValidationError', message: 'Surname can\'t be blank' }])
+  end
+end

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -4,12 +4,16 @@ RSpec.describe ProviderAuthorisation do
   include CourseOptionHelpers
 
   describe '#assert_can_make_decisions!' do
+    let(:auth_context) { ProviderAuthorisation.new(actor: nil) }
+
+    it 'raises a ValidationException if neither a course_option or a course_option_id is provided' do
+      expect { auth_context.assert_can_make_decisions!(application_choice: nil) }.to raise_error(ValidationException, 'Please provide a course_option or course_option_id')
+    end
+
     it 'raises an error if the actor cannot make decisions' do
-      auth_context = ProviderAuthorisation.new(actor: nil)
-      allow(auth_context).to receive(:can_make_decisions?).and_return(true)
-      expect { auth_context.assert_can_make_decisions!(application_choice: nil, course_option_id: nil) }.not_to raise_error
       allow(auth_context).to receive(:can_make_decisions?).and_return(false)
-      expect { auth_context.assert_can_make_decisions!(application_choice: nil, course_option_id: nil) }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
+
+      expect { auth_context.assert_can_make_decisions!(application_choice: nil, course_option_id: build_stubbed(:course_option).id) }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
     end
   end
 


### PR DESCRIPTION
## Context
Introduce a ValidationException and update ProviderAuthorisation to raise error if no course_option or course_option.id is provided. This enables getting more meaninful errors and being able to check if the user is authorised to perform certain actions before running validations and potentially disclosing information on data that they don't have the right to amend, for example in [MakeAnOffer](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/services/make_an_offer.rb#L37).

## Changes proposed in this pull request

- Introduce ValidationException
- Update ProviderAuthorisation to allow for course_option as well as course_option_id and validate presence of course_option prior to authorising user.

## Link to Trello card
Related to: 3620-add-make-offer-validations-to-the-vendor-api


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
