### PR TITLE
Backfill the selected boolean and ensure backwards compatibility

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -45,6 +45,8 @@ module ViewHelper
 
   def submitted_at_date
     dates = ApplicationDates.new(@application_form)
+    return if dates.submitted_at.nil?
+
     dates.submitted_at.to_s(:govuk_date).strip
   end
 

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -10,6 +10,8 @@ class ApplicationReference < ApplicationRecord
   has_many :reference_tokens, dependent: :destroy
   has_one :candidate, through: :application_form
 
+  scope :selected, -> { feedback_provided.where(selected: true) }
+
   audited associated_with: :application_form
 
   enum feedback_status: {

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -187,7 +187,7 @@ module VendorAPI
     end
 
     def references
-      application_form.application_references.feedback_provided.map do |reference|
+      application_form.application_references.selected.map do |reference|
         reference_to_hash(reference)
       end
     end

--- a/app/services/data_migrations/backfill_selected_boolean.rb
+++ b/app/services/data_migrations/backfill_selected_boolean.rb
@@ -1,0 +1,12 @@
+module DataMigrations
+  class BackfillSelectedBoolean
+    TIMESTAMP = 20210517161321
+    MANUAL_RUN = false
+
+    def change
+      ApplicationReference.feedback_provided.in_batches do |references_batch|
+        references_batch.update_all(selected: true)
+      end
+    end
+  end
+end

--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -8,7 +8,10 @@ class SubmitReference
   end
 
   def save!
-    @reference.update!(feedback_status: :feedback_provided, feedback_provided_at: Time.zone.now)
+    # Updating selected bool to true here will probably be done conditionally based
+    # on if enough references have been provided/the references section has been completed
+    # when we add in the new functionality
+    @reference.update!(feedback_status: :feedback_provided, feedback_provided_at: Time.zone.now, selected: true)
 
     cancel_feedback_requested_references if enough_references_have_been_provided?
 

--- a/app/views/provider_interface/application_choices/_references.html.erb
+++ b/app/views/provider_interface/application_choices/_references.html.erb
@@ -1,7 +1,7 @@
 <section class="app-section govuk-!-width-two-thirds">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="references">References</h2>
 
-  <% @application_choice.application_form.application_references.feedback_provided.each_with_index do |reference, i| %>
+  <% @application_choice.application_form.application_references.selected.each_with_index do |reference, i| %>
     <%= render ProviderInterface::ReferenceWithFeedbackComponent.new(reference: reference, index: i) %>
   <% end %>
 </section>

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillSelectedBoolean',
   'DataMigrations::SpecifyExportTypeForTADExports',
   'DataMigrations::SpecifyExportTypeForNotificationExports',
   'DataMigrations::DeleteAllCourseAudits',

--- a/spec/factories/reference.rb
+++ b/spec/factories/reference.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     referee_type { %i[academic professional school_based character].sample }
     questionnaire { nil }
     duplicate { false }
+    selected { false }
 
     trait :not_requested_yet do
       feedback_status { 'not_requested_yet' }
@@ -73,6 +74,7 @@ FactoryBot.define do
       feedback_provided_at { Time.zone.now }
       safeguarding_concerns { '' }
       relationship_correction { '' }
+      selected { true }
     end
 
     trait :feedback_provided_with_completed_referee_questionnaire do
@@ -89,6 +91,7 @@ FactoryBot.define do
       end
       safeguarding_concerns { '' }
       relationship_correction { '' }
+      selected { true }
     end
   end
 end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -71,6 +71,17 @@ RSpec.describe ViewHelper, type: :helper do
       it 'renders with correct submission date' do
         expect(helper.submitted_at_date).to include('22 October 2019')
       end
+
+      it 'returns nil if there is no submitted at date' do
+        @application_dates = instance_double(
+          ApplicationDates,
+          submitted_at: nil,
+          reject_by_default_at: Time.zone.local(2019, 12, 17, 12, 0, 0),
+        )
+        allow(ApplicationDates).to receive(:new).and_return(@application_dates)
+
+        expect(helper.submitted_at_date).to eq(nil)
+      end
     end
   end
 

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -574,10 +574,17 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
   describe 'attributes.references' do
     let(:application_choice) { create(:application_choice, :with_completed_application_form, :with_offer) }
 
-    it 'returns only references with feedback' do
-      with_feedback = create(
+    it 'returns only references with feedback which were selected by the candidate' do
+      with_feedback_and_selected = create(
         :reference,
         :feedback_provided,
+        application_form: application_choice.application_form,
+      )
+
+      with_feedback_but_not_selected = create(
+        :reference,
+        :feedback_provided,
+        selected: false,
         application_form: application_choice.application_form,
       )
 
@@ -588,7 +595,8 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       )
 
       presenter = VendorAPI::SingleApplicationPresenter.new(application_choice)
-      expect(presenter.as_json[:attributes][:references].map { |r| r[:id] }).to include(with_feedback.id)
+      expect(presenter.as_json[:attributes][:references].map { |r| r[:id] }).to include(with_feedback_and_selected.id)
+      expect(presenter.as_json[:attributes][:references].map { |r| r[:id] }).not_to include(with_feedback_but_not_selected.id)
       expect(presenter.as_json[:attributes][:references].map { |r| r[:id] }).not_to include(refused.id)
     end
 

--- a/spec/services/data_migrations/backfill_selected_boolean_spec.rb
+++ b/spec/services/data_migrations/backfill_selected_boolean_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillSelectedBoolean do
+  it 'sets selected to true for feedback provided references' do
+    reference = create(:reference, feedback_status: 'feedback_provided', selected: false)
+    described_class.new.change
+    expect(reference.reload.selected).to eq true
+  end
+
+  it 'does not set selected to true for all other feedback statuses' do
+    states_minus_feedback_provided = ApplicationReference.feedback_statuses.values.reject do |status|
+      status == 'feedback_provided'
+    end
+
+    states_minus_feedback_provided.each do |status|
+      reference = create(:reference, feedback_status: status, selected: false)
+      described_class.new.change
+      expect(reference.reload.selected).to eq false
+    end
+  end
+end

--- a/spec/services/submit_reference_spec.rb
+++ b/spec/services/submit_reference_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SubmitReference do
   describe '#save!' do
-    it 'updates the reference state to "feedback_provided" and sets feeedback_provided_at to the current time' do
+    it 'updates the reference to "feedback_provided", sets `feedback_provided_at` to the current time and selected to true' do
       Timecop.freeze do
         application_choice = create(:application_choice, status: :unsubmitted)
         application_form = application_choice.application_form
@@ -14,8 +14,10 @@ RSpec.describe SubmitReference do
 
         expect(reference_one).to be_feedback_provided
         expect(reference_one.feedback_provided_at).to eq Time.zone.now
+        expect(reference_one.selected).to eq true
         expect(reference_two).to be_feedback_provided
         expect(reference_two.feedback_provided_at).to eq Time.zone.now
+        expect(reference_two.selected).to eq true
         expect(application_form.reload.application_choices).to all(be_unsubmitted)
       end
     end


### PR DESCRIPTION
## Context

Previous pr - #4746 

This PR backfills the selected boolean when we receive a reference.

It also ensures that the provider UI and Vendor API only pass through references in with feedback provided and where the selected boolean is true.

## Changes proposed in this pull request

- Update selected to true when we receive a reference
- Only show selected references on the provider UI and Vendor API 

## Guidance to review

Have i missed anywhere that needs to be updated/integrated with the new selected bool?

## Link to Trello card

https://trello.com/c/hZVGCcxd/3378-dev-choose-from-more-than-2-feedback-provided-references

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
