### PR TITLE
Fix typo in EthnicBackgroundHelper and update affected ethnic_group and hesa_ethnicity values

### DIFF
--- a/app/helpers/ethnic_background_helper.rb
+++ b/app/helpers/ethnic_background_helper.rb
@@ -9,7 +9,7 @@ module EthnicBackgroundHelper
 
   ETHNIC_BACKGROUNDS = {
     'Asian or Asian British' => %w[Bangladeshi Chinese Indian Pakistani],
-    'Black, African, Black British or Caribbean' => %w[African Carribean],
+    'Black, African, Black British or Caribbean' => %w[African Caribbean],
     'Mixed or multiple ethnic groups' => ['Asian and White', 'Black African and White', 'Black Caribbean and White'],
     'White' => ['British, English, Northern Irish, Scottish, or Welsh', 'Irish', 'Irish Traveller or Gypsy'],
     'Another ethnic group' => %w[Arab],

--- a/app/lib/hesa/ethnicity.rb
+++ b/app/lib/hesa/ethnicity.rb
@@ -8,7 +8,7 @@ module Hesa
       elsif cycle_year == 2021
         HESA_ETHNICITIES_2020_2021.map { |ethnicity| EthnicityStruct.new(*ethnicity) }
       else
-        raise ArgumentError, "Do not know Hesa Ethnicities codes for #{recruitment_cycle_year}"
+        raise ArgumentError, "Do not know Hesa Ethnicities codes for #{cycle_year}"
       end
     end
 

--- a/app/services/data_migrations/fix_misspelling_of_caribbean_ethnic_group_and_set_hesa_codes.rb
+++ b/app/services/data_migrations/fix_misspelling_of_caribbean_ethnic_group_and_set_hesa_codes.rb
@@ -1,0 +1,20 @@
+module DataMigrations
+  class FixMisspellingOfCaribbeanEthnicGroupAndSetHesaCodes
+    TIMESTAMP = 20210513155136
+    MANUAL_RUN = false
+
+    def change
+      application_forms = ApplicationForm
+        .where("equality_and_diversity->>'ethnic_background' = 'Carribean'")
+        .where("equality_and_diversity->>'hesa_ethnicity' IS NULL")
+
+      application_forms.each do |af|
+        equality_and_diversity = af.equality_and_diversity
+        equality_and_diversity['ethnic_background'] = 'Caribbean'
+        equality_and_diversity['hesa_ethnicity'] = Hesa::Ethnicity.find('Caribbean', af.recruitment_cycle_year)&.hesa_code
+
+        af.update!(equality_and_diversity: equality_and_diversity, audit_comment: 'Fixing typo in ethnic background and adding correct hesa_ethnicity code')
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,6 +1,7 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
   'DataMigrations::DeleteAllCourseAudits',
+  'DataMigrations::FixMisspellingOfCaribbeanEthnicGroupAndSetHesaCodes',
   'DataMigrations::BackfillOpenedOnApplyAtFromAudits',
   'DataMigrations::PrefixNoteSubjectToMessage',
   'DataMigrations::TrimQualificationDegreeTypes',

--- a/spec/services/data_migrations/fix_misspelling_of_caribbean_ethnic_group_and_set_hesa_codes_spec.rb
+++ b/spec/services/data_migrations/fix_misspelling_of_caribbean_ethnic_group_and_set_hesa_codes_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::FixMisspellingOfCaribbeanEthnicGroupAndSetHesaCodes do
+  it 'fixes the misspelled Carribean ethnicity background value' do
+    equality_and_diversity = {
+      'sex' => 'female',
+      'hesa_sex' => '2',
+      'disabilities' => [],
+      'ethnic_group' => 'Black, African, Black British or Caribbean',
+      'hesa_ethnicity' => nil,
+      'ethnic_background' => 'Carribean',
+    }
+
+    application_form = create(:application_form, equality_and_diversity: equality_and_diversity)
+
+    described_class.new.change
+
+    updated_equality_and_diversity = application_form.reload.equality_and_diversity
+
+    expect(updated_equality_and_diversity['sex']).to eq('female')
+    expect(updated_equality_and_diversity['ethnic_background']).to eq('Caribbean')
+    expect(updated_equality_and_diversity['hesa_ethnicity']).to eq('21')
+  end
+end

--- a/spec/services/data_migrations/fix_misspelling_of_caribbean_ethnic_group_and_set_hesa_codes_spec.rb
+++ b/spec/services/data_migrations/fix_misspelling_of_caribbean_ethnic_group_and_set_hesa_codes_spec.rb
@@ -1,24 +1,63 @@
 require 'rails_helper'
 
 RSpec.describe DataMigrations::FixMisspellingOfCaribbeanEthnicGroupAndSetHesaCodes do
-  it 'fixes the misspelled Carribean ethnicity background value' do
-    equality_and_diversity = {
+  let(:cycle_year) { RecruitmentCycle.current_year }
+  let(:equality_and_diversity) do
+    {
       'sex' => 'female',
       'hesa_sex' => '2',
       'disabilities' => [],
       'ethnic_group' => 'Black, African, Black British or Caribbean',
-      'hesa_ethnicity' => nil,
-      'ethnic_background' => 'Carribean',
+      'hesa_ethnicity' => hesa_ethnicity,
+      'ethnic_background' => ethnic_background,
     }
+  end
+  let!(:application_form) { create(:application_form, equality_and_diversity: equality_and_diversity, recruitment_cycle_year: cycle_year) }
 
-    application_form = create(:application_form, equality_and_diversity: equality_and_diversity)
+  context 'when ethnic_background is set to Carribean' do
+    let(:ethnic_background) { 'Carribean' }
 
-    described_class.new.change
+    context 'when hesa_ethnicity is already set' do
+      let(:hesa_ethnicity) { '1' }
 
-    updated_equality_and_diversity = application_form.reload.equality_and_diversity
+      it 'makes no changes' do
+        described_class.new.change
 
-    expect(updated_equality_and_diversity['sex']).to eq('female')
-    expect(updated_equality_and_diversity['ethnic_background']).to eq('Caribbean')
-    expect(updated_equality_and_diversity['hesa_ethnicity']).to eq('21')
+        updated_equality_and_diversity = application_form.reload.equality_and_diversity
+
+        expect(updated_equality_and_diversity['sex']).to eq('female')
+        expect(updated_equality_and_diversity['hesa_ethnicity']).to eq('1')
+      end
+    end
+
+    context 'when hesa_ethnicity is nil' do
+      let(:hesa_ethnicity) { nil }
+
+      context 'in the current recruitment_cycle' do
+        it 'corrects the spelling mistake and sets the ethnicity code' do
+          described_class.new.change
+
+          updated_equality_and_diversity = application_form.reload.equality_and_diversity
+
+          expect(updated_equality_and_diversity['sex']).to eq('female')
+          expect(updated_equality_and_diversity['ethnic_background']).to eq('Caribbean')
+          expect(updated_equality_and_diversity['hesa_ethnicity']).to eq('21')
+        end
+      end
+
+      context 'in the previous recruitment_cycle' do
+        let(:cycle_year) { RecruitmentCycle.previous_year }
+
+        it 'corrects the spelling mistake and sets the ethnicity code' do
+          described_class.new.change
+
+          updated_equality_and_diversity = application_form.reload.equality_and_diversity
+
+          expect(updated_equality_and_diversity['sex']).to eq('female')
+          expect(updated_equality_and_diversity['ethnic_background']).to eq('Caribbean')
+          expect(updated_equality_and_diversity['hesa_ethnicity']).to eq('21')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

A typo in a view helper which supplies the ethnicity background for the _Black, African, Black British or Caribbean_  ethnic group meant that the code for `hesa_ethnicity` was not being set.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This PR fixes the typo changing _Carribean_ to _Caribbean_ in the view helper and adds a data migration which finds application forms with the ethnic group typo value updates them with the correct the ethnic group value and HESA ethnicity code.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/z0tg8C7o/3654-hesaethnicity-sometimes-null-or-incorrect-in-api-response-depending-on-ethnicity-chosen
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
