### PR TITLE
Backfill data migration to copy old offers to new offer and conditions tables

### DIFF
--- a/app/services/data_migrations/backfill_offer_data.rb
+++ b/app/services/data_migrations/backfill_offer_data.rb
@@ -3,6 +3,11 @@ module DataMigrations
     TIMESTAMP = 20210525144145
     MANUAL_RUN = false
 
+    CONDITION_STATUS = {
+      recruited: :met,
+      conditions_not_met: :unmet,
+    }.freeze
+
     def change
       application_choices = ApplicationChoice.where.not(offered_at: nil)
 
@@ -10,7 +15,9 @@ module DataMigrations
         application_choices.each do |application_choice|
           offer = Offer.new(application_choice: application_choice)
           application_choice.offer['conditions'].each do |condition|
-            offer.conditions.build(text: condition)
+            condition_details = { text: condition }
+            condition_details.merge!(status: CONDITION_STATUS[application_choice.status.to_sym]) if CONDITION_STATUS.key?(application_choice.status.to_sym)
+            offer.conditions.build(condition_details)
           end
           offer.save
         end

--- a/app/services/data_migrations/backfill_offer_data.rb
+++ b/app/services/data_migrations/backfill_offer_data.rb
@@ -13,6 +13,8 @@ module DataMigrations
 
       ActiveRecord::Base.no_touching do
         application_choices.each do |application_choice|
+          next if Offer.exists?(application_choice: application_choice)
+
           offer = Offer.new(application_choice: application_choice)
           application_choice.offer['conditions'].each do |condition|
             condition_details = { text: condition }

--- a/app/services/data_migrations/backfill_offer_data.rb
+++ b/app/services/data_migrations/backfill_offer_data.rb
@@ -1,0 +1,20 @@
+module DataMigrations
+  class BackfillOfferData
+    TIMESTAMP = 20210525144145
+    MANUAL_RUN = false
+
+    def change
+      application_choices = ApplicationChoice.where.not(offered_at: nil)
+
+      ActiveRecord::Base.no_touching do
+        application_choices.each do |application_choice|
+          offer = Offer.new(application_choice: application_choice)
+          application_choice.offer['conditions'].each do |condition|
+            offer.conditions.build(text: condition)
+          end
+          offer.save
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillOfferData',
   'DataMigrations::BackfillRestucturedWorkHistoryBoolean',
   'DataMigrations::BackfillValidationErrorsServiceColumn',
   'DataMigrations::BackfillSelectedBoolean',

--- a/spec/services/data_migrations/backfill_offer_data_spec.rb
+++ b/spec/services/data_migrations/backfill_offer_data_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe DataMigrations::BackfillOfferData do
     expect(OfferCondition.count).to be(3)
   end
 
+  it 'backfills the correct condition status based on the offer state' do
+    application_choice_with_offer = create(:application_choice, :with_offer)
+    application_choice_recruited = create(:application_choice, :with_offer, :recruited)
+    application_choice_conditions_not_met = create(:application_choice, :with_offer, :conditions_not_met)
+
+    expect { described_class.new.change }.to change(Offer, :count).by(3)
+
+    expect(Offer.find_by(application_choice: application_choice_with_offer).conditions.first.status).to eq('pending')
+    expect(Offer.find_by(application_choice: application_choice_recruited).conditions.first.status).to eq('met')
+    expect(Offer.find_by(application_choice: application_choice_conditions_not_met).conditions.first.status).to eq('unmet')
+  end
+
   it 'does not update the audit log' do
     create(:application_choice, :with_offer)
 

--- a/spec/services/data_migrations/backfill_offer_data_spec.rb
+++ b/spec/services/data_migrations/backfill_offer_data_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe DataMigrations::BackfillOfferData do
   end
 
   it 'backfills information of offers with conditions' do
-    application_choice = create(:application_choice, :with_offer)
-    other_application_choice = create(:application_choice, :with_offer, offer: { conditions: %w[One Two] })
+    application_choice = create(:application_choice, status: 'offer', offer: { conditions: %w[Three] }, offered_at: Time.zone.now)
+    other_application_choice = create(:application_choice, status: :offer, offer: { conditions: %w[One Two] }, offered_at: Time.zone.now)
 
     expect { described_class.new.change }.to change(Offer, :count).by(2)
 
