### PR TITLE
JS enhancements for "Add another" further conditions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
         run: bundle exec rake db:setup
 
       - name: ${{ matrix.tests }} tests with feature flags ${{ matrix.feature-flags }}
-        run: bundle exec --verbose rspec --exclude-pattern ${EXCLUDE_PATTERN} --pattern ${INCLUDE_PATTERN} --format documentation
+        run: apk add chromium chromium-chromedriver && bundle exec --verbose rspec --exclude-pattern ${EXCLUDE_PATTERN} --pattern ${INCLUDE_PATTERN} --format documentation
         env:
           INCLUDE_PATTERN: ${{ matrix.include-pattern }}
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern }}

--- a/app/components/provider_interface/conditions_form_component.html.erb
+++ b/app/components/provider_interface/conditions_form_component.html.erb
@@ -1,2 +1,2 @@
-<!-- We render a partial here due to a bug in ViewComponent around context and form_for. See https://github.com/github/view_component/pull/240 for details -->
+<%# We render a partial here due to a bug in ViewComponent around context and form_for. See https://github.com/github/view_component/pull/240 for details %>
 <%= render 'provider_interface/offer/conditions/form', form_object: form_object, application_choice: application_choice, form_method: form_method, form_heading: form_heading %>

--- a/app/controllers/provider_interface/offer/conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/conditions_controller.rb
@@ -26,10 +26,10 @@ module ProviderInterface
 
         if add_another_condition?
           @wizard.add_empty_condition
-          redirect_to action: action, anchor: anchor_for_further_condition
+          rerender_form(action)
         elsif remove_condition_param.present?
           @wizard.remove_condition(remove_condition_param)
-          redirect_to action: action, anchor: anchor_for_further_condition
+          rerender_form(action)
         else
           submit_form(action: action)
         end
@@ -56,6 +56,15 @@ module ProviderInterface
               .permit(further_conditions: {}, standard_conditions: [])
       end
 
+      def rerender_form(action)
+        @action = action
+        @element_id_to_focus = element_id_to_focus
+        respond_to do |format|
+          format.js { render :update_form }
+          format.html { redirect_to action: @action, anchor: @element_id_to_focus }
+        end
+      end
+
       def submit_form(action:)
         if @wizard.valid_for_current_step?
           @wizard.remove_empty_conditions!
@@ -63,11 +72,11 @@ module ProviderInterface
 
           redirect_to [action, :provider_interface, @application_choice, :offer, @wizard.next_step]
         else
-          render action
+          rerender_form(action)
         end
       end
 
-      def anchor_for_further_condition
+      def element_id_to_focus
         if remove_condition_param.present?
           'further-conditions-heading'
         elsif add_another_condition?

--- a/app/controllers/provider_interface/offer/conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/conditions_controller.rb
@@ -70,7 +70,12 @@ module ProviderInterface
           @wizard.remove_empty_conditions!
           @wizard.save_state!
 
-          redirect_to [action, :provider_interface, @application_choice, :offer, @wizard.next_step]
+          redirect_url = polymorphic_url([action, :provider_interface, @application_choice, :offer, @wizard.next_step])
+
+          respond_to do |format|
+            format.js { render js: "window.location.replace('#{redirect_url}')" }
+            format.html { redirect_to redirect_url }
+          end
         else
           rerender_form(action)
         end

--- a/app/frontend/packs/application-provider.js
+++ b/app/frontend/packs/application-provider.js
@@ -1,3 +1,4 @@
+import Rails from '@rails/ujs'
 import { initAll as govUKFrontendInitAll } from 'govuk-frontend'
 import initWarnOnUnsavedChanges from './warn-on-unsaved-changes'
 import filter from './components/paginated_filter'
@@ -6,6 +7,7 @@ import cookieBanners from './cookies/cookie-banners'
 
 require.context('govuk-frontend/govuk/assets')
 
+Rails.start()
 govUKFrontendInitAll()
 initWarnOnUnsavedChanges()
 filter()

