### PR TITLE
Stop clock container before starting new deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,3 +105,7 @@ jobs:
           ARM_ACCESS_KEY:           ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
           TF_VAR_azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           TF_VAR_paas_docker_image: ${{ env.DOCKER_IMAGE }}
+
+      - name: Start Clockwork container
+        if: always()
+        run: cf start apply-clock-${{ env.SPACE_SUFFIX || matrix.environment }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,12 +59,21 @@ jobs:
           echo "TF_VAR_key_vault_resource_group=$KEY_VAULT_RESOURCE_GROUP" >> $GITHUB_ENV
           echo "TF_VAR_key_vault_app_secret_name=$KEY_VAULT_APP_SECRET_NAME" >> $GITHUB_ENV
           echo "TF_VAR_key_vault_infra_secret_name=$KEY_VAULT_INFRA_SECRET_NAME" >> $GITHUB_ENV
+          if [ "${{ matrix.environment }}" = "production" ]; then echo "SPACE_SUFFIX=prod" >> $GITHUB_ENV; fi;
         env:
           DOCKER_IMAGE: ${{ format('ghcr.io/dfe-digital/apply-teacher-training:{0}', github.event.inputs.sha) }}
           KEY_VAULT_NAME: ${{ secrets.KEY_VAULT_NAME }}
           KEY_VAULT_RESOURCE_GROUP: ${{ secrets.KEY_VAULT_RESOURCE_GROUP }}
           KEY_VAULT_INFRA_SECRET_NAME: ${{ secrets.KEY_VAULT_INFRA_SECRET_NAME }}
           KEY_VAULT_APP_SECRET_NAME: ${{ secrets.KEY_VAULT_APP_SECRET_NAME }}
+
+      - name: Setup cf cli
+        uses: DFE-Digital/github-actions/setup-cf-cli@master
+        with:
+          CF_USERNAME:   ${{ secrets.CF_USERNAME }}
+          CF_PASSWORD:   ${{ secrets.CF_PASSWORD }}
+          CF_SPACE_NAME: ${{ secrets.CF_SPACE }}
+          INSTALL_CONDUIT: true
 
       - name: Use Terraform v0.14.9
         uses: hashicorp/setup-terraform@v1
@@ -82,6 +91,9 @@ jobs:
           SECRETS: |
             ${{ env.TF_VAR_key_vault_app_secret_name }}
             ${{ env.TF_VAR_key_vault_infra_secret_name }}
+
+      - name: Stop Clockwork container
+        run: cf stop apply-clock-${{ env.SPACE_SUFFIX || matrix.environment }}
 
       - name: Terraform init, plan & apply
         run: |


### PR DESCRIPTION
## Context

A bug is cf terraform provider is causing worker container deployments to fail occasionally.
Stopping the clockwork container before deploying and starting it back as part of the deployment to check if that solves the errors.

## Changes proposed in this pull request

Stop the clock container before initiating  a new deployment.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
