### PR TITLE
Add HostingEnvironment to TTAPI User-Agent

### DIFF
--- a/app/models/teacher_training_public_api/resource.rb
+++ b/app/models/teacher_training_public_api/resource.rb
@@ -1,7 +1,7 @@
 module TeacherTrainingPublicAPI
   class Resource < JsonApiClient::Resource
     self.site = ENV.fetch('TEACHER_TRAINING_API_BASE_URL')
-    self.connection_options = { headers: { user_agent: 'Apply for teacher training' } }
+    self.connection_options = { headers: { user_agent: "Apply for teacher training #{HostingEnvironment.environment_name}" } }
   end
 end
 


### PR DESCRIPTION
## Context

We send a custom user agent to TTAPI, and different envs connect to the production API. To make it easier to see where requests are coming from, include the `HostingEnvironment` name (`development`, `qa` etc) in the `User-Agent` string 
