### PR TITLE
Update flow and forms so that references are created after name step

### DIFF
--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -80,7 +80,7 @@ module CandidateInterface
     def name_row(reference)
       {
         key: 'Name',
-        value: reference.name,
+        value: reference.name || 'Not entered',
         action: "name for #{reference.name}",
         change_path: candidate_interface_references_edit_name_path(
           reference.id, return_to: :review
@@ -91,7 +91,7 @@ module CandidateInterface
     def email_row(reference)
       {
         key: 'Email address',
-        value: reference.email_address,
+        value: reference.email_address || 'Not entered',
         action: "email address for #{reference.name}",
         change_path: candidate_interface_references_edit_email_address_path(
           reference.id, return_to: :review
@@ -102,7 +102,7 @@ module CandidateInterface
     def relationship_row(reference)
       {
         key: 'Relationship to referee',
-        value: reference.relationship,
+        value: reference.relationship || 'Not entered',
         action: "relationship for #{reference.name}",
         change_path: candidate_interface_references_edit_relationship_path(
           reference.id, return_to: :review

--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -80,7 +80,7 @@ module CandidateInterface
     def name_row(reference)
       {
         key: 'Name',
-        value: reference.name || 'Not entered',
+        value: reference.name,
         action: "name for #{reference.name}",
         change_path: candidate_interface_references_edit_name_path(
           reference.id, return_to: :review
@@ -89,25 +89,49 @@ module CandidateInterface
     end
 
     def email_row(reference)
-      {
-        key: 'Email address',
-        value: reference.email_address || 'Not entered',
-        action: "email address for #{reference.name}",
-        change_path: candidate_interface_references_edit_email_address_path(
-          reference.id, return_to: :review
-        ),
-      }
+      if reference.email_address?
+        {
+          key: 'Email address',
+          value: reference.email_address,
+          action: "email address for #{reference.name}",
+          change_path: candidate_interface_references_edit_email_address_path(
+            reference.id, return_to: :review
+          ),
+        }
+      else
+        {
+          key: 'Email address',
+          value: govuk_link_to(
+            'Enter email address', candidate_interface_references_edit_email_address_path(
+                                     reference.id,
+                                   )
+          ),
+          action: "email address for #{reference.name}",
+        }
+      end
     end
 
     def relationship_row(reference)
-      {
-        key: 'Relationship to referee',
-        value: reference.relationship || 'Not entered',
-        action: "relationship for #{reference.name}",
-        change_path: candidate_interface_references_edit_relationship_path(
-          reference.id, return_to: :review
-        ),
-      }
+      if reference.relationship?
+        {
+          key: 'Relationship to referee',
+          value: reference.relationship,
+          action: "relationship for #{reference.name}",
+          change_path: candidate_interface_references_edit_relationship_path(
+            reference.id, return_to: :review
+          ),
+        }
+      else
+        {
+          key: 'Relationship to referee',
+          value: govuk_link_to(
+            'Enter relationship to referee', candidate_interface_references_edit_relationship_path(
+                                               reference.id, return_to: :review
+                                             )
+          ),
+          action: "relationship for #{reference.name}",
+        }
+      end
     end
 
     def reference_type_row(reference)

--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -17,9 +17,9 @@ module CandidateInterface
 
     def reference_rows(reference)
       [
+        reference_type_row(reference),
         name_row(reference),
         email_row(reference),
-        reference_type_row(reference),
         relationship_row(reference),
         feedback_status_row(reference),
         history_row(reference),

--- a/app/controllers/candidate_interface/references/email_address_controller.rb
+++ b/app/controllers/candidate_interface/references/email_address_controller.rb
@@ -26,7 +26,11 @@ module CandidateInterface
         @reference_email_address_form = Reference::RefereeEmailAddressForm.new(referee_email_address_param)
 
         if @reference_email_address_form.save(@reference)
-          if return_to_path.present?
+          if !@reference.relationship?
+            redirect_to candidate_interface_references_edit_relationship_path(
+              @reference.id,
+            )
+          elsif return_to_path.present?
             redirect_to return_to_path
           else
             redirect_to candidate_interface_references_review_unsubmitted_path(@reference.id)

--- a/app/controllers/candidate_interface/references/name_controller.rb
+++ b/app/controllers/candidate_interface/references/name_controller.rb
@@ -26,7 +26,11 @@ module CandidateInterface
         @reference_name_form = Reference::RefereeNameForm.new(referee_name_param)
 
         if @reference_name_form.update(@reference)
-          if return_to_path.present?
+          if !@reference.email_address?
+            redirect_to candidate_interface_references_edit_email_address_path(
+              @reference.id, return_to: :review
+            )
+          elsif return_to_path.present?
             redirect_to return_to_path
           else
             redirect_to candidate_interface_references_review_unsubmitted_path(@reference.id)

--- a/app/controllers/candidate_interface/references/name_controller.rb
+++ b/app/controllers/candidate_interface/references/name_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   module References
     class NameController < BaseController
-      before_action :redirect_to_review_page_unless_reference_is_editable
+      before_action :redirect_to_review_page_unless_reference_is_editable, only: %i[edit update]
 
       def new
         @reference_name_form = Reference::RefereeNameForm.new
@@ -10,8 +10,8 @@ module CandidateInterface
       def create
         @reference_name_form = Reference::RefereeNameForm.new(referee_name_param)
 
-        if @reference_name_form.save(@reference)
-          redirect_to candidate_interface_references_email_address_path(@reference.id)
+        if @reference_name_form.save(current_application, params[:referee_type])
+          redirect_to candidate_interface_references_email_address_path(current_application.application_references.last.id)
         else
           track_validation_error(@reference_name_form)
           render :new
@@ -25,7 +25,7 @@ module CandidateInterface
       def update
         @reference_name_form = Reference::RefereeNameForm.new(referee_name_param)
 
-        if @reference_name_form.save(@reference)
+        if @reference_name_form.update(@reference)
           if return_to_path.present?
             redirect_to return_to_path
           else

--- a/app/controllers/candidate_interface/references/type_controller.rb
+++ b/app/controllers/candidate_interface/references/type_controller.rb
@@ -11,8 +11,8 @@ module CandidateInterface
       def create
         @reference_type_form = Reference::RefereeTypeForm.new(referee_type: referee_type_param)
 
-        if @reference_type_form.save(current_application)
-          redirect_to candidate_interface_references_name_path(current_application.application_references.last.id)
+        if @reference_type_form.valid?
+          redirect_to candidate_interface_references_name_path(@reference_type_form.referee_type)
         else
           track_validation_error(@reference_type_form)
           render :new

--- a/app/controllers/candidate_interface/references/type_controller.rb
+++ b/app/controllers/candidate_interface/references/type_controller.rb
@@ -27,7 +27,11 @@ module CandidateInterface
         @reference_type_form = Reference::RefereeTypeForm.new(referee_type: referee_type_param)
 
         if @reference_type_form.update(@reference)
-          if return_to_path.present?
+          if !@reference.email_address?
+            redirect_to candidate_interface_references_edit_email_address_path(
+              @reference.id,
+            )
+          elsif return_to_path.present?
             redirect_to return_to_path
           else
             redirect_to candidate_interface_references_review_unsubmitted_path(@reference.id)

--- a/app/forms/candidate_interface/reference/referee_name_form.rb
+++ b/app/forms/candidate_interface/reference/referee_name_form.rb
@@ -10,7 +10,13 @@ module CandidateInterface
       new(name: reference.name)
     end
 
-    def save(reference)
+    def save(application_form, referee_type)
+      return false unless valid?
+
+      application_form.application_references.create!(name: name, referee_type: referee_type)
+    end
+
+    def update(reference)
       return false unless valid?
 
       reference.update!(name: name)

--- a/app/forms/candidate_interface/reference/referee_type_form.rb
+++ b/app/forms/candidate_interface/reference/referee_type_form.rb
@@ -10,12 +10,6 @@ module CandidateInterface
       new(referee_type: reference.referee_type)
     end
 
-    def save(application_form)
-      return false unless valid?
-
-      application_form.application_references.create!(referee_type: referee_type)
-    end
-
     def update(reference)
       return false unless valid?
 

--- a/app/views/candidate_interface/references/email_address/new.html.erb
+++ b/app/views/candidate_interface/references/email_address/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.references_email_address'), @reference_email_address_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_references_edit_name_path(@reference.id, return_to: :email_address)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/references/name/new.html.erb
+++ b/app/views/candidate_interface/references/name/new.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @reference_name_form,
-      url: candidate_interface_references_name_path(@reference.id),
+      url: candidate_interface_references_name_path(referee_type: params[:referee_type]),
       method: :patch,
     ) do |f| %>
       <%= render 'shared_form', f: f %>

--- a/app/views/candidate_interface/references/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/references/type/_shared_form.html.erb
@@ -8,4 +8,4 @@
   <%= f.govuk_radio_button :referee_type, 'character', label: { text: t('application_form.references.referee_type.character.label') }, hint: { text: t('application_form.references.referee_type.character.hint_text') } %>
 <% end %>
 
-<%= f.govuk_submit t('save_and_continue') %>
+<%= f.govuk_submit t('continue') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -443,8 +443,10 @@ Rails.application.routes.draw do
         get '/type/edit/:id' => 'references/type#edit', as: :references_edit_type
         patch '/type/edit/:id' => 'references/type#update'
 
-        get '/name/:referee_type' => 'references/name#new', as: :references_name
-        patch '/name/:referee_type' => 'references/name#create'
+        scope '/name/:referee_type', constraints: { referee_type: /(academic|professional|school-based|character)/ } do
+          get '/' => 'references/name#new', as: :references_name
+          patch '/' => 'references/name#create'
+        end
         get '/name/edit/:id' => 'references/name#edit', as: :references_edit_name
         patch '/name/edit/:id' => 'references/name#update'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -443,8 +443,8 @@ Rails.application.routes.draw do
         get '/type/edit/:id' => 'references/type#edit', as: :references_edit_type
         patch '/type/edit/:id' => 'references/type#update'
 
-        get '/name/:id' => 'references/name#new', as: :references_name
-        patch '/name/:id' => 'references/name#create'
+        get '/name/:referee_type' => 'references/name#new', as: :references_name
+        patch '/name/:referee_type' => 'references/name#create'
         get '/name/edit/:id' => 'references/name#edit', as: :references_edit_name
         patch '/name/edit/:id' => 'references/name#update'
 

--- a/spec/components/candidate_interface/references_review_component_spec.rb
+++ b/spec/components/candidate_interface/references_review_component_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe CandidateInterface::ReferencesReviewComponent, type: :component d
     reference = create(:reference, :not_requested_yet)
     result = render_inline(described_class.new(references: [reference]))
 
-    name_row = result.css('.govuk-summary-list__row')[0].text
-    email_row = result.css('.govuk-summary-list__row')[1].text
+    name_row = result.css('.govuk-summary-list__row')[1].text
+    email_row = result.css('.govuk-summary-list__row')[2].text
     expect(name_row).to include 'Name'
     expect(name_row).to include reference.name
     expect(email_row).to include 'Email address'
@@ -17,7 +17,7 @@ RSpec.describe CandidateInterface::ReferencesReviewComponent, type: :component d
     reference = create(:reference, :not_requested_yet, referee_type: :school_based)
     result = render_inline(described_class.new(references: [reference]))
 
-    type_row = result.css('.govuk-summary-list__row')[2].text
+    type_row = result.css('.govuk-summary-list__row')[0].text
     expect(type_row).to include 'Reference type'
     expect(type_row).to include 'School-based'
   end

--- a/spec/forms/candidate_interface/reference/referee_name_form_spec.rb
+++ b/spec/forms/candidate_interface/reference/referee_name_form_spec.rb
@@ -17,22 +17,23 @@ RSpec.describe CandidateInterface::Reference::RefereeNameForm, type: :model do
   end
 
   describe '#save' do
-    let(:application_reference) { create(:reference) }
+    let(:application_form) { create(:application_form) }
 
     context 'when name is blank' do
       it 'returns false' do
         form = described_class.new
 
-        expect(form.save(application_reference)).to be(false)
+        expect(form.save(application_form, 'academic')).to be(false)
       end
     end
 
-    context 'when name has a value' do
+    context 'when name and referee type have a value' do
       it 'creates the referee' do
         form = described_class.new(name: 'Walter White')
-        form.save(application_reference)
+        form.save(application_form, 'academic')
 
-        expect(application_reference.name).to eq('Walter White')
+        expect(application_form.application_references.last.referee_type).to eq('academic')
+        expect(application_form.application_references.last.name).to eq('Walter White')
       end
     end
   end

--- a/spec/forms/candidate_interface/reference/referee_type_form_spec.rb
+++ b/spec/forms/candidate_interface/reference/referee_type_form_spec.rb
@@ -10,27 +10,6 @@ RSpec.describe CandidateInterface::Reference::RefereeTypeForm, type: :model do
     end
   end
 
-  describe '#save' do
-    let(:application_form) { create(:application_form) }
-
-    context 'when referee_type is blank' do
-      it 'returns false' do
-        form = described_class.new
-
-        expect(form.save(application_form)).to be(false)
-      end
-    end
-
-    context 'when referee_type has a value' do
-      it 'creates the referee' do
-        form = described_class.new(referee_type: 'professional')
-        form.save(application_form)
-
-        expect(application_form.application_references.last.referee_type).to eq('professional')
-      end
-    end
-  end
-
   describe '#update' do
     let(:application_reference) { create(:reference) }
 

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -350,7 +350,7 @@ module CandidateHelper
     visit candidate_interface_references_start_path
     click_link t('continue')
     choose 'Academic'
-    click_button t('save_and_continue')
+    click_button t('continue')
 
     candidate_fills_in_referee
     choose 'Yes, send a reference request now'
@@ -359,7 +359,7 @@ module CandidateHelper
     click_link 'Add a second referee'
     click_link t('continue')
     choose 'Professional'
-    click_button t('save_and_continue')
+    click_button t('continue')
 
     candidate_fills_in_referee(
       name: 'Anne Other',

--- a/spec/system/candidate_interface/references/candidate_adding_incomplete_referees_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adding_incomplete_referees_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate adding incomplete referees' do
+  include CandidateHelper
+
+  scenario 'Candidate adds incomplete referees' do
+    given_i_am_signed_in
+    and_i_have_provided_my_personal_details
+
+    when_i_provide_a_referee_type_only
+    then_i_see_that_referee_is_not_created
+
+    when_i_provide_incomplete_referee_details
+    then_i_see_that_the_incomplete_referee_is_created
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_provided_my_personal_details
+    @candidate.current_application.update!(first_name: 'Michael', last_name: 'Antonio')
+  end
+
+  def when_i_provide_a_referee_type_only
+    visit candidate_interface_references_start_path
+    click_link t('continue')
+    choose 'Academic'
+    click_button t('continue')
+  end
+
+  def then_i_see_that_referee_is_not_created
+    visit candidate_interface_references_review_path
+    expect(page.text).to have_no_content('Academic')
+  end
+
+  def when_i_provide_incomplete_referee_details
+    visit candidate_interface_references_start_path
+    click_link t('continue')
+    choose 'Academic'
+    click_button t('continue')
+    fill_in 'What is the referee’s name?', with: 'Mike Dean'
+    click_button t('save_and_continue')
+  end
+
+  def then_i_see_that_the_incomplete_referee_is_created
+    visit candidate_interface_references_review_path
+
+    within_summary_row('Name') { expect(page.text).to have_content('Mike Dean') }
+    within_summary_row('Email address') { expect(page.text).to have_content('Not entered') }
+    within_summary_row('Reference type') { expect(page.text).to have_content('Academic') }
+    within_summary_row('Relationship to referee') { expect(page.text).to have_content('Not entered') }
+  end
+end

--- a/spec/system/candidate_interface/references/candidate_adding_incomplete_referees_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adding_incomplete_referees_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Candidate adding incomplete referees' do
   include CandidateHelper
 
-  scenario 'Candidate adds incomplete referees' do
+  scenario 'Candidate adds incomplete referees and then completes them' do
     given_i_am_signed_in
     and_i_have_provided_my_personal_details
 
@@ -12,6 +12,13 @@ RSpec.feature 'Candidate adding incomplete referees' do
 
     when_i_provide_incomplete_referee_details
     then_i_see_that_the_incomplete_referee_is_created
+
+    when_i_click_to_add_the_email_address
+    and_i_provide_a_valid_email_address
+    then_i_am_redirected_to_the_relationship_page
+
+    when_i_provide_a_valid_relationship_to_referee
+    then_i_see_that_referee_is_now_complete
   end
 
   def given_i_am_signed_in
@@ -48,8 +55,33 @@ RSpec.feature 'Candidate adding incomplete referees' do
     visit candidate_interface_references_review_path
 
     within_summary_row('Name') { expect(page.text).to have_content('Mike Dean') }
-    within_summary_row('Email address') { expect(page.text).to have_content('Not entered') }
+    within_summary_row('Email address') { expect(page).to have_link('Enter email address') }
     within_summary_row('Reference type') { expect(page.text).to have_content('Academic') }
-    within_summary_row('Relationship to referee') { expect(page.text).to have_content('Not entered') }
+    within_summary_row('Relationship to referee') { expect(page).to have_link('Enter relationship to referee') }
+  end
+
+  def when_i_click_to_add_the_email_address
+    click_link 'Enter email address'
+  end
+
+  def and_i_provide_a_valid_email_address
+    fill_in 'What is the referee’s email address?', with: 'mike.dean@thefa.co.uk'
+    click_button t('save_and_continue')
+  end
+
+  def then_i_am_redirected_to_the_relationship_page
+    expect(page).to have_current_path(candidate_interface_references_edit_relationship_path(@candidate.current_application.application_references.last.id))
+  end
+
+  def when_i_provide_a_valid_relationship_to_referee
+    fill_in 'How do you know this referee and how long have you known them?', with: 'Gave me a yellow card'
+    click_button t('save_and_continue')
+  end
+
+  def then_i_see_that_referee_is_now_complete
+    within_summary_row('Name') { expect(page.text).to have_content('Mike Dean') }
+    within_summary_row('Email address') { expect(page.text).to have_content('mike.dean@thefa.co.uk') }
+    within_summary_row('Reference type') { expect(page.text).to have_content('Academic') }
+    within_summary_row('Relationship to referee') { expect(page).to have_content('Gave me a yellow card') }
   end
 end

--- a/spec/system/candidate_interface/references/candidate_adding_referees_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adding_referees_in_sandbox_spec.rb
@@ -66,12 +66,14 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
     click_link t('continue')
     choose 'Academic'
     click_button t('save_and_continue')
+    fill_in 'What is the referee’s name?', with: 'Refbot Three'
+    click_button t('save_and_continue')
   end
 
   def then_i_see_that_the_incomplete_reference_rendered
     visit candidate_interface_references_review_path
     within all('.app-summary-card')[2] do
-      expect(all('.govuk-summary-list__value')[0].text).to have_content('Not entered')
+      expect(all('.govuk-summary-list__value')[0].text).to have_content('Refbot Three')
       expect(all('.govuk-summary-list__value')[1].text).to have_content('Not entered')
       expect(all('.govuk-summary-list__value')[2].text).to have_content('Academic')
       expect(all('.govuk-summary-list__value')[3].text).to have_content('Not entered')

--- a/spec/system/candidate_interface/references/candidate_adding_referees_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adding_referees_in_sandbox_spec.rb
@@ -9,6 +9,9 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
 
     when_i_provide_two_references
     then_i_see_that_references_are_given
+
+    when_i_provide_incomplete_reference_details
+    then_i_see_that_the_incomplete_reference_rendered
   end
 
   def given_i_am_signed_in
@@ -55,6 +58,23 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
 
     within all('.app-summary-card')[1] do
       expect(all('.govuk-summary-list__value')[4].text).to have_content('Reference given')
+    end
+  end
+
+  def when_i_provide_incomplete_reference_details
+    visit candidate_interface_references_start_path
+    click_link t('continue')
+    choose 'Academic'
+    click_button t('save_and_continue')
+  end
+
+  def then_i_see_that_the_incomplete_reference_rendered
+    visit candidate_interface_references_review_path
+    within all('.app-summary-card')[2] do
+      expect(all('.govuk-summary-list__value')[0].text).to have_content('Not entered')
+      expect(all('.govuk-summary-list__value')[1].text).to have_content('Not entered')
+      expect(all('.govuk-summary-list__value')[2].text).to have_content('Academic')
+      expect(all('.govuk-summary-list__value')[3].text).to have_content('Not entered')
     end
   end
 end

--- a/spec/system/candidate_interface/references/candidate_adding_referees_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adding_referees_in_sandbox_spec.rb
@@ -9,9 +9,6 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
 
     when_i_provide_two_references
     then_i_see_that_references_are_given
-
-    when_i_provide_incomplete_reference_details
-    then_i_see_that_the_incomplete_reference_rendered
   end
 
   def given_i_am_signed_in
@@ -27,7 +24,7 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
     visit candidate_interface_references_start_path
     click_link t('continue')
     choose 'Academic'
-    click_button t('save_and_continue')
+    click_button t('continue')
 
     candidate_fills_in_referee(
       name: 'Refbot One',
@@ -40,7 +37,7 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
     click_link 'Add a second referee'
     click_link t('continue')
     choose 'Professional'
-    click_button t('save_and_continue')
+    click_button t('continue')
 
     candidate_fills_in_referee(
       name: 'Refbot Two',
@@ -58,25 +55,6 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
 
     within all('.app-summary-card')[1] do
       expect(all('.govuk-summary-list__value')[4].text).to have_content('Reference given')
-    end
-  end
-
-  def when_i_provide_incomplete_reference_details
-    visit candidate_interface_references_start_path
-    click_link t('continue')
-    choose 'Academic'
-    click_button t('save_and_continue')
-    fill_in 'What is the referee’s name?', with: 'Refbot Three'
-    click_button t('save_and_continue')
-  end
-
-  def then_i_see_that_the_incomplete_reference_rendered
-    visit candidate_interface_references_review_path
-    within all('.app-summary-card')[2] do
-      expect(all('.govuk-summary-list__value')[0].text).to have_content('Refbot Three')
-      expect(all('.govuk-summary-list__value')[1].text).to have_content('Not entered')
-      expect(all('.govuk-summary-list__value')[2].text).to have_content('Academic')
-      expect(all('.govuk-summary-list__value')[3].text).to have_content('Not entered')
     end
   end
 end

--- a/spec/system/candidate_interface/references/candidate_adds_a_new_reference_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adds_a_new_reference_spec.rb
@@ -15,12 +15,12 @@ RSpec.feature 'References' do
     when_i_click_continue
     then_i_see_the_type_page
 
-    when_i_click_save_and_continue_without_providing_a_type
+    when_i_click_continue_without_providing_a_type
     then_i_should_be_told_to_provide_a_type
     and_a_validation_error_is_logged_for_type
 
     when_i_select_academic
-    and_i_click_save_and_continue
+    and_i_click_continue
     then_i_should_see_the_referee_name_page
 
     when_i_click_save_and_continue_without_providing_a_name
@@ -64,7 +64,7 @@ RSpec.feature 'References' do
 
     when_i_click_change_on_the_reference_type
     and_i_choose_professional
-    and_i_click_save_and_continue
+    and_i_click_continue
     then_i_see_the_updated_type
 
     when_i_click_change_on_relationship
@@ -126,8 +126,8 @@ RSpec.feature 'References' do
     expect(page).to have_current_path candidate_interface_references_type_path
   end
 
-  def when_i_click_save_and_continue_without_providing_a_type
-    and_i_click_save_and_continue
+  def when_i_click_continue_without_providing_a_type
+    and_i_click_continue
   end
 
   def then_i_should_be_told_to_provide_a_type
@@ -144,6 +144,10 @@ RSpec.feature 'References' do
 
   def and_i_click_save_and_continue
     click_button t('save_and_continue')
+  end
+
+  def and_i_click_continue
+    click_button t('continue')
   end
 
   def then_i_should_see_the_referee_name_page

--- a/spec/system/candidate_interface/references/candidate_adds_a_new_reference_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adds_a_new_reference_spec.rb
@@ -147,7 +147,7 @@ RSpec.feature 'References' do
   end
 
   def then_i_should_see_the_referee_name_page
-    expect(page).to have_current_path candidate_interface_references_name_path(@application.application_references.last.id)
+    expect(page).to have_current_path candidate_interface_references_name_path('academic')
   end
 
   def when_i_click_save_and_continue_without_providing_a_name
@@ -164,6 +164,7 @@ RSpec.feature 'References' do
 
   def when_i_fill_in_my_references_name
     fill_in 'candidate-interface-reference-referee-name-form-name-field-error', with: 'Walter White'
+    and_i_click_save_and_continue
   end
 
   def then_i_see_the_referee_email_page
@@ -179,7 +180,7 @@ RSpec.feature 'References' do
   end
 
   def and_a_validation_error_is_logged_for_blank_email_address
-    expect(ValidationError.count).to be 3
+    expect(ValidationError.count).to be 4
   end
 
   def when_i_provide_an_email_address_with_an_invalid_format
@@ -191,7 +192,7 @@ RSpec.feature 'References' do
   end
 
   def and_a_validation_error_is_logged_for_invalid_email_address
-    expect(ValidationError.count).to be 4
+    expect(ValidationError.count).to be 5
   end
 
   def when_i_provide_a_valid_email_address
@@ -211,7 +212,7 @@ RSpec.feature 'References' do
   end
 
   def and_a_validation_error_is_logged_for_relationship
-    expect(ValidationError.count).to be 5
+    expect(ValidationError.count).to be 6
   end
 
   def when_i_fill_in_my_references_relationship

--- a/spec/system/candidate_interface/references/candidate_receives_feedback_from_their_reference_requests_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_receives_feedback_from_their_reference_requests_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature 'References' do
     visit candidate_interface_references_start_path
     click_link t('continue')
     choose 'Academic'
-    click_button t('save_and_continue')
+    click_button t('continue')
 
     candidate_fills_in_referee
     choose 'Yes, send a reference request now'
@@ -40,7 +40,7 @@ RSpec.feature 'References' do
     click_link 'Add a second referee'
     click_link t('continue')
     choose 'Professional'
-    click_button t('save_and_continue')
+    click_button t('continue')
 
     candidate_fills_in_referee(
       name: 'Anne Other',
@@ -53,7 +53,7 @@ RSpec.feature 'References' do
     click_link 'Add another referee'
     click_link t('continue')
     choose 'School-based'
-    click_button t('save_and_continue')
+    click_button t('continue')
 
     candidate_fills_in_referee(
       name: 'Mr Declined',
@@ -66,7 +66,7 @@ RSpec.feature 'References' do
     click_link 'Add another referee'
     click_link t('continue')
     choose 'Character'
-    click_button t('save_and_continue')
+    click_button t('continue')
 
     candidate_fills_in_referee(
       name: 'Ms Cancelled',

--- a/spec/system/candidate_interface/references/candidate_replaces_reference_after_applying_again_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_replaces_reference_after_applying_again_spec.rb
@@ -83,7 +83,7 @@ RSpec.feature 'Candidate applying again' do
     click_link 'Add a second referee'
     click_link t('continue')
     choose 'Academic'
-    click_button t('save_and_continue')
+    click_button t('continue')
 
     candidate_fills_in_referee(
       name: 'Bob Lawblob',

--- a/spec/system/candidate_interface/references/candidate_views_reference_history_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_views_reference_history_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'Reference history on review page' do
     visit candidate_interface_references_start_path
     click_link t('continue')
     choose 'Academic'
-    click_button t('save_and_continue')
+    click_button t('continue')
 
     candidate_fills_in_referee
     @reference = current_candidate.current_application.application_references.first


### PR DESCRIPTION
## Context

When candidates  leave the flow part of the way through adding a reference, incomplete references are displayed on the review page.

## Changes proposed in this pull request

<img width="993" alt="image" src="https://user-images.githubusercontent.com/62567622/117739556-82d4fe00-b1f6-11eb-8d76-2588e61a4e56.png">

Candidates now see 'Not entered' in place of whitespace on the review component.

Candidates now only can create an incomplete reference by leaving the flow after submitting the referee name. submitting Referee Type now passes a param to the name form which creates the reference ehich created the db record.

## Guidance to review

Test in the review app and let me know RE: test coverage 

## Link to Trello card

https://trello.com/c/T3fMitzm/3261-candidates-can-remove-information-from-references-by-accident

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
