### PR TITLE
Let support users change conditions on accepted applications

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -107,8 +107,8 @@ module SupportInterface
       {
         key: 'Conditions',
         value: render(SupportInterface::ConditionsComponent.new(conditions: conditions)),
-        action: 'Change conditions',
-        action_path: support_interface_edit_application_choice_conditions_path(application_choice_id: @application_choice.id),
+        action: 'conditions',
+        change_path: support_interface_edit_application_choice_conditions_path(application_choice_id: @application_choice.id),
       }
     end
 

--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -17,6 +17,7 @@ module SupportInterface
         course_candidate_applied_for_row,
         course_offered_by_provider_row,
         course_row,
+        offer_conditions_row,
         rejected_at_or_by_default_at_row,
         rejection_reason_row,
         sent_to_provider_at_row,
@@ -95,6 +96,20 @@ module SupportInterface
       return unless rejection_reasons_text
 
       { key: 'Rejection reason', value: rejection_reasons_text }
+    end
+
+    def offer_conditions_row
+      return unless application_choice.pending_conditions? || application_choice.offer?
+
+      conditions = application_choice.offer&.[]('conditions')
+      return if conditions.blank?
+
+      {
+        key: 'Conditions',
+        value: render(SupportInterface::ConditionsComponent.new(conditions: conditions)),
+        action: 'Change conditions',
+        action_path: support_interface_edit_application_choice_conditions_path(application_choice_id: @application_choice.id),
+      }
     end
 
     def sent_to_provider_at_row

--- a/app/components/support_interface/conditions_component.html.erb
+++ b/app/components/support_interface/conditions_component.html.erb
@@ -1,0 +1,5 @@
+<ul class="govuk-list">
+  <% conditions.each do |condition| %>
+    <li><%= condition %></li>
+  <% end %>
+</ul>

--- a/app/components/support_interface/conditions_component.rb
+++ b/app/components/support_interface/conditions_component.rb
@@ -1,0 +1,9 @@
+module SupportInterface
+  class ConditionsComponent < ViewComponent::Base
+    attr_accessor :conditions
+
+    def initialize(conditions:)
+      @conditions = conditions
+    end
+  end
+end

--- a/app/controllers/support_interface/application_choice_conditions_controller.rb
+++ b/app/controllers/support_interface/application_choice_conditions_controller.rb
@@ -27,7 +27,7 @@ module SupportInterface
     def condition_params
       params
         .require(:support_interface_conditions_form)
-        .permit(:application_choice_id, further_conditions: {}, standard_conditions: [])
+        .permit(:application_choice_id, :audit_comment, further_conditions: {}, standard_conditions: [])
         .to_h
         .with_indifferent_access
     end

--- a/app/controllers/support_interface/application_choice_conditions_controller.rb
+++ b/app/controllers/support_interface/application_choice_conditions_controller.rb
@@ -17,7 +17,7 @@ module SupportInterface
         condition_params,
       )
 
-      if @form.valid? && @form.conditions_empty? && !@form.confirm_make_unconditional?
+      if @form.conditions_empty? && !@form.confirm_make_unconditional?
         redirect_to support_interface_confirm_make_application_choice_unconditional_path(
           @form.application_choice.id,
           audit_comment_ticket: @form.audit_comment_ticket,
@@ -27,6 +27,20 @@ module SupportInterface
         redirect_to support_interface_application_form_path(@form.application_choice.application_form_id)
       else
         render :edit
+      end
+    end
+
+    def make_unconditional
+      @form = SupportInterface::ConditionsForm.build_from_params(
+        application_choice,
+        condition_params,
+      )
+
+      if  @form.save
+        flash[:success] = 'Offer conditions updated'
+        redirect_to support_interface_application_form_path(@form.application_choice.application_form_id)
+      else
+        render :confirm_make_unconditional
       end
     end
 

--- a/app/controllers/support_interface/application_choice_conditions_controller.rb
+++ b/app/controllers/support_interface/application_choice_conditions_controller.rb
@@ -17,7 +17,7 @@ module SupportInterface
         condition_params,
       )
 
-      if @form.conditions_empty? && !@form.confirm_make_unconditional?
+      if @form.conditions_empty?
         redirect_to support_interface_confirm_make_application_choice_unconditional_path(
           @form.application_choice.id,
           audit_comment_ticket: @form.audit_comment_ticket,

--- a/app/controllers/support_interface/application_choice_conditions_controller.rb
+++ b/app/controllers/support_interface/application_choice_conditions_controller.rb
@@ -17,12 +17,12 @@ module SupportInterface
         condition_params,
       )
 
-      if @form.conditions_empty?
+      if @form.valid? && @form.conditions_empty?
         redirect_to support_interface_confirm_make_application_choice_unconditional_path(
           @form.application_choice.id,
           audit_comment_ticket: @form.audit_comment_ticket,
         )
-      elsif @form.save
+      elsif !@form.conditions_empty? && @form.save
         flash[:success] = 'Offer conditions updated'
         redirect_to support_interface_application_form_path(@form.application_choice.application_form_id)
       else

--- a/app/controllers/support_interface/application_choice_conditions_controller.rb
+++ b/app/controllers/support_interface/application_choice_conditions_controller.rb
@@ -4,13 +4,25 @@ module SupportInterface
       @form = SupportInterface::ConditionsForm.build_from_application_choice(application_choice)
     end
 
+    def confirm_make_unconditional
+      @form = SupportInterface::ConditionsForm.build_from_application_choice(
+        application_choice,
+        audit_comment_ticket: params[:audit_comment_ticket],
+      )
+    end
+
     def update
       @form = SupportInterface::ConditionsForm.build_from_params(
         application_choice,
         condition_params,
       )
 
-      if @form.save
+      if @form.valid? && @form.conditions_empty? && !@form.confirm_make_unconditional?
+        redirect_to support_interface_confirm_make_application_choice_unconditional_path(
+          @form.application_choice.id,
+          audit_comment_ticket: @form.audit_comment_ticket,
+        )
+      elsif @form.save
         flash[:success] = 'Offer conditions updated'
         redirect_to support_interface_application_form_path(@form.application_choice.application_form_id)
       else
@@ -27,7 +39,7 @@ module SupportInterface
     def condition_params
       params
         .require(:support_interface_conditions_form)
-        .permit(:application_choice_id, :audit_comment_ticket, further_conditions: {}, standard_conditions: [])
+        .permit(:application_choice_id, :audit_comment_ticket, :confirm_make_unconditional, further_conditions: {}, standard_conditions: [])
         .to_h
         .with_indifferent_access
     end

--- a/app/controllers/support_interface/application_choice_conditions_controller.rb
+++ b/app/controllers/support_interface/application_choice_conditions_controller.rb
@@ -5,18 +5,31 @@ module SupportInterface
     end
 
     def update
+      @form = SupportInterface::ConditionsForm.build_from_params(
+        application_choice,
+        condition_params,
+      )
+
+      if @form.save
+        flash[:success] = 'Offer conditions updated'
+        redirect_to support_interface_application_form_path(@form.application_choice.application_form_id)
+      else
+        render :edit
+      end
     end
 
   private
 
     def application_choice
-      @application_choice = ApplicationChoice.find(condition_params[:application_choice_id])
+      @application_choice = ApplicationChoice.find(params[:application_choice_id])
     end
 
     def condition_params
       params
-        .permit(:application_choice_id)
+        .require(:support_interface_conditions_form)
+        .permit(:application_choice_id, further_conditions: {}, standard_conditions: [])
         .to_h
+        .with_indifferent_access
     end
   end
 end

--- a/app/controllers/support_interface/application_choice_conditions_controller.rb
+++ b/app/controllers/support_interface/application_choice_conditions_controller.rb
@@ -27,7 +27,7 @@ module SupportInterface
     def condition_params
       params
         .require(:support_interface_conditions_form)
-        .permit(:application_choice_id, :audit_comment, further_conditions: {}, standard_conditions: [])
+        .permit(:application_choice_id, :audit_comment_ticket, further_conditions: {}, standard_conditions: [])
         .to_h
         .with_indifferent_access
     end

--- a/app/controllers/support_interface/application_choice_conditions_controller.rb
+++ b/app/controllers/support_interface/application_choice_conditions_controller.rb
@@ -1,0 +1,24 @@
+module SupportInterface
+  class ApplicationChoiceConditionsController < SupportInterfaceController
+    def edit
+      @form = SupportInterface::ConditionsForm.new(
+        application_choice: application_choice,
+      )
+    end
+
+    def update
+    end
+
+  private
+
+    def application_choice
+      @application_choice = ApplicationChoice.find(condition_params[:application_choice_id])
+    end
+
+    def condition_params
+      params
+        .permit(:application_choice_id)
+        .to_h
+    end
+  end
+end

