### PR TITLE
Reset locations on offer flow

### DIFF
--- a/app/controllers/provider_interface/offer/courses_controller.rb
+++ b/app/controllers/provider_interface/offer/courses_controller.rb
@@ -9,8 +9,7 @@ module ProviderInterface
       end
 
       def create
-        @wizard = OfferWizard.new(offer_store, { decision: 'change_offer', current_step: 'courses' })
-        reset_study_mode_if_course_has_changed_and_update_course
+        @wizard = OfferWizard.new(offer_store, attributes_for_wizard)
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!
@@ -31,8 +30,7 @@ module ProviderInterface
       end
 
       def update
-        @wizard = OfferWizard.new(offer_store, { current_step: 'courses' })
-        reset_study_mode_if_course_has_changed_and_update_course
+        @wizard = OfferWizard.new(offer_store, attributes_for_wizard)
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!
@@ -47,14 +45,12 @@ module ProviderInterface
 
     private
 
-      def reset_study_mode_if_course_has_changed_and_update_course
-        course_id = course_params['course_id']
-        @wizard.study_mode = nil if course_id != @wizard.course_id
-        @wizard.course_id = course_id
-      end
-
       def course_params
         params.require(:provider_interface_offer_wizard).permit(:course_id)
+      end
+
+      def attributes_for_wizard
+        course_params.to_h.merge!(current_step: 'courses')
       end
     end
   end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -20,6 +20,7 @@ module ProviderInterface
 
     def initialize(state_store, attrs = {})
       @state_store = state_store
+      attrs = sanitize_parameters(attrs)
 
       super(last_saved_state.deep_merge(attrs))
       setup_further_conditions
@@ -200,6 +201,13 @@ module ProviderInterface
           errors.add("further_conditions[#{model.id}][#{error.attribute}]", error.message)
         end
       end
+    end
+
+    def sanitize_parameters(attrs)
+      if !last_saved_state.empty? && attrs[:course_id].present? && last_saved_state['course_id'] != attrs[:course_id]
+        attrs.merge!(study_mode: nil, course_option_id: nil)
+      end
+      attrs
     end
   end
 end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -6,7 +6,7 @@ module ProviderInterface
               change_offer: %i[select_option providers courses study_modes locations conditions check] }.freeze
     NUMBER_OF_FURTHER_CONDITIONS = 4
 
-    attr_accessor :provider_id, :course_id, :course_option_id, :study_mode, :location_id,
+    attr_accessor :provider_id, :course_id, :course_option_id, :study_mode,
                   :standard_conditions, :further_conditions, :current_step, :decision,
                   :action, :path_history, :wizard_path_history,
                   :provider_user_id, :application_choice_id
@@ -36,7 +36,6 @@ module ProviderInterface
         course_option_id: course_option.id,
         provider_id: course_option.provider.id,
         study_mode: course_option.study_mode,
-        location_id: course_option.site.id,
         decision: :default,
         standard_conditions: standard_conditions_from(application_choice.offer),
         further_conditions: further_conditions_from(application_choice.offer),

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -70,6 +70,29 @@ RSpec.describe ProviderInterface::OfferWizard do
     end
   end
 
+  describe '#initialize' do
+    context 'is responsible for sanitising the attributes' do
+      context 'when the provided course_id does not match the stored value' do
+        let(:wizard) do
+          described_class.new(store, course_id: course_id)
+        end
+        let(:stored_data) { { course_id: 5, course_option_id: 3, study_mode: :full_time, provider_id: 10 }.to_json }
+        let(:course_id) { 4 }
+
+        before do
+          allow(store).to receive(:read).and_return(stored_data)
+        end
+
+        it 'resets the study mode and course_option_id' do
+          expect(wizard.study_mode).to eq(nil)
+          expect(wizard.course_option_id).to eq(nil)
+          expect(wizard.course_id).to eq(course_id)
+          expect(wizard.provider_id).to eq(10)
+        end
+      end
+    end
+  end
+
   describe '.build_from_application_choice' do
     let(:application_choice) { create(:application_choice, offer: offer) }
     let(:offer) { { 'conditions' => ['Fitness to train to teach check', 'Be cool'] } }

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe ProviderInterface::OfferWizard do
                         course_id: course_id,
                         course_option_id: course_option_id,
                         study_mode: study_mode,
-                        location_id: location_id,
                         application_choice_id: application_choice_id,
                         standard_conditions: standard_conditions,
                         further_conditions: further_conditions,
@@ -19,7 +18,6 @@ RSpec.describe ProviderInterface::OfferWizard do
   let(:course_id) { nil }
   let(:course_option_id) { nil }
   let(:study_mode) { nil }
-  let(:location_id) { nil }
   let(:application_choice_id) { create(:application_choice).id }
   let(:standard_conditions) { MakeAnOffer::STANDARD_CONDITIONS }
   let(:further_condition_1) { '' }


### PR DESCRIPTION
## Context

Resets course_option and study_mode when the course_id changes.

## Changes proposed in this pull request
- Refactor resetting study mode to be part of OffersWizard
- Remove unused `location_id` from OffersWizard


## Link to Trello card
https://trello.com/c/MQsW0Qle/3626-reset-locations-on-offer-flow

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
