### PR TITLE
Track validation errors on conditions actions

### DIFF
--- a/app/controllers/provider_interface/conditions_controller.rb
+++ b/app/controllers/provider_interface/conditions_controller.rb
@@ -13,7 +13,10 @@ module ProviderInterface
         conditions_met: params.dig(:provider_interface_confirm_conditions_form, :conditions_met),
       )
 
-      render action: :edit unless @conditions_form.valid?
+      unless @conditions_form.valid?
+        track_validation_error(@conditions_form)
+        render action: :edit
+      end
     end
 
     def update
@@ -21,25 +24,28 @@ module ProviderInterface
         conditions_met: params.dig(:provider_interface_confirm_conditions_form, :conditions_met),
       )
 
-      redirect_to action: :edit unless @conditions_form.valid?
+      if @conditions_form.valid?
+        if @conditions_form.conditions_met?
+          ConfirmOfferConditions.new(
+            actor: current_provider_user,
+            application_choice: @application_choice,
+          ).save || raise('ConfirmOfferConditions failure')
 
-      if @conditions_form.conditions_met?
-        ConfirmOfferConditions.new(
-          actor: current_provider_user,
-          application_choice: @application_choice,
-        ).save || raise('ConfirmOfferConditions failure')
+          flash[:success] = 'Conditions successfully marked as met'
+        else
+          ConditionsNotMet.new(
+            actor: current_provider_user,
+            application_choice: @application_choice,
+          ).save || raise('ConditionsNotMet failure')
 
-        flash[:success] = 'Conditions successfully marked as met'
+          flash[:success] = 'Conditions successfully marked as not met'
+        end
+
+        redirect_to provider_interface_application_choice_path(@application_choice.id)
       else
-        ConditionsNotMet.new(
-          actor: current_provider_user,
-          application_choice: @application_choice,
-        ).save || raise('ConditionsNotMet failure')
-
-        flash[:success] = 'Conditions successfully marked as not met'
+        track_validation_error(@conditions_form)
+        redirect_to action: :edit
       end
-
-      redirect_to provider_interface_application_choice_path(@application_choice.id)
     end
 
     def redirect_back_if_application_terminated


### PR DESCRIPTION
## Context

We've added a way to track validation errors from Manage and Apply. So now we need to make various controller actions track any validation errors.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Tracks validation errors on `confirm_update` and `update` conditions actions.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ROJfcasA/3609-track-validation-errors-on-manage

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
