### PR TITLE
Add explicit back links to contact details flow

### DIFF
--- a/app/components/candidate_interface/contact_details_review_component.html.erb
+++ b/app/components/candidate_interface/contact_details_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :contact_details, section_path: candidate_interface_contact_information_edit_phone_number_path, error: @missing_error)) %>
+  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :contact_details, section_path: candidate_interface_edit_phone_number_path, error: @missing_error)) %>
 <% else %>
   <%= render(SummaryCardComponent.new(rows: contact_details_form_rows, editable: @editable)) %>
 <% end %>

--- a/app/components/candidate_interface/contact_details_review_component.rb
+++ b/app/components/candidate_interface/contact_details_review_component.rb
@@ -27,12 +27,12 @@ module CandidateInterface
         key: t('application_form.contact_details.phone_number.label'),
         value: @contact_details_form.phone_number,
         action: t('application_form.contact_details.phone_number.change_action'),
-        change_path: candidate_interface_contact_information_edit_phone_number_path,
+        change_path: candidate_interface_edit_phone_number_path,
       }
     end
 
     def address_row
-      change_path = candidate_interface_contact_information_edit_address_type_path
+      change_path = candidate_interface_edit_address_type_path
 
       {
         key: t('application_form.contact_details.full_address.label'),

--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -2,6 +2,23 @@ module CandidateInterface
   class ContactDetails::AddressController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
 
+    def new
+      @contact_details_form = ContactDetailsForm.new(address_type: current_application.address_type)
+    end
+
+    def create
+      @contact_details_form = ContactDetailsForm.new(
+        contact_details_params.merge(address_type: current_application.address_type),
+      )
+
+      if @contact_details_form.save_address(current_application)
+        redirect_to candidate_interface_contact_information_review_path
+      else
+        track_validation_error(@contact_details_form)
+        render :edit
+      end
+    end
+
     def edit
       @contact_details_form = ContactDetailsForm.build_from_application(
         current_application,

--- a/app/controllers/candidate_interface/contact_details/address_type_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_type_controller.rb
@@ -2,6 +2,21 @@ module CandidateInterface
   class ContactDetails::AddressTypeController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
 
+    def new
+      @contact_details_form = ContactDetailsForm.new
+    end
+
+    def create
+      @contact_details_form = ContactDetailsForm.new(address_type_params)
+
+      if @contact_details_form.save_address_type(current_application)
+        redirect_to candidate_interface_new_address_path
+      else
+        track_validation_error(@contact_details_form)
+        render :edit
+      end
+    end
+
     def edit
       @contact_details_form = ContactDetailsForm.build_from_application(
         current_application,
@@ -12,7 +27,7 @@ module CandidateInterface
       @contact_details_form = ContactDetailsForm.new(address_type_params)
 
       if @contact_details_form.save_address_type(current_application)
-        redirect_to candidate_interface_contact_information_edit_address_path
+        redirect_to candidate_interface_edit_address_path
       else
         track_validation_error(@contact_details_form)
         render :edit

--- a/app/controllers/candidate_interface/contact_details/phone_number_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/phone_number_controller.rb
@@ -2,6 +2,20 @@ module CandidateInterface
   class ContactDetails::PhoneNumberController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
 
+    def new
+      @contact_details_form = ContactDetailsForm.new
+    end
+
+    def create
+      @contact_details_form = ContactDetailsForm.new(contact_details_params)
+      if @contact_details_form.save_base(current_application)
+        redirect_to candidate_interface_new_address_type_path
+      else
+        track_validation_error(@contact_details_form)
+        render :new
+      end
+    end
+
     def edit
       @contact_details_form = ContactDetailsForm.build_from_application(
         current_application,
@@ -12,15 +26,7 @@ module CandidateInterface
       @contact_details_form = ContactDetailsForm.new(contact_details_params)
 
       if @contact_details_form.save_base(current_application)
-        updated_contact_details_form = ContactDetailsForm.build_from_application(
-          current_application,
-        )
-
-        if updated_contact_details_form.valid?(:address)
-          redirect_to candidate_interface_contact_information_review_path
-        else
-          redirect_to candidate_interface_contact_information_edit_address_type_path
-        end
+        redirect_to candidate_interface_contact_information_review_path
       else
         track_validation_error(@contact_details_form)
         render :edit

--- a/app/views/candidate_interface/contact_details/address/_form.html.erb
+++ b/app/views/candidate_interface/contact_details/address/_form.html.erb
@@ -1,0 +1,56 @@
+<%= f.govuk_fieldset legend: { text: t('page_titles.address'), size: 'xl', tag: 'h1' } do %>
+
+<% if @contact_details_form.uk? %>
+  <%= f.govuk_text_field(
+    :address_line1,
+    label: -> { safe_join([@contact_details_form.label_for(:address_line1), ' ', tag.span(t('application_form.contact_details.address_line1.hidden'), class: 'govuk-visually-hidden')]) },
+    autocomplete: 'address-line1',
+  ) %>
+  <%= f.govuk_text_field(
+    :address_line2,
+    label: { text: @contact_details_form.label_for(:address_line2), hidden: true },
+    autocomplete: 'address-line2',
+  ) %>
+  <%= f.govuk_text_field(
+    :address_line3,
+    label: { text: @contact_details_form.label_for(:address_line3) },
+    width: 'two-thirds',
+    autocomplete: 'address-level2',
+  ) %>
+  <%= f.govuk_text_field(
+    :address_line4,
+    label: { text: @contact_details_form.label_for(:address_line4) },
+    width: 'two-thirds',
+    autocomplete: 'address-level1',
+  ) %>
+  <%= f.govuk_text_field(
+    :postcode,
+    label: { text: @contact_details_form.label_for(:postcode) },
+    width: 10,
+    autocomplete: 'postal-code',
+  ) %>
+<% else %>
+  <%= f.govuk_text_field(
+    :address_line1,
+    label: { text: @contact_details_form.label_for(:address_line1) },
+    autocomplete: 'address-line1',
+  ) %>
+  <%= f.govuk_text_field(
+    :address_line2,
+    label: { text: @contact_details_form.label_for(:address_line2) },
+    autocomplete: 'address-line2',
+  ) %>
+  <%= f.govuk_text_field(
+    :address_line3,
+    label: { text: @contact_details_form.label_for(:address_line3) },
+    autocomplete: 'address-level2',
+  ) %>
+  <%= f.govuk_text_field(
+    :address_line4,
+    label: { text: @contact_details_form.label_for(:address_line4) },
+    autocomplete: 'address-level1',
+  ) %>
+  <% end %>
+<% end %>
+
+<%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.address'), @contact_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_edit_address_type_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/contact_details/address/new.html.erb
+++ b/app/views/candidate_interface/contact_details/address/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.address'), @contact_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_new_address_type_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/contact_details/address/new.html.erb
+++ b/app/views/candidate_interface/contact_details/address/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_edit_address_path, method: :patch do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_new_address_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= render 'form', f: f %>

--- a/app/views/candidate_interface/contact_details/address_type/_form.html.erb
+++ b/app/views/candidate_interface/contact_details/address_type/_form.html.erb
@@ -1,0 +1,8 @@
+<%= f.govuk_radio_buttons_fieldset :address_types, legend: { text: t('page_titles.where_do_you_live'), size: 'xl', tag: 'h1' } do %>
+  <%= f.govuk_radio_button :address_type, 'uk', label: { text: t('application_form.contact_details.address_type.values.uk') } %>
+  <%= f.govuk_radio_button :address_type, 'international', label: { text: t('application_form.contact_details.address_type.values.international') }, link_errors: true do %>
+    <%= f.govuk_collection_select :country, select_country_options, :id, :name, label: { text: t('application_form.contact_details.country.label') } %>
+  <% end %>
+<% end %>
+
+<%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/contact_details/address_type/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address_type/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.where_do_you_live'), @contact_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_contact_information_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/contact_details/address_type/new.html.erb
+++ b/app/views/candidate_interface/contact_details/address_type/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.where_do_you_live'), @contact_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_new_phone_number_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/contact_details/address_type/new.html.erb
+++ b/app/views/candidate_interface/contact_details/address_type/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_edit_address_type_path, method: :patch do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_new_address_type_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= render 'form', f: f %>

--- a/app/views/candidate_interface/contact_details/phone_number/_form.html.erb
+++ b/app/views/candidate_interface/contact_details/phone_number/_form.html.erb
@@ -1,0 +1,2 @@
+<%= f.govuk_phone_field :phone_number, label: { text: t('application_form.contact_details.phone_number.label'), size: 'm' }, hint: { text: t('application_form.contact_details.phone_number.hint_text') }, width: 20, autocomplete: 'tel' %>
+<%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/contact_details/phone_number/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/phone_number/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.contact_details'), @contact_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_contact_information_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/contact_details/phone_number/new.html.erb
+++ b/app/views/candidate_interface/contact_details/phone_number/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_edit_phone_number_path, method: :patch do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_new_phone_number_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/contact_details/phone_number/new.html.erb
+++ b/app/views/candidate_interface/contact_details/phone_number/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.contact_details'), @contact_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -80,7 +80,7 @@
           <%= render(TaskListItemComponent.new(
             text: t('page_titles.contact_information'),
             completed: @application_form_presenter.contact_details_completed?,
-            path: @application_form_presenter.contact_details_valid? ? candidate_interface_contact_information_review_path : candidate_interface_edit_phone_number_path,
+            path: @application_form_presenter.contact_details_valid? ? candidate_interface_contact_information_review_path : candidate_interface_new_phone_number_path,
           )) %>
         </li>
       </ol>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -80,7 +80,7 @@
           <%= render(TaskListItemComponent.new(
             text: t('page_titles.contact_information'),
             completed: @application_form_presenter.contact_details_completed?,
-            path: @application_form_presenter.contact_details_valid? ? candidate_interface_contact_information_review_path : candidate_interface_contact_information_edit_phone_number_path,
+            path: @application_form_presenter.contact_details_valid? ? candidate_interface_contact_information_review_path : candidate_interface_edit_phone_number_path,
           )) %>
         </li>
       </ol>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,21 +161,27 @@ Rails.application.routes.draw do
       end
 
       scope '/contact-details' do
-        get '/', to: redirect('/candidate/application/contact-information')
+        get '/', to: redirect('/candidate/application/contact-information/phone-number')
         get '/address_type', to: redirect('/candidate/application/contact-information/address-type')
         get '/address', to: redirect('/candidate/application/contact-information/address')
         get '/review', to: redirect('/candidate/application/contact-information/review')
       end
 
       scope '/contact-information' do
-        get '/' => 'contact_details/phone_number#edit', as: :contact_information_edit_phone_number
-        patch '/' => 'contact_details/phone_number#update'
+        get '/phone-number' => 'contact_details/phone_number#new', as: :new_phone_number
+        post '/phone-number' => 'contact_details/phone_number#create'
+        get '/phone-number/edit' => 'contact_details/phone_number#edit', as: :edit_phone_number
+        patch '/phone-number/edit' => 'contact_details/phone_number#update'
 
-        get '/address-type' => 'contact_details/address_type#edit', as: :contact_information_edit_address_type
-        patch '/address-type' => 'contact_details/address_type#update'
+        get '/address-type' => 'contact_details/address_type#new', as: :new_address_type
+        post '/address-type' => 'contact_details/address_type#create'
+        get '/address-type/edit' => 'contact_details/address_type#edit', as: :edit_address_type
+        patch '/address-type/edit' => 'contact_details/address_type#update'
 
-        get '/address' => 'contact_details/address#edit', as: :contact_information_edit_address
-        patch '/address' => 'contact_details/address#update'
+        get '/address' => 'contact_details/address#new', as: :new_address
+        post '/address' => 'contact_details/address#create'
+        get '/address/edit' => 'contact_details/address#edit', as: :edit_address
+        patch '/address/edit' => 'contact_details/address#update'
 
         get '/review' => 'contact_details/review#show', as: :contact_information_review
         patch '/complete' => 'contact_details/review#complete', as: :contact_information_complete

--- a/spec/components/candidate_interface/contact_details_review_component_spec.rb
+++ b/spec/components/candidate_interface/contact_details_review_component_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CandidateInterface::ContactDetailsReviewComponent do
 
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.contact_details.phone_number.label'))
       expect(result.css('.govuk-summary-list__value').text).to include('07700 900 982')
-      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_contact_information_edit_phone_number_path)
+      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_edit_phone_number_path)
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.contact_details.phone_number.change_action')}")
     end
 
@@ -29,7 +29,7 @@ RSpec.describe CandidateInterface::ContactDetailsReviewComponent do
 
         expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.contact_details.full_address.label'))
         expect(result.css('.govuk-summary-list__value').to_html).to include('42<br>Much Wow Street<br>London<br>England<br>SW1P 3BT')
-        expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_contact_information_edit_address_type_path)
+        expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_edit_address_type_path)
         expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.contact_details.full_address.change_action')}")
       end
 
