### PR TITLE
De-dup provider users returned by `NotificationsList`

### DIFF
--- a/app/services/notifications_list.rb
+++ b/app/services/notifications_list.rb
@@ -15,13 +15,13 @@ class NotificationsList
       return application_choice.provider.provider_users.joins(:notification_preferences).where("#{notification_name} IS true") if application_choice.accredited_provider.nil? || !include_ratifying_provider
 
       application_choice.provider.provider_users.or(application_choice.accredited_provider.provider_users)
-        .joins(:notification_preferences).where("#{notification_name} IS true")
+        .joins(:notification_preferences).where("#{notification_name} IS true").distinct
     else
       return application_choice.provider.provider_users.where(send_notifications: true) if application_choice.accredited_provider.nil? || !include_ratifying_provider
 
       application_choice.provider.provider_users.where(send_notifications: true).or(
         application_choice.accredited_provider.provider_users.where(send_notifications: true),
-      )
+      ).distinct
     end
   end
 end

--- a/spec/services/notifications_list_spec.rb
+++ b/spec/services/notifications_list_spec.rb
@@ -35,6 +35,26 @@ RSpec.describe NotificationsList do
 
         expect(NotificationsList.for(application_choice, include_ratifying_provider: true, event: :offer_accepted).to_a).to match_array([training_provider_user, ratifying_provider_user])
       end
+
+      it 'returns a provider user who is a member of the training and ratifying providers without duplicates' do
+        ratifying_provider = create(:provider)
+        training_provider = create(:provider)
+        provider_user = create(:provider_user, send_notifications: true, providers: [training_provider, ratifying_provider])
+        application_choice = create(:application_choice, course_option: create(:course_option, course: create(:course, provider: training_provider, accredited_provider: ratifying_provider)))
+
+        create(
+          :provider_user_notification_preferences,
+          :all_off,
+          provider_user: create(:provider_user, send_notifications: false, providers: [training_provider, ratifying_provider]),
+        )
+        create(:provider_user_notification_preferences)
+
+        expect(NotificationsList.for(
+          application_choice,
+          include_ratifying_provider: true,
+          event: :offer_accepted,
+        ).to_a).to match_array([provider_user])
+      end
     end
 
     context 'when the configurable provider notifications feature flag is off' do
@@ -60,6 +80,26 @@ RSpec.describe NotificationsList do
         training_provider_user = create(:provider_user, send_notifications: true, providers: [application_choice.course.provider])
 
         expect(NotificationsList.for(application_choice, include_ratifying_provider: true).to_a).to match_array([training_provider_user, ratifying_provider_user])
+      end
+
+      it 'returns a provider user who is a member of the training and ratifying providers without duplicates' do
+        ratifying_provider = create(:provider)
+        training_provider = create(:provider)
+        provider_user = create(:provider_user, send_notifications: true, providers: [training_provider, ratifying_provider])
+        application_choice = create(:application_choice, course_option: create(:course_option, course: create(:course, provider: training_provider, accredited_provider: ratifying_provider)))
+
+        create(
+          :provider_user_notification_preferences,
+          :all_off,
+          provider_user: create(:provider_user, send_notifications: false, providers: [training_provider, ratifying_provider]),
+        )
+        create(:provider_user_notification_preferences)
+
+        expect(NotificationsList.for(
+          application_choice,
+          include_ratifying_provider: true,
+          event: :offer_accepted,
+        ).to_a).to match_array([provider_user])
       end
     end
   end

--- a/spec/services/notifications_list_spec.rb
+++ b/spec/services/notifications_list_spec.rb
@@ -42,12 +42,7 @@ RSpec.describe NotificationsList do
         provider_user = create(:provider_user, send_notifications: true, providers: [training_provider, ratifying_provider])
         application_choice = create(:application_choice, course_option: create(:course_option, course: create(:course, provider: training_provider, accredited_provider: ratifying_provider)))
 
-        create(
-          :provider_user_notification_preferences,
-          :all_off,
-          provider_user: create(:provider_user, send_notifications: false, providers: [training_provider, ratifying_provider]),
-        )
-        create(:provider_user_notification_preferences)
+        create(:provider_user_notification_preferences, provider_user: provider_user)
 
         expect(NotificationsList.for(
           application_choice,
@@ -87,13 +82,6 @@ RSpec.describe NotificationsList do
         training_provider = create(:provider)
         provider_user = create(:provider_user, send_notifications: true, providers: [training_provider, ratifying_provider])
         application_choice = create(:application_choice, course_option: create(:course_option, course: create(:course, provider: training_provider, accredited_provider: ratifying_provider)))
-
-        create(
-          :provider_user_notification_preferences,
-          :all_off,
-          provider_user: create(:provider_user, send_notifications: false, providers: [training_provider, ratifying_provider]),
-        )
-        create(:provider_user_notification_preferences)
 
         expect(NotificationsList.for(
           application_choice,


### PR DESCRIPTION
## Context

This came up as a support issue. A provider user who is a member of a training provider and ratifying provider is getting two notification emails for every event. This PR is an attempt to reproduce the issue and implement a fix.

## Changes proposed in this pull request

- Use DISTINCT for the queries that returns provider users

## Guidance to review

- Does this make sense?
- Should this be dealt with elsewhere?
- Are there any other situations that could lead to duplicates?

## Link to Trello card

https://trello.com/c/8YiMBz9D/540-dfe-emails-dfe-apply-application-notifications

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
