### PR TITLE
Ensure we save the course before attempting to open it

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -36,11 +36,12 @@ module TeacherTrainingPublicAPI
       assign_course_attributes(course, course_from_api, recruitment_cycle_year)
       add_accredited_provider(course, course_from_api[:accredited_body_code], recruitment_cycle_year)
 
-      if course.new_record?
+      new_course = course.new_record?
+      course.save!
+
+      if new_course
         SetOpenOnApplyForNewCourse.new(course).call
       end
-
-      course.save!
 
       if run_in_background
         TeacherTrainingPublicAPI::SyncSites.perform_async(provider.id, recruitment_cycle_year, course.id)


### PR DESCRIPTION
## Context

Addressing The following [Sentry error](https://sentry.io/organizations/dfe-bat/issues/2418962338/?project=1765973&referrer=slack):

There are cases where we do not open a course when its new, thus it is not persisted. If we attempt to call `support_interface_course_url` on an unopened new course in the slack notification, we get an error as the course id is `nil`.

## Changes proposed in this pull request

Persist a course before attempting to open it on apply/send Slack notifications

## Guidance to review

I started with saving the record in the [actual service](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/services/set_open_on_apply_for_new_course.rb) for opening a course, but I think doing it at the higher level is safer. 

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
