### PR TITLE
Start writing opened_on_apply_at for courses

### DIFF
--- a/app/controllers/support_interface/course_controller.rb
+++ b/app/controllers/support_interface/course_controller.rb
@@ -16,12 +16,26 @@ module SupportInterface
     def update
       @course = Course.find(params[:course_id])
 
-      if @course.update(params.require(:course).permit(:open_on_apply))
+      if set_open_on_apply!
         flash[:success] = 'Successfully updated course'
         redirect_to support_interface_course_path(@course)
       else
         render :show
       end
+    end
+
+  private
+
+    def set_open_on_apply!
+      if open_on_apply_params[:open_on_apply] == 'true'
+        @course.open!
+      else
+        @course.update!(open_on_apply: false)
+      end
+    end
+
+    def open_on_apply_params
+      params.require(:course).permit(:open_on_apply)
     end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -145,4 +145,13 @@ class Course < ApplicationRecord
   def ratifying_provider
     accredited_provider || provider
   end
+
+  def open!
+    return if persisted? && open_on_apply
+
+    update!(
+      open_on_apply: true,
+      opened_on_apply_at: Time.zone.now,
+    )
+  end
 end

--- a/app/services/open_provider_courses.rb
+++ b/app/services/open_provider_courses.rb
@@ -6,7 +6,10 @@ class OpenProviderCourses
   end
 
   def call
-    if run_courses.or(ratified_courses).update(open_on_apply: true).any?
+    if run_courses.or(ratified_courses).update(
+      open_on_apply: true,
+      opened_on_apply_at: Time.zone.now,
+    ).any?
       provider.provider_users.each do |provider_user|
         ProviderMailer.courses_open_on_apply(provider_user)
       end

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -56,7 +56,7 @@ task sync_dev_providers_and_open_courses: :environment do
 
     TeacherTrainingPublicAPI::SyncProvider.new(provider_from_api: provider_from_api, recruitment_cycle_year: RecruitmentCycle.previous_year).call(run_in_background: false, force_sync_courses: true)
 
-    Provider.find_by_code(code).courses.previous_cycle.exposed_in_find.update_all(open_on_apply: true)
+    Provider.find_by_code(code).courses.previous_cycle.exposed_in_find.update_all(open_on_apply: true, opened_on_apply_at: Time.zone.now)
 
     TeacherTrainingPublicAPI::SyncProvider.new(provider_from_api: provider_from_api, recruitment_cycle_year: RecruitmentCycle.current_year).call(run_in_background: false, force_sync_courses: true)
   end

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
     trait :open_on_apply do
       open_on_apply { true }
       exposed_in_find { true }
+      opened_on_apply_at { 2.months.ago }
     end
 
     trait :with_accredited_provider do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -137,4 +137,20 @@ RSpec.describe Course, type: :model do
       end
     end
   end
+
+  describe '#open!' do
+    it 'sets both open_on_apply and opened_on_apply_at' do
+      Timecop.freeze do
+        course = create(:course)
+        course.open!
+        expect(course.open_on_apply).to be(true)
+        expect(course.opened_on_apply_at).to eq(Time.zone.now)
+      end
+    end
+
+    it 'does not update the timestamp if course already open' do
+      course = create(:course, :open_on_apply)
+      expect { course.open! }.not_to change(course, :opened_on_apply_at)
+    end
+  end
 end

--- a/spec/services/open_provider_courses_spec.rb
+++ b/spec/services/open_provider_courses_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe OpenProviderCourses do
     expect(other_course.reload).not_to be_open_on_apply
   end
 
+  it 'sets the opened on apply timestamp' do
+    opened_on_apply = Time.zone.local(2021, 3, 24, 12)
+    course = create(:course, provider: provider, exposed_in_find: true)
+
+    Timecop.freeze(opened_on_apply) do
+      described_class.new(provider: provider).call
+
+      expect(course.reload.opened_on_apply_at).to eq(opened_on_apply)
+    end
+  end
+
   it 'creates audits for the changes it makes', with_audited: true do
     provider = create(:provider)
     course = create(:course, exposed_in_find: true, provider: provider)

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -316,6 +316,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
         course = Course.find_by(code: 'ABC1')
 
         expect(course.open_on_apply).to be true
+        expect(course.opened_on_apply_at).not_to be_nil
       end
     end
 
@@ -362,12 +363,14 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
 
         new_course = Course.find_by(recruitment_cycle_year: 2021)
         expect(new_course).to be_open_on_apply
+        expect(new_course.opened_on_apply_at).not_to be_nil
 
         new_course.update(open_on_apply: false)
 
         described_class.new.perform(existing_provider.id, 2021)
 
         expect(new_course.reload).not_to be_open_on_apply
+        expect(new_course.opened_on_apply_at).not_to be_nil
       end
     end
 


### PR DESCRIPTION
## Context

Following on from https://github.com/DFE-Digital/apply-for-teacher-training/pull/4687

## Changes proposed in this pull request

Populate `opened_on_apply_at` any time `open_on_apply` changes. If the course is being opened, record the timestamp. If the course is being closed (e.g. reverting an accidental opening), reset timestamp to `nil`.

## Guidance to review

Should be straightforward. Inspect the tests and the review app.

## Link to Trello card

https://trello.com/c/DG1rdUbK

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