--- a/app/controllers/support_interface/application_choice_conditions_controller.rb
+++ b/app/controllers/support_interface/application_choice_conditions_controller.rb
@@ -1,9 +1,7 @@
 module SupportInterface
   class ApplicationChoiceConditionsController < SupportInterfaceController
     def edit
-      @form = SupportInterface::ConditionsForm.new(
-        application_choice: application_choice,
-      )
+      @form = SupportInterface::ConditionsForm.build_from_application_choice(application_choice)
     end
 
     def update

--- a/app/controllers/support_interface/application_choice_conditions_controller.rb
+++ b/app/controllers/support_interface/application_choice_conditions_controller.rb
@@ -36,7 +36,7 @@ module SupportInterface
         condition_params,
       )
 
-      if  @form.save
+      if @form.save
         flash[:success] = 'Offer conditions updated'
         redirect_to support_interface_application_form_path(@form.application_choice.application_form_id)
       else

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -5,14 +5,15 @@ module SupportInterface
 
       attr_accessor :id, :text
 
-      validates :text, length: { maximum: 255, too_long: ->(c, _) { "Condition #{c.id + 1} must be %{count} characters or fewer" } }
+      validates :text, length: { maximum: MakeAnOffer::MAX_CONDITION_LENGTH, too_long: ->(c, _) { "Condition #{c.id + 1} must be %{count} characters or fewer" } }
     end
 
     include ActiveModel::Model
 
     attr_accessor :application_choice, :standard_conditions, :further_conditions, :audit_comment
 
-    NUMBER_OF_FURTHER_CONDITIONS = 4
+    MIN_FURTHER_CONDITIONS = 4
+    MAX_FURTHER_CONDITIONS = MakeAnOffer::MAX_CONDITIONS_COUNT - MakeAnOffer::STANDARD_CONDITIONS.length
 
     validates :application_choice, presence: true
     validates :audit_comment, presence: true
@@ -54,7 +55,13 @@ module SupportInterface
     end
 
     def add_slots_for_new_conditions
-      self.further_conditions = NUMBER_OF_FURTHER_CONDITIONS.times.map do |index|
+      further_condition_count = (further_conditions&.reject(&:blank?)&.count || 0)
+      number_of_conditions_to_display = [
+        [MIN_FURTHER_CONDITIONS, further_condition_count + 1].max,
+        MAX_FURTHER_CONDITIONS,
+      ].min
+
+      self.further_conditions = number_of_conditions_to_display.times.map do |index|
         existing_value = further_conditions && further_conditions[index]
         existing_value.presence || ''
       end

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -13,8 +13,17 @@ module SupportInterface
         standard_conditions: standard_conditions_from(application_choice.offer),
         further_conditions: further_conditions_from(application_choice.offer),
       }
-
       new(attrs).tap do |form|
+        form.setup_further_conditions
+      end
+    end
+
+    def self.build_from_params(application_choice, params)
+      form = build_from_application_choice(application_choice)
+
+      form.tap do |form|
+        form.standard_conditions = params['standard_conditions']
+        form.further_conditions = params['further_conditions'].values.map { |v| v['text'] }
         form.setup_further_conditions
       end
     end
@@ -47,7 +56,9 @@ module SupportInterface
     end
 
     def save
