### PR TITLE
Create local dev provider users in a consistent way

### DIFF
--- a/app/lib/create_example_provider_users_with_permissions.rb
+++ b/app/lib/create_example_provider_users_with_permissions.rb
@@ -1,38 +1,49 @@
 class CreateExampleProviderUsersWithPermissions
   def self.call
+    create_provider_user({
+      dfe_sign_in_uid: 'dev-provider',
+      email_address: 'provider@example.com',
+      first_name: 'Peter',
+      last_name: 'Rovider',
+    }, %w[1JA 1N1])
+
+    create_provider_user({
+      dfe_sign_in_uid: 'dev-support',
+      email_address: 'support@example.com',
+      first_name: 'Susan',
+      last_name: 'Upport',
+    }, %w[1JA 1JB 24J], {
+      manage_users: true,
+      manage_organisations: true,
+      view_safeguarding_information: true,
+      make_decisions: true,
+    })
+
     # can_view__with_safeguarding_information
-    user_1n1 = ProviderUser.create!(
+    create_provider_user({
       dfe_sign_in_uid: 'dev-1N1',
       email_address: '1N1@example.com',
       first_name: '1N1',
       last_name: 'User',
-    ) do |u|
-      u.providers = Provider.where(code: '1N1')
-    end
-
-    user_1n1.provider_permissions.update_all(
+    }, %w[1N1], {
       view_safeguarding_information: true,
-    )
+    })
 
     # cannot_view__no_org_level_perm__with_manage_orgs__ratifying_provider
-    user_24p = ProviderUser.create!(
+    create_provider_user({
       dfe_sign_in_uid: 'dev-24P',
       email_address: '24P@example.com',
       first_name: '24P',
       last_name: 'User',
-    ) do |u|
-      u.providers = Provider.where(code: '24P')
-    end
-
-    user_24p.provider_permissions.update_all(
+    }, %w[24P], {
       manage_organisations: true,
       view_safeguarding_information: true,
-    )
+    })
 
     ProviderRelationshipPermissions.find_or_create_by(
       training_provider: Provider.find_by_code('1JB'),
       ratifying_provider: Provider.find_by_code('24P'),
-    ).update_columns(
+    ).update(
       training_provider_can_make_decisions: true,
       training_provider_can_view_safeguarding_information: true,
       training_provider_can_view_diversity_information: true,
@@ -40,19 +51,15 @@ class CreateExampleProviderUsersWithPermissions
     )
 
     # cannot_view__no_org_level_perm__with_manage_orgs__training_provider
-    admin_1jb1 = ProviderUser.create!(
+    admin_1jb1 = create_provider_user({
       dfe_sign_in_uid: 'dev-1JB-admin-1',
       email_address: '1JB-admin-1@example.com',
       first_name: '1JB',
       last_name: 'Admin 1',
-    ) do |u|
-      u.providers = Provider.where(code: '1JB')
-    end
-
-    admin_1jb1.provider_permissions.update_all(
+    }, %w[1JB], {
       manage_organisations: true,
       view_safeguarding_information: true,
-    )
+    })
 
     ProviderAgreement.create!(
       provider: Provider.find_by_code('1JB'),
@@ -61,52 +68,40 @@ class CreateExampleProviderUsersWithPermissions
       accept_agreement: true,
     )
 
-    admin_1jb2 = ProviderUser.create!(
+    create_provider_user({
       dfe_sign_in_uid: 'dev-1JB-admin-2',
       email_address: '1JB-admin-2@example.com',
       first_name: '1JB',
       last_name: 'Admin 2',
-    ) do |u|
-      u.providers = Provider.where(code: '1JB')
-    end
-
-    admin_1jb2.provider_permissions.update_all(
+    }, %w[1JB], {
       manage_organisations: true,
       view_safeguarding_information: true,
-    )
+    })
 
-    admin_1ja = ProviderUser.create!(
+    create_provider_user({
       dfe_sign_in_uid: 'dev-1JA-admin',
       email_address: '1JA-admin@example.com',
       first_name: '1JA',
       last_name: 'Admin',
-    ) do |u|
-      u.providers = Provider.where(code: '1JA')
-    end
-
-    admin_1ja.provider_permissions.update_all(
+    }, %w[1JA], {
       manage_organisations: true,
       view_safeguarding_information: false,
-    )
+    })
 
     # cannot_view__no_org_level_perm__without_manage_orgs__ratifying_provider
-    user_d39 = ProviderUser.create!(
+    user_d39 = create_provider_user({
       dfe_sign_in_uid: 'dev-D39',
       email_address: 'D39@example.com',
       first_name: 'D39',
       last_name: 'User',
-    ) do |u|
-      u.providers = Provider.where(code: 'D39')
-    end
-
-    user_d39.provider_permissions.update_all(
+    }, %w[D39], {
       view_safeguarding_information: true,
-    )
+    })
 
     ProviderRelationshipPermissions.find_or_create_by(
       training_provider: Provider.find_by_code('1JB'),
       ratifying_provider: Provider.find_by_code('D39'),
-    ).update_columns(
+    ).update(
       training_provider_can_make_decisions: true,
       training_provider_can_view_safeguarding_information: true,
       training_provider_can_view_diversity_information: true,
@@ -121,37 +116,29 @@ class CreateExampleProviderUsersWithPermissions
     )
 
     # cannot_view__no_org_level_perm__without_manage_orgs__without_setup__training_provider
