### PR TITLE
Content change for ENIC description

### DIFF
--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -65,7 +65,7 @@ en:
       delete: Delete degree
       confirm_delete: Yes I’m sure - delete this degree
       enic_statement:
-        label: Do you have a statement of comparability from UK ENIC (the UK agency for international qualifications and skills)?
+        label: Do you have a statement of comparability from UK ENIC (the UK agency that recognises international qualifications and skills)?
         review_label: Do you have a UK ENIC statement of comparability?
         change_action: UK ENIC statement
       enic_reference:

--- a/config/locales/candidate_interface/gcse.yml
+++ b/config/locales/candidate_interface/gcse.yml
@@ -26,7 +26,7 @@ en:
         hint_text: For example, 1996
         gce_o_level_hint_text: For example, 1978
       enic_statement:
-        label: Do you have a statement of comparability from UK ENIC (the UK agency for international qualifications and skills)?
+        label: Do you have a statement of comparability from UK ENIC (the UK agency that recognises international qualifications and skills)?
         review_label: Do you have a UK ENIC statement of comparability?
         change_action: UK ENIC statement
       enic_reference:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,7 +12,7 @@ en:
     get_into_teaching: Get Into Teaching
     enic:
       short_name: UK ENIC
-      full_name: UK ENIC (the UK agency for international qualifications and skills)
+      full_name: UK ENIC (the UK agency that recognises international qualifications and skills)
       url: https://www.enic.org.uk
   teacher_training_courses_api:
     documentation_url: https://api.publish-teacher-training-courses.service.gov.uk/

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degrees_spec.rb
@@ -161,7 +161,7 @@ RSpec.feature 'Entering their degrees' do
   end
 
   def then_i_can_see_the_enic_page
-    expect(page).to have_content 'Do you have a statement of comparability from UK ENIC (the UK agency for international qualifications and skills)?'
+    expect(page).to have_content 'Do you have a statement of comparability from UK ENIC (the UK agency that recognises international qualifications and skills)?'
   end
 
   def then_i_see_validation_errors_for_enic_question


### PR DESCRIPTION
## Context

When a candidate needs to show how their international qualifications compare to their UK ones, they get a certificate from a particular agency. The agency used to be called the National Academic Recognition Information Centre (NARIC) but post Brexit it will be called UK ENIC

Work has been happening with the Digi comms team to change content on the start page (which is owned by GOV.UK). In the process of getting it approved, a last minute change was made which puts the GOV.UK content out of synch with the apply service. 

## Changes proposed in this pull request

Changing "UK ENIC (the UK agency *for*...)" to "UK ENIC (the UK agency *that recognises*...)"

|Before|After|
|---|---|
|![Screenshot 2021-05-05 at 12 55 04](https://user-images.githubusercontent.com/47917431/117137165-3a09e900-ada1-11eb-9bba-10748d921fb6.png)|![Screenshot 2021-05-05 at 12 54 41](https://user-images.githubusercontent.com/47917431/117137182-3f673380-ada1-11eb-8f42-cef2fec75e31.png)|

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/zAG23BXm/3356-enic-content-change-in-apply

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