-      raise 'TODO'
+      application_choice.update(
+        offer: { conditions: (standard_conditions + further_conditions).reject(&:blank?) }
+      )
     end
   end
 end

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -17,6 +17,7 @@ module SupportInterface
     validates :audit_comment_ticket, presence: true
     validates :audit_comment_ticket, format: { with: /\A((http|https):\/\/)?(www.)?becomingateacher.zendesk.com\/agent\/tickets\// }
     validate :further_conditions_length
+    validates :confirm_make_unconditional, presence: true, if: :conditions_empty?
 
     def self.build_from_application_choice(application_choice, attrs = {})
       attrs = {

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -20,12 +20,13 @@ module SupportInterface
 
     attr_accessor :application_choice, :standard_conditions, :further_conditions, :audit_comment_ticket
 
-    MAX_FURTHER_CONDITIONS = OfferValidations::MAX_CONDITIONS_COUNT - MakeAnOffer::STANDARD_CONDITIONS.length
+    MAX_FURTHER_CONDITIONS = OfferValidations::MAX_CONDITIONS_COUNT
 
     validates :application_choice, presence: true
     validates :audit_comment_ticket, presence: true
     validates :audit_comment_ticket, format: { with: /\A((http|https):\/\/)?(www.)?becomingateacher.zendesk.com\/agent\/tickets\// }
-    validate :further_conditions_valid
+    validate :condition_count_valid
+    validate :further_conditions_lengths_valid
 
     def self.build_from_application_choice(application_choice, attrs = {})
       attrs = {
@@ -82,7 +83,13 @@ module SupportInterface
       end
     end
 
-    def further_conditions_valid
+    def condition_count_valid
+      if all_conditions.count > OfferValidations::MAX_CONDITIONS_COUNT
+        errors.add(:further_conditions, :too_many, limit: OfferValidations::MAX_CONDITIONS_COUNT)
+      end
+    end
+
+    def further_conditions_lengths_valid
       further_condition_models.map(&:valid?).all?
 
       further_condition_models.each do |condition_model|

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -24,7 +24,7 @@ module SupportInterface
         further_conditions: further_conditions_from(application_choice.offer),
       }.merge(attrs)
 
-      new(attrs).tap(&:setup_further_conditions)
+      new(attrs).tap(&:add_slots_for_new_conditions)
     end
 
     def self.build_from_params(application_choice, params)
@@ -35,7 +35,7 @@ module SupportInterface
       }
 
       form = build_from_application_choice(application_choice, attrs)
-      form.setup_further_conditions
+      form.add_slots_for_new_conditions
       form
     end
 
@@ -53,7 +53,7 @@ module SupportInterface
       conditions - MakeAnOffer::STANDARD_CONDITIONS
     end
 
-    def setup_further_conditions
+    def add_slots_for_new_conditions
       self.further_conditions = NUMBER_OF_FURTHER_CONDITIONS.times.map do |index|
         existing_value = further_conditions && further_conditions[index]
         existing_value.presence || ''

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -2,30 +2,35 @@ module SupportInterface
   class ConditionsForm
     include ActiveModel::Model
 
-    attr_accessor :application_choice, :standard_conditions, :further_conditions
+    attr_accessor :application_choice, :standard_conditions, :further_conditions, :audit_comment
 
     NUMBER_OF_FURTHER_CONDITIONS = 4
-    validates :application_choice, presence: true
 
-    def self.build_from_application_choice(application_choice)
+    validates :application_choice, presence: true
+    validates :audit_comment, presence: true
+
+    def self.build_from_application_choice(application_choice, attrs = {})
       attrs = {
         application_choice: application_choice,
         standard_conditions: standard_conditions_from(application_choice.offer),
         further_conditions: further_conditions_from(application_choice.offer),
-      }
+      }.merge(attrs)
+
       new(attrs).tap do |form|
         form.setup_further_conditions
       end
     end
 
     def self.build_from_params(application_choice, params)
-      form = build_from_application_choice(application_choice)
+      attrs = {
+        standard_conditions: params['standard_conditions'],
+        audit_comment: params['audit_comment'],
+        further_conditions: params['further_conditions']&.values&.map { |v| v['text'] },
+      }
 
-      form.tap do |form|
-        form.standard_conditions = params['standard_conditions']
-        form.further_conditions = params['further_conditions'].values.map { |v| v['text'] }
-        form.setup_further_conditions
-      end
+      form = build_from_application_choice(application_choice, attrs)
+      form.setup_further_conditions
+      form
     end
 
     def self.standard_conditions_from(offer)
@@ -56,8 +61,11 @@ module SupportInterface
     end
 
     def save
+      return false unless valid?
+
       application_choice.update(
-        offer: { conditions: (standard_conditions + further_conditions).reject(&:blank?) }
+        offer: { conditions: (standard_conditions + further_conditions).reject(&:blank?) },
+        audit_comment: audit_comment,
       )
     end
   end

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -8,12 +8,13 @@ module SupportInterface
 
     include ActiveModel::Model
 
-    attr_accessor :application_choice, :standard_conditions, :further_conditions, :audit_comment
+    attr_accessor :application_choice, :standard_conditions, :further_conditions, :audit_comment_ticket
 
     MAX_FURTHER_CONDITIONS = OfferValidations::MAX_CONDITIONS_COUNT - MakeAnOffer::STANDARD_CONDITIONS.length
 
     validates :application_choice, presence: true
-    validates :audit_comment, presence: true
+    validates :audit_comment_ticket, presence: true
+    validates :audit_comment_ticket, format: { with: /\A((http|https):\/\/)?(www.)?becomingateacher.zendesk.com\/agent\/tickets\// }
     validate :further_conditions_length
 
     def self.build_from_application_choice(application_choice, attrs = {})
@@ -29,7 +30,7 @@ module SupportInterface
     def self.build_from_params(application_choice, params)
       attrs = {
         standard_conditions: params['standard_conditions'],
-        audit_comment: params['audit_comment'],
+        audit_comment_ticket: params['audit_comment_ticket'],
         further_conditions: params['further_conditions']&.values&.map { |v| v['text'] },
       }
 
@@ -86,7 +87,7 @@ module SupportInterface
 
       application_choice.update(
         offer: { conditions: (standard_conditions + further_conditions).reject(&:blank?) },
-        audit_comment: audit_comment,
+        audit_comment: "Change offer condition Zendesk request: #{audit_comment_ticket}",
       )
     end
   end

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -10,7 +10,6 @@ module SupportInterface
 
     attr_accessor :application_choice, :standard_conditions, :further_conditions, :audit_comment
 
-    MIN_FURTHER_CONDITIONS = 4
     MAX_FURTHER_CONDITIONS = OfferValidations::MAX_CONDITIONS_COUNT - MakeAnOffer::STANDARD_CONDITIONS.length
 
     validates :application_choice, presence: true
@@ -56,7 +55,7 @@ module SupportInterface
     def add_slots_for_new_conditions
       further_condition_count = (further_conditions&.reject(&:blank?)&.count || 0)
       number_of_conditions_to_display = [
-        [MIN_FURTHER_CONDITIONS, further_condition_count + 1].max,
+        further_condition_count + 1,
         MAX_FURTHER_CONDITIONS,
       ].min
 

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -1,5 +1,13 @@
 module SupportInterface
   class ConditionsForm
+    class OfferConditionField
+      include ActiveModel::Model
+
+      attr_accessor :id, :text
+
+      validates :text, length: { maximum: 255, too_long: ->(c, _) { "Condition #{c.id + 1} must be %{count} characters or fewer" } }
+    end
+
     include ActiveModel::Model
 
     attr_accessor :application_choice, :standard_conditions, :further_conditions, :audit_comment
@@ -16,9 +24,7 @@ module SupportInterface
         further_conditions: further_conditions_from(application_choice.offer),
       }.merge(attrs)
 
-      new(attrs).tap do |form|
-        form.setup_further_conditions
-      end
+      new(attrs).tap(&:setup_further_conditions)
     end
 
     def self.build_from_params(application_choice, params)
@@ -56,7 +62,7 @@ module SupportInterface
 
     def further_condition_models
       @further_condition_models ||= further_conditions.map.with_index do |further_condition, index|
-        ProviderInterface::OfferConditionField.new(id: index, text: further_condition)
+        OfferConditionField.new(id: index, text: further_condition)
       end
     end
 

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -7,9 +7,30 @@ module SupportInterface
     NUMBER_OF_FURTHER_CONDITIONS = 4
     validates :application_choice, presence: true
 
-    def initialize(attrs)
-      setup_further_conditions
-      super
+    def self.build_from_application_choice(application_choice)
+      attrs = {
+        application_choice: application_choice,
+        standard_conditions: standard_conditions_from(application_choice.offer),
+        further_conditions: further_conditions_from(application_choice.offer),
+      }
+
+      new(attrs).tap do |form|
+        form.setup_further_conditions
+      end
+    end
+
+    def self.standard_conditions_from(offer)
+      return [] if offer.blank?
+
+      conditions = offer['conditions']
+      conditions & MakeAnOffer::STANDARD_CONDITIONS
+    end
+
+    def self.further_conditions_from(offer)
+      return [] if offer.blank?
+
+      conditions = offer['conditions']
+      conditions - MakeAnOffer::STANDARD_CONDITIONS
     end
 
     def setup_further_conditions

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -1,0 +1,32 @@
+module SupportInterface
+  class ConditionsForm
+    include ActiveModel::Model
+
+    attr_accessor :application_choice, :standard_conditions, :further_conditions
+
+    NUMBER_OF_FURTHER_CONDITIONS = 4
+    validates :application_choice, presence: true
+
+    def initialize(attrs)
+      setup_further_conditions
+      super
+    end
+
+    def setup_further_conditions
+      self.further_conditions = NUMBER_OF_FURTHER_CONDITIONS.times.map do |index|
+        existing_value = further_conditions && further_conditions[index]
+        existing_value.presence || ''
+      end
+    end
+
+    def further_condition_models
+      @further_condition_models ||= further_conditions.map.with_index do |further_condition, index|
+        ProviderInterface::OfferConditionField.new(id: index, text: further_condition)
+      end
+    end
+
+    def save
+      raise 'TODO'
+    end
+  end
+end

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -8,8 +8,7 @@ module SupportInterface
 
     include ActiveModel::Model
 
-    attr_accessor :application_choice, :standard_conditions, :further_conditions, :audit_comment_ticket, :confirm_make_unconditional
-    alias_method :confirm_make_unconditional?, :confirm_make_unconditional
+    attr_accessor :application_choice, :standard_conditions, :further_conditions, :audit_comment_ticket
 
     MAX_FURTHER_CONDITIONS = OfferValidations::MAX_CONDITIONS_COUNT - MakeAnOffer::STANDARD_CONDITIONS.length
 
@@ -17,7 +16,6 @@ module SupportInterface
     validates :audit_comment_ticket, presence: true
     validates :audit_comment_ticket, format: { with: /\A((http|https):\/\/)?(www.)?becomingateacher.zendesk.com\/agent\/tickets\// }
     validate :further_conditions_length
-    validates :confirm_make_unconditional, presence: true, if: :conditions_empty?
 
     def self.build_from_application_choice(application_choice, attrs = {})
       attrs = {
@@ -33,7 +31,6 @@ module SupportInterface
       attrs = {
         standard_conditions: params['standard_conditions'] || [],
         audit_comment_ticket: params['audit_comment_ticket'],
-        confirm_make_unconditional: params['confirm_make_unconditional'],
         further_conditions: params['further_conditions']&.values&.map { |v| v['text'] } || [],
       }
 

--- a/app/services/update_accepted_offer_conditions.rb
+++ b/app/services/update_accepted_offer_conditions.rb
@@ -1,0 +1,24 @@
+class UpdateAcceptedOfferConditions
+  def initialize(application_choice:, conditions:, audit_comment_ticket:)
+    @application_choice = application_choice
+    @conditions = conditions
+    @audit_comment_ticket = audit_comment_ticket
+  end
+
+  def save!
+    ActiveRecord::Base.transaction do
+      @application_choice.update(
+        offer: { conditions: @conditions },
+        audit_comment: "Change offer condition Zendesk request: #{@audit_comment_ticket}",
+      )
+      if @conditions.empty?
+        ApplicationStateChange.new(@application_choice).confirm_conditions_met!
+        @application_choice.update!(recruited_at: Time.zone.now)
+      end
+    end
+
+    StateChangeNotifier.new(:recruited, @application_choice).application_outcome_notification
+  rescue Workflow::NoTransitionAllowed
+    false
+  end
+end

--- a/app/views/support_interface/application_choice_conditions/confirm_make_unconditional.html.erb
+++ b/app/views/support_interface/application_choice_conditions/confirm_make_unconditional.html.erb
@@ -1,0 +1,36 @@
+<% content_for :browser_title, title_with_error_prefix('Make offer unconditional', @form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@form.application_choice.application_form_id)) %>
+
+<%= form_with model: @form, url: support_interface_update_application_choice_conditions_path(@form.application_choice.id), method: :put do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        Are you sure you want to make this offer unconditional?
+      </h1>
+
+      <p class="govuk-body">Because this offer has already been accepted removing all conditions will recruit this candidate immediately.</p>
+
+      <%= f.govuk_text_field(
+        :audit_comment_ticket,
+        label: { text: 'Zendesk ticket URL', size: 'm' },
+        hint: { text: 'For example https://becomingateacher.zendesk.com/agent/tickets/12345' },
+      ) %>
+      <%= f.govuk_check_boxes_fieldset :confirm_make_unconditional, legend: nil do %>
+        <%= f.govuk_check_box(
+          :confirm_make_unconditional,
+          true,
+          multiple: false,
+          label: { text: 'I understand that I am making this offer unconditional' },
+          link_errors: true,
+        ) %>
+      <% end %>
+
+      <%= f.govuk_submit t('continue') %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to t('cancel'), support_interface_application_form_path(@form.application_choice.application_form_id), class: 'govuk-link--no-visited-state' %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/support_interface/application_choice_conditions/confirm_make_unconditional.html.erb
+++ b/app/views/support_interface/application_choice_conditions/confirm_make_unconditional.html.erb
@@ -11,22 +11,9 @@
 
       <p class="govuk-body">Because this offer has already been accepted removing all conditions will recruit this candidate immediately.</p>
 
-      <%= f.govuk_text_field(
-        :audit_comment_ticket,
-        label: { text: 'Zendesk ticket URL', size: 'm' },
-        hint: { text: 'For example https://becomingateacher.zendesk.com/agent/tickets/12345' },
-      ) %>
-      <%= f.govuk_check_boxes_fieldset :confirm_make_unconditional, legend: nil do %>
-        <%= f.govuk_check_box(
-          :confirm_make_unconditional,
-          true,
-          multiple: false,
-          label: { text: 'I understand that I am making this offer unconditional' },
-          link_errors: true,
-        ) %>
-      <% end %>
+      <%= f.hidden_field(:audit_comment_ticket) %>
 
-      <%= f.govuk_submit t('continue') %>
+      <%= f.govuk_submit('Yes I\'m sure - make offer unconditional and recruit candidate') %>
 
       <p class="govuk-body">
         <%= govuk_link_to t('cancel'), support_interface_application_form_path(@form.application_choice.application_form_id), class: 'govuk-link--no-visited-state' %>

--- a/app/views/support_interface/application_choice_conditions/confirm_make_unconditional.html.erb
+++ b/app/views/support_interface/application_choice_conditions/confirm_make_unconditional.html.erb
@@ -1,7 +1,7 @@
 <% content_for :browser_title, title_with_error_prefix('Make offer unconditional', @form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@form.application_choice.application_form_id)) %>
 
-<%= form_with model: @form, url: support_interface_update_application_choice_conditions_path(@form.application_choice.id), method: :put do |f| %>
+<%= form_with model: @form, url: support_interface_make_application_choice_unconditional_path(@form.application_choice.id), method: :put do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>

--- a/app/views/support_interface/application_choice_conditions/edit.html.erb
+++ b/app/views/support_interface/application_choice_conditions/edit.html.erb
@@ -1,13 +1,15 @@
 <% content_for :browser_title, title_with_error_prefix('Update conditions', @form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@form.application_choice.application_form_id)) %>
 
