### PR TITLE
Support interface revert a rejection

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -42,14 +42,10 @@ module SupportInterface
   private
 
     def status_row
-      if FeatureFlag.active?(:support_user_reinstate_offer) && application_choice.declined? && !application_choice.declined_by_default
-        { key: 'Status',
-          value: render(SupportInterface::ApplicationStatusTagComponent.new(status: application_choice.status)),
-          action: 'Reinstate offer',
-          action_path: support_interface_application_form_application_choice_reinstate_offer_path(application_form_id: @application_choice.application_form.id, application_choice_id: @application_choice.id) }
-      else
-        { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent.new(status: application_choice.status)) }
-      end
+      {
+        key: 'Status',
+        value: render(SupportInterface::ApplicationStatusTagComponent.new(status: application_choice.status)),
+      }.merge(status_action_link)
     end
 
     def offer_made_at_row
@@ -182,6 +178,22 @@ module SupportInterface
       GetRecruitedApplicationChoices.call(
         recruitment_cycle_year: RecruitmentCycle.current_year,
       ).find_by(id: application_choice.id).present?
+    end
+
+    def status_action_link
+      if FeatureFlag.active?(:support_user_reinstate_offer) && application_choice.declined? && !application_choice.declined_by_default
+        {
+          action: 'Reinstate offer',
+          action_path: support_interface_application_form_application_choice_reinstate_offer_path(application_form_id: @application_choice.application_form.id, application_choice_id: @application_choice.id),
+        }
+      elsif application_choice.rejected? && !application_choice.rejected_by_default?
+        {
+          action: 'Revert rejection',
+          action_path: support_interface_application_form_revert_rejection_path(application_form_id: @application_choice.application_form.id, application_choice_id: @application_choice.id),
+        }
+      else
+        {}
+      end
     end
   end
 end

