### PR TITLE
Vendor API docs: format bulleted list correctly

### DIFF
--- a/app/views/api_docs/vendor_api_docs/pages/home.md
+++ b/app/views/api_docs/vendor_api_docs/pages/home.md
@@ -18,6 +18,7 @@ To get an idea of how the API works, we recommend you [review the example usage 
 ## What the API doesn't support
 
 The API currently doesn’t support the following features:
+
 - Deferring offers
 - Interview scheduling and status
 - Decision codes (e.g. to provide structured reasons for rejection, or conditions)


### PR DESCRIPTION
Missing out a space before the list causes markdown to consider the bullets as ordinary paragraph text.

### Before

<img width="666" alt="Screenshot 2021-05-19 at 21 56 23" src="https://user-images.githubusercontent.com/642279/118883530-420f7000-b8ed-11eb-8f5a-5dd83ce0d8d7.png">

### After

<img width="695" alt="Screenshot 2021-05-19 at 21 56 15" src="https://user-images.githubusercontent.com/642279/118883553-476cba80-b8ed-11eb-9f37-9a8cdb6436c6.png">
