### PR TITLE
Add an expanded Qualifications export

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -30,6 +30,7 @@ class FeatureFlag
     [:configurable_provider_notifications, 'Providers can manage individual email notifications', 'Aga Dufrat'],
     [:content_security_policy, 'Enables the content security policy declared in `config/initializers/content_security_policy.rb`', 'Steve Hook'],
     [:support_user_reinstate_offer, 'Allows a support users to reinstate a declined course choice offer', 'James Glenn'],
+    [:expanded_quals_export, 'Rework the Qualifications export to contain all candidate qualifications', 'Malcolm Baig'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/services/support_interface/expanded_qualifications_export.rb
+++ b/app/services/support_interface/expanded_qualifications_export.rb
@@ -2,7 +2,7 @@ module SupportInterface
   class ExpandedQualificationsExport
     def data_for_export
       application_choices = ApplicationChoice
-        .select(:id, :application_form_id, :status, :course_option_id, :rejection_reason, :structured_rejection_reasons)
+        .select(:id, :application_form_id, :status, :course_option_id)
         .includes(:course_option, :course, :provider, application_form: [:application_qualifications])
         .order(:application_form_id)
 
@@ -22,7 +22,6 @@ module SupportInterface
             recruitment_cycle_year: application_form.recruitment_cycle_year,
 
             choice_status: application_choice.status,
-            rejection_reason: application_choice.structured_rejection_reasons || application_choice.rejection_reason,
             course_code: course.code,
             provider_code: course.provider.code,
 

--- a/app/services/support_interface/expanded_qualifications_export.rb
+++ b/app/services/support_interface/expanded_qualifications_export.rb
@@ -33,10 +33,10 @@ module SupportInterface
             predicted_grade: qualification.predicted_grade,
             grade: qualification.grade,
             constituent_grades: qualification.constituent_grades,
-            international: qualification.international,
+            international_qualification: qualification.international,
             non_uk_qualification_type: qualification.non_uk_qualification_type,
-            institution_name: qualification.institution_name,
-            institution_country: qualification.institution_country,
+            qualification_institution_name: qualification.institution_name,
+            qualification_institution_country: qualification.institution_country,
             comparable_uk_degree: qualification.comparable_uk_degree,
             comparable_uk_qualification: qualification.comparable_uk_qualification,
           }

--- a/app/services/support_interface/expanded_qualifications_export.rb
+++ b/app/services/support_interface/expanded_qualifications_export.rb
@@ -33,13 +33,13 @@ module SupportInterface
             subject: qualification.subject,
             predicted_grade: qualification.predicted_grade,
             grade: qualification.grade,
+            constituent_grades: qualification.constituent_grades,
+            international: qualification.international,
+            non_uk_qualification_type: qualification.non_uk_qualification_type,
             institution_name: qualification.institution_name,
             institution_country: qualification.institution_country,
-            international: qualification.international,
             comparable_uk_degree: qualification.comparable_uk_degree,
-            non_uk_qualification_type: qualification.non_uk_qualification_type,
             comparable_uk_qualification: qualification.comparable_uk_qualification,
-            constituent_grades: qualification.constituent_grades,
           }
         end
       end

