### PR TITLE
Allow Providers and Courses to be synced incrementally

### DIFF
--- a/app/controllers/support_interface/tasks_controller.rb
+++ b/app/controllers/support_interface/tasks_controller.rb
@@ -9,8 +9,8 @@ module SupportInterface
         flash[:success] = 'Scheduled job to generate test applications - this might take a while!'
         redirect_to support_interface_tasks_path
       when 'sync_providers'
-        TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async
-        flash[:success] = 'Scheduled job to sync providers - this might take a while!'
+        TeacherTrainingPublicAPI::IncrementalSyncAllProvidersAndCoursesWorker.perform_async
+        flash[:success] = 'Scheduled job to sync providers'
         redirect_to support_interface_tasks_path
       when 'recalculate_dates'
         RecalculateDates.perform_async

--- a/app/models/teacher_training_public_api/sync_check.rb
+++ b/app/models/teacher_training_public_api/sync_check.rb
@@ -14,6 +14,10 @@ module TeacherTrainingPublicAPI
       Redis.current.get(LAST_SUCCESSFUL_SYNC)
     end
 
+    def self.updated_since
+      (Time.zone.parse(last_sync) - 2.hours)
+    end
+
     def self.check
       if last_sync.nil?
         false

--- a/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
+++ b/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
@@ -1,15 +1,19 @@
 module TeacherTrainingPublicAPI
   class SyncAllProvidersAndCourses
-    def self.call(recruitment_cycle_year: ::RecruitmentCycle.current_year)
+    def self.call(recruitment_cycle_year: ::RecruitmentCycle.current_year, incremental_sync: true)
       is_last_page = false
       page_number = 0
       until is_last_page
         page_number += 1
-        response = TeacherTrainingPublicAPI::Provider
+
+        scope = TeacherTrainingPublicAPI::Provider
           .where(year: recruitment_cycle_year)
           .paginate(page: page_number, per_page: 500)
-          .all
-        sync_providers(response, recruitment_cycle_year)
+        scope = scope.where(updated_since: TeacherTrainingPublicAPI::SyncCheck.updated_since) if incremental_sync
+        response = scope.all
+
+        sync_providers(response, recruitment_cycle_year, incremental_sync: incremental_sync)
+
         is_last_page = true if response.links.links['next'].nil?
       end
 
@@ -18,12 +22,12 @@ module TeacherTrainingPublicAPI
       raise TeacherTrainingPublicAPI::SyncError
     end
 
-    def self.sync_providers(providers_from_api, recruitment_cycle_year)
+    def self.sync_providers(providers_from_api, recruitment_cycle_year, incremental_sync: true)
       providers_from_api.each do |provider_from_api|
         TeacherTrainingPublicAPI::SyncProvider.new(
           provider_from_api: provider_from_api,
           recruitment_cycle_year: recruitment_cycle_year,
-        ).call
+        ).call(incremental_sync: incremental_sync)
       end
     end
 

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -6,14 +6,18 @@ module TeacherTrainingPublicAPI
     include Sidekiq::Worker
     sidekiq_options retry: 3, queue: :low_priority
 
-    def perform(provider_id, recruitment_cycle_year, run_in_background: true)
+    def perform(provider_id, recruitment_cycle_year, incremental_sync, run_in_background: true)
       @provider = ::Provider.find(provider_id)
       @run_in_background = run_in_background
 
-      TeacherTrainingPublicAPI::Course.where(
+      scope = TeacherTrainingPublicAPI::Course.where(
         year: recruitment_cycle_year,
         provider_code: @provider.code,
-      ).paginate(per_page: 500).each do |course_from_api|
+      ).paginate(per_page: 500)
+
+      scope = scope.where(updated_since: TeacherTrainingPublicAPI::SyncCheck.updated_since) if incremental_sync
+
+      scope.each do |course_from_api|
         ActiveRecord::Base.transaction do
           create_or_update_course(course_from_api, recruitment_cycle_year)
         end

