### PR TITLE
Append custom messages to Semantic Logger

### DIFF
--- a/app/controllers/api_docs/api_docs_controller.rb
+++ b/app/controllers/api_docs/api_docs_controller.rb
@@ -1,6 +1,6 @@
 module APIDocs
   class APIDocsController < ActionController::Base
-    include LogQueryParams
+    include RequestQueryParams
     layout 'application'
 
   private
@@ -8,7 +8,7 @@ module APIDocs
     def append_info_to_payload(payload)
       super
 
-      payload.merge!(log_query_params)
+      payload.merge!(request_query_params)
     end
   end
 end

--- a/app/controllers/api_docs/api_docs_controller.rb
+++ b/app/controllers/api_docs/api_docs_controller.rb
@@ -2,5 +2,13 @@ module APIDocs
   class APIDocsController < ActionController::Base
     include LogQueryParams
     layout 'application'
+
+  private
+
+    def append_info_to_payload(payload)
+      super
+
+      payload.merge!(log_query_params)
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,4 +3,12 @@ class ApplicationController < ActionController::Base
   include EmitRequestEvents
 
   def current_user; end
+
+private
+
+  def append_info_to_payload(payload)
+    super
+
+    payload.merge!(log_query_params)
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  include LogQueryParams
+  include RequestQueryParams
   include EmitRequestEvents
 
   def current_user; end
@@ -9,6 +9,6 @@ private
   def append_info_to_payload(payload)
     super
 
-    payload.merge!(log_query_params)
+    payload.merge!(request_query_params)
   end
 end

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -9,7 +9,6 @@ module CandidateInterface
     alias_method :current_user, :current_candidate
 
     def add_identity_to_log(candidate_id = current_candidate&.id)
-      RequestLocals.store[:identity] = { candidate_id: candidate_id }
       Raven.user_context(id: "candidate_#{candidate_id}")
 
       return unless current_candidate
@@ -98,6 +97,13 @@ module CandidateInterface
 
     def strip_whitespace(params)
       StripWhitespace.from_hash(params)
+    end
+
+    def append_info_to_payload(payload)
+      super
+
+      payload.merge!({ candidate_id: current_candidate&.id })
+      payload.merge!(log_query_params)
     end
   end
 end

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -2,13 +2,13 @@ module CandidateInterface
   class CandidateInterfaceController < ApplicationController
     before_action :protect_with_basic_auth
     before_action :authenticate_candidate!
-    before_action :add_identity_to_log
+    before_action :set_user_context
     before_action :check_cookie_preferences
     layout 'application'
     alias_method :audit_user, :current_candidate
     alias_method :current_user, :current_candidate
 
-    def add_identity_to_log(candidate_id = current_candidate&.id)
+    def set_user_context(candidate_id = current_candidate&.id)
       Raven.user_context(id: "candidate_#{candidate_id}")
 
       return unless current_candidate

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -103,7 +103,7 @@ module CandidateInterface
       super
 
       payload.merge!({ candidate_id: current_candidate&.id })
-      payload.merge!(log_query_params)
+      payload.merge!(request_query_params)
     end
   end
 end

--- a/app/controllers/candidate_interface/content_controller.rb
+++ b/app/controllers/candidate_interface/content_controller.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   class ContentController < CandidateInterfaceController
     include ContentHelper
     skip_before_action :authenticate_candidate!
-    skip_before_action :add_identity_to_log
+    skip_before_action :set_user_context
 
     def accessibility
       render_content_page :accessibility

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -50,7 +50,7 @@ module CandidateInterface
         first_sign_in = candidate.last_signed_in_at.nil?
         flash[:success] = t('apply_from_find.account_created_message') if first_sign_in
         sign_in(candidate, scope: :candidate)
-        add_identity_to_log(candidate.id)
+        set_user_context(candidate.id)
         authentication_token.use!
 
         redirect_to candidate_interface_interstitial_path(path: params[:path])
@@ -86,7 +86,7 @@ module CandidateInterface
 
       if candidate
         CandidateInterface::RequestMagicLink.for_sign_in(candidate: candidate, path: authentication_token&.path)
-        add_identity_to_log candidate.id
+        set_user_context candidate.id
         redirect_to candidate_interface_check_email_sign_in_path
       else
         render 'errors/not_found', status: :forbidden

