### PR TITLE
Add currently unsupported features section to API docs

### DIFF
--- a/app/views/api_docs/vendor_api_docs/pages/home.md
+++ b/app/views/api_docs/vendor_api_docs/pages/home.md
@@ -15,6 +15,17 @@ Providers can then use the API for:
 
 To get an idea of how the API works, we recommend you [review the example usage scenarios](/api-docs/usage-scenarios).
 
+## What the API doesn't support
+
+The API currently doesn’t support the following features:
+- Deferring offers
+- Interview scheduling and status
+- Decision codes (e.g. to provide structured reasons for rejection, or conditions)
+- Tracking and confirming individual conditions
+- Notes
+
+We are exploring the addition of those features, and may support them in later API versions.
+
 ## Codes and reference data
 
 ### Course data


### PR DESCRIPTION
## Context

To give context to vendors as to why certain features cannot yet be done through the API.

## Changes proposed in this pull request

Updating the https://www.apply-for-teacher-training.service.gov.uk/api-docs page

## Link to Trello card

https://trello.com/c/8IqKrV60/3675-clarify-in-api-docs-that-interviews-and-deferral-isnt-available

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
