### PR TITLE
Remove Course qualification flip flops from audits table, keep recent ones

### DIFF
--- a/app/services/data_migrations/prune_qualification_flip_flops_from_course_audits.rb
+++ b/app/services/data_migrations/prune_qualification_flip_flops_from_course_audits.rb
@@ -1,0 +1,33 @@
+module DataMigrations
+  class PruneQualificationFlipFlopsFromCourseAudits
+    TIMESTAMP = 20210505154302
+    MANUAL_RUN = false
+
+    def change
+      sql = <<~REMOVE_DUPLICATE_QUALIFICATION_CHANGES_FROM_COURSE_AUDITS.squish
+        DELETE FROM audits
+        WHERE id IN (
+          SELECT id FROM (
+            SELECT
+              id,
+              ROW_NUMBER() OVER(
+                PARTITION BY auditable_id, audited_changes ORDER BY created_at DESC
+              ) AS row_num
+            FROM audits
+            WHERE
+              auditable_type = 'Course'
+              AND username = '(Automated process)'
+              AND audited_changes IN (
+                '{"qualifications": [null, ["qts"]]}'::jsonb,
+                '{"qualifications": [["qts"], null]}'::jsonb,
+                '{"qualifications": [null, ["qts", "pgce"]]}'::jsonb,
+                '{"qualifications": [["qts", "pgce"], null]}'::jsonb
+              )
+          ) t WHERE t.row_num > 1
+        )
+      REMOVE_DUPLICATE_QUALIFICATION_CHANGES_FROM_COURSE_AUDITS
+
+      ActiveRecord::Base.connection.execute(sql)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::PruneQualificationFlipFlopsFromCourseAudits',
   'DataMigrations::TrimQualificationDegreeTypes',
   'DataMigrations::BackfillCurrentCourseOptionId',
   'DataMigrations::BackfillExportType',

--- a/spec/services/data_migrations/prune_qualification_flip_flops_from_course_audits_spec.rb
+++ b/spec/services/data_migrations/prune_qualification_flip_flops_from_course_audits_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::PruneQualificationFlipFlopsFromCourseAudits, with_audited: true do
+  let(:first_course) { create(:course) }
+  let(:course_with_flip_flops) { create(:course) }
+  let(:other_course) { create(:course) }
+
+  it 'preserves most recent qualification change per type' do
+    Audited.audit_class.as_user('(Automated process)') do
+      first_course.update(qualifications: %w[qts pgce])
+
+      (1..5).each do |i|
+        course_with_flip_flops.update(qualifications: %w[qts], audit_comment: i)
+        course_with_flip_flops.update(qualifications: nil, audit_comment: i)
+        course_with_flip_flops.update(qualifications: %w[qts pgce], audit_comment: i)
+        course_with_flip_flops.update(qualifications: nil, audit_comment: i)
+      end
+      course_with_flip_flops.update(qualifications: %w[qts], audit_comment: 'final')
+
+      other_course.update(qualifications: %w[qts])
+    end
+
+    described_class.new.change
+
+    expect(first_course.audits.reload.count).to eq(2)
+    expect(first_course.audits.order('created_at').last.audited_changes).to \
+      eq({ 'qualifications' => [nil, %w[qts pgce]] })
+    expect(other_course.audits.reload.count).to eq(2)
+    expect(other_course.audits.order('created_at').last.audited_changes).to \
+      eq({ 'qualifications' => [nil, %w[qts]] })
+
+    expect(course_with_flip_flops.audits.reload.count).to eq(5)
+    audits = course_with_flip_flops.audits.where(action: 'update').order('created_at')
+    expect(audits.map(&:comment)).to eq(%w[5 5 5 final])
+    expect(audits.map(&:audited_changes)).to eq([
+      { 'qualifications' => [%w[qts], nil] },
+      { 'qualifications' => [nil, %w[qts pgce]] },
+      { 'qualifications' => [%w[qts pgce], nil] },
+      { 'qualifications' => [nil, %w[qts]] },
+    ])
+  end
+
+  it 'only deletes changes made by (Automated process)' do
+    3.times.each do
+      course_with_flip_flops.update(qualifications: %w[qts])
+      course_with_flip_flops.update(qualifications: nil)
+    end
+
+    described_class.new.change
+
+    expect(course_with_flip_flops.audits.reload.count).to eq(7)
+  end
+
+  it 'ignores events that change other fields as well as qualifications' do
+    3.times.each do
+      course_with_flip_flops.update(qualifications: %w[qts], withdrawn: true)
+      course_with_flip_flops.update(qualifications: nil, withdrawn: false)
+    end
+
+    described_class.new.change
+
+    expect(course_with_flip_flops.audits.reload.count).to eq(7)
+  end
+end


### PR DESCRIPTION
## Context

Our audits table on production has about 18 million records, and `Course`-related changes to `qualifications` account for ~9 million of these. There is probably a bug in our sync process there somewhere, but this PR focuses on removing most of these audit records to reclaim space.

## Changes proposed in this pull request

Add automatic data migration `DataMigrations::PruneQualificationFlipFlopsFromCourseAudits`, which removes all Course-related events by '(Automated process)' setting and unsetting `qualifications` except the most recent ones for each type of change.

## Guidance to review

Run the spec.

## Link to Trello card

https://trello.com/c/6UMC4zRm

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
