### PR TITLE
Add new flow for creating or updating a single provider user

### DIFF
--- a/app/components/support_interface/provider_users_table_component.html.erb
+++ b/app/components/support_interface/provider_users_table_component.html.erb
@@ -26,8 +26,14 @@
           </ul>
         </td>
         <td class="govuk-table__cell">
-          <%= govuk_link_to(edit_support_interface_provider_user_path(row[:provider_user])) do %>
-            Update permissions<span class="govuk-visually-hidden"> for <%= row[:provider_user].display_name %></span>
+          <% if FeatureFlag.active?(:new_provider_user_flow) %>
+            <%= govuk_link_to(support_interface_edit_permissions_path(row[:provider_user])) do %>
+              Update permissions<span class="govuk-visually-hidden"> for <%= row[:provider_user].display_name %></span>
+            <% end %>
+          <% else %>
+            <%= govuk_link_to(edit_support_interface_provider_user_path(row[:provider_user])) do %>
+              Update permissions<span class="govuk-visually-hidden"> for <%= row[:provider_user].display_name %></span>
+            <% end %>
           <% end %>
         </td>
       </tr>

--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -32,7 +32,7 @@ module SupportInterface
     end
 
     def users
-      @provider = Provider.includes(provider_users: [:provider_permissions]).find(params[:provider_id])
+      @provider = Provider.includes(provider_users: [provider_permissions: [:provider]]).find(params[:provider_id])
       @relationship_diagram = SupportInterface::ProviderRelationshipsDiagram.new(provider: @provider)
     end
 

--- a/app/controllers/support_interface/single_provider_users_controller.rb
+++ b/app/controllers/support_interface/single_provider_users_controller.rb
@@ -24,7 +24,7 @@ module SupportInterface
         form: @form,
         save_service: SaveProviderUser.new(
           provider_user: provider_user,
-          provider_permissions: @form.provider_permissions,
+          provider_permissions: [@form.provider_permissions],
         ),
         invite_service: InviteProviderUser.new(provider_user: provider_user),
       )
@@ -66,7 +66,7 @@ module SupportInterface
 
     def provider_user_params
       params.require(:support_interface_create_single_provider_user_form)
-            .permit(:email_address, :first_name, :last_name)
+            .permit(:email_address, :first_name, :last_name, :provider_id)
     end
 
     def create_provider_permissions_params

--- a/app/controllers/support_interface/single_provider_users_controller.rb
+++ b/app/controllers/support_interface/single_provider_users_controller.rb
@@ -1,0 +1,86 @@
+module SupportInterface
+  class SingleProviderUsersController < SupportInterfaceController
+    def new
+      @provider = Provider.find(provider_id_param)
+      @form = CreateSingleProviderUserForm.new(provider_id: provider_id_param)
+    end
+
+    def edit
+      provider_user = ProviderUser.find(params[:provider_user_id])
+      @form = EditSingleProviderUserForm.new(provider_user: provider_user)
+    end
+
+    def create
+      @form = CreateSingleProviderUserForm.new(
+        provider_user_params
+          .merge(provider_permissions: create_provider_permissions_params)
+          .merge(provider_id: provider_id_param),
+      )
+
+      @provider = Provider.find(provider_id_param)
+
+      provider_user = @form.build
+      service = SaveAndInviteProviderUser.new(
+        form: @form,
+        save_service: SaveProviderUser.new(
+          provider_user: provider_user,
+          provider_permissions: @form.provider_permissions,
+        ),
+        invite_service: InviteProviderUser.new(provider_user: provider_user),
+      )
+
+      render :new and return unless service.call
+
+      flash[:success] = "User #{provider_user.first_name} #{provider_user.last_name} added"
+      redirect_to support_interface_provider_user_list_path
+    end
+
+    def update
+      provider_user = ProviderUser.find(params[:provider_user_id])
+
+      @form = EditSingleProviderUserForm.new(
+        provider_user: provider_user,
+        provider_permissions: edit_providers_permissions_params,
+        provider_id: provider_id_param,
+      )
+
+      service = SaveProviderUser.new(
+        provider_user: provider_user,
+        provider_permissions: @form.provider_permissions,
+        deselected_provider_permissions: @form.deselected_provider_permissions,
+      )
+
+      if service.call!
+        flash[:success] = "User #{provider_user.first_name} #{provider_user.last_name} updated"
+        redirect_to support_interface_provider_user_path(provider_user)
+      else
+        render :edit
+      end
+    end
+
+  private
+
+    def provider_id_param
+      params[:provider_id].to_i
+    end
+
+    def provider_user_params
+      params.require(:support_interface_create_single_provider_user_form)
+            .permit(:email_address, :first_name, :last_name)
+    end
+
+    def create_provider_permissions_params
+      params.require(:support_interface_create_single_provider_user_form)
+            .permit(provider_permissions_form: {})
+            .fetch(:provider_permissions_form, {})
+            .to_h
+    end
+
+    def edit_providers_permissions_params
+      params.require(:support_interface_edit_single_provider_user_form)
+            .permit(provider_permissions_forms: {})
+            .fetch(:provider_permissions_forms, {})
+            .to_h
+    end
+  end
+end

