### PR TITLE
Sync every 10 minutes

### DIFF
--- a/app/models/teacher_training_public_api/sync_check.rb
+++ b/app/models/teacher_training_public_api/sync_check.rb
@@ -15,7 +15,11 @@ module TeacherTrainingPublicAPI
     end
 
     def self.updated_since
-      (Time.zone.parse(last_sync) - 2.hours)
+      if last_sync.present?
+        Time.zone.parse(last_sync) - 1.hour
+      else
+        Time.zone.now - 1.hour
+      end
     end
 
     def self.check

--- a/app/models/teacher_training_public_api/sync_check.rb
+++ b/app/models/teacher_training_public_api/sync_check.rb
@@ -2,8 +2,8 @@ module TeacherTrainingPublicAPI
   class SyncCheck
     LAST_SUCCESSFUL_SYNC = 'last-successful-sync-with-teacher-training-api'.freeze
 
-    def self.set_last_sync(date)
-      Redis.current.set(LAST_SUCCESSFUL_SYNC, date)
+    def self.set_last_sync(time)
+      Redis.current.set(LAST_SUCCESSFUL_SYNC, time)
     end
 
     def self.clear_last_sync

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -8,8 +8,10 @@ class Clock
 
   error_handler { |error| Raven.capture_exception(error) if defined? Raven }
 
+  # More-than-hourly jobs
+  every(10.minutes, 'IncrementalSyncAllFromTeacherTrainingPublicAPI') { TeacherTrainingPublicAPI::IncrementalSyncAllProvidersAndCoursesWorker.perform_async }
+
   # Hourly jobs
-  every(1.hour, 'IncrementalSyncAllFromTeacherTrainingPublicAPI', at: '**:00') { TeacherTrainingPublicAPI::IncrementalSyncAllProvidersAndCoursesWorker.perform_async }
   every(1.hour, 'RejectApplicationsByDefault', at: '**:10') { RejectApplicationsByDefaultWorker.perform_async }
   every(1.hour, 'DeclineOffersByDefault', at: '**:15') { DeclineOffersByDefaultWorker.perform_async }
   every(1.hour, 'ChaseReferences', at: '**:20') { ChaseReferences.perform_async }

--- a/spec/services/work_history_with_breaks_spec.rb
+++ b/spec/services/work_history_with_breaks_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe WorkHistoryWithBreaks do
       describe '#initialize' do
         let(:volunteering_experiences) { build_stubbed_list(:application_volunteering_experience, 2) }
 
-        it 'configures unpaid work' do
-          expect(work_history_with_breaks.unpaid_work).to eq(application_form.application_volunteering_experiences)
+        it 'returns volunteering experiences for #unpaid_work and sorts them by start_date' do
+          expect(work_history_with_breaks.unpaid_work).to eq(application_form.application_volunteering_experiences.sort_by(&:start_date))
         end
       end
 


### PR DESCRIPTION
## Context

Now that our sync costs the API and Apply almost nothing, do it little and often so we're always up to date

## Changes proposed in this pull request

- Sync every 10 minutes
- Fix an issue where the sync would fail in if no sync had already run, which can happen if you clean your Redis database in development