--- a/app/services/teacher_training_public_api/sync_provider.rb
+++ b/app/services/teacher_training_public_api/sync_provider.rb
@@ -5,7 +5,7 @@ module TeacherTrainingPublicAPI
       @recruitment_cycle_year = recruitment_cycle_year
     end
 
-    def call(run_in_background: true, force_sync_courses: false)
+    def call(run_in_background: true, force_sync_courses: false, incremental_sync: true)
       @force_sync_courses = force_sync_courses
 
       provider_attrs = if existing_provider
@@ -17,15 +17,15 @@ module TeacherTrainingPublicAPI
                        end
 
       provider = create_or_update_provider(provider_attrs)
-      sync_courses(run_in_background, provider)
+      sync_courses(run_in_background, provider, incremental_sync: incremental_sync)
     end
 
-    def sync_courses(run_in_background, provider)
+    def sync_courses(run_in_background, provider, incremental_sync: true)
       if sync_courses?
         if run_in_background
-          TeacherTrainingPublicAPI::SyncCourses.perform_async(provider.id, @recruitment_cycle_year)
+          TeacherTrainingPublicAPI::SyncCourses.perform_async(provider.id, @recruitment_cycle_year, incremental_sync)
         else
-          TeacherTrainingPublicAPI::SyncCourses.new.perform(provider.id, @recruitment_cycle_year, run_in_background: false)
+          TeacherTrainingPublicAPI::SyncCourses.new.perform(provider.id, @recruitment_cycle_year, incremental_sync, run_in_background: false)
         end
       end
     end

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -3,8 +3,9 @@
 <section class="app-section govuk-!-padding-top-0">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m">Sync providers</h2>
-      <p class="govuk-body">This task downloads providers, and the related entities (courses, course options etc.) from the Teacher Training API.</p>
+      <h2 class="govuk-heading-m">Incrementally sync providers</h2>
+      <p class="govuk-body">This task downloads any providers and related entities (courses, course options etc.) from the Teacher Training API that have been updated during the last 4 hours.</p>
+      <p class="govuk-body">If you wish to run a full sync outside of the regularly scheduled job (once every three days), this will need to be done via the console.</p>
     </div>
     <div class="govuk-grid-column-one-third">
       <%= govuk_button_to 'Sync providers', support_interface_run_task_path('sync_providers'), class: 'govuk-button--secondary' %>

--- a/app/workers/teacher_training_public_api/full_sync_all_providers_and_courses_worker.rb
+++ b/app/workers/teacher_training_public_api/full_sync_all_providers_and_courses_worker.rb
@@ -1,0 +1,11 @@
+module TeacherTrainingPublicAPI
+  class FullSyncAllProvidersAndCoursesWorker
+    include Sidekiq::Worker
+    sidekiq_options retry: 3, queue: :low_priority
+
+    def perform
+      SyncSubjects.new.perform
+      SyncAllProvidersAndCourses.call(incremental_sync: false)
+    end
+  end
+end

--- a/app/workers/teacher_training_public_api/incremental_sync_all_providers_and_courses_worker.rb
+++ b/app/workers/teacher_training_public_api/incremental_sync_all_providers_and_courses_worker.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingPublicAPI
-  class SyncAllProvidersAndCoursesWorker
+  class IncrementalSyncAllProvidersAndCoursesWorker
     include Sidekiq::Worker
     sidekiq_options retry: 3, queue: :low_priority
 

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -9,7 +9,7 @@ class Clock
   error_handler { |error| Raven.capture_exception(error) if defined? Raven }
 
   # Hourly jobs
-  every(1.hour, 'SyncAllFromTeacherTrainingPublicAPI', at: '**:00') { TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async }
+  every(1.hour, 'IncrementalSyncAllFromTeacherTrainingPublicAPI', at: '**:00') { TeacherTrainingPublicAPI::IncrementalSyncAllProvidersAndCoursesWorker.perform_async }
   every(1.hour, 'RejectApplicationsByDefault', at: '**:10') { RejectApplicationsByDefaultWorker.perform_async }
   every(1.hour, 'DeclineOffersByDefault', at: '**:15') { DeclineOffersByDefaultWorker.perform_async }
   every(1.hour, 'ChaseReferences', at: '**:20') { ChaseReferences.perform_async }
