### PR TITLE
Add Maintenance page

### DIFF
--- a/app/components/service_unavailable_component.html.erb
+++ b/app/components/service_unavailable_component.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :title, title_content %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title_content %></h1>
     <p class="govuk-body"><%= downtime_content %></p>
     <p class="govuk-body"><%= t('service_unavailable.body') %></p>

--- a/app/components/service_unavailable_component.html.erb
+++ b/app/components/service_unavailable_component.html.erb
@@ -1,0 +1,9 @@
+<%= content_for :title, title_content %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl"><%= title_content %></h1>
+    <p class="govuk-body"><%= downtime_content %></p>
+    <p class="govuk-body"><%= t('service_unavailable.body') %></p>
+  </div>
+</div>

--- a/app/components/service_unavailable_component.rb
+++ b/app/components/service_unavailable_component.rb
@@ -1,0 +1,11 @@
+class ServiceUnavailableComponent < ViewComponent::Base
+  def initialize; end
+
+  def title_content
+    HostingEnvironment.sandbox_mode? ? t('service_unavailable.sandbox_title') : t('service_unavailable.title')
+  end
+
+  def downtime_content
+    HostingEnvironment.sandbox_mode? ? t('service_unavailable.sandbox_downtime') : t('service_unavailable.downtime')
+  end
+end

--- a/app/middlewares/service_unavailable_middleware.rb
+++ b/app/middlewares/service_unavailable_middleware.rb
@@ -1,0 +1,44 @@
+class ServiceUnavailableMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    @request = Rack::Request.new(env)
+    if FeatureFlag.active?(:service_unavailable_page) && !monitoring_paths?
+      [503, { 'Content-Type' => content_type }, [body]]
+    else
+      @app.call(env)
+    end
+  end
+
+private
+
+  def content_type
+    return 'application/json' if api_path?
+
+    'text/html'
+  end
+
+  def body
+    return 'Service Unavailable' if api_path?
+
+    action_view.render(template: 'errors/service_unavailable', layout: 'layouts/error')
+  end
+
+  def lookup_context
+    @lookup_context ||= ActionView::LookupContext.new(ActionController::Base.view_paths)
+  end
+
+  def action_view
+    @action_view ||= ActionView::Base.with_empty_template_cache.new(lookup_context, {}, ActionController::Base.new)
+  end
+
+  def api_path?
+    @request.path =~ /^\/api\/.*$/
+  end
+
+  def monitoring_paths?
+    @request.path =~ /^\/check$/ || @request.path =~ /^\/integrations\/monitoring\/.*$/
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -19,6 +19,7 @@ class FeatureFlag
     [:provider_information_banner, 'Displays an information banner for providers on the start page and applications page', 'Apply team'],
     [:deadline_notices, 'Show candidates copy related to end of cycle deadlines', 'Apply team'],
     [:export_hesa_data, 'Providers can export applications including HESA data.', 'Apply team'],
