### PR TITLE
Support: Content tweaks and layout fixes for changing courses

### DIFF
--- a/app/components/support_interface/application_choice_component.html.erb
+++ b/app/components/support_interface/application_choice_component.html.erb
@@ -1,6 +1,6 @@
 <%= render SummaryCardComponent.new(rows: rows) do %>
   <%= render SummaryCardHeaderComponent.new(title: title, heading_level: 3, anchor: anchor) do %>
-    <% if FeatureFlag.active?(:support_user_change_offered_course) && application_choice.pending_conditions? %>
+    <% if FeatureFlag.active?(:support_user_change_offered_course) && (application_choice.pending_conditions? || application_choice.unconditional_offer?) %>
       <div class="app-summary-card__actions">
         <ul class="app-summary-card__actions-list">
           <div class="app-summary-card__actions">

--- a/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
+++ b/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
@@ -81,7 +81,11 @@ module SupportInterface
         end
 
         def redirect_to_application_form_unless_accepted_and_change_offered_course_course_flag_active
-          redirect_to support_interface_application_form_path(@application_form.id) unless FeatureFlag.active?(:support_user_change_offered_course) && @application_choice.pending_conditions?
+          redirect_to support_interface_application_form_path(@application_form.id) unless FeatureFlag.active?(:support_user_change_offered_course) &&
+            (
+              @application_choice.pending_conditions? ||
+              @application_choice.unconditional_offer?
+            )
         end
       end
     end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -163,6 +163,12 @@ class ApplicationChoice < ApplicationRecord
     )
   end
 
