### PR TITLE
Resolve API encoding error

### DIFF
--- a/app/middlewares/vendor_api_request_middleware.rb
+++ b/app/middlewares/vendor_api_request_middleware.rb
@@ -53,7 +53,7 @@ private
     {
       path: @request.path,
       params: @request.params,
-      body: @request.body.read,
+      body: @request.body.read.force_encoding('utf-8'),
       headers: request_headers,
       method: @request.request_method,
     }


### PR DESCRIPTION
## Context

Resolve API encoding error by forcing UTF-8 encoding.

## Guidance to review
You should be able to replicate the error by removing encording and running spec/requests/vendor_api/post_make_an_offer_spec.rb spec

## Link to Trello card

https://trello.com/c/pglY7nw1/3586-encoding-error-when-posting-an-offer-through-the-api

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
