### PR TITLE
Remove default false for 'safe_guarding_issues_completed' and 'interview_preferences_completed'

### DIFF
--- a/db/migrate/20210506101257_remove_more_defaults_from_application_forms_table.rb
+++ b/db/migrate/20210506101257_remove_more_defaults_from_application_forms_table.rb
@@ -1,0 +1,6 @@
+class RemoveMoreDefaultsFromApplicationFormsTable < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :application_forms, :safeguarding_issues_completed, from: false, to: nil
+    change_column_default :application_forms, :interview_preferences_completed, from: false, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_29_084354) do
+ActiveRecord::Schema.define(version: 2021_05_06_101257) do
   create_sequence "application_choices_id_seq"
   create_sequence "application_experiences_id_seq"
   create_sequence "application_feedback_id_seq"
@@ -177,10 +177,10 @@ ActiveRecord::Schema.define(version: 2021_04_29_084354) do
     t.boolean "english_gcse_completed"
     t.boolean "maths_gcse_completed"
     t.boolean "training_with_a_disability_completed"
-    t.boolean "safeguarding_issues_completed", default: false
+    t.boolean "safeguarding_issues_completed"
     t.boolean "becoming_a_teacher_completed"
     t.boolean "subject_knowledge_completed"
-    t.boolean "interview_preferences_completed", default: false
+    t.boolean "interview_preferences_completed"
     t.boolean "science_gcse_completed"
     t.datetime "edit_by"
     t.string "address_type", default: "uk", null: false


### PR DESCRIPTION
## Context

The corresponding sections in the application form now use radio buttons and we want candidates to see a validation error if they do not submit an answer to 'Have you completed this section?'

I missed two columns when [creating the last migration](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/db/migrate/20210429084354_remove_defaults_from_application_forms_table.rb).

## Changes proposed in this pull request

- Create db migration to remove default `false`  for 'safe_guarding_issues_completed' and 'interview_preferences_completed' columns

## Link to Trello card

https://trello.com/c/dxkMUjHV/3358-do-not-update-sectioncompleted-fields-to-false-when-updating-application-sections

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