-<h1 class="govuk-heading-l">
-  Change offer conditions
-</h1>
-
 <%= form_with model: @form, url: support_interface_update_application_choice_conditions_path(@form.application_choice.id), method: :put do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        Change offer conditions
+      </h1>
+
       <%= govuk_warning(
         text: 'Offer conditions should only be changed on accepted applications following a request from a provider that has already informed the candidate about the change',
       ) %>

--- a/app/views/support_interface/application_choice_conditions/edit.html.erb
+++ b/app/views/support_interface/application_choice_conditions/edit.html.erb
@@ -1,0 +1,37 @@
+<% content_for :browser_title, title_with_error_prefix('Update conditions', @form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@form.application_choice.application_form_id)) %>
+
+<h1 class="govuk-heading-l">
+  Change offer conditions
+</h1>
+
+<%= form_with model: @form, url: support_interface_update_application_choice_conditions_path(@form.application_choice.id), method: :post do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_collection_check_boxes(
+        :standard_conditions,
+        standard_conditions_checkboxes,
+        :id,
+        :name,
+        legend: { size: 'm', text: 'Standard conditions' },
+      ) %>
+
+      <%= f.govuk_fieldset legend: { text: 'Further conditions', size: 'm' } do %>
+        <p class="govuk-body">For example, studying a subject knowledge enhancement course.</p>
+
+        <% @form.further_condition_models.each do |model| %>
+          <%= f.fields_for 'further_conditions[]', model do |fc| %>
+            <%= fc.govuk_text_area :text, label: { text: "Condition #{model.id.to_i + 1}", size: 's' }, rows: 3 %>
+          <% end %>
+        <% end %>
+
+      <% end %>
+
+      <%= f.govuk_submit t('continue') %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to t('cancel'), support_interface_application_form_path(@form.application_choice.application_form_id), class: 'govuk-link--no-visited-state' %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/support_interface/application_choice_conditions/edit.html.erb
+++ b/app/views/support_interface/application_choice_conditions/edit.html.erb
@@ -8,12 +8,9 @@
 <%= form_with model: @form, url: support_interface_update_application_choice_conditions_path(@form.application_choice.id), method: :put do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= govuk_notification_banner(
-        title: t('notification_banner.warning'),
-        classes: 'govuk-notification-banner--warning',
-      ) do |_notification_banner| %>
-        <p class="govuk-body">Offer conditions should only be changed on accepted applications following a request from a provider that has already informed the candidate about the change</p>
-      <% end %>
+      <%= govuk_warning(
+        text: 'Offer conditions should only be changed on accepted applications following a request from a provider that has already informed the candidate about the change',
+      ) %>
 
       <%= f.govuk_text_area(
         :audit_comment,

--- a/app/views/support_interface/application_choice_conditions/edit.html.erb
+++ b/app/views/support_interface/application_choice_conditions/edit.html.erb
@@ -12,11 +12,10 @@
         text: 'Offer conditions should only be changed on accepted applications following a request from a provider that has already informed the candidate about the change',
       ) %>
 