--- a/app/forms/support_interface/create_single_provider_user_form.rb
+++ b/app/forms/support_interface/create_single_provider_user_form.rb
@@ -1,0 +1,67 @@
+module SupportInterface
+  class CreateSingleProviderUserForm
+    include ActiveModel::Model
+    include ActiveModel::Validations
+
+    attr_accessor :first_name, :last_name, :provider_user, :provider_id
+    attr_reader :provider_permissions, :email_address
+
+    validates :first_name, :last_name, :email_address, presence: true
+    validates :email_address, valid_for_notify: true
+    validates :provider_permissions, presence: true
+
+    def build
+      return unless valid?
+
+      @provider_user ||= ProviderUser.find_or_initialize_by(email_address: email_address)
+      @provider_user.first_name = first_name
+      @provider_user.last_name = last_name
+      @provider_user if @provider_user.valid?
+    end
+
+    def email_address=(raw_email_address)
+      @email_address = raw_email_address.downcase.strip
+    end
+
+    def persisted?
+      @provider_user&.persisted?
+    end
+
+    def permission_form
+      ProviderPermissionsForm.new(active: possible_permissions.persisted?, provider_permission: possible_permissions)
+    end
+
+    def possible_permissions
+      @possible_permissions ||= begin
+        if provider_user
+          existing_permissions_for_user = ProviderPermissions.includes(:provider, :provider_user).where(provider_user_id: provider_user.id)
+        else
+          existing_permissions_for_user = []
+        end
+
+        provider = Provider.where(id: provider_id).first
+        provider_permissions = existing_permissions_for_user.find { |existing_permission| existing_permission.provider_id == provider.id }
+        provider_permissions || ProviderPermissions.new(provider: provider)
+      end
+    end
+
+    def provider_permissions=(attributes)
+      return if attributes.empty?
+
+      form = ProviderPermissionsForm.new(attributes)
+
+      @provider_permissions = begin
+        permission = ProviderPermissions.find_or_initialize_by(
+          provider_id: form.provider_permission[:provider_id],
+          provider_user_id: provider_user.try(:id),
+        )
+
+        ProviderPermissions::VALID_PERMISSIONS.each do |permission_name|
+          permission.send("#{permission_name}=", form.provider_permission.fetch(permission_name, false))
+        end
+
+        [permission]
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/create_single_provider_user_form.rb
+++ b/app/forms/support_interface/create_single_provider_user_form.rb
@@ -8,7 +8,6 @@ module SupportInterface
 
     validates :first_name, :last_name, :email_address, presence: true
     validates :email_address, valid_for_notify: true
-    validates :provider_permissions, presence: true
 
     def build
       return unless valid?
@@ -21,10 +20,6 @@ module SupportInterface
 
     def email_address=(raw_email_address)
       @email_address = raw_email_address.downcase.strip
-    end
-
-    def permission_form
-      ProviderPermissionsForm.new(provider_permission: provider_permissions)
     end
 
     def provider_permissions=(attributes)
@@ -44,6 +39,10 @@ module SupportInterface
 
         permission
       end
+    end
+
+    def permission_form
+      ProviderPermissionsForm.new(provider_permission: provider_permissions)
     end
   end
 end

--- a/app/forms/support_interface/create_single_provider_user_form.rb
+++ b/app/forms/support_interface/create_single_provider_user_form.rb
@@ -8,6 +8,7 @@ module SupportInterface
 
     validates :first_name, :last_name, :email_address, presence: true
     validates :email_address, valid_for_notify: true
+    validate :user_with_provider_exists?
 
     def build
       return unless valid?
@@ -43,6 +44,16 @@ module SupportInterface
 
     def permission_form
       ProviderPermissionsForm.new(provider_permission: provider_permissions)
+    end
+
+  private
+
+    def user_with_provider_exists?
+      provider = Provider.find(provider_id)
+      provider_user = ProviderUser.where(email_address: email_address).first
+      return unless provider_user&.providers&.include?(provider)
+
+      errors.add(:email_address, 'A user with this email address already has permissions for this provider')
     end
   end
 end