--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -17,13 +17,13 @@ module CandidateInterface
 
       if @sign_up_form.existing_candidate?
         CandidateInterface::RequestMagicLink.for_sign_in(candidate: @sign_up_form.candidate)
-        add_identity_to_log @sign_up_form.candidate.id
+        set_user_context @sign_up_form.candidate.id
         candidate = Candidate.find(@sign_up_form.candidate.id)
         candidate.update!(course_from_find_id: @sign_up_form.course_from_find_id)
         redirect_to candidate_interface_check_email_sign_up_path
       elsif @sign_up_form.save
         CandidateInterface::RequestMagicLink.for_sign_up(candidate: @sign_up_form.candidate)
-        add_identity_to_log @sign_up_form.candidate.id
+        set_user_context @sign_up_form.candidate.id
         redirect_to candidate_interface_check_email_sign_up_path
       else
         track_validation_error(@sign_up_form)

--- a/app/controllers/integrations/notify_controller.rb
+++ b/app/controllers/integrations/notify_controller.rb
@@ -55,9 +55,17 @@ module Integrations
     end
 
     def log_params
-      relevant_parameters = params.permit(:reference, :status).to_h
-      RequestLocals.store[:identity] = relevant_parameters
-      Raven.extra_context(relevant_parameters)
+      Raven.extra_context(reference_status_parameters)
+    end
+
+    def reference_status_parameters
+      params.permit(:reference, :status).to_h
+    end
+
+    def append_info_to_payload(payload)
+      super
+
+      payload.merge!(reference_status_parameters)
     end
   end
 end

--- a/app/controllers/integrations/notify_controller.rb
+++ b/app/controllers/integrations/notify_controller.rb
@@ -1,6 +1,6 @@
 module Integrations
   class NotifyController < IntegrationsController
-    before_action :log_params
+    before_action :set_context
 
     include ActionController::HttpAuthentication::Token::ControllerMethods
 
@@ -54,7 +54,7 @@ module Integrations
       )
     end
 
-    def log_params
+    def set_context
       Raven.extra_context(reference_status_parameters)
     end
 

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -12,7 +12,7 @@ module ProviderInterface
 
   class ProviderInterfaceController < ApplicationController
     before_action :authenticate_provider_user!
-    before_action :add_identity_to_log
+    before_action :set_user_context
     before_action :redirect_if_setup_required
     before_action :check_cookie_preferences
 
@@ -61,7 +61,7 @@ module ProviderInterface
       redirect_to provider_interface_sign_in_path
     end
 
-    def add_identity_to_log
+    def set_user_context
       return unless current_provider_user
 
       Raven.user_context(id: "provider_#{current_provider_user.id}")

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -64,20 +64,16 @@ module ProviderInterface
     def add_identity_to_log
       return unless current_provider_user
 
-      useful_debugging_info = {
-        dfe_sign_in_uid: current_provider_user.dfe_sign_in_uid,
-        provider_user_admin_url: support_interface_provider_user_url(current_provider_user),
-      }
-
-      if (impersonator = current_provider_user.impersonator)
-        useful_debugging_info[:dfe_sign_in_uid] = impersonator.dfe_sign_in_uid
-        useful_debugging_info[:support_user_email] = impersonator.email_address
-        useful_debugging_info[:support_user_admin_url] = support_interface_support_user_url(impersonator)
-      end
-
-      RequestLocals.store[:identity] = useful_debugging_info
       Raven.user_context(id: "provider_#{current_provider_user.id}")
       Raven.extra_context(useful_debugging_info)
+    end
+
+    def append_info_to_payload(payload)
+      super
+
+      payload.merge!(useful_debugging_info) if current_provider_user
+      payload.merge!(application_support_url) if @application_choice
+      payload.merge!(log_query_params)
     end
 
     # Set the `@application_choice` instance variable for use in views.
@@ -86,12 +82,7 @@ module ProviderInterface
         providers: current_provider_user.providers,
       ).find(params[:application_choice_id])
 
-      debugging_info = {
-        application_support_url: support_interface_application_form_url(@application_choice.application_form),
-      }
-
-      Raven.extra_context(debugging_info)
-      RequestLocals.store[:debugging_info] = debugging_info
+      Raven.extra_context(application_support_url)
     rescue ActiveRecord::RecordNotFound
       render_404
     end
