### PR TITLE
Add Hidden Accessibility text to Restructured Work History view

### DIFF
--- a/app/components/candidate_interface/restructured_work_history/gap_component.html.erb
+++ b/app/components/candidate_interface/restructured_work_history/gap_component.html.erb
@@ -1,6 +1,10 @@
 <%= govuk_inset_text(classes: 'app-inset-text--important govuk-!-margin-top-0 govuk-!-margin-bottom-0') do %>
   You have a break in your work history (<%= format_months_to_years_and_months(@break_period.length) %>)
   <br>
-  <%= govuk_link_to 'Add another job', candidate_interface_new_restructured_work_history_path %> or
-  <%= govuk_link_to 'add a reason for this break', candidate_interface_new_restructured_work_history_break_path(start_date: @break_period.start_date, end_date: @break_period.end_date) %>
+  <%= govuk_link_to candidate_interface_new_restructured_work_history_path do %>
+    Add another job<span class="govuk-visually-hidden"> <%= between_formatted_dates %></span><% end %>
+    or
+  <%= govuk_link_to candidate_interface_new_restructured_work_history_break_path(start_date: @break_period.start_date, end_date: @break_period.end_date) do %>
+    add a reason for this break<span class="govuk-visually-hidden"> <%= between_formatted_dates %></span>
+  <% end %>
 <% end %>

--- a/app/components/candidate_interface/restructured_work_history/gap_component.rb
+++ b/app/components/candidate_interface/restructured_work_history/gap_component.rb
@@ -6,6 +6,10 @@ module CandidateInterface
       def initialize(break_period:)
         @break_period = break_period
       end
+
+      def between_formatted_dates
+        "between #{@break_period.start_date.to_s(:month_and_year)} and #{@break_period.end_date.to_s(:month_and_year)}"
+      end
     end
   end
 end

--- a/spec/components/candidate_interface/restructured_work_history/gap_component_spec.rb
+++ b/spec/components/candidate_interface/restructured_work_history/gap_component_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::GapComponent do
   it 'renders the component with a link to explain break' do
     result = render_inline(CandidateInterface::RestructuredWorkHistory::GapComponent.new(break_period: break_period))
 
-    expect(result.css('a').last.text).to eq('add a reason for this break')
+    expect(result.text).to include('Add another job between January 2020 and May 2020')
     expect(result.css('a').last.attributes['href'].value).to eq '/candidate/application/restructured-work-history/explain-break/new?end_date=2020-05-01&start_date=2020-01-01'
   end
 
   it 'renders the component with a link to add another job' do
     result = render_inline(CandidateInterface::RestructuredWorkHistory::GapComponent.new(break_period: break_period))
 
-    expect(result.css('a').first.text).to eq('Add another job')
+    expect(result.text).to include('Add another job between January 2020 and May 2020')
     expect(result.css('a').first.attributes['href'].value).to eq '/candidate/application/restructured-work-history/new'
   end
 


### PR DESCRIPTION
## Context

As part of a review of the resructured work history feature, designers noticed that the old accessibility text is missing.
This PR adds this back in.

## Changes proposed in this pull request

Please check mark up as intended in review app.

## Guidance to review

## Link to Trello card

https://trello.com/c/m84YjtGn/3313-add-accessible-text-to-work-history-break-action-links

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
