### PR TITLE
Bring back unauthorised edits check in DetectInvariants

### DIFF
--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -5,7 +5,7 @@ class DetectInvariants
   def perform
     detect_application_choices_in_old_states
     detect_outstanding_references_on_submitted_applications
-    # detect_unauthorised_application_form_edits # FIXME
+    detect_unauthorised_application_form_edits
     detect_applications_with_course_choices_in_previous_cycle
     detect_submitted_applications_with_more_than_three_course_choices
     detect_applications_submitted_with_the_same_course

--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -58,9 +58,9 @@ class DetectInvariants
 
   def detect_unauthorised_application_form_edits
     unauthorised_changes = Audited::Audit
-      .joins("INNER JOIN application_forms ON application_forms.id = audits.associated_id AND audits.associated_type = 'ApplicationForm'")
+      .joins("INNER JOIN application_forms ON audits.associated_type = 'ApplicationForm' AND application_forms.id = audits.associated_id")
       .joins('INNER JOIN candidates ON candidates.id = application_forms.candidate_id')
-      .where(audits: { user_type: 'Candidate' })
+      .where(user_type: 'Candidate')
       .where('candidates.id != audits.user_id')
       .pluck('application_forms.id').uniq
       .sort

--- a/spec/workers/detect_invariants_spec.rb
+++ b/spec/workers/detect_invariants_spec.rb
@@ -58,8 +58,6 @@ RSpec.describe DetectInvariants do
     end
 
     it 'detects unauthorised edits on data associated with an application form', with_audited: true do
-      skip 'until detect_unauthorised_application_form_edits is back'
-
       honest_bob = create(:candidate)
       nefarious_jim = create(:candidate)
       suspect_form = build(:application_form, candidate: honest_bob)


### PR DESCRIPTION
## Context

This was disabled because of timeout issues related to the size of `audits`. Re-instating.

## Changes proposed in this pull request

Bring back the unauthorised edits check within `DetectInvariants`.

Reverts https://github.com/DFE-Digital/apply-for-teacher-training/pull/4679

## Guidance to review

Trivial

## Link to Trello card

No card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