@@ -137,6 +128,27 @@ module ProviderInterface
 
     def render_403
       render 'errors/forbidden', status: :forbidden
+    end
+
+    def useful_debugging_info
+      information = {
+        dfe_sign_in_uid: current_provider_user.dfe_sign_in_uid,
+        provider_user_admin_url: support_interface_provider_user_url(current_provider_user),
+      }
+
+      if (impersonator = current_provider_user.impersonator)
+        information[:dfe_sign_in_uid] = impersonator.dfe_sign_in_uid
+        information[:support_user_email] = impersonator.email_address
+        information[:support_user_admin_url] = support_interface_support_user_url(impersonator)
+      end
+
+      information
+    end
+
+    def application_support_url
+      {
+        application_support_url: support_interface_application_form_url(@application_choice.application_form),
+      }
     end
   end
 end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -65,15 +65,15 @@ module ProviderInterface
       return unless current_provider_user
 
       Raven.user_context(id: "provider_#{current_provider_user.id}")
-      Raven.extra_context(useful_debugging_info)
+      Raven.extra_context(current_user_details)
     end
 
     def append_info_to_payload(payload)
       super
 
-      payload.merge!(useful_debugging_info) if current_provider_user
+      payload.merge!(current_user_details) if current_provider_user
       payload.merge!(application_support_url) if @application_choice
-      payload.merge!(log_query_params)
+      payload.merge!(request_query_params)
     end
 
     # Set the `@application_choice` instance variable for use in views.
@@ -130,7 +130,7 @@ module ProviderInterface
       render 'errors/forbidden', status: :forbidden
     end
 
