### PR TITLE
Resolve deprecation warnings

### DIFF
--- a/app/forms/provider_interface/application_data_export_form.rb
+++ b/app/forms/provider_interface/application_data_export_form.rb
@@ -49,7 +49,7 @@ module ProviderInterface
 
     def at_least_one_provider_is_selected
       if selected_providers.none?
-        errors[:provider_ids] << 'Select at least one organisation'
+        errors.add(:provider_ids, 'Select at least one organisation')
       end
     end
   end

--- a/app/services/cancel_interview.rb
+++ b/app/services/cancel_interview.rb
@@ -24,9 +24,7 @@ class CancelInterview
         interview.update!(cancellation_reason: cancellation_reason,
                           cancelled_at: Time.zone.now)
 
-        return if @application_choice.interviews.kept.any?
-
-        ApplicationStateChange.new(application_choice).cancel_interview!
+        ApplicationStateChange.new(application_choice).cancel_interview! if @application_choice.interviews.kept.none?
       end
 
       CandidateMailer.interview_cancelled(application_choice, interview, cancellation_reason).deliver_later


### PR DESCRIPTION
Resolve deprecation warnings

```ruby
DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead.
```
and 

```ruby
DEPRECATION WARNING: Using `return`, `break` or `throw` to exit a transaction block is
deprecated without replacement. If the `throw` came from
`Timeout.timeout(duration)`, pass an exception class as a second
argument so it doesn't use `throw` to abort its block. This results
in the transaction being committed, but in the next release of Rails
it will rollback.
```