### PR TITLE
Move sidekiq retries into invariant check

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -11,26 +11,12 @@ class SimulatedFailureCheck < OkComputer::Check
   end
 end
 
-class SidekiqRetriesCheck < OkComputer::Check
-  def check
-    retries_queue_length = Sidekiq::RetrySet.new.size
-    queue_length_text = " (#{retries_queue_length})"
-    if retries_queue_length > 50
-      mark_failure
-      mark_message "Sidekiq pending retries depth is high #{queue_length_text}. Suggests high error rate"
-    else
-      mark_message 'Sidekiq pending retries depth at reasonable level' + queue_length_text
-    end
-  end
-end
-
 OkComputer.mount_at = 'integrations/monitoring'
 
 OkComputer::Registry.register 'postgres', OkComputer::ActiveRecordCheck.new
 OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ENV['REDIS_URL'])
 OkComputer::Registry.register 'sidekiq_default_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'default', threshold: 100) # threshold in seconds
 OkComputer::Registry.register 'sidekiq_mailers_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'mailers', threshold: 100) # threshold in seconds
-OkComputer::Registry.register 'sidekiq_retries_count', SidekiqRetriesCheck.new
 OkComputer::Registry.register 'simulated_failure', SimulatedFailureCheck.new
 OkComputer::Registry.register 'version', OkComputer::AppVersionCheck.new
 


### PR DESCRIPTION


## Context

This is causing statuscake checks to fail which we shouldn't be doing as this doesn't indicate the site is down

## Changes proposed in this pull request

 Move this to invariant check instead to still be alerted.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