-    def useful_debugging_info
+    def current_user_details
       information = {
         dfe_sign_in_uid: current_provider_user.dfe_sign_in_uid,
         provider_user_admin_url: support_interface_provider_user_url(current_provider_user),

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -1,6 +1,6 @@
 module RefereeInterface
   class ReferenceController < ActionController::Base
-    include LogQueryParams
+    include RequestQueryParams
     before_action :set_user_context
     before_action :check_referee_has_valid_token
     before_action :set_token_param
@@ -158,7 +158,7 @@ module RefereeInterface
       super
 
       payload.merge!({ reference_id: reference.id }) if reference.present?
-      payload.merge!(log_query_params)
+      payload.merge!(request_query_params)
     end
 
     def reference

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -148,11 +148,17 @@ module RefereeInterface
     def add_identity_to_log
       return if reference.blank?
 
-      RequestLocals.store[:identity] = { reference_id: reference.id }
       Raven.extra_context(
         application_support_url: support_interface_application_form_url(reference.application_form),
         reference_id: reference.id,
       )
+    end
+
+    def append_info_to_payload(payload)
+      super
+
+      payload.merge!({ reference_id: reference.id }) if reference.present?
+      payload.merge!(log_query_params)
     end
 
     def reference

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -1,7 +1,7 @@
 module RefereeInterface
   class ReferenceController < ActionController::Base
     include LogQueryParams
-    before_action :add_identity_to_log
+    before_action :set_user_context
     before_action :check_referee_has_valid_token
     before_action :set_token_param
     before_action :show_finished_page_if_feedback_provided, except: %i[submit_feedback submit_questionnaire confirmation finish]
@@ -145,7 +145,7 @@ module RefereeInterface
       redirect_to referee_interface_finish_path(token: @token_param)
     end
 
-    def add_identity_to_log
+    def set_user_context
       return if reference.blank?
 
       Raven.extra_context(

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -40,7 +40,7 @@ module SupportInterface
       super
 
       payload.merge!({ support_user_id: current_support_user.id }) if current_support_user
-      payload.merge!(log_query_params)
+      payload.merge!(request_query_params)
     end
   end
 end

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -2,7 +2,7 @@ module SupportInterface
   class SupportInterfaceController < ApplicationController
     layout 'support_layout'
     before_action :authenticate_support_user!
-    before_action :add_identity_to_log
+    before_action :set_user_context
 
     helper_method :current_support_user, :dfe_sign_in_user
 
@@ -30,7 +30,7 @@ module SupportInterface
       redirect_to support_interface_sign_in_path
     end
 
-    def add_identity_to_log
+    def set_user_context
       return unless current_support_user
 
       Raven.user_context(id: "support_#{current_support_user.id}")

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -33,8 +33,14 @@ module SupportInterface
     def add_identity_to_log
       return unless current_support_user
 
-      RequestLocals.store[:identity] = { support_user_id: current_support_user.id }
       Raven.user_context(id: "support_#{current_support_user.id}")
+    end
+
+    def append_info_to_payload(payload)
+      super
+
+      payload.merge!({ support_user_id: current_support_user.id }) if current_support_user
+      payload.merge!(log_query_params)
     end
   end
 end

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -1,7 +1,7 @@
 module VendorAPI
   class VendorAPIController < ActionController::API
     include ActionController::HttpAuthentication::Token::ControllerMethods
-    include LogQueryParams
+    include RequestQueryParams
 
     rescue_from ActiveRecord::RecordNotFound, with: :application_not_found
     rescue_from ActionController::ParameterMissing, with: :parameter_missing
@@ -91,7 +91,7 @@ module VendorAPI
       }
 
       payload.merge!(user_info)
-      payload.merge!(log_query_params)
+      payload.merge!(request_query_params)
     end
 
     def validate_metadata!

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -9,7 +9,7 @@ module VendorAPI
 
     before_action :set_cors_headers
     before_action :require_valid_api_token!
-    before_action :add_identity_to_log
+    before_action :set_user_context
 
     def audit_user
       return unless @metadata
@@ -78,7 +78,7 @@ module VendorAPI
       @current_provider ||= @current_vendor_api_token&.provider
     end
 
-    def add_identity_to_log
+    def set_user_context
       Raven.user_context(id: "api_token_#{@current_vendor_api_token&.id}")
     end
 

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -78,15 +78,20 @@ module VendorAPI
       @current_provider ||= @current_vendor_api_token&.provider
     end
 
-    # controller-specific additional info to include in logstash logs
     def add_identity_to_log
+      Raven.user_context(id: "api_token_#{@current_vendor_api_token&.id}")
+    end
+
+    def append_info_to_payload(payload)
+      super
+
       user_info = {
         vendor_api_token_id: @current_vendor_api_token&.id,
         provider_id: current_provider&.id,
       }
 
-      RequestLocals.store[:identity] = user_info
-      Raven.user_context(id: "api_token_#{@current_vendor_api_token&.id}")
+      payload.merge!(user_info)
+      payload.merge!(log_query_params)
     end
 
     def validate_metadata!

--- a/app/lib/log_query_params.rb
+++ b/app/lib/log_query_params.rb
@@ -1,13 +1,8 @@
 module LogQueryParams
-  def self.included(base)
-    base.class_eval do
-      before_action :add_params_to_request_store
-    end
-  end
+  def log_query_params
+    parameters = request.query_parameters.except(*SANITIZED_REQUEST_PARAMS)
+    parameters.merge! request.path_parameters # e.g. /support/courses/:course_id
 
-  def add_params_to_request_store
-    params_to_log = request.query_parameters.except(*SANITIZED_REQUEST_PARAMS)
-    params_to_log.merge! request.path_parameters # e.g. /support/courses/:course_id
-    RequestLocals.store[:params] = params_to_log
+    parameters
   end
 end

--- a/app/lib/request_query_params.rb
+++ b/app/lib/request_query_params.rb
@@ -1,5 +1,5 @@
-module LogQueryParams
-  def log_query_params
+module RequestQueryParams
+  def request_query_params
     parameters = request.query_parameters.except(*SANITIZED_REQUEST_PARAMS)
     parameters.merge! request.path_parameters # e.g. /support/courses/:course_id
 

--- a/app/services/candidate_interface/sign_in_candidate.rb
+++ b/app/services/candidate_interface/sign_in_candidate.rb
@@ -21,7 +21,7 @@ module CandidateInterface
       if candidate.persisted?
         update_course_from_find(candidate)
         CandidateInterface::RequestMagicLink.for_sign_in(candidate: candidate)
-        controller.add_identity_to_log(candidate.id)
+        controller.set_user_context(candidate.id)
         redirect_to candidate_interface_check_email_sign_in_path
       elsif candidate.valid?
         AuthenticationMailer.sign_in_without_account_email(to: candidate.email_address).deliver_now

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -7,8 +7,6 @@ if Rails.env.production?
     def call(log, logger)
       super(log, logger)
       add_service_type
-      add_params
-      add_debugging_fields
       add_job_data
       hash.to_json
     end
@@ -20,21 +18,6 @@ if Rails.env.production?
       hash['environment'] = HostingEnvironment.environment_name
       hash['hosting_environment'] = HostingEnvironment.environment_name
       hash['service'] = ENV['SERVICE_TYPE']
-    end
-
-    def add_params
-      params = RequestLocals.fetch(:params) {} # block is required
-      if params
-        hash['params'] = params # add query params to the logs, if available
-      end
-    end
-
-    def add_debugging_fields
-      identity_hash = RequestLocals.fetch(:identity) {} # block is required
-      identity_hash&.each { |key, val| hash[key] = val }
-
-      debugging_info = RequestLocals.fetch(:debugging_info) {} # block is required
-      debugging_info&.each { |key, val| hash[key] = val }
     end
 
     def add_job_data

--- a/spec/support_specs/log_query_params_spec.rb
+++ b/spec/support_specs/log_query_params_spec.rb
@@ -9,28 +9,15 @@ class DummyController < ApplicationController
 end
 
 RSpec.describe LogQueryParams do
-  context 'module inclusion' do
-    it 'adds #add_params_to_request_store to the class' do
-      expect(DummyController.new).to respond_to(:add_params_to_request_store)
-    end
-
-    it 'sets before_action :add_params_to_request_store' do
-      expect(DummyController._process_action_callbacks.map(&:filter)).to \
-        include :add_params_to_request_store
-    end
-  end
-
   context 'excludes specific params' do
     let(:controller) { DummyController.new }
-    let(:logged_params) { RequestLocals.fetch(:params) { nil } }
+    let(:logged_params) { controller.log_query_params }
 
     it 'excludes the sign_in token from the logs' do
       allow(controller.request).to receive(:query_parameters).and_return(
         non_excluded: 'true',
         token: 'xyz',
       )
-
-      controller.add_params_to_request_store
 
       expect(logged_params[:non_excluded]).not_to be_nil
       expect(logged_params[:token]).to be_nil
@@ -42,8 +29,6 @@ RSpec.describe LogQueryParams do
         email_address: 'user@example.com',
       )
 
