### PR TITLE
Data migration to correct HESA equality and diversity codes

### DIFF
--- a/app/services/data_migrations/remove_incorrect_hesa_codes.rb
+++ b/app/services/data_migrations/remove_incorrect_hesa_codes.rb
@@ -23,17 +23,17 @@ module DataMigrations
 
     def disabilities_not_specified?(application_form)
       disabilities = application_form.equality_and_diversity.dig('disabilities')
-      disabilities.blank? || disabilities == ['no'] || disabilities == ['Prefer not to say']
+      disabilities.blank? || disabilities == %w[no] || disabilities == ['Prefer not to say']
     end
 
     def hesa_disabilities_present?(application_form)
       hesa_disabilities = application_form.equality_and_diversity.dig('hesa_disabilities')
-      hesa_disabilities != nil && hesa_disabilities != []
+      !hesa_disabilities.nil? && hesa_disabilities != []
     end
 
     def reset_disabilities(application_form)
-      # TODO: Audit comment
       application_form.equality_and_diversity['hesa_disabilities'] = []
+      application_form.audit_comment = 'Resetting incorrect HESA disability codes. See https://trello.com/c/U7W3r0tj/3402'
       application_form.save!
     end
 
@@ -47,9 +47,9 @@ module DataMigrations
     end
 
     def reset_ethnicity(application_form)
-      # TODO: Audit comment
       application_form.equality_and_diversity['hesa_ethnicity'] = nil
-      application_form.save
+      application_form.audit_comment = 'Resetting incorrect HESA ethnicity code. See https://trello.com/c/U7W3r0tj/3402'
+      application_form.save!
     end
   end
 end

--- a/app/services/data_migrations/remove_incorrect_hesa_codes.rb
+++ b/app/services/data_migrations/remove_incorrect_hesa_codes.rb
@@ -1,0 +1,55 @@
+module DataMigrations
+  class RemoveIncorrectHesaCodes
+    TIMESTAMP = 20210518233940
+    MANUAL_RUN = false
+
+    def change
+      ApplicationForm.where.not(equality_and_diversity: nil).find_each do |application_form|
+        remove_incorrect_codes_from(application_form)
+      end
+    end
+
+  private
+
+    def remove_incorrect_codes_from(application_form)
+      if disabilities_not_specified?(application_form) && hesa_disabilities_present?(application_form)
+        reset_disabilities(application_form)
+      end
+
+      if ethnicity_not_specified?(application_form) && hesa_ethnicity_present?(application_form)
+        reset_ethnicity(application_form)
+      end
+    end
+
+    def disabilities_not_specified?(application_form)
+      disabilities = application_form.equality_and_diversity.dig('disabilities')
+      disabilities.blank? || disabilities == ['no'] || disabilities == ['Prefer not to say']
+    end
+
+    def hesa_disabilities_present?(application_form)
+      hesa_disabilities = application_form.equality_and_diversity.dig('hesa_disabilities')
+      hesa_disabilities != nil && hesa_disabilities != []
+    end
+
+    def reset_disabilities(application_form)
+      # TODO: Audit comment
+      application_form.equality_and_diversity['hesa_disabilities'] = []
+      application_form.save!
+    end
+
+    def ethnicity_not_specified?(application_form)
+      ethnicity_group = application_form.equality_and_diversity.dig('ethnic_group')
+      ethnicity_group.blank? || ethnicity_group == 'Prefer not to say'
+    end
+
+    def hesa_ethnicity_present?(application_form)
+      application_form.equality_and_diversity.dig('hesa_ethnicity').present?
+    end
+
+    def reset_ethnicity(application_form)
+      # TODO: Audit comment
+      application_form.equality_and_diversity['hesa_ethnicity'] = nil
+      application_form.save
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -2,6 +2,7 @@ DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
   'DataMigrations::BackfillSelectedBoolean',
   'DataMigrations::DeleteAllSiteAudits',
+  'DataMigrations::RemoveIncorrectHesaCodes',
   'DataMigrations::SpecifyExportTypeForTADExports',
   'DataMigrations::SpecifyExportTypeForNotificationExports',
   'DataMigrations::FixMisspellingOfCaribbeanEthnicGroupAndSetHesaCodes',

--- a/spec/services/data_migrations/remove_incorrect_hesa_codes_spec.rb
+++ b/spec/services/data_migrations/remove_incorrect_hesa_codes_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DataMigrations::RemoveIncorrectHesaCodes do
     )
   end
 
-  it 'corrects any applications that have redundant HESA disability codes' do
+  it 'corrects any applications that have redundant HESA disability codes', with_audited: true do
     valid_application_form = application_with_disability_codes(
       %w[Deaf Blind],
       %w[Deaf Blind].map { |disability| Hesa::Disability.find(disability)&.hesa_code },
@@ -31,23 +31,27 @@ RSpec.describe DataMigrations::RemoveIncorrectHesaCodes do
       %w[Deaf Blind].map { |disability| Hesa::Disability.find(disability)&.hesa_code },
     )
     expect(invalid_application_form.reload.equality_and_diversity['hesa_disabilities']).to eq([])
