### PR TITLE
Make app submission work with selected references

### DIFF
--- a/app/components/selected_references_component.html.erb
+++ b/app/components/selected_references_component.html.erb
@@ -1,6 +1,4 @@
-<% if application_form.references_completed? %>
-  <%= render(SummaryCardComponent.new(rows: rows, editable: editable)) %>
-<% else %>
+<% if show_incomplete_banner? %>
   <%= render(
     CandidateInterface::IncompleteSectionComponent.new(
       section: :references_selected,
@@ -10,4 +8,6 @@
       error: is_errored,
     ),
   ) %>
+<% else %>
+  <%= render(SummaryCardComponent.new(rows: rows, editable: editable)) %>
 <% end %>

--- a/app/components/selected_references_component.html.erb
+++ b/app/components/selected_references_component.html.erb
@@ -1,0 +1,13 @@
+<% if application_form.references_completed? %>
+  <%= render(SummaryCardComponent.new(rows: rows, editable: editable)) %>
+<% else %>
+  <%= render(
+    CandidateInterface::IncompleteSectionComponent.new(
+      section: :references_selected,
+      section_path: incomplete_path,
+      text: incomplete_message,
+      link_text: incomplete_link_text,
+      error: is_errored,
+    ),
+  ) %>
+<% end %>

--- a/app/components/selected_references_component.rb
+++ b/app/components/selected_references_component.rb
@@ -1,13 +1,18 @@
 # frozen_string_literal: true
 
 class SelectedReferencesComponent < ViewComponent::Base
-  attr_reader :application_form, :selected_references, :editable, :is_errored
+  attr_reader :application_form, :selected_references, :editable, :show_incomplete, :is_errored
 
-  def initialize(application_form, editable: true, is_errored: false)
+  def initialize(application_form, editable: true, show_incomplete: false, is_errored: false)
     @application_form = application_form
     @selected_references = application_form.selected_references
     @editable = editable
+    @show_incomplete = show_incomplete
     @is_errored = is_errored
+  end
+
+  def show_incomplete_banner?
+    !application_form.references_completed? && show_incomplete
   end
 
   def rows

--- a/app/components/selected_references_component.rb
+++ b/app/components/selected_references_component.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class SelectedReferencesComponent < ViewComponent::Base
+  attr_reader :application_form, :selected_references, :editable, :is_errored
+
+  def initialize(application_form, editable: true, is_errored: false)
+    @application_form = application_form
+    @selected_references = application_form.selected_references
+    @editable = editable
+    @is_errored = is_errored
+  end
+
+  def rows
+    [
+      {
+        key: 'Selected references',
+        value: reference_values,
+        action: 'Change selected references',
+        change_path: candidate_interface_select_references_path,
+      },
+    ]
+  end
+
+  # TODO: refactor the following, possibly by enhancing SummaryCardComponent to
+  # support rendering of bulleted lists
+  def reference_values
+    list = '<ul class="govuk-list govuk-list--bullet">'.html_safe
+    selected_references.map do |reference|
+      list << '<li>'.html_safe << "#{reference.referee_type.humanize} reference from #{reference.name}" << '</li>'.html_safe
+    end
+    list + '</ul>'.html_safe
+  end
+
+  def incomplete_path
+    if !application_form.minimum_references_available_for_selection?
+      candidate_interface_references_review_path
+    elsif !application_form.selected_enough_references?
+      candidate_interface_select_references_path
+    else
+      candidate_interface_review_selected_references_path
+    end
+  end
+
+  def incomplete_link_text
+    if !application_form.minimum_references_available_for_selection?
+      'You need to receive at least 2 references'
+    elsif !application_form.selected_enough_references?
+      'You need to select 2 references'
+    else
+      'Complete your references'
+    end
+  end
+
+  def incomplete_message
+    'References not marked as complete'
+  end
+end

--- a/app/controllers/candidate_interface/references/selection_controller.rb
+++ b/app/controllers/candidate_interface/references/selection_controller.rb
@@ -31,29 +31,11 @@ module CandidateInterface
       def review
         @references_selected = current_application.application_references.includes(:application_form).selected
         @section_complete_form = SectionCompleteForm.new(completed: current_application.references_completed)
-
-        @selected_references_rows = [
-          {
-            key: 'Selected references',
-            value: reference_values,
-            action: 'Change selected references',
-            change_path: candidate_interface_select_references_path,
-          },
-        ]
       end
 
       def complete
         @references_selected = current_application.application_references.includes(:application_form).selected
         @section_complete_form = SectionCompleteForm.new(completed: section_complete_params[:completed])
-
-        @selected_references_rows = [
-          {
-            key: 'Selected references',
-            value: reference_values,
-            action: 'Change selected references',
-            change_path: candidate_interface_select_references_path,
-          },
-        ]
 
         if !@section_complete_form.valid?
           track_validation_error(@section_complete_form)
@@ -84,17 +66,6 @@ module CandidateInterface
 
       def section_complete_params
         strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
-      end
-
-      def reference_values
-        list = '<ul class="govuk-list govuk-list--bullet">'.html_safe
-        @references_selected.map do |reference|
-          list <<
-            '<li>'.html_safe <<
-            "#{reference.referee_type.humanize} reference from #{reference.name}" <<
-            '</li>'.html_safe
-        end
-        list + '</ul>'.html_safe
       end
 
       def render_404_unless_feature_enabled

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -359,6 +359,10 @@ class ApplicationForm < ApplicationRecord
     selected_references.count >= MINIMUM_COMPLETE_REFERENCES
   end
 