-      <%= f.govuk_text_area(
-        :audit_comment,
-        label: { text: 'Audit comment', size: 'm' },
-        hint: { text: 'Include a link to the support ticket that the provider raised for this change' },
-        rows: 3,
+      <%= f.govuk_text_field(
+        :audit_comment_ticket,
+        label: { text: 'Zendesk ticket URL', size: 'm' },
+        hint: { text: 'For example https://becomingateacher.zendesk.com/agent/tickets/12345' },
       ) %>
 
       <%= f.govuk_collection_check_boxes(

--- a/app/views/support_interface/application_choice_conditions/edit.html.erb
+++ b/app/views/support_interface/application_choice_conditions/edit.html.erb
@@ -8,6 +8,20 @@
 <%= form_with model: @form, url: support_interface_update_application_choice_conditions_path(@form.application_choice.id), method: :post do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <%= govuk_notification_banner(
+        title: t('notification_banner.warning'),
+        classes: 'govuk-notification-banner--warning',
+      ) do |_notification_banner| %>
+        <p class="govuk-body">Offer conditions should only be changed on accepted applications following a request from a provider that has already informed the candidate about the change</p>
+      <% end %>
+
+      <%= f.govuk_text_area(
+        :audit_comment,
+        label: { text: 'Audit comment', size: 'm' },
+        hint: { text: 'Include a link to the support ticket that the provider raised for this change' },
+        rows: 3,
+      ) %>
+
       <%= f.govuk_collection_check_boxes(
         :standard_conditions,
         standard_conditions_checkboxes,
@@ -27,7 +41,7 @@
 
       <% end %>
 
-      <%= f.govuk_submit t('continue') %>
+      <%= f.govuk_submit 'Update conditions' %>
 
       <p class="govuk-body">
         <%= govuk_link_to t('cancel'), support_interface_application_form_path(@form.application_choice.application_form_id), class: 'govuk-link--no-visited-state' %>

--- a/app/views/support_interface/application_choice_conditions/edit.html.erb
+++ b/app/views/support_interface/application_choice_conditions/edit.html.erb
@@ -5,7 +5,7 @@
   Change offer conditions
 </h1>
 
-<%= form_with model: @form, url: support_interface_update_application_choice_conditions_path(@form.application_choice.id), method: :post do |f| %>
+<%= form_with model: @form, url: support_interface_update_application_choice_conditions_path(@form.application_choice.id), method: :put do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= govuk_notification_banner(

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -55,8 +55,9 @@ en:
               blank: Please specify a provider
         support_interface/conditions_form:
           attributes:
-            audit_comment:
-              blank: Enter a comment for the audit trail
+            audit_comment_ticket:
+              blank: Enter a Zendesk ticket URL
+              invalid: Enter a valid Zendesk ticket URL
             further_conditions:
               too_long: 'Condition %{index} must be %{limit} characters or fewer'
         support_interface/new_offer_form:

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -60,6 +60,7 @@ en:
               invalid: Enter a valid Zendesk ticket URL
             further_conditions:
               too_long: 'Condition %{index} must be %{limit} characters or fewer'
+              too_many: 'You can only have %{limit} conditions or fewer'
         support_interface/conditions_form/offer_condition_field:
           attributes:
             text:

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -57,6 +57,8 @@ en:
           attributes:
             audit_comment:
               blank: Enter a comment for the audit trail
+            further_conditions:
+              too_long: 'Condition %{index} must be %{limit} characters or fewer'
         support_interface/new_offer_form:
           attributes:
             further_conditions:

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -55,12 +55,14 @@ en:
               blank: Please specify a provider
         support_interface/conditions_form:
           attributes:
-            confirm_make_unconditional:
-              blank: Select that you understand the consequences of making this offer unconditional
             audit_comment_ticket:
               blank: Enter a Zendesk ticket URL
               invalid: Enter a valid Zendesk ticket URL
             further_conditions:
+              too_long: 'Condition %{index} must be %{limit} characters or fewer'
+        support_interface/conditions_form/offer_condition_field:
+          attributes:
+            text:
               too_long: 'Condition %{index} must be %{limit} characters or fewer'
         support_interface/new_offer_form:
           attributes:

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -55,6 +55,8 @@ en:
               blank: Please specify a provider
         support_interface/conditions_form:
           attributes:
+            confirm_make_unconditional:
+              blank: Select that you understand the consequences of making this offer unconditional
             audit_comment_ticket:
               blank: Enter a Zendesk ticket URL
               invalid: Enter a valid Zendesk ticket URL

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -53,6 +53,10 @@ en:
               blank: Last name cannot be blank
             provider_permissions:
               blank: Please specify a provider
+        support_interface/conditions_form:
+          attributes:
+            audit_comment:
+              blank: Enter a comment for the audit trail
         support_interface/new_offer_form:
           attributes:
             further_conditions:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -824,6 +824,7 @@ Rails.application.routes.draw do
     get '/application-choices/:application_choice_id' => 'application_choices#show', as: :application_choice
     get '/application-choices/:application_choice_id/conditions' => 'application_choice_conditions#edit', as: :edit_application_choice_conditions
     put '/application-choices/:application_choice_id/conditions' => 'application_choice_conditions#update', as: :update_application_choice_conditions
+    get '/application-choices/:application_choice_id/make-unconditional' => 'application_choice_conditions#confirm_make_unconditional', as: :confirm_make_application_choice_unconditional
 
     get '/candidates' => 'candidates#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -822,6 +822,8 @@ Rails.application.routes.draw do
 
     get '/application_choices/:application_choice_id' => redirect('/application-choices/%{application_choice_id}')
     get '/application-choices/:application_choice_id' => 'application_choices#show', as: :application_choice
+    get '/application-choices/:application_choice_id/conditions' => 'application_choice_conditions#edit', as: :edit_application_choice_conditions
+    post '/application-choices/:application_choice_id/conditions' => 'application_choice_conditions#update', as: :update_application_choice_conditions
 
     get '/candidates' => 'candidates#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -823,7 +823,7 @@ Rails.application.routes.draw do
     get '/application_choices/:application_choice_id' => redirect('/application-choices/%{application_choice_id}')
     get '/application-choices/:application_choice_id' => 'application_choices#show', as: :application_choice
     get '/application-choices/:application_choice_id/conditions' => 'application_choice_conditions#edit', as: :edit_application_choice_conditions
-    post '/application-choices/:application_choice_id/conditions' => 'application_choice_conditions#update', as: :update_application_choice_conditions
+    put '/application-choices/:application_choice_id/conditions' => 'application_choice_conditions#update', as: :update_application_choice_conditions
 
     get '/candidates' => 'candidates#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -825,6 +825,7 @@ Rails.application.routes.draw do
     get '/application-choices/:application_choice_id/conditions' => 'application_choice_conditions#edit', as: :edit_application_choice_conditions
     put '/application-choices/:application_choice_id/conditions' => 'application_choice_conditions#update', as: :update_application_choice_conditions
     get '/application-choices/:application_choice_id/make-unconditional' => 'application_choice_conditions#confirm_make_unconditional', as: :confirm_make_application_choice_unconditional
+    put '/application-choices/:application_choice_id/make-unconditional' => 'application_choice_conditions#make_unconditional', as: :make_application_choice_unconditional
 
     get '/candidates' => 'candidates#index'
 

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -148,14 +148,14 @@ RSpec.describe SupportInterface::ConditionsForm do
       application_choice = build(:application_choice, offer: nil)
       form = described_class.build_from_application_choice(application_choice)
       expect(form.standard_conditions).to eq([])
-      expect(form.further_conditions).to eq(['', '', '', ''])
+      expect(form.further_conditions).to eq([''])
     end
 
     it 'handles an empty set of conditions' do
       application_choice = build(:application_choice, offer: { 'conditions' => [] })
       form = described_class.build_from_application_choice(application_choice)
       expect(form.standard_conditions).to eq([])
-      expect(form.further_conditions).to eq(['', '', '', ''])
+      expect(form.further_conditions).to eq([''])
     end
 
     it 'reads standard and further conditions' do
@@ -165,7 +165,7 @@ RSpec.describe SupportInterface::ConditionsForm do
       )
       form = described_class.build_from_application_choice(application_choice)
       expect(form.standard_conditions).to eq(['Fitness to train to teach check'])
-      expect(form.further_conditions).to eq(['Get a haircut', '', '', ''])
+      expect(form.further_conditions).to eq(['Get a haircut', ''])
     end
 
     it 'reads more than 4 further conditions' do

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -1,6 +1,58 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::ConditionsForm do
+  describe '#save' do
+    it 'adds an additional further and standard condition' do
+      application_choice = create(
+        :application_choice,
+        offer: { 'conditions' => ['Fitness to train to teach check', 'Get a haircut'] },
+      )
+      form = described_class.build_from_params(
+        application_choice,
+        'standard_conditions' => [
+          'Fitness to train to teach check',
+          'Disclosure and Barring Service (DBS) check',
+        ],
+        'further_conditions' => {
+          '0' => { 'text' => 'Get a haircut' },
+          '1' => { 'text' => 'Wear a tie' },
+        },
+      )
+      form.save
+      expect(application_choice.reload.offer).to eq(
+        'conditions' => [
+          'Fitness to train to teach check',
+          'Disclosure and Barring Service (DBS) check',
+          'Get a haircut',
+          'Wear a tie',
+        ],
+      )
+    end
+
+    it 'can remove conditions' do
+      application_choice = create(
+        :application_choice,
+        offer: { 'conditions' => ['Fitness to train to teach check', 'Get a haircut', 'Wear a tie'] },
+      )
+      form = described_class.build_from_params(
+        application_choice,
+        'standard_conditions' => [
+          'Disclosure and Barring Service (DBS) check',
+        ],
+        'further_conditions' => {
+          '0' => { 'text' => 'Wear a tie' },
+        },
+      )
+      form.save
+      expect(application_choice.reload.offer).to eq(
+        'conditions' => [
+          'Disclosure and Barring Service (DBS) check',
+          'Wear a tie',
+        ],
+      )
+    end
+  end
+
   describe '.build_from_application_choice' do
     it 'handles a missing offer value' do
       application_choice = build(:application_choice, offer: nil)

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe SupportInterface::ConditionsForm do
         },
       )
       expect(form.save).to be(false)
+      expect(form.errors.full_messages).to include('Audit comment Enter a comment for the audit trail')
       expect(application_choice.reload.offer['conditions']).to eq([
         'Fitness to train to teach check',
         'Get a haircut',

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -90,10 +90,12 @@ RSpec.describe SupportInterface::ConditionsForm do
         'audit_comment' => 'See support ticket #123',
       )
       form.save
-      expect(application_choice.audits.where(
-        action: 'update',
-        comment: 'See support ticket #123',
-      )).to be_present
+      expect(
+        application_choice.audits.where(
+          action: 'update',
+          comment: 'See support ticket #123',
+        ),
+      ).to be_present
     end
   end
 

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -2,6 +2,29 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::ConditionsForm do
   describe '#save' do
+    it 'returns false with a validation error if audit_comment is missing' do
+      application_choice = create(
+        :application_choice,
+        offer: { 'conditions' => ['Fitness to train to teach check', 'Get a haircut'] },
+      )
+      form = described_class.build_from_params(
+        application_choice,
+        'standard_conditions' => [
+          'Fitness to train to teach check',
+          'Disclosure and Barring Service (DBS) check',
+        ],
+        'further_conditions' => {
+          '0' => { 'text' => 'Get a haircut' },
+          '1' => { 'text' => 'Wear a tie' },
+        },
+      )
+      expect(form.save).to be(false)
+      expect(application_choice.reload.offer['conditions']).to eq([
+        'Fitness to train to teach check',
+        'Get a haircut',
+      ])
+    end
+
     it 'adds an additional further and standard condition' do
       application_choice = create(
         :application_choice,
@@ -17,6 +40,7 @@ RSpec.describe SupportInterface::ConditionsForm do
           '0' => { 'text' => 'Get a haircut' },
           '1' => { 'text' => 'Wear a tie' },
         },
+        'audit_comment' => 'See support ticket #123',
       )
       form.save
       expect(application_choice.reload.offer).to eq(
@@ -42,6 +66,7 @@ RSpec.describe SupportInterface::ConditionsForm do
         'further_conditions' => {
           '0' => { 'text' => 'Wear a tie' },
         },
+        'audit_comment' => 'See support ticket #123',
       )
       form.save
       expect(application_choice.reload.offer).to eq(
@@ -50,6 +75,25 @@ RSpec.describe SupportInterface::ConditionsForm do
           'Wear a tie',
         ],
       )
