### PR TITLE
Add offer validations to the vendor api

### DIFF
--- a/app/errors/identical_offer_error.rb
+++ b/app/errors/identical_offer_error.rb
@@ -1,0 +1,2 @@
+class IdenticalOfferError < StandardError
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -141,4 +141,8 @@ class Course < ApplicationRecord
   def subject_codes
     @subject_codes ||= subjects.includes(:course_subjects).map(&:code)
   end
+
+  def ratifying_provider
+    accredited_provider || provider
+  end
 end

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -1,4 +1,6 @@
 class MakeOffer
+  include ImpersonationAuditHelper
+
   attr_reader :actor, :application_choice, :course_option, :conditions
 
   def initialize(actor:,
@@ -12,17 +14,36 @@ class MakeOffer
   end
 
   def save!
-    make_an_offer = MakeAnOffer.new(actor: actor,
-                                    application_choice: application_choice,
-                                    course_option: course_option,
-                                    offer_conditions: conditions)
+    auth.assert_can_make_decisions!(application_choice: application_choice, course_option: course_option)
 
-    unless make_an_offer.save
-      if make_an_offer.errors[:base].include?(MakeAnOffer::STATE_TRANSITION_ERROR)
-        ApplicationStateChange.new(application_choice).make_offer!
-      else
-        raise 'Unable to complete save on make_an_offer'
+    if offer.valid?
+      audit(actor) do
+        ActiveRecord::Base.transaction do
+          ApplicationStateChange.new(application_choice).make_offer!
+
+          application_choice.current_course_option = course_option
+          application_choice.offer = { 'conditions' => conditions }
+          application_choice.offered_at = Time.zone.now
+          application_choice.save!
+
+          SetDeclineByDefault.new(application_form: application_choice.application_form).call
+        end
+
+        SendNewOfferEmailToCandidate.new(application_choice: application_choice).call
       end
+    else
+      raise ValidationException, offer.errors.map(&:message)
     end
+  end
+
+private
+
+  def auth
+    @auth ||= ProviderAuthorisation.new(actor: actor)
+  end
+
+  def offer
+    @offer ||= OfferValidations.new(course_option: course_option,
+                                    conditions: conditions)
   end
 end

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -11,6 +11,7 @@ class OfferValidations
   validate :conditions_count, if: :conditions
   validate :conditions_length, if: :conditions
   validate :identical_to_existing_offer?, if: %i[application_choice course_option]
+  validate :ratifying_provider_changed?, if: %i[application_choice course_option]
 
   def course_option_open_on_apply
     errors.add(:course_option, :not_open_on_apply) unless course_option.course.open_on_apply?
@@ -31,6 +32,12 @@ class OfferValidations
   def identical_to_existing_offer?
     if application_choice.current_course_option == course_option && application_choice.offer['conditions'] == conditions
       raise IdenticalOfferError
+    end
+  end
+
+  def ratifying_provider_changed?
+    if application_choice.current_course.ratifying_provider != course_option.course.ratifying_provider
+      errors.add(:base, :different_ratifying_provider)
     end
   end
 end

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -1,0 +1,7 @@
+class OfferValidations
+  include ActiveModel::Model
+
+  attr_accessor :course_option
+
+  validates :course_option, presence: true
+end

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -4,12 +4,13 @@ class OfferValidations
   MAX_CONDITIONS_COUNT = 20
   MAX_CONDITION_LENGTH = 255
 
-  attr_accessor :course_option, :conditions
+  attr_accessor :application_choice, :course_option, :conditions
 
   validates :course_option, presence: true
   validate :course_option_open_on_apply, if: :course_option
   validate :conditions_count, if: :conditions
   validate :conditions_length, if: :conditions
+  validate :identical_to_existing_offer?, if: %i[application_choice course_option]
 
   def course_option_open_on_apply
     errors.add(:course_option, :not_open_on_apply) unless course_option.course.open_on_apply?
@@ -24,6 +25,12 @@ class OfferValidations
   def conditions_length
     conditions.each_with_index do |condition, index|
       errors.add(:conditions, :too_long, index: index + 1, limit: MAX_CONDITION_LENGTH) if condition.length > MAX_CONDITION_LENGTH
+    end
+  end
+
+  def identical_to_existing_offer?
+    if application_choice.current_course_option == course_option && application_choice.offer['conditions'] == conditions
+      raise IdenticalOfferError
     end
   end
 end

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -1,12 +1,29 @@
 class OfferValidations
   include ActiveModel::Model
 
-  attr_accessor :course_option
+  MAX_CONDITIONS_COUNT = 20
+  MAX_CONDITION_LENGTH = 255
+
+  attr_accessor :course_option, :conditions
 
   validates :course_option, presence: true
   validate :course_option_open_on_apply, if: :course_option
+  validate :conditions_count, if: :conditions
+  validate :conditions_length, if: :conditions
 
   def course_option_open_on_apply
     errors.add(:course_option, :not_open_on_apply) unless course_option.course.open_on_apply?
+  end
+
+  def conditions_count
+    return if conditions.count <= MAX_CONDITIONS_COUNT
+
+    errors.add(:conditions, :too_many, count: MAX_CONDITIONS_COUNT)
+  end
+
+  def conditions_length
+    conditions.each_with_index do |condition, index|
+      errors.add(:conditions, :too_long, index: index + 1, limit: MAX_CONDITION_LENGTH) if condition.length > MAX_CONDITION_LENGTH
+    end
   end
 end

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -4,4 +4,9 @@ class OfferValidations
   attr_accessor :course_option
 
   validates :course_option, presence: true
+  validate :course_option_open_on_apply, if: :course_option
+
+  def course_option_open_on_apply
+    errors.add(:course_option, :not_open_on_apply) unless course_option.course.open_on_apply?
+  end
 end

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -88,3 +88,4 @@ en:
               too_long: 'Condition %{index} must be %{limit} characters or fewer'
             base:
               identical_to_existing: The new offer is identical to the current offer
+              different_ratifying_provider: The offered course's ratifying provider must be the same as the one originally requested

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -79,3 +79,7 @@ en:
               blank: Select course
             provider_id:
               blank: Select provider
+        offer_validations:
+          attributes:
+            course_option:
+              not_open_on_apply: The requested course is not open for applications via the Apply service

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -83,3 +83,6 @@ en:
           attributes:
             course_option:
               not_open_on_apply: The requested course is not open for applications via the Apply service
+            conditions:
+              too_many: Offer has over %{count} conditions
+              too_long: 'Condition %{index} must be %{limit} characters or fewer'

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -86,3 +86,5 @@ en:
             conditions:
               too_many: Offer has over %{count} conditions
               too_long: 'Condition %{index} must be %{limit} characters or fewer'
+            base:
+              identical_to_existing: The new offer is identical to the current offer

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :application_choice do
-    course_option
+    association :course_option, :open_on_apply
     application_form
 
     after(:stub, :build) do |application_choice, _evaluator|

--- a/spec/factories/course_option.rb
+++ b/spec/factories/course_option.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
     vacancy_status { 'vacancies' }
     site_still_valid { true }
 
+    trait :open_on_apply do
+      association :course, :open_on_apply
+    end
+
     trait :full_time do
       study_mode { :full_time }
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -119,4 +119,22 @@ RSpec.describe Course, type: :model do
       expect(course.subject_codes).to contain_exactly('01', '9X')
     end
   end
+
+  describe '#ratifying_provider' do
+    context 'when there is an accredited provider set' do
+      let(:course) { build(:course, accredited_provider: build(:provider)) }
+
+      it 'returns the accredited provider' do
+        expect(course.ratifying_provider).to eq(course.accredited_provider)
+      end
+    end
+
+    context 'when there is no accredited provider set' do
+      let(:course) { build(:course) }
+
+      it 'returns the provider' do
+        expect(course.ratifying_provider).to eq(course.provider)
+      end
+    end
+  end
 end

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -1,6 +1,33 @@
 require 'rails_helper'
 RSpec.describe OfferValidations, type: :model do
+  subject(:offer) { OfferValidations.new(course_option: course_option) }
+
+  let(:course_option) { create(:course_option, course: course) }
+  let(:course) { create(:course, :open_on_apply) }
+
   context 'validations' do
     it { is_expected.to validate_presence_of(:course_option) }
+
+    describe '#course_option_open_on_apply' do
+      context 'when no course_option' do
+        let(:course_option) { nil }
+
+        it 'does not add a :not_open_on_apply error' do
+          offer.valid?
+
+          expect(offer.errors[:course_option]).not_to contain_exactly('is not open for applications via the Apply service')
+        end
+      end
+
+      context 'when not open on apply' do
+        let(:course) { create(:course, :ucas_only) }
+
+        it 'adds a :not_open_on_apply error' do
+          expect(offer).to be_invalid
+
+          expect(offer.errors[:course_option]).to contain_exactly('The requested course is not open for applications via the Apply service')
+        end
+      end
+    end
   end
 end

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 RSpec.describe OfferValidations, type: :model do
-  subject(:offer) { OfferValidations.new(course_option: course_option, conditions: conditions) }
+  subject(:offer) { OfferValidations.new(application_choice: application_choice, course_option: course_option, conditions: conditions) }
 
+  let(:application_choice) { nil }
   let(:course_option) { create(:course_option, course: course) }
   let(:course) { create(:course, :open_on_apply) }
   let(:conditions) { [] }
@@ -55,6 +56,18 @@ RSpec.describe OfferValidations, type: :model do
           expect(offer).to be_invalid
 
           expect(offer.errors[:conditions]).to contain_exactly('Condition 1 must be 255 characters or fewer', 'Condition 3 must be 255 characters or fewer')
+        end
+      end
+    end
+
+    describe '#identical_to_existing_offer?' do
+      context 'when the offer details are identical to the existing offer' do
+        let(:application_choice) { build_stubbed(:application_choice, :with_offer) }
+        let(:course_option) { application_choice.course_option }
+        let(:conditions) { application_choice.offer['conditions'] }
+
+        it 'raises an IdenticalOfferError' do
+          expect { offer.valid? }.to raise_error(IdenticalOfferError)
         end
       end
     end

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+RSpec.describe OfferValidations, type: :model do
+  context 'validations' do
+    it { is_expected.to validate_presence_of(:course_option) }
+  end
+end

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -71,5 +71,20 @@ RSpec.describe OfferValidations, type: :model do
         end
       end
     end
+
+    describe '#ratifying_provider_changed?' do
+      context 'when the ratifying provider is different than the one of the requested course' do
+        let(:application_choice) { build_stubbed(:application_choice, :with_offer, current_course_option: current_course_option) }
+        let(:current_course_option) { create(:course_option, :open_on_apply) }
+        let(:course_option) { build(:course_option, :open_on_apply) }
+        let(:conditions) { application_choice.offer['conditions'] }
+
+        it 'adds a :different_ratifying_provider error' do
+          expect(offer).to be_invalid
+
+          expect(offer.errors[:base]).to contain_exactly('The offered course\'s ratifying provider must be the same as the one originally requested')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Introduces an OfferValidation service_model that can be used by both the `MakeOffer` and `ChangeOffer` services to check for data validity and updates `VendorAPI::DecisionsController` to use new services

## Changes proposed in this pull request
1. Add OfferValidation model
2. Update `MakeOffer` and `ChangeOffer` to use `OfferValidation`
3. Update `VendorAPI::DecisionsController` to use new Offer services when the `updated_offer_flow` flag is active.

## Link to Trello card

https://trello.com/c/TaJgQjeP/3620-add-make-offer-validations-to-the-vendor-api

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
