### PR TITLE
Run clock and worker apps in Sandbox

### DIFF
--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -6,8 +6,8 @@ paas_web_app_instances     = 1
 paas_postgres_service_plan = "small-11"
 paas_redis_service_plan    = "micro-5_x"
 paas_worker_app_stopped    = true
-paas_clock_app_command     = "sleep 180s" # to be changed after migrating to PaaS 
-paas_worker_app_command    = "sleep 180s" # to be changed after migrating to PaaS
+paas_clock_app_command     = "bundle exec clockwork config/clock.rb"
+paas_worker_app_command    = "bundle exec sidekiq -c 5 -C config/sidekiq.yml"
 
 # KeyVault
 key_vault_resource_group    = "s121p01-shared-rg"


### PR DESCRIPTION
## Context

`stopped` setting wasn't working and had changed the startup command to `sleep` to avoid running the worker containers while testing the deployment process.

## Changes proposed in this pull request

Use correct commands to start clock and worker instances.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
