### PR TITLE
Add equality and diversity response rate to the feature metric dashboard

### DIFF
--- a/app/models/equality_and_diversity_feature_metrics.rb
+++ b/app/models/equality_and_diversity_feature_metrics.rb
@@ -1,0 +1,54 @@
+class EqualityAndDiversityFeatureMetrics
+  include ActionView::Helpers::NumberHelper
+
+  def response_rate(
+    start_time,
+    end_time = Time.zone.now.end_of_day
+  )
+    success_count = application_forms_with_feedback(start_time, end_time).count.to_f
+    fail_count = application_forms_with_no_feedback(start_time, end_time).count.to_f
+    return nil if (fail_count + success_count).zero?
+
+    success_count / (fail_count + success_count)
+  end
+
+  def formatted_response_rate(
+    start_time,
+    end_time = Time.zone.now.end_of_day
+  )
+    format_as_percentage(response_rate(start_time, end_time))
+  end
+
+private
+
+  def format_as_percentage(ratio)
+    return 'n/a' if ratio.nil?
+
+    percentage = number_with_precision(
+      100.0 * ratio,
+      precision: 1,
+      strip_insignificant_zeros: true,
+    )
+    "#{percentage}%"
+  end
+
+  def application_forms_with_feedback(start_time, end_time)
+    ApplicationForm
+      .where(
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+      )
+      .where('application_forms.submitted_at BETWEEN ? AND ?', start_time, end_time)
+      .where.not(equality_and_diversity: '')
+      .where(recruitment_cycle_year: RecruitmentCycle.current_year)
+  end
+
+  def application_forms_with_no_feedback(start_time, end_time)
+    ApplicationForm
+      .where(
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+      )
+      .where('application_forms.submitted_at BETWEEN ? AND ?', start_time, end_time)
+      .where(equality_and_diversity: nil).or(ApplicationForm.where(equality_and_diversity: ''))
+      .where(recruitment_cycle_year: RecruitmentCycle.current_year)
+  end
+end

--- a/app/models/feature_metrics_dashboard.rb
+++ b/app/models/feature_metrics_dashboard.rb
@@ -23,6 +23,7 @@ class FeatureMetricsDashboard < ApplicationRecord
     load_carry_over_counts
     load_qualifications
     load_satisfaction_survey_response_rate
+    load_equality_and_diversity_response_rate
   end
 
   def last_updated_at
@@ -65,6 +66,10 @@ private
 
   def satisfaction_survey_statistics
     SatisfactionSurveyFeatureMetrics.new
+  end
+
+  def equality_and_diversity_statistics
+    EqualityAndDiversityFeatureMetrics.new
   end
 
   def load_avg_time_to_get_references
