### PR TITLE
Backfill the `feature_restructured_work_history` boolean

### DIFF
--- a/app/services/data_migrations/backfill_restuctured_work_history_boolean.rb
+++ b/app/services/data_migrations/backfill_restuctured_work_history_boolean.rb
@@ -1,0 +1,24 @@
+module DataMigrations
+  class BackfillRestucturedWorkHistoryBoolean
+    TIMESTAMP = 20210525132306
+    MANUAL_RUN = true
+
+    def change
+      ApplicationForm
+        .left_outer_joins(:application_work_experiences)
+        .where('application_experiences.id IS NOT NULL OR work_history_explanation is NOT NULL')
+        .where(feature_restructured_work_history: true)
+        .distinct
+        .each { |application_form| application_form.update!(feature_restructured_work_history: false) }
+      # there's 12 in the db hence no find each
+
+      ApplicationForm
+        .left_outer_joins(:application_work_experiences)
+        .where('application_experiences.id IS NULL AND work_history_explanation is NULL')
+        .where(feature_restructured_work_history: false)
+        .distinct
+        .find_each(batch_size: 100) { |application_form| application_form.update!(feature_restructured_work_history: true) }
+      # there's 564 of these
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillRestucturedWorkHistoryBoolean',
   'DataMigrations::BackfillValidationErrorsServiceColumn',
   'DataMigrations::BackfillSelectedBoolean',
   'DataMigrations::DeleteAllSiteAudits',

--- a/spec/services/data_migrations/backfill_restuctured_work_history_boolean_spec.rb
+++ b/spec/services/data_migrations/backfill_restuctured_work_history_boolean_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillRestucturedWorkHistoryBoolean do
+  context 'when `feature_restructured_work_history` is true' do
+    it 'sets `feature_restructured_work_history` to false if jobs or an explanation have been provided' do
+      application_form_with_jobs = create(:application_form, feature_restructured_work_history: true)
+      create(:application_work_experience, application_form: application_form_with_jobs)
+      application_form_with_explanation = create(
+        :application_form, work_history_explanation: 'I left school and have travelled, then went to uni.',
+                           feature_restructured_work_history: true
+      )
+      application_form_with_no_jobs_or_explanation = create(:application_form, feature_restructured_work_history: true)
+
+      described_class.new.change
+
+      expect(application_form_with_jobs.reload.feature_restructured_work_history).to eq false
+      expect(application_form_with_explanation.reload.feature_restructured_work_history).to eq false
+      expect(application_form_with_no_jobs_or_explanation.reload.feature_restructured_work_history).to eq true
+    end
+  end
+
+  context 'when `feature_restructured_work_history` is false' do
+    it 'sets `feature_restructured_work_history` to true if no jobs or an explanation have been provided' do
+      application_form_with_jobs = create(:application_form, feature_restructured_work_history: false)
+      create(:application_work_experience, application_form: application_form_with_jobs)
+      application_form_with_explanation = create(
+        :application_form, work_history_explanation: 'I left school and have travelled, then went to uni.',
+                           feature_restructured_work_history: false
+      )
+      application_form_with_no_jobs_or_explanation = create(:application_form, feature_restructured_work_history: false)
+
+      described_class.new.change
+
+      expect(application_form_with_jobs.reload.feature_restructured_work_history).to eq false
+      expect(application_form_with_explanation.reload.feature_restructured_work_history).to eq false
+      expect(application_form_with_no_jobs_or_explanation.reload.feature_restructured_work_history).to eq true
+    end
+  end
+end


### PR DESCRIPTION
## Context

We need to make sure that before we flip the `restructured_work_history` flag on that the data is in the expected shape. After looking at the data on prod, there are two groups of application forms that are in the wrong state.

The migration does the following:

- If the `feature_restructured_work_history` boolean is true and
they have already added a job/explanation for not working.

Updates the `feature_restructured_work_history` to false

There are 12 of these ☝️ and it looks like this was a hangover from when i accidentally flipped the flag on a few months ago 🤦 



- If the `feature_restructured_work_history` boolean is false and
they have have not added a job/explanation for not working.

Updates the `feature_restructured_work_history` to true

These are applicants that, largely, have not touched their application since close to the beginning of the cycle.

## Changes proposed in this pull request

- Ensure that the `feature_restructured_work_history` boolean is in the correct state 

## Guidance to review

I'll run this manually just before flipping the flag

All the other checks have taken place and the flow seems to be working as expected

## Link to Trello card

https://trello.com/c/s9jf3KsD/3433-ensure-restructured-work-history-section-is-working-as-expected-before-we-switch-the-feature-flag-on

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
