### PR TITLE
Show the locations filter section for users which belong to one provider

### DIFF
--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -139,9 +139,11 @@ module ProviderInterface
     end
 
     def provider_locations_filters
-      return [] if applied_filters[:provider].nil?
+      user_provider_ids = ProviderOptionsService.new(provider_user).providers.pluck(:id)
+      return [] if applied_filters[:provider].nil? && user_provider_ids.length > 1
 
-      providers = ProviderOptionsService.new(provider_user).providers_with_sites(provider_ids: applied_filters[:provider])
+      selected_provider_ids = applied_filters[:provider].presence || user_provider_ids
+      providers = ProviderOptionsService.new(provider_user).providers_with_sites(provider_ids: selected_provider_ids)
 
       providers.map do |provider|
         next unless provider.sites.count > 1

--- a/spec/models/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/models/provider_interface/provider_applications_filter_spec.rb
@@ -35,20 +35,23 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
       providers_array_index = 3
       number_of_courses = 2
 
+      headings = filter.filters.map { |f| f[:heading] }
+
       expect(filter.filters).to be_a(Array)
       expect(filter.filters.size).to eq(expected_number_of_filters)
       expect(filter.filters[recruitment_cycle_index][:options].size).to eq(2)
       expect(filter.filters[providers_array_index][:options].size).to eq(number_of_courses)
+      expect(headings).not_to include('Locations')
     end
 
-    it 'does not include providers if available providers is < 2' do
+    it 'does not include providers if available providers is > 2' do
       filter = described_class.new(
         params: ActionController::Parameters.new,
         provider_user: another_provider_user,
         state_store: {},
       )
 
-      expected_number_of_filters = 4
+      expected_number_of_filters = 5
 
       headings = filter.filters.map { |f| f[:heading] }
 
@@ -56,25 +59,50 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
       expect(headings).not_to include('Provider')
     end
 
-    it 'can return filter config for a list of provider locations' do
-      filter = described_class.new(
-        params: ActionController::Parameters.new({ provider: [provider1.id] }),
-        provider_user: another_provider_user,
-        state_store: {},
-      )
+    describe 'location filter' do
+      context 'when the user belongs to a single provider ' do
+        it 'displays the location filter by default' do
+          filter = described_class.new(
+            params: ActionController::Parameters.new,
+            provider_user: another_provider_user,
+            state_store: {},
+          )
 
-      headings = filter.filters.map { |f| f[:heading] }
+          headings = filter.filters.map { |f| f[:heading] }
 
-      expect(headings).to include("Locations for #{provider1.name}")
+          expect(headings).to include("Locations for #{provider1.name}")
 
-      relevant_provider_ids = [provider1.sites.first.id, provider1.sites.last.id]
-      relevant_provider_names = [provider1.sites.first.name, provider1.sites.last.name]
+          relevant_provider_ids = [provider1.sites.first.id, provider1.sites.last.id]
+          relevant_provider_names = [provider1.sites.first.name, provider1.sites.last.name]
 
-      expect(relevant_provider_ids).to include(filter.filters[4][:options][0][:value])
-      expect(relevant_provider_ids).to include(filter.filters[4][:options][1][:value])
+          expect(relevant_provider_ids).to include(filter.filters[4][:options][0][:value])
+          expect(relevant_provider_ids).to include(filter.filters[4][:options][1][:value])
 
-      expect(relevant_provider_names).to include(filter.filters[4][:options][0][:label])
-      expect(relevant_provider_names).to include(filter.filters[4][:options][1][:label])
+          expect(relevant_provider_names).to include(filter.filters[4][:options][0][:label])
+          expect(relevant_provider_names).to include(filter.filters[4][:options][1][:label])
+        end
+      end
+
+      it 'can return filter config for a list of provider locations' do
+        filter = described_class.new(
+          params: ActionController::Parameters.new({ provider: [provider1.id] }),
+          provider_user: another_provider_user,
+          state_store: {},
+        )
+
+        headings = filter.filters.map { |f| f[:heading] }
+
+        expect(headings).to include("Locations for #{provider1.name}")
+
+        relevant_provider_ids = [provider1.sites.first.id, provider1.sites.last.id]
+        relevant_provider_names = [provider1.sites.first.name, provider1.sites.last.name]
+
+        expect(relevant_provider_ids).to include(filter.filters[4][:options][0][:value])
+        expect(relevant_provider_ids).to include(filter.filters[4][:options][1][:value])
+
+        expect(relevant_provider_names).to include(filter.filters[4][:options][0][:label])
+        expect(relevant_provider_names).to include(filter.filters[4][:options][1][:label])
+      end
     end
 
     it 'can return filter config for a list of provider subjects' do


### PR DESCRIPTION
## Context

If a provider user belongs to a single provider, they are not able to see the "Locations for " filter section on the applications page. This PR displays the location filter for a single provider by default.

## Guidance to review

- Add a provider_user with a single provider
- Login to manage
- Go to /applications
- You should see the `Locations` filter without having to perform any actions

## Link to Trello card
https://trello.com/c/YbU4VlJS/3529-show-the-locations-filter-section-for-users-which-belong-to-one-provider

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
