### PR TITLE
Add redirect to application feedback form

### DIFF
--- a/app/controllers/candidate_interface/application_feedback_controller.rb
+++ b/app/controllers/candidate_interface/application_feedback_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class ApplicationFeedbackController < CandidateInterfaceController
     def new
+      redirect_to candidate_interface_application_form_path if params[:original_controller].nil?
       @application_feedback_form = CandidateInterface::ApplicationFeedbackForm.new(
         path: params[:path],
         page_title: params[:page_title],


### PR DESCRIPTION
## Context
Sentry error on prod was triggered by candidate visiting the
`/application-feedback` route directly. Logic on this form view is
dependant on controller params to render contextual text. 

## Changes proposed in this pull request

This PR adds a redirect to the controller to redirect to the application form if the controller params are nil.

## Guidance to review
Test in review app.

## Link to Trello card

https://trello.com/c/hNGTrW0r/528-fix-bug-on-application-feeedback-form

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