@@ -357,6 +362,28 @@ private
     write_metric(
       :satisfaction_survey_response_rate_last_month,
       satisfaction_survey_statistics.formatted_response_rate(
+        Time.zone.now.beginning_of_month - 1.month,
+        Time.zone.now.beginning_of_month,
+      ),
+    )
+  end
+
+  def load_equality_and_diversity_response_rate
+    write_metric(
+      :equality_and_diversity_response_rate,
+      equality_and_diversity_statistics.formatted_response_rate(
+        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+      ),
+    )
+    write_metric(
+      :equality_and_diversity_response_rate_this_month,
+      equality_and_diversity_statistics.formatted_response_rate(
+        Time.zone.now.beginning_of_month,
+      ),
+    )
+    write_metric(
+      :equality_and_diversity_response_rate_last_month,
+      equality_and_diversity_statistics.formatted_response_rate(
         Time.zone.now.beginning_of_month - 1.month,
         Time.zone.now.beginning_of_month,
       ),

--- a/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
+++ b/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
@@ -409,4 +409,34 @@
       </div>
     </div>
   </div>
+
+  <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Equality and Diversity</h3>
+  <div id="equality_and_diversity_dashboard_section" class="govuk-grid-row govuk-!-margin-bottom-4">
+    <div class="govuk-grid-column-one-half">
+      <div id="headline-stat" class="govuk-!-margin-bottom-4">
+        <%= render SupportInterface::TileComponent.new(
+          count: @dashboard.read_metric(:equality_and_diversity_response_rate),
+          label: 'Equality and Diversity Survey Response Rate',
+          colour: :blue,
+          size: :reduced,
+        ) %>
+      </div>
+      <div class="govuk-grid-row govuk-!-margin-bottom-4">
+        <div class="govuk-grid-column-one-half">
+          <%= render SupportInterface::TileComponent.new(
+            count: @dashboard.read_metric(:equality_and_diversity_response_rate_this_month),
+            label: 'this month',
+            size: :reduced,
+          ) %>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= render SupportInterface::TileComponent.new(
+            count: @dashboard.read_metric(:equality_and_diversity_response_rate_last_month),
+            label: 'last month',
+            size: :reduced,
+          ) %>
+        </div>
+      </div>
+    </div>
+  </div>
 <% end %>

--- a/spec/models/equality_and_diversity_feature_metrics_spec.rb
+++ b/spec/models/equality_and_diversity_feature_metrics_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SatisfactionSurveyFeatureMetrics, with_audited: true do
+RSpec.describe EqualityAndDiversityFeatureMetrics, with_audited: true do
   subject(:feature_metrics) { described_class.new }
 
   def create_application
@@ -8,8 +8,8 @@ RSpec.describe SatisfactionSurveyFeatureMetrics, with_audited: true do
     application_form
   end
 
-  def create_application_with_feedback
-    application_form = create(:completed_application_form, :with_feedback_completed, submitted_at: Time.zone.now)
+  def create_application_with_equality_and_diversity_data
+    application_form = create(:completed_application_form, :with_equality_and_diversity_data, submitted_at: Time.zone.now)
     application_form
   end
 
@@ -20,28 +20,28 @@ RSpec.describe SatisfactionSurveyFeatureMetrics, with_audited: true do
       end
     end
 
-    context 'with applications with feedback' do
+    context 'with applications with equality and diversity data' do
       it 'returns 0 when there are no submitted applications with feedback' do
         create_application
         expect(feature_metrics.formatted_response_rate(1.month.ago)).to eq('0%')
       end
 
-      it 'returns the right percentages when submitted applications with feedback exist' do
+      it 'returns the right percentages when submitted applications with equality and diversity data exist' do
         create_application
-        2.times { create_application_with_feedback }
+        2.times { create_application_with_equality_and_diversity_data }
         expect(feature_metrics.formatted_response_rate(1.month.ago)).to eq('66.7%')
       end
 
       it 'returns the right percentages over a range of dates' do
         @today = Time.zone.local(2021, 3, 10, 12)
         Timecop.freeze(@today - 40.days) do
-          2.times { create_application_with_feedback }
+          2.times { create_application_with_equality_and_diversity_data }
         end
         Timecop.freeze(@today - 20.days) do
           create_application
         end
         Timecop.freeze(@today - 5.days) do
-          create_application_with_feedback
+          create_application_with_equality_and_diversity_data
         end
         Timecop.freeze(@today) do
           expect(feature_metrics.formatted_response_rate(25.days.ago)).to eq('50%')

--- a/spec/models/equality_and_diversity_feature_metrics_spec.rb
+++ b/spec/models/equality_and_diversity_feature_metrics_spec.rb
@@ -4,13 +4,11 @@ RSpec.describe EqualityAndDiversityFeatureMetrics, with_audited: true do
   subject(:feature_metrics) { described_class.new }
 
   def create_application
-    application_form = create(:completed_application_form, submitted_at: Time.zone.now)
-    application_form
+    create(:completed_application_form, submitted_at: Time.zone.now)
   end
 
   def create_application_with_equality_and_diversity_data
-    application_form = create(:completed_application_form, :with_equality_and_diversity_data, submitted_at: Time.zone.now)
-    application_form
+    create(:completed_application_form, :with_equality_and_diversity_data, submitted_at: Time.zone.now)
   end
 
   describe '#formatted_response_rate' do

--- a/spec/models/feature_metrics_dashboard_spec.rb
+++ b/spec/models/feature_metrics_dashboard_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe FeatureMetricsDashboard do
       carry_over_metrics_double = instance_double(CarryOverFeatureMetrics)
       qualifications_metrics_double = instance_double(QualificationsFeatureMetrics)
       satisfaction_survey_metrics_double = instance_double(SatisfactionSurveyFeatureMetrics)
+      equality_and_diversity_metrics_double = instance_double(EqualityAndDiversityFeatureMetrics)
 
       allow(ReferenceFeatureMetrics).to receive(:new).and_return(reference_metrics_double)
       allow(WorkHistoryFeatureMetrics).to receive(:new).and_return(work_history_metrics_double)
@@ -64,6 +65,7 @@ RSpec.describe FeatureMetricsDashboard do
       allow(CarryOverFeatureMetrics).to receive(:new).and_return(carry_over_metrics_double)
       allow(QualificationsFeatureMetrics).to receive(:new).and_return(qualifications_metrics_double)
       allow(SatisfactionSurveyFeatureMetrics).to receive(:new).and_return(satisfaction_survey_metrics_double)
+      allow(EqualityAndDiversityFeatureMetrics).to receive(:new).and_return(equality_and_diversity_metrics_double)
 
       allow(reference_metrics_double).to receive(:average_time_to_get_references).and_return(1)
       allow(reference_metrics_double).to receive(:percentage_references_within).and_return(2)
@@ -76,6 +78,7 @@ RSpec.describe FeatureMetricsDashboard do
       allow(carry_over_metrics_double).to receive(:carry_over_count).and_return(20)
       allow(qualifications_metrics_double).to receive(:formatted_a_level_percentage).and_return('30%')
       allow(satisfaction_survey_metrics_double).to receive(:formatted_response_rate).and_return('15.4%')
+      allow(equality_and_diversity_metrics_double).to receive(:formatted_response_rate).and_return('50.7%')
 
       dashboard = described_class.new
       dashboard.load_updated_metrics
@@ -123,6 +126,9 @@ RSpec.describe FeatureMetricsDashboard do
         'satisfaction_survey_response_rate' => '15.4%',
         'satisfaction_survey_response_rate_this_month' => '15.4%',
         'satisfaction_survey_response_rate_last_month' => '15.4%',
+        'equality_and_diversity_response_rate' => '50.7%',
+        'equality_and_diversity_response_rate_this_month' => '50.7%',
+        'equality_and_diversity_response_rate_last_month' => '50.7%',
       })
     end
   end

