### PR TITLE
Use govuk mixins for notification banner warning variant

### DIFF
--- a/app/frontend/styles/_notification_banner.scss
+++ b/app/frontend/styles/_notification_banner.scss
@@ -1,20 +1,12 @@
-/* ==========================================================================
-   # NOTIFICATION BANNER
-   ========================================================================== */
-
 .govuk-notification-banner {
   &.govuk-notification-banner--warning {
-    border-color: govuk-colour("red");
-    background-color: govuk-colour("red");
-    color: govuk-colour("red");
+    border-color: $govuk-error-colour;
+    background-color: $govuk-error-colour;
+    color: $govuk-error-colour;
 
-    .govuk-notification-banner__link:link {
-      color: govuk-colour("red");
-    }
-
-    .govuk-notification-banner__link:hover,
-    .govuk-notification-banner__link:visited {
-      color: mix(black, govuk-colour("red"), 25%);
+    .govuk-notification-banner__link {
+      @include govuk-link-common;
+      @include govuk-link-style-error;
     }
   }
 
@@ -22,4 +14,3 @@
     max-width: 100%;
   }
 }
-


### PR DESCRIPTION
## Context

Tiny CSS refactor for `govuk-notification-banner--warning`, using the [Sass mixins and variables available in `govuk-frontend`](https://frontend.design-system.service.gov.uk/sass-api-reference/).

## Changes proposed in this pull request

Use `$govuk-error-colour` variable for the error colour, `govuk-link-common` and `govuk-link-style-error` mixins to style links using the same style as in the error summary component.

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
