### PR TITLE
Clear test data for applications the current provider ratifies.

### DIFF
--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -27,6 +27,7 @@ module VendorAPI
 
     def clear!
       current_provider.application_choices.map(&:application_form).map(&:candidate).map(&:destroy!)
+      clear_accredited_application_data!
 
       render json: { data: { message: 'Applications cleared' } }
     end
@@ -55,6 +56,13 @@ module VendorAPI
 
     def for_ratified_courses_param
       params[:for_ratified_courses] == 'true'
+    end
+
+    def clear_accredited_application_data!
+      Candidate
+        .joins(application_forms: { application_choices: { course_option: :course } })
+        .where("courses.accredited_provider": current_provider)
+        .map(&:destroy!)
     end
   end
 end

--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -26,8 +26,7 @@ module VendorAPI
     end
 
     def clear!
-      current_provider.application_choices.map(&:application_form).map(&:candidate).map(&:destroy!)
-      clear_accredited_application_data!
+      ClearApplicationDataForProvider.call(current_provider)
 
       render json: { data: { message: 'Applications cleared' } }
     end
@@ -56,13 +55,6 @@ module VendorAPI
 
     def for_ratified_courses_param
       params[:for_ratified_courses] == 'true'
-    end
-
-    def clear_accredited_application_data!
-      Candidate
-        .joins(application_forms: { application_choices: { course_option: :course } })
-        .where("courses.accredited_provider": current_provider)
-        .map(&:destroy!)
     end
   end
 end

--- a/app/services/vendor_api/clear_application_data_for_provider.rb
+++ b/app/services/vendor_api/clear_application_data_for_provider.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  class ClearApplicationDataForProvider
+    def self.call(provider)
+      scope = Candidate.joins(application_forms: { application_choices: { course_option: :course } })
+      scope.where("courses.accredited_provider": provider).or(scope.where("courses.provider": provider))
+        .delete_all
+    end
+  end
+end

--- a/spec/requests/vendor_api/post_test_data_clear_spec.rb
+++ b/spec/requests/vendor_api/post_test_data_clear_spec.rb
@@ -34,6 +34,21 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/clear', type: :request do
     }.from(1).to(0)
   end
 
+  it 'destroys applications accredited by the current provider' do
+    create(
+      :application_choice,
+      :awaiting_provider_decision,
+      course_option: course_option_for_accredited_provider(
+        accredited_provider: currently_authenticated_provider,
+        provider: create(:provider),
+      ),
+    )
+
+    expect { post_api_request('/api/v1/test-data/clear') }.to change(Candidate, :count).from(1).to(0)
+      .and change(ApplicationForm, :count).from(1).to(0)
+      .and change(ApplicationChoice, :count).from(1).to(0)
+  end
+
   it 'returns responses conforming to the schema' do
     post_api_request('/api/v1/test-data/clear')
     expect(parsed_response).to be_valid_against_openapi_schema('OkResponse')

--- a/spec/services/vendor_api/clear_application_data_for_provider_spec.rb
+++ b/spec/services/vendor_api/clear_application_data_for_provider_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe VendorAPI::ClearApplicationDataForProvider do
+  include CourseOptionHelpers
+
+  describe '.call' do
+    let(:provider) { create(:provider) }
+
+    it 'deletes a candidate if the course on their application is associated to the provider' do
+      create(
+        :application_choice,
+        :awaiting_provider_decision,
+        course_option: course_option_for_provider(provider: provider),
+      )
+
+      expect { described_class.call(provider) }.to change { Candidate.count }.from(1).to(0)
+    end
+
+    it 'deletes a candidate if the course on an application is associated to the accredited provider' do
+      create(
+        :application_choice,
+        :awaiting_provider_decision,
+        course_option: course_option_for_accredited_provider(
+          accredited_provider: provider,
+          provider: create(:provider),
+        ),
+      )
+
+      expect { described_class.call(provider) }.to change { Candidate.count }.from(1).to(0)
+    end
+
+    it 'deletes all associated application choices to the candidate' do
+      create(
+        :application_choice,
+        :awaiting_provider_decision,
+        course_option: course_option_for_provider(provider: provider),
+      )
+
+      expect { described_class.call(provider) }.to change { ApplicationChoice.count }.from(1).to(0)
+    end
+
+    it 'deletes all associated application forms to the candidate' do
+      create(
+        :application_choice,
+        :awaiting_provider_decision,
+        course_option: course_option_for_provider(provider: provider),
+      )
+
+      expect { described_class.call(provider) }.to change { ApplicationForm.count }.from(1).to(0)
+    end
+  end
+end


### PR DESCRIPTION
## Context

The API endpoint `test-data/clear` clears applications for courses run by the current provider.
It also needs to clear applications data for courses accredited/ratified by the current provider. 

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds an additional step in the test data controller `clear!` action which destroys any application data (Candidate, and dependents) where the current provider ratifies the course.
 
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/y1mz1pb3/3494-api-endpoint-for-test-data-clear-does-not-clear-data-for-courses-the-provider-ratifies
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
