### PR TITLE
Update the select references UI

### DIFF
--- a/app/components/task_list_item_references_component.html.erb
+++ b/app/components/task_list_item_references_component.html.erb
@@ -1,4 +1,9 @@
 <div class="app-task-list__content">
+  <% if FeatureFlag.active?(:reference_selection) %>
+    <p class="govuk-body">
+      <%= govuk_link_to t('page_titles.references_review'), references_path, 'aria-describedby': "#{t('page_titles.references_review').parameterize}-badge-id" %>
+    </p>
+  <% end %>
   <ul class="govuk-list">
     <% references.each do |reference| %>
       <li class="govuk-body-s">

--- a/app/components/task_list_item_references_component.rb
+++ b/app/components/task_list_item_references_component.rb
@@ -16,4 +16,12 @@ class TaskListItemReferencesComponent < ViewComponent::Base
 private
 
   attr_reader :references
+
+  def references_path
+    if @references.present?
+      Rails.application.routes.url_helpers.candidate_interface_references_review_path
+    else
+      Rails.application.routes.url_helpers.candidate_interface_references_start_path
+    end
+  end
 end

--- a/app/controllers/candidate_interface/references/selection_controller.rb
+++ b/app/controllers/candidate_interface/references/selection_controller.rb
@@ -1,28 +1,104 @@
 module CandidateInterface
   module References
     class SelectionController < BaseController
+      before_action :render_404_unless_feature_enabled
+      before_action :redirect_to_select_references_unless_enough_selected, only: %i[review complete]
+
       def new
         @selection_form = CandidateInterface::Reference::SelectionForm.new(
           application_form: current_application,
           selected: current_application.application_references.selected.pluck(:id),
         )
+        @enough_references_provided = current_application.minimum_references_available_for_selection?
       end
 
       def create
         @selection_form = CandidateInterface::Reference::SelectionForm.new(selection_params)
+        @enough_references_provided = current_application.minimum_references_available_for_selection?
+
         if @selection_form.save!
           track_validation_error(@section_complete_form)
-          redirect_to candidate_interface_references_review_path
+          redirect_to candidate_interface_review_selected_references_path
+        elsif !@enough_references_provided
+          flash.now[:warning] = I18n.t('application_form.references.review.need_two')
+          render :new and return
         else
+          track_validation_error(@selection_form)
           render :new
+        end
+      end
+
+      def review
+        @references_selected = current_application.application_references.includes(:application_form).selected
+        @section_complete_form = SectionCompleteForm.new(completed: current_application.references_completed)
+
+        @selected_references_rows = [
+          {
+            key: 'Selected references',
+            value: reference_values,
+            action: 'Change selected references',
+            change_path: candidate_interface_select_references_path,
+          },
+        ]
+      end
+
+      def complete
+        @references_selected = current_application.application_references.includes(:application_form).selected
+        @section_complete_form = SectionCompleteForm.new(completed: section_complete_params[:completed])
+
+        @selected_references_rows = [
+          {
+            key: 'Selected references',
+            value: reference_values,
+            action: 'Change selected references',
+            change_path: candidate_interface_select_references_path,
+          },
+        ]
+
+        if !@section_complete_form.valid?
+          track_validation_error(@section_complete_form)
+          render :review and return
+        end
+
+        if @section_complete_form.not_completed?
+          @section_complete_form.save(current_application, :references_completed)
+          redirect_to candidate_interface_application_form_path
+        elsif current_application.selected_enough_references?
+          @section_complete_form.save(current_application, :references_completed)
+          redirect_to candidate_interface_application_form_path
         end
       end
 
     private
 
+      def redirect_to_select_references_unless_enough_selected
+        if current_application.application_references.includes(:application_form).selected.count != 2
+          redirect_to candidate_interface_select_references_path
+        end
+      end
+
       def selection_params
         params.require(:candidate_interface_reference_selection_form).permit(selected: [])
           .merge(application_form: current_application)
+      end
+
+      def section_complete_params
+        strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
+      end
+
+      def reference_values
+        list = '<ul class="govuk-list govuk-list--bullet">'.html_safe
+        @references_selected.map do |reference|
+          list <<
+            '<li>'.html_safe <<
+            "#{reference.referee_type.humanize} reference from #{reference.name}" <<
+            '</li>'.html_safe
+        end
+        list + '</ul>'.html_safe
+      end
+
+      def render_404_unless_feature_enabled
+        render_404 unless FeatureFlag.active?(:reference_selection)
       end
     end
   end

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -38,9 +38,6 @@ class ApplicationReference < ApplicationRecord
     never_asked: 'never_asked',
   }
 
-  scope :selected, -> { where(selected: true) }
-  scope :feedback_provided_but_not_selected, -> { feedback_provided.where.not(selected: true) }
-
   def self.pending_feedback_or_failed
     where.not(feedback_status: %i[not_requested_yet feedback_provided])
   end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -146,6 +146,7 @@ module CandidateInterface
       end
     end
 
