### PR TITLE
Update content for banner/maintenance page for new downtime

### DIFF
--- a/config/locales/service_information_banner.yml
+++ b/config/locales/service_information_banner.yml
@@ -1,12 +1,12 @@
 en:
   service_information_banner:
     provider:
-      sandbox_header: The sandbox will be unavailable on Tuesday 4 May from 6pm to 7pm
+      sandbox_header: The sandbox will be unavailable on Tuesday 25 May from 8am to 9am
       sandbox_body: This will affect both the web service and the API. You may lose work if you are using the sandbox when it becomes unavailable.
-      header: The Manage service will be unavailable on Thursday 6 May from 7:30am to 9am
+      header: The Manage service will be unavailable on Wednesday 26 May from 8am to 9am
       body: This will affect both the web service and the API. You may lose work if you are using Manage when it becomes unavailable.
     candidate:
-      sandbox_header: The sandbox will be unavailable on Tuesday 4 May from 6pm to 7pm
+      sandbox_header: The sandbox will be unavailable on Tuesday 25 May from 8am to 9am
       sandbox_body: You may lose work if you are using the sandbox when it becomes unavailable.
-      header: This service will be unavailable on Thursday 6 May from 7:30am to 9am
+      header: This service will be unavailable on Wednesday 26 May from 8am to 9am
       body: You may lose work if you are using this service when it becomes unavailable.

--- a/config/locales/service_unavailable.yml
+++ b/config/locales/service_unavailable.yml
@@ -1,7 +1,7 @@
 en:
   service_unavailable:
     sandbox_title: Sorry, the sandbox is unavailable
-    sandbox_downtime: You will be able to use the sandbox from 7pm on Tuesday 4 May.
+    sandbox_downtime: You will be able to use the sandbox from 9am on Tuesday 25 May.
     title: Sorry, this service is unavailable
-    downtime: You will be able to use this service from 9am on Thursday 6 May.
+    downtime: You will be able to use this service from 9am on Wednesday 26 May.
     body: If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.


### PR DESCRIPTION
## Context

We're scheduling maintenance time for next Tuesday (Sandbox) and Wednesday (Prod)

## Changes proposed in this pull request

Update content for banner and maintenance page

## Guidance to review

content innit 

## Link to Trello card

https://trello.com/c/zFTTvDUL/3713-provider-information-banners-and-maintenance-pages-for-service-downtime-due-to-paas-migration

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
