### PR TITLE
Don't restore Azure sandbox to PaaS sandbox after migration

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [production, sandbox]
+        environment: [production]
         include:
          - environment: production
            NAME_SUFFIX: prod


### PR DESCRIPTION
## Context

Once sandbox is on PaaS, there is no need to restore data from Azure DB.

## Changes proposed in this pull request

Don't restore database from Azure sandbox to PaaS sandbox.

## Guidance to review

To be merged after Sandbox is migrated to run from PaaS. 

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