--- a/spec/models/satisfaction_survey_feature_metrics_spec.rb
+++ b/spec/models/satisfaction_survey_feature_metrics_spec.rb
@@ -4,13 +4,11 @@ RSpec.describe SatisfactionSurveyFeatureMetrics, with_audited: true do
   subject(:feature_metrics) { described_class.new }
 
   def create_application
-    application_form = create(:completed_application_form, submitted_at: Time.zone.now)
-    application_form
+    create(:completed_application_form, submitted_at: Time.zone.now)
   end
 
   def create_application_with_feedback
-    application_form = create(:completed_application_form, :with_feedback_completed, submitted_at: Time.zone.now)
-    application_form
+    create(:completed_application_form, :with_feedback_completed, submitted_at: Time.zone.now)
   end
 
   describe '#formatted_response_rate' do

--- a/spec/system/support_interface/feature_metrics_dashboard_spec.rb
+++ b/spec/system/support_interface/feature_metrics_dashboard_spec.rb
@@ -25,6 +25,7 @@ RSpec.feature 'Feature metrics dashboard' do
     and_i_should_see_apply_again_metrics
     and_i_should_see_carry_over_metrics
     and_i_should_see_satisfaction_survey_metrics
+    and_i_should_see_equality_and_diversity_metrics
   end
 
   def given_i_am_a_support_user
@@ -200,6 +201,14 @@ RSpec.feature 'Feature metrics dashboard' do
   def and_i_should_see_satisfaction_survey_metrics
     within('#satisfaction_survey_dashboard_section') do
       expect(page).to have_content('n/a Satisfaction Survey Response Rate')
+      expect(page).to have_content('n/a last month')
+      expect(page).to have_content('n/a this month')
+    end
+  end
+
+  def and_i_should_see_equality_and_diversity_metrics
+    within('#equality_and_diversity_dashboard_section') do
+      expect(page).to have_content('n/a Equality and Diversity Survey Response Rate')
       expect(page).to have_content('n/a last month')
       expect(page).to have_content('n/a this month')
     end


### PR DESCRIPTION
## Context

So that Support users can easily view the rate of E&D survey completion, this value needs to be exposed on the Feature Metrics Dashboard.

## Changes proposed in this pull request

This PR achieves this in much the same way as: https://github.com/DFE-Digital/apply-for-teacher-training/pull/4663

<img width="670" alt="image" src="https://user-images.githubusercontent.com/62567622/118297375-f49e9780-b4d5-11eb-8d18-5038f9cb98b7.png">

## Guidance to review
Please test in review app.

## Link to Trello card

https://trello.com/c/dSrr6jRd/3375-add-equality-and-diversity-response-rate-to-the-feature-metric-dashboard

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
