### PR TITLE
Handle 404s for resources that are not html format

### DIFF
--- a/app/controllers/candidate_interface/errors_controller.rb
+++ b/app/controllers/candidate_interface/errors_controller.rb
@@ -4,7 +4,7 @@ module CandidateInterface
     skip_before_action :authenticate_candidate!
 
     def not_found
-      render 'errors/not_found', status: :not_found
+      render 'errors/not_found', status: :not_found, formats: :html
     end
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,7 +2,7 @@ class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def not_found
-    render 'not_found', status: :not_found, formats: %i[html]
+    render 'not_found', status: :not_found, formats: :html
   end
 
   def unprocessable_entity

--- a/app/controllers/provider_interface/errors_controller.rb
+++ b/app/controllers/provider_interface/errors_controller.rb
@@ -4,7 +4,7 @@ module ProviderInterface
     skip_before_action :authenticate_provider_user!
 
     def not_found
-      render 'errors/not_found', status: :not_found
+      render 'errors/not_found', status: :not_found, formats: :html
     end
   end
 end

--- a/app/controllers/support_interface/errors_controller.rb
+++ b/app/controllers/support_interface/errors_controller.rb
@@ -4,7 +4,7 @@ module SupportInterface
     skip_before_action :authenticate_support_user!
 
     def not_found
-      render 'errors/not_found', status: :not_found
+      render 'errors/not_found', status: :not_found, formats: :html
     end
   end
 end


### PR DESCRIPTION
Previously we would 500 because we do not have 404 views for non-html formats (e.g. not_found.png does not exist, but not_found.html does exist)

https://sentry.io/organizations/dfe-bat/issues/2382797660/?project=1765973&referrer=slack

e.g. /candidate/my_image.png 500s, but candidate/my_image.html renders the correct html not found page