### PR TITLE
Add feature flag for 'reference selection'

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -33,6 +33,7 @@ class FeatureFlag
     [:support_user_reinstate_offer, 'Allows a support users to reinstate a declined course choice offer', 'James Glenn'],
     [:expanded_quals_export, 'Rework the Qualifications export to contain all candidate qualifications', 'Malcolm Baig'],
     [:support_user_change_offered_course, 'Allows support users to offer a different course option for an application choice', 'David Gisbey'],
+    [:reference_selection, 'Allow candidates to receive multiple references and then select which two are added to their application', 'Malcolm Baig'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|


### PR DESCRIPTION
We're going to build functionality that allows candidates to select
which received references are added to their application. Introduce a
feature flag so we can build this out incrementally.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/hZVGCcxd
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
