### PR TITLE
[1/3] Remove the subject field from notes: stop writing to subject field

### DIFF
--- a/app/controllers/provider_interface/notes_controller.rb
+++ b/app/controllers/provider_interface/notes_controller.rb
@@ -33,9 +33,8 @@ module ProviderInterface
   private
 
     def note_params
-      params.require(:provider_interface_new_note_form).permit(:subject, :message).merge \
-        application_choice: @application_choice,
-        provider_user: current_provider_user
+      params.require(:provider_interface_new_note_form).permit(:message)
+        .merge(application_choice: @application_choice, provider_user: current_provider_user)
     end
   end
 end

--- a/app/forms/provider_interface/new_note_form.rb
+++ b/app/forms/provider_interface/new_note_form.rb
@@ -1,10 +1,9 @@
 module ProviderInterface
   class NewNoteForm
     include ActiveModel::Model
-    attr_accessor :application_choice, :subject, :message, :provider_user
+    attr_accessor :application_choice, :message, :provider_user
 
     validates :application_choice, :provider_user, presence: true
-    validates :subject, length: { maximum: 40 }, presence: true
     validates :message, length: { maximum: 500 }, presence: true
 
     def save
@@ -12,7 +11,6 @@ module ProviderInterface
         Note.new(
           application_choice: application_choice,
           provider_user: provider_user,
-          subject: subject,
           message: message,
         ).save
       end

--- a/app/views/provider_interface/notes/index.html.erb
+++ b/app/views/provider_interface/notes/index.html.erb
@@ -12,7 +12,12 @@
           <div class="app-notes__note">
             <p class="govuk-body govuk-!-margin-top-1 govuk-!-margin-bottom-1">
               <%= govuk_link_to provider_interface_application_choice_note_path(@application_choice, note) do %>
-                <%= note.subject %>. <%= note.message %>
+                <% if note.subject %>
+                  Subject: <%= note.subject %>
+                  <br>
+                  <br>
+                <% end %>
+                <%= note.message %>
               <% end %>
             </p>
             <p class="meta">

--- a/app/views/provider_interface/notes/index.html.erb
+++ b/app/views/provider_interface/notes/index.html.erb
@@ -10,10 +10,11 @@
       <div class="app-notes">
         <% @notes.each do |note| %>
           <div class="app-notes__note">
-            <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-              <%= govuk_link_to note.subject, provider_interface_application_choice_note_path(@application_choice, note), id: note.id %>
-            </h2>
-            <p class="govuk-body govuk-!-margin-top-1 govuk-!-margin-bottom-1"><%= note.message %></p>
+            <p class="govuk-body govuk-!-margin-top-1 govuk-!-margin-bottom-1">
+              <%= govuk_link_to provider_interface_application_choice_note_path(@application_choice, note) do %>
+                <%= note.subject %>. <%= note.message %>
+              <% end %>
+            </p>
             <p class="meta">
               <%= "#{note.provider_user.full_name}," if note.provider_user.full_name.present? %>
               <%= note.created_at.to_s(:govuk_date_and_time) %>

--- a/app/views/provider_interface/notes/new.html.erb
+++ b/app/views/provider_interface/notes/new.html.erb
@@ -14,8 +14,6 @@
       <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
       <h1 class="govuk-heading-l">Add note</h1>
 
-      <%= f.govuk_text_area :subject, label: { text: 'Subject', size: 'm' }, rows: 1, max_chars: 40, hint: { text: 'This appears on your application list by the relevant candidate' } %>
-
       <%= f.govuk_text_area :message, label: { text: 'Note', size: 'm' }, max_chars: 500 %>
 
       <%= f.govuk_submit 'Save note' %>

--- a/app/views/provider_interface/notes/show.html.erb
+++ b/app/views/provider_interface/notes/show.html.erb
@@ -2,7 +2,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="app-notes__note">
-      <p class="govuk-body"><%= @note.subject %>. <%= @note.message %></p>
+      <p class="govuk-body">
+        <% if @note.subject %>
+          Subject: <%= @note.subject %>
+          <br>
+          <br>
+        <% end %>
+        <%= @note.message %>
+      </p>
       <p class="meta">
         <%= "#{@note.provider_user.full_name}," if @note.provider_user.full_name.present? %>
         <%= @note.created_at.to_s(:govuk_date_and_time) %>

