### PR TITLE
Update the personal statement section to use explicit backlinks

### DIFF
--- a/app/components/candidate_interface/becoming_a_teacher_review_component.html.erb
+++ b/app/components/candidate_interface/becoming_a_teacher_review_component.html.erb
@@ -2,7 +2,7 @@
   <%= render(
     CandidateInterface::IncompleteSectionComponent.new(
       section: :becoming_a_teacher,
-      section_path: candidate_interface_edit_becoming_a_teacher_path,
+      section_path: @application_form.becoming_a_teacher.present? ? candidate_interface_edit_becoming_a_teacher_path : candidate_interface_new_becoming_a_teacher_path,
       error: @missing_error,
       review_needed: review_needed?,
     ),

--- a/app/controllers/candidate_interface/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement_controller.rb
@@ -2,6 +2,21 @@ module CandidateInterface
   class PersonalStatementController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted, :render_application_feedback_component
 
+    def new
+      @becoming_a_teacher_form = BecomingATeacherForm.new
+    end
+
+    def create
+      @becoming_a_teacher_form = BecomingATeacherForm.new(becoming_a_teacher_params)
+
+      if @becoming_a_teacher_form.save(current_application)
+        redirect_to candidate_interface_becoming_a_teacher_show_path
+      else
+        track_validation_error(@becoming_a_teacher_form)
+        render :new
+      end
+    end
+
     def edit
       @becoming_a_teacher_form = BecomingATeacherForm.build_from_application(
         current_application,

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -256,7 +256,7 @@ module CandidateInterface
       if becoming_a_teacher_valid?
         Rails.application.routes.url_helpers.candidate_interface_becoming_a_teacher_show_path
       else
-        Rails.application.routes.url_helpers.candidate_interface_edit_becoming_a_teacher_path
+        Rails.application.routes.url_helpers.candidate_interface_new_becoming_a_teacher_path
       end
     end
 

--- a/app/views/candidate_interface/personal_statement/_form.html.erb
+++ b/app/views/candidate_interface/personal_statement/_form.html.erb
@@ -1,0 +1,19 @@
+<%= f.govuk_error_summary %>
+
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.becoming_a_teacher') %>
+</h1>
+
+<p class="govuk-body">You can include:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>your interest in the subject or age group</li>
+  <li>the demands and rewards of teaching</li>
+  <li>the personal qualities that would make you a good teacher</li>
+  <li>how you could contribute to a school outside of the classroom</li>
+  <li>any past experience working with children or young people, and what you learnt</li>
+  <li>your thoughts on welfare and education</li>
+</ul>
+<p class="govuk-body">If you need help, you can speak to a <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_get_an_advisor') %> adviser. They’re all experienced teachers who can give you advice on applying for teacher training.</p>
+
+<%= f.govuk_text_area :becoming_a_teacher, label: { text: t('application_form.personal_statement.becoming_a_teacher.label'), size: 'm' }, rows: 20, max_words: 600 %>
+<%= f.govuk_submit t('continue') %>

--- a/app/views/candidate_interface/personal_statement/new.html.erb
+++ b/app/views/candidate_interface/personal_statement/new.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.becoming_a_teacher'), @becoming_a_teacher_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_becoming_a_teacher_show_path) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @becoming_a_teacher_form, url: candidate_interface_edit_becoming_a_teacher_path, method: :patch do |f| %>
+    <%= form_with model: @becoming_a_teacher_form, url: candidate_interface_new_becoming_a_teacher_path, method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,8 +128,10 @@ Rails.application.routes.draw do
         get '/interview-preferences', to: redirect('/candidate/application/interview-needs')
         get '/interview-preferences/review', to: redirect('/candidate/application/interview-needs/review')
 
-        get '/' => 'personal_statement#edit', as: :edit_becoming_a_teacher
-        patch '/' => 'personal_statement#update'
+        get '/' => 'personal_statement#new', as: :new_becoming_a_teacher
+        patch '/' => 'personal_statement#create'
+        get '/edit' => 'personal_statement#edit', as: :edit_becoming_a_teacher
+        patch '/edit' => 'personal_statement#update'
         get '/review' => 'personal_statement#show', as: :becoming_a_teacher_show
         patch '/complete' => 'personal_statement#complete', as: :becoming_a_teacher_complete
       end

--- a/spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
     expect(validation_error).to be_present
     expect(validation_error.details).to have_key('becoming_a_teacher')
     expect(validation_error.user).to eq(current_candidate)
-    expect(validation_error.request_path).to eq(candidate_interface_edit_becoming_a_teacher_path)
+    expect(validation_error.request_path).to eq(candidate_interface_new_becoming_a_teacher_path)
   end
 
   def and_i_fill_in_some_details_but_omit_some_required_details

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_an_authentication_token_with_a_path_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_an_authentication_token_with_a_path_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature 'Candidates authentication token has the path attribute populated'
   end
 
   def then_i_am_redirected_to_the_personal_statement_page
-    expect(page).to have_current_path candidate_interface_edit_becoming_a_teacher_path
+    expect(page).to have_current_path candidate_interface_new_becoming_a_teacher_path
   end
 
   def given_i_am_signed_out


### PR DESCRIPTION
## Context

This adds in new and create actions and views to the personal statement section. This means that we can easily pass explicit
backlinks to each view.

## Changes proposed in this pull request

- Add new and create endpoints to the personal statement controller
- Add explicit backlinks to the new/edit view
- Update tests

## Guidance to review

Previous PR for contact details section #4766 

## Link to Trello card

https://trello.com/c/GuiJ30Jg/3397-catch-all-give-back-links-explicit-targets

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
