### PR TITLE
Make non visible text in work history links visible.

### DIFF
--- a/app/components/candidate_interface/break_placeholder_in_work_history_component.html.erb
+++ b/app/components/candidate_interface/break_placeholder_in_work_history_component.html.erb
@@ -4,15 +4,15 @@
       <ul class="app-summary-card__actions-list">
         <li class="app-summary-card__actions-list-item">
           <%= govuk_link_to candidate_interface_new_work_history_break_path(start_date: work_break.start_date, end_date: work_break.end_date) do %>
-            Explain break <span class="govuk-visually-hidden"><%= between_formatted_dates %></span>
+            Explain break [<%= between_formatted_dates %>]
           <% end %>
         </li>
         <li class="app-summary-card__actions-list-item">
-          or
+        or
         </li>
         <li class="app-summary-card__actions-list-item">
           <%= govuk_link_to candidate_interface_new_work_history_path(start_date: work_break.start_date, end_date: work_break.end_date) do %>
-            add another job <span class="govuk-visually-hidden"><%= between_formatted_dates %></span>
+            add another job [<%= between_formatted_dates %>]
           <% end %>
         </li>
       </ul>


### PR DESCRIPTION
## Context

As part of a design review designers have concluded that his text should be visible.

## Changes proposed in this pull request

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/62567622/116423305-7a64e680-a838-11eb-9f22-a6e80ff68684.png">

## Guidance to review

@paulrobertlloyd - does this look right?

## Link to Trello card

https://trello.com/c/m84YjtGn/3313-add-accessible-text-to-work-history-break-action-links

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
