### PR TITLE
Fix HESA equality and diversity codes not being reset in Apply 2 (part 1/2)

### DIFF
--- a/app/forms/candidate_interface/equality_and_diversity/disability_status_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/disability_status_form.rb
@@ -25,9 +25,11 @@ module CandidateInterface
         })
       elsif reset_disabilities?(application_form)
         application_form.equality_and_diversity['disabilities'] = []
+        application_form.equality_and_diversity['hesa_disabilities'] = []
         application_form.save
       elsif disability_status == 'Prefer not to say'
         application_form.equality_and_diversity['disabilities'] = ['Prefer not to say']
+        application_form.equality_and_diversity['hesa_disabilities'] = []
         application_form.save
       else
         true

--- a/app/forms/candidate_interface/equality_and_diversity/ethnic_group_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/ethnic_group_form.rb
@@ -23,8 +23,9 @@ module CandidateInterface
       else
         application_form.equality_and_diversity['ethnic_group'] = ethnic_group
 
-        if current_ethnic_group
-          application_form.equality_and_diversity['ethnic_background'] = nil if (ethnic_group == 'Prefer not to say') || (current_ethnic_group != ethnic_group)
+        if current_ethnic_group && ((ethnic_group == 'Prefer not to say') || (current_ethnic_group != ethnic_group))
+          application_form.equality_and_diversity['ethnic_background'] = nil
+          application_form.equality_and_diversity['hesa_ethnicity'] = nil
         end
 
         application_form.save

--- a/spec/forms/candidate_interface/equality_and_diversity/disability_status_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/disability_status_form_spec.rb
@@ -103,12 +103,14 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
       end
 
       it 'resets the disabilities of equality and diversity information if disability status is Prefer not to say' do
-        application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => %w[Blind] })
+        application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => %w[Blind], 'hesa_disabilities' => %w[58] })
         form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'Prefer not to say')
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
-          'sex' => 'male', 'disabilities' => ['Prefer not to say'],
+          'sex' => 'male',
+          'disabilities' => ['Prefer not to say'],
+          'hesa_disabilities' => [],
         )
       end
 

--- a/spec/forms/candidate_interface/equality_and_diversity/ethnic_group_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/ethnic_group_form_spec.rb
@@ -66,13 +66,14 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicGroupForm, type: 
         )
       end
 
-      it 'resets the ethnic background of equality and diversity information if ethnic group is "Prefer not to say"' do
+      it 'resets the ethnic background and hesa code of equality and diversity information if ethnic group is "Prefer not to say"' do
         application_form = build(
           :application_form,
           equality_and_diversity: {
             'sex' => 'male',
             'ethnic_group' => 'Another ethnic group',
             'ethnic_background' => 'Arab',
+            'hesa_ethnicity' => '50',
           },
         )
         form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.new(ethnic_group: 'Prefer not to say')
@@ -80,7 +81,10 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicGroupForm, type: 
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
-          'sex' => 'male', 'ethnic_group' => 'Prefer not to say', 'ethnic_background' => nil,
+          'sex' => 'male',
+          'ethnic_group' => 'Prefer not to say',
+          'ethnic_background' => nil,
+          'hesa_ethnicity' => nil,
         )
       end
     end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_equality_and_diversity_information_spec.rb
@@ -84,6 +84,16 @@ RSpec.feature 'Entering their equality and diversity information' do
 
     when_i_manually_restart_the_questionnaire
     then_i_go_straight_to_the_review_page
+
+    when_i_click_change_ethnic_group
+    when_i_choose_that_i_prefer_not_to_say_my_ethnic_group
+    and_i_click_on_continue
+    then_the_ethnicity_hesa_code_has_been_reset
+
+    when_i_click_change_my_disability
+    and_i_choose_that_i_prefer_not_to_state_my_disabilities
+    and_i_click_on_continue
+    then_the_disabilities_hesa_code_has_been_reset
   end
 
   def given_i_am_signed_in
@@ -295,5 +305,17 @@ RSpec.feature 'Entering their equality and diversity information' do
 
   def then_i_go_straight_to_the_review_page
     expect(page).to have_current_path candidate_interface_review_equality_and_diversity_path
+  end
+
+  def then_the_ethnicity_hesa_code_has_been_reset
+    expect(current_candidate.current_application.reload.equality_and_diversity['hesa_ethnicity']).to be_nil
+  end
+
+  def and_i_choose_that_i_prefer_not_to_state_my_disabilities
+    choose 'Prefer not to say'
+  end
+
+  def then_the_disabilities_hesa_code_has_been_reset
+    expect(current_candidate.current_application.reload.equality_and_diversity['hesa_disabilities']).to eq([])
   end
 end


### PR DESCRIPTION
## Context

If a candidate applies and declares ethnicity and disability information before submitting their application and then applies again but choose _Prefer not so say_ second time round the application retains the HESA codes that were selected in the first application. These should be reset.

There will need to be a follow PR with a data migration to fix up data left by this bug. It will need to be deployed after this one.

## Changes proposed in this pull request

- [x] Change logic in `DisabilityStatusForm` to reset HESA code whenever response is changed.
- [x] Change logic in `EthnicityGroupForm` to reset HESA code whenever response is changed.
- [x] Update existing system spec.

## Guidance to review

- Is anything missing?
- Is there are cleaner way to do this? 
- We could also reset the ethnicity and disability answers when copying from an unsuccessful Apply 1 application to Apply 2 (or rather just not copy those answers). Is that something we want to do?

## Link to Trello card

https://trello.com/c/U7W3r0tj/3402-hesa-equality-and-diversity-codes-not-being-set-when-filling-in-apply-2-form

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
