### PR TITLE
Add Cache-Control headers to assets served by Rails

### DIFF
--- a/config/initializers/asset_cache_headers.rb
+++ b/config/initializers/asset_cache_headers.rb
@@ -1,0 +1,3 @@
+Rails.application.config.public_file_server.headers = {
+  'Cache-Control' => 'max-age=31536000, public, immutable',
+}


### PR DESCRIPTION
We're currently using puma to serve assets, which is quite expensive from a memory POV.

Adding cache headers will allow CloudFront (and clients) to cache the assets, which should dramatically reduce the load on our servers.