### PR TITLE
Enable clockwork in prod (PaaS)

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -46,7 +46,7 @@ resource "cloudfoundry_app" "clock" {
   docker_image         = var.app_docker_image
   health_check_type    = "process"
   health_check_timeout = 180
-  command              = var.clock_app_command
+  command              = "bundle exec clockwork config/clock.rb"
   stopped              = var.worker_app_stopped
   instances            = var.clock_app_instances
   memory               = var.clock_app_memory

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -47,7 +47,6 @@ resource "cloudfoundry_app" "clock" {
   health_check_type    = "process"
   health_check_timeout = 180
   command              = "bundle exec clockwork config/clock.rb"
-  stopped              = var.worker_app_stopped
   instances            = var.clock_app_instances
   memory               = var.clock_app_memory
   space                = data.cloudfoundry_space.space.id
@@ -68,7 +67,6 @@ resource "cloudfoundry_app" "worker" {
   health_check_type    = "process"
   health_check_timeout = 180
   command              = "bundle exec sidekiq -c 5 -C config/sidekiq.yml"
-  stopped              = var.worker_app_stopped
   instances            = var.worker_app_instances
   memory               = var.worker_app_memory
   space                = data.cloudfoundry_space.space.id

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -34,8 +34,6 @@ variable "worker_app_instances" {}
 
 variable "worker_app_stopped" {}
 
-variable "clock_app_command" {}
-
 locals {
   web_app_name          = "apply-${var.app_environment}"
   clock_app_name        = "apply-clock-${var.app_environment}"

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -32,8 +32,6 @@ variable "clock_app_instances" {}
 
 variable "worker_app_instances" {}
 
-variable "worker_app_stopped" {}
-
 locals {
   web_app_name          = "apply-${var.app_environment}"
   clock_app_name        = "apply-clock-${var.app_environment}"

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -48,7 +48,6 @@ module "paas" {
   worker_app_memory         = var.paas_worker_app_memory
   clock_app_instances       = var.paas_clock_app_instances
   worker_app_instances      = var.paas_worker_app_instances
-  worker_app_stopped        = var.paas_worker_app_stopped
 }
 
 module "statuscake" {

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -49,7 +49,6 @@ module "paas" {
   clock_app_instances       = var.paas_clock_app_instances
   worker_app_instances      = var.paas_worker_app_instances
   worker_app_stopped        = var.paas_worker_app_stopped
-  clock_app_command         = var.paas_clock_app_command
 }
 
 module "statuscake" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,8 +23,6 @@ variable "paas_clock_app_instances" { default = 1 }
 
 variable "paas_worker_app_instances" { default = 1 }
 
-variable "paas_worker_app_stopped" { default = false }
-
 # Key Vault variables
 variable "azure_credentials" { default = null }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,8 +25,6 @@ variable "paas_worker_app_instances" { default = 1 }
 
 variable "paas_worker_app_stopped" { default = false }
 
-variable "paas_clock_app_command" {}
-
 # Key Vault variables
 variable "azure_credentials" { default = null }
 

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -7,7 +7,6 @@ paas_web_app_instances     = 4
 paas_worker_app_instances  = 2
 paas_postgres_service_plan = "small-ha-11"
 paas_redis_service_plan    = "micro-ha-5_x"
-paas_clock_app_command     = "sleep 180s" # to be changed after migrating to PaaS
 
 # KeyVault
 key_vault_resource_group    = "s121p01-shared-rg"

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -5,8 +5,6 @@ paas_web_app_memory        = 512
 paas_web_app_instances     = 1
 paas_postgres_service_plan = "small-11"
 paas_redis_service_plan    = "micro-5_x"
-paas_clock_app_command     = "bundle exec clockwork config/clock.rb"
-paas_worker_app_command    = "bundle exec sidekiq -c 5 -C config/sidekiq.yml"
 
 # KeyVault
 key_vault_resource_group    = "s121d01-shared-rg"

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -7,8 +7,6 @@ paas_web_app_instances     = 2
 paas_worker_app_instances  = 2
 paas_postgres_service_plan = "small-11"
 paas_redis_service_plan    = "micro-5_x"
-paas_clock_app_command     = "bundle exec clockwork config/clock.rb"
-paas_worker_app_command    = "bundle exec sidekiq -c 5 -C config/sidekiq.yml"
 
 # KeyVault
 key_vault_resource_group    = "s121p01-shared-rg"

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -5,8 +5,6 @@ paas_web_app_memory        = 512
 paas_web_app_instances     = 1
 paas_postgres_service_plan = "small-11"
 paas_redis_service_plan    = "micro-5_x"
-paas_clock_app_command     = "bundle exec clockwork config/clock.rb"
-paas_worker_app_command    = "bundle exec sidekiq -c 5 -C config/sidekiq.yml"
 
 # KeyVault
 key_vault_resource_group    = "s121t01-shared-rg"


### PR DESCRIPTION
## Context

clockwork container is stopped in PaaS prod.

## Changes proposed in this pull request

Start the clockwork container with correct command.

## Guidance to review

To be merged after prod is running on PaaS.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
