### PR TITLE
Correct documentation about qualification IDs in the API

### DIFF
--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -814,7 +814,7 @@ components:
       properties:
         id:
           type: integer
-          description: The qualification ID in the Apply system. These IDs are not guaranteed to be unique, for example when a candidate has multiple English GCSEs
+          description: The unique qualification ID in the Apply system
           example: 123
         qualification_type:
           type: string


### PR DESCRIPTION
## Context

A provider pointed out that we claim these IDs aren't guaranteed to be unique, but they are since #4017 

## Changes proposed in this pull request

Fix the docs to say the IDs are unique
