### PR TITLE
Remove 'updated_at' filter from Course sync

### DIFF
--- a/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
+++ b/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
@@ -12,7 +12,7 @@ module TeacherTrainingPublicAPI
         scope = scope.where(updated_since: TeacherTrainingPublicAPI::SyncCheck.updated_since) if incremental_sync
         response = scope.all
 
-        sync_providers(response, recruitment_cycle_year, incremental_sync: incremental_sync)
+        sync_providers(response, recruitment_cycle_year)
 
         is_last_page = true if response.links.links['next'].nil?
       end
@@ -22,12 +22,12 @@ module TeacherTrainingPublicAPI
       raise TeacherTrainingPublicAPI::SyncError
     end
 
-    def self.sync_providers(providers_from_api, recruitment_cycle_year, incremental_sync: true)
+    def self.sync_providers(providers_from_api, recruitment_cycle_year)
       providers_from_api.each do |provider_from_api|
         TeacherTrainingPublicAPI::SyncProvider.new(
           provider_from_api: provider_from_api,
           recruitment_cycle_year: recruitment_cycle_year,
-        ).call(incremental_sync: incremental_sync)
+        ).call
       end
     end
 

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -6,7 +6,7 @@ module TeacherTrainingPublicAPI
     include Sidekiq::Worker
     sidekiq_options retry: 3, queue: :low_priority
 
-    def perform(provider_id, recruitment_cycle_year, incremental_sync, run_in_background: true)
+    def perform(provider_id, recruitment_cycle_year, run_in_background: true)
       @provider = ::Provider.find(provider_id)
       @run_in_background = run_in_background
 
@@ -14,8 +14,6 @@ module TeacherTrainingPublicAPI
         year: recruitment_cycle_year,
         provider_code: @provider.code,
       ).paginate(per_page: 500)
-
-      scope = scope.where(updated_since: TeacherTrainingPublicAPI::SyncCheck.updated_since) if incremental_sync
 
       scope.each do |course_from_api|
         ActiveRecord::Base.transaction do

--- a/app/services/teacher_training_public_api/sync_provider.rb
+++ b/app/services/teacher_training_public_api/sync_provider.rb
@@ -5,7 +5,7 @@ module TeacherTrainingPublicAPI
       @recruitment_cycle_year = recruitment_cycle_year
     end
 
-    def call(run_in_background: true, force_sync_courses: false, incremental_sync: true)
+    def call(run_in_background: true, force_sync_courses: false)
       @force_sync_courses = force_sync_courses
 
       provider_attrs = if existing_provider
@@ -17,15 +17,15 @@ module TeacherTrainingPublicAPI
                        end
 
       provider = create_or_update_provider(provider_attrs)
-      sync_courses(run_in_background, provider, incremental_sync: incremental_sync)
+      sync_courses(run_in_background, provider)
     end
 
-    def sync_courses(run_in_background, provider, incremental_sync: true)
+    def sync_courses(run_in_background, provider)
       if sync_courses?
         if run_in_background
-          TeacherTrainingPublicAPI::SyncCourses.perform_async(provider.id, @recruitment_cycle_year, incremental_sync)
+          TeacherTrainingPublicAPI::SyncCourses.perform_async(provider.id, @recruitment_cycle_year)
         else
-          TeacherTrainingPublicAPI::SyncCourses.new.perform(provider.id, @recruitment_cycle_year, incremental_sync, run_in_background: false)
+          TeacherTrainingPublicAPI::SyncCourses.new.perform(provider.id, @recruitment_cycle_year, run_in_background: false)
         end
       end
     end

--- a/spec/services/teacher_training_public_api/sync_all_providers_and_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_all_providers_and_courses_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCourses, sidekiq: tr
 
       before do
         allow(TeacherTrainingPublicAPI::SyncCheck).to receive(:updated_since).and_return(updated_since)
-        allow(sync_provider).to receive(:call).with(incremental_sync: true)
+        allow(sync_provider).to receive(:call)
         allow(TeacherTrainingPublicAPI::SyncProvider)
           .to receive(:new)
             .with(provider_from_api: anything, recruitment_cycle_year: recruitment_cycle_year)
