### PR TITLE
Fix time to avoid flakey tests due to RBD

### DIFF
--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
 
   around do |example|
-    Timecop.freeze(Time.zone.now.midday) do
+    Timecop.freeze(Time.zone.local(2021, 4, 22, 12, 26, 0)) do
       example.run
     end
   end


### PR DESCRIPTION
 ## Context

We've been saying specs fail randomly due to different days. Example: https://github.com/DFE-Digital/apply-for-teacher-training/pull/4561/files

## Changes proposed in this pull request

Fix the time in the spec to avoid those failures while we investigate to unblock master failures. I've added a ticket to investigate on the provender board
https://trello.com/c/1ATaBJJn/3656-investigate-causes-of-flakey-tests-due-to-time

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
