### PR TITLE
Add Satisfaction Survey Response rate to the Feature Metric Dashboard

### DIFF
--- a/app/models/feature_metrics_dashboard.rb
+++ b/app/models/feature_metrics_dashboard.rb
@@ -22,6 +22,7 @@ class FeatureMetricsDashboard < ApplicationRecord
     load_apply_again_application_rate
     load_carry_over_counts
     load_qualifications
+    load_satisfaction_survey_response_rate
   end
 
   def last_updated_at
@@ -60,6 +61,10 @@ private
 
   def qualifications_statistics
     QualificationsFeatureMetrics.new
+  end
+
+  def satisfaction_survey_statistics
+    SatisfactionSurveyFeatureMetrics.new
   end
 
   def load_avg_time_to_get_references
@@ -331,6 +336,28 @@ private
       qualifications_statistics.formatted_a_level_percentage(
         3,
         Time.zone.now.beginning_of_month - 1.month,
+        Time.zone.now.beginning_of_month,
+      ),
+    )
+  end
+
+  def load_satisfaction_survey_response_rate
+    write_metric(
+      :satisfaction_survey_response_rate,
+      satisfaction_survey_statistics.formatted_response_rate(
+        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+      ),
+    )
+    write_metric(
+      :satisfaction_survey_response_rate_this_month,
+      satisfaction_survey_statistics.formatted_response_rate(
+        Time.zone.now.beginning_of_month,
+      ),
+    )
+    write_metric(
+      :satisfaction_survey_response_rate_last_month,
+      satisfaction_survey_statistics.formatted_response_rate(
+        EndOfCycleTimetable.apply_reopens.beginning_of_day,
         Time.zone.now.beginning_of_month,
       ),
     )

--- a/app/models/feature_metrics_dashboard.rb
+++ b/app/models/feature_metrics_dashboard.rb
@@ -357,7 +357,7 @@ private
     write_metric(
       :satisfaction_survey_response_rate_last_month,
       satisfaction_survey_statistics.formatted_response_rate(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        Time.zone.now.beginning_of_month - 1.month,
         Time.zone.now.beginning_of_month,
       ),
     )

--- a/app/models/satisfaction_survey_feature_metrics.rb
+++ b/app/models/satisfaction_survey_feature_metrics.rb
@@ -1,0 +1,50 @@
+class SatisfactionSurveyFeatureMetrics
+  include ActionView::Helpers::NumberHelper
+
+  def response_rate(
+    start_time,
+    end_time = Time.zone.now.end_of_day
+  )
+    success_count = 0.0
+    fail_count = 0.0
+    application_forms(start_time, end_time).find_each do |application_form|
+      if application_form.feedback_satisfaction_level? || application_form.feedback_suggestions?
+        success_count += 1
+      else
+        fail_count += 1
+      end
+    end
+    return nil if (fail_count + success_count).zero?
+
+    success_count / (fail_count + success_count)
+  end
+
+  def formatted_response_rate(
+    start_time,
+    end_time = Time.zone.now.end_of_day
+  )
+    format_as_percentage(response_rate(start_time, end_time))
+  end
+
+private
+
+  def format_as_percentage(ratio)
+    return 'n/a' if ratio.nil?
+
+    percentage = number_with_precision(
+      100.0 * ratio,
+      precision: 1,
+      strip_insignificant_zeros: true,
+    )
+    "#{percentage}%"
+  end
+
+  def application_forms(start_time, end_time)
+    ApplicationForm
+      .where(
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+      )
+      .where('application_forms.submitted_at BETWEEN ? AND ?', start_time, end_time)
+      .where(recruitment_cycle_year: RecruitmentCycle.current_year)
+  end
+end

--- a/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
+++ b/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
@@ -379,4 +379,34 @@
       </div>
     </div>
   </div>