+    [:service_unavailable_page, 'Displays a maintenance page on the whole application', 'Apply team'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [

--- a/app/views/errors/service_unavailable.html.erb
+++ b/app/views/errors/service_unavailable.html.erb
@@ -1,0 +1,1 @@
+<%= render ServiceUnavailableComponent.new %>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+  <head>
+    <meta charset="utf-8">
+    <title><%= try(:browser_title) %></title>
+
+    <meta name="robots" content="noindex, nofollow">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_pack_path('media/images/favicon.ico') %>" type="image/x-icon">
+    <link rel="mask-icon" href="<%= asset_pack_path('media/images/govuk-mask-icon.svg') %>" color="#0b0c0c">
+    <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png') %>">
+    <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png') %>">
+    <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_pack_path('media/images/govuk-apple-touch-icon-152x152.png') %>">
+    <link rel="apple-touch-icon" href="<%= asset_pack_path('media/images/govuk-apple-touch-icon.png') %>">
+
+    <meta property="og:image" content="<%= asset_pack_path('media/images/govuk-opengraph-image.png') %>">
+    <%= stylesheet_pack_tag 'application', media: 'all' %>
+  </head>
+
+  <body class="govuk-template__body">
+    <%= render(ProductHeaderComponent.new(
+      classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border",
+      product_name: 'Apply for teacher training',
+      service_url: '#',
+      navigation_items: [],
+    )) %>
+
+    <%= render PhaseBannerComponent.new %>
+    <div class="govuk-width-container">
+      <main class="govuk-main-wrapper" id="main-content" role="main">
+        <%= yield %>
+      </main>
+    </div>
+    <%= govuk_footer(classes: 'govuk-!-display-none-print') do |footer| %>
+      <%= footer.slot(:meta) do %>
+        <div class="govuk-footer__meta-item">
+          <a class="govuk-footer__link govuk-footer__copyright-logo govuk-!-margin-bottom-1" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+        </div>
+      <% end %>
+    <% end %>
+  </body>
+</html>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -37,6 +37,8 @@
     </div>
     <%= govuk_footer(classes: 'govuk-!-display-none-print') do |footer| %>
       <%= footer.slot(:meta) do %>
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+      </div>
         <div class="govuk-footer__meta-item">
           <a class="govuk-footer__link govuk-footer__copyright-logo govuk-!-margin-bottom-1" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
         </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,7 @@ Bundler.require(*Rails.groups)
 require './app/lib/hosting_environment'
 require './app/middlewares/redirect_to_service_gov_uk_middleware'
 require './app/middlewares/vendor_api_request_middleware'
+require './app/middlewares/service_unavailable_middleware'
 
 require 'pdfkit'
 
@@ -61,6 +62,7 @@ module ApplyForPostgraduateTeacherTraining
     config.cache_store = :memory_store
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
 
+    config.middleware.use ServiceUnavailableMiddleware
     config.middleware.insert_after ActionDispatch::HostAuthorization, RedirectToServiceGovUkMiddleware
     config.middleware.use VendorAPIRequestMiddleware
     config.middleware.use PDFKit::Middleware, { print_media_type: true, page_size: "A4" }, disposition: 'attachment', only: [%r[^/provider/applications/\d+]]

--- a/config/locales/service_unavailable.yml
+++ b/config/locales/service_unavailable.yml
@@ -1,7 +1,7 @@
 en:
   service_unavailable:
     sandbox_title: Sorry, the sandbox is unavailable
-    sandbox_downtime: You will be able to use the Apply for teacher training sandbox from 7pm on Tuesday 4th May.
-    title: Sorry, the service is unavailable
-    downtime: You will be able to use the Apply for teacher training service from 9am on Thursday 6th May.
+    sandbox_downtime: You will be able to use the sandbox from 7pm on Tuesday 4 May.
+    title: Sorry, this service is unavailable
+    downtime: You will be able to use this service from 9am on Thursday 6 May.
     body: If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.

--- a/config/locales/service_unavailable.yml
+++ b/config/locales/service_unavailable.yml
@@ -1,0 +1,7 @@
+en:
+  service_unavailable:
+    sandbox_title: Sorry, the sandbox is unavailable
+    sandbox_downtime: You will be able to use the Apply for teacher training sandbox from 7pm on Tuesday 4th May.
+    title: Sorry, the service is unavailable
+    downtime: You will be able to use the Apply for teacher training service from 9am on Thursday 6th May.
+    body: If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.

--- a/spec/components/previews/service_unavailable_component_preview.rb
+++ b/spec/components/previews/service_unavailable_component_preview.rb
@@ -1,0 +1,5 @@
+class ServiceUnavailableComponentPreview < ViewComponent::Preview
+  def service_unavailable_page
+    render ServiceUnavailableComponent.new
+  end
+end

--- a/spec/components/service_unavailable_component_spec.rb
+++ b/spec/components/service_unavailable_component_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe ServiceUnavailableComponent do
   subject(:result) { render_inline(ServiceUnavailableComponent.new) }
 
   it 'renders the page title' do
-    expect(result.text).to include('Sorry, the service is unavailable')
+    expect(result.text).to include('Sorry, this service is unavailable')
   end
 
   it 'renders the page downtime' do
-    expect(result.text).to include('Apply for teacher training service')
+    expect(result.text).to include('use this service')
   end
 
   context 'when the hosting environment is sandbox', sandbox: true do
@@ -17,7 +17,7 @@ RSpec.describe ServiceUnavailableComponent do
     end
 
     it 'renders the page downtime', sandbox: true do
-      expect(result.text).to include('Apply for teacher training sandbox')
+      expect(result.text).to include('use the sandbox')
     end
   end
 end

--- a/spec/components/service_unavailable_component_spec.rb
+++ b/spec/components/service_unavailable_component_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ServiceUnavailableComponent do
+  subject(:result) { render_inline(ServiceUnavailableComponent.new) }
+
+  it 'renders the page title' do
+    expect(result.text).to include('Sorry, the service is unavailable')
+  end
+
+  it 'renders the page downtime' do
+    expect(result.text).to include('Apply for teacher training service')
+  end
+
+  context 'when the hosting environment is sandbox', sandbox: true do
+    it 'renders the page title' do
+      expect(result.text).to include('Sorry, the sandbox is unavailable')
+    end
+
+    it 'renders the page downtime', sandbox: true do
+      expect(result.text).to include('Apply for teacher training sandbox')
+    end
+  end
+end

--- a/spec/middlewares/service_unavailable_middleware_spec.rb
+++ b/spec/middlewares/service_unavailable_middleware_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe ServiceUnavailableMiddleware, type: :request do
+  let(:status) { 200 }
+  let(:headers) { { 'HEADER' => 'Yeah!' } }
+  let(:mock_response) { ['Hellowwworlds!'] }
+
+  def mock_app
+    main_app = lambda { |env|
+      @env = env
+      [status, headers, @body]
+    }
+
+    builder = Rack::Builder.new
+    builder.use ServiceUnavailableMiddleware
+    builder.run main_app
+    @app = builder.to_app
+  end
+
+  before do
+    FeatureFlag.activate(:service_unavailable_page)
+    mock_app
+  end
+
+  describe '#call on a app path' do
+    it 'returns a 503' do
+      get '/provider'
+
+      expect(response.status).to eq(503)
+    end
+
+    it 'returns the correct content type' do
+      get '/provider'
+
+      expect(response.header['Content-type']).to include('text/html')
+    end
+
+    context 'when feature flag is off' do
+      it 'returns a 200' do
+        FeatureFlag.deactivate(:service_unavailable_page)
+        get '/provider'
+
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+
+  describe '#call on an API path' do
+    it 'returns a 503' do
+      get '/api/v1/applications/1', params: { 'foo': 'bar' }
+
+      expect(response.status).to eq(503)
+    end
+
+    it 'returns the correct content type' do
+      get '/api/v1/applications/1', params: { 'foo': 'bar' }
+
+      expect(response.header['Content-type']).to include('application/json')
+    end
+
+    context 'when feature flag is off' do
+      it 'returns a 200' do
+        FeatureFlag.deactivate(:service_unavailable_page)
+        get '/api/v1/applications/1', params: { 'foo': 'bar' }
+
+        expect(response.status).not_to eq(200)
+      end
+    end
+  end
+
+  describe '#call on monitoring paths' do
+    it 'returns a 200 when integrations path' do
+      get '/integrations/monitoring/all'
+
+      expect(response.status).to eq(200)
+    end
+
+    it 'returns a 200 when check path' do
+      get '/check'
+
+      expect(response.status).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
## Context

To switch to PaaS we need to stop anyone using the service.

## Changes proposed in this pull request

Add a maintenance page which will show on both candidate/provider urls. The exceptions are the monitoring and checks urls
![Screenshot 2021-05-04 at 11 52 54](https://user-images.githubusercontent.com/2732945/116993396-550c2880-accf-11eb-9c21-3864a0555f82.png)
 
As for the API the returned request value will be a 503 but with application/json format.


## Guidance to review

Try testing will all cases 

## Link to Trello card

https://trello.com/c/HpKuxGvH/3657-provider-information-banners-and-maintenance-pages-for-service-downtime-due-to-paas-migration

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