+  def selected_too_many_references?
+    selected_references.count > MINIMUM_COMPLETE_REFERENCES
+  end
+
   def selected_references
     application_references.selected
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -356,7 +356,11 @@ class ApplicationForm < ApplicationRecord
     # For the purposes of this method, we only care that we have at least the
     # minimum selected. Other parts of the system will enforce having no more
     # than the minimum selected.
-    application_references.selected.count >= MINIMUM_COMPLETE_REFERENCES
+    selected_references.count >= MINIMUM_COMPLETE_REFERENCES
+  end
+
+  def selected_references
+    application_references.selected
   end
 
   def minimum_references_available_for_selection?

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -42,6 +42,10 @@ class ApplicationReference < ApplicationRecord
     where.not(feedback_status: %i[not_requested_yet feedback_provided])
   end
 
+  def self_and_siblings
+    application_form.application_references
+  end
+
   def single_line_identifier
     "#{name} (#{referee_type.humanize})"
   end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -111,7 +111,11 @@ module CandidateInterface
 
     def reference_section_errors
       [].tap do |errors|
-        if @application_form.too_many_complete_references?
+        if FeatureFlag.active?(:reference_selection)
+          if @application_form.selected_too_many_references?
+            errors << OpenStruct.new(message: I18n.t('application_form.references.review.more_than_two_selected'), anchor: '#references')
+          end
+        elsif @application_form.too_many_complete_references?
           errors << OpenStruct.new(message: I18n.t('application_form.references.review.more_than_two'), anchor: '#references')
         end
       end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -35,8 +35,16 @@ module CandidateInterface
         [:interview_preferences, interview_preferences_completed?],
 
         # "References" section
-        [:references_provided, enough_references_provided?],
+        references_section_definition,
       ].compact
+    end
+
+    def references_section_definition
+      if FeatureFlag.active?(:reference_selection)
+        [:references_selected, references_completed?]
+      else
+        [:references_provided, references_completed?]
+      end
     end
 
     def incomplete_sections
@@ -321,8 +329,7 @@ module CandidateInterface
       @application_form.application_volunteering_experiences.any?
     end
 
-    # Rename this method to references_completed? when removing reference_selection feature flag
-    def enough_references_provided?
+    def references_completed?
       if FeatureFlag.active?(:reference_selection)
         @application_form.references_completed
       else
@@ -332,9 +339,9 @@ module CandidateInterface
 
     def references_in_progress?
       if FeatureFlag.active?(:reference_selection)
-        false
+        false # Irrelevant to the reference_selection flow
       else
-        !enough_references_provided? && @application_form.application_references.present?
+        !references_completed? && @application_form.application_references.present?
       end
     end
 

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -13,6 +13,13 @@ class SubmitApplication
       SendApplicationToProvider.call(application_choice)
     end
 
+    # Cancel any outstanding references
+    if FeatureFlag.active?(:reference_selection)
+      application_form.application_references.feedback_requested.each do |reference|
+        CancelReferee.new.call(reference: reference)
+      end
+    end
+
     if application_form.apply_2?
       CandidateMailer.application_submitted_apply_again(application_form).deliver_later
     else

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -27,7 +27,7 @@
 <section class="govuk-!-margin-bottom-8" id="references">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.references') %></h2>
   <% if FeatureFlag.active?(:reference_selection) %>
