### PR TITLE
Automatically open new courses if all the provider's courses are already open

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -48,8 +48,10 @@ class Provider < ApplicationRecord
     accredited_courses.current_cycle.exposed_in_find.any?
   end
 
-  def all_courses_open_in_current_cycle?
-    accredited_courses.or(courses).current_cycle.exposed_in_find.all?(&:open_on_apply?)
+  def all_courses_open_in_current_cycle?(exclude_ratified_courses: false)
+    courses_to_check = exclude_ratified_courses ? courses : accredited_courses.or(courses)
+
+    courses_to_check.current_cycle.exposed_in_find.all?(&:open_on_apply?)
   end
 
   def any_open_courses_in_current_cycle?

--- a/app/services/set_open_on_apply_for_new_course.rb
+++ b/app/services/set_open_on_apply_for_new_course.rb
@@ -9,6 +9,7 @@ class SetOpenOnApplyForNewCourse
     @course.open! if HostingEnvironment.sandbox_mode? || @course.in_previous_cycle&.open_on_apply?
 
     if @course.provider.any_open_courses_in_current_cycle?
+      @course.open! if @course.provider.all_courses_open_in_current_cycle?(exclude_ratified_courses: true)
       notify_of_new_course!(@course.provider, @course.accredited_provider)
     end
   end

--- a/app/services/set_open_on_apply_for_new_course.rb
+++ b/app/services/set_open_on_apply_for_new_course.rb
@@ -1,0 +1,34 @@
+class SetOpenOnApplyForNewCourse
+  include Rails.application.routes.url_helpers
+
+  def initialize(course)
+    @course = course
+  end
+
+  def call
+    @course.open! if HostingEnvironment.sandbox_mode? || @course.in_previous_cycle&.open_on_apply?
+
+    if @course.provider.any_open_courses_in_current_cycle?
+      notify_of_new_course!(@course.provider, @course.accredited_provider)
+    end
+  end
+
+private
+
+  def notify_of_new_course!(provider, accredited_provider)
+    notification = [":seedling: #{provider.name}, which has courses open on Apply, added a new course"]
+
+    if accredited_provider&.onboarded?
+      notification << "It’s ratified by #{accredited_provider.name}, who have signed the DSA"
+    elsif accredited_provider.present?
+      notification << "It’s ratified by #{accredited_provider.name}, who have NOT signed the DSA"
+    else
+      notification << 'There’s no separate accredited body for this course'
+    end
+
+    SlackNotificationWorker.perform_async(
+      notification.join('. ') + '.',
+      support_interface_provider_courses_url(provider),
+    )
+  end
+end

--- a/app/services/set_open_on_apply_for_new_course.rb
+++ b/app/services/set_open_on_apply_for_new_course.rb
@@ -38,7 +38,7 @@ private
 
     SlackNotificationWorker.perform_async(
       notification.join('. ') + '.',
-      support_interface_provider_courses_url(provider),
+      support_interface_course_url(@course),
     )
   end
 end

--- a/app/services/set_open_on_apply_for_new_course.rb
+++ b/app/services/set_open_on_apply_for_new_course.rb
@@ -9,15 +9,24 @@ class SetOpenOnApplyForNewCourse
     @course.open! if HostingEnvironment.sandbox_mode? || @course.in_previous_cycle&.open_on_apply?
 
     if @course.provider.any_open_courses_in_current_cycle?
-      @course.open! if @course.provider.all_courses_open_in_current_cycle?(exclude_ratified_courses: true)
-      notify_of_new_course!(@course.provider, @course.accredited_provider)
+      auto_open = @course.provider.all_courses_open_in_current_cycle?(exclude_ratified_courses: true)
+
+      @course.open! if auto_open
+
+      notify_of_new_course!(@course.provider, @course.accredited_provider, auto_open)
     end
   end
 
 private
 
