### PR TITLE
Add condition 1 max length on offers

### DIFF
--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -2,6 +2,8 @@ class OfferValidations
   include ActiveModel::Model
 
   MAX_CONDITIONS_COUNT = 20
+  # This is required for the API integrations which send conditions together
+  MAX_CONDITION_1_LENGTH = 2000
   MAX_CONDITION_LENGTH = 255
 
   attr_accessor :application_choice, :course_option, :conditions
@@ -25,7 +27,11 @@ class OfferValidations
 
   def conditions_length
     conditions.each_with_index do |condition, index|
-      errors.add(:conditions, :too_long, index: index + 1, limit: MAX_CONDITION_LENGTH) if condition.length > MAX_CONDITION_LENGTH
+      if index.zero?
+        errors.add(:conditions, :too_long, index: index + 1, limit: MAX_CONDITION_1_LENGTH) if condition.length > MAX_CONDITION_1_LENGTH
+      elsif condition.length > MAX_CONDITION_LENGTH
+        errors.add(:conditions, :too_long, index: index + 1, limit: MAX_CONDITION_LENGTH)
+      end
     end
   end
 

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe OfferValidations, type: :model do
     end
 
     describe '#conditions_length' do
-      context 'when any conditions are more than 255 characters long' do
+      context 'when any conditions after condition 1 are more than 255 characters long' do
         let(:conditions) do
           [Faker::Lorem.paragraph_by_chars(number: 256),
            Faker::Lorem.paragraph_by_chars(number: 254),
@@ -55,7 +55,21 @@ RSpec.describe OfferValidations, type: :model do
         it 'adds a :too_long error' do
           expect(offer).to be_invalid
 
-          expect(offer.errors[:conditions]).to contain_exactly('Condition 1 must be 255 characters or fewer', 'Condition 3 must be 255 characters or fewer')
+          expect(offer.errors[:conditions]).to contain_exactly('Condition 3 must be 255 characters or fewer')
+        end
+      end
+
+      context 'when conditions are merged into condition 1 in the API' do
+        let(:conditions) do
+          [Faker::Lorem.paragraph_by_chars(number: 2004),
+           Faker::Lorem.paragraph_by_chars(number: 254),
+           Faker::Lorem.paragraph_by_chars(number: 256)]
+        end
+
+        it 'adds a :too_long error' do
+          expect(offer).to be_invalid
+
+          expect(offer.errors[:conditions]).to contain_exactly('Condition 1 must be 2000 characters or fewer', 'Condition 3 must be 255 characters or fewer')
         end
       end
     end


### PR DESCRIPTION
## Context

Providers using SITS require a longer condition length as they cannot be separated in the API

## Changes proposed in this pull request

The API requires the condition 1 to be a max length of 2000.

## Guidance to review

I've included this in both manage/API validation for now 

## Link to Trello card

https://trello.com/c/1rO3K8vw/3660-sandbox-condition-1-validation

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