--- a/app/controllers/support_interface/application_forms/application_choices_controller.rb
+++ b/app/controllers/support_interface/application_forms/application_choices_controller.rb
@@ -1,0 +1,60 @@
+module SupportInterface
+  module ApplicationForms
+    class ApplicationChoicesController < SupportInterfaceController
+      before_action :build_application_form, :build_application_choice
+      before_action :redirect_to_application_form_unless_declined_and_flag_active, only: %i[reinstate_offer confirm_reinstate_offer]
+
+      def confirm_reinstate_offer
+        @declined_course_choice = ReinstateDeclinedOfferForm.new
+      end
+
+      def reinstate_offer
+        @declined_course_choice = ReinstateDeclinedOfferForm.new(reinstate_offer_params)
+
+        if @declined_course_choice.save(@application_choice)
+          flash[:success] = 'Offer was reinstated'
+          redirect_to support_interface_application_form_path(@application_form.id)
+        else
+          render :confirm_reinstate_offer
+        end
+      end
+
+      def confirm_revert_rejection
+        @form = RevertRejectionForm.new
+      end
+
+      def revert_rejection
+        @form = RevertRejectionForm.new(revert_rejection_params)
+
+        if @form.save(@application_choice)
+          flash[:success] = 'Rejection was reverted'
+          redirect_to support_interface_application_form_path(@application_form.id)
+        else
+          render :confirm_revert_rejection
+        end
+      end
+
+    private
+
+      def reinstate_offer_params
+        params.require(:support_interface_application_forms_reinstate_declined_offer_form).permit(:status, :audit_comment_ticket, :accept_guidance)
+      end
+
+      def revert_rejection_params
+        params.require(:support_interface_application_forms_revert_rejection_form).permit(:audit_comment_ticket, :accept_guidance)
+      end
+
+      def build_application_form
+        @application_form = ApplicationForm.find(params[:application_form_id])
+      end
+
+      def build_application_choice
+        @application_choice = @application_form.application_choices.find(params[:application_choice_id])
+      end
+
+      def redirect_to_application_form_unless_declined_and_flag_active
+        redirect_to support_interface_application_form_path(@application_form.id) unless FeatureFlag.active?(:support_user_reinstate_offer) && @application_choice.declined?
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/application_forms/revert_rejection_form.rb
+++ b/app/forms/support_interface/application_forms/revert_rejection_form.rb
@@ -1,0 +1,20 @@
+module SupportInterface
+  module ApplicationForms
+    class RevertRejectionForm
+      include ActiveModel::Model
+
+      attr_accessor :accept_guidance, :audit_comment_ticket
+
+      validates :accept_guidance, :audit_comment_ticket, presence: true
+      validates :audit_comment_ticket, format: { with: /\A((http|https):\/\/)?(www.)?becomingateacher.zendesk.com\/agent\/tickets\// }
+
+      def save(application_choice)
+        self.accept_guidance = ActiveModel::Type::Boolean.new.cast(accept_guidance)
+
+        return false unless valid?
+
+        # TODO: Call new service to update the application state
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/application_forms/revert_rejection_form.rb
+++ b/app/forms/support_interface/application_forms/revert_rejection_form.rb
@@ -13,7 +13,10 @@ module SupportInterface
 
         return false unless valid?
 
-        # TODO: Call new service to update the application state
+        SupportInterface::RevertRejection.new(
+          application_choice: application_choice,
+          zendesk_ticket: audit_comment_ticket,
+        ).save!
       end
     end
   end

--- a/app/services/support_interface/revert_rejection.rb
+++ b/app/services/support_interface/revert_rejection.rb
@@ -1,0 +1,18 @@
+module SupportInterface
+  class RevertRejection
+    def initialize(application_choice:, zendesk_ticket:)
+      @application_choice = application_choice
+      @zendesk_ticket = zendesk_ticket
+    end
+
+    def save!
+      @application_choice.update!(
+        status: :awaiting_provider_decision,
+        rejected_at: nil,
+        structured_rejection_reasons: nil,
+        rejection_reason: nil,
+        audit_comment: "Support request to revert rejection: #{@zendesk_ticket}",
+      )
+    end
+  end
+end

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/confirm_offered_course_option.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/confirm_offered_course_option.html.erb
@@ -32,19 +32,17 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%=
-        f.govuk_text_field(
-          :audit_comment,
-          label: {
-            text: t('support_interface.changed_offered_course_form.audit_comment_ticket.label'),
-            size: 'm',
-          },
-          rows: 1,
-          hint: {
-            text: t('support_interface.changed_offered_course_form.audit_comment_ticket.hint'),
-          },
-        )
-      %>
+      <%= f.govuk_text_field(
+        :audit_comment,
+        label: {
+          text: t('support_interface.audit_comment_ticket.label'),
+          size: 'm',
+        },
+        rows: 1,
+        hint: {
+          text: t('support_interface.audit_comment_ticket.hint'),
+        },
+      ) %>
     </div>
   </div>
 

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/confirm_offered_course_option.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/confirm_offered_course_option.html.erb
@@ -32,17 +32,19 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= f.govuk_text_field(
-            :audit_comment,
-            label: {
-              text: 'Zendesk ticket URL',
-              size: 'm',
-            },
-            rows: 1,
-            hint: {
-              text: 'For example https://becomingateacher.zendesk.com/agent/tickets/12345',
-            },
-          ) %>
+      <%=
+        f.govuk_text_field(
+          :audit_comment,
+          label: {
+            text: t('support_interface.changed_offered_course_form.audit_comment_ticket.label'),
+            size: 'm',
+          },
+          rows: 1,
+          hint: {
+            text: t('support_interface.changed_offered_course_form.audit_comment_ticket.hint'),
+          },
+        )
+      %>
     </div>
   </div>
 

--- a/app/views/support_interface/application_forms/application_choices/confirm_revert_rejection.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/confirm_revert_rejection.html.erb
@@ -1,0 +1,46 @@
+<% content_for :browser_title, title_with_error_prefix('Revert rejection', @application_choice.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(application_form_id: params[:application_form_id]), 'Back to application') %>
+
+<%= form_with(
+    model: @form,
+    url: support_interface_application_form_revert_rejection_path(application_form_id: params[:application_form_id], application_choice_id: params[:application_choice_id]),
+    method: :patch
+  ) do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        Are you sure you want to revert this rejection?
+      </h1>
+
+      <p class="govuk-body">A rejection can only be reverted if:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>it was rejected within 5 working days of the request to revert and,</li>
+        <li>the candidate has not accepted any other offers</li>
+      </ul>
+      <p class="govuk-body">In order to revert the rejection you must first contact the provider to confirm that they agree to this.</p>
+      <p class="govuk-body">Once the rejection has been reverted, please email the candidate using the macro.</p>
+      <p class="govuk-body">There are separate macros if the request was made after 5 working days or if the candidate has already accepted another offer.</p>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_text_field(
+              :audit_comment_ticket,
+              label: {
+                text: 'Zendesk ticket URL',
+                size: 'm',
+              },
+              rows: 1,
+              hint: { text: 'For example https://becomingateacher.zendesk.com/agent/tickets/12345' },
+            ) %>
+    </div>
+  </div>
+
+  <%= f.govuk_check_boxes_fieldset :accept_guidance, legend: nil do %>
+    <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
+  <% end %>
+
+  <%= f.govuk_submit t('continue') %>
+<% end %>

--- a/app/views/support_interface/application_forms/application_choices/confirm_revert_rejection.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/confirm_revert_rejection.html.erb
@@ -25,17 +25,15 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%=
-        f.govuk_text_field(
-          :audit_comment_ticket,
-          label: {
-            text: t('support_interface.conditions_form.audit_comment_ticket.label'),
-            size: 'm',
-          },
-          rows: 1,
-          hint: { text: t('support_interface.conditions_form.audit_comment_ticket.hint') },
-        )
-      %>
+      <%= f.govuk_text_field(
+        :audit_comment_ticket,
+        label: {
+          text: t('support_interface.audit_comment_ticket.label'),
+          size: 'm',
+        },
+        rows: 1,
+        hint: { text: t('support_interface.audit_comment_ticket.hint') },
+      ) %>
     </div>
   </div>
 

--- a/app/views/support_interface/application_forms/application_choices/confirm_revert_rejection.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/confirm_revert_rejection.html.erb
@@ -4,7 +4,7 @@
 <%= form_with(
     model: @form,
     url: support_interface_application_form_revert_rejection_path(application_form_id: params[:application_form_id], application_choice_id: params[:application_choice_id]),
-    method: :patch
+    method: :patch,
   ) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -19,8 +19,7 @@
         <li>the candidate has not accepted any other offers</li>
       </ul>
       <p class="govuk-body">In order to revert the rejection you must first contact the provider to confirm that they agree to this.</p>
-      <p class="govuk-body">Once the rejection has been reverted, please email the candidate using the macro.</p>
-      <p class="govuk-body">There are separate macros if the request was made after 5 working days or if the candidate has already accepted another offer.</p>
+      <p class="govuk-body">Once the rejection has been reverted, please email the candidate to let them know.</p>
     </div>
   </div>
 

--- a/app/views/support_interface/application_forms/application_choices/confirm_revert_rejection.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/confirm_revert_rejection.html.erb
@@ -25,15 +25,17 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= f.govuk_text_field(
-              :audit_comment_ticket,
-              label: {
-                text: 'Zendesk ticket URL',
-                size: 'm',
-              },
-              rows: 1,
-              hint: { text: 'For example https://becomingateacher.zendesk.com/agent/tickets/12345' },
-            ) %>
+      <%=
+        f.govuk_text_field(
+          :audit_comment_ticket,
+          label: {
+            text: t('support_interface.conditions_form.audit_comment_ticket.label'),
+            size: 'm',
+          },
+          rows: 1,
+          hint: { text: t('support_interface.conditions_form.audit_comment_ticket.hint') },
+        )
+      %>
     </div>
   </div>
 

--- a/app/views/support_interface/application_forms/application_choices/confirm_revert_rejection.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/confirm_revert_rejection.html.erb
@@ -15,7 +15,7 @@
 
       <p class="govuk-body">A rejection can only be reverted if:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>it was rejected within 5 working days of the request to revert and,</li>
+        <li>it was rejected within 5 working days of the request to revert</li>
         <li>the candidate has not accepted any other offers</li>
       </ul>
       <p class="govuk-body">In order to revert the rejection you must first contact the provider to confirm that they agree to this.</p>

--- a/app/views/support_interface/application_forms/application_choices/reinstate_declined_offer/confirm_reinstate_offer.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/reinstate_declined_offer/confirm_reinstate_offer.html.erb
@@ -27,15 +27,17 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= f.govuk_text_field(
-              :audit_comment_ticket,
-              label: {
-                text: 'Zendesk ticket URL',
-                size: 'm',
-              },
-              rows: 1,
-              hint: { text: 'For example https://becomingateacher.zendesk.com/agent/tickets/12345' },
-            ) %>
+      <%=
+        f.govuk_text_field(
+          :audit_comment_ticket,
+          label: {
+            text: t('support_interface.reinstate_declined_offer_form.audit_comment_ticket.label'),
+            size: 'm',
+          },
+          rows: 1,
+          hint: { text: t('support_interface.reinstate_declined_offer_form.audit_comment_ticket.hint') },
+        )
+      %>
     </div>
   </div>
 

--- a/app/views/support_interface/application_forms/application_choices/reinstate_declined_offer/confirm_reinstate_offer.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/reinstate_declined_offer/confirm_reinstate_offer.html.erb
@@ -27,17 +27,15 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%=
-        f.govuk_text_field(
-          :audit_comment_ticket,
-          label: {
-            text: t('support_interface.reinstate_declined_offer_form.audit_comment_ticket.label'),
-            size: 'm',
-          },
-          rows: 1,
-          hint: { text: t('support_interface.reinstate_declined_offer_form.audit_comment_ticket.hint') },
-        )
-      %>
+      <%= f.govuk_text_field(
+        :audit_comment_ticket,
+        label: {
+          text: t('support_interface.audit_comment_ticket.label'),
+          size: 'm',
+        },
+        rows: 1,
+        hint: { text: t('support_interface.audit_comment_ticket.hint') },
+      ) %>
     </div>
   </div>
 

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -28,6 +28,18 @@ en:
       audit_comment:
         label: Audit log comment
         hint: This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here
+    conditions_form:
+      audit_comment_ticket:
+        label: 'Zendesk ticket URL'
+        hint: 'For example https://becomingateacher.zendesk.com/agent/tickets/12345'
+    reinstate_declined_offer_form:
+      audit_comment_ticket:
+        label: 'Zendesk ticket URL'
+        hint: 'For example https://becomingateacher.zendesk.com/agent/tickets/12345'
+    changed_offered_course_form:
+      audit_comment_ticket:
+        label: 'Zendesk ticket URL'
+        hint: 'For example https://becomingateacher.zendesk.com/agent/tickets/12345'
   activemodel:
     errors:
       models:

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -160,3 +160,10 @@ en:
             audit_comment:
               blank: Enter a Zendesk ticket URL
               invalid: Enter a valid Zendesk ticket URL
+        support_interface/application_forms/revert_rejection_form:
+          attributes:
+            accept_guidance:
+              blank: Select that you have read the guidance
+            audit_comment_ticket:
+              blank: Enter a Zendesk ticket URL
+              invalid: Enter a valid Zendesk ticket URL

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -28,18 +28,9 @@ en:
       audit_comment:
         label: Audit log comment
         hint: This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here
-    conditions_form:
-      audit_comment_ticket:
-        label: 'Zendesk ticket URL'
-        hint: 'For example https://becomingateacher.zendesk.com/agent/tickets/12345'
-    reinstate_declined_offer_form:
-      audit_comment_ticket:
-        label: 'Zendesk ticket URL'
-        hint: 'For example https://becomingateacher.zendesk.com/agent/tickets/12345'
-    changed_offered_course_form:
-      audit_comment_ticket:
-        label: 'Zendesk ticket URL'
-        hint: 'For example https://becomingateacher.zendesk.com/agent/tickets/12345'
+    audit_comment_ticket:
+      label: 'Zendesk ticket URL'
+      hint: 'For example https://becomingateacher.zendesk.com/agent/tickets/12345'
   activemodel:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -821,6 +821,9 @@ Rails.application.routes.draw do
 
       get '/confirm-offered-course/:application_choice_id/:application_choice_id' => 'application_forms/application_choices/change_offered_course#confirm_offered_course_option', as: :application_form_application_choice_confirm_offered_course_option
       patch '/confirm-offered-course/:application_choice_id/:application_choice_id' => 'application_forms/application_choices/change_offered_course#update_offered_course_option'
+
+      get '/revert-rejection/:application_choice_id' => 'application_forms/application_choices#confirm_revert_rejection', as: :application_form_revert_rejection
+      patch '/revert-rejection/:application_choice_id' => 'application_forms/application_choices#revert_rejection'
     end
 
     get '/ucas-matches' => 'ucas_matches#index'

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -66,6 +66,32 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
     end
   end
 
+  context 'Rejected application' do
+    let(:rejected_application_choice) { create(:application_choice, :with_completed_application_form, :with_rejection) }
+
+    it 'Renders a link to the revert rejection page when application was manually rejected' do
+      result = render_inline(described_class.new(rejected_application_choice))
+
+      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
+        Rails.application.routes.url_helpers.support_interface_application_form_revert_rejection_path(
+          application_form_id: rejected_application_choice.application_form.id,
+          application_choice_id: rejected_application_choice.id,
+        ),
+      )
+      expect(result.css('.govuk-summary-list__actions').text.strip).to include('Revert rejection')
+    end
+
+    it 'Does not renders a link to the revert rejection page when application was rejected by default' do
+      rejected_application_choice.update!(
+        rejected_by_default: true,
+      )
+      result = render_inline(described_class.new(rejected_application_choice))
+
+      expect(result.css('.govuk-summary-list__actions a')).to be_empty
+      expect(result.css('.govuk-summary-list__actions').text.strip).not_to include('Revert rejection')
+    end
+  end
+
   it 'displays the date an application was rejected' do
     application_choice = create(:application_choice,
                                 :with_completed_application_form,

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
       expect(result.css('.govuk-summary-list__actions').text.strip).to include('Revert rejection')
     end
 
-    it 'Does not renders a link to the revert rejection page when application was rejected by default' do
+    it 'Does not render a link to the revert rejection page when application was rejected by default' do
       rejected_application_choice.update!(
         rejected_by_default: true,
       )

--- a/spec/forms/support_interface/application_forms/revert_rejection_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/revert_rejection_form_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationForms::RevertRejectionForm, type: :model, with_audited: true do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:accept_guidance) }
+    it { is_expected.to validate_presence_of(:audit_comment_ticket) }
+
+    context 'for an invalid zendesk link' do
+      invalid_link = 'nonsense'
+      it { is_expected.not_to allow_value(invalid_link).for(:audit_comment_ticket) }
+    end
+
+    context 'for an valid zendesk link' do
+      valid_link = 'www.becomingateacher.zendesk.com/agent/tickets/example'
+      it { is_expected.to allow_value(valid_link).for(:audit_comment_ticket) }
+    end
+  end
+
+  describe '#save' do
+    let(:zendesk_ticket) { 'www.becomingateacher.zendesk.com/agent/tickets/example' }
+
+    it 'updates the provided ApplicationChoice with the `awaiting_provider_decision` status if valid' do
+      Timecop.freeze do
+        application_choice = create(:application_choice, :with_rejection)
+
+        form = SupportInterface::ApplicationForms::RevertRejectionForm.new(
+          audit_comment_ticket: zendesk_ticket,
+          accept_guidance: true,
+        )
+
+        expect(form.save(application_choice)).to eq(true)
+
+        expect(application_choice).to have_attributes({
+          status: 'awaiting_provider_decision',
+        })
+
+        expect(application_choice.audits.last.comment).to include(zendesk_ticket)
+      end
+    end
+  end
+end

