### PR TITLE
Add DeleteApplication service for data deletion requests

### DIFF
--- a/app/services/delete_application.rb
+++ b/app/services/delete_application.rb
@@ -1,0 +1,92 @@
+class DeleteApplication
+  include ImpersonationAuditHelper
+
+  attr_reader :actor, :application_form, :zendesk_url
+
+  APPLICATION_FORM_FIELDS_TO_REDACT = %i[
+    first_name
+    last_name
+    first_nationality
+    second_nationality
+    english_main_language
+    english_language_details
+    other_language_details
+    date_of_birth
+    further_information
+    phone_number
+    address_line1
+    address_line2
+    address_line3
+    address_line4
+    country
+    postcode
+    disability_disclosure
+    uk_residency_status
+    work_history_explanation
+    becoming_a_teacher
+    subject_knowledge
+    interview_preferences
+    work_history_breaks
+    volunteering_experience
+    equality_and_diversity
+    safeguarding_issues
+    international_address
+    right_to_work_or_study
+    right_to_work_or_study_details
+    third_nationality
+    fourth_nationality
+    fifth_nationality
+    feedback_satisfaction_level
+    feedback_suggestions
+    work_history_status
+  ].freeze
+
+  ASSOCIATIONS_TO_DESTROY = %i[
+    application_work_experiences
+    application_volunteering_experiences
+    application_qualifications
+    application_references
+    application_work_history_breaks
+    application_feedback
+  ].freeze
+
+  def initialize(actor:, application_form:, zendesk_url:)
+    @actor = actor
+    @application_form = application_form
+    @zendesk_url = zendesk_url
+  end
+
+  def call!
+    raise 'Application has been sent to providers' \
+      unless application_form.application_choices.all?(&:unsubmitted?)
+
+    audit(actor) do
+      ActiveRecord::Base.transaction do
+        ASSOCIATIONS_TO_DESTROY.each { |assoc| application_form.send(assoc)&.destroy_all }
+        APPLICATION_FORM_FIELDS_TO_REDACT.each { |attr| application_form.send("#{attr}=", nil) }
+        application_form.save!
+
+        reference = application_form.support_reference
+        application_form.candidate.update!(email_address: "deleted-application-#{reference}@example.com")
+
+        application_form.own_and_associated_audits.destroy_all
+        add_audit_event_for_deletion!
+      end
+    end
+  end
+
+private
+
+  def add_audit_event_for_deletion!
+    comment = "Data deletion request: #{zendesk_url}"
+
+    application_form.reload.audits << Audited::Audit.new(
+      action: 'destroy',
+      user: actor,
+      version: 1,
+      audited_changes: {},
+      comment: comment,
+      created_at: Time.zone.now,
+    )
+  end
+end

--- a/spec/services/delete_application_spec.rb
+++ b/spec/services/delete_application_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe DeleteApplication do
+  let(:support_user) { create(:support_user) }
+  let(:application_form) do
+    create(
+      :completed_application_form,
+      application_choices_count: 3,
+      work_experiences_count: 2,
+      volunteering_experiences_count: 2,
+      references_count: 2,
+      full_work_history: true,
+    )
+  end
+  let(:zendesk_url) { 'https://becomingateacher.zendesk.com/agent/tickets/1234' }
+  let(:service) do
+    described_class.new(
+      actor: support_user,
+      application_form: application_form,
+      zendesk_url: zendesk_url,
+    )
+  end
+
+  describe '#call!', with_audited: true do
+    it 'raises error if application has been submitted to providers' do
+      application_choice = application_form.application_choices.first
+      SendApplicationToProvider.call(application_choice)
+      expect { service.call! }.to raise_error('Application has been sent to providers')
+    end
+
+    it 'deletes all personal information from the application form' do
+      service.call!
+
+      application_form.reload
+      DeleteApplication::APPLICATION_FORM_FIELDS_TO_REDACT.each do |attr|
+        expect(application_form.send(attr)).to be_blank
+      end
+    end
+
+    it 'does not remove their application choices' do
+      service.call!
+
+      application_form.reload
+      expect(application_form.application_choices.count).to eq(3)
+    end
+
+    it 'removes associations which can leak personal information' do
+      service.call!
+
+      application_form.reload
+      DeleteApplication::ASSOCIATIONS_TO_DESTROY.each do |assoc|
+        expect(application_form.send(assoc).count).to be_zero
+      end
+    end
+
+    it 'replaces all audits with a single entry documenting the deletion' do
+      service.call!
+
+      application_form.reload
+      expect(application_form.own_and_associated_audits.count).to eq(1)
+
+      audit = application_form.own_and_associated_audits.first
+      expect(audit.user).to eq(support_user)
+      expect(audit.comment).to eq("Data deletion request: #{zendesk_url}")
+    end
+  end
+end


### PR DESCRIPTION
## Context

Candidates who have started applications but decided not to submit their applications have requested the deletion of their data from our service. This is restricted to unsubmitted applications in this PR, but could be extended to service GDPR-style data deletion requests for any application. Once an application has been sent to providers, we may need to take additional steps.

## Changes proposed in this pull request

Overwrite ApplicationForm fields, drop most associations, rewrite the audit log.

## Guidance to review

We are erasing the audit log because it contains a lot of personal information. This means the application's history will be empty, except for a comment documenting the deletion event.

![image](https://user-images.githubusercontent.com/107591/116565776-1278d380-a8fe-11eb-86be-aa23db97f474.png)

We are keeping the ApplicationForm object, its unique support reference and any application choices so that we are still able to include it in our stats. Does this make sense?

Have I missed any fields/associations?

## Link to Trello card

Support-driven https://trello.com/c/3QATwvwN

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