--- a/app/services/support_interface/expanded_qualifications_export.rb
+++ b/app/services/support_interface/expanded_qualifications_export.rb
@@ -1,0 +1,48 @@
+module SupportInterface
+  class ExpandedQualificationsExport
+    def data_for_export
+      application_choices = ApplicationChoice
+        .select(:id, :application_form_id, :status, :course_option_id, :rejection_reason, :structured_rejection_reasons)
+        .includes(:course_option, :course, :provider, application_form: [:application_qualifications])
+        .order(:application_form_id)
+
+      application_choices.find_each(batch_size: 100).lazy.flat_map do |application_choice|
+        application_form = application_choice.application_form
+        course = application_choice.course
+        qualifications = application_form.application_qualifications
+
+        qualifications.map do |qualification|
+          {
+            application_form_id: application_form.id,
+            choice_id: application_choice.id,
+            qualification_id: qualification.id,
+            candidate_id: application_form.candidate_id,
+            support_reference: application_form.support_reference,
+            phase: application_form.phase,
+            recruitment_cycle_year: application_form.recruitment_cycle_year,
+
+            choice_status: application_choice.status,
+            rejection_reason: application_choice.structured_rejection_reasons || application_choice.rejection_reason,
+            course_code: course.code,
+            provider_code: course.provider.code,
+
+            level: qualification.level,
+            qualification_type: qualification.qualification_type,
+            other_uk_qualification_type: qualification.other_uk_qualification_type,
+            award_year: qualification.award_year,
+            subject: qualification.subject,
+            predicted_grade: qualification.predicted_grade,
+            grade: qualification.grade,
+            institution_name: qualification.institution_name,
+            institution_country: qualification.institution_country,
+            international: qualification.international,
+            comparable_uk_degree: qualification.comparable_uk_degree,
+            non_uk_qualification_type: qualification.non_uk_qualification_type,
+            comparable_uk_qualification: qualification.comparable_uk_qualification,
+            constituent_grades: qualification.constituent_grades,
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/support_interface/expanded_qualifications_export.rb
+++ b/app/services/support_interface/expanded_qualifications_export.rb
@@ -14,7 +14,6 @@ module SupportInterface
         qualifications.map do |qualification|
           {
             application_form_id: application_form.id,
-            choice_id: application_choice.id,
             qualification_id: qualification.id,
             candidate_id: application_form.candidate_id,
             support_reference: application_form.support_reference,

--- a/spec/services/support_interface/expanded_qualifications_export_spec.rb
+++ b/spec/services/support_interface/expanded_qualifications_export_spec.rb
@@ -48,10 +48,10 @@ RSpec.describe SupportInterface::ExpandedQualificationsExport do
         predicted_grade: qualification.predicted_grade,
         grade: qualification.grade,
         constituent_grades: qualification.constituent_grades,
-        international: qualification.international,
+        international_qualification: qualification.international,
         non_uk_qualification_type: qualification.non_uk_qualification_type,
-        institution_name: qualification.institution_name,
-        institution_country: qualification.institution_country,
+        qualification_institution_name: qualification.institution_name,
+        qualification_institution_country: qualification.institution_country,
         comparable_uk_degree: qualification.comparable_uk_degree,
         comparable_uk_qualification: qualification.comparable_uk_qualification,
       }

--- a/spec/services/support_interface/expanded_qualifications_export_spec.rb
+++ b/spec/services/support_interface/expanded_qualifications_export_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ExpandedQualificationsExport do
+  include CourseOptionHelpers
+
+  describe '#data_for_export' do
+    it 'returns an array of hashes with details about all qualifications and their related course choices' do
+      candidate = create(:candidate)
+      application_form = create(:completed_application_form, candidate: candidate)
+      course_option_one = course_option_for_provider_code(provider_code: 'AA1')
+      course_option_two = course_option_for_provider_code(provider_code: 'ZZ7')
+      choice_one = create(:application_choice, course_option: course_option_one, application_form: application_form)
+      choice_two = create(:application_choice, course_option: course_option_two, application_form: application_form)
+      qualification_one = create(
+        :gcse_qualification, application_form: application_form, subject: 'maths', grade: 'A'
+      )
+      qualification_two = create(
+        :degree_qualification, application_form: application_form, subject: 'english', qualification_type: 'BA', grade: '2:1'
+      )
+
+      expect(described_class.new.data_for_export).to contain_exactly(
+        row_data(application_form, choice_one, qualification_one),
+        row_data(application_form, choice_one, qualification_two),
+        row_data(application_form, choice_two, qualification_one),
+        row_data(application_form, choice_two, qualification_two),
+      )
+    end
+
+    def row_data(application_form, choice, qualification)
+      {
+        application_form_id: application_form.id,
+        choice_id: choice.id,
+        qualification_id: qualification.id,
+        candidate_id: application_form.candidate.id,
+        support_reference: application_form.support_reference,
+        phase: application_form.phase,
+        recruitment_cycle_year: application_form.recruitment_cycle_year,
+
+        choice_status: choice.status,
+        rejection_reason: choice.structured_rejection_reasons || choice.rejection_reason,
+        course_code: choice.course.code,
+        provider_code: choice.course.provider.code,
+
+        level: qualification.level,
+        qualification_type: qualification.qualification_type,
+        other_uk_qualification_type: qualification.other_uk_qualification_type,
+        award_year: qualification.award_year,
+        subject: qualification.subject,
+        predicted_grade: qualification.predicted_grade,
+        grade: qualification.grade,
+        institution_name: qualification.institution_name,
+        institution_country: qualification.institution_country,
+        international: qualification.international,
+        comparable_uk_degree: qualification.comparable_uk_degree,
+        non_uk_qualification_type: qualification.non_uk_qualification_type,
+        comparable_uk_qualification: qualification.comparable_uk_qualification,
+        constituent_grades: qualification.constituent_grades,
+      }
+    end
+  end
+end

--- a/spec/services/support_interface/expanded_qualifications_export_spec.rb
+++ b/spec/services/support_interface/expanded_qualifications_export_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe SupportInterface::ExpandedQualificationsExport do
         recruitment_cycle_year: application_form.recruitment_cycle_year,
 
         choice_status: choice.status,
-        rejection_reason: choice.structured_rejection_reasons || choice.rejection_reason,
         course_code: choice.course.code,
         provider_code: choice.course.provider.code,
 

--- a/spec/services/support_interface/expanded_qualifications_export_spec.rb
+++ b/spec/services/support_interface/expanded_qualifications_export_spec.rb
@@ -48,13 +48,13 @@ RSpec.describe SupportInterface::ExpandedQualificationsExport do
         subject: qualification.subject,
         predicted_grade: qualification.predicted_grade,
         grade: qualification.grade,
+        constituent_grades: qualification.constituent_grades,
+        international: qualification.international,
+        non_uk_qualification_type: qualification.non_uk_qualification_type,
         institution_name: qualification.institution_name,
         institution_country: qualification.institution_country,
-        international: qualification.international,
         comparable_uk_degree: qualification.comparable_uk_degree,
-        non_uk_qualification_type: qualification.non_uk_qualification_type,
         comparable_uk_qualification: qualification.comparable_uk_qualification,
-        constituent_grades: qualification.constituent_grades,
       }
     end
   end

