### PR TITLE
Adding Cloudfront to Trusted Proxies

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,8 @@ require './app/middlewares/redirect_to_service_gov_uk_middleware'
 require './app/middlewares/vendor_api_request_middleware'
 require './app/middlewares/service_unavailable_middleware'
 
+require_relative "../lib/modules/aws_ip_ranges"
+
 require 'pdfkit'
 
 module ApplyForPostgraduateTeacherTraining

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,7 +78,7 @@ Rails.application.configure do
 
   # log to STDOUT using standard verbose format + request_id + timestamp
   config.log_tags = [ :request_id ] # prepend these to log lines
-  
+
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
@@ -141,4 +141,10 @@ Rails.application.configure do
   end
 
   config.middleware.insert_before ActionDispatch::RemoteIp, FixAzureXForwardedForMiddleware
+
+  # Add AWS IP addresses to trusted proxy list
+  config.action_dispatch.trusted_proxies = [
+    ActionDispatch::RemoteIp::TRUSTED_PROXIES,
+    AWSIpRanges.cloudfront_ips.map { |proxy| IPAddr.new(proxy) },
+  ].flatten
 end

--- a/lib/modules/aws_ip_ranges.rb
+++ b/lib/modules/aws_ip_ranges.rb
@@ -1,0 +1,31 @@
+module AWSIpRanges
+  # Used based on this AWS instruction: https://forums.aws.amazon.com/ann.jspa?annID=2051
+  PATH = 'https://ip-ranges.amazonaws.com/ip-ranges.json'.freeze
+  COMPATIBLE_REGIONS = %w[GLOBAL eu-west-2].freeze
+  ResponseError = Class.new(StandardError)
+
+  def self.cloudfront_ips
+    uri = URI(PATH)
+
+    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 10, open_timeout: 5) do |http|
+      request = Net::HTTP::Get.new(uri)
+      response = http.request(request)
+      raise ResponseError, "#{response.code} - #{response.message}" unless response.is_a?(Net::HTTPSuccess)
+
+      parse_json_for_ips(response.body)
+    end
+  rescue StandardError => e
+    Raven.capture_exception(e)
+    []
+  end
+
+  def self.parse_json_for_ips(response)
+    aws_ip_ranges = JSON.parse(response)
+
+    aws_ip_ranges['prefixes'].each_with_object([]) do |record, arr|
+      next unless COMPATIBLE_REGIONS.include?(record['region']) && record['service'] == 'CLOUDFRONT'
+
+      arr << record['ip_prefix']
+    end
+  end
+end

--- a/spec/examples/aws_ip_ranges.json
+++ b/spec/examples/aws_ip_ranges.json
@@ -1,0 +1,31 @@
+{
+  "syncToken": "1527062178",
+  "createDate": "2018-05-23-07-56-18",
+  "prefixes": [
+    {
+      "ip_prefix": "13.32.0.0/15",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "13.35.0.0/16",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "13.32.0.0/15",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.35.0.0/16",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.56.127.0/25",
+      "region": "eu-west-2",
+      "service": "CLOUDFRONT"
+    }
+  ]
+}

--- a/spec/examples/bad_aws_ip_ranges.xml
+++ b/spec/examples/bad_aws_ip_ranges.xml
@@ -1,0 +1,18 @@
+HTTP/1.1 403 Forbidden
+Content-Type: application/xml
+Transfer-Encoding: chunked
+Connection: keep-alive
+Date: Thu, 30 Aug 2018 15:20:48 GMT
+Server: AmazonS3
+Age: 156
+X-Cache: Error from cloudfront
+Via: 1.1 dd12e7e803f596deb3908675a4e017be.cloudfront.net (CloudFront)
+X-Amz-Cf-Id: vFrd7pLiJmoGL4dUDJsvu41YR13_X_yQHymK5MlBHd3jdHQPlj153Q==
+
+<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>AccessDenied</Code>
+  <Message>Access Denied</Message>
+  <RequestId>41561330E5F1240B</RequestId>
+  <HostId>yQ4BdRISh5XUnE9nPKxrv7n5GF7W6nx8Ey6sgvtPjIkmb2MH/VCgHARQA1Mykmw/xir4xu6jrV8=</HostId>
+</Error>%

