### PR TITLE
add uuid field to sync api method

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -52,6 +52,7 @@ module TeacherTrainingPublicAPI
     end
 
     def assign_course_attributes(course, course_from_api, recruitment_cycle_year)
+      course.uuid = course_from_api.uuid
       course.name = course_from_api.name
       course.level = course_from_api.level
       course.study_mode = study_mode(course_from_api)

--- a/spec/examples/teacher_training_api/course_list_response.json
+++ b/spec/examples/teacher_training_api/course_list_response.json
@@ -17,6 +17,7 @@
         ],
         "changed_at": "2019-06-13T10:44:31Z",
         "code": "3GTY",
+        "uuid": "906c6f3c-b2d6-46e1-8bf7-3fbd13d3ea06",
         "course_length": "OneYear",
         "created_at": "2019-06-13T10:44:31Z",
         "fee_details": "For those wishing to top up their qualification to the full PGCE, a further £1800 will be payable.",

--- a/spec/examples/teacher_training_api/course_single_response.json
+++ b/spec/examples/teacher_training_api/course_single_response.json
@@ -16,6 +16,7 @@
       ],
       "changed_at": "2019-06-13T10:44:31Z",
       "code": "3GTY",
+      "uuid": "906c6f3c-b2d6-46e1-8bf7-3fbd13d3ea06",
       "course_length": "OneYear",
       "created_at": "2019-06-13T10:44:31Z",
       "fee_details": "For those wishing to top up their qualification to the full PGCE, a further £1800 will be payable.",

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
         described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
 
         course_option = CourseOption.last
+        expect(course_option.course.uuid).to eq '906c6f3c-b2d6-46e1-8bf7-3fbd13d3ea06'
         expect(course_option.course.provider.code).to eq 'ABC'
         expect(course_option.course.provider.provider_type).to eq 'scitt'
         expect(course_option.course.provider.region_code).to eq 'south_west'


### PR DESCRIPTION
## Context

In order to have the sync Api method add UUID fields to the existing items in the database, it needs to be added to the relevant method. This corresponds to point 2 of the attached Trello card. 


## Link to Trello card

https://trello.com/c/MFIi8aj1/3628-ensure-courses-we-get-from-ttapi-are-unique