+    end
+
+    it 'includes an audit comment', with_audited: true do
+      application_choice = create(
+        :application_choice,
+        offer: { 'conditions' => ['Fitness to train to teach check'] },
+      )
+      form = described_class.build_from_params(
+        application_choice,
+        'standard_conditions' => [
+          'Disclosure and Barring Service (DBS) check',
+        ],
+        'audit_comment' => 'See support ticket #123',
+      )
+      form.save
+      expect(application_choice.audits.where(
+        action: 'update',
+        comment: 'See support ticket #123',
+      )).to be_present
     end
   end
 

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -42,6 +42,28 @@ RSpec.describe SupportInterface::ConditionsForm do
       expect(form).not_to be_valid
       expect(form.errors.messages[:'further_conditions[1][text]']).to include('Condition 2 must be 255 characters or fewer')
     end
+
+    it 'can have 20 further conditions' do
+      application_choice = build(:application_choice)
+      form = described_class.build_from_params(
+        application_choice,
+        'further_conditions' => (0..19).map { |id| [id.to_s, { 'text' => "further condition #{id}" }] }.to_h,
+        'audit_comment_ticket' => 'https://becomingateacher.zendesk.com/agent/tickets/12345',
+      )
+      expect(form).to be_valid
+    end
+
+    it 'cannot have more than 20 conditions' do
+      application_choice = build(:application_choice)
+      form = described_class.build_from_params(
+        application_choice,
+        'standard_conditions' => ['Fitness to train to teach check'],
+        'further_conditions' => (0..19).map { |id| [id.to_s, { 'text' => "further condition #{id}" }] }.to_h,
+        'audit_comment_ticket' => 'https://becomingateacher.zendesk.com/agent/tickets/12345',
+      )
+      expect(form).not_to be_valid
+      expect(form.errors.messages[:further_conditions]).to include('You can only have 20 conditions or fewer')
+    end
   end
 
   describe '#save' do

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ConditionsForm do
+  describe '.build_from_application_choice' do
+    it 'handles a missing offer value' do
+      application_choice = build(:application_choice, offer: nil)
+      form = described_class.build_from_application_choice(application_choice)
+      expect(form.standard_conditions).to eq([])
+      expect(form.further_conditions).to eq(['', '', '', ''])
+    end
+
+    it 'handles an empty set of conditions' do
+      application_choice = build(:application_choice, offer: { 'conditions' => [] })
+      form = described_class.build_from_application_choice(application_choice)
+      expect(form.standard_conditions).to eq([])
+      expect(form.further_conditions).to eq(['', '', '', ''])
+    end
+
+    it 'reads standard and further conditions' do
+      application_choice = build(
+        :application_choice,
+        offer: { 'conditions' => ['Fitness to train to teach check', 'Get a haircut'] },
+      )
+      form = described_class.build_from_application_choice(application_choice)
+      expect(form.standard_conditions).to eq(['Fitness to train to teach check'])
+      expect(form.further_conditions).to eq(['Get a haircut', '', '', ''])
+    end
+  end
+end

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -124,5 +124,15 @@ RSpec.describe SupportInterface::ConditionsForm do
       expect(form.standard_conditions).to eq(['Fitness to train to teach check'])
       expect(form.further_conditions).to eq(['Get a haircut', '', '', ''])
     end
+
+    it 'reads more than 4 further conditions' do
+      application_choice = build(
+        :application_choice,
+        offer: { 'conditions' => ['Fitness to train to teach check', 'FC1', 'FC2', 'FC3', 'FC4', 'FC5'] },
+      )
+      form = described_class.build_from_application_choice(application_choice)
+      expect(form.standard_conditions).to eq(['Fitness to train to teach check'])
+      expect(form.further_conditions).to eq(['FC1', 'FC2', 'FC3', 'FC4', 'FC5', ''])
+    end
   end
 end

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SupportInterface::ConditionsForm do
           '0' => { 'text' => 2000.times.map { ('a'..'z').to_a[rand(26)] }.join },
           '1' => { 'text' => 255.times.map { ('a'..'z').to_a[rand(26)] }.join },
         },
-        'audit_comment' => 'See support ticket #123',
+        'audit_comment_ticket' => 'https://becomingateacher.zendesk.com/agent/tickets/12345',
       )
       expect(form).to be_valid
     end
@@ -23,7 +23,7 @@ RSpec.describe SupportInterface::ConditionsForm do
           '0' => { 'text' => 2001.times.map { ('a'..'z').to_a[rand(26)] }.join },
           '1' => { 'text' => 10.times.map { ('a'..'z').to_a[rand(26)] }.join },
         },
-        'audit_comment' => 'See support ticket #123',
+        'audit_comment_ticket' => 'https://becomingateacher.zendesk.com/agent/tickets/12345',
       )
       expect(form).not_to be_valid
       expect(form.errors.full_messages).to include('Further conditions Condition 1 must be 2000 characters or fewer')
@@ -37,7 +37,7 @@ RSpec.describe SupportInterface::ConditionsForm do
           '0' => { 'text' => 10.times.map { ('a'..'z').to_a[rand(26)] }.join },
           '1' => { 'text' => 256.times.map { ('a'..'z').to_a[rand(26)] }.join },
         },
-        'audit_comment' => 'See support ticket #123',
+        'audit_comment_ticket' => 'https://becomingateacher.zendesk.com/agent/tickets/12345',
       )
       expect(form).not_to be_valid
       expect(form.errors.full_messages).to include('Further conditions Condition 2 must be 255 characters or fewer')
@@ -45,7 +45,7 @@ RSpec.describe SupportInterface::ConditionsForm do
   end
 
   describe '#save' do
-    it 'returns false with a validation error if audit_comment is missing' do
+    it 'returns false with a validation error if audit_comment_ticket is missing' do
       application_choice = create(
         :application_choice,
         offer: { 'conditions' => ['Fitness to train to teach check', 'Get a haircut'] },
@@ -62,7 +62,7 @@ RSpec.describe SupportInterface::ConditionsForm do
         },
       )
       expect(form.save).to be(false)
