### PR TITLE
Use created_at for `opened_on_apply_at` if audits are missing

### DIFF
--- a/app/services/data_migrations/backfill_opened_on_apply_at_from_audits.rb
+++ b/app/services/data_migrations/backfill_opened_on_apply_at_from_audits.rb
@@ -4,11 +4,6 @@ module DataMigrations
     MANUAL_RUN = true
 
     def change
-      Course
-        .where(open_on_apply: true)
-        .where('created_at < \'2020-04-01\'')
-        .update_all('opened_on_apply_at = \'2020-03-26\'')
-
       Course.where(open_on_apply: true).in_batches(of: 50).each_with_index do |relation, batch_index|
         most_recent_open_events_per_course =
           Audited::Audit
@@ -23,6 +18,11 @@ module DataMigrations
           batch_index: batch_index,
         )
       end
+
+      Course
+        .where(open_on_apply: true)
+        .where(opened_on_apply_at: nil)
+        .update_all('opened_on_apply_at = created_at')
     end
 
     def update_courses_from_audits!(open_events_sql:, batch_index:)

--- a/spec/services/data_migrations/backfill_opened_on_apply_at_from_audits_spec.rb
+++ b/spec/services/data_migrations/backfill_opened_on_apply_at_from_audits_spec.rb
@@ -1,13 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe DataMigrations::BackfillOpenedOnApplyAtFromAudits, with_audited: true do
-  it 'hardcodes the timestamp to 2020-03-26 for courses predating audits' do
-    course = create(:course, open_on_apply: true, created_at: Time.zone.local(2020, 2, 10, 12, 0, 0))
-    course.audits.destroy_all
-    described_class.new.change
-    expect(course.reload.opened_on_apply_at).to eq(Time.zone.local(2020, 3, 26, 0, 0, 0))
-  end
-
   it 'uses the timestamp from last open in audits' do
     course = create(:course)
     last_opened_at = Time.zone.local(2021, 1, 12, 12, 30, 0)
@@ -43,5 +36,13 @@ RSpec.describe DataMigrations::BackfillOpenedOnApplyAtFromAudits, with_audited: 
       described_class.new.change
       expect(course.reload.opened_on_apply_at).to eq(opened_at)
     end
+  end
+
+  it 'uses created_at for courses lacking open_on_apply audits' do
+    created_at = Time.zone.local(2020, 2, 10, 12, 0, 0)
+    course = create(:course, open_on_apply: true, created_at: created_at)
+    course.audits.destroy_all
+    described_class.new.change
+    expect(course.reload.opened_on_apply_at).to eq(created_at)
   end
 end


### PR DESCRIPTION
## Context

On QA, there seem to be courses with created_at after 1st April 2020 all the way to September 2020 that are open on Apply but lack `open_on_apply` audits. We have decided to use the course `created_at` as `open_on_apply_at` in these cases.

Modifies https://github.com/DFE-Digital/apply-for-teacher-training/pull/4708

## Changes proposed in this pull request

At the end of the data migration, set any remaining `nil` values to the value of `created_at`. Drop the original hardcoding.

## Guidance to review

Migration hasn't been run on sandbox and production yet. We'll fix QA manually.

## Link to Trello card

https://trello.com/c/DG1rdUbK

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
