### PR TITLE
save and invite provider user spec split into two chunks

### DIFF
--- a/app/services/invite_provider_user.rb
+++ b/app/services/invite_provider_user.rb
@@ -12,7 +12,10 @@ class InviteProviderUser
   def call!
     lookup_provider_user
     invite_user_to_dfe_sign_in
+  end
 
+  def notify
+    lookup_provider_user
     send_welcome_email
     send_slack_notification
   end

--- a/app/services/save_and_invite_provider_user.rb
+++ b/app/services/save_and_invite_provider_user.rb
@@ -16,6 +16,7 @@ class SaveAndInviteProviderUser
         save_service.call!
         invite_service.call! if new_user
       end
+      invite_service.notify
     rescue DfeSignInAPIError => e
       form.errors.add(
         :base,

--- a/spec/services/invite_provider_user_spec.rb
+++ b/spec/services/invite_provider_user_spec.rb
@@ -42,29 +42,6 @@ RSpec.describe InviteProviderUser, sidekiq: true do
     it 'a provider user is created' do
       expect(ProviderUser.find_by_email_address('test+invite_provider_user@example.com')).not_to be_nil
     end
-
-    it 'queues an email' do
-      expect(ProviderMailer.deliveries.count).to be 1
-    end
-  end
-
-  describe '#call! if API response is successful given a ProviderUser#email_address' do
-    before do
-      allow(SlackNotificationWorker).to receive(:perform_async)
-      set_dsi_api_response(success: true)
-      InviteProviderUser.new(provider_user: provider_user.email_address).call!
-    end
-
-    it 'queues an email' do
-      expect(ProviderMailer.deliveries.count).to be 1
-    end
-
-    it 'sends a slack message' do
-      url = Rails.application.routes.url_helpers.edit_support_interface_provider_user_url(provider_user)
-
-      expect(SlackNotificationWorker).to have_received(:perform_async)
-        .with(":technologist: Provider user Firstname has been invited to join #{provider.name}", url)
-    end
   end
 
   describe '#call! if API response is not successful' do
@@ -83,6 +60,20 @@ RSpec.describe InviteProviderUser, sidekiq: true do
 
     it 'does not notify slack' do
       expect(SlackNotificationWorker).not_to have_received(:perform_async)
+    end
+  end
+
+  describe '#notify' do
+    before do
+      InviteProviderUser.new(provider_user: provider_user).notify
+    end
+
+    it 'queues an email' do
+      expect(ProviderMailer.deliveries.count).to be 1
+    end
+
+    it 'sends a slack message' do
+      expect_slack_message_with_text(":technologist: Provider user Firstname has been invited to join #{provider.name}")
     end
   end
 end

--- a/spec/services/save_and_invite_provider_user_spec.rb
+++ b/spec/services/save_and_invite_provider_user_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe SaveAndInviteProviderUser do
       deselected_provider_permissions: [],
     )
   end
-  let(:invite_service) { instance_double(InviteProviderUser, call!: true) }
+  let(:invite_service) { instance_double(InviteProviderUser, call!: true, notify: true) }
 
   describe '#initialize' do
     it 'requires a form, create service and invite service' do


### PR DESCRIPTION
## Context

In order to avoid the rerunning of enqueued sidekiq jobs inside a transaction the call functionality has been split into a invite service call method has been split into the dfe sign in chunk (which can be rollbacked should the transaction fail) and the notify method (which sends email/ slack notifications) . This should ensure we never resend emails as they will only be send should the transaction be successful. 

## Link to Trello card

https://trello.com/c/4OYkxMip/3677-avoid-enqueuing-sidekiq-jobs-inside-an-activerecord-transaction

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