+  def unconditional_offer?
+    return false unless recruited?
+
+    offer&.fetch('conditions', []).blank?
+  end
+
 private
 
   def set_initial_status

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/change_offered_course_search.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/change_offered_course_search.html.erb
@@ -1,22 +1,8 @@
-<% content_for :title, title_with_error_prefix('Search for a course code', @course_search.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix('Change offered course', @course_search.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    <p class="govuk-body">A candidate can only accept one of the courses offered to them.</p>
-    <p class="govuk-body">The support team can change the offered course only if the request is made before the end of the cycle.</p>
-    <p class="govuk-body">Candidates should decline any other offers they have received.</p>
-    <p class="govuk-body">You can find the course code by searching on
-      <%= govuk_link_to(
-        'Find postgraduate teacher training (opens in a new tab)',
-        'https://www.find-postgraduate-teacher-training.service.gov.uk/',
-        target: '_blank',
-        rel: 'nofollow',
-      ) %>.
-    </p>
-    <p class="govuk-body">The code you need is in the title of the course. For example, the course code for York St John University Primary (Q859), is Q859.</p>
-
     <%= form_with(
       model: @course_search,
       url: support_interface_application_form_application_choice_change_offered_course_search_path(
@@ -26,7 +12,27 @@
     ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field :course_code, label: { text: 'Course code', size: 'm' }, width: 5 %>
+      <h1 class="govuk-heading-l">Change offered course</h1>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>A candidate can only accept one of the courses offered to them.</li>
+        <li>An offered course can only be changed if a request is made before the end of the cycle.</li>
+        <li>Candidates should decline any other offers they have received.</li>
+      </ul>
+
+      <h2 class="govuk-heading-m">Search for a course code<h2>
+      <p class="govuk-body">
+        Find courses by searching on
+        <%= govuk_link_to(
+          'Find postgraduate teacher training',
+          'https://www.find-postgraduate-teacher-training.service.gov.uk/',
+          target: '_blank',
+          rel: 'nofollow',
+        ) %>.
+        Course codes are shown in brackets after the name of a course.
+      </p>
+
+      <%= f.govuk_text_field :course_code, label: { text: 'Course code', size: 's' }, width: 5 %>
       <%= f.govuk_submit 'Search' %>
     <% end %>
   </div>

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/change_offered_course_search.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/change_offered_course_search.html.erb
@@ -14,11 +14,7 @@
 
       <h1 class="govuk-heading-l">Change offered course</h1>
 
-      <ul class="govuk-list govuk-list--bullet">
-        <li>A candidate can only accept one of the courses offered to them.</li>
-        <li>An offered course can only be changed if a request is made before the end of the cycle.</li>
-        <li>Candidates should decline any other offers they have received.</li>
-      </ul>
+      <p class="govuk-body">An offered course can only be changed if a request is made before the end of the cycle.</p>
 
       <h2 class="govuk-heading-m">Search for a course code<h2>
       <p class="govuk-body">

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/confirm_offered_course_option.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/confirm_offered_course_option.html.erb
@@ -14,7 +14,6 @@
 
       <p class="govuk-body">An offer can only be changed if:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>the candidate has already accepted an offer and has another offer</li>
         <li>the application is in the ‘pending conditions’ state (or ‘recruited’ for an unconditional offer)</li>
         <li>the request is made before the end of the cycle</li>
       </ul>

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/confirm_offered_course_option.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/confirm_offered_course_option.html.erb
@@ -1,37 +1,29 @@
-<% content_for :browser_title, title_with_error_prefix('Confirm offered course', @update_offered_course_option_form.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix('Are you sure you want to offer this course?', @update_offered_course_option_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_application_choice_choose_offered_course_option_path(course_code: @update_offered_course_option_form.course_option.course.code)) %>
 
-<%= form_with(
-  model: @update_offered_course_option_form,
-  url: support_interface_application_form_application_choice_confirm_offered_course_option_path,
-  method: :patch
-  )do |f| %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @update_offered_course_option_form,
+      url: support_interface_application_form_application_choice_confirm_offered_course_option_path,
+      method: :patch,
+    ) do |f| %>
+      <%= f.govuk_error_summary %>
 
-  <%= f.govuk_error_summary %>
-  <%= f.hidden_field :course_option_id, value: @update_offered_course_option_form.course_option.id %>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">
-        Are you sure you want to offer this course?
-      </h1>
+      <h1 class="govuk-heading-l">Are you sure you want to offer this course?</h1>
 
       <p class="govuk-body">An offer can only be changed if:</p>
-
       <ul class="govuk-list govuk-list--bullet">
-        <li>The candidate has already accepted an offer and the application is in either the pending conditions or recruited states (for unconditional offers)</li>
-        <li>The candidate has another course offer</li>
-        <li>The request to change the course accepted to another offered is made before the end of the cycle</li>
+        <li>the candidate has already accepted an offer and has another offer</li>
+        <li>the application is in the ‘pending conditions’ state (or ‘recruited’ for an unconditional offer)</li>
+        <li>the request is made before the end of the cycle</li>
       </ul>
-
       <p class="govuk-body">In order to change the accepted course offer you must first contact the provider and candidate to confirm that they agree to this change.</p>
       <p class="govuk-body">By changing the course offer accepted, all of the candidate’s other course choices will be automatically withdrawn.</p>
       <p class="govuk-body">Once the course offer has been changed, please email the candidate using the macro.</p>
-    </div>
-  </div>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+      <%= f.hidden_field :course_option_id, value: @update_offered_course_option_form.course_option.id %>
+
       <%= f.govuk_text_field(
         :audit_comment,
         label: {
@@ -43,12 +35,12 @@
           text: t('support_interface.audit_comment_ticket.hint'),
         },
       ) %>
-    </div>
+
+      <%= f.govuk_check_boxes_fieldset :accept_guidance, legend: nil do %>
+        <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
+      <% end %>
+
+      <%= f.govuk_submit t('continue') %>
+    <% end %>
   </div>
-
-  <%= f.govuk_check_boxes_fieldset :accept_guidance, legend: nil do %>
-    <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
-  <% end %>
-
-  <%= f.govuk_submit t('continue') %>
-<% end %>
+</div>

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/offered_course_options.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/offered_course_options.html.erb
@@ -25,7 +25,7 @@
       <% end %>
     <% else %>
       <p class="govuk-body">No courses for <%= @application_choice.provider.name_and_code %> found.</p>
-      <%= govuk_link_to('Search again', support_interface_application_form_application_choice_change_offered_course_search_path(course_code: @pick_course.course_code)) %>
+      <%= govuk_link_to('Search again', support_interface_application_form_application_choice_change_offered_course_search_path(course_code: @pick_course.course_code), button: true) %>
     <% end %>
   </div>
 </div>

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/offered_course_options.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/offered_course_options.html.erb
@@ -1,31 +1,26 @@
 <% content_for :title, title_with_error_prefix("Choose a course to replace #{@application_choice.current_course_option.course.name_and_code}", @pick_course.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_application_choice_change_offered_course_search_path(course_code: @pick_course.course_code)) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<% if @pick_course.unavailable_courses.present? %>
+  <h2 class="govuk-heading-m">Courses with no vacancies</h2>
+  <% @pick_course.unavailable_courses.each do |course| %>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= "#{course.provider.name} (#{course.provider.code}) – #{course.name} (#{course.code})" %></li>
+    </ul>
+  <% end %>
+<% end %>
 
-    <% if @pick_course.unavailable_courses.present? %>
-      <h2 class="govuk-heading-m">Courses with no vacancies</h2>
-      <% @pick_course.unavailable_courses.each do |course| %>
-        <ul class="govuk-list">
-          <%= "#{course.provider.name} (#{course.provider.code}) - #{course.name} (#{course.code})" %>
-        </ul>
+<% if @pick_course.course_options_for_provider(@application_choice.provider).present? %>
+  <%= form_with model: @pick_course, url: support_interface_application_form_application_choice_choose_offered_course_option_path(course_code: @pick_course.course_code) do |f| %>
+    <%= f.govuk_error_summary %>
+    <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: 'Which course should be added to the application?', size: 'm' } do %>
+      <% @pick_course.course_options_for_provider(@application_choice.provider).each_with_index do |co, i| %>
+        <%= f.govuk_radio_button :course_option_id, co.course_option_id, label: { text: "#{co.provider_name} (#{co.provider_code}) – #{co.course_name} (#{co.course_code})" }, hint: { text: "#{co.site_name} – #{co.study_mode}" }, link_errors: i.zero? %>
       <% end %>
     <% end %>
-
-    <% if @pick_course.course_options_for_provider(@application_choice.provider).present? %>
-      <%= form_with model: @pick_course, url: support_interface_application_form_application_choice_choose_offered_course_option_path(course_code: @pick_course.course_code) do |f| %>
-        <%= f.govuk_error_summary %>
-        <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: 'Which course should be added to the application?', size: 'm' } do %>
-          <% @pick_course.course_options_for_provider(@application_choice.provider).each_with_index do |co, i| %>
-            <%= f.govuk_radio_button :course_option_id, co.course_option_id, label: { text: "#{co.provider_name} (#{co.provider_code}) - #{co.course_name} (#{co.course_code}) - #{co.site_name} - #{co.study_mode} " }, link_errors: i.zero? %>
-          <% end %>
-        <% end %>
-        <%= f.govuk_submit 'Continue' %>
-      <% end %>
-    <% else %>
-      <p class="govuk-body">No courses for <%= @application_choice.provider.name_and_code %> found.</p>
-      <%= govuk_link_to('Search again', support_interface_application_form_application_choice_change_offered_course_search_path(course_code: @pick_course.course_code), button: true) %>
-    <% end %>
-  </div>
-</div>
+    <%= f.govuk_submit 'Continue' %>
+  <% end %>
+<% else %>
+  <p class="govuk-body">No courses for <%= @application_choice.provider.name_and_code %> found.</p>
+  <%= govuk_link_to('Search again', support_interface_application_form_application_choice_change_offered_course_search_path(course_code: @pick_course.course_code), button: true) %>
+<% end %>

--- a/app/views/support_interface/application_forms/application_choices/confirm_revert_rejection.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/confirm_revert_rejection.html.erb
@@ -1,17 +1,16 @@
-<% content_for :browser_title, title_with_error_prefix('Revert rejection', @application_choice.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix('Are you sure you want to revert this rejection?', @application_choice.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(application_form_id: params[:application_form_id]), 'Back to application') %>
 
-<%= form_with(
-    model: @form,
-    url: support_interface_application_form_revert_rejection_path(application_form_id: params[:application_form_id], application_choice_id: params[:application_choice_id]),
-    method: :patch,
-  ) do |f| %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @form,
+      url: support_interface_application_form_revert_rejection_path(application_form_id: params[:application_form_id], application_choice_id: params[:application_choice_id]),
+      method: :patch,
+    ) do |f| %>
       <%= f.govuk_error_summary %>
-      <h1 class="govuk-heading-l">
-        Are you sure you want to revert this rejection?
-      </h1>
+
+      <h1 class="govuk-heading-l">Are you sure you want to revert this rejection?</h1>
 
       <p class="govuk-body">A rejection can only be reverted if:</p>
       <ul class="govuk-list govuk-list--bullet">
@@ -20,11 +19,7 @@
       </ul>
       <p class="govuk-body">In order to revert the rejection you must first contact the provider to confirm that they agree to this.</p>
       <p class="govuk-body">Once the rejection has been reverted, please email the candidate to let them know.</p>
-    </div>
-  </div>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_text_field(
         :audit_comment_ticket,
         label: {
@@ -34,12 +29,12 @@
         rows: 1,
         hint: { text: t('support_interface.audit_comment_ticket.hint') },
       ) %>
-    </div>
+
+      <%= f.govuk_check_boxes_fieldset :accept_guidance, legend: nil do %>
+        <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
   </div>
-
-  <%= f.govuk_check_boxes_fieldset :accept_guidance, legend: nil do %>
-    <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
-  <% end %>
-
-  <%= f.govuk_submit t('continue') %>
-<% end %>
+</div>

--- a/app/views/support_interface/application_forms/application_choices/reinstate_declined_offer/confirm_reinstate_offer.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/reinstate_declined_offer/confirm_reinstate_offer.html.erb
@@ -1,17 +1,16 @@
-<% content_for :browser_title, title_with_error_prefix('Reinstate offer', @declined_course_choice.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix('Are you sure you want to reinstate this offer?', @declined_course_choice.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(application_form_id: params[:application_form_id]), 'Back to application') %>
 
-<%= form_with(
-  model: @declined_course_choice,
-  url: support_interface_application_form_application_choice_reinstate_offer_path(application_form_id: params[:application_form_id], application_choice_id: params[:application_choice_id]),
-  method: :patch
-  )do |f| %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @declined_course_choice,
+      url: support_interface_application_form_application_choice_reinstate_offer_path(application_form_id: params[:application_form_id], application_choice_id: params[:application_choice_id]),
+      method: :patch,
+    ) do |f| %>
       <%= f.govuk_error_summary %>
-      <h1 class="govuk-heading-l">
-        Are you sure you want to reinstate this offer?
-      </h1>
+
+      <h1 class="govuk-heading-l">Are you sure you want to reinstate this offer?</h1>
 
       <p class="govuk-body">An offer can only be reinstated if:</p>
       <ul class="govuk-list govuk-list--bullet">
@@ -22,11 +21,7 @@
       <p class="govuk-body">By reinstating the offer, the DBD deadline for this offer (and any other offers) will be reset to 10 working days.</p>
       <p class="govuk-body">Once the offer has been reinstated, please email the candidate using the macro.</p>
       <p class="govuk-body">There are separate macros if the request was made after 5 working days or if the candidate has already accepted another offer.</p>
-    </div>
-  </div>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_text_field(
         :audit_comment_ticket,
         label: {
@@ -36,12 +31,12 @@
         rows: 1,
         hint: { text: t('support_interface.audit_comment_ticket.hint') },
       ) %>
-    </div>
+
+      <%= f.govuk_check_boxes_fieldset :accept_guidance, legend: nil do %>
+        <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
   </div>
-
-  <%= f.govuk_check_boxes_fieldset :accept_guidance, legend: nil do %>
-    <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
-  <% end %>
-
-  <%= f.govuk_submit t('continue') %>
-<% end %>
+</div>

--- a/app/views/support_interface/application_forms/courses/new.html.erb
+++ b/app/views/support_interface/application_forms/courses/new.html.erb
@@ -25,7 +25,7 @@
       <% end %>
     <% else %>
       <p class="govuk-body">No open courses found for current recruitment cycle.</p>
-      <%= govuk_link_to('Search again', support_interface_application_form_search_course_new_path(course_code: @pick_course.course_code)) %>
+      <%= govuk_link_to('Search again', support_interface_application_form_search_course_new_path(course_code: @pick_course.course_code), button: true) %>
     <% end %>
   </div>
 </div>

--- a/app/views/support_interface/application_forms/courses/new.html.erb
+++ b/app/views/support_interface/application_forms/courses/new.html.erb
@@ -1,31 +1,26 @@
 <% content_for :title, title_with_error_prefix("Select a course to add to #{@pick_course.applicant_name}’s application", @pick_course.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_search_course_new_path(course_code: @pick_course.course_code)) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<% if @pick_course.unavailable_courses.present? %>
+  <h2 class="govuk-heading-m">Courses with no vacancies</h2>
+  <% @pick_course.unavailable_courses.each do |course| %>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= "#{course.provider.name} (#{course.provider.code}) – #{course.name} (#{course.code})" %></li>
+    </ul>
+  <% end %>
+<% end %>
 
-    <% if @pick_course.unavailable_courses.present? %>
-      <h2 class="govuk-heading-m">Courses with no vacancies</h2>
-      <% @pick_course.unavailable_courses.each do |course| %>
-        <ul class="govuk-list">
-          <%= "#{course.provider.name} (#{course.provider.code}) - #{course.name} (#{course.code})" %>
-        </ul>
+<% if @pick_course.course_options.present? %>
+  <%= form_with model: @pick_course, url: support_interface_application_form_create_course_path(course_code: @pick_course.course_code) do |f| %>
+    <%= f.govuk_error_summary %>
+    <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: 'Which course should be added to the application?', size: 'm' } do %>
+      <% @pick_course.course_options.each_with_index do |co, i| %>
+        <%= f.govuk_radio_button :course_option_id, co.course_option_id, label: { text: "#{co.provider_name} (#{co.provider_code}) – #{co.course_name} (#{co.course_code})" }, hint: { text: "#{co.site_name} – #{co.study_mode}" }, link_errors: i.zero? %>
       <% end %>
     <% end %>
-
-    <% if @pick_course.course_options.present? %>
-      <%= form_with model: @pick_course, url: support_interface_application_form_create_course_path(course_code: @pick_course.course_code) do |f| %>
-        <%= f.govuk_error_summary %>
-        <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: 'Which course should be added to the application?', size: 'm' } do %>
-          <% @pick_course.course_options.each_with_index do |co, i| %>
-            <%= f.govuk_radio_button :course_option_id, co.course_option_id, label: { text: "#{co.provider_name} (#{co.provider_code}) - #{co.course_name} (#{co.course_code}) - #{co.site_name} - #{co.study_mode} " }, link_errors: i.zero? %>
-          <% end %>
-        <% end %>
-        <%= f.govuk_submit 'Add course to application' %>
-      <% end %>
-    <% else %>
-      <p class="govuk-body">No open courses found for current recruitment cycle.</p>
-      <%= govuk_link_to('Search again', support_interface_application_form_search_course_new_path(course_code: @pick_course.course_code), button: true) %>
-    <% end %>
-  </div>
-</div>
+    <%= f.govuk_submit 'Add course to application' %>
+  <% end %>
+<% else %>
+  <p class="govuk-body">No open courses found for current recruitment cycle.</p>
+  <%= govuk_link_to('Search again', support_interface_application_form_search_course_new_path(course_code: @pick_course.course_code), button: true) %>
+<% end %>

--- a/app/views/support_interface/application_forms/courses/new_search.html.erb
+++ b/app/views/support_interface/application_forms/courses/new_search.html.erb
@@ -1,29 +1,35 @@
-<% content_for :title, title_with_error_prefix('Search for a course code', @course_search.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix('Add a course', @course_search.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">A candidate can only add up to 3 courses. They cannot add the same course twice.</p>
-
-    <p class="govuk-body">The support team can modify the course selections within the first 5 working days that the application was submitted.</p>
-    <p class="govuk-body">Support team users can add course choices. Candidates should withdraw their own course choices if possible. If this is not possible, and the application was submitted within the first 5 working days, then a course choice can be sent to a developer to remove. The developer or support team could then add course choice(s).</p>
-    <p class="govuk-body">You can find the course code by searching on
-      <%= govuk_link_to(
-        'Find postgraduate teacher training',
-        'https://www.find-postgraduate-teacher-training.service.gov.uk/',
-        target: '_blank',
-        rel: 'nofollow',
-      ) %>.
-    </p>
-    <p class="govuk-body">The code you need is in the title of the course.</p>
-    <p class="govuk-body">For example, the course code for York St John University Primary (Q859), is Q859.</p>
     <%= form_with(
       model: @course_search,
       url: support_interface_application_form_search_course_path,
     ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field :course_code, label: { text: 'Course code', size: 'm' }, width: 5 %>
+      <h1 class="govuk-heading-l">Add a course</h1>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>A candidate can only add up to 3 courses. They cannot add the same course twice.</li>
+        <li>Course choices can only be changed within 5 working days of an application being submitted.</li>
+        <li>Candidates should withdraw their own course choices if possible. If this is not possible, a course choice can be removed by a developer. A developer or support agent can then add a course choice.</li>
+      </ul>
+
+      <h2 class="govuk-heading-m">Search for a course code<h2>
+      <p class="govuk-body">
+        Find courses by searching on
+        <%= govuk_link_to(
+          'Find postgraduate teacher training',
+          'https://www.find-postgraduate-teacher-training.service.gov.uk/',
+          target: '_blank',
+          rel: 'nofollow',
+        ) %>.
+        Course codes are shown in brackets after the name of a course.
+      </p>
+
+      <%= f.govuk_text_field :course_code, label: { text: 'Course code', size: 's' }, width: 5 %>
       <%= f.govuk_submit 'Search' %>
     <% end %>
   </div>

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -66,6 +66,33 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
     end
   end
 
+  context 'Unconditional offer' do
+    let(:unconditional_offer) { create(:application_choice, :with_completed_application_form, :with_recruited, offer: { 'conditions' => [] }) }
+
+    it 'renders a link to the change the offered course choice when the `change_offered_course` flag is active' do
+      FeatureFlag.activate(:support_user_change_offered_course)
+
+      result = render_inline(described_class.new(unconditional_offer))
+
+      expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include(
+        Rails.application.routes.url_helpers.support_interface_application_form_application_choice_change_offered_course_search_path(
+          application_form_id: unconditional_offer.application_form.id,
+          application_choice_id: unconditional_offer.id,
+        ),
+      )
+      expect(result.css('.app-summary-card__actions').text.strip).to include('Change offered course')
+    end
+
+    it 'does not render a link to the change the offered course choice  when the`change_offered_course` flag is not active' do
+      FeatureFlag.deactivate(:support_user_change_offered_course)
+
+      render_inline(described_class.new(unconditional_offer))
+
+      expect(page).not_to have_selector '.app-summary-card__actions a'
+      expect(page).not_to have_text 'Change offered course'
+    end
+  end
+
   context 'Rejected application' do
     let(:rejected_application_choice) { create(:application_choice, :with_completed_application_form, :with_rejection) }
 

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -236,4 +236,31 @@ RSpec.describe ApplicationChoice, type: :model do
       end
     end
   end
+
+  describe '#unconditional_offer?' do
+    context 'recruited with conditions' do
+      it 'returns false' do
+        application_choice = build_stubbed(:application_choice, :with_recruited)
+        expect(application_choice.unconditional_offer?).to eq false
+      end
+    end
+
+    context 'recruited unconditionally' do
+      it 'returns true' do
+        application_choice = build_stubbed(:application_choice, :with_recruited, offer: { 'conditions' => [] })
+        expect(application_choice.unconditional_offer?).to eq true
+      end
+    end
+
+    context 'all other statuses' do
+      it 'returns false' do
+        statuses = ApplicationChoice.statuses.values.reject { |value| value == 'recruited' }
+
+        statuses.each do |status|
+          application_choice = build_stubbed(:application_choice, status: status)
+          expect(application_choice.unconditional_offer?).to eq false
+        end
+      end
+    end
+  end
 end

--- a/spec/system/support_interface/add_course_to_submitted_application_spec.rb
+++ b/spec/system/support_interface/add_course_to_submitted_application_spec.rb
@@ -127,7 +127,7 @@ RSpec.feature 'Add course to submitted application' do
   end
 
   def when_i_select_a_course
-    choose "#{@course_option.course.name} (#{@course_code}) - #{@course_option.site.name}"
+    choose "#{@course_option.provider.name} (#{@course_option.provider.code}) – #{@course_option.course.name} (#{@course_code})"
   end
 
   def and_i_click_add_course_to_application

--- a/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
+++ b/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
@@ -125,7 +125,7 @@ RSpec.feature 'Add course to submitted application' do
   end
 
   def when_i_select_a_course
-    choose "#{@course_option.course.name} (#{@course_code}) - #{@course_option.site.name}"
+    choose "#{@course_option.provider.name} (#{@course_option.provider.code}) – #{@course_option.course.name} (#{@course_code})"
   end
 
   def when_i_click_to_change_the_offered_course


### PR DESCRIPTION
## Context

Content could be improved for some of the new application admin features in Support. Also, some suspect markup 👀 

## Changes proposed in this pull request

### Add a course

* Change the content for the start page to reflect the purpose the page (adding a course), and then explain how to search for a course code. Use bullets to outline the business rules.
* Use hint text to show location and study mode for available course choices 

| Before | After |
| - | - |
| ![add-a-course-start-page--OLD](https://user-images.githubusercontent.com/813383/119385655-59b87100-bcbe-11eb-9821-bbc6c4197fef.png) | ![add-a-course-start-page](https://user-images.githubusercontent.com/813383/119385662-5b823480-bcbe-11eb-9bc0-975c8f0b4bde.png) | 
| ![add-a-course-choices--OLD](https://user-images.githubusercontent.com/813383/119385647-54f3bd00-bcbe-11eb-9c76-e4e387affd9f.png) | ![add-a-course-choices](https://user-images.githubusercontent.com/813383/119386193-190d2780-bcbf-11eb-95ba-a77583ba40bf.png) |

### Change offered course

* Change the content for the start page to reflect the purpose the page (changing an offered course), and then explain how to search for a course code. Use bullets to outline the business rules.
* Use hint text to show location and study mode for available course choices
* Tweak content on the confirmation page

| Before | After |
| - | - |
| ![change-offered-course-start-page--OLD](https://user-images.githubusercontent.com/813383/119386357-507bd400-bcbf-11eb-9903-7122082d05ad.png) | ![change-offered-course-start-page](https://user-images.githubusercontent.com/813383/119386362-52459780-bcbf-11eb-8e2c-104330658f45.png) |
| ![change-offered-course-choices--OLD](https://user-images.githubusercontent.com/813383/119386329-4954c600-bcbf-11eb-83ce-04227efcc471.png) | ![change-offered-course-choices](https://user-images.githubusercontent.com/813383/119386336-4a85f300-bcbf-11eb-87c6-153c630c5e5f.png) |
| ![change-offered-course-confirm--OLD](https://user-images.githubusercontent.com/813383/119386341-4c4fb680-bcbf-11eb-82d6-496ad718c510.png) | ![change-offered-course-confirm](https://user-images.githubusercontent.com/813383/119386348-4eb21080-bcbf-11eb-8156-5e696042178a.png) |

### Other pages

Tweaked page titles to be consistent (browser title should be the same as page heading), and simplified the layout… lots of duplicated grid layout going on, for some reason.

## Guidance to review

For changing an offered course, there appears to be contradictory guidance. On the start page, we say:

> Candidates should decline any other offers they have received.

yet on the confirmation page we say:

> [An offer can only be changed if:] The candidate has another course offer

I’ve kept this, but changing the content to say:

> [An offer can only be changed if:] the candidate has already accepted an offer and has another offer

But I’m it sure this is right.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