--- a/app/views/provider_interface/notes/show.html.erb
+++ b/app/views/provider_interface/notes/show.html.erb
@@ -2,10 +2,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="app-notes__note">
-      <h1 class="govuk-heading-l govuk-!-margin-bottom-5">
-        <%= @note.subject %>
-      </h1>
-      <p class="govuk-body"><%= @note.message %></p>
+      <p class="govuk-body"><%= @note.subject %>. <%= @note.message %></p>
       <p class="meta">
         <%= "#{@note.provider_user.full_name}," if @note.provider_user.full_name.present? %>
         <%= @note.created_at.to_s(:govuk_date_and_time) %>

--- a/spec/forms/provider_interface/new_note_form_spec.rb
+++ b/spec/forms/provider_interface/new_note_form_spec.rb
@@ -10,15 +10,6 @@ RSpec.describe ProviderInterface::NewNoteForm do
         .with_message('Missing application_choice')
     end
 
-    it 'validates presence and length of :subject' do
-      expect(described_class.new).to validate_presence_of(:subject)
-        .with_message('Enter a subject')
-
-      expect(described_class.new).to validate_length_of(:subject)
-        .is_at_most(40)
-        .with_message('The subject must be 40 characters or fewer')
-    end
-
     it 'validates presence of and length of :message' do
       expect(described_class.new).to validate_presence_of(:message)
         .with_message('Enter a note')
@@ -39,7 +30,6 @@ RSpec.describe ProviderInterface::NewNoteForm do
       valid_form_object = described_class.new(
         application_choice: application_choice,
         provider_user: provider_user,
-        subject: 'A subject',
         message: 'Some text',
       )
 

--- a/spec/system/provider_interface/provider_adds_note_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_adds_note_to_application_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     when_i_visit_that_application_in_the_provider_interface
     and_i_visit_the_notes_tab
     and_i_click_to_add_a_note
-    and_i_write_a_note_with_a_subject_and_some_text
+    and_i_write_a_note_with_some_text
 
     then_i_am_still_on_the_notes_tab
     and_the_notes_tab_includes_the_new_note
@@ -44,13 +44,11 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     click_on 'Add note'
   end
 
-  def and_i_write_a_note_with_a_subject_and_some_text
-    @note_subject = 'Documents missing'
+  def and_i_write_a_note_with_some_text
     @note_text = 'The candidate has not forwarded the required documents yet.'
-    fill_in 'Subject', with: @note_subject
     fill_in 'Note', with: @note_text
     click_on 'Save note'
-    @note = Note.find_by_subject(@note_subject)
+    @note = Note.last
   end
 
   def then_i_am_still_on_the_notes_tab
@@ -58,14 +56,13 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   end
 
   def and_the_notes_tab_includes_the_new_note
-    expect(page).to have_link(@note_subject, href: provider_interface_application_choice_note_path(@application_choice, @note))
+    expect(page).to have_link(@note_text, href: provider_interface_application_choice_note_path(@application_choice, @note))
     expect(page).to have_content(@note_text)
   end
 
   def and_i_can_navigate_to_the_new_note
-    click_on @note_subject
+    click_on @note_text
 
-    expect(page).to have_content(@note_subject)
     expect(page).to have_content(@note_text)
 
     click_on 'Back'


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

1. Remove field from add note page
2. Remove field from notes show and index page
3. The value of the subject field of existing notes is prefixed at the start of the notes description field (https://ukgovernmentdfe.slack.com/archives/CPH8J9G65/p1617886095337000?thread_ts=1617872257.329800&cid=CPH8J9G65)
4. No update was require in the Notes export to support a note without a subject, as nothing will be rendered when there isn't one at this point


## Link to Trello card
https://trello.com/c/a0IxokKH/3641-1-remove-the-subject-field-from-notes-stop-writing-to-subject-field

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
