### PR TITLE
Add Offer and OfferCondition models

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,0 +1,4 @@
+class Offer < ApplicationRecord
+  belongs_to :application_choice
+  has_many :conditions, class_name: 'OfferCondition'
+end

--- a/app/models/offer_condition.rb
+++ b/app/models/offer_condition.rb
@@ -1,0 +1,12 @@
+class OfferCondition < ApplicationRecord
+  belongs_to :offer
+  has_one :application_choice, through: :offer
+
+  enum status: {
+    pending: 'pending',
+    met: 'met',
+    unmet: 'unmet',
+  }
+
+  audited associated_with: :application_choice
+end

--- a/db/migrate/20210525095036_create_offers.rb
+++ b/db/migrate/20210525095036_create_offers.rb
@@ -1,0 +1,9 @@
+class CreateOffers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :offers do |t|
+      t.references :application_choice, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210525095046_create_offer_conditions.rb
+++ b/db/migrate/20210525095046_create_offer_conditions.rb
@@ -1,0 +1,11 @@
+class CreateOfferConditions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :offer_conditions do |t|
+      t.references :offer, null: false, foreign_key: true
+      t.string :text
+      t.string :status, null: false, default: 'pending'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_19_132016) do
+ActiveRecord::Schema.define(version: 2021_05_25_095046) do
 
   create_sequence "application_choices_id_seq"
   create_sequence "application_experiences_id_seq"
@@ -40,6 +40,8 @@ ActiveRecord::Schema.define(version: 2021_05_19_132016) do
   create_sequence "ielts_qualifications_id_seq"
   create_sequence "interviews_id_seq"
   create_sequence "notes_id_seq"
+  create_sequence "offer_conditions_id_seq"
+  create_sequence "offers_id_seq"
   create_sequence "other_efl_qualifications_id_seq"
   create_sequence "provider_agreements_id_seq"
   create_sequence "provider_relationship_permissions_id_seq"
@@ -517,6 +519,22 @@ ActiveRecord::Schema.define(version: 2021_05_19_132016) do
     t.index ["provider_user_id"], name: "index_notes_on_provider_user_id"
   end
 
+  create_table "offer_conditions", force: :cascade do |t|
+    t.bigint "offer_id", null: false
+    t.string "text"
+    t.string "status", default: "pending", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["offer_id"], name: "index_offer_conditions_on_offer_id"
+  end
+
+  create_table "offers", force: :cascade do |t|
+    t.bigint "application_choice_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["application_choice_id"], name: "index_offers_on_application_choice_id"
+  end
+
   create_table "other_efl_qualifications", force: :cascade do |t|
     t.string "name", null: false
     t.string "grade", null: false
@@ -775,6 +793,8 @@ ActiveRecord::Schema.define(version: 2021_05_19_132016) do
   add_foreign_key "interviews", "providers", on_delete: :cascade
   add_foreign_key "notes", "application_choices", on_delete: :cascade
   add_foreign_key "notes", "provider_users", on_delete: :cascade
+  add_foreign_key "offer_conditions", "offers"
+  add_foreign_key "offers", "application_choices"
   add_foreign_key "provider_agreements", "provider_users"
   add_foreign_key "provider_agreements", "providers"
   add_foreign_key "provider_relationship_permissions", "providers", column: "ratifying_provider_id"

--- a/spec/factories/offer.rb
+++ b/spec/factories/offer.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :offer do
+    application_choice
+
+    conditions { [association(:offer_condition, offer: instance)] }
+  end
+end

--- a/spec/factories/offer_condition.rb
+++ b/spec/factories/offer_condition.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :offer_condition do
+    offer
+
+    text { 'Evidence of being cool' }
+  end
+end

--- a/spec/models/offer_condition_spec.rb
+++ b/spec/models/offer_condition_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe OfferCondition do
+  describe 'associations' do
+    it '#application_choice returns the associated application choice' do
+      offer_condition = create(:offer_condition, text: 'Provide evidence of degree qualification')
+
+      expect(offer_condition.application_choice).not_to be_nil
+    end
+  end
+
+  describe 'auditing', with_audited: true do
+    it 'audits changes to the model' do
+      offer_condition = create(:offer_condition, text: 'Provide evidence of degree qualification')
+
+      offer_condition.update!(status: 'met')
+
+      expect(offer_condition.audits.last.audited_changes).to eq({ 'status' => %w[pending met] })
+    end
+
+    it 'associates audits to the application choice' do
+      offer_condition = create(:offer_condition, text: 'Provide evidence of degree qualification')
+
+      expect(offer_condition.audits.last.associated_type).to eq('ApplicationChoice')
+      expect(offer_condition.audits.last.associated_id).to eq(offer_condition.application_choice.id)
+    end
+  end
+end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Offer do
+  describe 'associations' do
+    it '#conditions returns the list of conditions' do
+      condition1 = create(:offer_condition, text: 'Provide evidence of degree qualification')
+      condition2 = create(:offer_condition, text: 'Do a backflip and send us a video')
+      offer = create(:offer, conditions: [condition1, condition2])
+
+      expect(offer.conditions.map(&:text)).to contain_exactly('Provide evidence of degree qualification', 'Do a backflip and send us a video')
+    end
+  end
+end


### PR DESCRIPTION
## Context
We are migrating away from storing offers and conditions on the application choice. This allows us to individually manage offer condition statuses.

## Changes proposed in this pull request
Add offers and offer_conditions tables
Add Offer and OfferCondition models and their specs


## Link to Trello card
https://trello.com/c/JrmmIR0M/3718-migration-to-add-separate-offer-and-conditions-tables

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