+    audit_entry = invalid_application_form.audits.last
+    expect(audit_entry.comment).to eq('Resetting incorrect HESA disability codes. See https://trello.com/c/U7W3r0tj/3402')
   end
 
-  it 'corrects any applications that have a redundant HESA ethnicity code' do
+  it 'corrects any applications that have a redundant HESA ethnicity code', with_audited: true do
     valid_application_form = application_with_ethnicity_code(
       'Asian or Asian British',
       HesaEthnicityValues::CHINESE,
-      '34'
+      '34',
     )
     invalid_application_form = application_with_ethnicity_code(
       'Prefer not to say',
       nil,
-      '34'
+      '34',
     )
 
     described_class.new.change
 
     expect(valid_application_form.reload.equality_and_diversity['hesa_ethnicity']).to eq('34')
     expect(invalid_application_form.reload.equality_and_diversity['hesa_ethnicity']).to eq(nil)
+    audit_entry = invalid_application_form.audits.last
+    expect(audit_entry.comment).to eq('Resetting incorrect HESA ethnicity code. See https://trello.com/c/U7W3r0tj/3402')
   end
 end

--- a/spec/services/data_migrations/remove_incorrect_hesa_codes_spec.rb
+++ b/spec/services/data_migrations/remove_incorrect_hesa_codes_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe DataMigrations::RemoveIncorrectHesaCodes do
 
   it 'corrects any applications that have a redundant HESA ethnicity code', with_audited: true do
     valid_application_form = application_with_ethnicity_code(
-      'Asian or Asian British',
+      'Chinese',
       HesaEthnicityValues::CHINESE,
       '34',
     )

--- a/spec/services/data_migrations/remove_incorrect_hesa_codes_spec.rb
+++ b/spec/services/data_migrations/remove_incorrect_hesa_codes_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveIncorrectHesaCodes do
+  def application_with_ethnicity_code(ethnic_group, ethnic_background, hesa_ethnicity)
+    create(
+      :application_form,
+      equality_and_diversity: { 'ethnic_group': ethnic_group, 'ethnic_background': ethnic_background, 'hesa_ethnicity': hesa_ethnicity },
+    )
+  end
+
+  def application_with_disability_codes(disabilities, hesa_disabilities)
+    create(
+      :application_form,
+      equality_and_diversity: { disabilities: disabilities, hesa_disabilities: hesa_disabilities },
+    )
+  end
+
+  it 'corrects any applications that have redundant HESA disability codes' do
+    valid_application_form = application_with_disability_codes(
+      %w[Deaf Blind],
+      %w[Deaf Blind].map { |disability| Hesa::Disability.find(disability)&.hesa_code },
+    )
+    invalid_application_form = application_with_disability_codes(
+      ['Prefer not to say'],
+      %w[Deaf Blind].map { |disability| Hesa::Disability.find(disability)&.hesa_code },
+    )
+
+    described_class.new.change
+
+    expect(valid_application_form.reload.equality_and_diversity['hesa_disabilities']).to eq(
+      %w[Deaf Blind].map { |disability| Hesa::Disability.find(disability)&.hesa_code },
+    )
+    expect(invalid_application_form.reload.equality_and_diversity['hesa_disabilities']).to eq([])
+  end
+
+  it 'corrects any applications that have a redundant HESA ethnicity code' do
+    valid_application_form = application_with_ethnicity_code(
+      'Asian or Asian British',
+      HesaEthnicityValues::CHINESE,
+      '34'
+    )
+    invalid_application_form = application_with_ethnicity_code(
+      'Prefer not to say',
+      nil,
+      '34'
+    )
+
+    described_class.new.change
+
+    expect(valid_application_form.reload.equality_and_diversity['hesa_ethnicity']).to eq('34')
+    expect(invalid_application_form.reload.equality_and_diversity['hesa_ethnicity']).to eq(nil)
+  end
+end


### PR DESCRIPTION
## Context

In some cases (e.g. Apply again) a candidate may change their mind about what they want to declare on the equality and diversity questionnaire. If they switch the ethnicity or disability answer to _Prefer not to say_ we retained the HESA ethnicity and disability codes that were set when the candidate filled the questionnaire first time around. PR https://github.com/DFE-Digital/apply-for-teacher-training/pull/4761 implemented the code fix to stop this happening in future. This PR adds a data migration to fix up the data in cases where it happened in the past.

## Changes proposed in this pull request

- [x] Add data migration that finds application forms that have ethnicity or disability with HESA codes that are now redundant. Reset the HESA codes.

## Guidance to review

- How do we test this?

## Link to Trello card

https://trello.com/c/U7W3r0tj/3402-hesa-equality-and-diversity-codes-not-being-set-when-filling-in-apply-2-form

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