--- a/spec/services/support_interface/revert_rejection_spec.rb
+++ b/spec/services/support_interface/revert_rejection_spec.rb
@@ -3,15 +3,21 @@ require 'rails_helper'
 RSpec.describe SupportInterface::RevertRejection, with_audited: true do
   describe '#save!' do
     it 'reverts the application choice status back to `awaiting_provider_decision` and sets an audit comment' do
-      application_choice = create(:application_choice, :with_rejection)
+      application_choice = create(:application_choice, :awaiting_provider_decision)
+      original_application_choice = application_choice.clone
+
       zendesk_ticket = 'becomingateacher.zendesk.com/agent/tickets/example'
 
+      RejectApplication.new(
+        actor: create(:support_user),
+        application_choice: application_choice,
+      ).save
       described_class.new(
         application_choice: application_choice,
         zendesk_ticket: zendesk_ticket,
       ).save!
 
-      expect(application_choice).to be_awaiting_provider_decision
+      expect(application_choice).to eq(original_application_choice)
       expect(application_choice.audits.last.comment).to include(zendesk_ticket)
     end
   end

--- a/spec/services/support_interface/revert_rejection_spec.rb
+++ b/spec/services/support_interface/revert_rejection_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::RevertRejection, with_audited: true do
+  describe '#save!' do
+    it 'reverts the application choice status back to `awaiting_provider_decision` and sets an audit comment' do
+      application_choice = create(:application_choice, :with_rejection)
+      zendesk_ticket = 'becomingateacher.zendesk.com/agent/tickets/example'
+
+      described_class.new(
+        application_choice: application_choice,
+        zendesk_ticket: zendesk_ticket,
+      ).save!
+
+      expect(application_choice).to be_awaiting_provider_decision
+      expect(application_choice.audits.last.comment).to include(zendesk_ticket)
+    end
+  end
+end