@@ -47,4 +47,6 @@ class Clock
   end
 
   every(1.day, 'Generate export for TAD', at: '23:59') { DataAPI::TADExport.run_daily }
+
+  every(3.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: '00:59') { TeacherTrainingPublicAPI::FullSyncAllProvidersAndCoursesWorker.perform_async }
 end

--- a/spec/services/teacher_training_public_api/sync_all_providers_and_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_all_providers_and_courses_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCourses, sidekiq: tr
 
       it 'calls sync providers 3 times' do
         stub_teacher_training_api_providers_with_multiple_pages
-        described_class.call
+        described_class.call(incremental_sync: false)
 
         expect(described_class).to have_received(:sync_providers).exactly(3).times
       end
@@ -31,9 +31,34 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCourses, sidekiq: tr
 
       it 'calls sync provider with the previous year recruitment cycle' do
         stub_teacher_training_api_providers(recruitment_cycle_year: recruitment_cycle_year)
-        described_class.call(recruitment_cycle_year: recruitment_cycle_year)
+        described_class.call(recruitment_cycle_year: recruitment_cycle_year, incremental_sync: false)
 
         expect(sync_provider).to have_received(:call)
+      end
+    end
+
+    context 'incremental sync' do
+      let(:recruitment_cycle_year) { RecruitmentCycle.current_year }
+      let(:sync_provider) { instance_double(TeacherTrainingPublicAPI::SyncProvider) }
+      let(:updated_since) { Time.zone.now - 2.hours }
+
+      before do
+        allow(TeacherTrainingPublicAPI::SyncCheck).to receive(:updated_since).and_return(updated_since)
+        allow(sync_provider).to receive(:call).with(incremental_sync: true)
+        allow(TeacherTrainingPublicAPI::SyncProvider)
+          .to receive(:new)
+            .with(provider_from_api: anything, recruitment_cycle_year: recruitment_cycle_year)
+            .and_return(sync_provider)
+        stub_teacher_training_api_providers(
+          recruitment_cycle_year: recruitment_cycle_year,
+          filter_option: { 'filter[updated_since]' => updated_since },
+        )
+      end
+
+      it "calls sync provider with incremental sync 'true'" do
+        described_class.call(incremental_sync: true)
+
+        expect(sync_provider).to have_received(:call).with(incremental_sync: true)
       end
     end
   end

--- a/spec/services/teacher_training_public_api/sync_provider_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_provider_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncProvider, sidekiq: true do
     context 'ingesting an existing provider configured to sync courses, sites and course_options' do
       it 'calls the Sync Courses job with the correct parameters' do
         existing_provider = create(:provider, sync_courses: true)
+        incremental_sync = true
         provider_from_api = fake_api_provider(id: existing_provider.id, code: existing_provider.code)
 
         allow(TeacherTrainingPublicAPI::SyncCourses).to receive(:perform_async).and_return(true)
@@ -56,7 +57,43 @@ RSpec.describe TeacherTrainingPublicAPI::SyncProvider, sidekiq: true do
         sync_job = described_class.new(provider_from_api: provider_from_api, recruitment_cycle_year: stubbed_recruitment_cycle_year)
         sync_job.call(run_in_background: true)
 