+
+  <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Satisfaction Survey</h3>
+  <div id="satisfaction_survey_dashboard_section" class="govuk-grid-row govuk-!-margin-bottom-4">
+    <div class="govuk-grid-column-one-half">
+      <div id="headline-stat" class="govuk-!-margin-bottom-4">
+        <%= render SupportInterface::TileComponent.new(
+          count: @dashboard.read_metric(:satisfaction_survey_response_rate),
+          label: 'Satisfaction Survey Response Rate',
+          colour: :blue,
+          size: :reduced,
+        ) %>
+      </div>
+      <div class="govuk-grid-row govuk-!-margin-bottom-4">
+        <div class="govuk-grid-column-one-half">
+          <%= render SupportInterface::TileComponent.new(
+            count: @dashboard.read_metric(:satisfaction_survey_response_rate_this_month),
+            label: 'this month',
+            size: :reduced,
+          ) %>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= render SupportInterface::TileComponent.new(
+            count: @dashboard.read_metric(:satisfaction_survey_response_rate_last_month),
+            label: 'last month',
+            size: :reduced,
+          ) %>
+        </div>
+      </div>
+    </div>
+  </div>
 <% end %>

--- a/spec/models/feature_metrics_dashboard_spec.rb
+++ b/spec/models/feature_metrics_dashboard_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe FeatureMetricsDashboard do
       apply_again_metrics_double = instance_double(ApplyAgainFeatureMetrics)
       carry_over_metrics_double = instance_double(CarryOverFeatureMetrics)
       qualifications_metrics_double = instance_double(QualificationsFeatureMetrics)
+      satisfaction_survey_metrics_double = instance_double(SatisfactionSurveyFeatureMetrics)
 
       allow(ReferenceFeatureMetrics).to receive(:new).and_return(reference_metrics_double)
       allow(WorkHistoryFeatureMetrics).to receive(:new).and_return(work_history_metrics_double)
@@ -62,6 +63,7 @@ RSpec.describe FeatureMetricsDashboard do
       allow(ApplyAgainFeatureMetrics).to receive(:new).and_return(apply_again_metrics_double)
       allow(CarryOverFeatureMetrics).to receive(:new).and_return(carry_over_metrics_double)
       allow(QualificationsFeatureMetrics).to receive(:new).and_return(qualifications_metrics_double)
+      allow(SatisfactionSurveyFeatureMetrics).to receive(:new).and_return(satisfaction_survey_metrics_double)
 
       allow(reference_metrics_double).to receive(:average_time_to_get_references).and_return(1)
       allow(reference_metrics_double).to receive(:percentage_references_within).and_return(2)
@@ -73,6 +75,7 @@ RSpec.describe FeatureMetricsDashboard do
       allow(apply_again_metrics_double).to receive(:formatted_application_rate).and_return('18.7%')
       allow(carry_over_metrics_double).to receive(:carry_over_count).and_return(20)
       allow(qualifications_metrics_double).to receive(:formatted_a_level_percentage).and_return('30%')
+      allow(satisfaction_survey_metrics_double).to receive(:formatted_response_rate).and_return('15.4%')
 
       dashboard = described_class.new
       dashboard.load_updated_metrics
@@ -117,6 +120,9 @@ RSpec.describe FeatureMetricsDashboard do
         'pct_applications_with_three_a_levels' => '30%',
         'pct_applications_with_three_a_levels_this_month' => '30%',
         'pct_applications_with_three_a_levels_last_month' => '30%',
+        'satisfaction_survey_response_rate' => '15.4%',
+        'satisfaction_survey_response_rate_this_month' => '15.4%',
+        'satisfaction_survey_response_rate_last_month' => '15.4%',
       })
     end
   end

--- a/spec/models/satisfaction_survey_feature_metrics_spec.rb
+++ b/spec/models/satisfaction_survey_feature_metrics_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe SatisfactionSurveyFeatureMetrics, with_audited: true do
   end
 
   def create_application_with_feeback
-    application_form2 = create(:completed_application_form, :with_feedback_completed, submitted_at: Time.zone.now)
-    application_form2
+    application_form = create(:completed_application_form, :with_feedback_completed, submitted_at: Time.zone.now)
+    application_form
   end
 
   describe '#formatted_response_rate' do

