### PR TITLE
Add explicit backlinks to the training with a disability section

### DIFF
--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -7,6 +7,21 @@ module CandidateInterface
       @section_complete_form = SectionCompleteForm.new(completed: current_application.training_with_a_disability_completed)
     end
 
+    def new
+      @training_with_a_disability_form = TrainingWithADisabilityForm.new
+    end
+
+    def create
+      @training_with_a_disability_form = TrainingWithADisabilityForm.new(training_with_a_disability_params)
+
+      if @training_with_a_disability_form.save(current_application)
+        redirect_to candidate_interface_training_with_a_disability_show_path
+      else
+        track_validation_error(@training_with_a_disability_form)
+        render :new
+      end
+    end
+
     def edit
       @training_with_a_disability_form = TrainingWithADisabilityForm.build_from_application(current_application)
     end

--- a/app/views/candidate_interface/training_with_a_disability/_form.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/_form.html.erb
@@ -1,0 +1,31 @@
+<%= f.govuk_error_summary %>
+
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.training_with_a_disability') %>
+</h1>
+
+<p class="govuk-body">You might benefit from extra support if you’re disabled, have a mental health condition or educational needs.</p>
+<p class="govuk-body">If you choose to tell us you need support, we’ll let your training provider know. They can then make adjustments so you can attend an interview or do the training.</p>
+<p class="govuk-body">Examples of support could be:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>organising equipment like a hearing loop or an adapted keyboard</li>
+  <li>putting you in touch with support staff if you have a mental health condition</li>
+  <li>making sure classrooms are wheelchair accessible</li>
+</ul>
+<p class="govuk-body">If the help you need is not covered by your provider making adjustments, you might also be able to get support from <%= govuk_link_to 'Access to Work', 'https://www.gov.uk/access-to-work' %>. This could include a grant to help cover the costs of practical support in the workplace.</p>
+<h2 class="govuk-heading-m">It’s against the law to discriminate</h2>
+<p class="govuk-body">If you’re disabled, <%= govuk_link_to 'it’s against the law to discriminate against you', t('get_into_teaching.url_training_with_a_disability') %>. Training providers must not:</p>
+<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+  <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
+  <li>reject your application because you’re disabled</li>
+</ul>
+
+<%= f.govuk_radio_buttons_fieldset :disclose_disability, legend: { text: t('application_form.training_with_a_disability.disclose_disability.label'), size: 'm' } do %>
+  <%= f.govuk_radio_button :disclose_disability, 'yes', label: { text: t('application_form.training_with_a_disability.disclose_disability.yes') }, link_errors: true do %>
+    <%= f.govuk_text_area :disability_disclosure, rows: 8, label: { text: t('application_form.training_with_a_disability.disability_disclosure.label'), size: 's' }, max_words: 400 %>
+  <% end %>
+
+  <%= f.govuk_radio_button :disclose_disability, 'no', label: { text: t('application_form.training_with_a_disability.disclose_disability.no') } %>
+<% end %>
+
+<%= f.govuk_submit t('continue') %>

--- a/app/views/candidate_interface/training_with_a_disability/new.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/new.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.training_with_a_disability'), @training_with_a_disability_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_training_with_a_disability_show_path) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @training_with_a_disability_form, url: candidate_interface_edit_training_with_a_disability_path, method: :patch do |f| %>
+    <%= form_with model: @training_with_a_disability_form, url: candidate_interface_new_training_with_a_disability_path, method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -192,7 +192,7 @@
           <%= render(TaskListItemComponent.new(
             text: t('page_titles.training_with_a_disability'),
             completed: @application_form_presenter.training_with_a_disability_completed?,
-            path: @application_form_presenter.training_with_a_disability_valid? ? candidate_interface_training_with_a_disability_show_path : candidate_interface_edit_training_with_a_disability_path,
+            path: @application_form_presenter.training_with_a_disability_valid? ? candidate_interface_training_with_a_disability_show_path : candidate_interface_new_training_with_a_disability_path,
           )) %>
         </li>
         <li class="app-task-list__item govuk-hint">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,8 +156,10 @@ Rails.application.routes.draw do
       end
 
       scope '/additional-support' do
-        get '/' => 'training_with_a_disability#edit', as: :edit_training_with_a_disability
-        patch '/' => 'training_with_a_disability#update'
+        get '/' => 'training_with_a_disability#new', as: :new_training_with_a_disability
+        patch '/' => 'training_with_a_disability#create'
+        get '/edit' => 'training_with_a_disability#edit', as: :edit_training_with_a_disability
+        patch '/edit' => 'training_with_a_disability#update'
         get '/review' => 'training_with_a_disability#show', as: :training_with_a_disability_show
         patch '/complete' => 'training_with_a_disability#complete', as: :training_with_a_disability_complete
       end


### PR DESCRIPTION
## Context

This PR adds in new and create actions to the controller. This allows us to pass in explicit backlinks to the new and edit views.

## Changes proposed in this pull request

- Add new and create routes, controller actions and views to the training with a disability section needs controller
- Add explicit backlinks to the views

## Link to Trello card

https://trello.com/c/GuiJ30Jg/3397-catch-all-give-back-links-explicit-targets

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