--- a/app/forms/support_interface/edit_single_provider_user_form.rb
+++ b/app/forms/support_interface/edit_single_provider_user_form.rb
@@ -1,0 +1,60 @@
+module SupportInterface
+  class EditSingleProviderUserForm
+    include ActiveModel::Model
+    include ActiveModel::Validations
+
+    attr_accessor :provider_user, :provider_id
+    attr_reader :provider_permissions
+
+    validates :provider_permissions, presence: true
+
+    def persisted?
+      @provider_user&.persisted?
+    end
+
+    def forms_for_possible_permissions
+      all_possible_permissions.map do |p|
+        ProviderPermissionsForm.new(active: p.persisted?, provider_permission: p)
+      end
+    end
+
+    def all_possible_permissions
+      if provider_user
+        existing_permissions_for_user = ProviderPermissions.includes(:provider, :provider_user).where(provider_user_id: provider_user.id)
+      else
+        existing_permissions_for_user = []
+      end
+
+      existing_permissions_for_user
+    end
+
+    def provider_permissions=(attributes)
+      forms = attributes.map { |_, attrs| ProviderPermissionsForm.new(attrs) }
+      @provider_permissions = forms.map do |form|
+        permission = ProviderPermissions.find_or_initialize_by(
+          provider_id: form.provider_permission[:provider_id],
+          provider_user_id: provider_user.try(:id),
+        )
+
+        ProviderPermissions::VALID_PERMISSIONS.each do |permission_name|
+          permission.send("#{permission_name}=", form.provider_permission.fetch(permission_name, false))
+        end
+
+        permission
+      end
+    end
+
+    def deselected_provider_permissions
+      possible_permissions - @provider_permissions
+    end
+
+    def possible_permissions
+      @possible_permissions ||= begin
+        Provider.where(sync_courses: true).order(:name).map do |provider|
+          provider_permissions = all_possible_permissions.find { |existing_permission| existing_permission.provider_id == provider.id }
+          provider_permissions || ProviderPermissions.new(provider: provider)
+        end
+      end
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -34,7 +34,7 @@ class FeatureFlag
     [:expanded_quals_export, 'Rework the Qualifications export to contain all candidate qualifications', 'Malcolm Baig'],
     [:support_user_change_offered_course, 'Allows support users to offer a different course option for an application choice', 'David Gisbey'],
     [:reference_selection, 'Allow candidates to receive multiple references and then select which two are added to their application', 'Malcolm Baig'],