-      controller.add_params_to_request_store
-
       expect(logged_params[:email]).to be_nil
       expect(logged_params[:email_address]).to be_nil
     end
@@ -54,8 +39,6 @@ RSpec.describe LogQueryParams do
         controller: 'DummyController',
         action: 'index',
       )
-
-      controller.add_params_to_request_store
 
       expect(logged_params[:application_id]).to eq(15)
       expect(logged_params[:controller]).to eq('DummyController')

--- a/spec/support_specs/request_query_params_spec.rb
+++ b/spec/support_specs/request_query_params_spec.rb
@@ -1,17 +1,17 @@
 require 'rails_helper'
 
 class DummyController < ApplicationController
-  include LogQueryParams
+  include RequestQueryParams
   attr_accessor :request
   def initialize
     @request = Struct.new(:query_parameters, :path_parameters).new({}, {})
   end
 end
 
-RSpec.describe LogQueryParams do
+RSpec.describe RequestQueryParams do
   context 'excludes specific params' do
     let(:controller) { DummyController.new }
-    let(:logged_params) { controller.log_query_params }
+    let(:logged_params) { controller.request_query_params }
 
     it 'excludes the sign_in token from the logs' do
       allow(controller.request).to receive(:query_parameters).and_return(


### PR DESCRIPTION
## Context

In the previous logging methods, we could set and get `RequestLocal` store values. However due to the way the new logger is initialised the `RequestLocal` current store id isn't being set in the custom logger, all values retrieved are `nil`

## Changes proposed in this pull request

- Utilise [`append_infor_for_payload`](https://github.com/reidmorrison/semantic_logger/blob/6a7be665a8c6eaf5b9441d8aabc16ec47b3b0231/docs/rails.md#adding-custom-data-to-the-rails-completed-log-message) to add custom messages to append to our logs.

- Merge `params` as well, as we set those in `LogQueryParams`
- Remove methods to do this in our custom logger

## Guidance to review

Ideally this would be in the application controller, however we aren't inheriting from those, so I've kept the current pattern.
## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