--- a/app/views/provider_interface/offer/conditions/_form.html.erb
+++ b/app/views/provider_interface/offer/conditions/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: form_object, url: provider_interface_application_choice_offer_conditions_path(application_choice), method: form_method do |f| %>
+<%= form_with model: form_object, url: provider_interface_application_choice_offer_conditions_path(application_choice), method: form_method, local: false do |f| %>
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-l">

--- a/app/views/provider_interface/offer/conditions/update_form.js.erb
+++ b/app/views/provider_interface/offer/conditions/update_form.js.erb
@@ -1,0 +1,13 @@
+function renderForm() {
+  const rerenderedForm = '<%= j render template: "provider_interface/offer/conditions/#{@action}" %>';
+  const currentForm = document.querySelector('form');
+  currentForm.insertAdjacentHTML('afterend', rerenderedForm);
+  currentForm.remove();
+}
+
+function focusElement() {
+  document.getElementById('<%= @element_id_to_focus %>').focus();
+}
+
+renderForm();
+focusElement();

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@ministryofjustice/frontend": "^0.2.3",
+    "@rails/ujs": "^6.0.3-7",
     "@rails/webpacker": "^5.3.0",
     "accessible-autocomplete": "^2.0.3",
     "govuk-frontend": "^3.11.0",

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -5,8 +5,26 @@ if ENV['TEST_ENV_NUMBER']
   Capybara.server_port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
 end
 
+Capybara.register_driver :chrome_headless do |app|
+  options = ::Selenium::WebDriver::Chrome::Options.new
+
+  options.add_argument('--headless')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--disable-gpu')
+  options.add_argument('--window-size=1400,1400')
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.javascript_driver = :chrome_headless
+
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by(:rack_test)
+    if self.class.metadata[:js] == true
+      driven_by(:chrome_headless)
+    else
+      driven_by(:rack_test)
+    end
   end
 end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,1 +1,3 @@
 require 'webmock/rspec'
+
+WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -125,6 +125,7 @@ RSpec.feature 'Provider makes an offer' do
   def when_i_add_further_conditions
     click_on 'Add another condition'
     fill_in('provider_interface_offer_wizard[further_conditions][0][text]', with: 'A* on Maths A Level')
+    expect(page.current_url).to include("#provider-interface-offer-wizard-further-conditions-0-text-field")
   end
 
   def and_i_add_and_remove_another_condition

