### PR TITLE
Remove interviews feature flag

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -9,11 +9,7 @@
       <%= govuk_inset_text(classes: 'govuk-!-margin-top-0') do %>
         <% if respond_to_application? -%>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-            <% if FeatureFlag.active?(:interviews) %>
-              Set up an interview or make a decision
-            <% else %>
-              Make a decision
-            <% end %>
+            Set up an interview or make a decision
           </h2>
           <p class="govuk-body">
             <% if time_is_today_or_tomorrow?(application_choice.reject_by_default_at) -%>
@@ -23,14 +19,11 @@
             <% end -%>
           </p>
 
-          <% if FeatureFlag.active?(:interviews) %>
-            <div class="govuk-button-group">
-              <%= govuk_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice), button: true, class: 'govuk-!-margin-bottom-0 govuk-!-margin-right-2' %>
-              <%= govuk_link_to 'Make decision', new_provider_interface_application_choice_decision_path(application_choice), button: true, class: 'govuk-button--secondary govuk-!-margin-bottom-0 govuk-!-margin-right-2' %>
-            </div>
-          <% else %>
-            <%= govuk_link_to 'Make decision', new_provider_interface_application_choice_decision_path(application_choice), button: true %>
-          <% end %>
+          <div class="govuk-button-group">
+            <%= govuk_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice), button: true, class: 'govuk-!-margin-bottom-0 govuk-!-margin-right-2' %>
+            <%= govuk_link_to 'Make decision', new_provider_interface_application_choice_decision_path(application_choice), button: true, class: 'govuk-button--secondary govuk-!-margin-bottom-0 govuk-!-margin-right-2' %>
+          </div>
+
         <% elsif waiting_for_interview? %>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
             Make a decision

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -108,8 +108,6 @@ module ProviderInterface
     end
 
     def interviews_present?
-      return false unless FeatureFlag.active?(:interviews)
-
       application_choice.interviews.kept.any?
     end
 

--- a/app/controllers/provider_interface/interview_schedules_controller.rb
+++ b/app/controllers/provider_interface/interview_schedules_controller.rb
@@ -1,7 +1,5 @@
 module ProviderInterface
   class InterviewSchedulesController < ProviderInterfaceController
-    before_action :interview_flag_enabled?
-
     def show
       @interviews = Interview.for_application_choices(application_choices_for_user_providers)
         .undiscarded
@@ -30,13 +28,6 @@ module ProviderInterface
       GetApplicationChoicesForProviders.call(
         providers: current_provider_user.providers,
       )
-    end
-
-    def interview_flag_enabled?
-      unless FeatureFlag.active?(:interviews)
-        fallback_path = provider_interface_application_choice_path(@application_choice)
-        redirect_back(fallback_location: fallback_path)
-      end
     end
   end
 end

--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -1,7 +1,6 @@
 module ProviderInterface
   class InterviewsController < ProviderInterfaceController
     before_action :set_application_choice
-    before_action :interview_flag_enabled?
     before_action :requires_make_decisions_permission, except: %i[index]
     before_action :confirm_application_is_in_decision_pending_state, except: %i[index]
     before_action :redirect_to_index_if_store_cleared, only: %i[check commit]
@@ -123,13 +122,6 @@ module ProviderInterface
 
     def cancellation_params
       params.require(:provider_interface_cancel_interview_wizard).permit(:cancellation_reason)
-    end
-
-    def interview_flag_enabled?
-      unless FeatureFlag.active?(:interviews)
-        fallback_path = provider_interface_application_choice_path(@application_choice)
-        redirect_back(fallback_location: fallback_path)
-      end
     end
 
     def interview_form_context_params

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -52,9 +52,7 @@ class NavigationItems
 
       if current_provider_user && !performing_setup
         items << NavigationItem.new('Applications', provider_interface_applications_path, is_active(current_controller, %w[application_choices decisions offer_changes notes interviews offers feedback conditions reconfirm_deferred_offers]))
