### PR TITLE
File PG::QueryCanceled errors in Skylight against the right controller action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,13 @@ class ApplicationController < ActionController::Base
 
   def current_user; end
 
+  # Makes PG::QueryCanceled statement timeout errors appear in Skylight
+  # against the controller action that triggered them
+  # instead of bundling them with every other ErrorsController#internal_server_error
+  rescue_from ActiveRecord::QueryCanceled, with: lambda {
+    render template: 'errors/internal_server_error', status: :internal_server_error
+  }
+
 private
 
   def append_info_to_payload(payload)

--- a/app/controllers/data_api/tad_data_exports_controller.rb
+++ b/app/controllers/data_api/tad_data_exports_controller.rb
@@ -2,6 +2,11 @@ module DataAPI
   class TADDataExportsController < ActionController::API
     include ServiceAPIUserAuthentication
 
+    # Makes PG::QueryCanceled statement timeout errors appear in Skylight
+    # against the controller action that triggered them
+    # instead of bundling them with every other ErrorsController#internal_server_error
+    rescue_from ActiveRecord::QueryCanceled, with: :statement_timeout
+
     def index
       exports = DataAPI::TADExport.all
 
@@ -31,6 +36,10 @@ module DataAPI
     def serve_export(export)
       export.update!(audit_comment: "File downloaded via API using token ID #{@authenticating_token.id}")
       send_data export.data, filename: export.filename
+    end
+
+    def statement_timeout(e)
+      render json: { errors: [{ error: 'QueryCanceled', message: e }] }, status: :internal_server_error
     end
   end
 end

--- a/app/controllers/register_api/applications_controller.rb
+++ b/app/controllers/register_api/applications_controller.rb
@@ -5,6 +5,11 @@ module RegisterAPI
     rescue_from ActionController::ParameterMissing, with: :parameter_missing
     rescue_from ParameterInvalid, with: :parameter_invalid
 
+    # Makes PG::QueryCanceled statement timeout errors appear in Skylight
+    # against the controller action that triggered them
+    # instead of bundling them with every other ErrorsController#internal_server_error
+    rescue_from ActiveRecord::QueryCanceled, with: :statement_timeout
+
     def index
       render json: { data: serialized_application_choices }
     end
@@ -16,6 +21,10 @@ module RegisterAPI
 
     def parameter_invalid(e)
       render json: { errors: [{ error: 'ParameterInvalid', message: e }] }, status: :unprocessable_entity
+    end
+
+    def statement_timeout(e)
+      render json: { errors: [{ error: 'QueryCanceled', message: e }] }, status: :internal_server_error
     end
 
   private


### PR DESCRIPTION
## Context

We are trying to get a better picture of Postgres query performance against specific actions in the app, but execution times appear too good for actions that often result in statement timeouts.

Investigating this further, it appears that execution times from cancelled statements are logged in Skylight, but are bundled with execution times from any other type of internal server error. See `ErrorsController#internal_server_error` in Skylight.

## Changes proposed in this pull request

Before this change:

![image](https://user-images.githubusercontent.com/107591/118523978-97a11c80-b735-11eb-81f9-5bb1aa95f3fc.png)

After this change:

![image](https://user-images.githubusercontent.com/107591/118524018-a091ee00-b735-11eb-97e4-54f5fd2782d0.png)

## Guidance to review

You can trigger postgres statement timeouts in code with:

```ruby
  ActiveRecord::Base.connection.execute('SELECT pg_sleep(30);')
```

In Skylight, it will still be possible to distinguish between completed requests and timed-out ones by adding `response:html` or `response:error` to the search terms.

## Link to Trello card

https://trello.com/c/s6yUR4jF

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
