### PR TITLE
Use default startup command for worker in all env

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -67,7 +67,7 @@ resource "cloudfoundry_app" "worker" {
   docker_image         = var.app_docker_image
   health_check_type    = "process"
   health_check_timeout = 180
-  command              = var.worker_app_command
+  command              = "bundle exec sidekiq -c 5 -C config/sidekiq.yml"
   stopped              = var.worker_app_stopped
   instances            = var.worker_app_instances
   memory               = var.worker_app_memory

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -34,8 +34,6 @@ variable "worker_app_instances" {}
 
 variable "worker_app_stopped" {}
 
-variable "worker_app_command" {}
-
 variable "clock_app_command" {}
 
 locals {

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -49,7 +49,6 @@ module "paas" {
   clock_app_instances       = var.paas_clock_app_instances
   worker_app_instances      = var.paas_worker_app_instances
   worker_app_stopped        = var.paas_worker_app_stopped
-  worker_app_command        = var.paas_worker_app_command
   clock_app_command         = var.paas_clock_app_command
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,8 +25,6 @@ variable "paas_worker_app_instances" { default = 1 }
 
 variable "paas_worker_app_stopped" { default = false }
 
-variable "paas_worker_app_command" {}
-
 variable "paas_clock_app_command" {}
 
 # Key Vault variables

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -7,9 +7,7 @@ paas_web_app_instances     = 4
 paas_worker_app_instances  = 2
 paas_postgres_service_plan = "small-ha-11"
 paas_redis_service_plan    = "micro-ha-5_x"
-paas_worker_app_stopped    = true
-paas_clock_app_command     = "sleep 180s" # to be changed after migrating to PaaS 
-paas_worker_app_command    = "sleep 180s" # to be changed after migrating to PaaS
+paas_clock_app_command     = "sleep 180s" # to be changed after migrating to PaaS
 
 # KeyVault
 key_vault_resource_group    = "s121p01-shared-rg"

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -7,7 +7,6 @@ paas_web_app_instances     = 2
 paas_worker_app_instances  = 2
 paas_postgres_service_plan = "small-11"
 paas_redis_service_plan    = "micro-5_x"
-paas_worker_app_stopped    = true
 paas_clock_app_command     = "bundle exec clockwork config/clock.rb"
 paas_worker_app_command    = "bundle exec sidekiq -c 5 -C config/sidekiq.yml"
 


### PR DESCRIPTION
## Context

We had disabled worker app from running in Prod until the move to PaaS.

## Changes proposed in this pull request

Use default startup command for work app in all envs
Separate PR to be raised to start clock with correct command.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
