### PR TITLE
Bug: Add missing instance variable 

### DIFF
--- a/app/controllers/candidate_interface/volunteering/review_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/review_controller.rb
@@ -8,6 +8,7 @@ module CandidateInterface
     end
 
     def complete
+      @application_form = current_application
       @section_complete_form = SectionCompleteForm.new(form_params)
 
       if @section_complete_form.save(current_application, :volunteering_completed)


### PR DESCRIPTION
## Context

Followup to https://trello.com/c/dxkMUjHV/3358-do-not-update-sectioncompleted-fields-to-false-when-updating-application-sections

## Changes proposed in this pull request

Declare `@application` instance var in `#complete` action so that show page can render with validation error

## Link to Trello card

https://trello.com/c/dxkMUjHV/3358-do-not-update-sectioncompleted-fields-to-false-when-updating-application-sections

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
