### PR TITLE
Bugfix - set current_course_option in AddCourseChoiceAfterSubmission

### DIFF
--- a/app/services/support_interface/add_course_choice_after_submission.rb
+++ b/app/services/support_interface/add_course_choice_after_submission.rb
@@ -8,11 +8,11 @@ module SupportInterface
     end
 
     def call
-      application_choice = ApplicationChoice.create!(
+      application_choice = ApplicationChoice.new(
         application_form: application_form,
-        course_option: course_option,
         status: 'unsubmitted',
       )
+      application_choice.set_initial_course_choice!(course_option)
 
       SendApplicationToProvider.call(application_choice)
 

--- a/spec/services/support_interface/add_course_choice_after_submission_spec.rb
+++ b/spec/services/support_interface/add_course_choice_after_submission_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe SupportInterface::AddCourseChoiceAfterSubmission do
       expect(called).to eq(appended_application_choice)
       expect(called.application_form).to eq(application_form)
       expect(called.course_option).to eq(course_option)
+      expect(called.current_course_option).to eq(course_option)
       expect(called.status).to eq('unsubmitted')
       expect(SendApplicationToProvider).to have_received(:call).with(called)
     end


### PR DESCRIPTION


## Context
This is a service object invoked via the support UI when a candidate requests a course choice added to their application after they've already submitted.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Use the `set_initial_course_choice!` method to set both `course_option` and `current_course_option`

Not doing so causes the application dashboard to error out as it expects
the `current_course_option` to be set.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Is there a better way to approach this? Alternatives considered:
  - Fallback to course_option if current_course_option blank
  - Define a single method in `ApplicationChoice` for creating new ones, and use that wherever we're adding a choice to an application form.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
na
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
