### PR TITLE
Unify the names of provider permissions exports

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -97,15 +97,15 @@ class DataExport < ApplicationRecord
       class: SupportInterface::OfferConditionsExport,
     },
     organisation_permissions: {
-      name: 'Organisation permissions',
+      name: 'Organisational permissions changes',
       export_type: 'organisation_permissions',
       description: 'A list of changes to organisational permissions and audit information about the changes.',
       class: SupportInterface::OrganisationPermissionsExport,
     },
     provider_access_controls: {
-      name: 'Provider Access Controls',
+      name: 'Provider permissions stats',
       export_type: 'provider_access_controls',
-      description: 'A list of providers and information about their permissions.',
+      description: "A list of providers and aggregated information about the number of users they have, their permissions, the changes that they\'ve made and their relationships to other organisations.",
       class: SupportInterface::ProviderAccessControlsExport,
     },
     providers_export: {
@@ -163,7 +163,7 @@ class DataExport < ApplicationRecord
       class: SupportInterface::TADProviderStatsExport,
     },
     user_permissions: {
-      name: 'User permissions',
+      name: 'User permissions changes',
       export_type: 'user_permissions',
       description: 'A list of changes to user permissions and audit information about the changes.',
       class: SupportInterface::UserPermissionsExport,


### PR DESCRIPTION
## Context

Update the names of provider permissions exports so they are standardised.


## Link to Trello card

https://trello.com/c/ksTZBd0C/3631-unify-the-names-of-provider-permissions-exports

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