--- a/spec/models/satisfaction_survey_feature_metrics_spec.rb
+++ b/spec/models/satisfaction_survey_feature_metrics_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe SatisfactionSurveyFeatureMetrics, with_audited: true do
+  subject(:feature_metrics) { described_class.new }
+
+  def create_application
+    application_form = create(:completed_application_form, submitted_at: Time.zone.now)
+    application_form
+  end
+
+  def create_application_with_feeback
+    application_form2 = create(:completed_application_form, :with_feedback_completed, submitted_at: Time.zone.now)
+    application_form2
+  end
+
+  describe '#formatted_response_rate' do
+    context 'without any data' do
+      it 'returns n/a' do
+        expect(feature_metrics.formatted_response_rate(1.month.ago)).to eq('n/a')
+      end
+    end
+
+    context 'with applications with feedback' do
+      it 'returns 0 when there are no applications with feedback' do
+        create_application
+        expect(feature_metrics.formatted_response_rate(1.month.ago)).to eq('0%')
+      end
+
+      it 'returns the right percentages when applications with feedback exist' do
+        create_application
+        2.times { create_application_with_feeback }
+        expect(feature_metrics.formatted_response_rate(1.month.ago)).to eq('66.7%')
+      end
+
+      it 'returns the right percentages over a range of dates' do
+        @today = Time.zone.local(2021, 3, 10, 12)
+        Timecop.freeze(@today - 40.days) do
+          2.times { create_application_with_feeback }
+        end
+        Timecop.freeze(@today - 20.days) do
+          create_application
+        end
+        Timecop.freeze(@today - 5.days) do
+          create_application_with_feeback
+        end
+        Timecop.freeze(@today) do
+          expect(feature_metrics.formatted_response_rate(25.days.ago)).to eq('50%')
+          expect(feature_metrics.formatted_response_rate(25.days.ago, 10.days.ago)).to eq('0%')
+          expect(feature_metrics.formatted_response_rate(45.days.ago)).to eq('75%')
+        end
+      end
+    end
+  end
+end

--- a/spec/models/satisfaction_survey_feature_metrics_spec.rb
+++ b/spec/models/satisfaction_survey_feature_metrics_spec.rb
@@ -21,12 +21,12 @@ RSpec.describe SatisfactionSurveyFeatureMetrics, with_audited: true do
     end
 
     context 'with applications with feedback' do
-      it 'returns 0 when there are no applications with feedback' do
+      it 'returns 0 when there are no submitted applications with feedback' do
         create_application
         expect(feature_metrics.formatted_response_rate(1.month.ago)).to eq('0%')
       end
 
-      it 'returns the right percentages when applications with feedback exist' do
+      it 'returns the right percentages when submitted applications with feedback exist' do
         create_application
         2.times { create_application_with_feeback }
         expect(feature_metrics.formatted_response_rate(1.month.ago)).to eq('66.7%')

--- a/spec/system/support_interface/feature_metrics_dashboard_spec.rb
+++ b/spec/system/support_interface/feature_metrics_dashboard_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature 'Feature metrics dashboard' do
     and_i_should_see_reasons_for_rejection_metrics
     and_i_should_see_apply_again_metrics
     and_i_should_see_carry_over_metrics
+    and_i_should_see_satisfaction_survey_metrics
   end
 
   def given_i_am_a_support_user
@@ -193,6 +194,14 @@ RSpec.feature 'Feature metrics dashboard' do
       expect(page).to have_content('1 candidates carried over applications from previous cycle')
       expect(page).to have_content('0 last month')
       expect(page).to have_content('1 this month')
+    end
+  end
+
+  def and_i_should_see_satisfaction_survey_metrics
+    within('#satisfaction_survey_dashboard_section') do
+      expect(page).to have_content('n/a Satisfaction Survey Response Rate')
+      expect(page).to have_content('n/a last month')
+      expect(page).to have_content('n/a this month')
     end
   end
 end


### PR DESCRIPTION
## Context
Support Users currently cannot view the percentage rate of responses givento the post submission satisfaction survey. 

## Changes proposed in this pull request

This PR adds new section to the Feature Metrics Dashboard in order to display this info.

<img width="694" alt="image" src="https://user-images.githubusercontent.com/62567622/117223191-0a8cc800-ae05-11eb-829b-77637ab1772a.png">

## Guidance to review

Test in review app. I have left a couple of comments RE: testing.

## Link to Trello card

https://trello.com/c/EYeqCBJb/3335-add-satisfaction-survey-response-rate-to-the-feature-metric-dashboard

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
