### PR TITLE
Fix setup_local_dev_data sync

### DIFF
--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -27,11 +27,15 @@ task sync_dev_providers_and_open_courses: :environment do
         .where(year: RecruitmentCycle.current_year)
         .find(code).first
 
-    TeacherTrainingPublicAPI::SyncProvider.new(provider_from_api: provider_from_api, recruitment_cycle_year: RecruitmentCycle.previous_year).call(run_in_background: false, force_sync_courses: true)
+    TeacherTrainingPublicAPI::SyncProvider.new(
+      provider_from_api: provider_from_api, recruitment_cycle_year: RecruitmentCycle.previous_year,
+    ).call(run_in_background: false, force_sync_courses: true, incremental_sync: false)
 
     Provider.find_by_code(code).courses.previous_cycle.exposed_in_find.update_all(open_on_apply: true, opened_on_apply_at: Time.zone.now)
 
-    TeacherTrainingPublicAPI::SyncProvider.new(provider_from_api: provider_from_api, recruitment_cycle_year: RecruitmentCycle.current_year).call(run_in_background: false, force_sync_courses: true)
+    TeacherTrainingPublicAPI::SyncProvider.new(
+      provider_from_api: provider_from_api, recruitment_cycle_year: RecruitmentCycle.current_year,
+    ).call(run_in_background: false, force_sync_courses: true, incremental_sync: false)
   end
 
   puts 'Making all the courses open on Apply...'


### PR DESCRIPTION


## Context
This is often run on environments without a last_sync value present (eg - in development), so do a full sync.

Found by running the task locally and it breaking during the [course sync](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/services/teacher_training_public_api/sync_courses.rb#L17).

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Set both provider syncs to `incremental_sync: false`
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Simpler alternative to https://github.com/DFE-Digital/apply-for-teacher-training/pull/4790

Tested locally, works as expected.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
