### PR TITLE
Trim trail/leading whitespace in autosuggest inputs

### DIFF
--- a/app/frontend/packs/autosuggests/init-autosuggest.js
+++ b/app/frontend/packs/autosuggests/init-autosuggest.js
@@ -35,8 +35,8 @@ export const initAutosuggest = ({ inputIds, containerId, templates = {}, styles 
   }
 }
 
-initAutosuggest.stripWhitespaceFilter = (_source) => {
-  const source = _source
+initAutosuggest.stripWhitespaceFilter = (s) => {
+  const source = s
   return (query, populateResults) => {
     const matches = source.filter(r => r.toLowerCase().indexOf(query.toLowerCase().trim()) !== -1)
     populateResults(matches)

--- a/app/frontend/packs/autosuggests/init-autosuggest.js
+++ b/app/frontend/packs/autosuggests/init-autosuggest.js
@@ -1,6 +1,6 @@
 import { accessibleAutosuggestFromSource } from './helpers'
 
-export const initAutosuggest = ({ inputIds, containerId, templates = {}, styles = () => {} }) => {
+export const initAutosuggest = ({ inputIds, containerId, templates = {}, styles = () => {}, stripWhitespace = true }) => {
   try {
     inputIds.forEach(inputId => {
       const input = document.getElementById(inputId)
@@ -9,15 +9,25 @@ export const initAutosuggest = ({ inputIds, containerId, templates = {}, styles 
       const container = document.getElementById(containerId)
       if (!container) return
 
+      let options = {
+        templates: {
+          inputValue: templates.inputTemplate,
+          suggestion: templates.suggestionTemplate
+        },
+      };
+
+      if (stripWhitespace) {
+        const source = JSON.parse(container.dataset.source)
+        options.source = (query, populateResults) => {
+          const matches = source.filter(r => r.toLowerCase().indexOf(query.toLowerCase().trim()) !== -1)
+          populateResults(matches)
+        }
+      }
+
       accessibleAutosuggestFromSource(
         input,
         container,
-        {
-          templates: {
-            inputValue: templates.inputTemplate,
-            suggestion: templates.suggestionTemplate
-          }
-        }
+        options,
       )
 
       styles(containerId)

--- a/app/frontend/packs/autosuggests/init-autosuggest.js
+++ b/app/frontend/packs/autosuggests/init-autosuggest.js
@@ -9,30 +9,36 @@ export const initAutosuggest = ({ inputIds, containerId, templates = {}, styles 
       const container = document.getElementById(containerId)
       if (!container) return
 
-      let options = {
+      const options = {
         templates: {
           inputValue: templates.inputTemplate,
           suggestion: templates.suggestionTemplate
-        },
-      };
+        }
+      }
 
       if (stripWhitespace) {
-        const source = JSON.parse(container.dataset.source)
-        options.source = (query, populateResults) => {
-          const matches = source.filter(r => r.toLowerCase().indexOf(query.toLowerCase().trim()) !== -1)
-          populateResults(matches)
-        }
+        options.source = initAutosuggest.stripWhitespaceFilter(
+          JSON.parse(container.dataset.source)
+        )
       }
 
       accessibleAutosuggestFromSource(
         input,
         container,
-        options,
+        options
       )
 
       styles(containerId)
     })
   } catch (err) {
     console.error(`Could not enhance ${containerId}:`, err)
+  }
+}
+
+initAutosuggest.stripWhitespaceFilter = (_source) => {
+  const source = _source
+  return (query, populateResults) => {
+    const matches = source.filter(r => r.toLowerCase().indexOf(query.toLowerCase().trim()) !== -1)
+    populateResults(matches)
   }
 }

--- a/app/frontend/packs/autosuggests/init-autosuggest.spec.js
+++ b/app/frontend/packs/autosuggests/init-autosuggest.spec.js
@@ -40,3 +40,17 @@ describe('initAutoSuggest', () => {
     expect(document.querySelector('#outer-container')).toMatchSnapshot()
   })
 })
+
+describe('initAutoSuggest.stripWhitespaceFilter', () => {
+  it('stripWhitespaceFilter should return matching items', () => {
+    let result
+    initAutosuggest.stripWhitespaceFilter(['foo', 'bar', 'food'])('foo', (r) => { result = r })
+    expect(result).toEqual(['foo', 'food'])
+  })
+
+  it('stripWhitespaceFilter should return matching items ignoring trailing and leading whitespace', () => {
+    let result
+    initAutosuggest.stripWhitespaceFilter(['foo', 'bar', 'food'])('  foo ', (r) => { result = r })
+    expect(result).toEqual(['foo', 'food'])
+  })
+})


### PR DESCRIPTION
## Context

If a candidate enters spaces before or after an otherwise matching string into the degree type auto-suggest the potential matches are filtered out of the auto-suggestion list. We want to ignore trailing and leading whitespace for auto-suggest matching purposes.

## Changes proposed in this pull request

- [x] Add a `stripWhitespace` option to our `initAutosuggest` wrapper that injects a custom `source` function that strips off any trailing and leading whitespace before finding a match.
- [x] Add a test to exercise this behaviour.

## Guidance to review

- Does adding a `stripWhitespace` option make sense here?
- Can we extend this implementation to support synonym mappings? (another imminent requirement for auto-suggest)
- Is it sensible to make `stripWhitespace` on by default?
- How can I test the behaviour?

I wanted to write a test that exercises the autosuggest behaviour like this:
```
  it('should suggest matching options', () => {
    const autosuggest = document.querySelector('#autosuggest-containerId')
    const input = document.querySelector('#autosuggest-containerId input')
    const keyVal = 65
    input.value = ' A'
    input.dispatchEvent(new KeyboardEvent(
      'keydown',
      {
        keyCode: keyVal,
        which: keyVal,
        charCode: keyVal,
      })
    )
    # TODO: Assert that the matching options are rendered
  })
```
It doesn't work because the event isn't triggering the desired behaviour in Jest/JSDOM. I ended up writing unit tests to cover the filtering but would really like to know how to make this kind of test work.

## Link to Trello card

https://trello.com/c/f2yaj7CF/3318-strip-away-white-space-degree-autofill

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