-  def notify_of_new_course!(provider, accredited_provider)
+  def notify_of_new_course!(provider, accredited_provider, auto_open)
     notification = [":seedling: #{provider.name}, which has courses open on Apply, added a new course"]
+
+    if auto_open
+      notification << 'We opened it automatically'
+    else
+      notification << 'We didn’t automatically open it'
+    end
 
     if accredited_provider&.onboarded?
       notification << "It’s ratified by #{accredited_provider.name}, who have signed the DSA"

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -46,4 +46,29 @@ RSpec.describe Provider, type: :model do
       expect(result).to be false
     end
   end
+
+  describe '#all_courses_open_in_current_cycle?' do
+    let(:provider) { create(:provider) }
+
+    subject(:result) { provider.all_courses_open_in_current_cycle? }
+
+    it 'is true if all the provider’s other courses are open on apply except courses hidden in Find' do
+      create(:course, :open_on_apply, provider: provider)
+      create(:course, provider: provider, exposed_in_find: false)
+
+      expect(result).to be true
+    end
+
+    it 'is false if the provider’s other courses are a mixture of open on apply and open on UCAS' do
+      create(:course, provider: provider, exposed_in_find: true, open_on_apply: false)
+
+      expect(result).to be false
+    end
+
+    it 'is false if the provider’s other courses including ratified courses are a mixture of open on Apply and open on UCAS' do
+      create(:course, accredited_provider: provider, exposed_in_find: true, open_on_apply: false)
+
+      expect(result).to be false
+    end
+  end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -70,5 +70,15 @@ RSpec.describe Provider, type: :model do
 
       expect(result).to be false
     end
+
+    context 'exclude_ratified_courses: true' do
+      subject(:result) { provider.all_courses_open_in_current_cycle?(exclude_ratified_courses: true) }
+
+      it 'is true if the provider’s other courses including ratified courses are a mixture of open on Apply and open on UCAS' do
+        create(:course, accredited_provider: provider, exposed_in_find: true, open_on_apply: false)
+
+        expect(result).to be true
+      end
+    end
   end
 end

--- a/spec/services/set_open_on_apply_for_new_course_spec.rb
+++ b/spec/services/set_open_on_apply_for_new_course_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe SetOpenOnApplyForNewCourse do
       expect_no_slack_message
     end
 
+    it 'opens the course if all the provider’s other courses are open on apply' do
+      create(:course, :open_on_apply, provider: course.provider)
+
+      course_opener.call
+
+      expect(course).to be_open_on_apply
+    end
+
     context 'when the course has an accredited provider' do
       let(:accredited_provider) { create(:provider, name: 'Canterbury') }
       let(:course) { create(:course, open_on_apply: false, accredited_provider: accredited_provider) }

