### PR TITLE
Amend time of PaaS migration

### DIFF
--- a/config/locales/service_information_banner.yml
+++ b/config/locales/service_information_banner.yml
@@ -3,10 +3,10 @@ en:
     provider:
       sandbox_header: The sandbox will be unavailable on Tuesday 4 May from 6pm to 7pm
       sandbox_body: This will affect both the web service and the API. You may lose work if you are using the sandbox when it becomes unavailable.
-      header: The Manage service will be unavailable on Thursday 6 May from 8am to 9am
+      header: The Manage service will be unavailable on Thursday 6 May from 7:30am to 9am
       body: This will affect both the web service and the API. You may lose work if you are using Manage when it becomes unavailable.
     candidate:
       sandbox_header: The sandbox will be unavailable on Tuesday 4 May from 6pm to 7pm
       sandbox_body: You may lose work if you are using the sandbox when it becomes unavailable.
-      header: This service will be unavailable on Thursday 6 May from 8am to 9am
+      header: This service will be unavailable on Thursday 6 May from 7:30am to 9am
       body: You may lose work if you are using this service when it becomes unavailable.


### PR DESCRIPTION
## Context

We've changed the migration time from 8am to 7:30am

## Changes proposed in this pull request

Update banner data to reflect new time

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