@@ -36,9 +36,9 @@ RSpec.describe DataMigrations::BackfillOfferData do
   end
 
   it 'backfills the correct condition status based on the offer state' do
-    application_choice_with_offer = create(:application_choice, :with_offer)
-    application_choice_recruited = create(:application_choice, :with_offer, :recruited)
-    application_choice_conditions_not_met = create(:application_choice, :with_offer, :conditions_not_met)
+    application_choice_with_offer = create(:application_choice, :offer, offer: { conditions: %w[Three] }, offered_at: Time.zone.now)
+    application_choice_recruited = create(:application_choice, :recruited, offer: { conditions: %w[Three] }, offered_at: Time.zone.now)
+    application_choice_conditions_not_met = create(:application_choice, :conditions_not_met, offer: { conditions: %w[Three] }, offered_at: Time.zone.now)
 
     expect { described_class.new.change }.to change(Offer, :count).by(3)
 
@@ -48,7 +48,7 @@ RSpec.describe DataMigrations::BackfillOfferData do
   end
 
   it 'does not update the audit log' do
-    create(:application_choice, :with_offer)
+    create(:application_choice, status: 'offer', offer: { conditions: [] }, offered_at: Time.zone.now)
 
     expect { described_class.new.change }
       .to change(Offer, :count).by(1)

--- a/spec/services/data_migrations/backfill_offer_data_spec.rb
+++ b/spec/services/data_migrations/backfill_offer_data_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
+RSpec.describe DataMigrations::BackfillOfferData do
+  it 'does nothing when the application choice does not have an offer' do
+    create(:application_choice)
+
+    expect { described_class.new.change }.not_to change(Offer, :count)
+  end
+
+  it 'backfills information of offers without conditions' do
+    create_list(:application_choice, 3, offer: { conditions: [] }, offered_at: Time.zone.now)
+
+    expect { described_class.new.change }.to change(Offer, :count).by(3)
+    expect(OfferCondition.count).to be(0)
+  end
+
+  it 'backfills information of offers with conditions' do
+    application_choice = create(:application_choice, :with_offer)
+    other_application_choice = create(:application_choice, :with_offer, offer: { conditions: %w[One Two] })
+
+    expect { described_class.new.change }.to change(Offer, :count).by(2)
+
+    expect(Offer.find_by(application_choice: application_choice).conditions.map(&:text)).to eq(application_choice.offer['conditions'])
+    expect(Offer.find_by(application_choice: other_application_choice).conditions.map(&:text)).to eq(%w[One Two])
+    expect(OfferCondition.count).to be(3)
+  end
+
+  it 'does not update the audit log' do
+    create(:application_choice, :with_offer)
+
+    expect { described_class.new.change }
+      .to change(Offer, :count).by(1)
+      .and not_change(Audited::Audit, :count)
+  end
+end

--- a/spec/services/data_migrations/backfill_offer_data_spec.rb
+++ b/spec/services/data_migrations/backfill_offer_data_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe DataMigrations::BackfillOfferData do
     expect { described_class.new.change }.not_to change(Offer, :count)
   end
 
+  it 'does nothing when the application choice already has an offer associated with it' do
+    application_choice = create(:application_choice, offered_at: Time.zone.now)
+    create(:offer, application_choice: application_choice)
+    create_list(:application_choice, 2, offer: { conditions: [] }, offered_at: Time.zone.now)
+
+    expect { described_class.new.change }.to change(Offer, :count).by(2)
+  end
+
   it 'backfills information of offers without conditions' do
     create_list(:application_choice, 3, offer: { conditions: [] }, offered_at: Time.zone.now)
 


### PR DESCRIPTION
## Context

Backfill data migration to copy data from application choices `offer` column into new `offers` and `offer_conditions` in the DB.

## Link to Trello card

https://trello.com/c/76oWEZQr/3720-backfill-data-migration-to-copy-old-offers-to-new-offer-and-conditions-tables

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
