### PR TITLE
Change qualification card components to ENIC/NARIC

### DIFF
--- a/app/components/degree_qualification_cards_component.rb
+++ b/app/components/degree_qualification_cards_component.rb
@@ -44,7 +44,7 @@ class DegreeQualificationCardsComponent < ViewComponent::Base
   def enic(degree)
     if degree.enic_reference.present? && degree.comparable_uk_degree.present?
       degree_name = t("application_form.degree.comparable_uk_degree.values.#{degree.comparable_uk_degree}")
-      "#{t('service_name.enic.short_name')} statement #{degree.enic_reference} says this is comparable to a #{degree_name}"
+      "#{t('service_name.enic.short_name_with_naric')} statement #{degree.enic_reference} says this is comparable to a #{degree_name}"
     end
   end
 

--- a/app/components/gcse_qualification_cards_component.rb
+++ b/app/components/gcse_qualification_cards_component.rb
@@ -51,7 +51,7 @@ class GcseQualificationCardsComponent < ViewComponent::Base
 
   def enic_statement(qualification)
     if qualification.enic_reference.present? && qualification.comparable_uk_qualification.present?
-      "#{t('service_name.enic.short_name')} statement #{qualification.enic_reference} says this is comparable to a #{qualification.comparable_uk_qualification}."
+      "#{t('service_name.enic.short_name_with_naric')} statement #{qualification.enic_reference} says this is comparable to a #{qualification.comparable_uk_qualification}."
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
     get_into_teaching: Get Into Teaching
     enic:
       short_name: UK ENIC
+      short_name_with_naric: UK ENIC or NARIC
       full_name: UK ENIC (the UK agency that recognises international qualifications and skills)
       url: https://www.enic.org.uk
   teacher_training_courses_api:

--- a/spec/components/degree_qualification_cards_component_spec.rb
+++ b/spec/components/degree_qualification_cards_component_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe DegreeQualificationCardsComponent, type: :component do
       it 'renders a UK ENIC statement' do
         result = render_inline described_class.new([degree])
         expect(result.text).to include(
-          'UK ENIC statement 1234 says this is comparable to a Master’s degree / Integrated Master’s degree',
+          'UK ENIC or NARIC statement 1234 says this is comparable to a Master’s degree / Integrated Master’s degree',
         )
       end
     end

--- a/spec/components/gcse_qualification_cards_component_spec.rb
+++ b/spec/components/gcse_qualification_cards_component_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe GcseQualificationCardsComponent, type: :component do
         expect(result.text).to include 'Maths Diploma'
         expect(result.text).to include '2006, France'
         expect(result.text).to include 'C'
-        expect(result.text).to include 'UK ENIC statement 4000123456 says this is comparable to a Between GCSE and GCSE AS Level.'
+        expect(result.text).to include 'UK ENIC or NARIC statement 4000123456 says this is comparable to a Between GCSE and GCSE AS Level.'
       end
 
       context 'when the UK ENIC reference is not provided' do


### PR DESCRIPTION
## Context

The body that makes comparative decisions about qualifications changed their name from NARIC to ENIC. On the candidate side, we've updated the interface so that they know they're entering ENIC details - however, we can't track which details existing candidates input, which means at the moment, there may be ENIC or NARIC versions of information showing up provider-side. 

That means we want to change the qualification card components to account for this, and indicate that the ENIC reference may also have been entered in as a NARIC reference when the candidate was applying. 

## Changes proposed in this pull request
Old: 

![image](https://user-images.githubusercontent.com/25597009/118260264-fb171a00-b4a9-11eb-9f70-4316830aefab.png)

New: 

![image](https://user-images.githubusercontent.com/25597009/118260174-e20e6900-b4a9-11eb-9590-057411c677eb.png)

I've added the additional locale, rather than renaming an existing one, as the existing `short_name` is used in other parts of the app.

## Guidance to review

You'll need to either find or modify an application form's `application_qualification` so that one of them has the `enic_reference` and `comparable_uk_degree` filled in. This will trigger the additional part of the component that sets off the `ENIC or NARIC` text.

## Link to Trello card

https://trello.com/c/QIkk8wCr/3644-naric-to-enic-organisation

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
