### PR TITLE
[2-1/3] Remove the subject field from notes: stop reading from subject field

### DIFF
--- a/app/exports/notes_export.yml
+++ b/app/exports/notes_export.yml
@@ -5,10 +5,6 @@ common_columns:
 - provider_user_id
 
 custom_columns:
-  note_subject:
-    type: string
-    description: Subject of the note
-    example: Important
   note_message:
     type: string
     description: Body of the note

--- a/app/services/data_migrations/prefix_note_subject_to_message.rb
+++ b/app/services/data_migrations/prefix_note_subject_to_message.rb
@@ -1,0 +1,15 @@
+module DataMigrations
+  class PrefixNoteSubjectToMessage
+    TIMESTAMP = 20210505183930
+    MANUAL_RUN = true
+
+    def change
+      ActiveRecord::Base.no_touching do
+        Note.all.each do |note|
+          message = "Subject: #{note.subject}\r\n\r\n#{note.message}"
+          note.update(message: message)
+        end
+      end
+    end
+  end
+end

--- a/app/services/support_interface/notes_export.rb
+++ b/app/services/support_interface/notes_export.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class NotesExport
     def data_for_export
-      notes = Note.select(:subject, :message, :created_at, :application_choice_id, :provider_user_id)
+      notes = Note.select(:message, :created_at, :application_choice_id, :provider_user_id)
                 .includes(
                   { provider_user: { provider_permissions: :provider } },
                   { application_choice: [{ application_form: :candidate }, { course_option: { course: %i[provider accredited_provider] } }] },
@@ -23,7 +23,6 @@ module SupportInterface
         end
 
         {
-          note_subject: note.subject,
           note_message: note.message,
           note_created_at: note.created_at.iso8601,
           candidate_id: note.application_choice.application_form.candidate.id,

--- a/app/views/provider_interface/notes/index.html.erb
+++ b/app/views/provider_interface/notes/index.html.erb
@@ -10,16 +10,11 @@
       <div class="app-notes">
         <% @notes.each do |note| %>
           <div class="app-notes__note">
-            <p class="govuk-body govuk-!-margin-top-1 govuk-!-margin-bottom-1">
+            <div class="govuk-body govuk-!-margin-top-1 govuk-!-margin-bottom-1">
               <%= govuk_link_to provider_interface_application_choice_note_path(@application_choice, note) do %>
-                <% if note.subject %>
-                  Subject: <%= note.subject %>
-                  <br>
-                  <br>
-                <% end %>
-                <%= note.message %>
+                <%= simple_format(note.message) %>
               <% end %>
-            </p>
+            </div>
             <p class="meta">
               <%= "#{note.provider_user.full_name}," if note.provider_user.full_name.present? %>
               <%= note.created_at.to_s(:govuk_date_and_time) %>

--- a/app/views/provider_interface/notes/show.html.erb
+++ b/app/views/provider_interface/notes/show.html.erb
@@ -2,14 +2,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="app-notes__note">
-      <p class="govuk-body">
-        <% if @note.subject %>
-          Subject: <%= @note.subject %>
-          <br>
-          <br>
-        <% end %>
-        <%= @note.message %>
-      </p>
+      <div class="govuk-body">
+        <%= simple_format(@note.message) %>
+      </div>
       <p class="meta">
         <%= "#{@note.provider_user.full_name}," if @note.provider_user.full_name.present? %>
         <%= @note.created_at.to_s(:govuk_date_and_time) %>

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::PrefixNoteSubjectToMessage',
   'DataMigrations::TrimQualificationDegreeTypes',
   'DataMigrations::BackfillExportType',
   'DataMigrations::FixLatLongFlipFlops',

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -85,7 +85,6 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       application_choice = create(:application_choice)
       note = Note.new(
         provider_user: provider_user,
-        subject: 'This is a note',
         message: 'Notes are a new feature',
       )
       application_choice.notes << note

--- a/spec/factories/note.rb
+++ b/spec/factories/note.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     application_choice
     provider_user
 
-    subject { Faker::Company.bs.capitalize }
     message { Faker::Quote.most_interesting_man_in_the_world }
   end
 end

--- a/spec/services/data_migrations/prefix_note_subject_to_message_spec.rb
+++ b/spec/services/data_migrations/prefix_note_subject_to_message_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::PrefixNoteSubjectToMessage do
+  let!(:note) { create(:note, subject: 'Marvel', message: 'Avengers Assemble') }
+
+  it 'appends the note subject to the message' do
+    described_class.new.change
+
+    expect(note.reload.message.to_s).to eq(%(Subject: Marvel\r\n\r\nAvengers Assemble))
+  end
+
+  it 'does not update the application_choice timestamps' do
+    application_choice_created_at = note.application_choice.created_at
+    application_choice_updated_at = note.application_choice.updated_at
+
+    described_class.new.change
+
+    expect(note.application_choice.created_at).to eq(application_choice_created_at)
+    expect(note.application_choice.updated_at).to eq(application_choice_updated_at)
+  end
+
+  it 'does not update the audit log' do
+    application_choice_created_at = note.application_choice.created_at
+    application_choice_updated_at = note.application_choice.updated_at
+
+    expect { described_class.new.change }.not_to(change { Audited::Audit.count })
+
+    expect(note.application_choice.created_at).to eq(application_choice_created_at)
+    expect(note.application_choice.updated_at).to eq(application_choice_updated_at)
+  end
+end

--- a/spec/services/support_interface/notes_export_spec.rb
+++ b/spec/services/support_interface/notes_export_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe SupportInterface::NotesExport do
 
       expect(data).to match_array([
         {
-          note_subject: note1.subject,
           note_message: note1.message,
           note_created_at: note1.created_at.iso8601,
           candidate_id: candidate.id,
@@ -45,7 +44,6 @@ RSpec.describe SupportInterface::NotesExport do
           total_number_of_provider_relationships: 2,
         },
         {
-          note_subject: note2.subject,
           note_message: note2.message,
           note_created_at: note2.created_at.iso8601,
           candidate_id: candidate.id,
@@ -82,7 +80,6 @@ RSpec.describe SupportInterface::NotesExport do
 
       expect(data).to match_array([
         {
-          note_subject: note1.subject,
           note_message: note1.message,
           note_created_at: note1.created_at.iso8601,
           candidate_id: candidate.id,
@@ -93,7 +90,6 @@ RSpec.describe SupportInterface::NotesExport do
           total_number_of_provider_relationships: nil,
         },
         {
-          note_subject: note2.subject,
           note_message: note2.message,
           note_created_at: note2.created_at.iso8601,
           candidate_id: candidate.id,


### PR DESCRIPTION
## Context
1. Add data migration to prefix existing subject to note message
2. Only read message in notes show, index and export
3. Remove subject from note factory

## Link to Trello card

https://trello.com/c/KtL53Ipv/3642-2-remove-the-subject-field-from-notes-stop-reading-from-subject-field

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
