### PR TITLE
enable ssh for debugging crash issue

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -20,7 +20,6 @@ resource "cloudfoundry_app" "web_app" {
   health_check_type          = "http"
   health_check_http_endpoint = "/check"
   health_check_timeout       = 180
-  enable_ssh                 = false
   instances                  = var.web_app_instances
   memory                     = var.web_app_memory
   space                      = data.cloudfoundry_space.space.id


### PR DESCRIPTION
enable ssh on the web app to debug the crash issue.