### PR TITLE
Make filters use provider, location, year etc. of *current* course

### DIFF
--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -7,13 +7,13 @@ module ProviderInterface
                   :site_name_and_code
 
     def initialize(application_choice:)
-      @accredited_provider = application_choice.accredited_provider
+      @accredited_provider = application_choice.current_accredited_provider
       @application_choice = application_choice
       @candidate_name = application_choice.application_form.full_name
       @course_name_and_code = application_choice.current_course.name_and_code
-      @course_provider_name = application_choice.current_course.provider.name
+      @course_provider_name = application_choice.current_provider.name
       @changed_at = application_choice.updated_at.to_s(:govuk_date_and_time)
-      @site_name_and_code = application_choice.site.name_and_code
+      @site_name_and_code = application_choice.current_site.name_and_code
     end
 
     def days_to_respond_text

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -21,7 +21,7 @@ module ProviderInterface
 
       # Eager load / prevent Bullet::Notification::UnoptimizedQueryError
       with_includes = ApplicationChoice.includes(
-        %i[application_form provider current_course_option current_course site accredited_provider],
+        %i[application_form current_course_option current_course current_site current_provider current_accredited_provider],
       )
 
       # Using id: below turns all previous queries into a subquery for sorting

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
         provider: current_provider,
         accredited_provider: accredited_provider,
       ),
+      site: create(
+        :site,
+        code: 'L123',
+        name: 'Skywalker Training',
+        provider: current_provider,
+      ),
     )
   end
 
@@ -44,7 +50,6 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
         first_name: 'Jim',
         last_name: 'James',
       ),
-      site: create(:site, code: 'L123', name: 'Skywalker Training'),
       updated_at: Date.parse('25-03-2020'),
     )
   end
@@ -81,6 +86,27 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
 
     it 'renders the location of the course' do
       expect(card).to include('Skywalker Training (L123)')
+    end
+
+    it 'renders the new location if application choice has been updated' do
+      new_course_option = course_option_for_provider(
+        provider: current_provider,
+        course: create(
+          :course,
+          name: 'Alchemy',
+          provider: current_provider,
+          accredited_provider: accredited_provider,
+        ),
+        site: create(
+          :site,
+          code: 'L456',
+          name: 'Darth Vader Academy',
+          provider: current_provider,
+        ),
+      )
+      application_choice.update(current_course_option: new_course_option)
+
+      expect(card).to include('Darth Vader Academy (L456)')
     end
 
     context 'when there is no accredited provider' do

--- a/spec/services/filter_application_choices_for_providers_spec.rb
+++ b/spec/services/filter_application_choices_for_providers_spec.rb
@@ -106,17 +106,5 @@ RSpec.describe FilterApplicationChoicesForProviders do
 
       expect(result).to eq([application_choices.last])
     end
-
-    it 'works with GetApplicationChoicesForProvider' do
-      accredited_provider = create(:provider)
-      application_choices.first.course.update(accredited_provider: accredited_provider)
-      query_to_be_combined = GetApplicationChoicesForProviders.call(providers: [accredited_provider])
-      result = described_class.call(
-        application_choices: query_to_be_combined,
-        filters: { accredited_provider: accredited_provider.id },
-      )
-
-      expect(result).to eq([application_choices.first])
-    end
   end
 end


### PR DESCRIPTION
## Context

Application filters in Manage currently use the original course details when filtering by provider, recruitment cycle or site, which means the filters will not work as they should when the offered course details are different (e.g. the provider has modified the location, or has even transferred the application to a different provider).

Furthermore, course/provider info presented alongside each application for applications in offer state and beyond is only partially accurate when the provider has modified the course details, indicating a component bug/inconsistency.