--- a/spec/system/support_interface/revert_rejection_spec.rb
+++ b/spec/system/support_interface/revert_rejection_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.feature 'Revert an accidental rejection' do
+  include DfESignInHelpers
+
+  scenario 'Revert a rejected application and return it to the `awaiting_provider_decision` status', with_audited: true do
+    given_i_am_a_support_user
+    and_there_is_a_rejected_application
+
+    when_i_visit_the_application_page
+    then_i_see_a_revert_rejection_link
+
+    when_i_click_revert_rejection
+    then_i_see_a_confirmation_page_prompting_for_an_audit_comment
+
+    when_i_click_continue
+    then_i_see_a_validation_error
+
+    when_i_add_an_audit_comment_and_click_continue
+    then_i_see_the_application_page
+    and_the_application_is_now_awaiting_provider_decision
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_a_rejected_application
+    application_form = create(
+      :application_form,
+      submitted_at: Time.zone.now,
+    )
+    @application_choice = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      application_form: application_form,
+    )
+    @application_choice.update!(status: :rejected, rejected_at: Time.zone.now)
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@application_choice.application_form_id)
+  end
+
+  def then_i_see_a_revert_rejection_link
+    expect(page).to have_link('Revert rejection')
+  end
+
+  def when_i_click_revert_rejection
+    click_link('Revert rejection')
+  end
+
+  def then_i_see_a_confirmation_page_prompting_for_an_audit_comment
+    expect(page).to have_current_path(
+      support_interface_application_form_revert_rejection_path(
+        application_form_id: @application_choice.application_form_id,
+        application_choice_id: @application_choice.id,
+      ),
+    )
+    expect(page).to have_content('Are you sure you want to revert this rejection?')
+  end
+
+  def when_i_click_continue
+    click_on 'Continue'
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_current_path(
+      support_interface_application_form_revert_rejection_path(
+        application_form_id: @application_choice.application_form_id,
+        application_choice_id: @application_choice.id,
+      ),
+    )
+    expect(page).to have_content('Enter a Zendesk ticket URL')
+    expect(page).to have_content('Select that you have read the guidance')
+  end
+
+  def when_i_add_an_audit_comment_and_click_continue
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/123'
+    check 'I have read the guidance'
+    click_on 'Continue'
+  end
+
+  def then_i_see_the_application_page
+    pending 'TODO'
+    expect(page).to have_current_path(support_interface_application_form_path(@application_choice.application_form_id))
+  end
+
+  def and_the_application_is_now_awaiting_provider_decision
+    pending 'TODO'
+    expect(@application_choice.reload.awaiting_provider_decision?).to be true
+  end
+end