@@ -46,7 +46,7 @@ RSpec.describe CandidateInterface::ContactDetailsReviewComponent do
 
         expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.contact_details.full_address.label'))
         expect(result.css('.govuk-summary-list__value').to_html).to include('321 MG Road<br>Mumbai<br>India')
-        expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_contact_information_edit_address_type_path)
+        expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_edit_address_type_path)
         expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.contact_details.full_address.change_action')}")
       end
     end

--- a/spec/requests/candidate_interface/validation_error_tracking_spec.rb
+++ b/spec/requests/candidate_interface/validation_error_tracking_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe 'Candidate interface - validation error tracking', type: :request
 
   it 'does NOT create validation error when request is valid' do
     expect {
-      patch candidate_interface_contact_information_edit_phone_number_url(valid_attributes)
+      patch candidate_interface_edit_phone_number_url(valid_attributes)
     }.not_to(change { ValidationError.count })
   end
 
   it 'creates validation error when request is invalid' do
     expect {
-      patch candidate_interface_contact_information_edit_phone_number_url(invalid_attributes)
+      patch candidate_interface_edit_phone_number_url(invalid_attributes)
     }.to(change { ValidationError.count }.by(1))
   end
 end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -35,7 +35,6 @@ module CandidateHelper
     candidate_fills_in_personal_details
 
     click_link t('page_titles.contact_information')
