### PR TITLE
Start writing to offer and conditions tables when making and changing offers

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,4 +1,4 @@
 class Offer < ApplicationRecord
   belongs_to :application_choice
-  has_many :conditions, class_name: 'OfferCondition'
+  has_many :conditions, class_name: 'OfferCondition', dependent: :destroy
 end

--- a/app/models/offer_condition.rb
+++ b/app/models/offer_condition.rb
@@ -7,6 +7,4 @@ class OfferCondition < ApplicationRecord
     met: 'met',
     unmet: 'unmet',
   }
-
-  audited associated_with: :application_choice
 end

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -23,6 +23,7 @@ class ChangeOffer
 
           application_choice.current_course_option = course_option
           application_choice.offer = { 'conditions' => conditions }
+          UpdateOfferConditions.new(application_choice: application_choice).call
           application_choice.offer_changed_at = Time.zone.now
           application_choice.save!
 

--- a/app/services/conditions_not_met.rb
+++ b/app/services/conditions_not_met.rb
@@ -13,6 +13,7 @@ class ConditionsNotMet
     audit(@auth.actor) do
       ApplicationStateChange.new(@application_choice).conditions_not_met!
       @application_choice.update!(conditions_not_met_at: Time.zone.now)
+      UpdateOfferConditions.new(application_choice: @application_choice).call
       CandidateMailer.conditions_not_met(@application_choice).deliver_later
     end
   rescue Workflow::NoTransitionAllowed

--- a/app/services/confirm_offer_conditions.rb
+++ b/app/services/confirm_offer_conditions.rb
@@ -13,6 +13,7 @@ class ConfirmOfferConditions
     audit(@auth.actor) do
       ApplicationStateChange.new(@application_choice).confirm_conditions_met!
       @application_choice.update!(recruited_at: Time.zone.now)
+      UpdateOfferConditions.new(application_choice: @application_choice).call
       CandidateMailer.conditions_met(@application_choice).deliver_later
       StateChangeNotifier.new(:recruited, @application_choice).application_outcome_notification
     end

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -25,6 +25,7 @@ class MakeOffer
 
           application_choice.current_course_option = course_option
           application_choice.offer = { 'conditions' => conditions }
+          UpdateOfferConditions.new(application_choice: application_choice).call
           application_choice.offered_at = Time.zone.now
           application_choice.save!
 

--- a/app/services/reinstate_conditions_met.rb
+++ b/app/services/reinstate_conditions_met.rb
@@ -25,6 +25,7 @@ class ReinstateConditionsMet
         ActiveRecord::Base.transaction do
           ApplicationStateChange.new(application_choice).reinstate_conditions_met!
           application_choice.update(attrs)
+          UpdateOfferConditions.new(application_choice: application_choice).call
           CandidateMailer.reinstated_offer(application_choice).deliver_later
         end
       end

--- a/app/services/reinstate_pending_conditions.rb
+++ b/app/services/reinstate_pending_conditions.rb
@@ -21,6 +21,7 @@ class ReinstatePendingConditions
       if valid?
         ActiveRecord::Base.transaction do
           ApplicationStateChange.new(application_choice).reinstate_pending_conditions!
+          UpdateOfferConditions.new(application_choice: application_choice).call
           @application_choice.update(
             current_course_option_id: course_option.id,
             recruited_at: nil,

--- a/app/services/update_accepted_offer_conditions.rb
+++ b/app/services/update_accepted_offer_conditions.rb
@@ -11,6 +11,7 @@ class UpdateAcceptedOfferConditions
         offer: { conditions: @conditions },
         audit_comment: "Change offer condition Zendesk request: #{@audit_comment_ticket}",
       )
+      UpdateOfferConditions.new(application_choice: @application_choice).call
       if @conditions.empty?
         ApplicationStateChange.new(@application_choice).confirm_conditions_met!
         @application_choice.update!(recruited_at: Time.zone.now)

