### PR TITLE
Don't show withdrawal reasons if choice is not 'offer_withdrawn'

### DIFF
--- a/app/components/candidate_interface/application_dashboard_course_choices_component.rb
+++ b/app/components/candidate_interface/application_dashboard_course_choices_component.rb
@@ -160,6 +160,8 @@ module CandidateInterface
     end
 
     def offer_withdrawal_reason_row(application_choice)
+      return nil unless application_choice.offer_withdrawn?
+
       if application_choice.offer_withdrawal_reason.present?
         {
           key: 'Reason for offer withdrawal',

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -186,6 +186,8 @@ module CandidateInterface
     end
 
     def offer_withdrawal_reason_row(application_choice)
+      return nil unless application_choice.offer_withdrawn?
+
       if application_choice.offer_withdrawal_reason.present?
         {
           key: 'Reason for offer withdrawal',

--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -100,23 +100,33 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent do
     end
   end
 
-  context 'when a course choice is withdrawn by provider' do
-    it 'renders component with the status as Offer withdrawn and displays the reason' do
-      application_form = create(:application_form)
+  context 'when a course choice offer is withdrawn by provider' do
+    let!(:application_form) { create(:application_form) }
+    let!(:application_choice) do
       create(
         :application_choice,
+        :with_withdrawn_offer,
         application_form: application_form,
-        status: 'offer_withdrawn',
-        offer_withdrawn_at: Time.zone.now,
         offer_withdrawal_reason: 'Course full',
       )
+    end
 
+    it 'renders component with the status as Offer withdrawn and displays the reason' do
       result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
 
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
       expect(result.css('.govuk-summary-list__value').to_html).to include('Offer withdrawn')
       expect(result.css('.govuk-summary-list__key').text).to include('Reason for offer withdrawal')
       expect(result.css('.govuk-summary-list__value').to_html).to include('Course full')
+    end
+
+    it 'does not render the reason if an offer is subsequently made' do
+      application_choice.offer!
+
+      result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
+
+      expect(result.css('.govuk-summary-list__key').text).not_to include('Reason for offer withdrawal')
+      expect(result.css('.govuk-summary-list__value').to_html).not_to include('Course full')
     end
   end
 

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -261,23 +261,33 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
     end
   end
 
-  context 'when a course choice is withdrawn by provider' do
-    it 'renders component with the status as Offer withdrawn and displays the reason' do
-      application_form = build(:application_form)
+  context 'when a course choice offer is withdrawn by provider' do
+    let!(:application_form) { create(:application_form) }
+    let!(:application_choice) do
       create(
         :application_choice,
+        :with_withdrawn_offer,
         application_form: application_form,
-        status: 'offer_withdrawn',
-        offer_withdrawn_at: Time.zone.now,
         offer_withdrawal_reason: 'Course full',
       )
+    end
 
+    it 'renders component with the status as Offer withdrawn and displays the reason' do
       result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
 
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
       expect(result.css('.govuk-summary-list__value').to_html).to include('Offer withdrawn')
       expect(result.css('.govuk-summary-list__key').text).to include('Reason for offer withdrawal')
       expect(result.css('.govuk-summary-list__value').to_html).to include('Course full')
+    end
+
+    it 'does not render the reason if an offer is subsequently made' do
+      application_choice.offer!
+
+      result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
+
+      expect(result.css('.govuk-summary-list__key').text).not_to include('Reason for offer withdrawal')
+      expect(result.css('.govuk-summary-list__value').to_html).not_to include('Course full')
     end
   end
 


### PR DESCRIPTION




## Context
In a couple of places in the app, we have components which summarise a
candidate's course choices. In the scenario where an 'offer_withdrawn'
application choice has another offer made against it, we still show the
withdrawal reasons in the summary.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Hide the reasons in this scenario by checking the state of the
application choice.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Can be reviewed manually by starting with an application choice that has an offer against it.
  - Withdraw the offer as a provider
  - Review the app dashboard for this application and note that the withdrawal reasons are rendered.
  - Use the console (or the vendor API?) to make the state of the application choice `offer`.
  - Review the app dashboard for this application and note that we no longer display the withdrawal reason.
- To answer a question posed in the card - rejected choices already make a similar state check before displaying.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/GtPA69fk
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
