### PR TITLE
Ensure for_ratified_courses checks for existing course_option

### DIFF
--- a/app/queries/get_courses_ratified_by_provider.rb
+++ b/app/queries/get_courses_ratified_by_provider.rb
@@ -1,9 +1,10 @@
 class GetCoursesRatifiedByProvider
-  DEFAULT_RECRUITMENT_CYCLE_YEAR = RecruitmentCycle.current_year
-
-  def self.call(provider:, recruitment_cycle_year: DEFAULT_RECRUITMENT_CYCLE_YEAR)
+  def self.call(provider:)
     provider.accredited_courses
-      .where(recruitment_cycle_year: recruitment_cycle_year)
-      .where.not(provider: provider)
+            .current_cycle
+            .open_on_apply
+            .joins(:course_options)
+            .distinct
+            .where.not(provider: provider)
   end
 end

--- a/spec/queries/get_courses_ratified_by_provider_spec.rb
+++ b/spec/queries/get_courses_ratified_by_provider_spec.rb
@@ -1,24 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe GetCoursesRatifiedByProvider do
-  let!(:provider) { create(:provider) }
-  let!(:course_current_year) { create(:course, accredited_provider: provider) }
-  let!(:course_previous_year) { create(:course, :previous_year, accredited_provider: provider) }
-  let!(:course_run_by_provider) { create(:course, provider: provider, accredited_provider: provider) }
-  let!(:course_unrelated) { create(:course) }
+  let(:provider) { create(:provider) }
 
-  it 'uses the current recruitment cycle year by default' do
+  it 'returns courses in the current year' do
+    course_current_year = create(:course, :open_on_apply, accredited_provider: provider)
+    create_list(:course_option, 3, course: course_current_year)
+
+    create(:course_option, course: create(:course, :open_on_apply, :previous_year, accredited_provider: provider))
+
     result = described_class.call(provider: provider)
-    expect(result).to match_array([course_current_year])
+    expect(result).to contain_exactly(course_current_year)
   end
 
-  it 'can return courses for a different year if required' do
-    result = described_class.call(provider: provider, recruitment_cycle_year: RecruitmentCycle.previous_year)
-    expect(result).to match_array([course_previous_year])
+  it 'only returns courses with a course option' do
+    create(:course, :open_on_apply, accredited_provider: provider)
+
+    result = described_class.call(provider: provider)
+    expect(result).to be_empty
   end
 
   it 'excludes courses a provider runs' do
+    create(:course, :open_on_apply, provider: provider, accredited_provider: provider)
+    create(:course, :open_on_apply, provider: provider)
+
     result = described_class.call(provider: provider)
-    expect(result).not_to include(course_run_by_provider)
+    expect(result).to be_empty
+  end
+
+  it 'only returns courses that are open on apply' do
+    create(:course, accredited_provider: provider)
+
+    result = described_class.call(provider: provider)
+    expect(result).to be_empty
   end
 end

--- a/spec/services/vendor_api/generate_test_applications_for_provider_spec.rb
+++ b/spec/services/vendor_api/generate_test_applications_for_provider_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe VendorAPI::GenerateTestApplicationsForProvider, sidekiq: true do
       create(:course_option, course: create(:course, :open_on_apply, provider: provider))
     end
     3.times do
-      create(:course_option, course: create(:course, accredited_provider: provider))
+      create(:course_option, course: create(:course, :open_on_apply, accredited_provider: provider))
     end
     # rubocop:enable FactoryBot/CreateList
   end


### PR DESCRIPTION
## Context
Sentry error: https://sentry.io/organizations/dfe-bat/issues/2391273181/?project=1765973&referrer=slack

## Changes proposed in this pull request
Check for open on apply, and existence of course options before generating test applications

