### PR TITLE
Add explicit backlinks to the interview needs section

### DIFF
--- a/app/controllers/candidate_interface/interview_needs_controller.rb
+++ b/app/controllers/candidate_interface/interview_needs_controller.rb
@@ -2,6 +2,21 @@ module CandidateInterface
   class InterviewNeedsController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
 
+    def new
+      @interview_preferences_form = InterviewPreferencesForm.new
+    end
+
+    def create
+      @interview_preferences_form = InterviewPreferencesForm.new(interview_preferences_params)
+
+      if @interview_preferences_form.save(current_application)
+        redirect_to candidate_interface_interview_preferences_show_path
+      else
+        track_validation_error(@interview_preferences_form)
+        render :new
+      end
+    end
+
     def edit
       @interview_preferences_form = InterviewPreferencesForm.build_from_application(
         current_application,

--- a/app/views/candidate_interface/interview_needs/_form.html.erb
+++ b/app/views/candidate_interface/interview_needs/_form.html.erb
@@ -1,0 +1,39 @@
+<%= f.govuk_error_summary %>
+
+<h1 class="govuk-heading-xl"><%= t('page_titles.interview_preferences') %></h1>
+
+<p class="govuk-body">
+  Providers do not usually have much flexibility when setting a date
+  and time for interview unless you need adjustments due to a
+  <%= govuk_link_to(
+    'health condition or disability',
+    candidate_interface_edit_training_with_a_disability_path,
+  ) %>.
+</p>
+
+<p class="govuk-body">
+  However, if you need flexibility for other reasons you can tell us about it here.
+</p>
+
+<p class="govuk-body">
+  For example: you have commitments like caring responsibilities or employment.
+</p>
+
+<p class="govuk-body">
+  Interview processes might be different at the moment because of
+  coronavirus (COVID-19).
+</p>
+
+<p class="govuk-body">
+  Contact your provider if you’re concerned about the interview process.
+</p>
+
+<%= f.govuk_radio_buttons_fieldset :any_preferences, legend: { text: t('application_form.personal_statement.interview_preferences.label'), size: 'm' } do %>
+  <%= f.govuk_radio_button :any_preferences, 'yes', label: { text: 'Yes' }, link_errors: true do %>
+    <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.personal_statement.interview_preferences.yes_label'), size: 's' }, rows: 8, max_words: 200 %>
+  <% end %>
+
+  <%= f.govuk_radio_button :any_preferences, 'no', label: { text: 'No' } %>
+<% end %>
+
+<%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/interview_needs/new.html.erb
+++ b/app/views/candidate_interface/interview_needs/new.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.interview_preferences'), @interview_preferences_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_interview_preferences_show_path) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @interview_preferences_form, url: candidate_interface_edit_interview_preferences_path, method: :patch do |f| %>
+    <%= form_with model: @interview_preferences_form, url: candidate_interface_new_interview_preferences_path, method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -199,7 +199,7 @@
           <%= render(TaskListItemComponent.new(
             text: t('page_titles.interview_preferences'),
             completed: @application_form_presenter.interview_preferences_completed?,
-            path: @application_form_presenter.interview_preferences_valid? ? candidate_interface_interview_preferences_show_path : candidate_interface_edit_interview_preferences_path,
+            path: @application_form_presenter.interview_preferences_valid? ? candidate_interface_interview_preferences_show_path : candidate_interface_new_interview_preferences_path,
           )) %>
         </li>
       </ol>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,8 +144,10 @@ Rails.application.routes.draw do
       end
 
       scope '/interview-needs' do
-        get '/' => 'interview_needs#edit', as: :edit_interview_preferences
-        patch '/' => 'interview_needs#update'
+        get '/' => 'interview_needs#new', as: :new_interview_preferences
+        patch '/' => 'interview_needs#create'
+        get '/edit' => 'interview_needs#edit', as: :edit_interview_preferences
+        patch '/edit' => 'interview_needs#update'
         get '/review' => 'interview_needs#show', as: :interview_preferences_show
         patch '/complete' => 'interview_needs#complete', as: :interview_preferences_complete
       end


### PR DESCRIPTION
## Context

This PR adds in new and create actions to the controller. This allows us to pass in explicit backlinks to the new and edit views.

## Changes proposed in this pull request

- Add new and create routes, controller actions and views to the interview needs controller
- Add explicit backlinks to the views

## Link to Trello card

https://trello.com/c/GuiJ30Jg/3397-catch-all-give-back-links-explicit-targets

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