+    # TODO: remove this method when deleting the reference_selection feature flag
     def references_path
       if @application_form.application_references.present?
         Rails.application.routes.url_helpers.candidate_interface_references_review_path

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -154,6 +154,14 @@ module CandidateInterface
       end
     end
 
+    def references_selection_path
+      if @application_form.application_references.includes(:application_form).selected.count >= 2
+        Rails.application.routes.url_helpers.candidate_interface_review_selected_references_path
+      else
+        Rails.application.routes.url_helpers.candidate_interface_select_references_path
+      end
+    end
+
     def work_experience_path
       if @application_form.feature_restructured_work_history && FeatureFlag.active?(:restructured_work_history)
         if @application_form.application_work_experiences.any? || @application_form.work_history_explanation.present?

--- a/app/views/candidate_interface/references/selection/new.html.erb
+++ b/app/views/candidate_interface/references/selection/new.html.erb
@@ -1,19 +1,42 @@
 <% content_for :title, t('page_titles.references') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"> <%= t('page_titles.references_select') %> </h1>
+<% if @enough_references_provided %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-    <%= form_with(model: @selection_form, url: candidate_interface_select_references_path, method: :patch) do |f| %>
-      <%= f.govuk_check_boxes_fieldset :selected, multiple: true, legend: { text: '' } do %>
-        <% @selection_form.available_references.each do |reference| %>
-          <%= f.govuk_check_box :selected, reference.id, label: { text: reference.single_line_identifier, size: 's' } %>
-          <%= render(CandidateInterface::ReferencesReviewComponent.new(references: [reference], show_history: false, heading_level: 3)) %>
+      <%= form_with(model: @selection_form, url: candidate_interface_select_references_path, method: :patch) do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-xl"><%= t('page_titles.references_select') %></h1>
+
+        <%= f.govuk_check_boxes_fieldset :selected, multiple: true, legend: { text: '' } do %>
+          <% @selection_form.available_references.each do |reference| %>
+            <%= f.govuk_check_box(
+              :selected,
+              reference.id,
+              label: { text: reference.name, size: 's' },
+              hint: { text: "#{reference.referee_type.humanize} reference" },
+            ) %>
+          <% end %>
         <% end %>
-      <% end %>
 
-      <%= f.govuk_submit t('continue') %>
-    <% end %>
+        <%= f.govuk_submit t('save_and_continue') %>
+      <% end %>
+    </div>
   </div>
-</div>
+
+<% else %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl"><%= t('page_titles.references_selection') %></h1>
+
+      <p class="govuk-body">Once 2 or more references have been given, you can then select which you want to include in your application.</p>
+
+      <p class="govuk-body">You can <%= govuk_link_to 'request references and track their progress', candidate_interface_references_review_path %> in the references section.</p>
+
+      <%= govuk_link_to 'Return to application', candidate_interface_application_form_path, button: true %>
+    </div>
+  </div>
+
+<% end %>

--- a/app/views/candidate_interface/references/selection/review.html.erb
+++ b/app/views/candidate_interface/references/selection/review.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, t('page_titles.references') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<%= form_with(model: @section_complete_form, url: candidate_interface_complete_selected_references_path, method: :post) do |f| %>
+
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-xl"> <%= t('page_titles.references') %> </h1>
+
+  <%= render(SummaryCardComponent.new(rows: @selected_references_rows)) %>
+
+  <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
+
+  <%= f.govuk_submit t('save_and_continue') %>
+<% end %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -49,15 +49,21 @@
         <li class="app-task-list__item">
           <%= render(TaskListItemComponent.new(
             text: @application_form_presenter.references_link_text,
-            completed: @application_form_presenter.enough_references_provided?,
+            completed: nil,
             path: @application_form_presenter.references_path,
-            custom_status: @application_form_presenter.references_in_progress? ? 'In progress' : nil,
+            custom_status: nil,
           )) %>
           <% if @application_form_presenter.references.present? %>
             <%= render(TaskListItemReferencesComponent.new(
               references: @application_form_presenter.references,
             )) %>
           <% end %>
+
+          <%= render(TaskListItemComponent.new(
+             text: 'Selected references',
+             completed: @application_form_presenter.enough_references_provided?,
+             path: @application_form_presenter.references_selection_path,
+           )) %>
         </li>
       </ol>
     </section>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -45,27 +45,47 @@
         <p class="govuk-body">It takes 8 days to get a reference on average.</p>
       <% end %>
 
-      <ol class="app-task-list">
-        <li class="app-task-list__item">
-          <%= render(TaskListItemComponent.new(
-            text: @application_form_presenter.references_link_text,
-            completed: nil,
-            path: @application_form_presenter.references_path,
-            custom_status: nil,
-          )) %>
-          <% if @application_form_presenter.references.present? %>
-            <%= render(TaskListItemReferencesComponent.new(
-              references: @application_form_presenter.references,
-            )) %>
-          <% end %>
+      <% if FeatureFlag.active?(:reference_selection) %>
 
