### PR TITLE
Add further sanitization to double science GCSE

### DIFF
--- a/app/forms/candidate_interface/science_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/science_gcse_grade_form.rb
@@ -203,7 +203,11 @@ module CandidateInterface
     end
 
     def sanitize(grade)
-      grade&.delete(' ')&.upcase
+      if DOUBLE_GCSE_GRADES.exclude?(grade)
+        grade&.gsub(/[^*\w]/, '')&.upcase
+      else
+        grade
+      end
     end
 
     def new_record?

--- a/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
         let(:form) { CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification) }
 
         it 'returns no errors if grade is valid' do
-          mistyped_grades = ['A a', 'A    a', 'b b']
+          mistyped_grades = ['A a', 'A    a', 'b b', 'A-a', 'B/b', 'C,c']
           valid_grades = DOUBLE_GCSE_GRADES + mistyped_grades
 
           valid_grades.each do |grade|
@@ -266,7 +266,25 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
         expect(qualification.grade).to eq('D')
       end
 
-      it 'stores a sanitized grade when it is a single or double award' do
+      it 'stores a sanitized grade when it is a single' do
+        application_form = build(:application_form)
+        qualification = ApplicationQualification.create(
+          level: 'gcse',
+          application_form: application_form,
+        )
+
+        details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+
+        details_form.subject = ApplicationQualification::SCIENCE_SINGLE_AWARD
+        details_form.grade = 'a*'
+
+        details_form.save
+        qualification.reload
+
+        expect(qualification.grade).to eq('A*')
+      end
+
+      it 'stores a sanitized grade when it is double award' do
         application_form = build(:application_form)
         qualification = ApplicationQualification.create(
           level: 'gcse',
@@ -276,7 +294,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
         details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
 
         details_form.subject = ApplicationQualification::SCIENCE_DOUBLE_AWARD
-        details_form.grade = 'a* a*'
+        details_form.grade = 'a* -/, a*'
 
         details_form.save
         qualification.reload


### PR DESCRIPTION
## Context

Mike (BA) has discovered a large number of validation errors in
production associated with the double award field. 

## Changes proposed in this pull request

This PR adds further
conditions to the sanitize method in order to combat common mistyped
errors, -/, and ' '.

## Guidance to review

Test in review app with mistyped values.

Dev - woulfd this also require a system spec?

## Link to Trello card

https://trello.com/c/ajbpi20L/3394-double-gcse-grades

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
