### PR TITLE
Add recruitment cycle year arg to sync

### DIFF
--- a/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
+++ b/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
@@ -1,15 +1,15 @@
 module TeacherTrainingPublicAPI
   class SyncAllProvidersAndCourses
-    def self.call
+    def self.call(recruitment_cycle_year: ::RecruitmentCycle.current_year)
       is_last_page = false
       page_number = 0
       until is_last_page
         page_number += 1
         response = TeacherTrainingPublicAPI::Provider
-          .where(year: ::RecruitmentCycle.current_year)
+          .where(year: recruitment_cycle_year)
           .paginate(page: page_number, per_page: 500)
           .all
-        sync_providers(response)
+        sync_providers(response, recruitment_cycle_year)
         is_last_page = true if response.links.links['next'].nil?
       end
 
@@ -18,11 +18,11 @@ module TeacherTrainingPublicAPI
       raise TeacherTrainingPublicAPI::SyncError
     end
 
-    def self.sync_providers(providers_from_api)
+    def self.sync_providers(providers_from_api, recruitment_cycle_year)
       providers_from_api.each do |provider_from_api|
         TeacherTrainingPublicAPI::SyncProvider.new(
           provider_from_api: provider_from_api,
-          recruitment_cycle_year: ::RecruitmentCycle.current_year,
+          recruitment_cycle_year: recruitment_cycle_year,
         ).call
       end
     end

--- a/spec/services/teacher_training_public_api/sync_all_providers_and_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_all_providers_and_courses_spec.rb
@@ -3,17 +3,37 @@ require 'rails_helper'
 RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCourses, sidekiq: true do
   include TeacherTrainingPublicAPIHelper
 
-  before do
-    allow(described_class).to receive(:sync_providers)
-  end
-
   describe '.call' do
     context 'paginates the correct number of pages' do
+      before do
+        allow(described_class).to receive(:sync_providers)
+      end
+
       it 'calls sync providers 3 times' do
         stub_teacher_training_api_providers_with_multiple_pages
         described_class.call
 
         expect(described_class).to have_received(:sync_providers).exactly(3).times
+      end
+    end
+
+    context 'a previous year recruitment cycle' do
+      let(:recruitment_cycle_year) { RecruitmentCycle.previous_year }
+      let(:sync_provider) { instance_double(TeacherTrainingPublicAPI::SyncProvider) }
+
+      before do
+        allow(sync_provider).to receive(:call)
+        allow(TeacherTrainingPublicAPI::SyncProvider)
+          .to receive(:new)
+          .with(provider_from_api: anything, recruitment_cycle_year: recruitment_cycle_year)
+          .and_return(sync_provider)
+      end
+
+      it 'calls sync provider with the previous year recruitment cycle' do
+        stub_teacher_training_api_providers(recruitment_cycle_year: recruitment_cycle_year)
+        described_class.call(recruitment_cycle_year: recruitment_cycle_year)
+
+        expect(sync_provider).to have_received(:call)
       end
     end
   end

--- a/spec/support/test_helpers/teacher_training_public_api_helper.rb
+++ b/spec/support/test_helpers/teacher_training_public_api_helper.rb
@@ -112,7 +112,7 @@ private
       symbolize_names: true,
     )
 
-    if specified_attributes
+    if specified_attributes.present?
       record_or_array = api_response[:data]
 
       new_data = if record_or_array.is_a? Array


### PR DESCRIPTION
Co-authored-by: Richard Pattinson <richie.pattinson@googlemail.com>

## Context

Adding a recruitment cycle arg to the sync service, so that we can run the sync against previous year courses and providers

We're going to be running a sync for 2020 on prod, to assign uuids to all the courses from then. This will be using the following command: `TeacherTrainingPublicAPI::SyncAllProvidersAndCourses.call(recruitment_cycle_year: 2020)` which this PR will be enabling.

## Changes proposed in this pull request

Adds a recruitment cycle option for running the course sync

## Link to Trello card

https://trello.com/c/MFIi8aj1/3628-ensure-courses-we-get-from-ttapi-are-unique