-    user_1jb = ProviderUser.create!(
+    create_provider_user({
       dfe_sign_in_uid: 'dev-1JB-user',
       email_address: '1JB-user@example.com',
       first_name: '1JB',
       last_name: 'User',
-    ) do |u|
-      u.providers = Provider.where(code: '1JB')
-    end
-
-    user_1jb.provider_permissions.update_all(
+    }, %w[1JB], {
       view_safeguarding_information: true,
-    )
+    })
 
     # can_view__with_org_level_perm__with_user_level__ratifying_provider
-    user_s72 = ProviderUser.create!(
+    user_s72 = create_provider_user({
       dfe_sign_in_uid: 'dev-S72',
       email_address: 'S72@example.com',
       first_name: 'S72',
       last_name: 'User',
-    ) do |u|
-      u.providers = Provider.where(code: 'S72')
-    end
-
-    user_s72.provider_permissions.update_all(
+    }, %w[S72], {
       view_safeguarding_information: true,
-    )
+    })
 
     ProviderRelationshipPermissions.find_or_create_by(
       training_provider: Provider.find_by_code('1JB'),
       ratifying_provider: Provider.find_by_code('S72'),
-    ).update_columns(
+    ).update(
       ratifying_provider_can_make_decisions: true,
       ratifying_provider_can_view_safeguarding_information: true,
       ratifying_provider_can_view_diversity_information: true,
@@ -166,27 +153,34 @@ class CreateExampleProviderUsersWithPermissions
     )
 
     # cannot_view__no_org_level_perm__without_manage_orgs__with_setup__training_provider
-    user_4t7 = ProviderUser.create!(
+    create_provider_user({
       dfe_sign_in_uid: 'dev-4T7',
       email_address: '4T7@example.com',
       first_name: '4T7',
       last_name: 'User',
-    ) do |u|
-      u.providers = Provider.where(code: '4T7')
-    end
-
-    user_4t7.provider_permissions.update_all(
+    }, %w[4T7], {
       view_safeguarding_information: true,
-    )
+    })
 
     ProviderRelationshipPermissions.find_or_create_by(
       training_provider: Provider.find_by_code('4T7'),
       ratifying_provider: Provider.find_by_code('24P'),
-    ).update_columns(
+    ).update(
       ratifying_provider_can_make_decisions: true,
       ratifying_provider_can_view_safeguarding_information: true,
       ratifying_provider_can_view_diversity_information: true,
       setup_at: Time.zone.now,
     )
+  end
+
+  def self.create_provider_user(attrs, provider_codes, permissions = {})
+    user = ProviderUser.new(attrs)
+    SaveProviderUser.new(provider_user: user).call!
+    user.providers = Provider.where(code: provider_codes).all
+    user.save!
+
+    user.provider_permissions.update_all(permissions) if permissions.any?
+
+    user
   end
 end

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -1,17 +1,6 @@
 desc 'Set up your local development environment with data from the Teacher training public API'
 task setup_local_dev_data: %i[environment copy_feature_flags_from_production sync_dev_providers_and_open_courses] do
-  puts 'Creating a provider-only user with DfE Sign-in UID `dev-provider` and email `provider@example.com`...'
-  ProviderUser.create!(
-    dfe_sign_in_uid: 'dev-provider',
-    email_address: 'provider@example.com',
-    first_name: 'Peter',
-    last_name: 'Rovider',
-  ) do |u|
-    u.providers = Provider.where(code: %w[1JA 1N1]).all
-  end
-
   puts 'Creating a support & provider user with DfE Sign-in UID `dev-support` and email `support@example.com`...'
-
   SupportUser.create!(
     dfe_sign_in_uid: 'dev-support',
     email_address: 'support@example.com',
@@ -19,27 +8,11 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
     last_name: 'Upport',
   )
 
-  admin_provider_user = ProviderUser.create!(
-    dfe_sign_in_uid: 'dev-support',
-    email_address: 'support@example.com',
-    first_name: 'Susan',
-    last_name: 'Upport',
-  ) do |u|
-    u.providers = Provider.where(code: %w[1JA 1JB 24J]).all
-  end
-
-  admin_provider_user.provider_permissions.update_all(
-    manage_users: true,
-    manage_organisations: true,
-    view_safeguarding_information: true,
-    make_decisions: true,
-  )
-
-  puts 'Creating users for providers 1N1, 24P, 1JB, D39 with various permission combinations...'
+  puts 'Creating various provider users...'
   CreateExampleProviderUsersWithPermissions.call
 
   puts 'Generating a Vendor API token...'
-  VendorAPIToken.create_with_random_token!(provider: admin_provider_user.providers.first)
+  VendorAPIToken.create_with_random_token!(provider: Provider.find_by(code: '1JA'))
 
   Rake::Task['generate_test_applications'].invoke
 end

--- a/spec/lib/create_example_provider_users_with_permissions_spec.rb
+++ b/spec/lib/create_example_provider_users_with_permissions_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe CreateExampleProviderUsersWithPermissions do
+  it 'creates users' do
+    %w[1JA 24J 24P D39 S72 1JB 4T7 1N1].each do |code|
+      create(:provider, code: code)
+    end
+
+    expect {
+      CreateExampleProviderUsersWithPermissions.call
+    }.to(change { ProviderUser.count })
+  end
+end


### PR DESCRIPTION
We weren't creating notification prefs for provider users in `setup_local_dev_data` so the app crashed when trying to view one of these users through support.

Move all user creation into the `CreateExampleProviderUsersWithPermissions` class and use a method which depends on `SaveProviderUser` to do the saving.