--- a/app/services/update_offer_conditions.rb
+++ b/app/services/update_offer_conditions.rb
@@ -1,7 +1,7 @@
 class UpdateOfferConditions
   def initialize(application_choice:)
     @application_choice = application_choice
-    @conditions = application_choice.offer&.[]('conditions')
+    @conditions = application_choice.offer&.[]('conditions') || []
   end
 
   def call
@@ -15,7 +15,7 @@ class UpdateOfferConditions
         updated_at: Time.zone.now,
       }
     end
-    offer.conditions.insert_all!(conditions_attrs)
+    offer.conditions.insert_all!(conditions_attrs) if conditions_attrs.any?
   end
 
 private

--- a/app/services/update_offer_conditions.rb
+++ b/app/services/update_offer_conditions.rb
@@ -10,10 +10,23 @@ class UpdateOfferConditions
     conditions_attrs = @conditions.map do |condition|
       {
         text: condition,
+        status: condition_status,
         created_at: Time.zone.now,
         updated_at: Time.zone.now,
       }
     end
     offer.conditions.insert_all!(conditions_attrs)
+  end
+
+private
+
+  def condition_status
+    @condition_status ||= if @application_choice.recruited?
+                            :met
+                          elsif @application_choice.conditions_not_met?
+                            :unmet
+                          else
+                            :pending
+                          end
   end
 end

--- a/app/services/update_offer_conditions.rb
+++ b/app/services/update_offer_conditions.rb
@@ -6,7 +6,7 @@ class UpdateOfferConditions
 
   def call
     offer = Offer.find_or_create_by(application_choice: @application_choice)
