### PR TITLE
Configure seconds value for BusinessTime end of workday

### DIFF
--- a/config/initializers/business_time.rb
+++ b/config/initializers/business_time.rb
@@ -13,4 +13,4 @@ UCAS_HOLIDAYS.each do |date|
 end
 
 BusinessTime::Config.beginning_of_workday = '0:00 am'
-BusinessTime::Config.end_of_workday = '11:59 pm'
+BusinessTime::Config.end_of_workday = '11:59:59 pm'

--- a/spec/services/set_decline_by_default_spec.rb
+++ b/spec/services/set_decline_by_default_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SetDeclineByDefault do
   describe '#call' do
     let(:application_form) { create(:completed_application_form, application_choices_count: 3) }
     let(:choices) { application_form.application_choices }
-    let(:now) { Time.zone.local(2021, 4, 22, 12, 26, 0) }
+    let(:now) { Time.zone.now }
     let(:call_service) { SetDeclineByDefault.new(application_form: application_form).call }
 
     around do |example|

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
 
   around do |example|
-    Timecop.freeze(Time.zone.local(2021, 4, 22, 12, 26, 0)) do
+    Timecop.freeze(Time.zone.now) do
       example.run
     end
   end


### PR DESCRIPTION
## Context

The end of the business day was configured as `23:59` and the `end_of_day` date helper uses the time `23:59:59.999999999`.
These tests were failing when the revised dbd date fell at the end of the week or weekend ie. after the close of business. 
This meant depending on which day the test was run we'd see a failure because the rails helper calculates the end of day just outside the business day and any further business day calculations make the equality comparison off by one day.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->

Amend the `BusinessTime::Config.end_of_workday` value to include seconds. (There's no millisecond value stored against `BusinessTime::ParsedTime`). This fixed the `SetDeclineByDefault` tests which were relying a modified dbd date.

## Guidance to review

It's still possible for us to introduce tests which will fail in a similar way if we compare date time instances including millisecond values to instances of `BusinessTime::ParsedTime`. 
We usually call `end_of_day` in conjunction with `business_days` which means we get a millisecond value which works fine eg. https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/services/time_limit_calculator.rb#L23 or as in `spec/services/set_decline_by_default_spec.rb` [we disregard the millisecond value when making date time comparisons](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/spec/services/set_decline_by_default_spec.rb#L17).

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/1ATaBJJn/3656-investigate-causes-of-flakey-tests-due-to-time
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
