### PR TITLE
Fix bug on Previous Unsubmitted Application Review

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -45,6 +45,8 @@ module ViewHelper
 
   def submitted_at_date
     dates = ApplicationDates.new(@application_form)
+    return if dates.submitted_at.nil?
+
     dates.submitted_at.to_s(:govuk_date).strip
   end
 

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -71,6 +71,17 @@ RSpec.describe ViewHelper, type: :helper do
       it 'renders with correct submission date' do
         expect(helper.submitted_at_date).to include('22 October 2019')
       end
+
+      it 'returns nil if there is no submitted at date' do
+        @application_dates = instance_double(
+          ApplicationDates,
+          submitted_at: nil,
+          reject_by_default_at: Time.zone.local(2019, 12, 17, 12, 0, 0),
+        )
+        allow(ApplicationDates).to receive(:new).and_return(@application_dates)
+
+        expect(helper.submitted_at_date).to eq(nil)
+      end
     end
   end
 


### PR DESCRIPTION
## Context

A candidate has encountered a bug when clicking through to the previous
application review view. On Investigation this is because they carried
over their application as opposed to applying again. As submitted_at is
nil in this case it breaks a helper method. 

## Changes proposed in this pull request

This PR updates this method include a guard clause that returns nil before hitting that line in this case.


## Guidance to review

Test in review app using carried over application.

## Link to Trello card

https://trello.com/c/vXoQ9Zqx/520-fix-view-helper-method-returning-error-to-candidates

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
