### PR TITLE
Increase statuscake confirmations to 2

### DIFF
--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -84,6 +84,6 @@ statuscake_alerts = {
     contact_group  = [204421]
     trigger_rate   = 0
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-    confirmations  = 1
+    confirmations  = 2
   }
 }

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -44,6 +44,6 @@ statuscake_alerts = {
     contact_group  = [204421]
     trigger_rate   = 0
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-    confirmations  = 1
+    confirmations  = 2
   }
 }


### PR DESCRIPTION
## Context

Have confirmation from 2 statuscake locations to stop any false alerts.

## Changes proposed in this pull request

Increase statuscake confirmations to 2 for the cloudapps test.


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
