### PR TITLE
Set DBD day to last descision timestamp

### DIFF
--- a/spec/services/set_decline_by_default_spec.rb
+++ b/spec/services/set_decline_by_default_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe SetDeclineByDefault do
 
     context 'when the service is run multiple times' do
       let(:last_decision_at) { 2.business_days.before(now).end_of_day }
-      let(:old_dbd_date) { 8.business_days.after(now).end_of_day }
+      let(:old_dbd_date) { 10.business_days.after(last_decision_at) }
 
       before do
         choices[0].update(status: :rejected, rejected_at: 2.business_days.before(last_decision_at))


### PR DESCRIPTION
## Context

We are setting the DBD through business days from now. However due to weekends the DBD can be true to a certain date for 3 days: Saturday/Sunday/Monday. This however causes failures with us setting the `last_decision_at` to two days before as it doesn't take into account weekends.

## Changes proposed in this pull request

If we set the DBD to be relative to `last_decision_at` we no longer have the dependency on weekends and thus resolve the flakey tests. This has been tested with the next 100 days in the future and there were no failures.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
