### PR TITLE
Add validation to ensure max allowed number of conditions is never ex…

### DIFF
--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -16,6 +16,7 @@ module ProviderInterface
     validates :study_mode, presence: true, on: %i[study_modes save]
     validates :course_id, presence: true, on: %i[courses save]
     validate :further_conditions_valid, on: %i[conditions]
+    validate :max_conditions_length, on: %i[conditions]
     validate :course_option_details, if: :course_option_id, on: :save
 
     def initialize(state_store, attrs = {})
@@ -212,6 +213,12 @@ module ProviderInterface
           errors.add("further_conditions[#{model.id}][#{error.attribute}]", error.message)
         end
       end
+    end
+
+    def max_conditions_length
+      return unless (condition_models.count + standard_conditions.compact_blank.length) > OfferValidations::MAX_CONDITIONS_COUNT
+
+      errors.add(:base, :exceeded_max_conditions, count: OfferValidations::MAX_CONDITIONS_COUNT)
     end
 
     def sanitize_parameters(attrs)

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -75,6 +75,8 @@ en:
               blank: Select course
             provider_id:
               blank: Select provider
+            base:
+              exceeded_max_conditions: The offer must have %{count} conditions or fewer
         offer_validations:
           attributes:
             course_option:

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -55,6 +55,16 @@ RSpec.describe ProviderInterface::OfferWizard do
       end
     end
 
+    context 'if the offer has too many conditions' do
+      let(:further_conditions) { 22.times.map { Faker::Lorem.paragraph } }
+
+      it 'adds the correct validation error messages to the wizard' do
+        expect(wizard.valid?(:conditions)).to eq(false)
+
+        expect(wizard.errors[:base]).to contain_exactly("The offer must have #{OfferValidations::MAX_CONDITIONS_COUNT} conditions or fewer")
+      end
+    end
+
     context 'if the course option is in an invalid state' do
       let(:course_option) { create(:course_option) }
       let(:course_option_id) { course_option.id }


### PR DESCRIPTION
…ceeded

This can happen when 20 (further) conditions are set via the API and then the offer is edited through Manage.

## Context

Extend offer wizard to incldue validation for the total number of conditions (standard + further).

## Guidance to review

- Create a new offer via the API with 20 conditions, or amend an offer through the console and add more than 18 conditions. 
- Login to manage and amend the offer's condition by ticking both standard conditions
- Click continue
- You should now see an error

## Link to Trello card

https://trello.com/c/IDxakqWz/3700-its-possible-to-get-an-application-error-by-setting-20-conditions-over-the-api-and-editing-them-in-manage-to-include-standard-co

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
