### PR TITLE
Allow the candidate to receive > 2 references

### DIFF
--- a/app/components/candidate_interface/add_reference_component.html.erb
+++ b/app/components/candidate_interface/add_reference_component.html.erb
@@ -7,7 +7,9 @@
     <%= govuk_link_to 'Add a second referee', candidate_interface_references_start_path, button: true %>
   <% else %>
     <p class="govuk-body">You can add more referees to increase the chances of getting 2 references quickly.</p>
-    <p class="govuk-body">We’ll cancel any remaining requests when you’ve received 2 references.</p>
+    <% unless FeatureFlag.active?(:reference_selection) %>
+      <p class="govuk-body">We’ll cancel any remaining requests when you’ve received 2 references.</p>
+    <% end %>
     <%= govuk_link_to 'Add another referee', candidate_interface_references_start_path, button: true, class: 'govuk-button--secondary' %>
   <% end %>
 <% end %>

--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -55,7 +55,11 @@ module CandidateInterface
     end
 
     def too_many_complete_references?
-      references.select(&:feedback_provided?).size > ApplicationForm::MINIMUM_COMPLETE_REFERENCES
+      if FeatureFlag.active?(:reference_selection)
+        false
+      else
+        references.select(&:feedback_provided?).size > ApplicationForm::MINIMUM_COMPLETE_REFERENCES
+      end
     end
 
     def container_class

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -236,7 +236,11 @@ class ApplicationForm < ApplicationRecord
   end
 
   def too_many_complete_references?
-    application_references.feedback_provided.size > MINIMUM_COMPLETE_REFERENCES
+    if FeatureFlag.active?(:reference_selection)
+      false
+    else
+      application_references.feedback_provided.size > MINIMUM_COMPLETE_REFERENCES
+    end
   end
 
   def incomplete_degree_information?
@@ -341,7 +345,11 @@ class ApplicationForm < ApplicationRecord
   end
 
   def enough_references_have_been_provided?
-    application_references.feedback_provided.count >= MINIMUM_COMPLETE_REFERENCES
+    if FeatureFlag.active?(:reference_selection)
+      false
+    else
+      application_references.feedback_provided.count >= MINIMUM_COMPLETE_REFERENCES
+    end
   end
 
   def address_formatted_for_geocoding

--- a/app/services/reference_actions_policy.rb
+++ b/app/services/reference_actions_policy.rb
@@ -46,7 +46,11 @@ private
   attr_reader :reference
 
   def needs_more_references?
-    !reference.application_form.enough_references_have_been_provided?
+    if FeatureFlag.active?(:reference_selection)
+      true
+    else
+      !reference.application_form.enough_references_have_been_provided?
+    end
   end
 
   def valid_reference?

--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -11,9 +11,13 @@ class SubmitReference
     # Updating selected bool to true here will probably be done conditionally based
     # on if enough references have been provided/the references section has been completed
     # when we add in the new functionality
-    @reference.update!(feedback_status: :feedback_provided, feedback_provided_at: Time.zone.now, selected: true)
 
-    cancel_feedback_requested_references if enough_references_have_been_provided?
+    if FeatureFlag.active?(:reference_selection)
+      @reference.update!(feedback_status: :feedback_provided, feedback_provided_at: Time.zone.now, selected: false)
+    else
+      @reference.update!(feedback_status: :feedback_provided, feedback_provided_at: Time.zone.now, selected: true)
+      cancel_feedback_requested_references if enough_references_have_been_provided?
+    end
 
     if @send_emails
       CandidateMailer.reference_received(reference).deliver_later

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,6 +107,12 @@ RSpec.configure do |config|
 
   config.before { Redis.new.flushdb }
 
+  # Temporarily disable the reference_selection feature. This flag will be
+  # selectively enabled as the feature is being built out. The line below will
+  # be removed prior to switching the feature on in production. See:
+  # https://trello.com/c/hZVGCcxd
+  config.before { FeatureFlag.deactivate(:reference_selection) }
+
   # If running tests in parallel, use a unique Redis database per test process.
   # This allocates databases from 1 onwards, as it's assumed that 0 is the
   # development database.

--- a/spec/system/candidate_interface/references/reference_selection/candidate_can_continuously_request_references_spec.rb
+++ b/spec/system/candidate_interface/references/reference_selection/candidate_can_continuously_request_references_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.feature 'References' do
+  include CandidateHelper
+
+  scenario 'the candidate can continue to request and add references on an unsubmitted application' do
+    given_i_am_signed_in
+    and_i_have_provided_my_personal_details
+    and_the_select_references_flag_is_active
+    and_i_have_three_reference_requests_pending
+
+    when_i_receive_two_references
+    then_i_still_have_a_reference_request_outstanding
+    and_i_can_add_more_reference_requests
+    and_i_can_receive_more_references
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+    @application = @candidate.current_application
+  end
+
+  def and_i_have_provided_my_personal_details
+    @candidate.current_application.update!(first_name: 'Mr', last_name: 'Bot')
+  end
+
+  def and_the_select_references_flag_is_active
+    FeatureFlag.activate(:reference_selection)
+  end
+
+  def and_i_have_three_reference_requests_pending
+    create_list(:reference, 3, :feedback_requested, application_form: @application)
+  end
+
+  def when_i_receive_two_references
+    receive_references
+  end
+
+  def then_i_still_have_a_reference_request_outstanding
+    visit candidate_interface_references_review_path
+    expect(page).to have_content 'Awaiting response'
+  end
+
+  def and_i_can_add_more_reference_requests
+    visit candidate_interface_references_start_path
+    click_link t('continue')
+    choose 'Academic'
+    click_button t('continue')
+    candidate_fills_in_referee(name: 'Anne Other')
+    choose 'Yes, send a reference request now'
+    click_button t('save_and_continue')
+    expect(page).to have_content 'Reference request sent to Anne Other'
+  end
+
+  def and_i_can_receive_more_references
+    reference = @application.application_references.last
+    SubmitReference.new(reference: reference).save!
+    expect(reference.reload.feedback_status).to eq 'feedback_provided'
+  end
+end


### PR DESCRIPTION
## Context

At the moment, when a candidate receives 2 references, we automatically cancel any outstanding reference requests. This is one of the things that the impact squad have noted that we can improve on

Going forward we want a candidate to be able to receive more than 2 references. They will then get the option to select the two references they want to submit before they complete the section.

## Changes proposed in this pull request

With the 'reference_selection' feature flag active:

- Don't cancel outstanding references when two references are received
- Don't show errors about having too many references
- Update the ReferenceActionsPolicy to ignore received reference count
  when deciding on permitted actions (this allow continual requesting
  and receiving of references)

Also included in this PR is a system spec outlining the new
behaviour.

## Guidance to review

In the review app:
- Switch on `reference_selection` feature flag
- Add 2 or more references to an application
- Provide feedback on 2 or more references
- You should be able to continue requesting/receiving references

We don't currently enforce a maximum reference count - should we?
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/hZVGCcxd
https://trello.com/c/hZVGCcxd/3378-dev-choose-from-more-than-2-feedback-provided-references

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
