### PR TITLE
Fix TT API incremental sync when no last_sync present

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -14,7 +14,9 @@ module TeacherTrainingPublicAPI
         provider_code: @provider.code,
       ).paginate(per_page: 500)
 
-      scope = scope.where(updated_since: TeacherTrainingPublicAPI::SyncCheck.updated_since) if incremental_sync
+      if incremental_sync && SyncCheck.last_sync
+        scope = scope.where(updated_since: TeacherTrainingPublicAPI::SyncCheck.updated_since)
+      end
 
       scope.each do |course_from_api|
         ActiveRecord::Base.transaction do


### PR DESCRIPTION


## Context
If an incremental sync is requested in an environment that hasn't yet
populated a last_sync entry, course sync breaks with a nil error.

Encountered when running the 'setup_local_dev_data' rake task.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Fix by checking last_sync is present before updating the database scope
with an updated_since.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Does this fix make sense? An alternative would be to make setup_local_dev_data sync with `incremental: false`, but it depends on what we want the sync behaviour of that rake task to be.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
