### PR TITLE
Do not detect unauthorised edits in DetectInvariants for now

### DIFF
--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -5,7 +5,7 @@ class DetectInvariants
   def perform
     detect_application_choices_in_old_states
     detect_outstanding_references_on_submitted_applications
-    detect_unauthorised_application_form_edits
+    # detect_unauthorised_application_form_edits # FIXME
     detect_applications_with_course_choices_in_previous_cycle
     detect_submitted_applications_with_more_than_three_course_choices
     detect_applications_submitted_with_the_same_course

--- a/spec/workers/detect_invariants_spec.rb
+++ b/spec/workers/detect_invariants_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe DetectInvariants do
     end
 
     it 'detects unauthorised edits on data associated with an application form', with_audited: true do
+      skip 'until detect_unauthorised_application_form_edits is back'
+
       honest_bob = create(:candidate)
       nefarious_jim = create(:candidate)
       suspect_form = build(:application_form, candidate: honest_bob)


### PR DESCRIPTION
## Context

Since our migration this morning, `DetectInvariants` worker keeps failing because of statement timeouts, because of these checks. Sidekiq's retry mechanism means we get hundred of Sentry errors.

## Changes proposed in this pull request

Reduce the number of Sentries by removing this part of `DetectInvariants`. Once we have solved the performance problems of this query we can bring it back.