![image](https://user-images.githubusercontent.com/107591/119531600-00167c00-bd7c-11eb-9d7b-ca05484f6aec.png)

Since https://github.com/DFE-Digital/apply-for-teacher-training/pull/4546 and its sibling PRs, we are always writing to `current_course_option_id` and this field is guaranteed to provide an up-to-date association between application choice and course details.

## Changes proposed in this pull request

Change all filtering in Manage to respect `current_course_option` and its associations so that filtering works as expected for modified offers.

## Guidance to review

The service has been modified to use a `combined_query`, which is then added to for the filters. This `combined_query` includes the external query passed to the service and all joins required for filtering.

I've used `.includes` at the very top of the query to ensure there is only one set of joins used for all filtering criteria

I've used the `.with`/`.joins` trick to isolate any `ApplicationChoice`-based external query (e.g. GetApplicationChoicesForProviders) and maintain control of joins for filtering.

This is what the new SQL looks like (in combination with the GetApplicationChoicesForProviders query):

```sql
WITH "supplied_choices" AS (
  SELECT 
    "application_choices".* 
  FROM 
    "application_choices" 
    INNER JOIN course_options AS current_course_option ON current_course_option_id = current_course_option.id 
    INNER JOIN course_options AS original_option ON course_option_id = original_option.id 
    INNER JOIN courses AS current_course ON current_course_option.course_id = current_course.id 
    INNER JOIN courses AS original_course ON original_option.course_id = original_course.id 
  WHERE 
    (
      "original_course"."recruitment_cycle_year" IN (2021, 2020) 
      AND (
        "original_course"."provider_id" = 787 
        OR "original_course"."accredited_provider_id" = 787
      ) 
      OR "current_course"."provider_id" = 787 
      AND "current_course"."recruitment_cycle_year" IN (2021, 2020) 
      OR "current_course"."accredited_provider_id" = 787 
      AND "current_course"."recruitment_cycle_year" IN (2021, 2020)
    ) 
    AND (
      status IN (
        'awaiting_provider_decision', 'interviewing', 
        'offer', 'pending_conditions', 'recruited', 
        'rejected', 'declined', 'withdrawn', 
        'conditions_not_met', 'offer_withdrawn', 
        'offer_deferred'
      )
    )
) 
SELECT 
  "application_choices"."id" AS t0_r0, 
  "application_choices"."application_form_id" AS t0_r1, 
  "application_choices"."created_at" AS t0_r2, 
  "application_choices"."updated_at" AS t0_r3, 
  "application_choices"."status" AS t0_r4, 
  "application_choices"."offer" AS t0_r5, 
  "application_choices"."rejection_reason" AS t0_r6, 
  "application_choices"."course_option_id" AS t0_r7, 
  "application_choices"."reject_by_default_at" AS t0_r8, 
  "application_choices"."rejected_by_default" AS t0_r9, 
  "application_choices"."reject_by_default_days" AS t0_r10, 
  "application_choices"."decline_by_default_at" AS t0_r11, 
  "application_choices"."decline_by_default_days" AS t0_r12, 
  "application_choices"."offered_at" AS t0_r13, 
  "application_choices"."rejected_at" AS t0_r14, 
  "application_choices"."withdrawn_at" AS t0_r15, 
  "application_choices"."declined_at" AS t0_r16, 
  "application_choices"."declined_by_default" AS t0_r17, 
  "application_choices"."accepted_at" AS t0_r18, 
  "application_choices"."recruited_at" AS t0_r19, 
  "application_choices"."conditions_not_met_at" AS t0_r20, 
  "application_choices"."offer_withdrawal_reason" AS t0_r21, 
  "application_choices"."offer_withdrawn_at" AS t0_r22, 
  "application_choices"."sent_to_provider_at" AS t0_r23, 
  "application_choices"."structured_rejection_reasons" AS t0_r24, 
  "application_choices"."withdrawal_feedback" AS t0_r25, 
  "application_choices"."offer_deferred_at" AS t0_r26, 
  "application_choices"."status_before_deferral" AS t0_r27, 
  "application_choices"."reject_by_default_feedback_sent_at" AS t0_r28, 
  "application_choices"."offer_changed_at" AS t0_r29, 
  "application_choices"."current_course_option_id" AS t0_r30, 
  "course_options"."id" AS t1_r0, 
  "course_options"."site_id" AS t1_r1, 
  "course_options"."course_id" AS t1_r2, 
  "course_options"."vacancy_status" AS t1_r3, 
  "course_options"."created_at" AS t1_r4, 
  "course_options"."updated_at" AS t1_r5, 
  "course_options"."study_mode" AS t1_r6, 
  "course_options"."site_still_valid" AS t1_r7, 
  "sites"."id" AS t2_r0, 
  "sites"."code" AS t2_r1, 
  "sites"."name" AS t2_r2, 
  "sites"."provider_id" AS t2_r3, 
  "sites"."created_at" AS t2_r4, 
  "sites"."updated_at" AS t2_r5, 
  "sites"."address_line1" AS t2_r6, 
  "sites"."address_line2" AS t2_r7, 
  "sites"."address_line3" AS t2_r8, 
  "sites"."address_line4" AS t2_r9, 
  "sites"."postcode" AS t2_r10, 
  "sites"."latitude" AS t2_r11, 
  "sites"."longitude" AS t2_r12, 
  "sites"."region" AS t2_r13, 
  "courses"."id" AS t3_r0, 
  "courses"."provider_id" AS t3_r1, 
  "courses"."name" AS t3_r2, 
  "courses"."code" AS t3_r3, 
  "courses"."created_at" AS t3_r4, 
  "courses"."updated_at" AS t3_r5, 
  "courses"."level" AS t3_r6, 
  "courses"."exposed_in_find" AS t3_r7, 
  "courses"."open_on_apply" AS t3_r8, 
  "courses"."recruitment_cycle_year" AS t3_r9, 
  "courses"."study_mode" AS t3_r10, 
  "courses"."financial_support" AS t3_r11, 
  "courses"."start_date" AS t3_r12, 
  "courses"."course_length" AS t3_r13, 
  "courses"."description" AS t3_r14, 
  "courses"."accredited_provider_id" AS t3_r15, 
  "courses"."funding_type" AS t3_r16, 
  "courses"."age_range" AS t3_r17, 
  "courses"."qualifications" AS t3_r18, 
  "courses"."program_type" AS t3_r19, 
  "courses"."withdrawn" AS t3_r20, 
  "courses"."uuid" AS t3_r21, 
  "courses"."opened_on_apply_at" AS t3_r22, 
  "providers"."id" AS t4_r0, 
  "providers"."name" AS t4_r1, 
  "providers"."code" AS t4_r2, 
  "providers"."created_at" AS t4_r3, 
  "providers"."updated_at" AS t4_r4, 
  "providers"."sync_courses" AS t4_r5, 
  "providers"."region_code" AS t4_r6, 
  "providers"."postcode" AS t4_r7, 
  "providers"."provider_type" AS t4_r8, 
  "providers"."latitude" AS t4_r9, 
  "providers"."longitude" AS t4_r10, 
  "accredited_provider"."id" AS t5_r0, 
  "accredited_provider"."name" AS t5_r1, 
  "accredited_provider"."code" AS t5_r2, 
  "accredited_provider"."created_at" AS t5_r3, 
  "accredited_provider"."updated_at" AS t5_r4, 
  "accredited_provider"."sync_courses" AS t5_r5, 
  "accredited_provider"."region_code" AS t5_r6, 
  "accredited_provider"."postcode" AS t5_r7, 
  "accredited_provider"."provider_type" AS t5_r8, 
  "accredited_provider"."latitude" AS t5_r9, 
  "accredited_provider"."longitude" AS t5_r10, 
  "course_subjects"."id" AS t6_r0, 
  "course_subjects"."course_id" AS t6_r1, 
  "course_subjects"."subject_id" AS t6_r2, 
  "course_subjects"."created_at" AS t6_r3, 
  "course_subjects"."updated_at" AS t6_r4 
FROM 
  "application_choices" 
  LEFT OUTER JOIN "course_options" ON "course_options"."id" = "application_choices"."current_course_option_id" 
  LEFT OUTER JOIN "sites" ON "sites"."id" = "course_options"."site_id" 
  LEFT OUTER JOIN "courses" ON "courses"."id" = "course_options"."course_id" 
  LEFT OUTER JOIN "providers" ON "providers"."id" = "courses"."provider_id" 
  LEFT OUTER JOIN "providers" "accredited_provider" ON "accredited_provider"."id" = "courses"."accredited_provider_id" 
  LEFT OUTER JOIN "course_subjects" ON "course_subjects"."course_id" = "courses"."id" 
  INNER JOIN supplied_choices ON supplied_choices.id = application_choices.id 
WHERE 
  "accredited_provider"."id" = 787
```

## Link to Trello card

https://trello.com/c/mwF7TeXg

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
