### PR TITLE
Immediately sync new providers’ courses

### DIFF
--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -92,7 +92,7 @@ module SupportInterface
     end
 
     def enable_course_syncing
-      update_provider('Courses will now be synced') { |provider| SyncProvider.new(provider) }
+      update_provider('Course sync enabled and running') { |provider| SyncProvider.new(provider: provider).call }
     end
 
   private

--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -92,7 +92,7 @@ module SupportInterface
     end
 
     def enable_course_syncing
-      update_provider('Courses will now be synced') { |provider| provider.update!(sync_courses: true) }
+      update_provider('Courses will now be synced') { |provider| SyncProvider.new(provider) }
     end
 
   private

--- a/app/models/teacher_training_public_api/provider.rb
+++ b/app/models/teacher_training_public_api/provider.rb
@@ -2,5 +2,15 @@ module TeacherTrainingPublicAPI
   class Provider < TeacherTrainingPublicAPI::Resource
     belongs_to :recruitment_cycle, param: :year
     has_many :courses
+
+    def self.fetch(provider_code)
+      where(year: ::RecruitmentCycle.current_year)
+        .find(provider_code).first
+    rescue JsonApiClient::Errors::NotFound
+      nil
+    rescue JsonApiClient::Errors::ServerError, JsonApiClient::Errors::ConnectionError => e
+      Raven.capture_exception(e)
+      nil
+    end
   end
 end

--- a/app/services/sync_provider.rb
+++ b/app/services/sync_provider.rb
@@ -5,5 +5,6 @@ class SyncProvider
 
   def call
     @provider.update!(sync_courses: true)
+    TeacherTrainingPublicAPI::SyncProviderWorker.perform_async(@provider.code)
   end
 end

--- a/app/services/sync_provider.rb
+++ b/app/services/sync_provider.rb
@@ -1,0 +1,9 @@
+class SyncProvider
+  def initialize(provider:)
+    @provider = provider
+  end
+
+  def call
+    @provider.update!(sync_courses: true)
+  end
+end

--- a/app/views/support_interface/providers/courses.html.erb
+++ b/app/views/support_interface/providers/courses.html.erb
@@ -34,6 +34,6 @@
   <p class="govuk-body">There aren’t any courses for this provider because the courses aren’t synced yet.</p>
 
   <%= form_with model: @provider, url: support_interface_enable_provider_course_syncing_path(@provider), method: :post do |f| %>
-    <%= f.govuk_submit 'Enable course syncing from Find' %>
+    <%= f.govuk_submit 'Enable course syncing from the Teacher Training API' %>
   <% end %>
 <% end %>

--- a/app/workers/teacher_training_public_api/sync_provider_worker.rb
+++ b/app/workers/teacher_training_public_api/sync_provider_worker.rb
@@ -1,0 +1,17 @@
+module TeacherTrainingPublicAPI
+  class SyncProviderWorker
+    include Sidekiq::Worker
+    sidekiq_options retry: 3, queue: :low_priority
+
+    def perform(provider_code)
+      provider_from_api = Provider.fetch(provider_code)
+
+      if provider_from_api.present?
+        TeacherTrainingPublicAPI::SyncProvider.new(
+          provider_from_api: provider_from_api,
+          recruitment_cycle_year: ::RecruitmentCycle.current_year,
+        ).call(incremental_sync: false)
+      end
+    end
+  end
+end

--- a/spec/models/teacher_training_public_api/provider_spec.rb
+++ b/spec/models/teacher_training_public_api/provider_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe TeacherTrainingPublicAPI::Provider do
+  include TeacherTrainingPublicAPIHelper
+
+  describe '.fetch' do
+    it 'returns a provider that exists' do
+      stub_teacher_training_api_provider(provider_code: 'MMM')
+
+      provider = TeacherTrainingPublicAPI::Provider.fetch('MMM')
+
+      expect(provider).to be_present
+    end
+
+    it 'returns nil when the provider does not exist' do
+      stub_teacher_training_api_provider_404(provider_code: 'OOO')
+
+      provider = TeacherTrainingPublicAPI::Provider.fetch('OOO')
+
+      expect(provider).to be_nil
+    end
+  end
+end

--- a/spec/services/sync_provider_spec.rb
+++ b/spec/services/sync_provider_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe SyncProvider do
+  let(:provider) { create(:provider, sync_courses: false) }
+
+  it 'enables course syncing' do
+    SyncProvider.new(provider: provider).call
+
+    expect(provider.sync_courses).to be true
+  end
+end

--- a/spec/services/sync_provider_spec.rb
+++ b/spec/services/sync_provider_spec.rb
@@ -1,11 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe SyncProvider do
-  let(:provider) { create(:provider, sync_courses: false) }
+  include TeacherTrainingPublicAPIHelper
+  let(:provider) { create(:provider, code: 'ABC', sync_courses: false) }
 
   it 'enables course syncing' do
     SyncProvider.new(provider: provider).call
 
     expect(provider.sync_courses).to be true