--- a/spec/lib/modules/aws_ip_ranges_spec.rb
+++ b/spec/lib/modules/aws_ip_ranges_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe AWSIpRanges do
+  describe '.cloudfront_ips' do
+    before do
+      aws_ip_ranges = File.read(
+        Rails.root.join('spec/examples/aws_ip_ranges.json'),
+      )
+      stub_request(:get, AWSIpRanges::PATH).to_return(body: aws_ip_ranges, status: 200)
+    end
+
+    it 'returns the CLOUDFRONT ip in the GLOBAL or eu-west-2 area' do
+      expected_result = %w[13.32.0.0/15 13.35.0.0/16 52.56.127.0/25]
+
+      expect(AWSIpRanges.cloudfront_ips).to eq(expected_result)
+    end
+
+    context 'when there was any connectivity issue' do
+      before do
+        stub_request(:get, AWSIpRanges::PATH).to_timeout
+      end
+
+      it 'returns an empty array' do
+        expect(AWSIpRanges.cloudfront_ips).to eq([])
+      end
+
+      it 'logs a warning to sentry' do
+        allow(Raven).to receive(:capture_exception)
+        AWSIpRanges.cloudfront_ips
+        expect(Raven).to have_received(:capture_exception)
+      end
+    end
+
+    context 'when another type of Net::HTTP error is raised' do
+      before do
+        stub_request(:get, AWSIpRanges::PATH).to_raise(Net::ProtocolError)
+      end
+
+      it 'returns an empty array' do
+        expect(AWSIpRanges.cloudfront_ips).to eq([])
+      end
+
+      it 'logs a warning to sentry' do
+        allow(Raven).to receive(:capture_exception)
+        AWSIpRanges.cloudfront_ips
+        expect(Raven).to have_received(:capture_exception)
+      end
+    end
+
+    context 'when the response was 403 and not JSON' do
+      before do
+        aws_ip_ranges = File.read(
+          Rails.root.join('spec/examples/bad_aws_ip_ranges.xml'),
+        )
+        stub_request(:get, AWSIpRanges::PATH).to_return(body: aws_ip_ranges, status: 403)
+      end
+
+      it 'returns an empty array' do
+        expect(AWSIpRanges.cloudfront_ips).to eq([])
+      end
+
+      it 'logs a warning' do
+        allow(Raven).to receive(:capture_exception)
+        AWSIpRanges.cloudfront_ips
+        expect(Raven).to have_received(:capture_exception)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We're showing the wrong IP address for the 'new sign-in' emails. It turns out the way we order the `X-Forwarded-For` IP addresses means that we pick our cloudfront proxy, rather than the more relevant IP from the source. 

See here for a bit more detail - https://docs.cloud.service.gov.uk/deploying_services/route_services/#example-route-service-to-add-username-and-password-authentication

After some investigating, it looks like TVS had the same issue, and resolved it [here](https://github.com/DFE-Digital/teaching-vacancies/commit/8bb7eecf9861fd49c256bcaca8385143f3e32b3c)

## Changes proposed in this pull request

Adding the proxy's IP address range to our trusted proxies list will mean it gets ignored by the `request.remote_ip`, and instead will show the next one along the chain (probably the source IP).

We'll be pulling the IPs from here - https://ip-ranges.amazonaws.com/ip-ranges.json - it appears to be the best dynamic list available.

I've tested this on QA, and it looks like it's filtering out problematic IPs that we were seeing before. In postman, I set the `X-Forwarded-For` header with an appropriate proxy IP, called the `request.remote_ip` as part of the response, and it managed to filter it out

![image](https://user-images.githubusercontent.com/25597009/119001854-433fac00-b984-11eb-8134-8bdfee5771a3.png)


## Link to Trello card

https://trello.com/c/ygIIRlhE/3694-ip-in-new-sign-in-to-manage-email-is-incorrect

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