@@ -55,10 +55,10 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCourses, sidekiq: tr
         )
       end
 
-      it "calls sync provider with incremental sync 'true'" do
+      it 'calls sync provider' do
         described_class.call(incremental_sync: true)
 
-        expect(sync_provider).to have_received(:call).with(incremental_sync: true)
+        expect(sync_provider).to have_received(:call)
       end
     end
   end

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
   include TeacherTrainingPublicAPIHelper
 
   describe '.call' do
-    let(:incremental_sync_false) { false }
-
     context 'ingesting an existing provider configured to sync courses, sites and course_options' do
       let(:existing_provider) do
         create(:provider, code: 'ABC', sync_courses: true, provider_type: 'scitt', region_code: 'south_west', postcode: 'SK2 6AA')
@@ -43,7 +41,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
           vacancy_status: 'full_time_vacancies',
         )
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
 
         course_option = CourseOption.last
         expect(course_option.course.uuid).to eq '906c6f3c-b2d6-46e1-8bf7-3fbd13d3ea06'
@@ -81,7 +79,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
 
         it 'when there is no entry for the subject it creates a new one' do
           expect {
-            described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+            described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
           }.to change(Subject, :count).by(1)
 
           expect(Subject.exists?(code: '00')).to be true
@@ -90,7 +88,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
         it 'when the subject exists it associates the existing entry' do
           subject = create(:subject, code: '00')
           expect {
-            described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+            described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
           }.to change(Subject, :count).by(0)
 
           course = Course.last
@@ -121,7 +119,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
           }],
         )
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
 
         course_option = CourseOption.last
         expect(course_option.site.address_line2).to be_nil
@@ -134,11 +132,11 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                                                    site_code: 'A',
                                                    vacancy_status: 'full_time_vacancies')
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
         expect(CourseOption.count).to eq 1
         CourseOption.first.update!(vacancy_status: 'no_vacancies')
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
         expect(CourseOption.count).to eq 1
         expect(CourseOption.first.vacancy_status).to eq 'vacancies'
       end
@@ -149,11 +147,11 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                                                    course_attributes: [{ study_mode: 'full_time', accredited_body_code: nil, state: 'withdrawn' }],
                                                    site_code: 'A')
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
         expect(CourseOption.count).to eq 1
         Course.first.update!(withdrawn: false)
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
         expect(Course.first.withdrawn).to eq true
       end
 
@@ -166,7 +164,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                                                    site_code: 'A',
                                                    vacancy_status: 'full_time_vacancies')
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
         course_option = CourseOption.first
         expect(course_option.course.accredited_provider.code).to eq 'DEF'
         expect(course_option.course.accredited_provider.name).to eq 'Foobar College'
@@ -178,7 +176,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                                                    course_attributes: [{ accredited_body_code: 'ABC' }],
                                                    site_code: 'A')
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
         expect(Course.find_by(code: 'ABC1').accredited_provider).to be_nil
       end
 
@@ -190,7 +188,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                                                    course_attributes: [{ accredited_body_code: nil, uuid: '9875793b-83b6-4a6f-a3d7-4775e76a9ae7' }],
                                                    site_code: 'A')
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
         expect(course.reload.accredited_provider).to be_nil
       end
 
@@ -202,7 +200,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                                                    site_code: 'A')
 
         expect {
-          described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+          described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
         }.to change(ProviderRelationshipPermissions, :count).by(1)
 
         permissions = ProviderRelationshipPermissions.last
@@ -219,7 +217,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                                                    site_code: 'A')
 
         expect {
-          described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+          described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
         }.not_to change(ProviderRelationshipPermissions, :count)
       end
 
@@ -230,7 +228,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                                                    site_code: 'A')
 
         expect {
-          described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+          described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
         }.not_to change(ProviderRelationshipPermissions, :count)
       end
 