-    <%= render(SelectedReferencesComponent.new(application_form, is_errored: missing_error)) %>
+    <%= render(SelectedReferencesComponent.new(application_form, show_incomplete: true, is_errored: missing_error)) %>
   <% else %>
     <% if !application_form.enough_references_have_been_provided? && editable %>
       <%= render(

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -24,21 +24,35 @@
 
 <section class="govuk-!-margin-bottom-8" id="references">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.references') %></h2>
-  <% if !application_form.enough_references_have_been_provided? && editable %>
-    <%= render(CandidateInterface::IncompleteSectionComponent.new(
-      section: :references_provided,
-      section_path: candidate_interface_references_review_path,
-      text: t('review_application.references_provided.incomplete', minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES),
-      link_text: t('review_application.references_provided.complete_section'),
-      error: missing_error,
-    )) %>
+  <% if FeatureFlag.active?(:reference_selection) %>
+    <% if application_form.references_completed? %>
+      <%= render(CandidateInterface::ReferencesReviewComponent.new(
+        references: application_form.selected_references,
+        editable: editable,
+        is_errored: reference_section_error)) %>
+    <% else %>
+      <%= render(CandidateInterface::IncompleteSectionComponent.new(
+        section: :references_selected,
+        section_path: candidate_interface_select_references_path,
+        text: t('review_application.references_selected.incomplete', minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES),
+        link_text: t('review_application.references_selected.complete_section'),
+        error: missing_error)) %>
+    <% end %>
   <% else %>
-    <%= render(CandidateInterface::ReferencesReviewComponent.new(
-      references: application_form.application_references.includes(:application_form).feedback_provided,
-      editable: false,
-      heading_level: 3,
-      is_errored: reference_section_error,
-    )) %>
+    <% if !application_form.enough_references_have_been_provided? && editable %>
+      <%= render(CandidateInterface::IncompleteSectionComponent.new(
+        section: :references_provided,
+        section_path: candidate_interface_references_review_path,
+        text: t('review_application.references_provided.incomplete', minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES),
+        link_text: t('review_application.references_provided.complete_section'),
+        error: missing_error)) %>
+    <% else %>
+      <%= render(CandidateInterface::ReferencesReviewComponent.new(
+        references: application_form.application_references.includes(:application_form).feedback_provided,
+        editable: false,
+        heading_level: 3,
+        is_errored: reference_section_error)) %>
+    <% end %>
   <% end %>
 </section>
 

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -11,47 +11,61 @@
       You can keep making changes to the rest of your application until then.
     </p>
   <% else %>
-    <%= render(CandidateInterface::CourseChoicesReviewComponent.new(
-      application_form: application_form,
-      editable: editable,
-      heading_level: 3,
-      show_incomplete: true,
-      missing_error: missing_error,
-      application_choice_error: application_choice_error,
-    )) %>
- <% end %>
+    <%= render(
+      CandidateInterface::CourseChoicesReviewComponent.new(
+        application_form: application_form,
+        editable: editable,
+        heading_level: 3,
+        show_incomplete: true,
+        missing_error: missing_error,
+        application_choice_error: application_choice_error,
+      ),
+    ) %>
+  <% end %>
 </section>
 
 <section class="govuk-!-margin-bottom-8" id="references">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.references') %></h2>
   <% if FeatureFlag.active?(:reference_selection) %>
     <% if application_form.references_completed? %>
-      <%= render(CandidateInterface::ReferencesReviewComponent.new(
-        references: application_form.selected_references,
-        editable: editable,
-        is_errored: reference_section_error)) %>
+      <%= render(
+        CandidateInterface::ReferencesReviewComponent.new(
+          references: application_form.selected_references,
+          editable: editable,
+          is_errored: reference_section_error,
+        ),
+      ) %>
     <% else %>
-      <%= render(CandidateInterface::IncompleteSectionComponent.new(
-        section: :references_selected,
-        section_path: candidate_interface_select_references_path,
-        text: t('review_application.references_selected.incomplete', minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES),
-        link_text: t('review_application.references_selected.complete_section'),
-        error: missing_error)) %>
+      <%= render(
+        CandidateInterface::IncompleteSectionComponent.new(
+          section: :references_selected,
+          section_path: candidate_interface_select_references_path,
+          text: t('review_application.references_selected.incomplete', minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES),
+          link_text: t('review_application.references_selected.complete_section'),
+          error: missing_error,
+        ),
+      ) %>
     <% end %>
   <% else %>
     <% if !application_form.enough_references_have_been_provided? && editable %>
-      <%= render(CandidateInterface::IncompleteSectionComponent.new(
-        section: :references_provided,
-        section_path: candidate_interface_references_review_path,
-        text: t('review_application.references_provided.incomplete', minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES),
-        link_text: t('review_application.references_provided.complete_section'),
-        error: missing_error)) %>
+      <%= render(
+        CandidateInterface::IncompleteSectionComponent.new(
+          section: :references_provided,
+          section_path: candidate_interface_references_review_path,
+          text: t('review_application.references_provided.incomplete', minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES),
+          link_text: t('review_application.references_provided.complete_section'),
+          error: missing_error,
+        ),
+      ) %>
     <% else %>
-      <%= render(CandidateInterface::ReferencesReviewComponent.new(
-        references: application_form.application_references.includes(:application_form).feedback_provided,
-        editable: false,
-        heading_level: 3,
-        is_errored: reference_section_error)) %>
+      <%= render(
+        CandidateInterface::ReferencesReviewComponent.new(
+          references: application_form.application_references.includes(:application_form).feedback_provided,
+          editable: false,
+          heading_level: 3,
+          is_errored: reference_section_error,
+        ),
+      ) %>
     <% end %>
   <% end %>
 </section>

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -27,25 +27,7 @@
 <section class="govuk-!-margin-bottom-8" id="references">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.references') %></h2>
   <% if FeatureFlag.active?(:reference_selection) %>
-    <% if application_form.references_completed? %>
-      <%= render(
-        CandidateInterface::ReferencesReviewComponent.new(
-          references: application_form.selected_references,
-          editable: editable,
-          is_errored: reference_section_error,
-        ),
-      ) %>
-    <% else %>
-      <%= render(
-        CandidateInterface::IncompleteSectionComponent.new(
-          section: :references_selected,
-          section_path: candidate_interface_select_references_path,
-          text: t('review_application.references_selected.incomplete', minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES),
-          link_text: t('review_application.references_selected.complete_section'),
-          error: missing_error,
-        ),
-      ) %>
-    <% end %>
+    <%= render(SelectedReferencesComponent.new(application_form, is_errored: missing_error)) %>
   <% else %>
     <% if !application_form.enough_references_have_been_provided? && editable %>
       <%= render(

--- a/app/views/candidate_interface/references/selection/review.html.erb
+++ b/app/views/candidate_interface/references/selection/review.html.erb
@@ -7,7 +7,7 @@
 
   <h1 class="govuk-heading-xl"> <%= t('page_titles.references') %> </h1>
 
-  <%= render(SummaryCardComponent.new(rows: @selected_references_rows)) %>
+  <%= render(SelectedReferencesComponent.new(current_application)) %>
 
   <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
 

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -39,7 +39,7 @@
     <section class="govuk-!-margin-bottom-8">
       <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.references') %></h2>
 
-      <% unless @application_form_presenter.enough_references_provided? %>
+      <% unless @application_form_presenter.references_completed? %>
         <p class="govuk-body">You have to get 2 references back before you can send your application to training providers.</p>
 
         <p class="govuk-body">It takes 8 days to get a reference on average.</p>
@@ -61,7 +61,7 @@
           <li class="app-task-list__item">
             <%= render(TaskListItemComponent.new(
               text: t('page_titles.references_selection'),
-              completed: @application_form_presenter.enough_references_provided?,
+              completed: @application_form_presenter.references_completed?,
               path: @application_form_presenter.references_selection_path,
             )) %>
           </li>
@@ -73,7 +73,7 @@
           <li class="app-task-list__item">
             <%= render(TaskListItemComponent.new(
               text: @application_form_presenter.references_link_text,
-              completed: @application_form_presenter.enough_references_provided?,
+              completed: @application_form_presenter.references_completed?,
               path: @application_form_presenter.references_path,
               custom_status: @application_form_presenter.references_in_progress? ? 'In progress' : nil,
             )) %>

--- a/config/locales/candidate_interface/references.yml
+++ b/config/locales/candidate_interface/references.yml
@@ -88,6 +88,7 @@ en:
       review:
         more_than_two: More than 2 references have been given
         need_two: You need to have received at least 2 references before marking this section complete
+        more_than_two_selected: More than 2 references have been selected
 
   activemodel:
     errors:

--- a/config/locales/candidate_interface/review_application.yml
+++ b/config/locales/candidate_interface/review_application.yml
@@ -69,3 +69,7 @@ en:
     references_provided:
       incomplete: You need %{minimum_references} references before you can submit your application
       complete_section: Manage your references
+    references_selected:
+      incomplete: References not marked as complete
+      complete_section: Manage your references
+

--- a/spec/components/selected_references_component_spec.rb
+++ b/spec/components/selected_references_component_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe SelectedReferencesComponent, type: :component do
+  context 'when references section is completed' do
+    # The component only checks ApplicationForm#references_completed?, and
+    # expects that the correct number of reference selections are present if
+    # this boolean is true.
+    it 'renders selected references' do
+      application = create(:application_form, references_completed: true)
+      reference1 = create(:reference, :feedback_provided, selected: true, application_form: application)
+      reference2 = create(:reference, :feedback_provided, selected: true, application_form: application)
+
+      render_inline(described_class.new(application)).to_html
+
+      expect(page).to have_content(reference1.name)
+      expect(page).to have_content(reference2.name)
+    end
+  end
+
+  context 'when references section is not completed' do
+    let(:application) { create(:application_form, references_completed: false) }
+
+    context 'and the minimum number of references has not been received' do
+      it 'warns that not enough references received and links to the appropriate page' do
+        render_inline(described_class.new(application))
+
+        expect(page).to have_link(
+          'You need to receive at least 2 references',
+          href: url_helpers.candidate_interface_references_review_path,
+        )
+      end
+    end
+
+    context 'and the minimum number of references has not been selected' do
+      before do
+        create(:reference, :feedback_provided, selected: false, application_form: application)
+        create(:reference, :feedback_provided, selected: false, application_form: application)
+      end
+
+      it 'warns that not enough references selected and links to the appropriate page ' do
+        render_inline(described_class.new(application))
+
+        expect(page).to have_link(
+          'You need to select 2 references',
+          href: url_helpers.candidate_interface_select_references_path,
+        )
+      end
+    end
+
+    context 'when enough references selected' do
+      before do
+        create(:reference, :feedback_provided, selected: true, application_form: application)
+        create(:reference, :feedback_provided, selected: true, application_form: application)
+      end
+
+      it 'warns that the section is incomplete and links to the appropriate page' do
+        render_inline(described_class.new(application))
+
+        expect(page).to have_link(
+          'Complete your references',
+          href: url_helpers.candidate_interface_review_selected_references_path,
+        )
+      end
+    end
+  end
+
+private
+
+  def url_helpers
+    Rails.application.routes.url_helpers
+  end
+end

--- a/spec/components/selected_references_component_spec.rb
+++ b/spec/components/selected_references_component_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SelectedReferencesComponent, type: :component do
   context 'when references section is not completed' do
     let(:application) { create(:application_form, references_completed: false) }
 
-    context 'and the minimum number of references has not been received' do
+    context 'and no references exist on the application' do
       it 'warns that not enough references received and links to the appropriate page' do
         render_inline(described_class.new(application))
 
@@ -31,7 +31,23 @@ RSpec.describe SelectedReferencesComponent, type: :component do
       end
     end
 
-    context 'and the minimum number of references has not been selected' do
+    context 'and the minimum number of references has not been received' do
+      before do
+        create(:reference, :feedback_requested, selected: false, application_form: application)
+        create(:reference, :feedback_requested, selected: false, application_form: application)
+      end
+
+      it 'warns that not enough references received and links to the appropriate page' do
+        render_inline(described_class.new(application))
+
+        expect(page).to have_link(
+          'You need to receive at least 2 references',
+          href: url_helpers.candidate_interface_references_review_path,
+        )
+      end
+    end
+
+    context 'and the required number of references has not been selected' do
       before do
         create(:reference, :feedback_provided, selected: false, application_form: application)
         create(:reference, :feedback_provided, selected: false, application_form: application)

--- a/spec/components/selected_references_component_spec.rb
+++ b/spec/components/selected_references_component_spec.rb
@@ -20,62 +20,71 @@ RSpec.describe SelectedReferencesComponent, type: :component do
   context 'when references section is not completed' do
     let(:application) { create(:application_form, references_completed: false) }
 
-    context 'and no references exist on the application' do
-      it 'warns that not enough references received and links to the appropriate page' do
-        render_inline(described_class.new(application))
+    context 'and `show_incomplete` is false' do
+      it 'simply renders the summary table' do
+        render_inline(described_class.new(application, show_incomplete: false))
 
-        expect(page).to have_link(
-          'You need to receive at least 2 references',
-          href: url_helpers.candidate_interface_references_review_path,
-        )
+        expect(page).to have_css '.app-summary-card'
+        expect(page).to have_content 'Selected references'
       end
     end
 
-    context 'and the minimum number of references has not been received' do
-      before do
-        create(:reference, :feedback_requested, selected: false, application_form: application)
-        create(:reference, :feedback_requested, selected: false, application_form: application)
+    context 'and `show_incomplete` is true' do
+      let(:render) { render_inline(described_class.new(application, show_incomplete: true)) }
+
+      context 'and no references exist on the application' do
+        it 'warns that not enough references received and links to the appropriate page' do
+          render
+          expect(page).to have_link(
+            'You need to receive at least 2 references',
+            href: url_helpers.candidate_interface_references_review_path,
+          )
+        end
       end
 
-      it 'warns that not enough references received and links to the appropriate page' do
-        render_inline(described_class.new(application))
+      context 'and the minimum number of references has not been received' do
+        before do
+          create(:reference, :feedback_requested, selected: false, application_form: application)
+          create(:reference, :feedback_requested, selected: false, application_form: application)
+        end
 
-        expect(page).to have_link(
-          'You need to receive at least 2 references',
-          href: url_helpers.candidate_interface_references_review_path,
-        )
-      end
-    end
-
-    context 'and the required number of references has not been selected' do
-      before do
-        create(:reference, :feedback_provided, selected: false, application_form: application)
-        create(:reference, :feedback_provided, selected: false, application_form: application)
-      end
-
-      it 'warns that not enough references selected and links to the appropriate page ' do
-        render_inline(described_class.new(application))
-
-        expect(page).to have_link(
-          'You need to select 2 references',
-          href: url_helpers.candidate_interface_select_references_path,
-        )
-      end
-    end
-
-    context 'when enough references selected' do
-      before do
-        create(:reference, :feedback_provided, selected: true, application_form: application)
-        create(:reference, :feedback_provided, selected: true, application_form: application)
+        it 'warns that not enough references received and links to the appropriate page' do
+          render
+          expect(page).to have_link(
+            'You need to receive at least 2 references',
+            href: url_helpers.candidate_interface_references_review_path,
+          )
+        end
       end
 
-      it 'warns that the section is incomplete and links to the appropriate page' do
-        render_inline(described_class.new(application))
+      context 'and the required number of references has not been selected' do
+        before do
+          create(:reference, :feedback_provided, selected: false, application_form: application)
+          create(:reference, :feedback_provided, selected: false, application_form: application)
+        end
 
-        expect(page).to have_link(
-          'Complete your references',
-          href: url_helpers.candidate_interface_review_selected_references_path,
-        )
+        it 'warns that not enough references selected and links to the appropriate page ' do
+          render
+          expect(page).to have_link(
+            'You need to select 2 references',
+            href: url_helpers.candidate_interface_select_references_path,
+          )
+        end
+      end
+
+      context 'when enough references selected' do
+        before do
+          create(:reference, :feedback_provided, selected: true, application_form: application)
+          create(:reference, :feedback_provided, selected: true, application_form: application)
+        end
+
+        it 'warns that the section is incomplete and links to the appropriate page' do
+          render
+          expect(page).to have_link(
+            'Complete your references',
+            href: url_helpers.candidate_interface_review_selected_references_path,
+          )
+        end
       end
     end
   end

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -645,20 +645,44 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   end
 
   describe '#reference_section_errors' do
-    it 'returns an error if the application form has too many references' do
-      application_form = instance_double(ApplicationForm, too_many_complete_references?: true)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+    context 'with reference_selection feature on' do
+      before { FeatureFlag.activate(:reference_selection) }
 
-      expect(presenter.reference_section_errors).to eq(
-        [OpenStruct.new(message: 'More than 2 references have been given', anchor: '#references')],
-      )
+      it 'returns an error if the application form has too many selected references' do
+        application_form = instance_double(ApplicationForm, selected_too_many_references?: true)
+        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+        expect(presenter.reference_section_errors).to eq(
+          [OpenStruct.new(message: 'More than 2 references have been selected', anchor: '#references')],
+        )
+      end
+
+      it 'returns an empty array if the application form does not have too many selected references' do
+        application_form = instance_double(ApplicationForm, selected_too_many_references?: false)
+        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+        expect(presenter.reference_section_errors).to eq []
+      end
     end
 
-    it 'returns an empty array if the application form does not have too many references' do
-      application_form = instance_double(ApplicationForm, too_many_complete_references?: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+    context 'with reference_selection feature off' do
+      before { FeatureFlag.deactivate(:reference_selection) }
 
-      expect(presenter.reference_section_errors).to eq []
+      it 'returns an error if the application form has too many references' do
+        application_form = instance_double(ApplicationForm, too_many_complete_references?: true)
+        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+        expect(presenter.reference_section_errors).to eq(
+          [OpenStruct.new(message: 'More than 2 references have been given', anchor: '#references')],
+        )
+      end
+
+      it 'returns an empty array if the application form does not have too many references' do
+        application_form = instance_double(ApplicationForm, too_many_complete_references?: false)
+        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+        expect(presenter.reference_section_errors).to eq []
+      end
     end
   end
 

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -313,22 +313,42 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
   end
 
-  describe '#enough_references_provided?' do
-    it 'returns true if the referees section has been created and two references have been provided' do
-      application_form = create(:application_form)
-      create_list(:reference, 2, :feedback_provided, application_form: application_form)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+  describe '#references_completed?' do
+    context 'with reference_selection feature on' do
+      before { FeatureFlag.activate(:reference_selection) }
 
-      expect(presenter).to be_enough_references_provided
+      it 'returns true if application form references_completed is true' do
+        application_form = build(:application_form, references_completed: true)
+        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+        expect(presenter).to be_references_completed
+      end
+
+      it 'returns false if application form references_completed is false' do
+        application_form = build(:application_form, references_completed: false)
+        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+        expect(presenter).not_to be_references_completed
+      end
     end
 
-    it 'returns false if the referees section has been completed and only one reference has been provided' do
-      application_form = create(:application_form)
-      create(:reference, :feedback_provided, application_form: application_form)
-      create(:reference, :feedback_requested, application_form: application_form)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+    context 'with reference_selection feature off' do
+      before { FeatureFlag.deactivate(:reference_selection) }
 
-      expect(presenter).not_to be_enough_references_provided
+      it 'returns true if the referees section has been completed and two references have been provided' do
+        application_form = create(:application_form)
+        create_list(:reference, 2, :feedback_provided, application_form: application_form)
+        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+        expect(presenter).to be_references_completed
+      end
+
+      it 'returns false if the referees section has been completed and only one reference has been provided' do
+        application_form = create(:application_form)
+        create(:reference, :feedback_provided, application_form: application_form)
+        create(:reference, :feedback_requested, application_form: application_form)
+        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+        expect(presenter).not_to be_references_completed
+      end
     end
   end
 
@@ -634,7 +654,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
       )
     end
 
-    it 'returns an empty array  if the application form does not have too many references' do
+    it 'returns an empty array if the application form does not have too many references' do
       application_form = instance_double(ApplicationForm, too_many_complete_references?: false)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -38,6 +38,25 @@ RSpec.describe SubmitApplication do
       expect(action_mailer_double).to have_received(:deliver_later)
     end
 
+    context 'when the reference_selection feature is on' do
+      before { FeatureFlag.activate(:reference_selection) }
+
+      context 'when the application has requested references' do
+        let(:application_form) { create(:application_form) }
+        let!(:requested_reference_1) { create(:reference, :feedback_requested, application_form: application_form) }
+        let!(:requested_reference_2) { create(:reference, :feedback_requested, application_form: application_form) }
+        let!(:provided_reference) { create(:reference, :feedback_provided, application_form: application_form) }
+
+        it 'cancels them' do
+          described_class.new(application_form).call
+
+          expect(requested_reference_1.reload).to be_cancelled
+          expect(requested_reference_2.reload).to be_cancelled
+          expect(provided_reference.reload).to be_feedback_provided
+        end
+      end
+    end
+
     context 'when the application is apply_2' do
       let(:application_form) { create(:application_form, phase: :apply_2) }
 

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -73,7 +73,14 @@ module CandidateHelper
     click_link t('page_titles.interview_preferences')
     candidate_fills_in_interview_preferences
 
-    candidate_provides_two_referees if with_referees
+    if with_referees
+      candidate_provides_two_referees
+      receive_references
+      if FeatureFlag.active?(:reference_selection)
+        click_link 'Selected references'
+        select_references_and_complete_section
+      end
+    end
 
     @application = ApplicationForm.last
   end
@@ -120,12 +127,12 @@ module CandidateHelper
     application_form = ApplicationForm.last
     first_reference = application_form.application_references.first
     second_reference = application_form.application_references.second
+    check first_reference.name
+    check second_reference.name
+    click_button t('save_and_continue')
 
     choose 'Yes, I have completed this section'
-    click_button t('continue')
-    check first_reference.single_line_identifier
-    check second_reference.single_line_identifier
-    click_button t('continue')
+    click_button t('save_and_continue')
   end
 
   def given_courses_exist

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -116,6 +116,18 @@ module CandidateHelper
     ).save!
   end
 
+  def select_references_and_complete_section
+    application_form = ApplicationForm.last
+    first_reference = application_form.application_references.first
+    second_reference = application_form.application_references.second
+
+    choose 'Yes, I have completed this section'
+    click_button t('continue')
+    check first_reference.single_line_identifier
+    check second_reference.single_line_identifier
+    click_button t('continue')
+  end
+
   def given_courses_exist
     @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
     site = create(:site, name: 'Main site', code: '-', provider: @provider)

--- a/spec/system/candidate_interface/references/candidate_has_too_many_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_has_too_many_references_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'References' do
   end
 
   def and_it_has_too_many_references
-    create_list(:reference, 3, feedback_status: :feedback_provided, application_form: @application)
+    create(:reference, feedback_status: :feedback_provided, application_form: @application)
   end
 
   def then_i_see_errors_on_the_reference_review_page

--- a/spec/system/candidate_interface/references/reference_selection/candidate_has_too_many_selected_references_spec.rb
+++ b/spec/system/candidate_interface/references/reference_selection/candidate_has_too_many_selected_references_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+# This isn't a state that should ordinarily be allowed by the system, but if a
+# candidate somehow ends up with more than two references selected, we handle
+# it defensively so that we don't send more than the permitted number of
+# references to providers.
+RSpec.feature 'Handle applications with too many selected references' do
+  include CandidateHelper
+
+  scenario 'Candidate tries to submit an application with too many references' do
+    given_the_reference_selection_feature_flag_is_active
+    and_i_have_a_completed_application_with_more_than_two_selected_references
+
+    when_i_try_to_submit_my_application
+    then_i_see_an_error_message
+    and_my_application_is_not_submitted
+  end
+
+  def given_the_reference_selection_feature_flag_is_active
+    FeatureFlag.activate(:reference_selection)
+  end
+
+  def and_i_have_a_completed_application_with_more_than_two_selected_references
+    create_and_sign_in_candidate
+    candidate_completes_application_form
+    create(:reference, :feedback_provided, selected: true, application_form: @application)
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_try_to_submit_my_application
+    click_link 'Check and submit'
+    click_link 'Continue'
+  end
+
+  def then_i_see_an_error_message
+    within('.govuk-error-summary') do
+      expect(page).to have_content 'More than 2 references have been selected'
+    end
+  end
+
+  def and_my_application_is_not_submitted
+    expect(@application.submitted?).to eq false
+  end
+end

--- a/spec/system/candidate_interface/references/reference_selection/candidate_submits_an_application_spec.rb
+++ b/spec/system/candidate_interface/references/reference_selection/candidate_submits_an_application_spec.rb
@@ -12,12 +12,18 @@ RSpec.feature 'Submitting an application' do
     when_i_have_added_references
     then_i_can_see_references_are_in_progress
     when_i_submit_the_application
-    then_i_get_an_error_about_my_references
+    then_i_get_an_error_about_not_having_enough_references
 
     when_most_of_my_references_have_been_provided
     and_i_submit_the_application
-    then_i_get_an_error_about_my_references
-    when_i_have_selected_references
+    then_i_get_an_error_about_not_selecting_enough_references
+
+    when_i_select_my_references
+    and_leave_the_references_section_incomplete
+    and_i_submit_the_application
+    then_i_get_an_error_about_not_marking_the_references_section_complete
+
+    when_i_mark_the_references_section_complete
     then_i_can_see_the_references_section_is_complete
     when_i_submit_the_application
     then_i_can_see_my_application_has_been_successfully_submitted
@@ -80,26 +86,74 @@ RSpec.feature 'Submitting an application' do
   end
   alias_method :when_i_submit_the_application, :and_i_submit_the_application
 
-  def then_i_get_an_error_about_my_references
-    error = 'References not marked as complete'
+  def then_i_get_an_error_about_not_having_enough_references
+    error_summary = 'References not marked as complete'
+    link_text = 'You need to receive at least 2 references'
 
     within '.govuk-error-summary' do
-      expect(page).to have_content error
+      expect(page).to have_content error_summary
     end
 
     within '#incomplete-references_selected-error' do
-      expect(page).to have_content error
+      expect(page).to have_content link_text
     end
   end
 
-  def when_i_have_selected_references
-    click_link 'You need to select 2 references'
-    select_references_and_complete_section
+  def then_i_get_an_error_about_not_selecting_enough_references
+    error_summary = 'References not marked as complete'
+    link_text = 'You need to select 2 references'
+
+    within '.govuk-error-summary' do
+      expect(page).to have_content error_summary
+    end
+
+    within '#incomplete-references_selected-error' do
+      expect(page).to have_content link_text
+    end
+  end
+
+  def then_i_get_an_error_about_not_marking_the_references_section_complete
+    error_summary = 'References not marked as complete'
+    link_text = 'Complete your references'
+
+    within '.govuk-error-summary' do
+      expect(page).to have_content error_summary
+    end
+
+    within '#incomplete-references_selected-error' do
+      expect(page).to have_content link_text
+    end
   end
 
   def when_most_of_my_references_have_been_provided
     receive_references
     SubmitReference.new(reference: @reference3).save!
+  end
+
+  def when_i_select_my_references
+    click_link 'You need to select 2 references'
+    application_form = ApplicationForm.last
+    first_reference = application_form.application_references.first
+    second_reference = application_form.application_references.second
+    check first_reference.name
+    check second_reference.name
+    click_button t('save_and_continue')
+  end
+
+  def and_leave_the_references_section_incomplete
+    choose 'No, I’ll come back to it later'
+    click_button t('save_and_continue')
+  end
+
+  def when_i_mark_the_references_section_complete
+    click_link 'Complete your references'
+
+    expect(page).not_to have_content 'References not marked as complete'
+    expect(page).to have_content @reference1.name
+    expect(page).to have_content @reference2.name
+
+    choose 'Yes, I have completed this section'
+    click_button t('save_and_continue')
   end
 
   def then_i_can_see_my_application_has_been_successfully_submitted

--- a/spec/system/candidate_interface/references/reference_selection/candidate_submits_an_application_spec.rb
+++ b/spec/system/candidate_interface/references/reference_selection/candidate_submits_an_application_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature 'Submitting an application' do
   end
 
   def when_i_have_selected_references
-    click_link 'Manage your references'
+    click_link 'You need to select 2 references'
     select_references_and_complete_section
   end
 

--- a/spec/system/candidate_interface/references/reference_selection/candidate_submits_an_application_spec.rb
+++ b/spec/system/candidate_interface/references/reference_selection/candidate_submits_an_application_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+RSpec.feature 'Submitting an application' do
+  include CandidateHelper
+
+  scenario 'Candidate submits complete application' do
+    given_i_am_signed_in
+    and_the_reference_selection_feature_flag_is_active
+    and_i_have_completed_my_application_except_references
+    then_i_can_see_references_are_incomplete
+
+    when_i_have_added_references
+    then_i_can_see_references_are_in_progress
+    when_i_submit_the_application
+    then_i_get_an_error_about_my_references
+
+    when_my_references_have_been_provided
+    and_i_submit_the_application
+    then_i_get_an_error_about_my_references
+    when_i_have_selected_references
+    then_i_can_see_references_are_complete
+    when_i_submit_the_application
+    then_i_can_see_my_application_has_been_successfully_submitted
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_the_reference_selection_feature_flag_is_active
+    FeatureFlag.activate('reference_selection')
+  end
+
+  def and_i_have_completed_my_application_except_references
+    candidate_completes_application_form(with_referees: false)
+  end
+
+  def when_i_have_added_references
+    @reference1 = create(:reference, :not_requested_yet, application_form: current_candidate.current_application)
+    @reference2 = create(:reference, :not_requested_yet, application_form: current_candidate.current_application)
+    @reference3 = create(:reference, :not_requested_yet, application_form: current_candidate.current_application)
+  end
+
+  def then_i_can_see_references_are_in_progress
+    visit candidate_interface_application_form_path
+    expect(page).to have_content('You have to get 2 references back before you can send your application to training providers.')
+    within(all('.app-task-list')[1]) do
+      expect(page).to have_content("#{@reference1.name}: Not requested yet")
+      expect(page).to have_content("#{@reference2.name}: Not requested yet")
+      expect(page).to have_content("#{@reference3.name}: Not requested yet")
+    end
+  end
+
+  def then_i_can_see_references_are_incomplete
+    expect(page).to have_content('You have to get 2 references back before you can send your application to training providers.')
+    within(all('.app-task-list')[1]) do
+      expect(page).to have_content('Incomplete')
+    end
+  end
+
+  def then_i_can_see_references_are_complete
+    visit candidate_interface_application_form_path
+    expect(page).not_to have_content('You have to get 2 references back before you can send your application to training providers.')
+    within(all('.app-task-list')[1]) do
+      expect(page).to have_content('Complete')
+      expect(page).to have_content("#{@reference1.name}: Reference given")
+      expect(page).to have_content("#{@reference2.name}: Reference given")
+      expect(page).to have_content("#{@reference3.name}: Reference given")
+    end
+  end
+
+  def and_i_submit_the_application
+    visit candidate_interface_application_form_path
+    click_link 'Check and submit your application'
+    click_link t('continue')
+  end
+  alias_method :when_i_submit_the_application, :and_i_submit_the_application
+
+  def then_i_get_an_error_about_my_references
+    error = 'References not marked as complete'
+
+    within '.govuk-error-summary' do
+      expect(page).to have_content error
+    end
+
+    within '#incomplete-references_selected-error' do
+      expect(page).to have_content error
+    end
+  end
+
+  def when_i_have_selected_references
+    click_link 'Manage your references'
+    select_references_and_complete_section
+  end
+
+  def when_my_references_have_been_provided
+    receive_references
+    SubmitReference.new(reference: @reference3).save!
+  end
+
+  def then_i_can_see_my_application_has_been_successfully_submitted
+    choose 'No'
+    click_button t('continue')
+    choose 'No'
+    click_button 'Send application'
+    click_button 'Continue'
+    expect(page).to have_content 'Application successfully submitted'
+  end
+
+private
+
+  def application
+    current_candidate.current_application
+  end
+
+  def provider
+    application.application_choices.first.provider
+  end
+end


### PR DESCRIPTION
## Context

The app submission part of the system needs to be aware of reference selections, and should validate the section appropriately.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
When submitting the application, validate for:

- Section completeness
- Too many reference selections

See commit messages for detail
<!-- If there are UI changes, please include Before and After screenshots. -->
![Screenshot_20210526_170319](https://user-images.githubusercontent.com/519250/119693553-4d5e2080-be44-11eb-902e-cf20624a387a.png)


## Guidance to review
Per-commit code review recommended.

For manual testing:

Try and submit an application on the review app:
 - With no references selected
 - With the references section marked incomplete
 - After deleting a selected reference in a different tab

Only success scenario should be a complete references section with two selected references.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/hZVGCcxd
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