-          <%= render(TaskListItemComponent.new(
-             text: 'Selected references',
-             completed: @application_form_presenter.enough_references_provided?,
-             path: @application_form_presenter.references_selection_path,
-           )) %>
-        </li>
-      </ol>
+        <ol class="app-task-list">
+          <li class="app-task-list__item">
+            <% if @application_form_presenter.references.present? %>
+              <%= render(TaskListItemReferencesComponent.new(
+                references: @application_form_presenter.references,
+              )) %>
+            <% else %>
+              <%= govuk_link_to t('page_titles.references_review'), @application_form_presenter.references_path %>
+            <% end %>
+          </li>
+
+          <li class="app-task-list__item">
+            <%= render(TaskListItemComponent.new(
+              text: t('page_titles.references_selection'),
+              completed: @application_form_presenter.enough_references_provided?,
+              path: @application_form_presenter.references_selection_path,
+            )) %>
+          </li>
+        </ol>
+
+      <% else %>
+
+        <ol class="app-task-list">
+          <li class="app-task-list__item">
+            <%= render(TaskListItemComponent.new(
+              text: @application_form_presenter.references_link_text,
+              completed: @application_form_presenter.enough_references_provided?,
+              path: @application_form_presenter.references_path,
+              custom_status: @application_form_presenter.references_in_progress? ? 'In progress' : nil,
+            )) %>
+            <% if @application_form_presenter.references.present? %>
+              <%= render(TaskListItemReferencesComponent.new(
+                references: @application_form_presenter.references,
+              )) %>
+            <% end %>
+          </li>
+        </ol>
+
+      <% end %>
     </section>
 
     <section class="govuk-!-margin-bottom-8">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,7 +157,9 @@ en:
     references_delete_referee: Are you sure you want to delete this referee?
     references_delete_reference: Are you sure you want to delete this reference?
     references_send_reminder: Would you like to send a reminder to this referee?
-    references_select: Select your references
+    references_select: Which 2 references do you want to include in your application?
+    references_review: Review your references
+    references_selection: Selected references
     application_feedback: How can we improve %{section} section?
     application_feedback_thank_you: Thank you for your feedback
     find_feedback: Help us improve this service

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -498,10 +498,11 @@ Rails.application.routes.draw do
         get '/candidate-name/:id' => 'references/candidate_name#new', as: :references_new_candidate_name
         post '/candidate-name/:id' => 'references/candidate_name#create', as: :references_create_candidate_name
 
-        post '/complete' => 'references/review#complete', as: :complete_references
-
         get '/select' => 'references/selection#new', as: :select_references
         patch '/select' => 'references/selection#create'
+
+        get '/select/review' => 'references/selection#review', as: :review_selected_references
+        post '/select/review' => 'references/selection#complete', as: :complete_selected_references
       end
 
       scope '/equality-and-diversity' do


### PR DESCRIPTION
## Context

This PR is an update to the initial design of the _reference selection_ section in [#4793](https://github.com/DFE-Digital/apply-for-teacher-training/pull/4793).

## Changes proposed in this pull request

### For a candidate who hasn't received feedback:

|Application review|Reference selection|
|---|---|
|![image](https://user-images.githubusercontent.com/47917431/119539650-57b8e580-bd84-11eb-9829-877abe936f76.png)|![Screenshot 2021-05-25 at 17 47 59](https://user-images.githubusercontent.com/47917431/119537129-a5801e80-bd81-11eb-8c78-662eed164d8f.png)|

### For a candidate who has feedback available for selection:

|Application review|Reference selection|Reference review|
|---|---|---|
|![Screenshot 2021-05-25 at 17 48 23](https://user-images.githubusercontent.com/47917431/119537136-a749e200-bd81-11eb-8935-6a96c83b4d17.png)|![Screenshot 2021-05-25 at 17 48 49](https://user-images.githubusercontent.com/47917431/119537146-a9ac3c00-bd81-11eb-977e-febb938a15d9.png)|![Screenshot 2021-05-25 at 17 52 48](https://user-images.githubusercontent.com/47917431/119537546-0b6ca600-bd82-11eb-8c52-f51e2fc5b6ef.png)|

## Guidance to review

- Use the review app with the `reference_selection` feature flag on
- A candidate will need to have received two or more pieces of feedback in order for the selection view to render
- Some states still haven't been covered yet and will follow in a separate PR

This is a temporary fix to show the references in a bulleted list:
```
def reference_values
  list = '<ul class="govuk-list govuk-list--bullet">'.html_safe
  @references_selected.map do |reference|
    list <<
      '<li>'.html_safe <<
      "#{reference.referee_type.humanize} reference from #{reference.name}" <<
      '</li>'.html_safe
  end
  list + '</ul>'.html_safe
end
```

## Link to Trello card

https://trello.com/c/hZVGCcxd/3378-dev-choose-from-more-than-2-feedback-provided-references

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