--- a/spec/system/support_interface/revert_rejection_spec.rb
+++ b/spec/system/support_interface/revert_rejection_spec.rb
@@ -82,12 +82,10 @@ RSpec.feature 'Revert an accidental rejection' do
   end
 
   def then_i_see_the_application_page
-    pending 'TODO'
     expect(page).to have_current_path(support_interface_application_form_path(@application_choice.application_form_id))
   end
 
   def and_the_application_is_now_awaiting_provider_decision
-    pending 'TODO'
     expect(@application_choice.reload.awaiting_provider_decision?).to be true
   end
 end


### PR DESCRIPTION
## Context

This PR will allow support users to revert accidental rejections by a provider. To revert a rejection a support user must enter a support ticket URL.

The design used in this PR is based on https://github.com/DFE-Digital/apply-for-teacher-training/pull/4572.

## Changes proposed in this pull request

- [x] Add a new _Revert rejection_ link to the status line on application page in the support interface.
<img width="1145" alt="image" src="https://user-images.githubusercontent.com/450843/118509548-08d9d300-b728-11eb-8831-320e2ce1fda1.png">

- [x] The above link is to a new confirmation page:
<img width="700" alt="image" src="https://user-images.githubusercontent.com/450843/118947235-0d340500-b94f-11eb-8e6e-71916eec49bc.png">

- [x] Implement a form and service backing the UI above.
- [x] New system spec

## Guidance to review

- The content for the confirmation is adapted from the reinstate offer feature. It needs some work, in particular I don't know what the guidance should be notifications for candidate and provider.

## Link to Trello card

https://trello.com/c/LPKMNuUN/3361-add-functionality-to-the-support-ui-to-revert-a-rejection

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
