### PR TITLE
Track provider interface interviews validation errors

### DIFF
--- a/app/components/provider_interface/interview_details_component.rb
+++ b/app/components/provider_interface/interview_details_component.rb
@@ -20,11 +20,11 @@ module ProviderInterface
   private
 
     def date_row
-      build_row(:date, @interview_form.date_and_time.to_s(:govuk_date))
+      build_row(:date, @interview_form.date_and_time&.to_s(:govuk_date))
     end
 
     def time_row
-      build_row(:time, @interview_form.date_and_time.to_s(:govuk_time))
+      build_row(:time, @interview_form.date_and_time&.to_s(:govuk_time))
     end
 
     def organisation_row

--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -38,7 +38,11 @@ module ProviderInterface
 
       @wizard = InterviewWizard.new(interview_store, interview_params.merge(current_step: 'check'))
       @wizard.save_state!
-      render :new unless @wizard.valid?
+
+      unless @wizard.valid?
+        track_validation_error(@wizard)
+        render :new
+      end
     end
 
     def commit
@@ -59,6 +63,7 @@ module ProviderInterface
         flash[:success] = t('.success')
         redirect_to provider_interface_application_choice_interviews_path(@application_choice)
       else
+        track_validation_error(@wizard)
         render :check
       end
     end
@@ -82,6 +87,7 @@ module ProviderInterface
         flash[:success] = t('.success')
         redirect_to provider_interface_application_choice_interviews_path(@application_choice)
       else
+        track_validation_error(@wizard)
         render :check
       end
     end

--- a/spec/requests/provider_interface/interviews_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews_controller_spec.rb
@@ -99,4 +99,35 @@ RSpec.describe ProviderInterface::InterviewsController, type: :request do
       end
     end
   end
+
+  describe 'validation errors' do
+    let(:application_choice) do
+      create(:application_choice, :awaiting_provider_decision, application_form: application_form, course_option: course_option)
+    end
+
+    let(:store) { instance_double(WizardStateStores::RedisStore, read: %({ "provider_user" : "#{provider_user.id}" }), write: true) }
+
+    before { allow(WizardStateStores::RedisStore).to receive(:new).and_return(store) }
+
+    it 'tracks validation errors on check' do
+      expect {
+        post new_check_provider_interface_application_choice_interviews_path(application_choice),
+             params: { provider_interface_interview_wizard: { location: 'here' } }
+      }.to change(ValidationError, :count).by(1)
+    end
+
+    it 'tracks validation errors on commit' do
+      expect {
+        post confirm_provider_interface_application_choice_interviews_path(application_choice),
+             params: { provider_interface_interview_wizard: { location: 'here' } }
+      }.to change(ValidationError, :count).by(1)
+    end
+
+    it 'tracks validation errors on update' do
+      expect {
+        put update_provider_interface_application_choice_interview_path(application_choice, interview),
+            params: { provider_interface_interview_wizard: { location: 'here' } }
+      }.to change(ValidationError, :count).by(1)
+    end
+  end
 end


### PR DESCRIPTION
## Context

We've added a way to track validation errors from Manage and Apply. So now we need to make various controller actions track any validation errors.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds validation error tracking to provider interface interviews actions `check` `commit` and `update`
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ROJfcasA/3609-track-validation-errors-on-manage

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
