### PR TITLE
Only enable rails_semantic_logger in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk -U upgrade && \
     bundler -v && \
     bundle config set no-cache 'true' && \
     bundle config set no-binstubs 'true' && \
-    bundle --retry=5 --jobs=4 --without=development && \
+    bundle --retry=5 --jobs=4 --without=development --with=production && \
     yarn install --check-files && \
     apk del .gem-installdeps && \
     rm -rf /usr/local/bundle/cache && \

--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,6 @@ gem 'okcomputer'
 gem 'skylight'
 
 # Logging
-gem 'rails_semantic_logger'
 gem 'request_store_rails'
 gem 'request_store-sidekiq'
 
@@ -108,6 +107,10 @@ gem 'strong_migrations'
 
 # Rails console colours
 gem 'colorize'
+
+group :production do
+  gem 'rails_semantic_logger'
+end
 
 group :development do
   gem 'web-console', '>= 3.3.0'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,10 +55,7 @@ Rails.application.configure do
 
   # Logging configuration
   config.log_level = :debug
-  config.rails_semantic_logger.semantic   = false
-  config.rails_semantic_logger.started    = true
-  config.rails_semantic_logger.processing = true
-  config.rails_semantic_logger.rendered   = true
+  Rails.logger = ActiveSupport::Logger.new(STDOUT)
 
   config.x.read_only_database_url = "postgres://localhost/bat_apply_development"
 end

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -2,54 +2,56 @@
 
 require 'request_store_rails'
 
-class CustomLogFormatter < SemanticLogger::Formatters::Raw
-  def call(log, logger)
-    super(log, logger)
-    add_service_type
-    add_params
-    add_debugging_fields
-    add_job_data
-    hash.to_json
-  end
+if Rails.env.production?
+  class CustomLogFormatter < SemanticLogger::Formatters::Raw
+    def call(log, logger)
+      super(log, logger)
+      add_service_type
+      add_params
+      add_debugging_fields
+      add_job_data
+      hash.to_json
+    end
 
-private
+  private
 
-  def add_service_type
-    hash['domain'] = HostingEnvironment.hostname
-    hash['environment'] = HostingEnvironment.environment_name
-    hash['hosting_environment'] = HostingEnvironment.environment_name
-    hash['service'] = ENV['SERVICE_TYPE']
-  end
+    def add_service_type
+      hash['domain'] = HostingEnvironment.hostname
+      hash['environment'] = HostingEnvironment.environment_name
+      hash['hosting_environment'] = HostingEnvironment.environment_name
+      hash['service'] = ENV['SERVICE_TYPE']
+    end
 
-  def add_params
-    params = RequestLocals.fetch(:params) {} # block is required
-    if params
-      hash['params'] = params # add query params to the logs, if available
+    def add_params
+      params = RequestLocals.fetch(:params) {} # block is required
+      if params
+        hash['params'] = params # add query params to the logs, if available
+      end
+    end
+
+    def add_debugging_fields
+      identity_hash = RequestLocals.fetch(:identity) {} # block is required
+      identity_hash&.each { |key, val| hash[key] = val }
+
+      debugging_info = RequestLocals.fetch(:debugging_info) {} # block is required
+      debugging_info&.each { |key, val| hash[key] = val }
+    end
+
+    def add_job_data
+      hash[:job_id] = RequestStore.store[:job_id] if RequestStore.store[:job_id].present?
+      hash[:job_queue] = RequestStore.store[:job_queue] if RequestStore.store[:job_queue].present?
+      tid = Thread.current['sidekiq_tid']
+      if tid.present?
+        ctx = Sidekiq::Context.current
+        hash['tid'] = tid
+        hash['ctx'] = ctx
+      end
     end
   end
 
-  def add_debugging_fields
-    identity_hash = RequestLocals.fetch(:identity) {} # block is required
-    identity_hash&.each { |key, val| hash[key] = val }
-
-    debugging_info = RequestLocals.fetch(:debugging_info) {} # block is required
-    debugging_info&.each { |key, val| hash[key] = val }
-  end
-
-  def add_job_data
-    hash[:job_id] = RequestStore.store[:job_id] if RequestStore.store[:job_id].present?
-    hash[:job_queue] = RequestStore.store[:job_queue] if RequestStore.store[:job_queue].present?
-    tid = Thread.current['sidekiq_tid']
-    if tid.present?
-      ctx = Sidekiq::Context.current
-      hash['tid'] = tid
-      hash['ctx'] = ctx
-    end
-  end
+  rails_config = Rails.application.config
+  log_formatter = CustomLogFormatter.new
+  Clockwork.configure { |config| config[:logger] = SemanticLogger[Clockwork] if defined?(Clockwork) }
+  SemanticLogger.add_appender(io: STDOUT, level: rails_config.log_level, formatter: log_formatter)
+  rails_config.logger.info('Application logging to STDOUT')
 end
-
-rails_config = Rails.application.config
-log_formatter = HostingEnvironment.development? ? rails_config.rails_semantic_logger.format : CustomLogFormatter.new
-Clockwork.configure { |config| config[:logger] = SemanticLogger[Clockwork] if defined?(Clockwork) }
-SemanticLogger.add_appender(io: STDOUT, level: rails_config.log_level, formatter: log_formatter)
-rails_config.logger.info('Application logging to STDOUT')


### PR DESCRIPTION
This keeps dev and test logs clean and readable. I tested the logging config still worked in prod by running in prod RAILS_ENV locally — example prod-style log line:

```json
{"host":"maple.local","application":"Semantic Logger","environment":"qa","time":"2021-05-06T12:40:36.987+01:00","level":"info","level_index":2,"pid":71457,"thread":"puma threadpool 003","duration_ms":4.019000101834536,"duration":"4.019ms","tags":["[\"1a3d372a-e967-4003-91d6-683d649e26d0\"]"],"name":"CandidateInterface::SubmittedApplicationFormController","message":"Completed #complete","payload":{"controller":"CandidateInterface::SubmittedApplicationFormController","action":"complete","format":"HTML","method":"GET","path":"/candidate/application/complete","view_runtime":0.0,"db_runtime":0.0,"status":401,"allocations":1216,"status_message":"Unauthorized"},"domain":null,"hosting_environment":"qa","service":"web"}
```

## Context

### Before
<img width="729" alt="Screenshot 2021-05-06 at 10 13 51" src="https://user-images.githubusercontent.com/642279/117292902-a13ea080-ae68-11eb-8053-f1edfd13e385.png">

<img width="1657" alt="Screenshot 2021-05-06 at 12 44 13" src="https://user-images.githubusercontent.com/642279/117293065-d9de7a00-ae68-11eb-9f52-b6a3c48dc532.png">

### After

<img width="648" alt="Screenshot 2021-05-06 at 12 43 05" src="https://user-images.githubusercontent.com/642279/117292924-a865ae80-ae68-11eb-9b2a-04a00e74acb3.png">

<img width="1120" alt="Screenshot 2021-05-06 at 12 44 38" src="https://user-images.githubusercontent.com/642279/117293082-de0a9780-ae68-11eb-9181-58df0433fe78.png">