-        expect(TeacherTrainingPublicAPI::SyncCourses).to have_received(:perform_async).with(provider_from_api.id, stubbed_recruitment_cycle_year).exactly(1).time
+        expect(TeacherTrainingPublicAPI::SyncCourses).to have_received(:perform_async).with(
+          provider_from_api.id,
+          stubbed_recruitment_cycle_year,
+          incremental_sync,
+        ).exactly(1).time
+      end
+    end
+
+    context 'Incremental sync' do
+      it 'updates the providers that have changes since the last sync' do
+        existing_provider = create(:provider, sync_courses: true, name: 'Foo school')
+        provider_from_api = fake_api_provider(id: existing_provider.id, code: existing_provider.code)
+        incremental_sync = true
+
+        allow(TeacherTrainingPublicAPI::SyncCourses).to receive(:perform_async).and_return(true)
+
+        sync_job = described_class.new(
+          provider_from_api: provider_from_api,
+          recruitment_cycle_year: stubbed_recruitment_cycle_year,
+        )
+
+        sync_job.call(run_in_background: true, incremental_sync: true)
+
+        expect(TeacherTrainingPublicAPI::SyncCourses)
+          .to have_received(:perform_async)
+            .with(
+              provider_from_api.id,
+              stubbed_recruitment_cycle_year,
+              incremental_sync,
+            )
+            .exactly(1)
+            .time
+
+        existing_provider.reload
+
+        expect(Provider.count).to eq 1
+        expect(existing_provider.name).to eq('Long School')
       end
     end
   end

--- a/spec/support/test_helpers/teacher_training_public_api_helper.rb
+++ b/spec/support/test_helpers/teacher_training_public_api_helper.rb
@@ -1,11 +1,15 @@
 module TeacherTrainingPublicAPIHelper
