### PR TITLE
Remove reference to deleted data migration file

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,7 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
   'DataMigrations::TrimQualificationDegreeTypes',
-  'DataMigrations::BackfillCurrentCourseOptionId',
   'DataMigrations::BackfillExportType',
   'DataMigrations::FixLatLongFlipFlops',
 ].freeze


### PR DESCRIPTION
```ruby
DataMigrations::BackfillCurrentCourseOptionId skipped with error: uninitialized constant DataMigrations::BackfillCurrentCourseOptionId
 ```