### PR TITLE
Bug: candidate can change their course to one already on their application

### DIFF
--- a/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
@@ -29,10 +29,8 @@ module CandidateInterface
         )
         render :new and return unless @pick_course.valid?
 
-        if params[:course_choice_id].blank?
-          redirect_to_review_page_if_course_already_added(current_application, course_id)
-          return if performed?
-        end
+        redirect_to_review_page_if_course_already_added(current_application, course_id)
+        return if performed?
 
         if !@pick_course.open_on_apply?
           redirect_to candidate_interface_course_choices_ucas_with_course_path(@pick_course.provider_id, @pick_course.course_id)

--- a/spec/system/candidate_interface/course_selection/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_edits_course_choices_spec.rb
@@ -70,6 +70,10 @@ RSpec.describe 'Candidate edits course choices' do
     and_i_choose_part_time_study_mode
     then_i_should_be_on_the_course_choice_review_page
     and_i_should_see_the_updated_study_mode_for_the_third_choice
+
+    when_i_click_to_change_the_course_of_my_third_choice
+    and_i_select_the_course_associated_with_my_second_choice
+    then_i_am_told_that_i_have_already_added_that_course
   end
 
   def given_i_am_signed_in
@@ -261,5 +265,18 @@ RSpec.describe 'Candidate edits course choices' do
     third_choice = page.all('.govuk-summary-list').to_a.second.text
 
     expect(third_choice).to have_content("Full time or part time\nPart time")
+  end
+
+  def when_i_click_to_change_the_course_of_my_third_choice
+    click_change_link "course choice for #{@provider.courses.third.name_and_code}"
+  end
+
+  def and_i_select_the_course_associated_with_my_second_choice
+    choose @provider.courses.second.name_and_code
+    click_button t('continue')
+  end
+
+  def then_i_am_told_that_i_have_already_added_that_course
+    expect(page).to have_content t('errors.application_choices.already_added', course_name_and_code: @provider.courses.second.name_and_code)
   end
 end


### PR DESCRIPTION
## Context

If a candidate adds two courses from the same provider and clicks the link of the review page to update their course, then currently, they are able to update the course to one that is already on another application choice.

## Changes proposed in this pull request

- Remove logic that  stops the check that a course is not on another application when editing from the review page

## Guidance to review

Does anyone know why this logic was there? I can't see an obvious reason. Have i missed something?

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
