### PR TITLE
Update the Subject Knowledge section to use explicit backlinks

### DIFF
--- a/app/controllers/candidate_interface/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/subject_knowledge_controller.rb
@@ -2,6 +2,23 @@ module CandidateInterface
   class SubjectKnowledgeController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted, :render_application_feedback_component
 
+    def new
+      @subject_knowledge_form = SubjectKnowledgeForm.new
+      @course_names = chosen_course_names
+    end
+
+    def create
+      @subject_knowledge_form = SubjectKnowledgeForm.new(subject_knowledge_params)
+
+      if @subject_knowledge_form.save(current_application)
+        redirect_to candidate_interface_subject_knowledge_show_path
+      else
+        track_validation_error(@subject_knowledge_form)
+        @course_names = chosen_course_names
+        render :new
+      end
+    end
+
     def edit
       @subject_knowledge_form = SubjectKnowledgeForm.build_from_application(
         current_application,

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -276,7 +276,7 @@ module CandidateInterface
       if subject_knowledge_valid?
         Rails.application.routes.url_helpers.candidate_interface_subject_knowledge_show_path
       else
-        Rails.application.routes.url_helpers.candidate_interface_edit_subject_knowledge_path
+        Rails.application.routes.url_helpers.candidate_interface_new_subject_knowledge_path
       end
     end
 

--- a/app/views/candidate_interface/subject_knowledge/_form.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/_form.html.erb
@@ -1,0 +1,28 @@
+<%= f.govuk_error_summary %>
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.subject_knowledge') %>
+</h1>
+
+<% if @course_names.any? %>
+  <p class="govuk-body">
+    Give us detailed evidence for the knowledge and interest you bring to:
+  </p>
+  <ul class="govuk-list govuk-list--bullet">
+    <% @course_names.each do |course_name| %>
+      <li><%= course_name %></li>
+    <% end %>
+  </ul>
+<% else %>
+  <p class="govuk-body">Give us detailed evidence for the knowledge and interest you bring to the subject(s) you’d like to teach.</p>
+<% end %>
+<p class="govuk-body">Evidence can include:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>the subject of your undergraduate degree</li>
+  <li>modules you studied as part of your degree</li>
+  <li>postgraduate degrees (for example, a Masters or PhD)</li>
+  <li>your A level subjects</li>
+  <li>expertise you’ve gained at work</li>
+</ul>
+
+<%= f.govuk_text_area :subject_knowledge, label: { text: t('application_form.personal_statement.subject_knowledge.label'), size: 'm' }, rows: 20, max_words: 400 %>
+<%= f.govuk_submit t('continue') %>

--- a/app/views/candidate_interface/subject_knowledge/new.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/new.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.subject_knowledge'), @subject_knowledge_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_subject_knowledge_show_path) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @subject_knowledge_form, url: candidate_interface_edit_subject_knowledge_path, method: :patch do |f| %>
+    <%= form_with model: @subject_knowledge_form, url: candidate_interface_new_subject_knowledge_path, method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,8 +137,10 @@ Rails.application.routes.draw do
       end
 
       scope '/subject-knowledge' do
-        get '/' => 'subject_knowledge#edit', as: :edit_subject_knowledge
-        patch '/' => 'subject_knowledge#update'
+        get '/' => 'subject_knowledge#new', as: :new_subject_knowledge
+        patch '/' => 'subject_knowledge#create'
+        get '/edit' => 'subject_knowledge#edit', as: :edit_subject_knowledge
+        patch '/edit' => 'subject_knowledge#update'
         get '/review' => 'subject_knowledge#show', as: :subject_knowledge_show
         patch '/complete' => 'subject_knowledge#complete', as: :subject_knowledge_complete
       end


### PR DESCRIPTION
## Context

This PR adds in new and create actions to the controller. This allows us to pass in explicit backlinks to the new and edit views.

## Changes proposed in this pull request

- Add new and create routes, controller actions and views to the subject knowledge controller
- Add explicit backlinks to the views

## Link to Trello card

https://trello.com/c/GuiJ30Jg/3397-catch-all-give-back-links-explicit-targets

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
