### PR TITLE
Display vacancy status on course selection

### DIFF
--- a/app/forms/candidate_interface/pick_course_form.rb
+++ b/app/forms/candidate_interface/pick_course_form.rb
@@ -11,13 +11,13 @@ module CandidateInterface
 
     def radio_available_courses
       @radio_available_courses ||= begin
-        courses_for_current_cycle.exposed_in_find.order(:name)
+        courses_for_current_cycle.exposed_in_find.order(:name).includes(:course_options)
       end
     end
 
     def dropdown_available_courses
       @dropdown_available_courses ||= begin
-        courses = courses_for_current_cycle.exposed_in_find.includes(:accredited_provider)
+        courses = courses_for_current_cycle.exposed_in_find.includes(:accredited_provider, :course_options)
 
         courses_with_names = courses.map(&:name).map(&:downcase)
         courses_with_descriptions = courses.map(&:name_and_description).map(&:downcase)
@@ -36,6 +36,14 @@ module CandidateInterface
                  else
                    course.name_and_code
                  end
+
+          if !course.open_on_apply?
+            name += ' – Only on UCAS'
+          end
+
+          if course.course_options.available.blank?
+            name += ' – No vacancies'
+          end
 
           DropdownOption.new(course.id, name)
         end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -75,7 +75,7 @@ class Course < ApplicationRecord
   end
 
   def name_code_and_age_range
-    "#{name} (#{code}) – #{age_range}"
+    "#{name}, #{age_range} (#{code})"
   end
 
   def name_description_provider_and_age_range

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -83,7 +83,7 @@ class Course < ApplicationRecord
   end
 
   def provider_and_name_code
-    "#{provider.name} - #{name_and_code}"
+    "#{provider.name} – #{name_and_code}"
   end
 
   def currently_has_both_study_modes_available?

--- a/app/views/candidate_interface/course_choices/course_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/course_selection/new.html.erb
@@ -22,7 +22,13 @@
       <% else %>
         <%= f.govuk_radio_buttons_fieldset :course_id, legend: { size: 'xl', text: t('page_titles.which_course'), tag: 'h1' } do %>
           <% @pick_course.radio_available_courses.each_with_index do |course, i| %>
-            <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code})" }, hint: { text: course.description }, link_errors: i.zero? %>
+            <% if !course.open_on_apply? %>
+              <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code}) – Only on UCAS" }, hint: { text: course.description }, link_errors: i.zero? %>
+            <% elsif course.course_options.available.blank? %>
+              <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code}) – No vacancies" }, hint: { text: course.description }, link_errors: i.zero? %>
+            <% else %>
+              <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code})" }, hint: { text: course.description }, link_errors: i.zero? %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/spec/forms/candidate_interface/pick_course_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_course_form_spec.rb
@@ -18,10 +18,36 @@ RSpec.describe CandidateInterface::PickCourseForm do
   end
 
   describe '#dropdown_available_courses' do
+    it 'displays the vacancy status' do
+      provider = create(:provider)
+      course = create(:course, open_on_apply: true, exposed_in_find: true, name: 'Maths', code: '123', provider: provider)
+      create(:course, open_on_apply: true, exposed_in_find: true, name: 'English', code: '456', description: 'PGCE with QTS full time', provider: provider)
+      create(:course, open_on_apply: true, exposed_in_find: true, name: 'English', code: '789', description: 'PGCE full time', provider: provider)
+      create(:course_option, course: course)
+
+      form = described_class.new(provider_id: provider.id)
+
+      expect(form.dropdown_available_courses.map(&:name)).to eql(['English (456) – PGCE with QTS full time – No vacancies', 'English (789) – PGCE full time – No vacancies', 'Maths (123)'])
+    end
+
+    it 'displays the ucas status' do
+      provider = create(:provider)
+      maths = create(:course, exposed_in_find: true, open_on_apply: false, name: 'Maths', code: '123', provider: provider)
+      english = create(:course, exposed_in_find: true, open_on_apply: true, name: 'English', code: '456', provider: provider)
+      create(:course_option, course: maths)
+      create(:course_option, course: english)
+
+      form = described_class.new(provider_id: provider.id)
+
+      expect(form.dropdown_available_courses.map(&:name)).to eql(['English (456)', 'Maths (123) – Only on UCAS'])
+    end
+
     it 'respects the current recruitment cycle' do
       provider = create(:provider)
-      create(:course, :open_on_apply, name: 'This cycle', code: 'A', provider: provider)
+      course = create(:course, :open_on_apply, name: 'This cycle', code: 'A', provider: provider)
       create(:course, :open_on_apply, name: 'A past cycle', code: 'F', provider: provider, recruitment_cycle_year: 2016)
+
+      create(:course_option, course: course)
 
       form = described_class.new(provider_id: provider.id)
 
@@ -31,8 +57,10 @@ RSpec.describe CandidateInterface::PickCourseForm do
     context 'with no ambiguous courses' do
       it 'returns each courses name and code' do
         provider = create(:provider)
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE full time', provider: provider)
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'English', code: '789', description: 'PGCE with QTS full time', provider: provider)
+        maths_course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE full time', provider: provider)
+        english_course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'English', code: '789', description: 'PGCE with QTS full time', provider: provider)
+        create(:course_option, course: maths_course)
+        create(:course_option, course: english_course)
 
         form = described_class.new(provider_id: provider.id)
 
