### PR TITLE
Make it easier for providers to spot gaps in work history in manage

### DIFF
--- a/app/components/work_history_and_unpaid_experience_component.html.erb
+++ b/app/components/work_history_and_unpaid_experience_component.html.erb
@@ -1,0 +1,7 @@
+<section class="app-section govuk-!-width-two-thirds" data-qa="work-history-and-unpaid-experience">
+  <h2 class="govuk-heading-m govuk-!-font-size-27" id="work-history">Work history and unpaid experience</h2>
+
+  <% history.each do |item| %>
+    <%= render WorkHistoryAndUnpaidExperienceItemComponent.new(item: item) %>
+  <% end %>
+</section>

--- a/app/components/work_history_and_unpaid_experience_component.rb
+++ b/app/components/work_history_and_unpaid_experience_component.rb
@@ -1,0 +1,5 @@
+class WorkHistoryAndUnpaidExperienceComponent < WorkHistoryComponent
+  def history
+    @history ||= WorkHistoryWithBreaks.new(application_form, include_unpaid_experience: true).timeline
+  end
+end

--- a/app/components/work_history_and_unpaid_experience_item_component.html.erb
+++ b/app/components/work_history_and_unpaid_experience_item_component.html.erb
@@ -1,0 +1,39 @@
+<section>
+  <% if break? %>
+    <div class="govuk-inset-text">
+  <% end %>
+
+  <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
+    <%= title %>
+  </h3>
+  <p class="govuk-!-margin-bottom-0 govuk-body">
+    <%= organisation %>
+  </p>
+  <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-top-0">
+    <%= dates %>
+  </p>
+  <p class="govuk-body">
+    <%= details %>
+    <% if relevant_skills? %>
+      <p class="govuk-body govuk-!-font-size-16">
+        <svg class="app-icon govuk-!-margin-right-1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 200 200" focusable="false" fill="currentColor" aria-hidden="true">
+          <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"></path>
+        </svg>
+        This role used skills relevant to teaching
+      </p>
+    <% elsif working_with_children? %>
+      <p class="govuk-body govuk-!-font-size-16">
+        <svg class="app-icon govuk-!-margin-right-1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 200 200" focusable="false" fill="currentColor" aria-hidden="true">
+          <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"></path>
+        </svg>
+        Worked with children
+      </p>
+    <% end %>
+  </p>
+  <% if break? %>
+    </div>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  <% else %>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  <% end %>
+</section>

--- a/app/components/work_history_and_unpaid_experience_item_component.rb
+++ b/app/components/work_history_and_unpaid_experience_item_component.rb
@@ -1,0 +1,19 @@
+class WorkHistoryAndUnpaidExperienceItemComponent < WorkHistoryItemComponent
+  def title
+    if item.respond_to?(:role) && item.respond_to?(:working_pattern)
+      "#{item.role} - #{working_pattern} #{role_type}"
+    elsif item.respond_to?(:reason)
+      explained_absence_title
+    else
+      unexplained_absence_title
+    end
+  end
+
+  def break?
+    item.is_a?(ApplicationWorkHistoryBreak) || item.is_a?(WorkHistoryWithBreaks::BreakPlaceholder) ? true : false
+  end
+
+  def role_type
+    '(unpaid)' if item.is_a?(ApplicationVolunteeringExperience)
+  end
+end

--- a/app/components/work_history_component.rb
+++ b/app/components/work_history_component.rb
@@ -1,11 +1,11 @@
 # NOTE: This component is used by both provider and support UIs
 class WorkHistoryComponent < ViewComponent::Base
   def initialize(application_form:)
-    self.application_form = application_form
+    @application_form = application_form
   end
 
   def history
-    @history ||= WorkHistoryWithBreaks.new(@application_form).timeline
+    @history ||= WorkHistoryWithBreaks.new(application_form).timeline
   end
 
   def render?

--- a/app/components/work_history_item_component.rb
+++ b/app/components/work_history_item_component.rb
@@ -3,7 +3,7 @@ class WorkHistoryItemComponent < ViewComponent::Base
   include ViewHelper
 
   def initialize(item:)
-    self.item = item
+    @item = item
   end
 
   def dates

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -36,11 +36,17 @@
 
 <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_choice: @application_choice, current_provider_user: current_provider_user) %>
 
-<%= render QualificationsComponent.new(application_form: @application_choice.application_form, application_choice_state: @application_choice.status) %>
+<% if FeatureFlag.active?(:restructured_work_history) %>
+  <%= render WorkHistoryAndUnpaidExperienceComponent.new(application_form: @application_choice.application_form) %>
 
-<%= render WorkHistoryComponent.new(application_form: @application_choice.application_form) %>
+  <%= render QualificationsComponent.new(application_form: @application_choice.application_form, application_choice_state: @application_choice.status) %>
+<% else %>
+  <%= render QualificationsComponent.new(application_form: @application_choice.application_form, application_choice_state: @application_choice.status) %>
 
-<%= render VolunteeringHistoryComponent.new(application_form: @application_choice.application_form) %>
+  <%= render WorkHistoryComponent.new(application_form: @application_choice.application_form) %>
+
+  <%= render VolunteeringHistoryComponent.new(application_form: @application_choice.application_form) %>
+<% end %>
 
 <%= render LanguageSkillsComponent.new(application_form: @application_choice.application_form) %>
 

