### PR TITLE
Fix Flakey Provider Interview Schedule Spec

### DIFF
--- a/spec/system/provider_interface/provider_can_view_interview_schedule_spec.rb
+++ b/spec/system/provider_interface/provider_can_view_interview_schedule_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe 'A Provider user' do
   let(:course) { create(:course, :open_on_apply, provider: provider) }
   let(:course_options) { create_list(:course_option, 4, course: course) }
 
+  around do |example|
+    Timecop.freeze(Time.zone.now.midday) do
+      example.run
+    end
+  end
+
   scenario 'can view all present and past interviews scheduled for their provider' do
     given_i_am_a_provider_user
     and_i_sign_in_to_the_provider_interface


### PR DESCRIPTION
## Context

Last night I noticed that this particular spec was failing on both my branch and master.
The problem is due to scope of the Time values when the local time is around midnight as
 it assigns interviews on different days.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/62567622/118116864-be342000-b3e2-11eb-9fe1-2469bab97141.png">

## Changes proposed in this pull request
This PR adds Timecop freeze to solve the issue.

## Guidance to review

If you want to replicate error set the local time to midnight.

## Link to Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