@@ -240,7 +238,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                                                    course_attributes: [{ accredited_body_code: 'ABC', study_mode: 'both' }],
                                                    site_code: 'A')
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
         expect(Course.find_by(code: 'ABC1').study_mode).to eq 'full_time_or_part_time'
       end
 
@@ -264,7 +262,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                                  }],
         )
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
 
         provider = Provider.find_by(code: 'ABC')
         course_options = Course.find_by(code: 'ABC1').course_options
@@ -282,7 +280,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                                                    site_code: 'A',
                                                    vacancy_status: 'full_time_vacancies')
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
         expect(Course.count).to eq 1
         expect(CourseOption.count).to eq 1
 
@@ -299,7 +297,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
         create(:application_choice, course_option: invalid_course_option_two)
         create(:application_choice, course_option: valid_course_option, current_course_option: invalid_course_option_three)
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
         expect(CourseOption.exists?(invalid_course_option_one.id)).to eq false
         expect(invalid_course_option_two.reload).not_to be_site_still_valid
         expect(invalid_course_option_three.reload).not_to be_site_still_valid
@@ -313,7 +311,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                                                    site_code: 'A',
                                                    vacancy_status: 'full_time_vacancies')
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year)
 
         course = Course.find_by(code: 'ABC1')
 
@@ -333,7 +331,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                                                    site_code: 'A',
                                                    vacancy_status: 'full_time_vacancies')
 
-        described_class.new.perform(existing_provider.id, 2020, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, 2020)
       end
 
       it 'creates separate courses for the courses in this cycle' do
@@ -346,7 +344,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                                                    site_code: 'A',
                                                    vacancy_status: 'full_time_vacancies')
 
-        described_class.new.perform(existing_provider.id, 2021, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, 2021)
         expect(Course.count).to eq 2
       end
 
@@ -361,7 +359,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                                                    site_code: 'A',
                                                    vacancy_status: 'full_time_vacancies')
 
-        described_class.new.perform(existing_provider.id, 2021, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, 2021)
 
         new_course = Course.find_by(recruitment_cycle_year: 2021)
         expect(new_course).to be_open_on_apply
@@ -369,7 +367,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
 
         new_course.update(open_on_apply: false)
 
-        described_class.new.perform(existing_provider.id, 2021, incremental_sync_false)
+        described_class.new.perform(existing_provider.id, 2021)
 
         expect(new_course.reload).not_to be_open_on_apply
         expect(new_course.opened_on_apply_at).not_to be_nil
@@ -398,7 +396,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
       it 'notifies Slack when the provider already has open courses on Apply in this cycle', sidekiq: true do
         create(:course, :open_on_apply, provider: provider) # existing course
 
-        described_class.new.perform(provider.id, RecruitmentCycle.current_year, incremental_sync_false)
+        described_class.new.perform(provider.id, RecruitmentCycle.current_year)
 
         expect_slack_message_with_text('University of Life, which has courses open on Apply, added a new course. There’s no separate accredited body for this course.')
       end
@@ -410,7 +408,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
           accredited_provider = create(:provider, :with_signed_agreement, code: 'DEF', name: 'Canterbury')
           create(:course, :open_on_apply, provider: provider, accredited_provider: accredited_provider) # existing course
 
-          described_class.new.perform(provider.id, RecruitmentCycle.current_year, incremental_sync_false)
+          described_class.new.perform(provider.id, RecruitmentCycle.current_year)
 
           expect_slack_message_with_text('University of Life, which has courses open on Apply, added a new course. It’s ratified by Canterbury, who have signed the DSA.')
         end
@@ -419,7 +417,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
           accredited_provider = create(:provider, code: 'DEF', name: 'Canterbury')
           create(:course, :open_on_apply, provider: provider, accredited_provider: accredited_provider) # existing course
 
-          described_class.new.perform(provider.id, RecruitmentCycle.current_year, incremental_sync_false)
+          described_class.new.perform(provider.id, RecruitmentCycle.current_year)
 
           expect_slack_message_with_text('University of Life, which has courses open on Apply, added a new course. It’s ratified by Canterbury, who have NOT signed the DSA.')
         end