--- a/spec/services/set_open_on_apply_for_new_course_spec.rb
+++ b/spec/services/set_open_on_apply_for_new_course_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe SetOpenOnApplyForNewCourse do
+  let(:course) { create(:course, open_on_apply: false) }
+
+  subject(:course_opener) { SetOpenOnApplyForNewCourse.new(course) }
+
+  context 'in Sandbox', sandbox: true do
+    it 'opens the course' do
+      course_opener.call
+
+      expect(course).to be_open_on_apply
+    end
+  end
+
+  context 'the course was open in the previous cycle' do
+    before do
+      create(:course, provider: course.provider, code: course.code, recruitment_cycle_year: RecruitmentCycle.previous_year, open_on_apply: true)
+    end
+
+    it 'opens the course' do
+      course_opener.call
+
+      expect(course).to be_open_on_apply
+    end
+  end
+
+  context 'the provider has open courses in the current cycle', sidekiq: true do
+    before do
+      create(:course, provider: course.provider, open_on_apply: true)
+    end
+
+    it 'notifies slack about the new course' do
+      create(:course, :open_on_apply, provider: course.provider) # existing course
+
+      course_opener.call
+
+      expect_slack_message_with_text("#{course.provider.name}, which has courses open on Apply, added a new course. There’s no separate accredited body for this course.")
+    end
+
+    it 'does not notify Slack when the provider does not have open courses on Apply in this cycle' do
+      create(:course, :open_on_apply, provider: course.provider, recruitment_cycle_year: RecruitmentCycle.previous_year)
+
+      course_opener.call
+
+      expect_no_slack_message
+    end
+
+    context 'when the course has an accredited provider' do
+      let(:accredited_provider) { create(:provider, name: 'Canterbury') }
+      let(:course) { create(:course, open_on_apply: false, accredited_provider: accredited_provider) }
+
+      it 'includes the accredited provider details and the DSA status' do
+        create(:course, :open_on_apply, provider: course.provider) # existing course
+
+        course_opener.call
+
+        expect_slack_message_with_text("#{course.provider.name}, which has courses open on Apply, added a new course. It’s ratified by Canterbury, who have NOT signed the DSA.")
+      end
+
+      context 'and the accredited provider has signed the DSA' do
+        let(:accredited_provider) { create(:provider, :with_signed_agreement, name: 'Canterbury') }
+
+        it 'includes the accredited provider details and the DSA status' do
+          create(:course, :open_on_apply, provider: course.provider) # existing course
+
+          course_opener.call
+
+          expect_slack_message_with_text("#{course.provider.name}, which has courses open on Apply, added a new course. It’s ratified by Canterbury, who have signed the DSA.")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/set_open_on_apply_for_new_course_spec.rb
+++ b/spec/services/set_open_on_apply_for_new_course_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe SetOpenOnApplyForNewCourse do
       course_opener.call
 
       expect_slack_message_with_text("#{course.provider.name}, which has courses open on Apply, added a new course. We opened it automatically. There’s no separate accredited body for this course.")
+      expect_slack_message_with_text("support/courses/#{course.id}")
     end
 
     it 'does not notify Slack when the provider does not have open courses on Apply in this cycle' do

--- a/spec/services/set_open_on_apply_for_new_course_spec.rb
+++ b/spec/services/set_open_on_apply_for_new_course_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SetOpenOnApplyForNewCourse do
 
       course_opener.call
 
-      expect_slack_message_with_text("#{course.provider.name}, which has courses open on Apply, added a new course. There’s no separate accredited body for this course.")
+      expect_slack_message_with_text("#{course.provider.name}, which has courses open on Apply, added a new course. We opened it automatically. There’s no separate accredited body for this course.")
     end
 
     it 'does not notify Slack when the provider does not have open courses on Apply in this cycle' do
@@ -52,6 +52,17 @@ RSpec.describe SetOpenOnApplyForNewCourse do
       course_opener.call
 
       expect(course).to be_open_on_apply
+      expect_slack_message_with_text('We opened it automatically')
+    end
+
+    it 'does not open the course if all the provider’s other courses are not open on apply' do
+      create(:course, :open_on_apply, provider: course.provider)
+      create(:course, :ucas_only, provider: course.provider)
+
+      course_opener.call
+
+      expect(course).not_to be_open_on_apply
+      expect_slack_message_with_text('We didn’t automatically open it')
     end
 
     context 'when the course has an accredited provider' do
@@ -63,7 +74,7 @@ RSpec.describe SetOpenOnApplyForNewCourse do
 
         course_opener.call
 
-        expect_slack_message_with_text("#{course.provider.name}, which has courses open on Apply, added a new course. It’s ratified by Canterbury, who have NOT signed the DSA.")
+        expect_slack_message_with_text("#{course.provider.name}, which has courses open on Apply, added a new course. We opened it automatically. It’s ratified by Canterbury, who have NOT signed the DSA.")
       end
 
       context 'and the accredited provider has signed the DSA' do
@@ -74,7 +85,7 @@ RSpec.describe SetOpenOnApplyForNewCourse do
 
           course_opener.call
 