@@ -43,9 +71,12 @@ RSpec.describe CandidateInterface::PickCourseForm do
     context 'when courses have ambiguous names and different descriptions' do
       it 'adds the course description to the name of the course' do
         provider = create(:provider)
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE full time', provider: provider)
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', description: 'PGCE with QTS full time', provider: provider)
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'English', code: '789', description: 'PGCE with QTS full time', provider: provider)
+        maths123 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE full time', provider: provider)
+        maths456 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', description: 'PGCE with QTS full time', provider: provider)
+        english789 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'English', code: '789', description: 'PGCE with QTS full time', provider: provider)
+        create(:course_option, course: maths123)
+        create(:course_option, course: maths456)
+        create(:course_option, course: english789)
 
         form = described_class.new(provider_id: provider.id)
 
@@ -58,8 +89,10 @@ RSpec.describe CandidateInterface::PickCourseForm do
         provider = create(:provider)
         provider2 = create(:provider, name: 'BIG SCITT')
         provider3 = create(:provider, name: 'EVEN BIGGER SCITT')
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider3)
+        maths123 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
+        maths456 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider3)
+        create(:course_option, course: maths123)
+        create(:course_option, course: maths456)
 
         form = described_class.new(provider_id: provider.id)
 
@@ -72,8 +105,10 @@ RSpec.describe CandidateInterface::PickCourseForm do
         provider = create(:provider)
         provider2 = create(:provider, name: 'BIG SCITT')
         provider3 = create(:provider, name: 'EVEN BIGGER SCITT')
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE full time', provider: provider, accredited_provider: provider2)
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider3)
+        maths123 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE full time', provider: provider, accredited_provider: provider2)
+        maths456 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider3)
+        create(:course_option, course: maths123)
+        create(:course_option, course: maths456)
 
         form = described_class.new(provider_id: provider.id)
 
@@ -85,12 +120,14 @@ RSpec.describe CandidateInterface::PickCourseForm do
       it 'returns the course name_code_and_age_range' do
         provider = create(:provider)
         provider2 = create(:provider, name: 'BIG SCITT')
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', age_range: '8 to 12', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
+        maths4to8 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
+        maths8to12 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', age_range: '8 to 12', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
+        create(:course_option, course: maths4to8)
+        create(:course_option, course: maths8to12)
 
         form = described_class.new(provider_id: provider.id)
 
-        expect(form.dropdown_available_courses.map(&:name)).to eql(['Maths (123) – 4 to 8', 'Maths (456) – 8 to 12'])
+        expect(form.dropdown_available_courses.map(&:name)).to eql(['Maths, 4 to 8 (123)', 'Maths, 8 to 12 (456)'])
       end
     end
 
@@ -98,8 +135,10 @@ RSpec.describe CandidateInterface::PickCourseForm do
       it 'returns course name and code' do
         provider = create(:provider)
         provider2 = create(:provider, name: 'BIG SCITT')
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
+        maths123 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
+        maths456 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
+        create(:course_option, course: maths123)
+        create(:course_option, course: maths456)
 
         form = described_class.new(provider_id: provider.id)
 
@@ -112,12 +151,18 @@ RSpec.describe CandidateInterface::PickCourseForm do
         provider = create(:provider)
         provider2 = create(:provider, name: 'BIG SCITT')
         provider3 = create(:provider, name: 'EVEN BIGGER SCITT')
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE full time', provider: provider, accredited_provider: provider2)
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '789', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider3)
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'English', code: 'A01', description: 'PGCE full time', provider: provider, accredited_provider: provider3)
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'English', code: 'A02', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
-        create(:course, exposed_in_find: true, open_on_apply: true, name: 'English', code: 'A03', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider3)
+        maths123 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE full time', provider: provider, accredited_provider: provider2)
+        maths456 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
+        maths789 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '789', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider3)
+        english_a01 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'English', code: 'A01', description: 'PGCE full time', provider: provider, accredited_provider: provider3)
+        english_a02 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'English', code: 'A02', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
+        english_a03 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'English', code: 'A03', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider3)
+        create(:course_option, course: maths123)
+        create(:course_option, course: maths456)
+        create(:course_option, course: maths789)
+        create(:course_option, course: english_a01)
+        create(:course_option, course: english_a02)
+        create(:course_option, course: english_a03)
 
         form = described_class.new(provider_id: provider.id)
 

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe 'Selecting a full course' do
     select @course.provider.name
     click_button t('continue')
 
+    expect(page).to have_text("#{@course.name_and_code} – No vacancies")
+
     choose @course.name
     click_button t('continue')
   end


### PR DESCRIPTION
## Context

At the moment, when a candidate chooses a course, there's no indication that it is full in the drop down. As more courses close towards the end of the cycle a candidate could end up selecting many full courses in a row

As a candidate I want to know whether a course has vacancies or is only available via UCAS at the point that I select it (rather than finding out two screens further into the journey).

## Changes proposed in this pull request

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/47917431/117810561-792fb280-b257-11eb-9b31-cb71a2bca85a.png)|![image](https://user-images.githubusercontent.com/47917431/117963655-911b3b00-b318-11eb-9359-cb76ce004aa5.png)|
|![image](https://user-images.githubusercontent.com/47917431/117825159-fd3d6680-b266-11eb-8995-c1bb042cde9f.png)|![image](https://user-images.githubusercontent.com/47917431/117824927-c8c9aa80-b266-11eb-95c9-e9048ba7683d.png)|

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/rgEO3WLn/2133-display-vacancy-status-and-ucas-only-when-prompting-candidates-for-course

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
