### PR TITLE
Fix test failure in `DisabilityStatusForm`

### DIFF
--- a/app/forms/candidate_interface/equality_and_diversity/disability_status_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/disability_status_form.rb
@@ -25,11 +25,11 @@ module CandidateInterface
         })
       elsif reset_disabilities?(application_form)
         application_form.equality_and_diversity['disabilities'] = []
-        application_form.equality_and_diversity['hesa_disabilities'] = []
+        reset_hesa_disabilities(application_form)
         application_form.save
       elsif disability_status == 'Prefer not to say'
         application_form.equality_and_diversity['disabilities'] = ['Prefer not to say']
-        application_form.equality_and_diversity['hesa_disabilities'] = []
+        reset_hesa_disabilities(application_form)
         application_form.save
       else
         true
@@ -50,6 +50,10 @@ module CandidateInterface
       application_form.equality_and_diversity['disabilities'].nil? ||
         disability_status == 'no' ||
         application_form.equality_and_diversity['disabilities'].include?('Prefer not to say')
+    end
+
+    def reset_hesa_disabilities(application_form)
+      application_form.equality_and_diversity['hesa_disabilities'] = [] if application_form.equality_and_diversity['hesa_disabilities'].present?
     end
   end
 end


### PR DESCRIPTION
## Context

This PR attempts to fix some broken tests in https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/spec/forms/candidate_interface/equality_and_diversity/disability_status_form_spec.rb . They are failing when run locally, though it seems to have passed CI at some point (though I still need to work out how).

e.g.
```
CandidateInterface::EqualityAndDiversity::DisabilityStatusForm#save when disability status has a value resets the disabilities of equality and di
versity information if disability status is no
     Failure/Error:
       expect(application_form.equality_and_diversity).to eq(
         'sex' => 'male', 'disabilities' => [],
       )

       Expected { "sex" => "male", "disabilities" => [], "hesa_disabilities" => [] }
          to eq { "sex" => "male", "disabilities" => [] }

       Diff:

       ┌ (Key) ──────────────────────────┐
       │ ‹-› in expected, not in actual  │
       │ ‹+› in actual, not in expected  │
       │ ‹ › in both expected and actual │
       └─────────────────────────────────┘

         {
           "sex" => "male",
           "disabilities" => [],
       +   "hesa_disabilities" => []
         }
     # ./spec/forms/candidate_interface/equality_and_diversity/disability_status_form_spec.rb:100:in `block (4 levels) in <top (required)>'
```

## Changes proposed in this pull request

The change here is to skip resetting `hesa_disabilities` if it's already `nil` or some other blank value. It's just not necessary to replace `nil` with `[]` so the original code was a bit over-zealous. We only ever need to reset values where there are one or more HESA disability codes present. So this change makes sense logically I think and fixes the specs as a side-effect.

## Guidance to review

Does this change make sense? Does it fix the specs?

## Link to Trello card

n/a

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