-      expect(form.errors.full_messages).to include('Audit comment Enter a comment for the audit trail')
+      expect(form.errors.full_messages).to include('Audit comment ticket Enter a Zendesk ticket URL')
       expect(application_choice.reload.offer['conditions']).to eq([
         'Fitness to train to teach check',
         'Get a haircut',
@@ -84,7 +84,7 @@ RSpec.describe SupportInterface::ConditionsForm do
           '0' => { 'text' => 'Get a haircut' },
           '1' => { 'text' => 'Wear a tie' },
         },
-        'audit_comment' => 'See support ticket #123',
+        'audit_comment_ticket' => 'https://becomingateacher.zendesk.com/agent/tickets/12345',
       )
       form.save
       expect(application_choice.reload.offer).to eq(
@@ -110,7 +110,7 @@ RSpec.describe SupportInterface::ConditionsForm do
         'further_conditions' => {
           '0' => { 'text' => 'Wear a tie' },
         },
-        'audit_comment' => 'See support ticket #123',
+        'audit_comment_ticket' => 'https://becomingateacher.zendesk.com/agent/tickets/12345',
       )
       form.save
       expect(application_choice.reload.offer).to eq(
@@ -131,13 +131,13 @@ RSpec.describe SupportInterface::ConditionsForm do
         'standard_conditions' => [
           'Disclosure and Barring Service (DBS) check',
         ],
-        'audit_comment' => 'See support ticket #123',
+        'audit_comment_ticket' => 'https://becomingateacher.zendesk.com/agent/tickets/12345',
       )
       form.save
       expect(
         application_choice.audits.where(
           action: 'update',
-          comment: 'See support ticket #123',
+          comment: 'Change offer condition Zendesk request: https://becomingateacher.zendesk.com/agent/tickets/12345',
         ),
       ).to be_present
     end

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe SupportInterface::ConditionsForm do
         'audit_comment_ticket' => 'https://becomingateacher.zendesk.com/agent/tickets/12345',
       )
       expect(form).not_to be_valid
-      expect(form.errors.full_messages).to include('Further conditions Condition 1 must be 2000 characters or fewer')
+      expect(form.errors.messages[:'further_conditions[0][text]']).to include('Condition 1 must be 2000 characters or fewer')
     end
 
     it 'second further condition cannot be more than 255 characters' do
@@ -40,7 +40,7 @@ RSpec.describe SupportInterface::ConditionsForm do
         'audit_comment_ticket' => 'https://becomingateacher.zendesk.com/agent/tickets/12345',
       )
       expect(form).not_to be_valid
-      expect(form.errors.full_messages).to include('Further conditions Condition 2 must be 255 characters or fewer')
+      expect(form.errors.messages[:'further_conditions[1][text]']).to include('Condition 2 must be 255 characters or fewer')
     end
   end
 

--- a/spec/system/support_interface/add_course_to_submitted_application_spec.rb
+++ b/spec/system/support_interface/add_course_to_submitted_application_spec.rb
@@ -5,10 +5,10 @@ RSpec.feature 'Add course to submitted application' do
 
   scenario 'Support user adds course to submitted application' do
     given_i_am_a_support_user
-    and_there_is_a_submitted_application_in_the_system_logged_by_a_candidate
+    and_there_is_a_submitted_application_in_the_system
     and_i_visit_the_support_page
 
-    when_i_click_on_an_application
+    when_i_click_on_the_application
     when_i_click_on_add_a_course
 
     then_i_should_see_the_course_search_page

--- a/spec/system/support_interface/add_course_to_submitted_application_spec.rb
+++ b/spec/system/support_interface/add_course_to_submitted_application_spec.rb
@@ -5,10 +5,10 @@ RSpec.feature 'Add course to submitted application' do
 
   scenario 'Support user adds course to submitted application' do
     given_i_am_a_support_user
-    and_there_is_a_submitted_application_in_the_system
+    and_there_is_a_submitted_application_in_the_system_logged_by_a_candidate
     and_i_visit_the_support_page
 
-    when_i_click_on_the_application
+    when_i_click_on_an_application
     when_i_click_on_add_a_course
 
     then_i_should_see_the_course_search_page

--- a/spec/system/support_interface/change_offer_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_conditions_spec.rb
@@ -14,7 +14,10 @@ RSpec.feature 'Add course to submitted application' do
     when_i_click_on_change_conditions
     then_i_see_the_condition_edit_form_with_a_warning
 
-    when_i_add_a_new_condition_and_click_update_conditions
+    when_i_add_a_new_condition_and_click_update_conditions_without_an_audit_comment
+    then_i_see_a_validation_error
+
+    when_i_add_a_new_condition_and_click_update_conditions_with_an_audit_comment
     then_i_see_the_new_condition_as_well_as_the_original_ones
   end
 
@@ -63,10 +66,22 @@ RSpec.feature 'Add course to submitted application' do
     )
   end
 
-  def when_i_add_a_new_condition_and_click_update_conditions
+  def when_i_add_a_new_condition_and_click_update_conditions_without_an_audit_comment
     check 'Fitness to train to teach check'
     fill_in 'Condition 2', with: 'Learn to play piano'
-    click_on 'Continue'
+    click_on 'Update conditions'
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_current_path(support_interface_update_application_choice_conditions_path(@application_choice))
+    expect(page).to have_content('Enter a comment for the audit trail')
+  end
+
+  def when_i_add_a_new_condition_and_click_update_conditions_with_an_audit_comment
+    check 'Fitness to train to teach check'
+    fill_in 'Audit comment', with: 'See support ticket #123'
+    fill_in 'Condition 2', with: 'Learn to play piano'
+    click_on 'Update conditions'
   end
 
   def then_i_see_the_new_condition_as_well_as_the_original_ones

--- a/spec/system/support_interface/change_offer_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_conditions_spec.rb
@@ -15,9 +15,6 @@ RSpec.feature 'Add course to submitted application' do
     then_i_see_the_condition_edit_form_with_a_warning
 
     when_i_add_a_new_condition_and_click_update_conditions
-    then_i_see_a_confirmation_page
-
-    when_i_click_continue
     then_i_see_the_new_condition_as_well_as_the_original_ones
   end
 
@@ -61,5 +58,20 @@ RSpec.feature 'Add course to submitted application' do
   end
 
   def then_i_see_the_condition_edit_form_with_a_warning
+    expect(page).to have_current_path(
+      support_interface_update_application_choice_conditions_path(@application_choice)
+    )
+  end
+
+  def when_i_add_a_new_condition_and_click_update_conditions
+    check 'Fitness to train to teach check'
+    fill_in 'Condition 2', with: 'Learn to play piano'
+    click_on 'Continue'
+  end
+
+  def then_i_see_the_new_condition_as_well_as_the_original_ones
+    expect(page).to have_content(
+      "Conditions\nFitness to train to teach check Be cool Learn to play piano",
+    )
   end
 end

--- a/spec/system/support_interface/change_offer_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_conditions_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.feature 'Add course to submitted application' do
+  include DfESignInHelpers
+
+  scenario 'Support user adds course to submitted application' do
+    given_i_am_a_support_user
+    and_there_is_an_offered_application_in_the_system
+    and_i_visit_the_support_page
+
+    when_i_click_on_the_application
+    then_i_should_see_the_current_conditions
+
+    when_i_click_on_change_conditions
+    then_i_see_the_condition_edit_form_with_a_warning
+
+    when_i_add_a_new_condition_and_click_update_conditions
+    then_i_see_a_confirmation_page
+
+    when_i_click_continue
+    then_i_see_the_new_condition_as_well_as_the_original_ones
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_an_offered_application_in_the_system
+    candidate = create :candidate, email_address: 'candy@example.com'
+
+    Audited.audit_class.as_user(candidate) do
+      @application_form = create(
+        :completed_application_form,
+        first_name: 'Candy',
+        last_name: 'Dayte',
+        candidate: candidate,
+      )
+
+      @application_choice = create(
+        :application_choice,
+        :with_accepted_offer,
+        application_form: @application_form,
+      )
+    end
+  end
+
+  def and_i_visit_the_support_page
+    visit support_interface_path
+  end
+
+  def when_i_click_on_the_application
+    click_on 'Candy Dayte'
+  end
+
+  def then_i_should_see_the_current_conditions
+    expect(page).to have_content("Conditions\nBe cool")
+  end
+
+  def when_i_click_on_change_conditions
+    click_on 'Change conditions'
+  end
+
+  def then_i_see_the_condition_edit_form_with_a_warning
+  end
+end

--- a/spec/system/support_interface/change_offer_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_conditions_spec.rb
@@ -19,6 +19,13 @@ RSpec.feature 'Add course to submitted application' do
 
     when_i_add_a_new_condition_and_click_update_conditions_with_a_support_ticket_url
     then_i_see_the_new_condition_as_well_as_the_original_ones
+
+    when_i_click_on_change_conditions
+    and_i_remove_all_conditions_and_click_update_conditions
+    then_i_see_a_confirmation_page_about_candidate_being_recruited
+
+    when_i_check_that_i_understand_and_click_continue
+    then_i_see_that_the_candidate_has_been_recruited_and_conditions_have_been_removed
   end
 
   def given_i_am_a_support_user
@@ -85,8 +92,33 @@ RSpec.feature 'Add course to submitted application' do
   end
 
   def then_i_see_the_new_condition_as_well_as_the_original_ones