--- a/spec/services/support_interface/expanded_qualifications_export_spec.rb
+++ b/spec/services/support_interface/expanded_qualifications_export_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe SupportInterface::ExpandedQualificationsExport do
     def row_data(application_form, choice, qualification)
       {
         application_form_id: application_form.id,
-        choice_id: choice.id,
         qualification_id: qualification.id,
         candidate_id: application_form.candidate.id,
         support_reference: application_form.support_reference,

--- a/spec/services/support_interface/qualifications_export_spec.rb
+++ b/spec/services/support_interface/qualifications_export_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe SupportInterface::QualificationsExport do
   include CourseOptionHelpers
 
+  before { FeatureFlag.deactivate(:expanded_quals_export) }
+
   describe 'documentation' do
     before do
       application_form = create(:completed_application_form, candidate: create(:candidate))


### PR DESCRIPTION
## Context
The Qualifications export currently only contains a subset of each
candidate's qualifications. It needs to cover all qualifications in the
system so that a more complete analysis can take place.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Add a new export class that:
- Contains details about every qualification for any given candidate
- Maintains the relationship between application form and course choices
  that was present in the previous export as well. Note that this means
  that each set of qualification data per candidate is repeated in the
  data table for every course choice.
## Guidance to review

- Switch on `expanded_quals_export` feature flag
- Download Qualifications export from support interface
- Review export

This PR will be followed by a separate documentation update for the export once Milan/Mike have had a chance to review and any changes are agreed.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/JxXFJ5KG
## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