-    offer.conditions.destroy_all
+    offer.conditions.delete_all
     conditions_attrs = @conditions.map do |condition|
       {
         text: condition,

--- a/app/services/update_offer_conditions.rb
+++ b/app/services/update_offer_conditions.rb
@@ -1,0 +1,19 @@
+class UpdateOfferConditions
+  def initialize(application_choice:)
+    @application_choice = application_choice
+    @conditions = application_choice.offer&.[]('conditions')
+  end
+
+  def call
+    offer = Offer.find_or_create_by(application_choice: @application_choice)
+    offer.conditions.destroy_all
+    conditions_attrs = @conditions.map do |condition|
+      {
+        text: condition,
+        created_at: Time.zone.now,
+        updated_at: Time.zone.now,
+      }
+    end
+    offer.conditions.insert_all!(conditions_attrs)
+  end
+end

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -164,6 +164,13 @@ FactoryBot.define do
       decline_by_default_days { 10 }
       offer { { 'conditions' => ['Be cool'] } }
       offered_at { Time.zone.now }
+
+      after(:build) do |choice, _evaluator|
+        offer = create(:offer, application_choice: choice, conditions: [])
+        choice.offer['conditions'].each do |condition|
+          create(:offer_condition, text: condition, offer: offer)
+        end
+      end
     end
 
     trait :with_modified_offer do

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe SupportInterface::ConditionsForm do
     it 'returns false with a validation error if audit_comment_ticket is missing' do
       application_choice = create(
         :application_choice,
+        :with_offer,
         offer: { 'conditions' => ['Fitness to train to teach check', 'Get a haircut'] },
       )
       form = described_class.build_from_params(
@@ -94,6 +95,7 @@ RSpec.describe SupportInterface::ConditionsForm do
     it 'adds an additional further and standard condition' do
       application_choice = create(
         :application_choice,
+        :with_offer,
         offer: { 'conditions' => ['Fitness to train to teach check', 'Get a haircut'] },
       )
       form = described_class.build_from_params(
@@ -119,9 +121,41 @@ RSpec.describe SupportInterface::ConditionsForm do
       )
     end
 
+    it 'updates the attached offer model' do
+      application_choice = create(
+        :application_choice,
+        :with_offer,
+        offer: { 'conditions' => ['Fitness to train to teach check', 'Get a haircut'] },
+      )
+      form = described_class.build_from_params(
+        application_choice,
+        'standard_conditions' => [
+          'Fitness to train to teach check',
+          'Disclosure and Barring Service (DBS) check',
+        ],
+        'further_conditions' => {
+          '0' => { 'text' => 'Get a haircut' },
+          '1' => { 'text' => 'Wear a tie' },
+        },
+        'audit_comment_ticket' => 'https://becomingateacher.zendesk.com/agent/tickets/12345',
+      )
+      form.save
+
+      offer = Offer.find_by(application_choice: application_choice)
+      expect(offer.conditions.map(&:text)).to eq(
+        [
+          'Fitness to train to teach check',
+          'Disclosure and Barring Service (DBS) check',
+          'Get a haircut',
+          'Wear a tie',
+        ],
+      )
+    end
+
     it 'can remove conditions' do
       application_choice = create(
         :application_choice,
+        :with_offer,
         offer: { 'conditions' => ['Fitness to train to teach check', 'Get a haircut', 'Wear a tie'] },
       )
       form = described_class.build_from_params(
@@ -146,6 +180,7 @@ RSpec.describe SupportInterface::ConditionsForm do
     it 'includes an audit comment', with_audited: true do
       application_choice = create(
         :application_choice,
+        :with_offer,
         offer: { 'conditions' => ['Fitness to train to teach check'] },
       )
       form = described_class.build_from_params(

--- a/spec/models/offer_condition_spec.rb
+++ b/spec/models/offer_condition_spec.rb
@@ -8,21 +8,4 @@ RSpec.describe OfferCondition do
       expect(offer_condition.application_choice).not_to be_nil
     end
   end
-
-  describe 'auditing', with_audited: true do
-    it 'audits changes to the model' do
-      offer_condition = create(:offer_condition, text: 'Provide evidence of degree qualification')
-
-      offer_condition.update!(status: 'met')
-
-      expect(offer_condition.audits.last.audited_changes).to eq({ 'status' => %w[pending met] })
-    end
-
-    it 'associates audits to the application choice' do
-      offer_condition = create(:offer_condition, text: 'Provide evidence of degree qualification')
-
-      expect(offer_condition.audits.last.associated_type).to eq('ApplicationChoice')
-      expect(offer_condition.audits.last.associated_id).to eq(offer_condition.application_choice.id)
-    end
-  end
 end

--- a/spec/requests/vendor_api/post_conditions_met_spec.rb
+++ b/spec/requests/vendor_api/post_conditions_met_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-conditio
 
   it 'confirms the conditions have been met' do
     application_choice = create_application_choice_for_currently_authenticated_provider(status: 'pending_conditions')
+    create(:offer, application_choice: application_choice)
 
     post_api_request "/api/v1/applications/#{application_choice.id}/confirm-conditions-met"
 

--- a/spec/requests/vendor_api/post_conditions_not_met_spec.rb
+++ b/spec/requests/vendor_api/post_conditions_not_met_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/conditions-not-m
 
   it 'confirms the conditions have not been met' do
     application_choice = create_application_choice_for_currently_authenticated_provider(status: 'pending_conditions')
+    create(:offer, application_choice: application_choice)
 
     post_api_request "/api/v1/applications/#{application_choice.id}/conditions-not-met"
 

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -78,13 +78,18 @@ RSpec.describe ChangeOffer do
 
       it 'then it executes the service without errors ' do
         set_declined_by_default = instance_double(SetDeclineByDefault, call: true)
+        update_offer_conditions_service = instance_double(UpdateOfferConditions, call: true)
         allow(SetDeclineByDefault)
             .to receive(:new).with(application_form: application_choice.application_form)
                     .and_return(set_declined_by_default)
+        allow(UpdateOfferConditions)
+            .to receive(:new).with(application_choice: application_choice)
+                    .and_return(update_offer_conditions_service)
 
         change_offer.save!
 
-        expect(SetDeclineByDefault).to have_received(:new).with(application_form: application_choice.application_form)
+        expect(set_declined_by_default).to have_received(:call)
+        expect(update_offer_conditions_service).to have_received(:call)
       end
     end
 

--- a/spec/services/conditions_not_met_spec.rb
+++ b/spec/services/conditions_not_met_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ConditionsNotMet do
     provider_user = create(:provider_user)
     provider_user.providers << application_choice.current_course.provider
 
-    service = ConditionsNotMet.new(
+    service = described_class.new(
       actor: provider_user,
       application_choice: application_choice,
     )
@@ -17,15 +17,41 @@ RSpec.describe ConditionsNotMet do
   end
 
   it 'sets the conditions_not_met_at date for the application_choice' do
-    application_choice = create(:application_choice, status: :pending_conditions)
+    application_choice = create(:application_choice, :with_offer, status: :pending_conditions)
 
     Timecop.freeze do
       expect {
-        ConditionsNotMet.new(
+        described_class.new(
           actor: create(:support_user),
           application_choice: application_choice,
         ).save
       }.to change { application_choice.conditions_not_met_at }.to(Time.zone.now)
     end
+  end
+
+  it 'sets the status of all the offer conditions to unmet' do
+    application_choice = create(:application_choice, :with_offer, status: :pending_conditions)
+    offer = Offer.find_by(application_choice: application_choice)
+
+    expect {
+      described_class.new(
+        actor: create(:support_user),
+        application_choice: application_choice,
+      ).save
+    }.to change { offer.reload.conditions.first.status }.from('pending').to('unmet')
+  end
+
+  it 'creates an offer object if it does not exist' do
+    application_choice = create(:application_choice, offer: { conditions: ['Be cool'] }, status: :pending_conditions)
+
+    described_class.new(
+      actor: create(:support_user),
+      application_choice: application_choice,
+    ).save
+
+    offer = Offer.find_by(application_choice: application_choice)
+
+    expect(offer).not_to be_nil
+    expect(offer.conditions.first.status).to eq('unmet')
   end
 end

--- a/spec/services/confirm_offer_conditions_spec.rb
+++ b/spec/services/confirm_offer_conditions_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ConfirmOfferConditions do
     provider_user = create(:provider_user)
     provider_user.providers << application_choice.current_course.provider
 
-    service = ConfirmOfferConditions.new(
+    service = described_class.new(
       actor: provider_user,
       application_choice: application_choice,
     )
@@ -17,13 +17,13 @@ RSpec.describe ConfirmOfferConditions do
   end
 
   it 'updates the application_choice and sends a Slack notification' do
-    application_choice = create(:application_choice, status: :pending_conditions)
+    application_choice = create(:application_choice, :with_offer, status: :pending_conditions)
     notifier = instance_double(StateChangeNotifier, application_outcome_notification: nil)
     allow(StateChangeNotifier).to receive(:new).and_return(notifier)
 
     Timecop.freeze do
       expect {
-        ConfirmOfferConditions.new(
+        described_class.new(
           actor: create(:support_user),
           application_choice: application_choice,
         ).save
@@ -32,5 +32,31 @@ RSpec.describe ConfirmOfferConditions do
       expect(StateChangeNotifier).to have_received(:new).with(:recruited, application_choice)
       expect(notifier).to have_received(:application_outcome_notification)
     end
+  end
+
+  it 'sets the status of all the offer conditions to met' do
+    application_choice = create(:application_choice, :with_offer, status: :pending_conditions)
+    offer = Offer.find_by(application_choice: application_choice)
+
+    expect {
+      described_class.new(
+        actor: create(:support_user),
+        application_choice: application_choice,
+      ).save
+    }.to change { offer.conditions.first.status }.from('pending').to('met')
+  end
+
+  it 'creates an offer object if it does not exist' do
+    application_choice = create(:application_choice, offer: { conditions: ['Be cool'] }, status: :pending_conditions)
+
+    described_class.new(
+      actor: create(:support_user),
+      application_choice: application_choice,
+    ).save
+
+    offer = Offer.find_by(application_choice: application_choice)
+
+    expect(offer).not_to be_nil
+    expect(offer.conditions.first.status).to eq('met')
   end
 end

--- a/spec/services/make_offer_spec.rb
+++ b/spec/services/make_offer_spec.rb
@@ -57,17 +57,22 @@ RSpec.describe MakeOffer do
       it 'then it executes the service without errors ' do
         set_declined_by_default = instance_double(SetDeclineByDefault, call: true)
         send_new_offer_email_to_candidate = instance_double(SendNewOfferEmailToCandidate, call: true)
+        update_offer_conditions_service = instance_double(UpdateOfferConditions, call: true)
         allow(SetDeclineByDefault)
             .to receive(:new).with(application_form: application_choice.application_form)
                     .and_return(set_declined_by_default)
         allow(SendNewOfferEmailToCandidate)
             .to receive(:new).with(application_choice: application_choice)
                     .and_return(send_new_offer_email_to_candidate)
+        allow(UpdateOfferConditions)
+            .to receive(:new).with(application_choice: application_choice)
+                     .and_return(update_offer_conditions_service)
 
         make_offer.save!
 
-        expect(SetDeclineByDefault).to have_received(:new).with(application_form: application_choice.application_form)
-        expect(SendNewOfferEmailToCandidate).to have_received(:new).with(application_choice: application_choice)
+        expect(set_declined_by_default).to have_received(:call)
+        expect(send_new_offer_email_to_candidate).to have_received(:call)
+        expect(update_offer_conditions_service).to have_received(:call)
       end
     end
 

--- a/spec/services/reinstate_pending_conditions_spec.rb
+++ b/spec/services/reinstate_pending_conditions_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ReinstatePendingConditions do
   let(:application_choice) { create(:application_choice, :with_deferred_offer, course_option: previous_course_option) }
 
   def service
-    ReinstatePendingConditions.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option)
+    described_class.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option)
   end
 
   it 'changes application status to \'pending_conditions\'' do
@@ -31,9 +31,36 @@ RSpec.describe ReinstatePendingConditions do
     end
   end
 
+  it 'updates the status of all conditions to pending' do
+    offer = Offer.find_by(application_choice: application_choice)
+    offer.conditions.update(status: :met)
+
+    expect { service.save }.to change { offer.reload.conditions.first.status }.from('met').to('pending')
+  end
+
+  context 'when the application does not have an offer object associated' do
+    let(:application_choice) do
+      create(
+        :application_choice,
+        offer: { conditions: ['Be cool'] },
+        status: :offer_deferred,
+        status_before_deferral: :pending_conditions,
+        course_option: previous_course_option,
+      )
+    end
+
+    it 'creates an offer object' do
+      service.save
+
+      offer = Offer.find_by(application_choice: application_choice)
+      expect(offer).not_to be_nil
+      expect(offer.conditions.first.status).to eq('pending')
+    end
+  end
+
   describe 'course option validation' do
     it 'checks the course option is present' do
-      reinstate = ReinstatePendingConditions.new(actor: provider_user, application_choice: application_choice, course_option: nil)
+      reinstate = described_class.new(actor: provider_user, application_choice: application_choice, course_option: nil)
 
       expect(reinstate).not_to be_valid
 
@@ -42,7 +69,7 @@ RSpec.describe ReinstatePendingConditions do
 
     it 'checks the course is open on apply' do
       new_course_option = create(:course_option, course: create(:course, provider: provider, open_on_apply: false))
-      reinstate = ReinstatePendingConditions.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option)
+      reinstate = described_class.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option)
 
       expect(reinstate).not_to be_valid
 
@@ -50,7 +77,7 @@ RSpec.describe ReinstatePendingConditions do
     end
 
     it 'checks course option matches the current RecruitmentCycle' do
-      reinstate = ReinstatePendingConditions.new(actor: provider_user, application_choice: application_choice, course_option: previous_course_option)
+      reinstate = described_class.new(actor: provider_user, application_choice: application_choice, course_option: previous_course_option)
 
       expect(reinstate).not_to be_valid
 

--- a/spec/services/update_offer_conditions_spec.rb
+++ b/spec/services/update_offer_conditions_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+RSpec.describe UpdateOfferConditions do
+  let(:conditions) { ['Test', 'Test but longer'] }
+  let(:application_choice) { create(:application_choice, offer: { conditions: conditions }) }
+
+  describe '#call' do
+    it 'writes the conditions to the offer conditions model' do
+      described_class.new(application_choice: application_choice).call
+      offer = Offer.find_by(application_choice: application_choice)
+      expect(offer.conditions.count).to eq(2)
+      expect(offer.conditions.first.text).to eq('Test')
+      expect(offer.conditions.last.text).to eq('Test but longer')
+    end
+
+    context 'when there is an existing offer' do
+      let!(:existing_offer) { create(:offer, application_choice: application_choice) }
+
+      it 'overwrites the existing offer' do
+        offer = Offer.find_by(application_choice: application_choice)
+        expect(offer.conditions.count).to eq(1)
+        expect(offer.conditions.first.text).to eq('Evidence of being cool')
+        described_class.new(application_choice: application_choice).call
+        offer = Offer.find_by(application_choice: application_choice)
+        expect(offer.conditions.count).to eq(2)
+        expect(offer.conditions.first.text).to eq('Test')
+        expect(offer.conditions.last.text).to eq('Test but longer')
+      end
+    end
+  end
+end

--- a/spec/services/update_offer_conditions_spec.rb
+++ b/spec/services/update_offer_conditions_spec.rb
@@ -12,6 +12,28 @@ RSpec.describe UpdateOfferConditions do
       expect(offer.conditions.last.text).to eq('Test but longer')
     end
 
+    context 'when the application choice is in the recruited state' do
+      let(:application_choice) { create(:application_choice, :with_offer, status: :recruited) }
+
+      it 'creates new conditions in the met state' do
+        described_class.new(application_choice: application_choice).call
+
+        offer = Offer.find_by(application_choice: application_choice)
+        expect(offer.conditions.map(&:status).uniq).to contain_exactly('met')
+      end
+    end
+
+    context 'when the application choice is in the conditions_not_met state' do
+      let(:application_choice) { create(:application_choice, :with_offer, status: :conditions_not_met) }
+
+      it 'creates new conditions in the unmet state' do
+        described_class.new(application_choice: application_choice).call
+
+        offer = Offer.find_by(application_choice: application_choice)
+        expect(offer.conditions.map(&:status).uniq).to contain_exactly('unmet')
+      end
+    end
+
     context 'when there is an existing offer' do
       let!(:existing_offer) { create(:offer, application_choice: application_choice) }
 

--- a/spec/services/update_offer_conditions_spec.rb
+++ b/spec/services/update_offer_conditions_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe UpdateOfferConditions do
       expect(offer.conditions.last.text).to eq('Test but longer')
     end
 
+    context 'when the application choice has an offer with no conditions' do
+      let(:conditions) { nil }
+
+      it 'does not create any offer conditions' do
+        described_class.new(application_choice: application_choice).call
+
+        offer = Offer.find_by(application_choice: application_choice)
+        expect(offer.conditions).to be_empty
+      end
+    end
+
     context 'when the application choice is in the recruited state' do
       let(:application_choice) { create(:application_choice, :with_offer, status: :recruited) }
 


### PR DESCRIPTION
## Context
We are migrating from the current offer structure, to a new model where we store conditions individually in their own table. This is the second step where we start writing to the new structure in parallel to the old structure.

Worked on with @richardpattinson 

## Changes proposed in this pull request
Write to Offer and OfferCondition models in:
MakeOffer
ChangeOffer
Support - change accepted offer conditions
Application choice factories

## Guidance to review
Deleting and recreating conditions is not ideal in terms of auditing. I think we will need to revisit this anyway when we start tracking condition statuses individually. For now this does the job of leaving us with conditions in the correct states at all times.

## Link to Trello card
https://trello.com/c/gFet4v13/3719-start-writing-to-offer-and-conditions-tables-when-making-and-changing-offers

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
