### PR TITLE
Reduce worker app instances to 2

### DIFF
--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -2,10 +2,10 @@
 paas_app_environment       = "prod"
 paas_cf_space              = "bat-prod"
 paas_web_app_memory        = 6144
-paas_worker_app_memory     = 6144
+paas_worker_app_memory     = 4096
 paas_clock_app_memory      = 1024
 paas_web_app_instances     = 8
-paas_worker_app_instances  = 4
+paas_worker_app_instances  = 2
 paas_postgres_service_plan = "small-ha-11"
 paas_redis_service_plan    = "micro-ha-5_x"
 


### PR DESCRIPTION
## Context

The increased number of worker instances is causing load on TTAPI.

The worker app's metrics show that the memory usage 
does not go above 20% of the currently allocated 6GB,

Will be monitoring the usage after reducing allocated RAM to 4GB for the worker.

## Changes proposed in this pull request

Reduce number of worker app instances to 2
and reduce RAM to 4 GB from 6GB for the worker instance.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