@@ -429,44 +427,9 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
         # existing course in wrong cycle
         create(:course, :open_on_apply, provider: provider, recruitment_cycle_year: RecruitmentCycle.previous_year)
 
-        described_class.new.perform(provider.id, RecruitmentCycle.current_year, incremental_sync_false)
+        described_class.new.perform(provider.id, RecruitmentCycle.current_year)
 
         expect_no_slack_message
-      end
-    end
-
-    describe 'incremental sync' do
-      let(:course_code) { 'ABC' }
-      let(:course_uuid) { SecureRandom.uuid }
-      let(:provider_code) { 'DEF' }
-      let(:provider) { create(:provider, code: provider_code, sync_courses: true) }
-      let(:updated_since) { Time.zone.now - 2.hours }
-      let(:course) { create(:course, provider: provider, code: course_code, study_mode: 'part_time', uuid: course_uuid) }
-      let(:incremental_sync_true) { true }
-
-      before do
-        course
-
-        allow(TeacherTrainingPublicAPI::SyncCheck).to receive(:updated_since).and_return(updated_since)
-
-        stub_teacher_training_api_course_with_site(
-          provider_code: provider_code,
-          course_code: course_code,
-          recruitment_cycle_year: RecruitmentCycle.current_year,
-          course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time', uuid: course_uuid }],
-          site_code: 'A',
-          vacancy_status: 'full_time_vacancies',
-          filter_option: { 'filter[updated_since]' => updated_since },
-        )
-      end
-
-      it 'updates courses that have changed since the last sync' do
-        described_class.new.perform(provider.id, RecruitmentCycle.current_year, incremental_sync_true)
-
-        course.reload
-
-        expect(Course.count).to eq 1
-        expect(course.study_mode).to eq('full_time')
       end
     end
   end

--- a/spec/services/teacher_training_public_api/sync_provider_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_provider_spec.rb
@@ -46,30 +46,10 @@ RSpec.describe TeacherTrainingPublicAPI::SyncProvider, sidekiq: true do
       end
     end
 
-    context 'ingesting an existing provider configured to sync courses, sites and course_options' do
-      it 'calls the Sync Courses job with the correct parameters' do
-        existing_provider = create(:provider, sync_courses: true)
-        incremental_sync = true
-        provider_from_api = fake_api_provider(id: existing_provider.id, code: existing_provider.code)
-
-        allow(TeacherTrainingPublicAPI::SyncCourses).to receive(:perform_async).and_return(true)
-
-        sync_job = described_class.new(provider_from_api: provider_from_api, recruitment_cycle_year: stubbed_recruitment_cycle_year)
-        sync_job.call(run_in_background: true)
-
-        expect(TeacherTrainingPublicAPI::SyncCourses).to have_received(:perform_async).with(
-          provider_from_api.id,
-          stubbed_recruitment_cycle_year,
-          incremental_sync,
-        ).exactly(1).time
-      end
-    end
-
     context 'Incremental sync' do
       it 'updates the providers that have changes since the last sync' do
         existing_provider = create(:provider, sync_courses: true, name: 'Foo school')
         provider_from_api = fake_api_provider(id: existing_provider.id, code: existing_provider.code)
-        incremental_sync = true
 
         allow(TeacherTrainingPublicAPI::SyncCourses).to receive(:perform_async).and_return(true)
 
@@ -78,14 +58,13 @@ RSpec.describe TeacherTrainingPublicAPI::SyncProvider, sidekiq: true do
           recruitment_cycle_year: stubbed_recruitment_cycle_year,
         )
 
-        sync_job.call(run_in_background: true, incremental_sync: true)
+        sync_job.call(run_in_background: true)
 
         expect(TeacherTrainingPublicAPI::SyncCourses)
           .to have_received(:perform_async)
             .with(
               provider_from_api.id,
               stubbed_recruitment_cycle_year,
-              incremental_sync,
             )
             .exactly(1)
             .time