-    visit candidate_interface_contact_information_edit_phone_number_path
     candidate_fills_in_contact_details
 
     click_link t('page_titles.work_history')

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature 'Entering their contact information' do
     expect(validation_error).to be_present
     expect(validation_error.details).to have_key('phone_number')
     expect(validation_error.user).to eq(current_candidate)
-    expect(validation_error.request_path).to eq(candidate_interface_contact_information_edit_phone_number_path)
+    expect(validation_error.request_path).to eq(candidate_interface_new_phone_number_path)
   end
 
   def when_i_fill_in_my_phone_number
@@ -123,7 +123,7 @@ RSpec.feature 'Entering their contact information' do
   end
 
   def when_i_click_to_change_my_phone_number
-    find_link('Change', href: candidate_interface_contact_information_edit_phone_number_path).click
+    find_link('Change', href: candidate_interface_edit_phone_number_path).click
   end
 
   def then_i_can_see_my_phone_number
@@ -140,7 +140,7 @@ RSpec.feature 'Entering their contact information' do
   end
 
   def when_i_click_to_change_my_address_type
-    find_link('Change', href: candidate_interface_contact_information_edit_address_type_path).click
+    find_link('Change', href: candidate_interface_edit_address_type_path).click
   end
 
   def then_i_can_see_my_address_type

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -70,7 +70,6 @@ RSpec.feature 'International candidate submits the application' do
     click_button t('continue')
 
     click_link t('page_titles.contact_information')
-    visit candidate_interface_contact_information_edit_phone_number_path
     candidate_fills_in_international_contact_details
 
     click_link t('page_titles.work_history')


### PR DESCRIPTION
## Context
Rather than use the HTTP referer, which can result in navigation loops,
we want to explicitly state the target of each back link in this flow.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Rework the controllers to have new/create and edit/update action pairs rather than just edit/update
- Add path helpers to each `govuk_back_link_to` used on these pages

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Can be reviewed by adding contact details to a new application in the review app
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/GuiJ30Jg
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