-    [:create_update_single_provider_user, 'New flow for creating or updating a single ProviderUser', 'Toby Retallick'],
+    [:new_provider_user_flow, 'New flow for creating or updating a single ProviderUser and adding Provider users in bulk', 'Toby Retallick'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -34,6 +34,7 @@ class FeatureFlag
     [:expanded_quals_export, 'Rework the Qualifications export to contain all candidate qualifications', 'Malcolm Baig'],
     [:support_user_change_offered_course, 'Allows support users to offer a different course option for an application choice', 'David Gisbey'],
     [:reference_selection, 'Allow candidates to receive multiple references and then select which two are added to their application', 'Malcolm Baig'],
+    [:create_update_single_provider_user, 'New flow for creating or updating a single ProviderUser', 'Toby Retallick'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/views/support_interface/providers/users.html.erb
+++ b/app/views/support_interface/providers/users.html.erb
@@ -1,11 +1,9 @@
-<%= render 'provider_navigation', title: 'Provider users' %>
+<%= render 'provider_navigation', title: 'Users' %>
 
-<% unless FeatureFlag.active?(:create_update_single_provider_user) %>
-  <%= govuk_link_to 'Add provider user', new_support_interface_provider_user_path, button: true %>
-<% end %>
-
-<% if FeatureFlag.active?(:create_update_single_provider_user) && @provider.sync_courses %>
+<% if FeatureFlag.active?(:new_provider_user_flow) %>
    <%= govuk_link_to 'Add user', support_interface_new_single_provider_user_path, button: true %>
+<% else %>
+  <%= govuk_link_to 'Add provider user', new_support_interface_provider_user_path, button: true %>
 <% end %>
 
 <%= render(SupportInterface::ProviderUsersTableComponent.new(provider_users: @provider.provider_users)) %>

--- a/app/views/support_interface/providers/users.html.erb
+++ b/app/views/support_interface/providers/users.html.erb
@@ -1,6 +1,12 @@
 <%= render 'provider_navigation', title: 'Provider users' %>
 
-<%= govuk_link_to 'Add provider user', new_support_interface_provider_user_path, button: true %>
+<% unless FeatureFlag.active?(:create_update_single_provider_user) %>
+  <%= govuk_link_to 'Add provider user', new_support_interface_provider_user_path, button: true %>
+<% end %>
+
+<% if FeatureFlag.active?(:create_update_single_provider_user) && @provider.sync_courses %>
+   <%= govuk_link_to 'Add user', support_interface_new_single_provider_user_path, button: true %>
+<% end %>
 
 <%= render(SupportInterface::ProviderUsersTableComponent.new(provider_users: @provider.provider_users)) %>
 

--- a/app/views/support_interface/single_provider_users/_edit_provider_permissions.html.erb
+++ b/app/views/support_interface/single_provider_users/_edit_provider_permissions.html.erb
@@ -1,0 +1,42 @@
+<% f.object.forms_for_possible_permissions.each do |permission_form| %>
+  <%= f.fields_for 'provider_permissions_forms[]', permission_form do |pf| %>
+    <%= pf.fields_for :provider_permission, permission_form.provider_permission do |ppf| %>
+      <%= ppf.hidden_field :provider_id %>
+      <%= ppf.govuk_check_boxes_fieldset :permissions,
+        legend: { text: permission_form.provider.name_and_code, size: 's' },
+        hint: { text: 'The user will be able to view applications. You can also give them additional permissions.' } do %>
+        <%= ppf.govuk_check_box(
+              :manage_users,
+              true,
+              multiple: false,
+              label: { text: 'Manage users' },
+              link_errors: true,
+            ) %>
+        <%= ppf.govuk_check_box(
+              :manage_organisations,
+              true,
+              multiple: false,
+              label: { text: 'Manage organisational permissions' },
+            ) %>
+        <%= ppf.govuk_check_box(
+              :make_decisions,
+              true,
+              multiple: false,
+              label: { text: 'Make decisions' },
+            ) %>
+        <%= ppf.govuk_check_box(
+              :view_safeguarding_information,
+              true,
+              multiple: false,
+              label: { text: 'Access safeguarding information' },
+            ) %>
+        <%= ppf.govuk_check_box(
+              :view_diversity_information,
+              true,
+              multiple: false,
+              label: { text: 'Access diversity information' },
+            ) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/support_interface/single_provider_users/_provider_permissions.html.erb
+++ b/app/views/support_interface/single_provider_users/_provider_permissions.html.erb
@@ -1,0 +1,42 @@
+<%= f.fields_for :provider_permissions_form, f.object.permission_form do |pf| %>
+  <%= pf.fields_for :provider_permission, f.object.permission_form.provider_permission do |ppf| %>
+    <%= ppf.hidden_field :provider_id %>
+    <%= ppf.govuk_check_boxes_fieldset :permissions,
+      legend: {
+        text: 'Permissions (optional)', size: 's'
+},
+      hint: { text: 'The user will be able to view applications. You can also give them additional permissions.' } do %>
+      <%= ppf.govuk_check_box(
+            :manage_users,
+            true,
+            multiple: false,
+            label: { text: 'Manage users' },
+            link_errors: true,
+          ) %>
+      <%= ppf.govuk_check_box(
+            :manage_organisations,
+            true,
+            multiple: false,
+            label: { text: 'Manage organisational permissions' },
+          ) %>
+      <%= ppf.govuk_check_box(
+            :make_decisions,
+            true,
+            multiple: false,
+            label: { text: 'Make decisions' },
+          ) %>
+      <%= ppf.govuk_check_box(
+            :view_safeguarding_information,
+            true,
+            multiple: false,
+            label: { text: 'Access safeguarding information' },
+          ) %>
+      <%= ppf.govuk_check_box(
+            :view_diversity_information,
+            true,
+            multiple: false,
+            label: { text: 'Access diversity information' },
+          ) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/support_interface/single_provider_users/_provider_permissions.html.erb
+++ b/app/views/support_interface/single_provider_users/_provider_permissions.html.erb
@@ -1,6 +1,5 @@
 <%= f.fields_for :provider_permissions_form, f.object.permission_form do |pf| %>
   <%= pf.fields_for :provider_permission, f.object.permission_form.provider_permission do |ppf| %>
-    <%= ppf.hidden_field :provider_id %>
     <%= ppf.govuk_check_boxes_fieldset :permissions,
       legend: {
         text: 'Permissions (optional)', size: 's'

--- a/app/views/support_interface/single_provider_users/edit.html.erb
+++ b/app/views/support_interface/single_provider_users/edit.html.erb
@@ -1,0 +1,16 @@
+<% content_for :browser_title, title_with_error_prefix("Change #{@form.provider_user.display_name}’s permissions", @form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_provider_user_path(@form.provider_user)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: support_interface_update_permissions_path(provider_user_id: @form.provider_user.id), patch: true do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_check_boxes_fieldset :provider, legend: { text: "Change #{@form.provider_user.display_name}’s permissions", tag: 'h1', size: 'l' }, classes: 'govuk-!-margin-top-6' do %>
+        <%= render 'edit_provider_permissions', f: f %>
+      <% end %>
+
+      <%= f.govuk_submit 'Save permissions' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/single_provider_users/new.html.erb
+++ b/app/views/support_interface/single_provider_users/new.html.erb
@@ -1,0 +1,20 @@
+<% content_for :browser_title, title_with_error_prefix('Add provider user', @form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_provider_users_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: support_interface_create_single_provider_user_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class='govuk-heading-l'>Add user to <%= @provider.name %></h1>
+
+      <%= f.govuk_text_field :first_name, label: { text: 'First name', size: 's' }, class: 'govuk-!-width-two-thirds' %>
+      <%= f.govuk_text_field :last_name, label: { text: 'Last name', size: 's' }, class: 'govuk-!-width-two-thirds' %>
+      <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 's' }, class: 'govuk-!-width-two-thirds' %>
+
+      <%= render 'provider_permissions', f: f %>
+
+      <%= f.govuk_submit 'Add user' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/single_provider_users/new.html.erb
+++ b/app/views/support_interface/single_provider_users/new.html.erb
@@ -11,6 +11,7 @@
       <%= f.govuk_text_field :first_name, label: { text: 'First name', size: 's' }, class: 'govuk-!-width-two-thirds' %>
       <%= f.govuk_text_field :last_name, label: { text: 'Last name', size: 's' }, class: 'govuk-!-width-two-thirds' %>
       <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 's' }, class: 'govuk-!-width-two-thirds' %>
+      <%= f.hidden_field :provider_id %>
 
       <%= render 'provider_permissions', f: f %>
 

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -56,6 +56,16 @@ en:
               blank: Last name cannot be blank
             provider_permissions:
               blank: Please specify a provider
+        support_interface/create_single_provider_user_form:
+          attributes:
+            email_address:
+              blank: Enter an email address in the correct format, like name@example.com
+            first_name:
+              blank: Enter a first name
+            last_name:
+              blank: Enter a last name
+            provider_permissions:
+              blank: Please specify a provider
         support_interface/conditions_form:
           attributes:
             audit_comment_ticket:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -884,6 +884,11 @@ Rails.application.routes.draw do
 
     get '/providers' => 'providers#index', as: :providers
 
+    scope path: '/providers/users/:provider_user_id' do
+      get '/permissions/edit' => 'single_provider_users#edit', as: :edit_permissions
+      patch '/permissions' => 'single_provider_users#update', as: :update_permissions
+    end
+
     scope path: '/providers/:provider_id' do
       get '/' => 'providers#show', as: :provider
       get '/courses' => 'providers#courses', as: :provider_courses
@@ -895,6 +900,9 @@ Rails.application.routes.draw do
       get '/history' => 'providers#history', as: :provider_history
       get '/relationships' => 'providers#relationships', as: :provider_relationships
       post '/relationships' => 'providers#update_relationships', as: :update_provider_relationships
+
+      get '/user/new' => 'single_provider_users#new', as: :new_single_provider_user
+      post '/user' => 'single_provider_users#create', as: :create_single_provider_user
 
       post '' => 'providers#open_all_courses'
       post '/enable_course_syncing' => redirect('/enable-course-syncing')

--- a/spec/forms/support_interface/create_single_provider_user_form_spec.rb
+++ b/spec/forms/support_interface/create_single_provider_user_form_spec.rb
@@ -51,14 +51,5 @@ RSpec.describe SupportInterface::CreateSingleProviderUserForm do
         expect(provider_user_form.errors[:email_address]).not_to be_empty
       end
     end
-
-    context 'provider permissions must be present' do
-      let(:provider_permissions) { {} }
-
-      it 'is invalid' do
-        expect(provider_user_form.valid?).to be false
-        expect(provider_user_form.errors[:provider_permissions]).not_to be_empty
-      end
-    end
   end
 end

--- a/spec/forms/support_interface/create_single_provider_user_form_spec.rb
+++ b/spec/forms/support_interface/create_single_provider_user_form_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::CreateSingleProviderUserForm do
+  let(:email_address) { 'provider@example.com' }
+  let(:first_name) { 'Fred' }
+  let(:last_name) { 'Smith' }
+  let(:provider) { build_stubbed(:provider, id: 2) }
+  let(:provider_permissions) do
+    {
+      provider_permission: {
+        provider_id: provider.id,
+      },
+    }
+  end
+  let(:form_params) do
+    {
+      first_name: first_name,
+      last_name: last_name,
+      email_address: email_address,
+      provider_permissions: provider_permissions,
+      provider_id: provider.id,
+    }
+  end
+
+  subject(:provider_user_form) { described_class.new(form_params) }
+
+  describe 'validations' do
+    context 'first name must be present' do
+      let(:first_name) { '' }
+
+      it 'is invalid' do
+        expect(provider_user_form.valid?).to be false
+        expect(provider_user_form.errors[:first_name]).not_to be_empty
+      end
+    end
+
+    context 'last name must be present' do
+      let(:last_name) { '' }
+
+      it 'is invalid' do
+        expect(provider_user_form.valid?).to be false
+        expect(provider_user_form.errors[:last_name]).not_to be_empty
+      end
+    end
+
+    context 'email address must be present' do
+      let(:email_address) { '' }
+
+      it 'is invalid' do
+        expect(provider_user_form.valid?).to be false
+        expect(provider_user_form.errors[:email_address]).not_to be_empty
+      end
+    end
+
+    context 'provider permissions must be present' do
+      let(:provider_permissions) { {} }
+
+      it 'is invalid' do
+        expect(provider_user_form.valid?).to be false
+        expect(provider_user_form.errors[:provider_permissions]).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/forms/support_interface/create_single_provider_user_form_spec.rb
+++ b/spec/forms/support_interface/create_single_provider_user_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SupportInterface::CreateSingleProviderUserForm do
   let(:email_address) { 'provider@example.com' }
   let(:first_name) { 'Fred' }
   let(:last_name) { 'Smith' }
-  let(:provider) { build_stubbed(:provider, id: 2) }
+  let(:provider) { create(:provider, id: 2) }
   let(:provider_permissions) do
     {
       provider_permission: {
@@ -47,6 +47,15 @@ RSpec.describe SupportInterface::CreateSingleProviderUserForm do
       let(:email_address) { '' }
 
       it 'is invalid' do
+        expect(provider_user_form.valid?).to be false
+        expect(provider_user_form.errors[:email_address]).not_to be_empty
+      end
+    end
+
+    context 'provider with user exists?' do
+      it 'is invalid' do
+        create(:provider_user, email_address: email_address, providers: [provider])
+
         expect(provider_user_form.valid?).to be false
         expect(provider_user_form.errors[:email_address]).not_to be_empty
       end

--- a/spec/forms/support_interface/edit_single_provider_user_form_spec.rb
+++ b/spec/forms/support_interface/edit_single_provider_user_form_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::EditSingleProviderUserForm do
+  let(:provider) { build_stubbed(:provider, id: 2) }
+  let(:provider_permissions) do
+    {
+      provider_permission: {
+        provider_id: provider.id,
+      },
+    }
+  end
+  let(:form_params) do
+    {
+      provider_permissions: provider_permissions,
+      provider_id: provider.id,
+    }
+  end
+
+  subject(:provider_user_form) { described_class.new(form_params) }
+
+  describe 'validations' do
+    context 'provider permissions must be present' do
+      let(:provider_permissions) { {} }
+
+      it 'is invalid' do
+        expect(provider_user_form.valid?).to be false
+        expect(provider_user_form.errors[:provider_permissions]).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/system/support_interface/managing_users_v2/adding_a_new_provider_user_spec.rb
+++ b/spec/system/support_interface/managing_users_v2/adding_a_new_provider_user_spec.rb
@@ -1,0 +1,158 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing provider users v2' do
+  include DfESignInHelpers
+  include DsiAPIHelper
+
+  scenario 'adding a new provider user', with_audited: true do
+    FeatureFlag.activate(:new_provider_user_flow)
+
+    given_dfe_signin_is_configured
+    and_i_am_a_support_user
+    and_providers_exist
+
+    when_i_visit_the_support_console
+    and_i_navigate_to_provider_users_page
+    and_i_filter_providers_by_synced_courses
+    then_i_see_synced_providers
+
+    when_i_click_on_a_synced_provider
+    and_i_click_on_users
+    and_i_click_add_user
+    then_i_should_see_the_add_user_form
+
+    when_i_submit_the_form
+    then_i_see_blank_validation_errors
+
+    when_i_enter_the_users_email_and_name
+    and_i_check_permission_to_manage_users
+    and_i_check_permission_to_manage_organisations
+    and_i_check_permission_to_view_safeguarding_information
+    and_i_check_permission_to_make_decisions
+    and_i_check_permission_to_view_diversity_information
+    and_i_submit_the_form
+    then_i_should_see_the_provider_user_has_been_successfully_added
+    and_the_user_should_be_sent_a_welcome_email
+  end
+
+  def given_dfe_signin_is_configured
+    set_dsi_api_response(success: true)
+  end
+
+  def and_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_providers_exist
+    @provider = create(:provider, name: 'Example provider', code: 'ABC', sync_courses: true)
+    create(:course, :open_on_apply, provider: @provider)
+    create(:provider, name: 'Another provider', code: 'DEF', sync_courses: true)
+    create(:provider, name: 'Not shown provider', code: 'GHI')
+  end
+
+  def then_i_see_synced_providers
+    expect(page).to have_content 'Example provider'
+    expect(page).to have_content 'Another provider'
+    expect(page).not_to have_content 'Not shown provider'
+  end
+
+  def when_i_visit_the_support_console
+    visit support_interface_path
+  end
+
+  def and_i_navigate_to_provider_users_page
+    click_link 'Providers'
+  end
+
+  def and_i_filter_providers_by_synced_courses
+    check 'With synced courses'
+    click_on 'Apply filters'
+  end
+
+  def and_i_click_add_user
+    click_on 'Add user'
+  end
+
+  def when_i_click_on_a_synced_provider
+    click_on 'Example provider (ABC)'
+  end
+
+  def and_i_click_on_users
+    click_on 'Users'
+  end
+
+  def and_i_submit_the_form
+    when_i_submit_the_form
+  end
+
+  def and_i_check_permission_to_manage_users
+    check 'Manage users'
+  end
+
+  def and_i_check_permission_to_manage_organisations
+    check 'Manage organisational permissions'
+  end
+
+  def and_i_check_permission_to_view_safeguarding_information
+    check 'Access safeguarding information'
+  end
+
+  def and_i_check_permission_to_make_decisions
+    check 'Make decisions'
+  end
+
+  def and_i_check_permission_to_view_diversity_information
+    check 'Access diversity information'
+  end
+
+  def when_i_submit_the_form
+    click_on 'Add user'
+  end
+
+  def then_i_see_blank_validation_errors
+    expect(page).to have_content 'Enter an email address'
+    expect(page).to have_content 'Enter a first name'
+    expect(page).to have_content 'Enter a last name'
+  end
+
+  def when_i_enter_the_users_email_and_name
+    fill_in 'support_interface_create_single_provider_user_form[email_address]', with: 'harrison@example.com'
+    fill_in 'support_interface_create_single_provider_user_form[first_name]', with: 'Harrison'
+    fill_in 'support_interface_create_single_provider_user_form[last_name]', with: 'Bergeron'
+  end
+
+  def and_i_enter_the_users_email_and_name
+    when_i_enter_the_users_email_and_name
+  end
+
+  def then_i_should_see_the_add_user_form
+    expect(page).to have_content('Add user to Example provider')
+  end
+
+  def then_i_should_see_the_provider_user_has_been_successfully_added
+    expect(page).to have_content('User Harrison Bergeron added')
+  end
+
+  def when_i_filter_the_list_of_provider_users
+    expect(page).to have_field('Has signed in')
+
+    fill_in :q, with: 'harrison'
+    check 'Never signed in'
+    click_on 'Apply filters'
+  end
+
+  def and_i_should_see_the_user_i_created
+    expect(page).to have_content('harrison@example.com')
+  end
+
+  def when_i_filter_the_list_of_provider_users_by_id
+    @new_user = ProviderUser.find_by_email_address('harrison@example.com')
+    fill_in :q, with: @new_user.id
+    click_on 'Apply filters'
+  end
+
+  def and_the_user_should_be_sent_a_welcome_email
+    open_email('harrison@example.com')
+    expect(current_email.subject).to have_content t('provider_mailer.account_created.subject')
+  end
+end

--- a/spec/system/support_interface/managing_users_v2/adding_provider_to_existing_provider_user_spec.rb
+++ b/spec/system/support_interface/managing_users_v2/adding_provider_to_existing_provider_user_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing provider users v2' do
+  include DfESignInHelpers
+  include DsiAPIHelper
+
+  scenario 'adding provider to an existing provider user', with_audited: true do
+    FeatureFlag.activate(:new_provider_user_flow)
+
+    given_dfe_signin_is_configured
+    and_i_am_a_support_user
+    and_synced_providers_exist
+    and_a_provider_user_exists_for_the_first_provider
+
+    when_i_visit_the_second_provider_page
+    and_i_click_on_users
+    then_i_should_not_see_the_provider_user_listed
+
+    when_i_click_add_user
+    and_i_enter_the_users_details
+    and_i_check_permissions
+    and_i_submit_the_form
+    then_i_should_see_the_provider_user_has_been_successfully_added
+    and_the_provider_user_is_now_associated_with_both_providers
+  end
+
+  def given_dfe_signin_is_configured
+    set_dsi_api_response(success: true)
+  end
+
+  def and_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_synced_providers_exist
+    @provider_one = create(:provider, name: 'Example provider one', code: 'ABC', sync_courses: true)
+    @provider_two = create(:provider, name: 'Example provider two', code: 'DEF', sync_courses: true)
+
+    create(:course, :open_on_apply, provider: @provider_one)
+    create(:course, :open_on_apply, provider: @provider_two)
+  end
+
+  def and_a_provider_user_exists_for_the_first_provider
+    @provider_user = create(:provider_user, providers: [@provider_one])
+  end
+
+  def when_i_visit_the_second_provider_page
+    visit support_interface_provider_path(@provider_two)
+  end
+
+  def and_i_click_on_users
+    click_on 'Users'
+  end
+
+  def then_i_should_not_see_the_provider_user_listed
+    expect(page).not_to have_content("#{@provider_user.first_name} #{@provider_user.last_name}")
+  end
+
+  def when_i_click_add_user
+    click_on 'Add user'
+  end
+
+  def and_i_enter_the_users_details
+    fill_in 'support_interface_create_single_provider_user_form[email_address]', with: @provider_user.email_address
+    fill_in 'support_interface_create_single_provider_user_form[first_name]', with: @provider_user.first_name
+    fill_in 'support_interface_create_single_provider_user_form[last_name]', with: @provider_user.last_name
+  end
+
+  def and_i_check_permissions
+    check 'Manage users'
+    check 'Manage organisational permissions'
+  end
+
+  def and_i_submit_the_form
+    click_on 'Add user'
+  end
+
+  def then_i_should_see_the_provider_user_has_been_successfully_added
+    expect(page).to have_content("User #{@provider_user.first_name} #{@provider_user.last_name} added")
+  end
+
+  def and_the_provider_user_is_now_associated_with_both_providers
+    within '.govuk-table__body' do
+      expect(page).to have_content(@provider_one.name)
+      expect(page).to have_content(@provider_two.name)
+    end
+  end
+end

--- a/spec/system/support_interface/managing_users_v2/editing_permissions_for_a_provider_user_spec.rb
+++ b/spec/system/support_interface/managing_users_v2/editing_permissions_for_a_provider_user_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing provider users v2' do
+  include DfESignInHelpers
+  include DsiAPIHelper
+
+  scenario 'editing permissions for a provider user', with_audited: true do
+    FeatureFlag.activate(:new_provider_user_flow)
+
+    given_dfe_signin_is_configured
+    and_i_am_a_support_user
+    and_synced_providers_exist
+    and_a_provider_user_exists_for_both_provider
+
+    when_i_visit_the_first_provider_page
+    and_i_click_on_users
+    then_i_should_see_the_provider_user_listed
+
+    when_i_click_update_permissions
+    then_i_see_the_edit_permissions_form
+    and_i_see_that_can_edit_permissions_for_both_providers
+
+    when_i_check_permission_to_manage_users_for_the_first_provider
+    and_i_check_permission_to_access_diversity_information_for_the_second_provider
+    and_i_click_save_permissions
+    then_i_can_see_the_provider_user_page
+    then_i_should_see_the_provider_user_has_been_successfully_added
+    and_the_provider_user_has_manage_user_permissions_for_the_first_provider
+    and_access_diversity_info_permissions_for_the_second_provider
+  end
+
+  def given_dfe_signin_is_configured
+    set_dsi_api_response(success: true)
+  end
+
+  def and_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_synced_providers_exist
+    @provider_one = create(:provider, name: 'Example provider one', code: 'ABC', sync_courses: true)
+    @provider_two = create(:provider, name: 'Example provider two', code: 'DEF', sync_courses: true)
+
+    create(:course, :open_on_apply, provider: @provider_one)
+    create(:course, :open_on_apply, provider: @provider_two)
+  end
+
+  def and_a_provider_user_exists_for_both_provider
+    @provider_user = create(:provider_user, providers: [@provider_one, @provider_two])
+  end
+
+  def when_i_visit_the_first_provider_page
+    visit support_interface_provider_path(@provider_one)
+  end
+
+  def and_i_click_on_users
+    click_on 'Users'
+  end
+
+  def then_i_should_see_the_provider_user_listed
+    expect(page).to have_content("#{@provider_user.first_name} #{@provider_user.last_name}")
+  end
+
+  def when_i_click_update_permissions
+    click_on 'Update permissions'
+  end
+
+  def then_i_see_the_edit_permissions_form
+    expect(page).to have_content("Change #{@provider_user.first_name} #{@provider_user.last_name}’s permissions")
+  end
+
+  def and_i_see_that_can_edit_permissions_for_both_providers
+    expect(page).to have_content(@provider_one.name_and_code)
+    expect(page).to have_content(@provider_two.name_and_code)
+  end
+
+  def when_i_check_permission_to_manage_users_for_the_first_provider
+    within first('.govuk-checkboxes__item') do
+      check 'Manage users'
+    end
+  end
+
+  def and_i_check_permission_to_access_diversity_information_for_the_second_provider
+    within all('.govuk-checkboxes__item').last do
+      check 'Access diversity information'
+    end
+  end
+
+  def and_i_click_save_permissions
+    click_on 'Save permissions'
+  end
+
+  def then_i_can_see_the_provider_user_page
+    expect(page).to have_content("#{@provider_user.first_name} #{@provider_user.last_name}")
+  end
+
+  def and_the_provider_user_has_manage_user_permissions_for_the_first_provider
+    within permissions_summary_for_provider(@provider_one) do
+      expect(page).to have_content('Manage users')
+    end
+  end
+
+  def and_access_diversity_info_permissions_for_the_second_provider
+    within permissions_summary_for_provider(@provider_two) do
+      expect(page).to have_content('Access diversity information')
+    end
+  end
+
+  def then_i_should_see_the_provider_user_has_been_successfully_added
+    expect(page).to have_content("User #{@provider_user.first_name} #{@provider_user.last_name} updated")
+  end
+
+  def permissions_summary_for_provider(provider)
+    "#provider-#{provider.id}-enabled-permissions"
+  end
+end


### PR DESCRIPTION
## Context

As part of the Transition team's provider onboarding process, they need to be able to add users individually and in bulk.

The process of adding users individually has been [updated in the prototype](https://support-for-apply-prototype.herokuapp.com/providers/T92/users
) - this PR focuses solely on the single provider user journey


## Changes proposed in this pull request

- Add feature flag
- Creating a new ProviderUser **is now scoped to a single Provider**. Before it was possible to add permissions for multiple providers
- If that same ProviderUser is created elsewhere, but scoped to a different provider, then we update the ProviderPermissions for that ProviderUser, i.e we do not create a new ProviderUser, rather we add the permissions to the existing ProviderUser.
- When editing a provider user's permissions, we display all Providers that that particular ProviderUser is associated with.

## Guidance to review

These changes may potentially be a little confusing so do let me know if you prefer a demo.

To view the changes:

- the `create_update_single_provider_user` feature flag needs to be switched on.
- the provider must have synced courses on Apply (is this still a requirement)

### Creating a new provider user

![creating_a_provider_user](https://user-images.githubusercontent.com/5256922/119520489-3f3fcf80-bd72-11eb-9c42-f161cc235bc5.gif)

### Add provider permissions to existing provider user

![add_permissions_to_existing_user](https://user-images.githubusercontent.com/5256922/119629186-af4b6580-be05-11eb-956c-8740ff6c4ff7.gif)


### Editing a provider user's permissions

![editing_permissions](https://user-images.githubusercontent.com/5256922/119521610-37ccf600-bd73-11eb-956b-cee8545425a1.gif)

## Link to Trello card

https://trello.com/c/ow63AQnC/3389-%E2%9B%B5%EF%B8%8F-epic-add-provider-user

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
