### PR TITLE
Sentry - show application support url in tags

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -14,7 +14,7 @@ module CandidateInterface
 
       return unless current_candidate
 
-      Raven.extra_context(application_support_url: support_interface_application_form_url(current_application))
+      Raven.tags_context(application_support_url: support_interface_application_form_url(current_application))
     end
 
     def check_cookie_preferences


### PR DESCRIPTION


## Context
Right now we're displaying this as extra info. Move it into the tags
context for better visibility and convenience.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
See diff
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
I think we need a development environment set up in Sentry to test this locally. This might be one to merge and test on QA.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/gIUsCtQa
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
