### PR TITLE
Fix queries running multiple times in application choices index

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -30,8 +30,7 @@ module ProviderInterface
         application_choices: with_includes.where(id: application_choices),
       )
 
-      @application_choices_count = application_choices.count
-      @application_choices = application_choices.page(params[:page] || 1).per(30)
+      @application_choices = application_choices.page(params[:page] || 1).per(30).load
     end
 
     def show

--- a/app/queries/get_application_choices_for_providers.rb
+++ b/app/queries/get_application_choices_for_providers.rb
@@ -4,9 +4,11 @@ class GetApplicationChoicesForProviders
     :current_course_option,
     :provider,
     :site,
-    application_form: %i[candidate application_references application_work_experiences application_volunteering_experiences application_qualifications application_work_history_breaks],
-    course: %i[provider accredited_provider],
-    course_option: [{ course: %i[provider] }, :site],
+    {
+      application_form: %i[candidate application_references application_work_experiences application_volunteering_experiences application_qualifications application_work_history_breaks],
+      course: %i[provider accredited_provider],
+      course_option: [{ course: %i[provider] }, :site],
+    },
   ].freeze
 
   DEFAULT_RECRUITMENT_CYCLE_YEAR = RecruitmentCycle.years_visible_to_providers

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -58,8 +58,7 @@ class FilterApplicationChoicesForProviders
       filtered_application_choices = provider(filtered_application_choices, filters[:provider])
       filtered_application_choices = accredited_provider(filtered_application_choices, filters[:accredited_provider])
       filtered_application_choices = status(filtered_application_choices, filters[:status])
-      filtered_application_choices = provider_location(filtered_application_choices, filters[:provider_location])
-      filtered_application_choices
+      provider_location(filtered_application_choices, filters[:provider_location])
     end
   end
 end

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -1,11 +1,11 @@
-<% content_for :browser_title, "Applications (#{@application_choices_count})" %>
+<% content_for :browser_title, "Applications (#{@application_choices.total_count})" %>
 
 <%= render ServiceInformationBanner.new(namespace: :provider) %>
 
-<h1 class="govuk-heading-xl">Applications (<%= @application_choices_count %>)</h1>
+<h1 class="govuk-heading-xl">Applications (<%= @application_choices.total_count %>)</h1>
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @application_choices) do %>
-  <% if @application_choices.any? %>
+  <% if @application_choices.size > 0 %>
     <div class="app-application-cards">
       <% previous_header = '' %>
       <% @application_choices.each do |choice| %>


### PR DESCRIPTION
## Context

Obtaining the count of applications and then checking whether we had applications to render was causing duplicate queries to run in the `/provider/applications` action and views.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Use Kaminari's `#total_count` method after `#load` to reduce the number of queries. [Kaminari will check to see if records have been loaded when determining the total count of records](https://github.com/kaminari/kaminari/blob/00657f252244413b512349f4de20c63ee478baa5/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb#L25), this allows us to make one query for the page of applications _if_ the applications count is less than the page size. This won't always be the case and inevitably we'll see a query with limit and offset (fetching a page of results) _and_ a count query for total record count. 
This seemed to be the best compromise as it removes the EXISTS query being issued by the call to `any?` in the view. In some cases, (eg. pages with refined results from filtering) it will only issue one query for the results as the results are contained in one page. In most cases there will be a paginating query and a count query for applications.
 
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Currently we perform 3 `ApplicationChoice` db queries when rendering the applications index (count, exists? and load). These queries can be seen in the development log.
This PR should reduce this so that for 1 page of results there should only be 1 `ApplicationChoice` db query and for more than 1 page of results there should be 2 queries (pagination and count).


<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/d1lsWdCD/3681-fix-queries-running-multiple-times-in-applicationchoicesindex

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
