### PR TITLE
Expanded qualifications export - add documentation and minor refinements

### DIFF
--- a/app/exports/expanded_qualifications_export.yml
+++ b/app/exports/expanded_qualifications_export.yml
@@ -1,0 +1,69 @@
+common_columns:
+  - application_form_id
+  - application_choice_id
+  - candidate_id
+  - support_reference
+  - phase
+  - recruitment_cycle_year
+  - choice_status
+  - course_code
+  - provider_code
+
+custom_columns:
+  level:
+    type: string
+    description: An internal convention describing the level at which the qualification sits
+    enum:
+      - degree
+      - gcse
+      - other
+  qualification_type:
+    type: string
+    description: The specific type of qualification at a given level
+    example: BSc Computer Science
+  other_uk_qualification_type:
+    type: string
+    description: A flexible type description for candidates inputting 'Other' qualifications
+    example: Intermediate GNVQ
+  award_year:
+    type: integer
+    description: The year the qualification was awarded
+    example: 1999
+  subject:
+    type: string
+    description: The qualification subject
+    example: Chemistry
+  predicted_grade:
+    type: boolean
+    description: Whether or not the provided grade is predicted
+  grade:
+    type: string
+    description: The qualification grade
+    example: First class honours
+  constituent_grades:
+    type: string
+    description: A composite grade for subjects like Triple Science GCSE where more than one grade is awarded for the qualification
+    example: '{"biology"=>{"grade"=>"B"}, "physics"=>{"grade"=>"B"}, "chemistry"=>{"grade"=>"A"}}'
+  international_degree:
+    type: boolean
+    description: Whether or not this is an international degree. Note that this only applies to qualifications entered via the Degree flow - candidates sometimes enter degrees in the 'A levels and other qualifications' section.
+  non_uk_qualification_type:
+    type: string
+    description: The specific type of any non-uk qualification (entered via the 'A levels and other qualifications' section).
+    example: High School Diploma
+  qualification_institution_name:
+    type: string
+    description: Name of the awarding institution
+    example: Loughborough Grammar School
+  qualification_institution_country:
+    type: string
+    description: Country of the awarding institution
+    example: FR
+  comparable_uk_degree:
+    type: string
+    description: The UK equivalent of an international degree
+    example: "Bachelor of Science"
+  comparable_uk_qualification:
+    type: string
+    description: The UK equivalent of a non-uk qualification
+    example: GCE Advanced (A) level

--- a/app/services/data_set_documentation.rb
+++ b/app/services/data_set_documentation.rb
@@ -1,6 +1,6 @@
 class DataSetDocumentation
   def self.for(klass)
-    name = klass.name.demodulize.underscore
+    name = with_feature_flag_handling(klass.name.demodulize.underscore)
 
     spec = YAML.load_file(Rails.root.join("app/exports/#{name}.yml"))
     common_columns = load_common_columns
@@ -22,6 +22,15 @@ class DataSetDocumentation
     Dir[Rails.root.join('app/exports/common_columns/*')]
         .map { |file| YAML.load_file(file) }
         .reduce({}, :merge)
+  end
+
+  def self.with_feature_flag_handling(spec_name)
+    case spec_name
+    when 'qualifications_export'
+      FeatureFlag.active?(:expanded_quals_export) ? 'expanded_qualifications_export' : spec_name
+    else
+      spec_name
+    end
   end
 
   private_class_method :load_common_columns, :check_for_shadowed_columns

--- a/app/services/support_interface/expanded_qualifications_export.rb
+++ b/app/services/support_interface/expanded_qualifications_export.rb
@@ -29,7 +29,7 @@ module SupportInterface
             other_uk_qualification_type: qualification.other_uk_qualification_type,
             award_year: qualification.award_year,
             subject: qualification.subject,
-            predicted_grade: qualification.predicted_grade,
+            predicted_grade: qualification.predicted_grade || false,
             grade: qualification.grade,
             constituent_grades: qualification.constituent_grades,
             international_degree: qualification.international,

--- a/app/services/support_interface/expanded_qualifications_export.rb
+++ b/app/services/support_interface/expanded_qualifications_export.rb
@@ -32,7 +32,7 @@ module SupportInterface
             predicted_grade: qualification.predicted_grade,
             grade: qualification.grade,
             constituent_grades: qualification.constituent_grades,
-            international_qualification: qualification.international,
+            international_degree: qualification.international,
             non_uk_qualification_type: qualification.non_uk_qualification_type,
             qualification_institution_name: qualification.institution_name,
             qualification_institution_country: qualification.institution_country,

--- a/spec/services/support_interface/expanded_qualifications_export_spec.rb
+++ b/spec/services/support_interface/expanded_qualifications_export_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe SupportInterface::ExpandedQualificationsExport do
         predicted_grade: qualification.predicted_grade,
         grade: qualification.grade,
         constituent_grades: qualification.constituent_grades,
-        international_qualification: qualification.international,
+        international_degree: qualification.international,
         non_uk_qualification_type: qualification.non_uk_qualification_type,
         qualification_institution_name: qualification.institution_name,
         qualification_institution_country: qualification.institution_country,


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
A production run of the export has been reviewed by Milan, this PR adds documentation and a few bits of cleanup identified during review.

## Changes proposed in this pull request
- Rename the `international_qualification` field
- Add documentation along with a feature flag switch to decide which documentation file to use
- Default predicted_grade to false

(see commits for more detail)
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Can check that the documentation for the Qualifications export changes by switching on the `expanded_quals_export` feature flag in the review app. A quick download of the export to check the field changes would be helpful too.
- Does the documentation make sense?
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/JxXFJ5KG
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
