### PR TITLE
[Do not merge] Backfill existing ValidationErrors service column

### DIFF
--- a/app/models/validation_error.rb
+++ b/app/models/validation_error.rb
@@ -1,4 +1,9 @@
 class ValidationError < ApplicationRecord
+  enum service: {
+    apply: 'apply',
+    manage: 'manage',
+  }
+
   validates :form_object, presence: true
 
   belongs_to :user, polymorphic: true, optional: true

--- a/app/services/data_migrations/backfill_validation_errors_service_column.rb
+++ b/app/services/data_migrations/backfill_validation_errors_service_column.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class BackfillValidationErrorsServiceColumn
+    TIMESTAMP = 20210520104254
+    MANUAL_RUN = false
+
+    def change
+      ValidationError.update_all(service: 'apply')
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillValidationErrorsServiceColumn',
   'DataMigrations::SpecifyExportTypeForTADExports',
   'DataMigrations::SpecifyExportTypeForNotificationExports',
   'DataMigrations::DeleteAllCourseAudits',

--- a/spec/factories/validation_error.rb
+++ b/spec/factories/validation_error.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     details { { feedback: { messages: ['Enter feedback'], value: '' } } }
     association :user, factory: :candidate
     request_path { '/candidate' }
+    service { 'apply' }
   end
 end

--- a/spec/services/data_migrations/backfill_validation_errors_service_column_spec.rb
+++ b/spec/services/data_migrations/backfill_validation_errors_service_column_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillValidationErrorsServiceColumn do
+  it 'assigns the apply service to all existing ValidationErrors' do
+    create_list(:validation_error, 3, service: nil)
+
+    described_class.new.change
+
+    expect(ValidationError.all.pluck(:service).uniq).to eq(%w[apply])
+  end
+end


### PR DESCRIPTION
## Do not merge

Depends on migration in https://github.com/DFE-Digital/apply-for-teacher-training/pull/4784

## Context

We're going to track validation errors from Manage as well as from Apply. To date all existing `ValidationError`s have come from the candidate interface.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This PR introduces an enum on `ValidationError` which defines valid `#service` values. It also backfills all existing `ValidationError`s with the `apply` value.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ROJfcasA/3609-track-validation-errors-on-manage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
