### PR TITLE
Increase app memory to 2GB

### DIFF
--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -1,10 +1,11 @@
 # PaaS
 paas_app_environment       = "prod"
 paas_cf_space              = "bat-prod"
-paas_web_app_memory        = 1536
-paas_worker_app_memory     = 1536
+paas_web_app_memory        = 2048
+paas_worker_app_memory     = 2048
+paas_clock_app_memory      = 1024
 paas_web_app_instances     = 4
-paas_worker_app_instances  = 2
+paas_worker_app_instances  = 4
 paas_postgres_service_plan = "small-ha-11"
 paas_redis_service_plan    = "micro-ha-5_x"
 


### PR DESCRIPTION
## Changes proposed in this pull request

Increase web & worker app memory to 2 GB and increase worker app instances to 4.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