+    expect(page).to have_current_path(support_interface_application_form_path(@application_choice.application_form_id))
     expect(page).to have_content(
       "Conditions\nFitness to train to teach check Be cool Learn to play piano",
     )
+  end
+
+  def and_i_remove_all_conditions_and_click_update_conditions
+    uncheck 'Fitness to train to teach check'
+    fill_in 'Condition 1', with: ''
+    fill_in 'Condition 2', with: ''
+    fill_in 'Zendesk ticket URL', with: 'becomingateacher.zendesk.com/agent/tickets/12345'
+    click_on 'Update conditions'
+  end
+
+  def then_i_see_a_confirmation_page_about_candidate_being_recruited
+    expect(page).to have_content('Are you sure you want to make this offer unconditional?')
+    expect(page).to have_content('Because this offer has already been accepted removing all conditions will recruit this candidate immediately.')
+  end
+
+  def when_i_check_that_i_understand_and_click_continue
+    check 'I understand that I am making this offer unconditional'
+    click_on 'Continue'
+  end
+
+  def then_i_see_that_the_candidate_has_been_recruited_and_conditions_have_been_removed
+    expect(page).to have_current_path(support_interface_application_form_path(@application_choice.application_form_id))
+    expect(page).to have_content('Recruited')
+    expect(page).not_to have_content('Conditions')
   end
 end

--- a/spec/system/support_interface/change_offer_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_conditions_spec.rb
@@ -24,10 +24,7 @@ RSpec.feature 'Add course to submitted application' do
     and_i_remove_all_conditions_and_click_update_conditions
     then_i_see_a_confirmation_page_about_candidate_being_recruited
 
-    when_i_click_continue_without_checking_confirmation_box
-    then_i_see_a_unconditional_offer_validation_error
-
-    when_i_check_that_i_understand_and_click_continue
+    when_i_click_yes_im_sure
     then_i_see_that_the_candidate_has_been_recruited_and_conditions_have_been_removed
   end
 
@@ -114,22 +111,8 @@ RSpec.feature 'Add course to submitted application' do
     expect(page).to have_content('Because this offer has already been accepted removing all conditions will recruit this candidate immediately.')
   end
 
-  def when_i_click_continue_without_checking_confirmation_box
-    click_on 'Continue'
-  end
-
-  def then_i_see_a_unconditional_offer_validation_error
-    expect(page).to have_current_path(
-      support_interface_confirm_make_application_choice_unconditional_path(
-        @application_choice.id,
-      ),
-    )
-    expect(page).to have_content('Select that you understand the consequences of making this offer unconditional')
-  end
-
-  def when_i_check_that_i_understand_and_click_continue
-    check 'I understand that I am making this offer unconditional'
-    click_on 'Continue'
+  def when_i_click_yes_im_sure
+    click_on 'Yes I\'m sure - make offer unconditional and recruit candidate'
   end
 
   def then_i_see_that_the_candidate_has_been_recruited_and_conditions_have_been_removed

--- a/spec/system/support_interface/change_offer_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_conditions_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature 'Add course to submitted application' do
 
   def then_i_see_the_condition_edit_form_with_a_warning
     expect(page).to have_current_path(
-      support_interface_update_application_choice_conditions_path(@application_choice)
+      support_interface_update_application_choice_conditions_path(@application_choice),
     )
   end
 

--- a/spec/system/support_interface/change_offer_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_conditions_spec.rb
@@ -24,6 +24,9 @@ RSpec.feature 'Add course to submitted application' do
     and_i_remove_all_conditions_and_click_update_conditions
     then_i_see_a_confirmation_page_about_candidate_being_recruited
 
+    when_i_click_continue_without_checking_confirmation_box
+    then_i_see_a_unconditional_offer_validation_error
+
     when_i_check_that_i_understand_and_click_continue
     then_i_see_that_the_candidate_has_been_recruited_and_conditions_have_been_removed
   end
@@ -109,6 +112,19 @@ RSpec.feature 'Add course to submitted application' do
   def then_i_see_a_confirmation_page_about_candidate_being_recruited
     expect(page).to have_content('Are you sure you want to make this offer unconditional?')
     expect(page).to have_content('Because this offer has already been accepted removing all conditions will recruit this candidate immediately.')
+  end
+
+  def when_i_click_continue_without_checking_confirmation_box
+    click_on 'Continue'
+  end
+
+  def then_i_see_a_unconditional_offer_validation_error
+    expect(page).to have_current_path(
+      support_interface_confirm_make_application_choice_unconditional_path(
+        @application_choice.id,
+      ),
+    )
+    expect(page).to have_content('Select that you understand the consequences of making this offer unconditional')
   end
 
   def when_i_check_that_i_understand_and_click_continue

--- a/spec/system/support_interface/change_offer_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_conditions_spec.rb
@@ -14,10 +14,10 @@ RSpec.feature 'Add course to submitted application' do
     when_i_click_on_change_conditions
     then_i_see_the_condition_edit_form_with_a_warning
 
-    when_i_add_a_new_condition_and_click_update_conditions_without_an_audit_comment
+    when_i_add_a_new_condition_and_click_update_conditions_without_a_support_ticket_url
     then_i_see_a_validation_error
 
-    when_i_add_a_new_condition_and_click_update_conditions_with_an_audit_comment
+    when_i_add_a_new_condition_and_click_update_conditions_with_a_support_ticket_url
     then_i_see_the_new_condition_as_well_as_the_original_ones
   end
 
@@ -66,7 +66,7 @@ RSpec.feature 'Add course to submitted application' do
     )
   end
 
-  def when_i_add_a_new_condition_and_click_update_conditions_without_an_audit_comment
+  def when_i_add_a_new_condition_and_click_update_conditions_without_a_support_ticket_url
     check 'Fitness to train to teach check'
     fill_in 'Condition 2', with: 'Learn to play piano'
     click_on 'Update conditions'
@@ -74,12 +74,12 @@ RSpec.feature 'Add course to submitted application' do
 
   def then_i_see_a_validation_error
     expect(page).to have_current_path(support_interface_update_application_choice_conditions_path(@application_choice))
-    expect(page).to have_content('Enter a comment for the audit trail')
+    expect(page).to have_content('Enter a Zendesk ticket URL')
   end
 
-  def when_i_add_a_new_condition_and_click_update_conditions_with_an_audit_comment
+  def when_i_add_a_new_condition_and_click_update_conditions_with_a_support_ticket_url
     check 'Fitness to train to teach check'
-    fill_in 'Audit comment', with: 'See support ticket #123'
+    fill_in 'Zendesk ticket URL', with: 'becomingateacher.zendesk.com/agent/tickets/12345'
     fill_in 'Condition 2', with: 'Learn to play piano'
     click_on 'Update conditions'
   end


### PR DESCRIPTION
## Context

Providers regularly ask support to change the conditions for accepted applications. This should only be done after the candidate has consented to the change and we should link the change (via the audit trail) to a ZenDesk ticket that records the request.

## Changes proposed in this pull request

- Show the current conditions for applications in the `offer` and `pending_conditions` statuses:
<img width="861" alt="image" src="https://user-images.githubusercontent.com/450843/117270626-51081400-ae51-11eb-87e0-dbfa81d72527.png">
- Add a _Change conditions_ link that leads to a new form for editing conditions. This mirrors the form in the provider interface for adding conditions (before the offer is made) but includes a warning notification and an additional field to prompt for an audit comment
<img width="584" alt="image" src="https://user-images.githubusercontent.com/450843/118101661-bcad2c80-b3cf-11eb-9e5c-d78f15d266c0.png">

- Support more than 4 further conditions (to match upcoming changes in the provider interface). To allow more than 4 conditions we display at least one empty text box at the end of the list of further conditions up to a maximum of 18 (because there is still a limit of 20 on the total number of conditions).
- If the support user removes all the conditions then the offer will be made unconditional and the application choice is moved straight to the `recruited` status. To ensure that this is intentional the user will see an extra confirmation page in this case:
<img width="768" alt="image" src="https://user-images.githubusercontent.com/450843/118643338-56137e80-b7d4-11eb-92c0-bcad2340da8a.png">

## Guidance to review

- The 'design' for the changes to the dashboard and the new change conditions for are up for debate.
- Is the content for these new pages OK?
- Should we be sending email notifications to candidates/providers?
- Can we extract and reuse some of the code that's in the provider interface for editing conditions?

## Link to Trello card

https://trello.com/c/TisFW3VV/3337-enable-conditions-to-be-changed-after-offer-acceptance
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
