### PR TITLE
Remove 'multiple hints' functionality from Section Completed component

### DIFF
--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -5,13 +5,7 @@
 
   <%= f.govuk_radio_buttons_fieldset :completed, classes: 'govuk-!-width-two-thirds ', legend: { text: t('application_form.completed_question'), size: 'm' } do %>
     <% if hint_text %>
-      <% if hint_text.is_a?(Array) %>
-        <% hint_text.each do |paragraph| %>
-          <div class="govuk-hint"><%= paragraph %></div>
-        <% end %>
-      <% else %>
-        <div class="govuk-hint"><%= hint_text %></div>
-      <% end %>
+      <div class="govuk-hint"><%= hint_text %></div>
     <% end %>
     <%= f.govuk_radio_button :completed, true, label: { text: complete_or_reviewed_radio_button_label }, link_errors: true %>
     <%= f.govuk_radio_button :completed, false, label: { text: t('application_form.incomplete_radio') } %>

--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -3,12 +3,17 @@
 
   <%= render(review_component) %>
 
-  <%= f.govuk_radio_buttons_fieldset :completed, classes: 'govuk-!-width-two-thirds ', legend: { text: t('application_form.completed_question'), size: 'm' } do %>
-    <% if hint_text %>
-      <div class="govuk-hint"><%= hint_text %></div>
-    <% end %>
-    <%= f.govuk_radio_button :completed, true, label: { text: complete_or_reviewed_radio_button_label }, link_errors: true %>
-    <%= f.govuk_radio_button :completed, false, label: { text: t('application_form.incomplete_radio') } %>
+  <%= f.govuk_collection_radio_buttons :completed,
+    [[true, complete_or_reviewed_radio_button_label], [false, t('application_form.incomplete_radio')]],
+    :first,
+    :last,
+    legend: { text: t('application_form.completed_question'), size: 'm' },
+    hint: -> do %>
+      <% if hint_text %>
+        <div class="govuk-!-width-two-thirds">
+          <%= hint_text %>
+        </div>
+      <% end %>
   <% end %>
 
   <%= f.govuk_submit t('continue') %>

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -32,9 +32,6 @@
   path: candidate_interface_becoming_a_teacher_complete_path,
   request_method: :patch,
   review_component: CandidateInterface::BecomingATeacherReviewComponent.new(application_form: @application_form),
-  hint_text: [
-    t('application_form.personal_statement.becoming_a_teacher.complete_hint_text_one'),
-    t('application_form.personal_statement.becoming_a_teacher.complete_hint_text_two'),
-  ],
+  hint_text: t('application_form.personal_statement.becoming_a_teacher.complete_hint_text'),
   section_review: @application_form.reviewable?(:becoming_a_teacher),
 )) %>

--- a/app/views/candidate_interface/subject_knowledge/show.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/show.html.erb
@@ -25,8 +25,5 @@
   request_method: :patch,
   section_review: @application_form.reviewable?(:subject_knowledge),
   review_component: CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: @application_form),
-  hint_text: [
-    t('application_form.personal_statement.subject_knowledge.complete_hint_text_one'),
-    t('application_form.personal_statement.subject_knowledge.complete_hint_text_two'),
-  ],
+  hint_text: t('application_form.personal_statement.subject_knowledge.complete_hint_text'),
 )) %>

--- a/config/locales/candidate_interface/personal_statement.yml
+++ b/config/locales/candidate_interface/personal_statement.yml
@@ -4,14 +4,12 @@ en:
       becoming_a_teacher:
         change_action: why do you want to be a teacher?
         label: Why do you want to be a teacher?
-        complete_hint_text_one: Proofread this section carefully for spelling and grammar. Ask someone you trust for their opinion.
-        complete_hint_text_two: Ensure this is all your own work as plagiarism will be penalised.
+        complete_hint_text: Proofread this section carefully for spelling and grammar. Ask someone you trust for their opinion. Ensure this is all your own work as plagiarism will be penalised.
       subject_knowledge:
         key: Your knowledge about the subject you want to teach
         change_action: evidence of subject knowledge
         label: Tell us what you know about the subject you want to teach
-        complete_hint_text_one: Proofread this section carefully for spelling and grammar. Ask someone you trust for their opinion.
-        complete_hint_text_two: Ensure this is all your own work as plagiarism will be penalised.
+        complete_hint_text: Proofread this section carefully for spelling and grammar. Ask someone you trust for their opinion. Ensure this is all your own work as plagiarism will be penalised.
       interview_preferences:
         key: Interview needs
         change_action: interview needs

--- a/spec/components/candidate_interface/complete_section_component_spec.rb
+++ b/spec/components/candidate_interface/complete_section_component_spec.rb
@@ -41,23 +41,6 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
     expect(result.to_html).to include hint_text
   end
 
-  it 'renders more than one hint' do
-    another_hint_text = 'Another hint text'
-
-    result = render_inline(
-      described_class.new(
-        section_complete_form: section_complete_form,
-        path: path,
-        request_method: request_method,
-        hint_text: [hint_text, another_hint_text],
-        review_component: review_component,
-      ),
-    )
-
-    expect(result.to_html).to include hint_text
-    expect(result.to_html).to include another_hint_text
-  end
-
   it 'renders a review radio button label if specified' do
     result = render_inline(
       described_class.new(


### PR DESCRIPTION
## Context

Originally the design intent was to be able to pass in multiple hints into the `SectionCompletedComponent` and display as separate paragraphs. However for simplicity we will now pass in a single string and display as a single paragraph. This will also allow us to use the `govuk_collection_radio_buttons` from Govuk Design System Formbuilder gem.

## Changes proposed in this pull request

- `SectionCompleteComponent` now displays a single hint only
- Migrate to `govuk_collection_radio_buttons` in the `SectionCompleteComponent`

## Guidance to review

- Go to any review section in the application to view the SectionCompleteComponent

<img width="621" alt="section_complete_single_hint" src="https://user-images.githubusercontent.com/5256922/116257574-1117a180-a76c-11eb-926e-14176d39877f.png">

## Link to Trello card

https://trello.com/c/Fu5pfwQi/3333-remove-multiple-hints-functionality-from-section-completed-component

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
