### PR TITLE
Populate correct data for city and county…

### DIFF
--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -120,9 +120,8 @@ FactoryBot.define do
       further_information { Faker::Lorem.paragraph_by_chars(number: 300) }
       disclose_disability { %w[true false].sample }
       disability_disclosure { Faker::Lorem.paragraph_by_chars(number: 300) }
-      address_line2 { Faker::Address.city }
-      address_line3 { Faker::Address.county }
-      address_line4 { '' }
+      address_line3 { Faker::Address.city }
+      address_line4 { Faker::Address.county }
       postcode { Faker::Address.postcode }
       becoming_a_teacher { Faker::Lorem.paragraph_by_chars(number: 500) }
       subject_knowledge { Faker::Lorem.paragraph_by_chars(number: 300) }

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -471,13 +471,15 @@ RSpec.describe ApplicationForm do
         :completed_application_form,
         address_line1: 'Flat 4 Prospect House',
         address_line2: 'Technique Street',
-        address_line3: 'West Glamorgan',
+        address_line3: 'Crynant',
+        address_line4: 'West Glamorgan',
         postcode: 'NW1 8TQ',
       )
 
       expect(application_form.full_address).to eq [
         'Flat 4 Prospect House',
         'Technique Street',
+        'Crynant',
         'West Glamorgan',
         'NW1 8TQ',
       ]
@@ -488,8 +490,8 @@ RSpec.describe ApplicationForm do
         :completed_application_form,
         :international_address,
         address_line1: 'Beverley Hills',
-        address_line2: nil,
-        address_line3: '90210',
+        address_line3: nil,
+        address_line4: '90210',
         postcode: nil,
         country: 'US',
       )


### PR DESCRIPTION
## Context
Currently the application form factory (used by the test data generator) incorrectly maps city to address line 2, and county to address line 3.

## Changes proposed in this pull request

Map city to address line 3 and county to address line 4

Before:
<img width="360" alt="generated-address-before" src="https://user-images.githubusercontent.com/159200/119385481-165e0280-bcbe-11eb-9bcd-4bbbed21e558.png">


After:
<img width="336" alt="generated-address-after" src="https://user-images.githubusercontent.com/159200/119385501-1cec7a00-bcbe-11eb-8420-8a041439a71c.png">


## Link to Trello card

https://trello.com/c/HIWaqtcm/3712-test-data-puts-county-in-the-town-or-city-field-for-uk-addresses

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
