### PR TITLE
Extend work history and unpaid experience to include additional details

### DIFF
--- a/app/components/work_history_and_unpaid_experience_component.html.erb
+++ b/app/components/work_history_and_unpaid_experience_component.html.erb
@@ -1,6 +1,12 @@
 <section class="app-section govuk-!-width-two-thirds" data-qa="work-history-and-unpaid-experience">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="work-history">Work history and unpaid experience</h2>
 
+  <%= render SummaryListComponent.new(rows: rows) %>
+
+  <% if subtitle %>
+    <h3 class="govuk-heading-m" id="work-history-subheader"><%= subtitle %></h3>
+  <% end %>
+
   <% history.each do |item| %>
     <%= render WorkHistoryAndUnpaidExperienceItemComponent.new(item: item) %>
   <% end %>

--- a/app/components/work_history_and_unpaid_experience_component.rb
+++ b/app/components/work_history_and_unpaid_experience_component.rb
@@ -1,5 +1,45 @@
 class WorkHistoryAndUnpaidExperienceComponent < WorkHistoryComponent
-  def history
-    @history ||= WorkHistoryWithBreaks.new(application_form, include_unpaid_experience: true).timeline
+  def initialize(application_form:)
+    @application_form = application_form
+    @work_history_with_breaks ||= WorkHistoryWithBreaks.new(application_form, include_unpaid_experience: true)
+  end
+
+  def subtitle
+    if has_work_history? && !has_unpaid_experience?
+      'Details of work history'
+    elsif !has_work_history? && has_unpaid_experience?
+      'Details of unpaid experience'
+    end
+  end
+
+private
+
+  def rows
+    {
+      'Do you have any work history' => work_history_text,
+      'Do you have any unpaid experience' => unpaid_experience_text,
+    }
+  end
+
+  def work_history_text
+    if !has_work_history? && full_time_education?
+      ' No, I have always been in full time education'
+    else
+      has_work_history? ? 'Yes' : 'No'
+    end
+  end
+
+  def unpaid_experience_text
+    has_unpaid_experience? ? 'Yes' : 'No'
+  end
+
+  delegate :full_time_education?, to: :application_form
+
+  def has_work_history?
+    work_history_with_breaks.work_history.any?
+  end
+
+  def has_unpaid_experience?
+    work_history_with_breaks.unpaid_work.any?
   end
 end

--- a/app/components/work_history_component.rb
+++ b/app/components/work_history_component.rb
@@ -2,10 +2,11 @@
 class WorkHistoryComponent < ViewComponent::Base
   def initialize(application_form:)
     @application_form = application_form
+    @work_history_with_breaks ||= WorkHistoryWithBreaks.new(application_form)
   end
 
   def history
-    @history ||= WorkHistoryWithBreaks.new(application_form).timeline
+    @history ||= work_history_with_breaks.timeline
   end
 
   def render?
@@ -14,5 +15,5 @@ class WorkHistoryComponent < ViewComponent::Base
 
 private
 
-  attr_accessor :application_form
+  attr_accessor :application_form, :work_history_with_breaks
 end

--- a/spec/components/work_history_and_unpaid_experience_component_spec.rb
+++ b/spec/components/work_history_and_unpaid_experience_component_spec.rb
@@ -1,60 +1,67 @@
 require 'rails_helper'
 
-RSpec.describe WorkHistoryAndUnpaidExperienceComponent do
-  let(:application_form) { instance_double(ApplicationForm, submitted_at: 2.months.ago) }
+RSpec.describe WorkHistoryAndUnpaidExperienceComponent, type: :component do
+  let(:application_form) do
+    instance_double(ApplicationForm,
+                    submitted_at: 2.months.ago,
+                    full_time_education?: full_time_education,
+                    application_work_experiences: work_experiences,
+                    application_volunteering_experiences: volunteering_experiences,
+                    application_work_history_breaks: breaks)
+  end
+
+  let(:work_experiences) do
+    [build(:application_work_experience,
+           start_date: 6.years.ago,
+           end_date: 2.years.ago,
+           role: 'Sheep herder',
+           commitment: 'full_time',
+           details: 'Livestock management'),
+     build(:application_work_experience,
+           start_date: 2.months.ago,
+           end_date: nil,
+           role: 'Pig herder',
+           commitment: 'part_time',
+           details: 'Livestock management')]
+  end
+
+  let(:volunteering_experiences) do
+    [build(:application_volunteering_experience,
+           role: 'Designer',
+           working_pattern: 'Part time',
+           details: 'Designing things for a charity',
+           start_date: 7.years.ago,
+           end_date: nil)]
+  end
+  let(:breaks) { [] }
+  let(:full_time_education) { false }
 
   before do
     FeatureFlag.activate(:restructured_work_history)
   end
 
   context 'with an empty history' do
-    it 'renders nothing' do
-      allow(application_form).to receive(:application_work_experiences).and_return([])
-      allow(application_form).to receive(:application_work_history_breaks).and_return([])
-      allow(application_form).to receive(:application_volunteering_experiences).and_return([])
+    let(:work_experiences) { [] }
+    let(:volunteering_experiences) { [] }
 
+    it 'renders nothing' do
       rendered = render_inline(described_class.new(application_form: application_form))
+
       expect(rendered.text).to eq ''
     end
   end
 
   context 'with full work experience including unpaid experience' do