--- a/spec/support/test_helpers/teacher_training_public_api_helper.rb
+++ b/spec/support/test_helpers/teacher_training_public_api_helper.rb
@@ -32,10 +32,10 @@ module TeacherTrainingPublicAPIHelper
     )
   end
 
-  def stub_teacher_training_api_course_with_site(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, course_code:, site_code:, vacancy_status: 'full_time_vacancies', course_attributes: [], site_attributes: [], filter_option: nil)
+  def stub_teacher_training_api_course_with_site(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, course_code:, site_code:, vacancy_status: 'full_time_vacancies', course_attributes: [], site_attributes: [])
     course_attributes = course_attributes.any? ? [course_attributes.first.merge(code: course_code)] : [{ code: course_code }]
     site_attributes = site_attributes.any? ? [site_attributes.first.merge(code: site_code)] : [{ code: site_code }]
-    stub_teacher_training_api_courses(recruitment_cycle_year: recruitment_cycle_year, provider_code: provider_code, specified_attributes: course_attributes, filter_option: filter_option)
+    stub_teacher_training_api_courses(recruitment_cycle_year: recruitment_cycle_year, provider_code: provider_code, specified_attributes: course_attributes)
     stub_teacher_training_api_sites(recruitment_cycle_year: recruitment_cycle_year, provider_code: provider_code, course_code: course_code, specified_attributes: site_attributes, vacancy_status: vacancy_status)
   end
 
@@ -44,9 +44,9 @@ module TeacherTrainingPublicAPIHelper
     stub_teacher_training_single_api_request("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses/#{course_code}", response_body)
   end
 
-  def stub_teacher_training_api_courses(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, specified_attributes: [], filter_option: nil)
+  def stub_teacher_training_api_courses(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, specified_attributes: [])
     response_body = build_response_body('course_list_response.json', specified_attributes)
-    stub_teacher_training_list_api_request("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses", response_body, filter_option: filter_option)
+    stub_teacher_training_list_api_request("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses", response_body)
   end
 
   def stub_teacher_training_api_sites(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, course_code:, specified_attributes: [], vacancy_status: 'full_time_vacancies')
@@ -100,15 +100,13 @@ private
     )
   end
 
-  def stub_teacher_training_list_api_request(url, response_body, filter_option: nil)
+  def stub_teacher_training_list_api_request(url, response_body)
     scope = stub_request(
       :get,
       url,
     ).with(
       query: { page: { per_page: 500 } },
     )
-
-    scope = scope.with(query: filter_option) if filter_option
 
     scope.to_return(
       status: 200,

--- a/spec/system/find_sync/syncing_providers_spec.rb
+++ b/spec/system/find_sync/syncing_providers_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe 'Syncing providers', sidekiq: true do
     stub_teacher_training_api_courses(
       provider_code: 'ABC',
       specified_attributes: [{ code: 'ABC1', accredited_body_code: nil, subject_codes: %w[08], uuid: @course_uuid }],
-      filter_option: { 'filter[updated_since]' => @updated_since },
     )
     stub_teacher_training_api_sites(
       provider_code: 'ABC',

--- a/spec/system/support_interface/provider_sync_courses_spec.rb
+++ b/spec/system/support_interface/provider_sync_courses_spec.rb
@@ -78,7 +78,6 @@ RSpec.feature 'See provider course syncing' do
           accredited_body_code: nil,
         },
       ],
-      filter_option: { 'filter[updated_since]' => @updated_since },
     )
 
     stub_teacher_training_api_sites(

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -131,19 +131,16 @@ RSpec.feature 'Providers and courses' do
                                                course_code: 'ABC1',
                                                course_attributes: [{ accredited_body_code: 'XYZ', qualifications: %w[qts pgce], name: 'Primary' }],
                                                site_code: 'X',
-                                               site_attributes: [{ name: 'Main site' }],
-                                               filter_option: { 'filter[updated_since]' => @updated_since })
+                                               site_attributes: [{ name: 'Main site' }])
 
     stub_teacher_training_api_course_with_site(provider_code: 'DEF',
                                                course_code: 'DEF1',
                                                course_attributes: [{ accredited_body_code: 'ABC' }],
-                                               filter_option: { 'filter[updated_since]' => @updated_since },
                                                site_code: 'Y')
 
     stub_teacher_training_api_course_with_site(provider_code: 'GHI',
                                                course_code: 'GHI1',
                                                course_attributes: [{ accredited_body_code: 'GHI' }],
-                                               filter_option: { 'filter[updated_since]' => @updated_since },
                                                site_code: 'C')
 
     Sidekiq::Testing.inline! do

