### PR TITLE
Replace 'onchange' with a JS script in the validation error summary

### DIFF
--- a/app/components/support_interface/validation_errors_summary_component.html.erb
+++ b/app/components/support_interface/validation_errors_summary_component.html.erb
@@ -17,8 +17,10 @@
                 },
                 class: 'sortedby-label',
                 selected: 2,
-                onchange: 'this.form.submit()',
                 role: 'listbox',
+                data: {
+                  module: 'sort-by-filter-option',
+                },
               ) %>
         </div>
         <%= f.govuk_submit('Update') %>

--- a/app/frontend/packs/application-support.js
+++ b/app/frontend/packs/application-support.js
@@ -4,6 +4,7 @@ import filter from './components/paginated_filter'
 import 'accessible-autocomplete/dist/accessible-autocomplete.min.css'
 import { initAutocomplete } from './autocompletes/init-autocomplete'
 import { supportAutocompleteInputs } from './autocompletes/support/support-autocomplete-inputs'
+import sortByFilter from './sort-by-filter'
 
 require.context('govuk-frontend/govuk/assets')
 
@@ -14,3 +15,4 @@ supportAutocompleteInputs.forEach((autocompleteInput) => {
 })
 
 filter()
+sortByFilter()

--- a/app/frontend/packs/sort-by-filter.js
+++ b/app/frontend/packs/sort-by-filter.js
@@ -1,0 +1,10 @@
+const sortByFilter = () => {
+  const filter = document.querySelector('[data-module="sort-by-filter-option"]')
+  if (filter) {
+    filter.addEventListener('change', (event) => {
+      event.target.form.submit()
+    })
+  };
+}
+
+export default sortByFilter


### PR DESCRIPTION
## Context

When viewing the validation error summary table, the order of the errors doesn't change when using 'last week' or 'last month' sorting drop down option (unless you press `enter` afterwards).

The console would display the following message, after attempting to change the 'sort by' value:

![image](https://user-images.githubusercontent.com/47917431/117329036-24252280-ae8c-11eb-9789-08bf3dc0d43a.png)


## Changes proposed in this pull request

Replace `onchange: 'this.form.submit()'` with a separate JS script that has an event listener for this change.

## Guidance to review

This works locally now. My JS script knowledge is quite rusty though, so I'm interested to hear if there is a more efficient/better way of writing this script.

## Link to Trello card

https://trello.com/c/LSaBKlO6/3359-validation-error-table-order-doesnt-change-when-using-last-week-or-last-month-sorting

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