-    it 'renders all experience' do
-      breaks = [
-        build(:application_work_history_break,
-              start_date: 8.years.ago,
-              end_date: 6.years.ago,
-              reason: 'Raising my kids'),
-      ]
-      volunteering_xperiences = [
-        build(:application_volunteering_experience,
-              role: 'Designer',
-              working_pattern: 'Part time',
-              details: 'Designing things for a charity',
-              start_date: 7.years.ago,
-              end_date: nil),
-      ]
-      experiences = [
-        build(:application_work_experience,
-              start_date: 6.years.ago,
-              end_date: 2.years.ago,
-              role: 'Sheep herder',
-              commitment: 'full_time',
-              working_pattern: '',
-              details: 'Livestock management'),
-        build(:application_work_experience,
-              start_date: 2.months.ago,
-              end_date: nil,
-              role: 'Pig herder',
-              commitment: 'part_time',
-              working_pattern: '',
-              details: 'Livestock management'),
-      ]
-      allow(application_form).to receive(:application_work_experiences).and_return(experiences)
-      allow(application_form).to receive(:application_work_history_breaks).and_return(breaks)
-      allow(application_form).to receive(:application_volunteering_experiences).and_return(volunteering_xperiences)
+    let(:breaks) do
+      [build(:application_work_history_break,
+             start_date: 8.years.ago,
+             end_date: 6.years.ago,
+             reason: 'Raising my kids')]
+    end
 
+    it 'renders all experience' do
       rendered = render_inline(described_class.new(application_form: application_form))
+
       expect(rendered.text).to include 'Break (2 years)'
       expect(rendered.text).to include 'Raising my kids'
       expect(rendered.text).to include "#{7.years.ago.to_s(:month_and_year)} - Present"
@@ -65,6 +72,86 @@ RSpec.describe WorkHistoryAndUnpaidExperienceComponent do
       expect(rendered.text).to include 'Unexplained break (1 year and 10 months)'
       expect(rendered.text).to include "#{2.months.ago.to_s(:month_and_year)} - Present"
       expect(rendered.text).to include 'Pig herder - Part time'
+    end
+  end
+
+  context 'in full time education with unpaid experience' do
+    subject! { render_inline(described_class.new(application_form: application_form)) }
+
+    let(:work_experiences) { [] }
+    let(:full_time_education) { true }
+
+    it 'renders the correct details' do
+      expect(page).to have_css('dl', class: 'govuk-summary-list') do |summary|
+        expect(summary).to have_text('No, I have always been in full time education')
+        expect(summary).to have_text('Yes')
+      end
+
+      expect(page).to have_css('h3#work-history-subheader', class: 'govuk-heading-m') do |subheader|
+        expect(subheader).to have_text('Details of unpaid experience')
+      end
+
+      expect(page).to have_css('section', class: 'app-section') do |section|
+        expect(section).to have_text 'Designer - Part time (unpaid)'
+        expect(section).to have_text 'Designing things for a charity'
+        expect(section).to have_text "#{7.years.ago.to_s(:month_and_year)} - Present"
+      end
+    end
+  end
+
+  context 'with both work history and unpaid experience' do
+    subject! { render_inline(described_class.new(application_form: application_form)) }
+
+    it 'renders the correct details' do
+      expect(page).to have_css('dl', class: 'govuk-summary-list') do |summary|
+        expect(summary).to have_css('dd', class: 'govuk-summary-list__value', text: 'Yes')
+        expect(summary).not_to have_css('dd', class: 'govuk-summary-list__value', text: 'No')
+      end
+
+      expect(page).not_to have_css('h3#work-history-subheader', class: 'govuk-heading-m')
+
+      expect(page).to have_css('section', class: 'app-section') do |section|
+        expect(section).to have_text 'Livestock management'
+        expect(section).to have_text 'Pig herder'
+        expect(section).to have_text "#{6.years.ago.to_s(:month_and_year)} - #{2.years.ago.to_s(:month_and_year)}"
+
+        expect(section).to have_text 'Livestock management'
+        expect(section).to have_text 'Sheep herder'
+        expect(section).to have_text "#{2.months.ago.to_s(:month_and_year)} - Present"
+      end
+
+      expect(page).to have_css('section', class: 'app-section') do |section|
+        expect(section).to have_text 'Designer - Part time (unpaid)'
+        expect(section).to have_text 'Designing things for a charity'
+        expect(section).to have_text "#{7.years.ago.to_s(:month_and_year)} - Present"
+      end
+    end
+  end
+
+  context 'with only work history' do
+    subject! { render_inline(described_class.new(application_form: application_form)) }
+
+    let(:volunteering_experiences) { [] }
+
+    it 'renders the correct details' do
+      expect(page).to have_css('dl', class: 'govuk-summary-list') do |summary|
+        expect(summary).to have_css('dd', class: 'govuk-summary-list__value', text: 'Yes')
+        expect(summary).to have_css('dd', class: 'govuk-summary-list__value', text: 'No')
+      end
+
+      expect(page).to have_css('h3#work-history-subheader', class: 'govuk-heading-m') do |subheader|
+        expect(subheader).to have_text('Details of work history')
+      end
+
+      expect(page).to have_css('section', class: 'app-section') do |section|
+        expect(section).to have_text 'Livestock management'
+        expect(section).to have_text 'Pig herder'
+        expect(section).to have_text "#{6.years.ago.to_s(:month_and_year)} - #{2.years.ago.to_s(:month_and_year)}"
+
+        expect(section).to have_text 'Livestock management'
+        expect(section).to have_text 'Sheep herder'
+        expect(section).to have_text "#{2.months.ago.to_s(:month_and_year)} - Present"
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

Update provider work history view

## Guidance to review
Enable the `restructed_work_history` flag

Create candiate applications with the following details and test each scenario. I should reflect the relevant screenshot that you can find attached to the trello card.

- setting `work_history_status` to `full_time_education` and no paid work
- paid work only
- unpaid work only
- both paid and unpaid work

## Link to Trello card

https://trello.com/c/2DjydBlX/3572-tell-providers-whether-candidates-have-provided-a-work-history-or-any-unpaid-experience

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
