### PR TITLE
Temporarily disable new course notification

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -36,7 +36,8 @@ module TeacherTrainingPublicAPI
           HostingEnvironment.sandbox_mode? || new_course.in_previous_cycle&.open_on_apply
 
         if provider.any_open_courses_in_current_cycle?
-          notify_of_new_course!(provider, course_from_api[:accredited_body_code])
+          # TODO: fix https://ukgovernmentdfe.slack.com/archives/CQA64BETU/p1620925219441400
+          # notify_of_new_course!(provider, course_from_api[:accredited_body_code])
         end
       end
 

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -374,7 +374,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
       end
     end
 
-    describe 'Slack notification' do
+    xdescribe 'Slack notification' do
       let(:accredited_body_code) { nil }
 
       let!(:provider) do


### PR DESCRIPTION
## Context

These are causing a lot of noise in Slack and we're not quite sure why