-  def stub_teacher_training_api_providers(recruitment_cycle_year: RecruitmentCycle.current_year, specified_attributes: [])
-    stub_request(
+  def stub_teacher_training_api_providers(recruitment_cycle_year: RecruitmentCycle.current_year, specified_attributes: [], filter_option: nil)
+    scope = stub_request(
       :get,
       "#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers",
     ).with(
       query: { page: { page: 1, per_page: 500 } },
-    ).to_return(
+    )
+
+    scope = scope.with(query: filter_option) if filter_option
+
+    scope.to_return(
       status: 200,
       headers: { 'Content-Type': 'application/vnd.api+json' },
       body: build_response_body('provider_list_response.json', specified_attributes),
@@ -18,19 +22,20 @@ module TeacherTrainingPublicAPIHelper
     end
   end
 
-  def stub_teacher_training_api_provider(provider_code:, recruitment_cycle_year: RecruitmentCycle.current_year, specified_attributes: [])
+  def stub_teacher_training_api_provider(provider_code:, recruitment_cycle_year: RecruitmentCycle.current_year, specified_attributes: [], filter_option: nil)
     response_body = build_response_body('single_provider_response.json', specified_attributes)
 
     stub_teacher_training_single_api_request(
       "#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}",
       response_body,
+      filter_option: filter_option,
     )
   end
 
-  def stub_teacher_training_api_course_with_site(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, course_code:, site_code:, vacancy_status: 'full_time_vacancies', course_attributes: [], site_attributes: [])
+  def stub_teacher_training_api_course_with_site(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, course_code:, site_code:, vacancy_status: 'full_time_vacancies', course_attributes: [], site_attributes: [], filter_option: nil)
     course_attributes = course_attributes.any? ? [course_attributes.first.merge(code: course_code)] : [{ code: course_code }]
     site_attributes = site_attributes.any? ? [site_attributes.first.merge(code: site_code)] : [{ code: site_code }]
-    stub_teacher_training_api_courses(recruitment_cycle_year: recruitment_cycle_year, provider_code: provider_code, specified_attributes: course_attributes)
+    stub_teacher_training_api_courses(recruitment_cycle_year: recruitment_cycle_year, provider_code: provider_code, specified_attributes: course_attributes, filter_option: filter_option)
     stub_teacher_training_api_sites(recruitment_cycle_year: recruitment_cycle_year, provider_code: provider_code, course_code: course_code, specified_attributes: site_attributes, vacancy_status: vacancy_status)
   end
 
@@ -39,9 +44,9 @@ module TeacherTrainingPublicAPIHelper
     stub_teacher_training_single_api_request("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses/#{course_code}", response_body)
   end
 
-  def stub_teacher_training_api_courses(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, specified_attributes: [])
+  def stub_teacher_training_api_courses(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, specified_attributes: [], filter_option: nil)
     response_body = build_response_body('course_list_response.json', specified_attributes)
-    stub_teacher_training_list_api_request("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses", response_body)
+    stub_teacher_training_list_api_request("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses", response_body, filter_option: filter_option)
   end
 
   def stub_teacher_training_api_sites(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, course_code:, specified_attributes: [], vacancy_status: 'full_time_vacancies')
@@ -80,24 +85,32 @@ module TeacherTrainingPublicAPIHelper
 
 private
 
-  def stub_teacher_training_single_api_request(url, response_body)
-    stub_request(
+  def stub_teacher_training_single_api_request(url, response_body, filter_option: nil)
+    scope = stub_request(
       :get,
       url,
-    ).to_return(
+    )
+
+    scope = scope.with(query: filter_option) if filter_option
+
+    scope.to_return(
       status: 200,
       headers: { 'Content-Type': 'application/vnd.api+json' },
       body: response_body,
     )
   end
 
-  def stub_teacher_training_list_api_request(url, response_body)
-    stub_request(
+  def stub_teacher_training_list_api_request(url, response_body, filter_option: nil)
+    scope = stub_request(
       :get,
       url,
     ).with(
       query: { page: { per_page: 500 } },
-    ).to_return(
+    )
+
+    scope = scope.with(query: filter_option) if filter_option
+
+    scope.to_return(
       status: 200,
       headers: { 'Content-Type': 'application/vnd.api+json' },
       body: response_body,

--- a/spec/system/find_sync/syncing_providers_spec.rb
+++ b/spec/system/find_sync/syncing_providers_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Syncing providers', sidekiq: true do
     sync_subjects_service = instance_double(TeacherTrainingPublicAPI::SyncSubjects, perform: nil)
     allow(TeacherTrainingPublicAPI::SyncSubjects).to receive(:new).and_return(sync_subjects_service)
 
-    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async
+    TeacherTrainingPublicAPI::IncrementalSyncAllProvidersAndCoursesWorker.perform_async
   end
 
   def then_it_updates_the_course_subjects

--- a/spec/system/support_interface/provider_sync_courses_spec.rb
+++ b/spec/system/support_interface/provider_sync_courses_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'See provider course syncing' do
 
   scenario 'User switches sync courses on Provider' do
     given_i_am_a_support_user
+    and_the_last_sync_was_two_hours_ago
     and_a_provider_exists
     when_i_visit_the_providers_page
     then_i_see_that_the_provider_is_not_configured_to_sync_courses
@@ -22,6 +23,11 @@ RSpec.feature 'See provider course syncing' do
 
   def given_i_am_a_support_user
     sign_in_as_support_user
+  end
+
+  def and_the_last_sync_was_two_hours_ago
+    @updated_since = Time.zone.now - 2.hours
+    allow(TeacherTrainingPublicAPI::SyncCheck).to receive(:updated_since).and_return(@updated_since)
   end
 
   def and_a_provider_exists
@@ -61,9 +67,20 @@ RSpec.feature 'See provider course syncing' do
           name: 'ABC College',
         },
       ],
+      filter_option: { 'filter[updated_since]' => @updated_since },
     )
 
-    stub_teacher_training_api_courses(provider_code: 'ABC', specified_attributes: [{ code: 'ABC1', accredited_body_code: nil }])
+    stub_teacher_training_api_courses(
+      provider_code: 'ABC',
+      specified_attributes: [
+        {
+          code: 'ABC1',
+          accredited_body_code: nil,
+        },
+      ],
+      filter_option: { 'filter[updated_since]' => @updated_since },
+    )
+
     stub_teacher_training_api_sites(
       provider_code: 'ABC',
       course_code: 'ABC1',

--- a/spec/system/support_interface/provider_sync_courses_spec.rb
+++ b/spec/system/support_interface/provider_sync_courses_spec.rb
@@ -89,7 +89,7 @@ RSpec.feature 'See provider course syncing' do
     sync_subjects_service = instance_double(TeacherTrainingPublicAPI::SyncSubjects, perform: nil)
     allow(TeacherTrainingPublicAPI::SyncSubjects).to receive(:new).and_return(sync_subjects_service)
 
-    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async
+    TeacherTrainingPublicAPI::IncrementalSyncAllProvidersAndCoursesWorker.perform_async
 
     refresh
   end

--- a/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
+++ b/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Sync from Teacher Training API' do
 
   scenario 'a courses study mode changes between syncs' do
     given_there_is_a_full_time_course_on_the_teacher_training_api
+    and_the_last_sync_was_two_hours_ago
 
     when_sync_provider_is_called
     then_the_correct_course_option_is_created_on_apply
@@ -21,12 +22,18 @@ RSpec.describe 'Sync from Teacher Training API' do
   end
 
   def given_there_is_a_full_time_course_on_the_teacher_training_api
+    @updated_since = Time.zone.now - 2.hours
     @provider = create :provider, code: 'ABC', sync_courses: true
     stub_teacher_training_api_course_with_site(provider_code: 'ABC',
                                                course_code: 'ABC1',
                                                course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
+                                               filter_option: { 'filter[updated_since]' => @updated_since },
                                                site_code: 'A',
                                                vacancy_status: 'full_time_vacancies')
+  end
+
+  def and_the_last_sync_was_two_hours_ago
+    allow(TeacherTrainingPublicAPI::SyncCheck).to receive(:updated_since).and_return(@updated_since)
   end
 
   def when_sync_provider_is_called
@@ -52,6 +59,7 @@ RSpec.describe 'Sync from Teacher Training API' do
     stub_teacher_training_api_course_with_site(provider_code: 'ABC',
                                                course_code: 'ABC1',
                                                course_attributes: [{ accredited_body_code: nil, study_mode: 'both' }],
+                                               filter_option: { 'filter[updated_since]' => @updated_since },
                                                site_code: 'A',
                                                vacancy_status: 'both_full_time_and_part_time_vacancies')
   end
@@ -66,6 +74,7 @@ RSpec.describe 'Sync from Teacher Training API' do
     stub_teacher_training_api_course_with_site(provider_code: 'ABC',
                                                course_code: 'ABC1',
                                                course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
+                                               filter_option: { 'filter[updated_since]' => @updated_since },
                                                site_code: 'A',
                                                vacancy_status: 'full_time_vacancies')
   end

--- a/spec/system/teacher_training_public_api/sync_course_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_course_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Sync courses', sidekiq: true do
   end
 
   def when_the_sync_runs
-    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async
+    TeacherTrainingPublicAPI::IncrementalSyncAllProvidersAndCoursesWorker.perform_async
   end
 
   def then_it_creates_one_course

--- a/spec/system/teacher_training_public_api/sync_provider_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_provider_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Sync provider', sidekiq: true do
 
   scenario 'Creates and updates providers' do
     given_there_are_2_providers_in_the_teacher_training_api
+    and_the_last_sync_was_two_hours_ago
     and_one_of_the_providers_exists_already
 
     when_the_sync_runs
@@ -14,6 +15,7 @@ RSpec.describe 'Sync provider', sidekiq: true do
   end
 
   def given_there_are_2_providers_in_the_teacher_training_api
+    @updated_since = Time.zone.now - 2.hours
     stub_teacher_training_api_providers(
       specified_attributes: [
         {
@@ -25,7 +27,12 @@ RSpec.describe 'Sync provider', sidekiq: true do
           name: 'DER College',
         },
       ],
+      filter_option: { 'filter[updated_since]' => @updated_since },
     )
+  end
+
+  def and_the_last_sync_was_two_hours_ago
+    allow(TeacherTrainingPublicAPI::SyncCheck).to receive(:updated_since).and_return(@updated_since)
   end
 
   def and_one_of_the_providers_exists_already

--- a/spec/system/teacher_training_public_api/sync_provider_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_provider_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Sync provider', sidekiq: true do
     sync_subjects_service = instance_double(TeacherTrainingPublicAPI::SyncSubjects, perform: nil)
     allow(TeacherTrainingPublicAPI::SyncSubjects).to receive(:new).and_return(sync_subjects_service)
 
-    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async
+    TeacherTrainingPublicAPI::IncrementalSyncAllProvidersAndCoursesWorker.perform_async
   end
 
   def then_it_creates_one_provider

--- a/spec/system/teacher_training_public_api/sync_site_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_site_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'Sync sites', sidekiq: true do
   end
 
   def when_the_sync_runs
-    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async
+    TeacherTrainingPublicAPI::IncrementalSyncAllProvidersAndCoursesWorker.perform_async
   end
 
   def then_it_creates_one_site

--- a/spec/workers/teacher_training_public_api/full_sync_all_providers_and_courses_worker_spec.rb
+++ b/spec/workers/teacher_training_public_api/full_sync_all_providers_and_courses_worker_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe TeacherTrainingPublicAPI::FullSyncAllProvidersAndCoursesWorker do
+  describe '#perform' do
+    it 'calls the SyncSubjects service' do
+      allow(TeacherTrainingPublicAPI::SyncAllProvidersAndCourses).to receive(:call).with(incremental_sync: false)
+
+      sync_subjects_service = instance_double(TeacherTrainingPublicAPI::SyncSubjects, perform: nil)
+      allow(TeacherTrainingPublicAPI::SyncSubjects).to receive(:new).and_return(sync_subjects_service)
+
+      described_class.new.perform
+
+      expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCourses).to have_received(:call).with(incremental_sync: false)
+      expect(sync_subjects_service).to have_received(:perform)
+    end
+  end
+end

--- a/spec/workers/teacher_training_public_api/incremental_sync_all_providers_and_courses_worker_spec.rb
+++ b/spec/workers/teacher_training_public_api/incremental_sync_all_providers_and_courses_worker_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker do
+RSpec.describe TeacherTrainingPublicAPI::IncrementalSyncAllProvidersAndCoursesWorker do
   describe '#perform' do
     it 'calls the SyncSubjects service' do
       allow(TeacherTrainingPublicAPI::SyncAllProvidersAndCourses).to receive(:call)


### PR DESCRIPTION
## Context
At the moment the course sync is quite taxing on our infrastructure and it takes several minutes to run.

The new public TTAPI supports fetching only providers and courses which have changed over the API, which means we don't need to iterate over every single provider (and their courses) every time. We can also potentially sync more frequently. 

The TTAPI will be updated so that [Providers are touched whenever, a Course is updated](https://github.com/DFE-Digital/teacher-training-api/pull/1910).

## Changes proposed in this pull request

- Add the ability to sync providers and courses incrementally
- By default `incremental_sync` is set to true however, this can be set to `false` if a full sync is required.

## Guidance to review

- Fire up the TTAPI locally (pointing to this PR branch if not merged - https://github.com/DFE-Digital/teacher-training-api/pull/1910) and in the TTAPI database update an attribute on a course the current recruitment cycle (this will also `touch` the associated Provider). In your Apply `.env.development` set `TEACHER_TRAINING_API_BASE_URL=http://127.0.0.1:3001/api/public/v1`
- run `TeacherTrainingPublicAPI::IncrementalSyncAllProvidersAndCourses.call` from the console or go to the tasks dashboard in the support UI and run the sync that way
- You should see in the logs that only this Provider and Course are synced, and that the course has been updated with the new attribute value in the Apply DB

## Link to Trello card

https://trello.com/c/RsbjA4sq/3299-incrementally-sync-courses-from-the-ttapi

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