-        if FeatureFlag.active?(:interviews)
-          items << NavigationItem.new('Interview schedule', provider_interface_interview_schedule_path, is_active(current_controller, %w[interview_schedules]))
-        end
+        items << NavigationItem.new('Interview schedule', provider_interface_interview_schedule_path, is_active(current_controller, %w[interview_schedules]))
 
         if FeatureFlag.active?(:provider_activity_log)
           items << NavigationItem.new('Activity log', provider_interface_activity_log_path, is_active(current_controller, %w[activity_log]))

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -104,15 +104,11 @@ class ApplicationStateChange
   end
 
   def self.valid_states
-    return workflow_spec.states.keys if FeatureFlag.active?(:interviews)
-
-    workflow_spec.states.keys - [:interviewing]
+    workflow_spec.states.keys
   end
 
   def self.states_visible_to_provider
-    return STATES_VISIBLE_TO_PROVIDER if FeatureFlag.active?(:interviews)
-
-    STATES_VISIBLE_TO_PROVIDER - [:interviewing]
+    STATES_VISIBLE_TO_PROVIDER
   end
 
   def self.states_visible_to_provider_without_deferred

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -25,7 +25,6 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = [
     [:provider_activity_log, 'Show provider users a log of all application activity', 'Michael Nacos'],
     [:export_application_data, 'Providers can export a customised selection of application data', 'Ben Swannack'],
-    [:interviews, 'Providers can filter applications by interviewing state', 'Despo Pentara'],
     [:restructured_work_history, 'Candidates use the new design for the Work History section', 'David Gisbey'],
     [:unconditional_offers_via_api, 'Activates the ability to accept unconditional offers via the API', 'Steve Laing'],
     [:configurable_provider_notifications, 'Providers can manage individual email notifications', 'Aga Dufrat'],

--- a/spec/components/provider_interface/application_choice_header_component_spec.rb
+++ b/spec/components/provider_interface/application_choice_header_component_spec.rb
@@ -12,47 +12,21 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
     context 'when the application is awaiting provider decision and the user can make decisions' do
       let(:reject_by_default_at) { 1.day.from_now }
 
-      context 'when the interviews FeatureFlag is enabled' do
-        before do
-          FeatureFlag.activate(:interviews)
-        end
-
-        it 'the Make decision and Set up interview buttons are available and RDB info is presented ' do
-          expect(result.css('.govuk-button').first.text).to eq('Set up interview')
-          expect(result.css('.govuk-button').last.text).to eq('Make decision')
-          expect(result.css('.govuk-inset-text').text).to include(
-            "This application will be automatically rejected at the end of tomorrow (#{reject_by_default_at.to_s(:govuk_date_and_time)}) if you do not make a decision.",
-          )
-        end
-      end
-
-      context 'when the interviews FeatureFlag is disabled' do
-        it 'the Make decision button is available and RDB info is presented ' do
-          expect(result.css('.govuk-button').last.text).to eq('Make decision')
-          expect(result.css('.govuk-inset-text').text).to include(
-            "This application will be automatically rejected at the end of tomorrow (#{reject_by_default_at.to_s(:govuk_date_and_time)}) if you do not make a decision.",
-          )
-        end
+      it 'the Make decision and Set up interview buttons are available and RDB info is presented ' do
+        expect(result.css('.govuk-button').first.text).to eq('Set up interview')
+        expect(result.css('.govuk-button').last.text).to eq('Make decision')
+        expect(result.css('.govuk-inset-text').text).to include(
+          "This application will be automatically rejected at the end of tomorrow (#{reject_by_default_at.to_s(:govuk_date_and_time)}) if you do not make a decision.",
+        )
       end
     end
 
     context 'when the application is awaiting provider decision and the user cannot make decisions' do
       let(:provider_can_respond) { false }
+      let(:status) { 'interviewing' }
 
       it 'presents content without a heading or button' do
         expect(result.css('.govuk-inset-text').text).to include('There are 10 days to respond.')
-      end
-
-      context 'when the interviews FeatureFlag is enabled' do
-        let(:status) { 'interviewing' }
-
-        before do
-          FeatureFlag.activate(:interviews)
-        end
-
-        it 'presents content without a heading or button' do
-          expect(result.css('.govuk-inset-text').text).to include('There are 10 days to respond.')
-        end
       end
     end
 
@@ -94,7 +68,6 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
 
       before do
         allow(application_choice).to receive(:interviews).and_return(interviews)
-        FeatureFlag.activate(:interviews)
       end
 
       context 'when there are no interviews' do

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -227,7 +227,6 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
   end
 
   it 'has a title for all state transitions' do
-    FeatureFlag.activate(:interviews)
     expect(ApplicationStateChange.states_visible_to_provider).to match_array(ProviderInterface::ApplicationTimelineComponent::TITLES.keys.map(&:to_sym))
   end
 end

--- a/spec/requests/provider_interface/interviews_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews_controller_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe ProviderInterface::InterviewsController, type: :request do
   before do
     allow(DfESignInUser).to receive(:load_from_session).and_return(provider_user)
 
-    FeatureFlag.activate(:interviews)
-
     user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
   end
 

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -2,10 +2,6 @@ require 'rails_helper'
 
 RSpec.describe ApplicationStateChange do
   context 'when the interview flag is active' do
-    before do
-      FeatureFlag.activate(:interviews)
-    end
-
     describe '.valid_states' do
       it 'has human readable translations' do
         expect(ApplicationStateChange.valid_states)
@@ -28,37 +24,6 @@ RSpec.describe ApplicationStateChange do
       it 'matches the valid states and states not visible' do
         expect(ApplicationStateChange.states_visible_to_provider)
           .to match_array(ApplicationStateChange.valid_states - ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER)
-      end
-    end
-  end
-
-  context 'when the interview flag is inactive' do
-    before do
-      FeatureFlag.deactivate(:interviews)
-    end
-
-    describe '.valid_states' do
-      it 'has human readable translations' do
-        expect(ApplicationStateChange.valid_states)
-          .to match_array(I18n.t('application_states').keys - %i[interviewing])
-
-        expect(ApplicationStateChange.valid_states)
-          .to match_array(I18n.t('candidate_application_states').keys - %i[interviewing])
-
-        expect(ApplicationStateChange.valid_states)
-          .to match_array(I18n.t('provider_application_states').keys - %i[interviewing])
-      end
-
-      it 'has corresponding entries in the ApplicationChoice#status enum' do
-        expect(ApplicationStateChange.valid_states)
-          .to match_array(ApplicationChoice.statuses.keys.map(&:to_sym) - %i[interviewing])
-      end
-    end
-
-    describe '.states_visible_to_provider' do
-      it 'matches the valid states and states not visible' do
-        expect(ApplicationStateChange.states_visible_to_provider)
-          .to match_array(ApplicationStateChange.valid_states - ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER - %i[interviewing])
       end
     end
   end

--- a/spec/services/update_interview_spec.rb
+++ b/spec/services/update_interview_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe UpdateInterview do
     }
   end
 
-  before { FeatureFlag.activate(:interviews) }
-
   describe '#save!' do
     it 'updates the existing interview with provided params' do
       described_class.new(service_params).save!

--- a/spec/system/provider_interface/provider_can_view_interview_schedule_spec.rb
+++ b/spec/system/provider_interface/provider_can_view_interview_schedule_spec.rb
@@ -9,10 +9,6 @@ RSpec.describe 'A Provider user' do
   let(:course) { create(:course, :open_on_apply, provider: provider) }
   let(:course_options) { create_list(:course_option, 4, course: course) }
 
-  before do
-    FeatureFlag.activate(:interviews)
-  end
-
   scenario 'can view all present and past interviews scheduled for their provider' do
     given_i_am_a_provider_user
     and_i_sign_in_to_the_provider_interface

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -14,10 +14,6 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     end
   end
 
-  before do
-    FeatureFlag.activate(:interviews)
-  end
-
   scenario 'can view, create and cancel interviews' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider


### PR DESCRIPTION
## Context

Opening PR as work has already been completed, but reviewing is not a priority as it's part of sprint 44.

## Link to Trello card

https://trello.com/c/lVMqGNuP/1476-remove-interviews-feature-flag

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
