### PR TITLE
Fix the link to "Logit logs about this application" from Support

### DIFF
--- a/app/components/support_interface/application_navigation_component.rb
+++ b/app/components/support_interface/application_navigation_component.rb
@@ -33,14 +33,25 @@ module SupportInterface
     end
 
     def logit_link
-      environment = HostingEnvironment.environment_name
-      candidate_id = @application_form.candidate_id
-      link = "https://kibana.logit.io/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-14d,to:now))&_a=(columns:!(_source),index:'8ac115c0-aac1-11e8-88ea-0383c11b333a',interval:auto,query:(language:kuery,query:'candidate_id:#{candidate_id}+AND+hosting_environment:#{environment}'),sort:!('@timestamp',desc))"
+      link = "https://kibana.logit.io/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15d,to:now))&_a=(columns:!(_source),filters:!(),index:'8ac115c0-aac1-11e8-88ea-0383c11b333c',interval:auto,query:(language:kuery,query:'application:%22#{current_logit_application_name}%22%20AND%20payload.candidate_id:#{@application_form.candidate_id}'),sort:!('@timestamp',desc))"
 
       {
         title: 'Logit logs for this candidate',
         href: link,
       }
+    end
+
+    def current_logit_application_name
+      if HostingEnvironment.environment_name == 'production' && HostingEnvironment.sandbox_mode?
+        'apply-sandbox'
+      elsif HostingEnvironment.production?
+        'apply-prod'
+      else
+        {
+          'staging' => 'apply-staging',
+          'qa' => 'apply-qa',
+        }[HostingEnvironment.environment_name]
+      end
     end
   end
 end

--- a/spec/components/support_interface/application_navigation_component_spec.rb
+++ b/spec/components/support_interface/application_navigation_component_spec.rb
@@ -1,14 +1,59 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::ApplicationNavigationComponent do
+  let(:form) { build_stubbed(:application_form) }
+
   it 'renders a list of links' do
-    form = build_stubbed(:application_form)
     candidate_id = form.candidate_id
 
     render_inline(described_class.new(form))
 
     expect(page).to have_link('Emails about this application', href: %r{email-log.+#{form.id}})
     expect(page).to have_link('Sentry errors for this candidate', href: %r{sentry.io.+#{candidate_id}})
-    expect(page).to have_link('Logit logs for this candidate', href: %r{logit.io.+#{candidate_id}.+hosting_environment:test})
+    expect(page).to have_link('Logit logs for this candidate', href: %r{logit.io.+#{candidate_id}})
+  end
+
+  describe 'logit link' do
+    it 'is correct in the sandbox' do
+      ClimateControl.modify(HOSTING_ENVIRONMENT_NAME: 'production', SANDBOX: 'true') do
+        render_inline(described_class.new(form))
+        expect(page).to have_link('Logit logs for this candidate', href: %r{logit.io.+apply-sandbox})
+      end
+    end
+
+    it 'is correct in production' do
+      ClimateControl.modify(HOSTING_ENVIRONMENT_NAME: 'production') do
+        render_inline(described_class.new(form))
+        expect(page).to have_link('Logit logs for this candidate', href: %r{logit.io.+apply-prod})
+      end
+    end
+
+    it 'is correct in qa' do
+      ClimateControl.modify(HOSTING_ENVIRONMENT_NAME: 'qa') do
+        render_inline(described_class.new(form))
+        expect(page).to have_link('Logit logs for this candidate', href: %r{logit.io.+apply-qa})
+      end
+    end
+
+    it 'is correct in staging' do
+      ClimateControl.modify(HOSTING_ENVIRONMENT_NAME: 'staging') do
+        render_inline(described_class.new(form))
+        expect(page).to have_link('Logit logs for this candidate', href: %r{logit.io.+apply-staging})
+      end
+    end
+
+    it 'leaves empty quote marks in review' do
+      ClimateControl.modify(HOSTING_ENVIRONMENT_NAME: 'review') do
+        render_inline(described_class.new(form))
+        expect(page).to have_link('Logit logs for this candidate', href: %r{logit.io.+application:%22%22})
+      end
+    end
+
+    it 'leaves empty quote marks in development' do
+      ClimateControl.modify(HOSTING_ENVIRONMENT_NAME: 'development') do
+        render_inline(described_class.new(form))
+        expect(page).to have_link('Logit logs for this candidate', href: %r{logit.io.+application:%22%22})
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

This broke when we moved to PaaS because the logging changed

## Changes proposed in this pull request

Fix the link