### PR TITLE
Remove duplicate accrediting providers

### DIFF
--- a/app/services/data_migrations/remove_duplicate_provider.rb
+++ b/app/services/data_migrations/remove_duplicate_provider.rb
@@ -10,10 +10,11 @@ module DataMigrations
         .where('tp.name = rp.name')
 
       if permissions.any?
-        ActiveRecord::Base.transaction do
-          permissions.each do |permission|
+        permissions.each do |permission|
+          ActiveRecord::Base.transaction do
             courses = permission.training_provider.courses.where(accredited_provider: permission.ratifying_provider)
-            next if courses.empty?
+
+            next if permission.ratifying_provider.courses.any?
 
             courses.each do |course|
               course.update!(accredited_provider: nil, audit_comment: 'Deduplicating accredited provider, this course is self-ratified')

--- a/app/services/data_migrations/remove_duplicate_provider.rb
+++ b/app/services/data_migrations/remove_duplicate_provider.rb
@@ -12,16 +12,21 @@ module DataMigrations
       if permissions.any?
         permissions.each do |permission|
           ActiveRecord::Base.transaction do
-            courses = permission.training_provider.courses.where(accredited_provider: permission.ratifying_provider)
-
             next if permission.ratifying_provider.courses.any?
+
+            courses = permission.training_provider.courses.where(accredited_provider: permission.ratifying_provider)
 
             courses.each do |course|
               course.update!(accredited_provider: nil, audit_comment: 'Deduplicating accredited provider, this course is self-ratified')
             end
 
             permission.destroy!
-            permission.ratifying_provider.destroy!
+
+            # Ensure we don't orphan any users who were only associated with the duplicate provider
+            providers_for_ratifying_provider_users = permission.ratifying_provider.provider_users.map(&:providers).flatten
+            if (providers_for_ratifying_provider_users - [permission.ratifying_provider]).any?
+              permission.ratifying_provider.destroy!
+            end
           end
         end
       end

--- a/app/services/data_migrations/remove_duplicate_provider.rb
+++ b/app/services/data_migrations/remove_duplicate_provider.rb
@@ -1,0 +1,29 @@
+module DataMigrations
+  class RemoveDuplicateProvider
+    TIMESTAMP = 20210505095417
+    MANUAL_RUN = false
+
+    def change
+      permissions = ProviderRelationshipPermissions
+        .joins('INNER JOIN providers tp ON training_provider_id = tp.id')
+        .joins('INNER JOIN providers rp ON ratifying_provider_id = rp.id')
+        .where('tp.name = rp.name')
+
+      if permissions.any?
+        ActiveRecord::Base.transaction do
+          permissions.each do |permission|
+            courses = permission.training_provider.courses.where(accredited_provider: permission.ratifying_provider)
+            next if courses.empty?
+
+            courses.each do |course|
+              course.update!(accredited_provider: nil, audit_comment: 'Deduplicating accredited provider, this course is self-ratified')
+            end
+
+            permission.destroy!
+            permission.ratifying_provider.destroy!
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveDuplicateProvider',
   'DataMigrations::TrimQualificationDegreeTypes',
   'DataMigrations::BackfillCurrentCourseOptionId',
   'DataMigrations::BackfillExportType',

--- a/spec/services/data_migrations/remove_duplicate_provider_spec.rb
+++ b/spec/services/data_migrations/remove_duplicate_provider_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveDuplicateProvider do
+  let(:provider) { create(:provider, name: 'Test Provider 001') }
+  let(:duplicate_provider) { create(:provider, name: 'Test Provider 001') }
+  let!(:provider_relationship_permissions) { create(:provider_relationship_permissions, training_provider: provider, ratifying_provider: duplicate_provider) }
+  let!(:self_ratified_course) { create(:course, provider: provider, accredited_provider: duplicate_provider) }
+  let!(:other_course) { create(:course, provider: provider, accredited_provider: create(:provider)) }
+
+  it 'makes courses accredited by the duplicate provider self-ratified by the training provider' do
+    DataMigrations::RemoveDuplicateProvider.new.change
+
+    expect(self_ratified_course.reload.accredited_provider).to be_nil
+    expect(other_course.reload.accredited_provider).not_to be_nil
+  end
+
+  it 'destroys the relationship between the training provider and the duplicate' do
+    expect { DataMigrations::RemoveDuplicateProvider.new.change }.to change(ProviderRelationshipPermissions, :count).by(-1)
+  end
+
+  it 'destroys the duplicate provider' do
+    expect { DataMigrations::RemoveDuplicateProvider.new.change }.to change(Provider, :count).by(-1)
+  end
+end

--- a/spec/services/data_migrations/remove_duplicate_provider_spec.rb
+++ b/spec/services/data_migrations/remove_duplicate_provider_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe DataMigrations::RemoveDuplicateProvider do
   let(:provider) { create(:provider, name: 'Test Provider 001') }
   let(:duplicate_provider) { create(:provider, name: 'Test Provider 001') }
+  let!(:provider_user) { create(:provider_user, providers: [provider, duplicate_provider]) }
   let!(:provider_relationship_permissions) { create(:provider_relationship_permissions, training_provider: provider, ratifying_provider: duplicate_provider) }
   let!(:self_ratified_course) { create(:course, provider: provider, accredited_provider: duplicate_provider) }
   let!(:other_course) { create(:course, provider: provider, accredited_provider: create(:provider)) }


### PR DESCRIPTION
## Context

There are 9 provider relationships in production where the training and ratifying provider have the same name. 
There are 457 courses for these providers which are provided/ratified by the two sides of the seemingly unnecessary relationships. 
This seems to be bad data as a self-ratified course should have a nil accredited provider and the duplication of provider records and relationship records are undesirable.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This data migration finds these relationships and iterates over courses concerned nillifying the accredited_provider thus making them self-ratified. 
The relationship and duplicate provider records are then destroyed.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Are my assumptions about self-ratified courses still correct? (I may be working on old info)
What are the side effects of updating these courses and relationships? Perhaps there should also be a check that the ratifying provider is never also a training provider for other courses?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

From support query https://trello.com/c/IEHp1BE0/446-united-teaching-national-scitt-codes
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
