### PR TITLE
Re-add colorize gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,9 @@ gem 'strip_attributes'
 # Automate checks for potentially unsafe migrations
 gem 'strong_migrations'
 
+# Rails console colours
+gem 'colorize'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
       clockwork
       timecop
     coderay (1.1.3)
+    colorize (0.8.1)
     commonmarker (0.21.1)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.8)
@@ -553,6 +554,7 @@ DEPENDENCIES
   climate_control
   clockwork
   clockwork-test
+  colorize
   db-query-matchers
   deepsort
   devise


### PR DESCRIPTION
## Context

This was [implicitly removed as part of the removal of logstash-logger gem](https://github.com/DFE-Digital/apply-for-teacher-training/commit/727e3744c4a9f0617f84b65ad26434b20a23a270) but is necessary for rails console access.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds the `colorize` gem.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
