### PR TITLE
Track validation errors in make decisions actions

### DIFF
--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -29,6 +29,7 @@ module ProviderInterface
           redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
         end
       else
+        track_validation_error(@wizard)
         render 'new'
       end
     end
@@ -47,6 +48,7 @@ module ProviderInterface
         offer_withdrawal_reason: params.dig(:withdraw_offer, :offer_withdrawal_reason),
       )
       if !@withdraw_offer.valid?
+        track_validation_error(@withdraw_offer)
         render action: :new_withdraw_offer
       end
     end
@@ -63,6 +65,7 @@ module ProviderInterface
           application_choice_id: @application_choice.id,
         )
       else
+        track_validation_error(@withdraw_offer)
         render action: :new_withdraw_offer
       end
     end

--- a/spec/requests/provider_interface/decisions_controller_spec.rb
+++ b/spec/requests/provider_interface/decisions_controller_spec.rb
@@ -9,25 +9,25 @@ RSpec.describe ProviderInterface::DecisionsController, type: :request do
   let(:course) { build(:course, :open_on_apply, provider: provider) }
   let(:course_option) { build(:course_option, course: course) }
 
+  let!(:application_choice) do
+    create(:application_choice, :withdrawn,
+           application_form: application_form,
+           course_option: course_option)
+  end
+
+  before do
+    allow(DfESignInUser).to receive(:load_from_session)
+      .and_return(
+        DfESignInUser.new(
+          email_address: provider_user.email_address,
+          dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+          first_name: provider_user.first_name,
+          last_name: provider_user.last_name,
+        ),
+      )
+  end
+
   describe 'if application choice is not in a pending decision state' do
-    let!(:application_choice) do
-      create(:application_choice, :withdrawn,
-             application_form: application_form,
-             course_option: course_option)
-    end
-
-    before do
-      allow(DfESignInUser).to receive(:load_from_session)
-        .and_return(
-          DfESignInUser.new(
-            email_address: provider_user.email_address,
-            dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
-            first_name: provider_user.first_name,
-            last_name: provider_user.last_name,
-          ),
-        )
-    end
-
     context 'GET new' do
       it 'responds with 302' do
         get new_provider_interface_application_choice_decision_path(application_choice)
@@ -42,6 +42,54 @@ RSpec.describe ProviderInterface::DecisionsController, type: :request do
 
         expect(response.status).to eq(302)
       end
+    end
+  end
+
+  describe 'validation errors' do
+    let(:withdraw_offer) do
+      instance_double(
+        WithdrawOffer,
+        valid?: false,
+        save: false,
+        offer_withdrawal_reason: nil,
+        errors: instance_double(ActiveModel::Errors, any?: true, messages: { offer_withdrawal_reason: ["can't be blank"] }),
+        model_name: ActiveModel::Name.new(WithdrawOffer),
+      )
+    end
+
+    before { application_choice.update!(status: 'awaiting_provider_decision') }
+
+    it 'tracks validation errors on create' do
+      wizard_class = ProviderInterface::OfferWizard
+      wizard = instance_double(
+        wizard_class,
+        decision: nil,
+        valid_for_current_step?: false,
+        errors: instance_double(ActiveModel::Errors, any?: true, messages: { decision: ["can't be blank"] }),
+        model_name: ActiveModel::Name.new(wizard_class),
+      )
+
+      allow(ProviderInterface::OfferWizard).to receive(:new).and_return(wizard)
+
+      expect {
+        post provider_interface_application_choice_decision_path(application_choice)
+      }.to change(ValidationError, :count).by(1)
+    end
+
+    it 'tracks validation errors on confirm withdraw offer' do
+      allow(WithdrawOffer).to receive(:new).and_return(withdraw_offer)
+
+      expect {
+        post provider_interface_application_choice_confirm_withdraw_offer_path(application_choice)
+      }.to change(ValidationError, :count).by(1)
+    end
+
+    it 'tracks validation errors on withdraw offer' do
+      allow(WithdrawOffer).to receive(:new).and_return(withdraw_offer)
+
+      expect {
+        post provider_interface_application_choice_withdraw_offer_path(application_choice)
+      }.to change(ValidationError, :count).by(1)
     end
   end
 end


### PR DESCRIPTION
## Context

We've added a way to track validation errors from Manage and Apply. So now we need to make various controller actions track any validation errors.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

 This PR adds tracking to the provider decisions actions where the underlying wizard or service may have validation errors.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

Part of https://trello.com/c/ROJfcasA/3609-track-validation-errors-on-manage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
