### PR TITLE
Amend content in Provider information banner for PaaS migration

### DIFF
--- a/app/components/provider_interface/information_banner_component.html.erb
+++ b/app/components/provider_interface/information_banner_component.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= govuk_notification_banner(title: t('notification_banner.info')) do |notification_banner| %>
+      <%= notification_banner.slot(:heading, text: header_content) %>
+      <p class="govuk-body"><%= body_content %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/components/provider_interface/information_banner_component.rb
+++ b/app/components/provider_interface/information_banner_component.rb
@@ -1,0 +1,17 @@
+module ProviderInterface
+  class InformationBannerComponent < ViewComponent::Base
+    def initialize; end
+
+    def header_content
+      HostingEnvironment.sandbox_mode? ? t('notification_banner.sandbox_header') : t('notification_banner.header')
+    end
+
+    def body_content
+      HostingEnvironment.sandbox_mode? ? t('notification_banner.sandbox_body') : t('notification_banner.body')
+    end
+
+    def render?
+      FeatureFlag.active?('provider_information_banner')
+    end
+  end
+end

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -1,15 +1,6 @@
 <% content_for :browser_title, "Applications (#{@application_choices_count})" %>
 
-<% if FeatureFlag.active?('provider_information_banner') %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <%= govuk_notification_banner(title: t('notification_banner.info')) do |notification_banner| %>
-        <%= notification_banner.slot(:heading, text: '2 April to 16 April 2021 do not count as working days') %>
-        <p class="govuk-body">This period will not be included when calculating dates for applications to be automatically rejected. This is to match the dates used by UCAS.</p>
-      <% end %>
-    </div>
-  </div>
-<% end %>
+<%= render ProviderInterface::InformationBannerComponent.new %>
 
 <h1 class="govuk-heading-xl">Applications (<%= @application_choices_count %>)</h1>
 

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -24,16 +24,7 @@
   </div>
 </div>
 
-<% if FeatureFlag.active?('provider_information_banner') %>
-  <div class="govuk-width-container">
-    <div class="govuk-width-container govuk-!-margin-top-4">
-      <%= govuk_notification_banner(title: t('notification_banner.info')) do |notification_banner| %>
-        <%= notification_banner.slot(:heading, text: '2 April to 16 April 2021 do not count as working days') %>
-        <p class="govuk-body">This period will not be included when calculating dates for applications to be automatically rejected. This is to match the dates used by UCAS.</p>
-      <% end %>
-    </div>
-  </div>
-<% end %>
+<%= render ProviderInterface::InformationBannerComponent.new %>
 
 <div class="govuk-width-container">
   <section class="app-section">

--- a/config/locales/notification_banner.yml
+++ b/config/locales/notification_banner.yml
@@ -3,3 +3,8 @@ en:
     info: Information
     warning: Warning
     success: Success
+    sandbox_header: The Manage sandbox will be unavailable on Tuesday 4th May from 6pm to 7pm
+    sandbox_body: This will affect both the web service and the API. You may lose work if you are using the Manage sandbox when it becomes unavailable.
+    header: The Manage service will be unavailable on Thursday 6th May from 8am to 9am
+    body: This will affect both the web service and the API. You may lose work if you are using Manage when it becomes unavailable.
+

--- a/spec/components/provider_interface/information_banner_component_spec.rb
+++ b/spec/components/provider_interface/information_banner_component_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::InformationBannerComponent do
+  subject(:result) { render_inline(ProviderInterface::InformationBannerComponent.new) }
+
+  context 'when the provider information banner feature flag is on' do
+    before { FeatureFlag.activate('provider_information_banner') }
+
+    it 'renders the banner header' do
+      expect(result.text).to include('The Manage service will be unavailable on Thursday 6th May from 8am to 9am')
+    end
+
+    it 'renders the banner body' do
+      expect(result.text).to include('This will affect both the web service and the API. You may lose work if you are using Manage when it becomes unavailable.')
+    end
+
+    context 'when the hosting environment is sandbox' do
+      it 'renders the banner header', sandbox: true do
+        expect(result.text).to include('The Manage sandbox will be unavailable on Tuesday 4th May from 6pm to 7pm')
+      end
+
+      it 'renders the banner body', sandbox: true do
+        expect(result.text).to include('This will affect both the web service and the API. You may lose work if you are using the Manage sandbox when it becomes unavailable.')
+      end
+    end
+  end
+
+  context 'when the provider information banner feature flag is off' do
+    it 'does not render the banner' do
+      FeatureFlag.deactivate('provider_information_banner')
+
+      expect(result.text).to eq('')
+    end
+  end
+end

--- a/spec/system/provider_interface/providers_can_view_information_in_the_banner_spec.rb
+++ b/spec/system/provider_interface/providers_can_view_information_in_the_banner_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Provider can view information in the banner' do
   end
 
   def then_i_see_information_about_working_days_changes
-    expect(page).to have_content '2 April to 16 April 2021 do not count as working days'
+    expect(page).to have_content 'The Manage service will be unavailable on Thursday 6th May from 8am to 9am'
   end
 
   def when_feature_flag_is_off
@@ -31,6 +31,6 @@ RSpec.feature 'Provider can view information in the banner' do
   end
 
   def then_i_dont_see_information_about_working_days_changes
-    expect(page).not_to have_content '2 April to 16 April 2021 do not count as working days'
+    expect(page).not_to have_content 'The Manage service will be unavailable on Thursday 6th May from 8am to 9am'
   end
 end


### PR DESCRIPTION
## Context

We are migrating to PaaS, add a banner on the provider interface to warn of the migration

## Changes proposed in this pull request

- Add new content for information banner
- Move current banner into component
- Use different content for sandbox/prod

## Guidance to review

@duncanjbrown could you double check with James around the Apply side banners

## Link to Trello card

https://trello.com/c/HpKuxGvH/3657-provider-information-banners-and-maintenance-pages-for-service-downtime-due-to-paas-migration

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