--- a/spec/components/work_history_and_unpaid_experience_component_spec.rb
+++ b/spec/components/work_history_and_unpaid_experience_component_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe WorkHistoryAndUnpaidExperienceComponent do
+  let(:application_form) { instance_double(ApplicationForm, submitted_at: 2.months.ago) }
+
+  before do
+    FeatureFlag.activate(:restructured_work_history)
+  end
+
+  context 'with an empty history' do
+    it 'renders nothing' do
+      allow(application_form).to receive(:application_work_experiences).and_return([])
+      allow(application_form).to receive(:application_work_history_breaks).and_return([])
+      allow(application_form).to receive(:application_volunteering_experiences).and_return([])
+
+      rendered = render_inline(described_class.new(application_form: application_form))
+      expect(rendered.text).to eq ''
+    end
+  end
+
+  context 'with full work experience including unpaid experience' do
+    it 'renders all experience' do
+      breaks = [
+        build(:application_work_history_break,
+              start_date: 8.years.ago,
+              end_date: 6.years.ago,
+              reason: 'Raising my kids'),
+      ]
+      volunteering_xperiences = [
+        build(:application_volunteering_experience,
+              role: 'Designer',
+              working_pattern: 'Part time',
+              details: 'Designing things for a charity',
+              start_date: 7.years.ago,
+              end_date: nil),
+      ]
+      experiences = [
+        build(:application_work_experience,
+              start_date: 6.years.ago,
+              end_date: 2.years.ago,
+              role: 'Sheep herder',
+              commitment: 'full_time',
+              working_pattern: '',
+              details: 'Livestock management'),
+        build(:application_work_experience,
+              start_date: 2.months.ago,
+              end_date: nil,
+              role: 'Pig herder',
+              commitment: 'part_time',
+              working_pattern: '',
+              details: 'Livestock management'),
+      ]
+      allow(application_form).to receive(:application_work_experiences).and_return(experiences)
+      allow(application_form).to receive(:application_work_history_breaks).and_return(breaks)
+      allow(application_form).to receive(:application_volunteering_experiences).and_return(volunteering_xperiences)
+
+      rendered = render_inline(described_class.new(application_form: application_form))
+      expect(rendered.text).to include 'Break (2 years)'
+      expect(rendered.text).to include 'Raising my kids'
+      expect(rendered.text).to include "#{7.years.ago.to_s(:month_and_year)} - Present"
+      expect(rendered.text).to include 'Designer - Part time (unpaid)'
+      expect(rendered.text).to include 'Designing things for a charity'
+      expect(rendered.text).to include "#{6.years.ago.to_s(:month_and_year)} - #{2.years.ago.to_s(:month_and_year)}"
+      expect(rendered.text).to include 'Sheep herder - Full time'
+      expect(rendered.text).to include 'Unexplained break (1 year and 10 months)'
+      expect(rendered.text).to include "#{2.months.ago.to_s(:month_and_year)} - Present"
+      expect(rendered.text).to include 'Pig herder - Part time'
+    end
+  end
+end

--- a/spec/components/work_history_and_unpaid_experience_item_component_spec.rb
+++ b/spec/components/work_history_and_unpaid_experience_item_component_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe WorkHistoryAndUnpaidExperienceItemComponent do
+  subject(:experience_item) { described_class.new(item: item) }
+
+  describe '#title' do
+    context 'when the item is a voluntery role' do
+      let(:item) { build(:application_volunteering_experience, role: 'Teacher', working_pattern: 'Full time') }
+
+      it 'includes (unpaid) for any volunteer roles' do
+        expect(experience_item.title).to eq('Teacher - Full time (unpaid)')
+      end
+    end
+
+    context 'when the item is an explained break' do
+      let(:item) { build(:application_work_history_break, reason: 'No reason') }
+
+      it 'includes (unpaid) for any volunteer roles' do
+        expect(experience_item.title).to start_with('Break (')
+      end
+    end
+  end
+
+  describe '#break' do
+    context 'when ApplicationWorkHistoryBreak or BreakPlaceHolder' do
+      let(:item) { build(:application_work_history_break) }
+
+      it 'returns true' do
+        expect(experience_item.break?).to eq(true)
+      end
+    end
+
+    context 'when not ApplicationWorkHistoryBreak or BreakPlaceHolder' do
+      let(:item) { build(:application_volunteering_experience) }
+
+      it 'returns false' do
+        expect(experience_item.break?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   include CourseOptionHelpers
   include DfESignInHelpers
 
+  before do
+    FeatureFlag.deactivate(:restructured_work_history)
+  end
+
   around do |example|
     Timecop.freeze(Time.zone.local(2020, 3, 1, 12, 0, 0)) do
       example.run


### PR DESCRIPTION
## Changes proposed in this pull request

Display voluntary work as part of work history in manage.

As the existing components are reused by the candidate side I decided to introduce a new WorkHistoryAndUnpaidExperience component to avoid accidentally changing the candidate view.

## Guidance to review

- Enable restructred work history flag
- Navigate to a candidate application

## Link to Trello card

https://trello.com/c/Gg9XKGw2/3573-make-it-easier-for-providers-to-spot-gaps-in-work-history-in-manage

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
