### PR TITLE
Add export type to notifications exports

### DIFF
--- a/app/services/data_api/tad_export.rb
+++ b/app/services/data_api/tad_export.rb
@@ -1,15 +1,16 @@
 module DataAPI
   class TADExport
-    EXPORT_NAME = 'Daily export of applications for TAD'.freeze
-
     def self.run_daily
-      data_export = DataExport.create!(name: EXPORT_NAME)
+      data_export = DataExport.create!(
+        name: 'Daily export of applications for TAD',
+        export_type: :tad_applications,
+      )
       DataExporter.perform_async(DataAPI::TADExport, data_export.id)
     end
 
     def self.all
       DataExport
-        .where(name: EXPORT_NAME)
+        .where(export_type: :tad_applications)
         .where('completed_at IS NOT NULL')
     end
 

--- a/app/services/data_migrations/specify_export_type_for_notification_exports.rb
+++ b/app/services/data_migrations/specify_export_type_for_notification_exports.rb
@@ -1,0 +1,13 @@
+module DataMigrations
+  class SpecifyExportTypeForNotificationExports
+    TIMESTAMP = 20210513141008
+    MANUAL_RUN = false
+
+    def change
+      DataExport
+        .where(name: 'Daily export of notifications breakdown')
+        .where(export_type: nil)
+        .update_all(export_type: :notifications_export)
+    end
+  end
+end

--- a/app/services/data_migrations/specify_export_type_for_tad_exports.rb
+++ b/app/services/data_migrations/specify_export_type_for_tad_exports.rb
@@ -1,0 +1,13 @@
+module DataMigrations
+  class SpecifyExportTypeForTADExports
+    TIMESTAMP = 20210513141008
+    MANUAL_RUN = false
+
+    def change
+      DataExport
+        .where(name: 'Daily export of applications for TAD')
+        .where(export_type: nil)
+        .update_all(export_type: :tad_applications)
+    end
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -42,7 +42,10 @@ class Clock
   end
 
   every(1.day, 'Generate export for Notifications', at: '23:57') do
-    data_export = DataExport.create!(name: 'Daily export of notifications breakdown')
+    data_export = DataExport.create!(
+      name: 'Daily export of notifications breakdown',
+      export_type: :notifications_export,
+    )
     DataExporter.perform_async(SupportInterface::NotificationsExport, data_export.id)
   end
 

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::SpecifyExportTypeForNotificationExports',
   'DataMigrations::DeleteAllCourseAudits',
   'DataMigrations::BackfillOpenedOnApplyAtFromAudits',
   'DataMigrations::PrefixNoteSubjectToMessage',

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::SpecifyExportTypeForTADExports',
   'DataMigrations::SpecifyExportTypeForNotificationExports',
   'DataMigrations::DeleteAllCourseAudits',
   'DataMigrations::BackfillOpenedOnApplyAtFromAudits',

--- a/spec/requests/data_api/tad_latest_spec.rb
+++ b/spec/requests/data_api/tad_latest_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe 'GET /data-api/tad-data-exports/latest', type: :request, sidekiq:
   it 'returns the latest data export' do
     create(:submitted_application_choice, :with_completed_application_form, status: 'rejected')
 
-    data_export = DataExport.create!(name: 'Daily export of applications for TAD')
+    data_export = DataExport.create!(
+      name: 'Daily export of applications for TAD',
+      export_type: :tad_applications,
+    )
     DataExporter.perform_async(DataAPI::TADExport, data_export.id)
 
     get_api_request '/data-api/tad-data-exports/latest', token: tad_api_token

--- a/spec/requests/data_api/tad_single_export_spec.rb
+++ b/spec/requests/data_api/tad_single_export_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe 'GET /data-api/tad-data-exports/:id', type: :request, sidekiq: tr
   it 'returns the latest data export' do
     create(:submitted_application_choice, :with_completed_application_form, status: 'rejected')
 
-    data_export = DataExport.create!(name: 'Daily export of applications for TAD')
+    data_export = DataExport.create!(
+      name: 'Daily export of applications for TAD',
+      export_type: :tad_applications,
+    )
     DataExporter.perform_async(DataAPI::TADExport, data_export.id)
 
     get_api_request "/data-api/tad-data-exports/#{data_export.id}", token: tad_api_token

--- a/spec/services/data_migrations/specify_export_type_for_notification_exports_spec.rb
+++ b/spec/services/data_migrations/specify_export_type_for_notification_exports_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::SpecifyExportTypeForNotificationExports do
+  it 'backfills export_type for notification exports' do
+    notifications_export = create(
+      :data_export,
+      name: 'Daily export of notifications breakdown',
+      export_type: nil,
+    )
+
+    described_class.new.change
+    expect(notifications_export.reload.export_type).to eq('notifications_export')
+  end
+end

--- a/spec/services/data_migrations/specify_export_type_for_tad_exports_spec.rb
+++ b/spec/services/data_migrations/specify_export_type_for_tad_exports_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::SpecifyExportTypeForTADExports do
+  it 'backfills export_type for tad application exports' do
+    notifications_export = create(
+      :data_export,
+      name: 'Daily export of applications for TAD',
+      export_type: nil,
+    )
+
+    described_class.new.change
+    expect(notifications_export.reload.export_type).to eq('tad_applications')
+  end
+end


### PR DESCRIPTION
## Context

These exports run but are not accessible because `export_type` has not been set when they were triggered.

## Changes proposed in this pull request

Set it when scheduling it. Backfill `export_type` for all previous notifications exports.

Do the same for daily TAD applications exports.

## Guidance to review

Straightforward

## Link to Trello card

https://trello.com/c/82W7yz61

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
