### PR TITLE
Remove specs about running SetDeclineByDefault twice

### DIFF
--- a/spec/services/set_decline_by_default_spec.rb
+++ b/spec/services/set_decline_by_default_spec.rb
@@ -154,63 +154,6 @@ RSpec.describe SetDeclineByDefault do
       end
     end
 
-    context 'when the service is run multiple times' do
-      let(:last_decision_at) { 2.business_days.before(now).end_of_day }
-      let(:old_dbd_date) { 8.business_days.after(now).end_of_day }
-
-      before do
-        choices[0].update(status: :rejected, rejected_at: 2.business_days.before(last_decision_at))
-        choices[1].update(
-          status: :offer,
-          offered_at: last_decision_at,
-          decline_by_default_at: old_dbd_date,
-          decline_by_default_days: 10,
-        )
-        choices[2].update(
-          status: :offer,
-          offered_at: last_decision_at,
-          decline_by_default_at: old_dbd_date,
-          decline_by_default_days: 10,
-        )
-      end
-
-      it 'the DBD for all offers is extended if an offer is updated' do
-        choices[1].update(
-          status: :offer,
-          offered_at: last_decision_at,
-          offer_changed_at: last_decision_at + 1.day,
-        )
-
-        call_service
-        # adding 1 day to a time _after business hours_ takes you 2.business_days fwd
-        new_dbd_date = 1.business_days.after(old_dbd_date).end_of_day
-
-        expect_all_relevant_decline_by_default_at_values_to_be new_dbd_date
-      end
-
-      it 'the DBD for all offers is extended if an offer becomes a rejection' do
-        choices[1].update(status: :rejected, rejected_at: last_decision_at + 1.day)
-
-        call_service
-
-        # adding 1 day to a time _after business hours_ takes you 2.business_days fwd
-        new_dbd_date = 1.business_days.after(old_dbd_date).end_of_day
-
-        expect_all_relevant_decline_by_default_at_values_to_be new_dbd_date
-      end
-
-      it 'the DBD for all offers is extended if a rejection becomes an offer' do
-        choices[0].update(status: :offer, offered_at: last_decision_at + 1.day)
-
-        call_service
-
-        # adding 1 day to a time _after business hours_ takes you 2.business_days fwd
-        new_dbd_date = 1.business_days.after(old_dbd_date).end_of_day
-
-        expect_all_relevant_decline_by_default_at_values_to_be new_dbd_date
-      end
-    end
-
     it 'the decline_by_default_days is set to 10 days when DBD is present' do
       choices[0].update(status: :offer, offered_at: 1.business_days.before(now).end_of_day)
       choices[1].update(status: :offer, offered_at: 2.business_days.before(now).end_of_day)


### PR DESCRIPTION
These tests always flake at weekends, and they are also misleading.

Consider: on a weekend, the end of the next business day from Saturday is the end of Monday. If you make the same calculation on Sunday, the next business day will also be the end of Monday. i.e. changing the date from which you calculate DBD will not always give you a different DBD.

Therefore adding days to the last_decision_at and recalculating DBD is dependent on context, and these specs run in "real" time, so they will always be able to flake.

I think the behaviour of changing DBD if a later timestamp is present on the fields we care about could reasonably be expected from `SetDeclineByDefault`, and the logic for doing this is no different. So remove these specs.
