### PR TITLE
Backfill `opened_on_apply_at` for all courses using audits

### DIFF
--- a/app/services/data_migrations/backfill_opened_on_apply_at_from_audits.rb
+++ b/app/services/data_migrations/backfill_opened_on_apply_at_from_audits.rb
@@ -1,0 +1,24 @@
+module DataMigrations
+  class BackfillOpenedOnApplyAtFromAudits
+    TIMESTAMP = 20210511084457
+    MANUAL_RUN = false
+
+    def change
+      sql = <<~SET_OPENED_ON_APPLY_AT_FROM_AUDITS.squish
+        UPDATE courses c
+        SET opened_on_apply_at = courses_with_open_events.last_opened_at
+        FROM (
+          SELECT auditable_id AS course_id, max(created_at) AS last_opened_at
+          FROM audits
+          WHERE
+            auditable_type = 'Course'
+            AND audited_changes->>'open_on_apply' IN ('true', '[false, true]')
+          GROUP BY auditable_id
+        ) AS courses_with_open_events
+        WHERE c.id = courses_with_open_events.course_id
+      SET_OPENED_ON_APPLY_AT_FROM_AUDITS
+
+      ActiveRecord::Base.connection.execute(sql)
+    end
+  end
+end

--- a/app/services/data_migrations/backfill_opened_on_apply_at_from_audits.rb
+++ b/app/services/data_migrations/backfill_opened_on_apply_at_from_audits.rb
@@ -1,24 +1,40 @@
 module DataMigrations
   class BackfillOpenedOnApplyAtFromAudits
     TIMESTAMP = 20210511084457
-    MANUAL_RUN = false
+    MANUAL_RUN = true
 
     def change
-      sql = <<~SET_OPENED_ON_APPLY_AT_FROM_AUDITS.squish
+      Course
+        .where(open_on_apply: true)
+        .where('created_at < \'2020-04-01\'')
+        .update_all('opened_on_apply_at = \'2020-03-26\'')
+
+      Course.where(open_on_apply: true).in_batches(of: 50).each_with_index do |relation, batch_index|
+        most_recent_open_events_per_course =
+          Audited::Audit
+            .with(open_courses: relation)
+            .joins('INNER JOIN open_courses ON auditable_type = \'Course\' AND auditable_id = open_courses.id')
+            .where('audited_changes->>\'open_on_apply\' IN (\'true\', \'[false, true]\')')
+            .group('auditable_id')
+            .select('auditable_id AS course_id, MAX(audits.created_at) AS opened_at')
+
+        update_courses_from_audits!(
+          open_events_sql: most_recent_open_events_per_course.to_sql,
+          batch_index: batch_index,
+        )
+      end
+    end
+
+    def update_courses_from_audits!(open_events_sql:, batch_index:)
+      update_sql = <<~SET_OPENED_ON_APPLY_AT_FROM_AUDITS.squish
         UPDATE courses c
