### PR TITLE
add uuid field to sync api method

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -28,9 +28,10 @@ module TeacherTrainingPublicAPI
       open_required = false
 
       course = provider.courses.find_or_create_by(
-        code: course_from_api.code,
+        uuid: course_from_api.uuid,
         recruitment_cycle_year: recruitment_cycle_year,
       ) do |new_course|
+        new_course.code = course_from_api.code
         open_required =
           HostingEnvironment.sandbox_mode? || new_course.in_previous_cycle&.open_on_apply
 
@@ -54,6 +55,7 @@ module TeacherTrainingPublicAPI
 
     def assign_course_attributes(course, course_from_api, recruitment_cycle_year)
       course.uuid = course_from_api.uuid
+      course.code = course_from_api.code
       course.name = course_from_api.name
       course.level = course_from_api.level
       course.study_mode = study_mode(course_from_api)

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -181,11 +181,11 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
       end
 
       it 'resets the accredited provider if it is no longer specified' do
-        course = create(:course, accredited_provider: create(:provider), code: 'ABC1', provider: create(:provider, code: 'ABC'))
+        course = create(:course, uuid: '9875793b-83b6-4a6f-a3d7-4775e76a9ae7', accredited_provider: create(:provider), code: 'ABC1', provider: create(:provider, code: 'ABC'))
 
         stub_teacher_training_api_course_with_site(provider_code: 'ABC',
                                                    course_code: 'ABC1',
-                                                   course_attributes: [{ accredited_body_code: nil }],
+                                                   course_attributes: [{ accredited_body_code: nil, uuid: '9875793b-83b6-4a6f-a3d7-4775e76a9ae7' }],
                                                    site_code: 'A')
 
         described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
@@ -355,7 +355,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
         stub_teacher_training_api_course_with_site(provider_code: 'ABC',
                                                    course_code: 'ABC1',
                                                    recruitment_cycle_year: 2021,
-                                                   course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
+                                                   course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time', uuid: SecureRandom.uuid }],
                                                    site_code: 'A',
                                                    vacancy_status: 'full_time_vacancies')
 

--- a/spec/system/find_sync/syncing_providers_spec.rb
+++ b/spec/system/find_sync/syncing_providers_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe 'Syncing providers', sidekiq: true do
   end
 
   def given_there_is_an_existing_provider_and_course_in_apply
+    @course_uuid = SecureRandom.uuid
     @existing_provider = create :provider, code: 'ABC', sync_courses: true
-    create :course, code: 'ABC1', provider: @existing_provider, subjects: %w[]
+    create :course, code: 'ABC1', provider: @existing_provider, subjects: %w[], uuid: @course_uuid
   end
 
   def and_there_is_a_provider_with_a_course_in_find
@@ -27,7 +28,7 @@ RSpec.describe 'Syncing providers', sidekiq: true do
 
     stub_teacher_training_api_courses(
       provider_code: 'ABC',
-      specified_attributes: [{ code: 'ABC1', accredited_body_code: nil, subject_codes: %w[08] }],
+      specified_attributes: [{ code: 'ABC1', accredited_body_code: nil, subject_codes: %w[08], uuid: @course_uuid }],
     )
     stub_teacher_training_api_sites(
       provider_code: 'ABC',

--- a/spec/system/teacher_training_public_api/sync_course_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_course_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'Sync courses', sidekiq: true do
   def given_there_are_2_courses_in_the_teacher_training_api
     sync_subjects_service = instance_double(TeacherTrainingPublicAPI::SyncSubjects, perform: nil)
     allow(TeacherTrainingPublicAPI::SyncSubjects).to receive(:new).and_return(sync_subjects_service)
+    @course_uuid = SecureRandom.uuid
 
     stub_teacher_training_api_providers(
       specified_attributes: [
@@ -44,6 +45,7 @@ RSpec.describe 'Sync courses', sidekiq: true do
         state: 'published',
         qualifications: %w[qts pgce],
         accredited_body_code: '',
+        uuid: @course_uuid,
       },
                              {
                                code: 'ABC2',
@@ -76,7 +78,7 @@ RSpec.describe 'Sync courses', sidekiq: true do
   def and_one_of_the_courses_exists_already
     provider = create :provider, code: 'ABC', sync_courses: true
     create :provider, code: 'DEF', sync_courses: true
-    create(:course, code: 'ABC1', provider: provider, name: 'Secondary')
+    create(:course, code: 'ABC1', provider: provider, name: 'Secondary', uuid: @course_uuid)
   end
 
   def when_the_sync_runs

--- a/spec/system/teacher_training_public_api/sync_site_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_site_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'Sync sites', sidekiq: true do
   end
 
   def given_there_are_2_sites_in_the_teacher_training_api
+    @course_uuid = SecureRandom.uuid
     sync_subjects_service = instance_double(TeacherTrainingPublicAPI::SyncSubjects, perform: nil)
     allow(TeacherTrainingPublicAPI::SyncSubjects).to receive(:new).and_return(sync_subjects_service)
 
@@ -34,6 +35,7 @@ RSpec.describe 'Sync sites', sidekiq: true do
         code: 'ABC1',
         accredited_body_code: 'ABC',
         study_mode: 'both',
+        uuid: @course_uuid,
       }],
     )
     stub_teacher_training_api_sites(
@@ -60,7 +62,7 @@ RSpec.describe 'Sync sites', sidekiq: true do
 
   def and_one_of_the_sites_exists_already
     provider = create :provider, code: 'ABC', sync_courses: true
-    create(:course, code: 'ABC1', provider: provider)
+    create(:course, code: 'ABC1', provider: provider, uuid: @course_uuid)
     create(:site, code: 'A', provider: provider, name: 'Hogwarts School of Witchcraft and Wizardry')
   end
 


### PR DESCRIPTION
## Context

In order to ensure we never duplicate courses from publish over to apply a UUID was added to each course. This PR will ensure that the UUID is what the sync checks against for ensuring uniqueness.

## Changes proposed in this pull request

Alter the sync courses service to find or create by uuid rather than code.


## Link to Trello card

https://trello.com/c/MFIi8aj1/3628-ensure-courses-we-get-from-ttapi-are-unique

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