-          expect_slack_message_with_text("#{course.provider.name}, which has courses open on Apply, added a new course. It’s ratified by Canterbury, who have signed the DSA.")
+          expect_slack_message_with_text("#{course.provider.name}, which has courses open on Apply, added a new course. We opened it automatically. It’s ratified by Canterbury, who have signed the DSA.")
         end
       end
     end

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -376,65 +376,6 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
       end
     end
 
-    xdescribe 'Slack notification' do
-      let(:accredited_body_code) { nil }
-
-      let!(:provider) do
-        create(:provider, code: 'ABC', name: 'University of Life', sync_courses: true)
-      end
-
-      before do
-        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
-                                                   course_code: 'ABC1',
-                                                   recruitment_cycle_year: RecruitmentCycle.current_year,
-                                                   course_attributes: [{
-                                                     accredited_body_code: accredited_body_code,
-                                                     study_mode: 'full_time',
-                                                   }],
-                                                   site_code: 'A',
-                                                   vacancy_status: 'full_time_vacancies')
-      end
-
-      it 'notifies Slack when the provider already has open courses on Apply in this cycle', sidekiq: true do
-        create(:course, :open_on_apply, provider: provider) # existing course
-
-        described_class.new.perform(provider.id, RecruitmentCycle.current_year, incremental_sync_false)
-
-        expect_slack_message_with_text('University of Life, which has courses open on Apply, added a new course. There’s no separate accredited body for this course.')
-      end
-
-      context 'the course from TTAPI has an accredited_body_code' do
-        let(:accredited_body_code) { 'DEF' }
-
-        it 'includes the accredited provider details when DSA is signed' do
-          accredited_provider = create(:provider, :with_signed_agreement, code: 'DEF', name: 'Canterbury')
-          create(:course, :open_on_apply, provider: provider, accredited_provider: accredited_provider) # existing course
-
-          described_class.new.perform(provider.id, RecruitmentCycle.current_year, incremental_sync_false)
-
-          expect_slack_message_with_text('University of Life, which has courses open on Apply, added a new course. It’s ratified by Canterbury, who have signed the DSA.')
-        end
-
-        it 'includes the accredited provider details when DSA is not signed' do
-          accredited_provider = create(:provider, code: 'DEF', name: 'Canterbury')
-          create(:course, :open_on_apply, provider: provider, accredited_provider: accredited_provider) # existing course
-
-          described_class.new.perform(provider.id, RecruitmentCycle.current_year, incremental_sync_false)
-
-          expect_slack_message_with_text('University of Life, which has courses open on Apply, added a new course. It’s ratified by Canterbury, who have NOT signed the DSA.')
-        end
-      end
-
-      it 'does not notify Slack when the provider does not have open courses on Apply in this cycle', sidekiq: true do
-        # existing course in wrong cycle
-        create(:course, :open_on_apply, provider: provider, recruitment_cycle_year: RecruitmentCycle.previous_year)
-
-        described_class.new.perform(provider.id, RecruitmentCycle.current_year, incremental_sync_false)
-
-        expect_no_slack_message
-      end
-    end
-
     describe 'incremental sync' do
       let(:course_code) { 'ABC' }
       let(:course_uuid) { SecureRandom.uuid }


### PR DESCRIPTION
## Context

We notify twd_apply_support about new courses, but often no intervention is required: we can open the courses if all that provider's other courses are already open. We'll continue to notify Slack about courses we open automatically.

## Changes proposed in this pull request

see commits:

- refactor the slack-notifying, course-opening logic from `SyncCourses` into its own class and unit test it
- also test the `Provider#all_courses_open_in_current_cycle?` method so we can enhance it to consider only courses _run_ by the current provider
- implement the automatic opening
- fix the Slack messages to include details of auto-opening
- also replace the annoying link in the Slack messages with a link to the course itself

## Guidance to review

Commit by commit