--- a/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
+++ b/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Sync from Teacher Training API' do
 
   scenario 'a courses study mode changes between syncs' do
     given_there_is_a_full_time_course_on_the_teacher_training_api
-    and_the_last_sync_was_two_hours_ago
 
     when_sync_provider_is_called
     then_the_correct_course_option_is_created_on_apply
@@ -22,18 +21,12 @@ RSpec.describe 'Sync from Teacher Training API' do
   end
 
   def given_there_is_a_full_time_course_on_the_teacher_training_api
-    @updated_since = Time.zone.now - 2.hours
     @provider = create :provider, code: 'ABC', sync_courses: true
     stub_teacher_training_api_course_with_site(provider_code: 'ABC',
                                                course_code: 'ABC1',
                                                course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
-                                               filter_option: { 'filter[updated_since]' => @updated_since },
                                                site_code: 'A',
                                                vacancy_status: 'full_time_vacancies')
-  end
-
-  def and_the_last_sync_was_two_hours_ago
-    allow(TeacherTrainingPublicAPI::SyncCheck).to receive(:updated_since).and_return(@updated_since)
   end
 
   def when_sync_provider_is_called
@@ -59,7 +52,6 @@ RSpec.describe 'Sync from Teacher Training API' do
     stub_teacher_training_api_course_with_site(provider_code: 'ABC',
                                                course_code: 'ABC1',
                                                course_attributes: [{ accredited_body_code: nil, study_mode: 'both' }],
-                                               filter_option: { 'filter[updated_since]' => @updated_since },
                                                site_code: 'A',
                                                vacancy_status: 'both_full_time_and_part_time_vacancies')
   end
@@ -74,7 +66,6 @@ RSpec.describe 'Sync from Teacher Training API' do
     stub_teacher_training_api_course_with_site(provider_code: 'ABC',
                                                course_code: 'ABC1',
                                                course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
-                                               filter_option: { 'filter[updated_since]' => @updated_since },
                                                site_code: 'A',
                                                vacancy_status: 'full_time_vacancies')
   end

--- a/spec/system/teacher_training_public_api/sync_course_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_course_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe 'Sync courses', sidekiq: true do
                                qualifications: %w[qts pgce],
                                accredited_body_code: 'DEF',
                              }],
-      filter_option: { 'filter[updated_since]' => @updated_since },
     )
     stub_teacher_training_api_sites(
       provider_code: 'ABC',

--- a/spec/system/teacher_training_public_api/sync_site_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_site_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe 'Sync sites', sidekiq: true do
         study_mode: 'both',
         uuid: @course_uuid,
       }],
-      filter_option: { 'filter[updated_since]' => @updated_since },
     )
     stub_teacher_training_api_sites(
       provider_code: 'ABC',


### PR DESCRIPTION
## Context

We recently implemented an 'incremental' sync for Providers and Courses (which calls the Teacher Training API)
 https://github.com/DFE-Digital/apply-for-teacher-training/pull/4712

The Public V1 Teacher Training API (TTAPI) does not implement an 'updated_at' filter on the _courses_ endpoint and can therefore be removed.

Note that the TTAPI does implement an 'updated_filter' on the _providers_ endpoint and this is where the incremental sync achieves largest proportion of optimisation.

## Changes proposed in this pull request

Remove `incremental_sync` flag from Courses sync

## Link to Trello card

https://trello.com/c/RsbjA4sq/3299-incrementally-sync-courses-from-the-ttapi

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
