### PR TITLE
Fix the provider information banner on the start page

### DIFF
--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -24,10 +24,13 @@
   </div>
 </div>
 
-<%= render ProviderInterface::InformationBannerComponent.new %>
-
 <div class="govuk-width-container">
   <section class="app-section">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <%= render ProviderInterface::InformationBannerComponent.new %>
+      </div>
+    </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <h2 class="govuk-heading-m">View applications</h2>


### PR DESCRIPTION
### Before

<img width="1680" alt="Screenshot 2021-05-04 at 08 25 01" src="https://user-images.githubusercontent.com/642279/116971978-482d0c00-acb2-11eb-9b41-092a97b7c6f1.png">

### After

<img width="1015" alt="Screenshot 2021-05-04 at 08 24 53" src="https://user-images.githubusercontent.com/642279/116971966-4400ee80-acb2-11eb-90ad-436298a3711a.png">