--- a/spec/system/provider_interface/set_offer_conditions_js_spec.rb
+++ b/spec/system/provider_interface/set_offer_conditions_js_spec.rb
@@ -1,0 +1,134 @@
+require 'rails_helper'
+
+RSpec.describe 'Provider makes an offer with JS enabled', js: true do
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
+  let(:provider) { provider_user.providers.first }
+  let(:ratifying_provider) { create(:provider) }
+
+  let(:application_form) { build(:application_form, :minimum_info) }
+  let(:course) { build(:course, :open_on_apply, provider: provider, accredited_provider: ratifying_provider) }
+  let(:course_option) { build(:course_option, course: course) }
+
+  scenario 'Setting offer conditions' do
+    given_i_am_a_provider_user
+    and_i_am_permitted_to_make_decisions_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+
+    given_there_is_an_application_to_a_course_i_can_make_decisions_on
+
+    when_i_make_an_offer_on_an_application_choice
+    then_the_conditions_page_is_loaded
+    and_the_default_conditions_are_checked
+
+    when_i_add_a_further_condition(text: 'Be cool', index: 0)
+    and_i_add_another_further_condition(text: 'Show us a photo of your dog', index: 1)
+    and_i_add_another_further_condition(text: 'Wear a tie', index: 2)
+    and_i_click_continue
+    then_the_review_page_is_loaded
+    and_the_conditions_are_displayed(['Be cool', 'Show us a photo of your dog', 'Wear a tie'])
+
+    when_i_click_change_conditions
+    then_the_conditions_page_is_loaded
+
+    when_i_remove_the_second_condition
+    and_i_click_continue
+    then_the_review_page_is_loaded
+    and_the_conditions_are_displayed(['Be cool', 'Wear a tie'])
+  end
+
+  def given_i_am_a_provider_user
+    user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+  end
+
+  def and_i_am_permitted_to_make_decisions_for_my_provider
+    permit_make_decisions!
+  end
+
+  def and_i_sign_in_to_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def given_there_is_an_application_to_a_course_i_can_make_decisions_on
+    create(
+      :provider_relationship_permissions,
+      training_provider: provider,
+      ratifying_provider: ratifying_provider,
+    )
+    create(
+      :application_choice,
+      :awaiting_provider_decision,
+      application_form: application_form,
+      course_option: course_option,
+    )
+  end
+
+  def when_i_make_an_offer_on_an_application_choice
+    visit provider_interface_applications_path
+    click_on application_form.full_name
+    click_on 'Make decision'
+    expect(page).to have_content('Make a decision')
+    expect(page).to have_content('Course applied for')
+    choose('Make an offer', visible: false)
+    and_i_click_continue
+  end
+
+  def then_the_conditions_page_is_loaded
+    expect(page).to have_content('Conditions of offer')
+    expect(page).to have_content('Standard conditions')
+    expect(page).to have_content('Further conditions')
+  end
+
+  def and_the_default_conditions_are_checked
+    expect(find("input[value='Fitness to train to teach check']", visible: false)).to be_checked
+    expect(find("input[value='Disclosure and Barring Service (DBS) check']", visible: false)).to be_checked
+  end
+
+  def when_i_add_a_further_condition(text:, index:)
+    click_on 'Add another condition'
+    fill_in("provider_interface_offer_wizard[further_conditions][#{index}][text]", with: text)
+    expect(page.current_url).not_to include("#provider-interface-offer-wizard-further-conditions-#{index}-text-field")
+  end
+
+  alias_method :and_i_add_another_further_condition, :when_i_add_a_further_condition
+
+  def and_i_click_continue
+    click_on t('continue')
+  end
+
+  def then_the_review_page_is_loaded
+    expect(page).to have_content('Check and send offer')
+  end
+
+  def and_the_conditions_are_displayed(conditions)
+    expected_conditions = [
+      'Fitness to train to teach check',
+      'Disclosure and Barring Service (DBS) check',
+    ] + conditions
+
+    within('.app-offer-panel') do
+      expect(all('.conditions-row > td:first-child').map(&:text)).to eq expected_conditions
+    end
+  end
+
+  def when_i_click_change_conditions
+    click_on 'Add or change conditions'
+  end
+
+  def when_i_remove_the_second_condition
+    click_on 'Remove condition 2'
+    expect(page).not_to have_content('Condition 3')
+  end
+
+  def when_i_send_the_offer
+    click_on 'Send offer'
+  end
+
+  def then_i_see_that_the_offer_was_successfuly_made
+    within('.govuk-notification-banner--success') do
+      expect(page).to have_content('Offer sent')
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1329,6 +1329,11 @@
   dependencies:
     mkdirp "^1.0.4"
 
+"@rails/ujs@^6.0.3-7":
+  version "6.0.3-7"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.0.3-7.tgz#8be007e500baafed256895830ae446178511773b"
+  integrity sha512-J7dvCTkZ/zaQLge1mttypoE/1j5YDcSAuu4fun8CoTqVGkcbwZu4f4jy+HKxdomtrZzXWSHlSeIe9vOtLnhmeA==
+
 "@rails/webpacker@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-5.3.0.tgz#9d7a615735f850572b9c5e2ad4c57f4af70d70fd"


### PR DESCRIPTION
## Context
We added the ability to add and remove further conditions previously. This required refreshing the page each time though. This PR adds progressive JS enhancements for that feature to avoid page reloads.

## Changes proposed in this pull request
Add Rails UJS
Use remote form to submit using JS
Add JS system spec for the feature

## Guidance to review
This is pretty simple codewise. We render the whole form again serverside, and inject it into the page with js. Are there any limitations to this approach?

To test: Go though the flow in the review app. Try this with JS enabled and disabled and ensure the behaviour is the same

## Link to Trello card
https://trello.com/c/u0fZBMtg/3613-implement-js-progressive-enhancements-to-infinite-offer-conditions

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)