+  end
+
+  it 'syncs the provider', sidekiq: true do
+    stub_teacher_training_api_provider(provider_code: 'ABC', specified_attributes: { code: 'ABC' })
+    stub_teacher_training_api_course_with_site(provider_code: 'ABC', course_code: '123', site_code: 'A', course_attributes: [{ accredited_body_code: nil }])
+
+    expect(provider.courses.count).to be 0
+
+    SyncProvider.new(provider: provider).call
+
+    expect(provider.courses.count).to be 1
   end
 end

--- a/spec/support/test_helpers/teacher_training_public_api_helper.rb
+++ b/spec/support/test_helpers/teacher_training_public_api_helper.rb
@@ -62,6 +62,10 @@ module TeacherTrainingPublicAPIHelper
     stub_teacher_training_list_api_request(url, response)
   end
 
+  def stub_teacher_training_api_provider_404(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:)
+    stub_404("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}")
+  end
+
   def stub_teacher_training_api_course_404(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, course_code:)
     stub_404("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses/#{course_code}")
   end

--- a/spec/system/support_interface/provider_sync_courses_spec.rb
+++ b/spec/system/support_interface/provider_sync_courses_spec.rb
@@ -8,6 +8,8 @@ RSpec.feature 'See provider course syncing' do
     given_i_am_a_support_user
     and_the_last_sync_was_two_hours_ago
     and_a_provider_exists
+    and_it_has_courses_in_publish
+
     when_i_visit_the_providers_page
     then_i_see_that_the_provider_is_not_configured_to_sync_courses
 
@@ -17,7 +19,6 @@ RSpec.feature 'See provider course syncing' do
     when_i_click_on_the_enable_course_syncing_button
     then_i_see_that_course_syncing_is_on
 
-    when_provider_syncing_runs
     then_i_see_that_a_course_has_been_synced
   end
 
@@ -32,6 +33,25 @@ RSpec.feature 'See provider course syncing' do
 
   def and_a_provider_exists
     create :provider, code: 'ABC', name: 'ABC College'
+  end
+
+  def and_it_has_courses_in_publish
+    stub_teacher_training_api_provider(provider_code: 'ABC', specified_attributes: { code: 'ABC' })
+
+    stub_teacher_training_api_courses(
+      provider_code: 'ABC',
+      specified_attributes: [
+        {
+          code: 'ABC1',
+          accredited_body_code: nil,
+        },
+      ],
+    )
+
+    stub_teacher_training_api_sites(
+      provider_code: 'ABC',
+      course_code: 'ABC1',
+    )
   end
 
   def when_i_visit_the_providers_page
@@ -57,41 +77,6 @@ RSpec.feature 'See provider course syncing' do
 
   def then_i_see_that_course_syncing_is_on
     expect(page).not_to have_content('There aren’t any courses for this provider because the courses aren’t synced yet')
-  end
-
-  def when_provider_syncing_runs
-    stub_teacher_training_api_providers(
-      specified_attributes: [
-        {
-          code: 'ABC',
-          name: 'ABC College',
-        },
-      ],
-      filter_option: { 'filter[updated_since]' => @updated_since },
-    )
-
-    stub_teacher_training_api_courses(
-      provider_code: 'ABC',
-      specified_attributes: [
-        {
-          code: 'ABC1',
-          accredited_body_code: nil,
-        },
-      ],
-      filter_option: { 'filter[updated_since]' => @updated_since },
-    )
-
-    stub_teacher_training_api_sites(
-      provider_code: 'ABC',
-      course_code: 'ABC1',
-    )
-
-    sync_subjects_service = instance_double(TeacherTrainingPublicAPI::SyncSubjects, perform: nil)
-    allow(TeacherTrainingPublicAPI::SyncSubjects).to receive(:new).and_return(sync_subjects_service)
-
-    TeacherTrainingPublicAPI::IncrementalSyncAllProvidersAndCoursesWorker.perform_async
-
-    refresh
   end
 
   def then_i_see_that_a_course_has_been_synced

--- a/spec/system/support_interface/provider_sync_courses_spec.rb
+++ b/spec/system/support_interface/provider_sync_courses_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature 'See provider course syncing' do
   end
 
   def when_i_click_on_the_enable_course_syncing_button
-    click_button 'Enable course syncing from Find'
+    click_button 'Enable course syncing from the Teacher Training API'
   end
 
   def then_i_see_that_course_syncing_is_on


### PR DESCRIPTION
## Context

When we start syncing a provider, enqueue a job to sync their courses straight away.

This fixes a bug whereby newly synced providers would not receive courses until the big sync ran (currently it runs at 3-day intervals).

This will be also useful for gradually adding providers as we start to sync more and more of them.

## Changes proposed in this pull request

Kick off an ad-hoc sync for this provider as soon as we enable syncing.

## Guidance to review

Commit by commit

## Link to Trello card

https://trello.com/c/0T1nDswd/3714-sync-providers-as-soon-as-course-syncing-is-turned-on
