### PR TITLE
Fix bug where courses were wrongly opened automatically

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -51,7 +51,9 @@ class Provider < ApplicationRecord
   def all_courses_open_in_current_cycle?(exclude_ratified_courses: false)
     courses_to_check = exclude_ratified_courses ? courses : accredited_courses.or(courses)
 
-    courses_to_check.current_cycle.exposed_in_find.all?(&:open_on_apply?)
+    open_in_find = courses_to_check.current_cycle.exposed_in_find
+
+    open_in_find.any? && open_in_find.all?(&:open_on_apply?)
   end
 
   def any_open_courses_in_current_cycle?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -56,8 +56,10 @@ class Provider < ApplicationRecord
     open_in_find.any? && open_in_find.all?(&:open_on_apply?)
   end
 
-  def any_open_courses_in_current_cycle?
-    accredited_courses.or(courses).current_cycle.exposed_in_find.any?(&:open_on_apply?)
+  def any_courses_open_in_current_cycle?(exclude_ratified_courses: false)
+    courses_to_check = exclude_ratified_courses ? courses : accredited_courses.or(courses)
+
+    courses_to_check.current_cycle.open_on_apply.any?
   end
 
   def application_forms

--- a/app/services/set_open_on_apply_for_new_course.rb
+++ b/app/services/set_open_on_apply_for_new_course.rb
@@ -20,7 +20,7 @@ class SetOpenOnApplyForNewCourse
 private
 
   def notify_of_new_course!(provider, accredited_provider, auto_open)
-    notification = [":seedling: #{provider.name}, which has courses open on Apply, added a new course"]
+    notification = [":seedling: #{provider.name}, which has courses open on Apply, added #{@course.name_and_code}"]
 
     if auto_open
       notification << 'We opened it automatically'

--- a/app/services/set_open_on_apply_for_new_course.rb
+++ b/app/services/set_open_on_apply_for_new_course.rb
@@ -8,7 +8,7 @@ class SetOpenOnApplyForNewCourse
   def call
     @course.open! if HostingEnvironment.sandbox_mode? || @course.in_previous_cycle&.open_on_apply?
 
-    if @course.provider.any_open_courses_in_current_cycle?
+    if @course.provider.any_courses_open_in_current_cycle?(exclude_ratified_courses: true)
       auto_open = @course.provider.all_courses_open_in_current_cycle?(exclude_ratified_courses: true)
 
       @course.open! if auto_open

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -71,10 +71,15 @@ RSpec.describe Provider, type: :model do
       expect(result).to be false
     end
 
+    it 'is false if the provider has no courses' do
+      expect(result).to be false
+    end
+
     context 'exclude_ratified_courses: true' do
       subject(:result) { provider.all_courses_open_in_current_cycle?(exclude_ratified_courses: true) }
 
-      it 'is true if the provider’s other courses including ratified courses are a mixture of open on Apply and open on UCAS' do
+      it 'is true if the provider’s ratified courses are not open but its own are' do
+        create(:course, :open_on_apply, provider: provider)
         create(:course, accredited_provider: provider, exposed_in_find: true, open_on_apply: false)
 
         expect(result).to be true

--- a/spec/services/set_open_on_apply_for_new_course_spec.rb
+++ b/spec/services/set_open_on_apply_for_new_course_spec.rb
@@ -13,6 +13,50 @@ RSpec.describe SetOpenOnApplyForNewCourse do
     end
   end
 
+  context 'the provider has no courses in the current cycle' do
+    it 'does not open the course' do
+      course_opener.call
+
+      expect(course).not_to be_open_on_apply
+    end
+  end
+
+  context 'the provider has a course in the current cycle but it’s hidden in find' do
+    before do
+      create(:course, provider: course.provider, exposed_in_find: false)
+    end
+
+    it 'does not open the course' do
+      course_opener.call
+
+      expect(course).not_to be_open_on_apply
+    end
+  end
+
+  context 'the provider has a course in the current cycle and it’s exposed in find but not open' do
+    before do
+      create(:course, provider: course.provider, exposed_in_find: true, open_on_apply: false)
+    end
+
+    it 'does not open the course' do
+      course_opener.call
+
+      expect(course).not_to be_open_on_apply
+    end
+  end
+
+  context 'the provider ratifies an open course in the current cycle' do
+    before do
+      create(:course, :open_on_apply, accredited_provider: course.provider)
+    end
+
+    it 'does not open the course' do
+      course_opener.call
+
+      expect(course).not_to be_open_on_apply
+    end
+  end
+
   context 'the course was open in the previous cycle' do
     before do
       create(:course, provider: course.provider, code: course.code, recruitment_cycle_year: RecruitmentCycle.previous_year, open_on_apply: true)

--- a/spec/services/set_open_on_apply_for_new_course_spec.rb
+++ b/spec/services/set_open_on_apply_for_new_course_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe SetOpenOnApplyForNewCourse do
 
       course_opener.call
 
-      expect_slack_message_with_text("#{course.provider.name}, which has courses open on Apply, added a new course. We opened it automatically. There’s no separate accredited body for this course.")
+      expect_slack_message_with_text("#{course.provider.name}, which has courses open on Apply, added #{course.name_and_code}. We opened it automatically. There’s no separate accredited body for this course.")
       expect_slack_message_with_text("support/courses/#{course.id}")
     end
 
@@ -119,7 +119,7 @@ RSpec.describe SetOpenOnApplyForNewCourse do
 
         course_opener.call
 
-        expect_slack_message_with_text("#{course.provider.name}, which has courses open on Apply, added a new course. We opened it automatically. It’s ratified by Canterbury, who have NOT signed the DSA.")
+        expect_slack_message_with_text("#{course.provider.name}, which has courses open on Apply, added #{course.name_and_code}. We opened it automatically. It’s ratified by Canterbury, who have NOT signed the DSA.")
       end
 
       context 'and the accredited provider has signed the DSA' do
@@ -130,7 +130,7 @@ RSpec.describe SetOpenOnApplyForNewCourse do
 
           course_opener.call
 
-          expect_slack_message_with_text("#{course.provider.name}, which has courses open on Apply, added a new course. We opened it automatically. It’s ratified by Canterbury, who have signed the DSA.")
+          expect_slack_message_with_text("#{course.provider.name}, which has courses open on Apply, added #{course.name_and_code}. We opened it automatically. It’s ratified by Canterbury, who have signed the DSA.")
         end
       end
     end


### PR DESCRIPTION
## Context

The auto course opener opened a course for an HEI where that HEI had no courses open but one of its training providers did

https://ukgovernmentdfe.slack.com/archives/CQA64BETU/p1621938356057300

## Changes proposed in this pull request

- Fix a bug in `Provider#any_courses_open_in_current_cycle?` which returned true when they had no courses
- Only consider the current provider's courses, not its ratified courses, when we make the decision to auto-open
- while we're here, include the course name in the message