-        SET opened_on_apply_at = courses_with_open_events.last_opened_at
-        FROM (
-          SELECT auditable_id AS course_id, max(created_at) AS last_opened_at
-          FROM audits
-          WHERE
-            auditable_type = 'Course'
-            AND audited_changes->>'open_on_apply' IN ('true', '[false, true]')
-          GROUP BY auditable_id
-        ) AS courses_with_open_events
-        WHERE c.id = courses_with_open_events.course_id
+        SET opened_on_apply_at = open_events.opened_at
+        FROM (#{open_events_sql}) open_events
+        WHERE c.id = open_events.course_id
       SET_OPENED_ON_APPLY_AT_FROM_AUDITS
 
-      ActiveRecord::Base.connection.execute(sql)
+      result = ActiveRecord::Base.connection.execute(update_sql)
+      Rails.logger.info("Updating opened_on_apply_at - batch no. #{batch_index + 1}: #{result.cmd_status}")
     end
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -143,26 +143,6 @@
     {
       "warning_type": "Unscoped Find",
       "warning_code": 82,
-      "fingerprint": "77d33cae7c75a2a5315e9cae27cdcf4fcfccfca45eedb3202e75043fd5801bf0",
-      "check_name": "UnscopedFind",
-      "message": "Unscoped call to `CourseOption#find`",
-      "file": "app/controllers/provider_interface/decisions_controller.rb",
-      "line": 69,
-      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
-      "code": "CourseOption.find(params[:course_option_id])",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ProviderInterface::DecisionsController",
-        "method": "confirm_offer"
-      },
-      "user_input": "params[:course_option_id]",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Unscoped Find",
-      "warning_code": 82,
       "fingerprint": "888df680e5c3ed7e243853bd4e44a6a4d10fe664576ff034ae15da1480ca8b15",
       "check_name": "UnscopedFind",
       "message": "Unscoped call to `ProviderRelationshipPermissions#find`",
@@ -201,43 +181,23 @@
       "note": "not a user input"
     },
     {
-      "warning_type": "Unscoped Find",
-      "warning_code": 82,
-      "fingerprint": "c156deb252a43bc828b89928a0bccce9f8d8e776f8e742ed012929f3211205f4",
-      "check_name": "UnscopedFind",
-      "message": "Unscoped call to `CourseOption#find`",
-      "file": "app/controllers/provider_interface/decisions_controller.rb",
-      "line": 56,
-      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
-      "code": "CourseOption.find(params[:course_option_id])",
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "a467468b65951f8497a03f76e03c5af0d7daa801e4abaef50c94db98c1df7be1",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/data_migrations/backfill_opened_on_apply_at_from_audits.rb",
+      "line": 31,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ActiveRecord::Base.connection.execute(\"UPDATE courses c\\nSET opened_on_apply_at = open_events.opened_at\\nFROM (#{open_events_sql}) open_events\\nWHERE c.id = open_events.course_id\\n\".squish)",
       "render_path": null,
       "location": {
         "type": "method",
-        "class": "ProviderInterface::DecisionsController",
-        "method": "new_offer"
+        "class": "DataMigrations::BackfillOpenedOnApplyAtFromAudits",
+        "method": "update_courses_from_audits!"
       },
-      "user_input": "params[:course_option_id]",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Unscoped Find",
-      "warning_code": 82,
-      "fingerprint": "d910924006fc5ba7182ea2b067b9113b5ea86616fc332f0f15291fd9f34cec66",
-      "check_name": "UnscopedFind",
-      "message": "Unscoped call to `CourseOption#find`",
-      "file": "app/controllers/provider_interface/decisions_controller.rb",
-      "line": 87,
-      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
-      "code": "CourseOption.find(params[:course_option_id])",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ProviderInterface::DecisionsController",
-        "method": "create_offer"
-      },
-      "user_input": "params[:course_option_id]",
-      "confidence": "Weak",
+      "user_input": "open_events_sql",
+      "confidence": "Medium",
       "note": ""
     },
     {
@@ -301,6 +261,6 @@
       "note": ""
     }
   ],
-  "updated": "2021-04-27 10:45:46 +0100",
-  "brakeman_version": "5.0.0"
+  "updated": "2021-05-11 21:11:55 +0100",
+  "brakeman_version": "5.0.1"
 }

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillOpenedOnApplyAtFromAudits',
   'DataMigrations::PrefixNoteSubjectToMessage',
   'DataMigrations::TrimQualificationDegreeTypes',
   'DataMigrations::BackfillExportType',

--- a/spec/services/data_migrations/backfill_opened_on_apply_at_from_audits_spec.rb
+++ b/spec/services/data_migrations/backfill_opened_on_apply_at_from_audits_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillOpenedOnApplyAtFromAudits, with_audited: true do
+  it 'uses the timestamp from last open in audits' do
+    course = create(:course)
+    last_opened_at = Time.zone.local(2021, 1, 12, 12, 30, 0)
+
+    Timecop.freeze(last_opened_at - 2.minutes) { course.update(open_on_apply: true) }
+    Timecop.freeze(last_opened_at - 1.minute) { course.update(open_on_apply: false) }
+    Timecop.freeze(last_opened_at) { course.update(open_on_apply: true) }
+    Timecop.freeze(last_opened_at + 1.minute) { course.update(open_on_apply: false) }
+
+    described_class.new.change
+    expect(course.reload.opened_on_apply_at).to eq(last_opened_at)
+  end
+
+  it 'works with test courses that were open from the start' do
+    opened_at = Time.zone.local(2021, 1, 12, 12, 30, 0)
+
+    Timecop.freeze(opened_at) do
+      course = create(:course, open_on_apply: true)
+      described_class.new.change
+      expect(course.reload.opened_on_apply_at).to eq(opened_at)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Following on from: https://github.com/DFE-Digital/apply-for-teacher-training/pull/4702

## Changes proposed in this pull request

Add a data migration updating `opened_on_apply_at` for all courses that have had an 'open' event in the audits. Last such event wins in terms of timestamp.

## Guidance to review

The `open_on_apply` field is boolean, not nullable and with a default value of `false`. Therefore, there are two types of open event within the audits table:
- Course was created with `open_on_apply` set to `false` and was later opened, which results in  `"open_on_apply":[false, true]` within audited_changes
- Course was created with `open_on_apply` set to `true` (e.g. a test course). This will have `"open_on_apply":true` within audited_changes

To avoid timeouts on production, considering the size of the audits table and the lack of appropriate indexes, I have modified the query to be run in batches. We'll run this migration manually to monitor and retry, if needed.

Does 2020-03-26 make sense as a value for `opened_on_apply_at` for courses that were created before auditing was added to courses? See comments.

## Link to Trello card

https://trello.com/c/DG1rdUbK

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
