### PR TITLE
Remove unused require statement for csv

### DIFF
--- a/app/services/ucas_matching/matching_data_file.rb
+++ b/app/services/ucas_matching/matching_data_file.rb
@@ -1,6 +1,3 @@
-require 'csv'
-# require 'archive/zip'
-
 module UCASMatching
   class MatchingDataFile
     # @returns filename


### PR DESCRIPTION
## Context
While doing an audit for non safe csvs, spotted this unused require. SafeCSV does its own requiring.

## Link to Trello card
https://trello.com/c/PN6vWaqt/3676-check-for-usage-of-safecsv-in-manage
