### PR TITLE
render candidate answers of no for both work experience and volenteer…

### DIFF
--- a/app/components/work_history_and_unpaid_experience_component.rb
+++ b/app/components/work_history_and_unpaid_experience_component.rb
@@ -12,6 +12,10 @@ class WorkHistoryAndUnpaidExperienceComponent < WorkHistoryComponent
     end
   end
 
+  def render?
+    true
+  end
+
 private
 
   def rows

--- a/spec/components/work_history_and_unpaid_experience_component_spec.rb
+++ b/spec/components/work_history_and_unpaid_experience_component_spec.rb
@@ -40,17 +40,6 @@ RSpec.describe WorkHistoryAndUnpaidExperienceComponent, type: :component do
     FeatureFlag.activate(:restructured_work_history)
   end
 
-  context 'with an empty history' do
-    let(:work_experiences) { [] }
-    let(:volunteering_experiences) { [] }
-
-    it 'renders nothing' do
-      rendered = render_inline(described_class.new(application_form: application_form))
-
-      expect(rendered.text).to eq ''
-    end
-  end
-
   context 'with full work experience including unpaid experience' do
     let(:breaks) do
       [build(:application_work_history_break,
@@ -151,6 +140,20 @@ RSpec.describe WorkHistoryAndUnpaidExperienceComponent, type: :component do
         expect(section).to have_text 'Livestock management'
         expect(section).to have_text 'Sheep herder'
         expect(section).to have_text "#{2.months.ago.to_s(:month_and_year)} - Present"
+      end
+    end
+
+    context 'with no work history or unpaid experience' do
+      subject! { render_inline(described_class.new(application_form: application_form)) }
+
+      let(:volunteering_experiences) { [] }
+      let(:work_experiences) { [] }
+
+      it 'renders the correct details' do
+        expect(page).to have_css('dl', class: 'govuk-summary-list') do |summary|
+          expect(summary).to have_css('dd', class: 'govuk-summary-list__value', text: 'No')
+          expect(summary).to have_css('dd', class: 'govuk-summary-list__value', text: 'No')
+        end
       end
     end
   end


### PR DESCRIPTION

## Context

Overwrite the render? method on the WorkHistoryComponent class so that it always returns true, this will ensure that even if no work history is provided the component will render (and thus we can see that a candidate has answered in the negative).

## Link to Trello card

https://trello.com/c/ijexHZa8/3693-tell-providers-when-work-history-and-unpaid-experience-are-both-not-provided-by-candidates

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
