### PR TITLE
Filter ValidationErrors by service to display candidate ones

### DIFF
--- a/app/controllers/support_interface/validation_errors/candidate_controller.rb
+++ b/app/controllers/support_interface/validation_errors/candidate_controller.rb
@@ -16,7 +16,7 @@ module SupportInterface
       def summary
         sort_param = params.permit(:sortby)[:sortby]
 
-        @validation_error_summary = ::ValidationErrorSummaryQuery.new(sort_param).call
+        @validation_error_summary = ::ValidationErrorSummaryQuery.new(:apply, sort_param).call
       end
     end
   end

--- a/app/controllers/support_interface/validation_errors/candidate_controller.rb
+++ b/app/controllers/support_interface/validation_errors/candidate_controller.rb
@@ -1,22 +1,8 @@
 module SupportInterface
   module ValidationErrors
-    class CandidateController < SupportInterface::ValidationErrorsController
-      def index
-        @grouped_counts = ValidationError.group(:form_object).order('count_all DESC').count
-        @list_of_distinct_errors_with_counts = ValidationError.list_of_distinct_errors_with_count
-      end
-
-      def search
-        @validation_errors = ValidationError
-          .search(params)
-          .order('created_at DESC')
-          .page(params[:page] || 1)
-      end
-
-      def summary
-        sort_param = params.permit(:sortby)[:sortby]
-
-        @validation_error_summary = ::ValidationErrorSummaryQuery.new(:apply, sort_param).call
+    class CandidateController < SupportInterface::ValidationErrors::UserController
+      def service_scope
+        :apply
       end
     end
   end

--- a/app/controllers/support_interface/validation_errors/user_controller.rb
+++ b/app/controllers/support_interface/validation_errors/user_controller.rb
@@ -1,0 +1,29 @@
+module SupportInterface
+  module ValidationErrors
+    class UserController < SupportInterfaceController
+      def index
+        @grouped_counts = validation_error_scope.group(:form_object).order('count_all DESC').count
+        @list_of_distinct_errors_with_counts = validation_error_scope.list_of_distinct_errors_with_count
+      end
+
+      def search
+        @validation_errors = validation_error_scope
+          .search(params)
+          .order('created_at DESC')
+          .page(params[:page] || 1)
+      end
+
+      def summary
+        sort_param = params.permit(:sortby)[:sortby]
+
+        @validation_error_summary = ::ValidationErrorSummaryQuery.new(service_scope, sort_param).call
+      end
+
+    private
+
+      def validation_error_scope
+        ValidationError.send(service_scope)
+      end
+    end
+  end
+end

--- a/app/queries/validation_error_summary_query.rb
+++ b/app/queries/validation_error_summary_query.rb
@@ -3,7 +3,8 @@ class ValidationErrorSummaryQuery
   LAST_WEEK = 'last_week'.freeze
   LAST_MONTH = 'last_month'.freeze
 
-  def initialize(sort_param = ALL_TIME)
+  def initialize(service_name, sort_param = ALL_TIME)
+    @service_name = service_name
     @sort_param = sort_param
   end
 
@@ -49,6 +50,7 @@ private
         1 AS incident,
         user_id AS user_id
       FROM validation_errors
+      WHERE service = '#{@service_name}'
     )
     SELECT
       form_object,

--- a/spec/components/previews/support_interface/validation_errors_component_preview.rb
+++ b/spec/components/previews/support_interface/validation_errors_component_preview.rb
@@ -15,7 +15,7 @@ module SupportInterface
     end
 
     def validation_error_summary
-      validation_error_summary = ::ValidationErrorSummaryQuery.new('all_time').call
+      validation_error_summary = ::ValidationErrorSummaryQuery.new(:apply, 'all_time').call
 
       render SupportInterface::ValidationErrorsSummaryComponent.new(
         validation_error_summary: validation_error_summary,

--- a/spec/components/previews/support_interface/validation_errors_component_preview.rb
+++ b/spec/components/previews/support_interface/validation_errors_component_preview.rb
@@ -2,8 +2,8 @@ module SupportInterface
   class ValidationErrorsComponentPreview < ViewComponent::Preview
     include SelectOptionsHelper
     def validation_error_list
-      distinct_errors_with_counts = ValidationError.list_of_distinct_errors_with_count
-      grouped_counts = ValidationError.group(:form_object).count
+      distinct_errors_with_counts = ValidationError.apply.list_of_distinct_errors_with_count
+      grouped_counts = ValidationError.apply.group(:form_object).count
 
       render SupportInterface::ValidationErrorsListComponent.new(
         distinct_errors_with_counts: distinct_errors_with_counts,


### PR DESCRIPTION
## Context
We are adding manage validation errors to support. We need to scope them out of the candidate views

## Changes proposed in this pull request
Only display service = apply validation errors in the candidate validation errors sections

## Link to Trello card
https://trello.com/c/ROJfcasA/3609-track-validation-errors-on-manage

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
