### PR TITLE
Use the correct role value for success and warning flash components

### DIFF
--- a/app/components/flash_message_component.html.erb
+++ b/app/components/flash_message_component.html.erb
@@ -1,7 +1,6 @@
 <%= govuk_notification_banner(
   title: title,
   classes: classes,
-  disable_auto_focus: disable_auto_focus,
   html_attributes: { role: role },
 ) do |notification_banner| %>
   <%= notification_banner.slot(:heading, text: heading) %>

--- a/app/components/flash_message_component.rb
+++ b/app/components/flash_message_component.rb
@@ -21,10 +21,6 @@ class FlashMessageComponent < ViewComponent::Base
     %i[warning success].include?(message_key) ? 'alert' : 'region'
   end
 
-  def disable_auto_focus
-    message_key == 'info'
-  end
-
   def heading
     messages.is_a?(Array) ? messages[0] : messages
   end

--- a/app/components/flash_message_component.rb
+++ b/app/components/flash_message_component.rb
@@ -2,11 +2,11 @@ class FlashMessageComponent < ViewComponent::Base
   ALLOWED_PRIMARY_KEYS = %i[info warning success].freeze
 
   def initialize(flash:)
-    @flash = flash
+    @flash = flash.to_hash.symbolize_keys!
   end
 
   def message_key
-    flash.keys.detect { |key| ALLOWED_PRIMARY_KEYS.include?(key.to_sym) }
+    flash.keys.detect { |key| ALLOWED_PRIMARY_KEYS.include?(key) }
   end
 
   def title

--- a/spec/components/flash_message_component_spec.rb
+++ b/spec/components/flash_message_component_spec.rb
@@ -17,15 +17,39 @@ RSpec.describe FlashMessageComponent do
   end
 
   context 'when a valid flash key is provided' do
-    let(:flash) { { info: 'Your application has been updated' } }
+    let(:flash) { { success: 'Your application has been updated' } }
 
     it 'the component is rendered with the correct content' do
       expect(component.css('.govuk-notification-banner__heading').text).to include('Your application has been updated')
     end
   end
 
+  context 'when an info flash key is provided' do
+    let(:flash) { { info: 'This service will be unavailable tomorrow' } }
+
+    it 'the component is rendered with a region role' do
+      expect(component.css('.govuk-notification-banner').attribute('role').value).to eq('region')
+    end
+  end
+
+  context 'when a success flash key is provided' do
+    let(:flash) { { success: 'Your application has been updated' } }
+
+    it 'the component is rendered with an alert role' do
+      expect(component.css('.govuk-notification-banner').attribute('role').value).to eq('alert')
+    end
+  end
+
+  context 'when a warning flash key is provided' do
+    let(:flash) { { warning: 'There is a problem' } }
+
+    it 'the component is rendered with an alert role' do
+      expect(component.css('.govuk-notification-banner').attribute('role').value).to eq('alert')
+    end
+  end
+
   context 'when a secondary message is provided' do
-    let(:flash) { { success: ['Message', 'Some more details...'] } }
+    let(:flash) { { info: ['Message', 'Some more details...'] } }
 
     it 'the component is rendered with the correct content' do
       expect(component.text).to include('Message')


### PR DESCRIPTION
## Context

When a success (or warning) banner is shown, it should have an alert role (which in turn triggers some JS to pull focus to this component, which then means it’s also highlighted with a yellow outline).

This behaviour is not currently present.

## Changes proposed in this pull request

Learning some things about Ruby here I think… when defining `role` value, `message_key` is a string, but I was comparing it to an array of symbols. Therefore `region` would always be returned. By casting `message_key` as a symbol, means we’re comparing apples with apples, and the right value for `role` is returned.

Added some addition tests so this behaviour doesn’t break again in the future. (Fun fact; writing the tests meant I had to turn `message_key` into a symbol, rather than what I had before, which was test against an array of strings. No idea why needed to do it that way round, but it means both the app works correctly, and the tests are happy too.)

## Guidance to review

Visit a page in the application where a success banner is shown. I’ve been using the ‘Sign in as this candidate’ feature in the support interface.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
