### PR TITLE
Start reading from new offer and conditions tables

### DIFF
--- a/app/components/candidate_interface/application_dashboard_course_choices_component.rb
+++ b/app/components/candidate_interface/application_dashboard_course_choices_component.rb
@@ -109,13 +109,13 @@ module CandidateInterface
 
     def conditions_row(application_choice)
       return unless (application_choice.pending_conditions? || application_choice.offer?) &&
-        (application_choice.offer.present? && !application_choice.offer['conditions'].count.zero?)
+        (application_choice.offer.present? && application_choice.offer.conditions.any?)
 
       {
-        key: 'Condition'.pluralize(application_choice.offer['conditions'].count),
+        key: 'Condition'.pluralize(application_choice.offer.conditions.count),
         value: render(
           OfferConditionsReviewComponent.new(
-            conditions: application_choice.offer['conditions'],
+            conditions: application_choice.offer.conditions.map(&:text),
             provider: application_choice.current_course.provider.name,
           ),
         ),

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -10,7 +10,7 @@ module CandidateInterface
         course_row,
         location_row,
       ]
-      rows << conditions_row if @course_choice.offer&.dig('conditions')&.present?
+      rows << conditions_row if @course_choice.offer.conditions.any?
       rows
     end
 
@@ -42,7 +42,7 @@ module CandidateInterface
     def conditions_row
       {
         key: 'Conditions',
-        value: render(OfferConditionsReviewComponent.new(conditions: @course_choice.offer['conditions'], provider: @course_choice.current_course.provider.name)),
+        value: render(OfferConditionsReviewComponent.new(conditions: @course_choice.offer.conditions.map(&:text), provider: @course_choice.current_course.provider.name)),
       }
     end
 

--- a/app/components/provider_interface/conditions_component.html.erb
+++ b/app/components/provider_interface/conditions_component.html.erb
@@ -1,20 +1,26 @@
 <table class="govuk-table govuk-!-margin-bottom-2">
   <tbody class="govuk-table__body">
-    <% condition_rows.each do |row| %>
+    <% if conditions.none? %>
       <tr class="govuk-table__row conditions-row">
-        <td class="govuk-table__cell"><%= row %></td>
-        <td class="govuk-table__cell govuk-table__cell--numeric">
-          <% if conditions.present? %>
-            <% if conditions_met? %>
-              <%= govuk_tag(text: 'Met', colour: 'green') %>
-            <% elsif known_conditions_state? %>
-              <%= govuk_tag(text: 'Not met', colour: 'red') %>
-            <% else %>
-              <%= govuk_tag(text: 'Pending', colour: 'grey') %>
-            <% end %>
-          <% end %>
+        <td class="govuk-table__cell">
+          No conditions have been set for this offer.
         </td>
       </tr>
-    <% end %>
+    <% else %>
+        <% conditions.each do |condition| %>
+          <tr class="govuk-table__row conditions-row">
+            <td class="govuk-table__cell"><%= condition.text %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric">
+              <% if condition.met? %>
+                <%= govuk_tag(text: 'Met', colour: 'green') %>
+              <% elsif condition.unmet? %>
+                <%= govuk_tag(text: 'Not met', colour: 'red') %>
+              <% else %>
+                <%= govuk_tag(text: 'Pending', colour: 'grey') %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      <% end %>
   </tbody>
 </table>

--- a/app/components/provider_interface/conditions_component.rb
+++ b/app/components/provider_interface/conditions_component.rb
@@ -13,25 +13,7 @@ module ProviderInterface
     end
 
     def conditions
-      application_choice.offer['conditions']
-    end
-
-    def condition_rows
-      conditions&.any? ? conditions : ['No conditions have been set for this offer.']
-    end
-
-    def application_state
-      @application_state ||= ApplicationStateChange.new(application_choice)
-    end
-
-    def conditions_met?
-      return application_choice.status_before_deferral == 'recruited' if application_choice.status == 'offer_deferred'
-
-      application_state.current_state >= :recruited
-    end
-
-    def known_conditions_state?
-      conditions_met? || application_state.conditions_not_met?
+      application_choice.offer.conditions
     end
   end
 end

--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -25,9 +25,9 @@
           <tr class="govuk-table__row conditions-row">
             <td class="govuk-table__cell"><%= condition %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric">
-              <% if conditions_met? %>
+              <% if condition.met? %>
                 <%= govuk_tag(text: 'Met', colour: 'green') %>
-              <% elsif conditions_not_met? %>
+              <% elsif condition.unmet? %>
                 <%= govuk_tag(text: 'Not met', colour: 'red') %>
               <% else %>
                 <%= govuk_tag(text: 'Pending', colour: 'grey') %>

--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -23,7 +23,7 @@
       <tbody class="govuk-table__body">
         <% conditions.each do |condition| %>
           <tr class="govuk-table__row conditions-row">
-            <td class="govuk-table__cell"><%= condition %></td>
+            <td class="govuk-table__cell"><%= condition.text %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric">
               <% if condition.met? %>
                 <%= govuk_tag(text: 'Met', colour: 'green') %>

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -73,10 +73,6 @@ module ProviderInterface
         change_path: nil }
     end
 
-    def application_state
-      @application_state ||= ApplicationStateChange.new(application_choice)
-    end
-
     def border_class
       'no-border' unless border
     end

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -57,14 +57,6 @@ module ProviderInterface
       course.full_time_or_part_time? ? new_provider_interface_application_choice_offer_study_modes_path(application_choice) : nil
     end
 
-    def conditions_met?
-      return application_choice.status_before_deferral == 'recruited' if application_choice.status == 'offer_deferred'
-
-      application_state.current_state == :recruited
-    end
-
-    delegate :conditions_not_met?, to: :application_state
-
   private
 
     def accredited_body_details(course_option)

--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -97,8 +97,8 @@ module SupportInterface
     def offer_conditions_row
       return unless application_choice.pending_conditions? || application_choice.offer?
 
-      conditions = application_choice.offer&.[]('conditions')
-      return if conditions.blank?
+      conditions = application_choice.offer.conditions
+      return if conditions.empty?
 
       {
         key: 'Conditions',

--- a/app/components/support_interface/conditions_component.html.erb
+++ b/app/components/support_interface/conditions_component.html.erb
@@ -1,5 +1,5 @@
 <ul class="govuk-list">
   <% conditions.each do |condition| %>
-    <li><%= condition %></li>
+    <li><%= condition.text %></li>
   <% end %>
 </ul>

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -67,7 +67,7 @@ module VendorAPI
     end
 
     def render_application
-      render json: { data: SingleApplicationPresenter.new(application_choice).as_json }
+      render json: { data: SingleApplicationPresenter.new(application_choice.reload).as_json }
     end
 
     def respond_to_decision(decision)

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -111,7 +111,7 @@ module ProviderInterface
     def self.standard_conditions_from(offer)
       return MakeOffer::STANDARD_CONDITIONS if offer.blank?
 
-      conditions = offer['conditions']
+      conditions = offer.conditions.map(&:text)
       conditions & MakeOffer::STANDARD_CONDITIONS
     end
 
@@ -120,7 +120,7 @@ module ProviderInterface
     def self.further_conditions_from(offer)
       return [] if offer.blank?
 
-      conditions = offer['conditions']
+      conditions = offer.conditions.map(&:text)
       conditions - MakeOffer::STANDARD_CONDITIONS
     end
 

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -48,6 +48,10 @@ module ProviderInterface
       @conditions = (standard_conditions + further_conditions).reject(&:blank?)
     end
 
+    def conditions_to_render
+      conditions.map { |condition| OfferCondition.new(text: condition, status: 'pending') }
+    end
+
     def course_option
       CourseOption.find(course_option_id)
     end

--- a/app/forms/provider_interface/reconfirm_deferred_offer_wizard.rb
+++ b/app/forms/provider_interface/reconfirm_deferred_offer_wizard.rb
@@ -68,15 +68,19 @@ module ProviderInterface
     def modified_application_choice
       return unless application_choice
 
-      clone = application_choice.dup
-      clone.id = application_choice.id
-
-      clone.status = if conditions_status.present?
-                       conditions_met? ? 'recruited' : 'pending_conditions'
-                     else
-                       clone.status_before_deferral
-                     end
-      clone
+      modified_application_choice = application_choice.clone
+      modified_application_choice.status = if conditions_status.present?
+                                             if conditions_met?
+                                               modified_application_choice.offer.conditions.each { |condition| condition.status = 'met' }
+                                               'recruited'
+                                             else
+                                               modified_application_choice.offer.conditions.each { |condition| condition.status = 'pending' }
+                                               'pending_conditions'
+                                             end
+                                           else
+                                             application_choice.status_before_deferral
+                                           end
+      modified_application_choice
     end
 
     def next_step

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -53,14 +53,14 @@ module SupportInterface
     def self.standard_conditions_from(offer)
       return [] if offer.blank?
 
-      conditions = offer['conditions']
+      conditions = offer.conditions.map(&:text)
       conditions & MakeOffer::STANDARD_CONDITIONS
     end
 
     def self.further_conditions_from(offer)
       return [] if offer.blank?
 
-      conditions = offer['conditions']
+      conditions = offer.conditions.map(&:text)
       conditions - MakeOffer::STANDARD_CONDITIONS
     end
 

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -217,7 +217,7 @@ class CandidateMailer < ApplicationMailer
 
   def changed_offer(application_choice)
     @application_choice = application_choice
-    @conditions = @application_choice.offer&.dig('conditions') || []
+    @conditions = @application_choice.offer.conditions.map(&:text)
 
     @course_option = @application_choice.course_option
     @current_course_option = @application_choice.current_course_option
@@ -256,7 +256,7 @@ class CandidateMailer < ApplicationMailer
   def reinstated_offer(application_choice)
     @application_choice = application_choice
     @course_option = @application_choice.current_course_option
-    @conditions = @application_choice.offer&.dig('conditions') || []
+    @conditions = @application_choice.offer.conditions.map(&:text)
 
     email_for_candidate(
       @application_choice.application_form,
@@ -429,7 +429,7 @@ private
     course_option = CourseOption.find_by(id: @application_choice.current_course_option_id) || @application_choice.course_option
     @provider_name = course_option.course.provider.name
     @course_name = course_option.course.name_and_code
-    @conditions = @application_choice.offer&.dig('conditions') || []
+    @conditions = @application_choice.offer.conditions.map(&:text)
     @offers = @application_choice.self_and_siblings.select(&:offer?).map do |offer|
       "#{offer.course_option.course.name_and_code} at #{offer.course_option.course.provider.name}"
     end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -78,6 +78,10 @@ class ApplicationChoice < ApplicationRecord
     end
   end
 
+  def offer
+    @offer ||= Offer.find_by(application_choice: self)
+  end
+
   delegate :course_not_available?, to: :course_option
   delegate :withdrawn?, to: :course, prefix: true
 

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -170,7 +170,7 @@ class ApplicationChoice < ApplicationRecord
   def unconditional_offer?
     return false unless recruited?
 
-    offer&.fetch('conditions', []).blank?
+    offer.conditions.none?
   end
 
 private

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -352,13 +352,12 @@ module VendorAPI
     def offer
       return nil if application_choice.offer.nil?
 
-      application_choice.offer
-        .merge(current_course)
-        .merge({
-          offer_made_at: application_choice.offered_at,
-          offer_accepted_at: application_choice.accepted_at,
-          offer_declined_at: application_choice.declined_at,
-        })
+      {
+        conditions: application_choice.offer.conditions.map(&:text),
+        offer_made_at: application_choice.offered_at,
+        offer_accepted_at: application_choice.accepted_at,
+        offer_declined_at: application_choice.declined_at,
+      }.merge(current_course)
     end
 
     def hesa_itt_data

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -46,6 +46,6 @@ private
   end
 
   def unconditional_offer?
-    @application_choice.offer&.fetch('conditions', []).blank?
+    @application_choice.offer.conditions.none?
   end
 end

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -23,7 +23,7 @@ class ChangeOffer
 
           application_choice.current_course_option = course_option
           application_choice.offer = { 'conditions' => conditions }
-          UpdateOfferConditions.new(application_choice: application_choice).call
+          UpdateOfferConditions.new(application_choice: application_choice, conditions: conditions).call
           application_choice.offer_changed_at = Time.zone.now
           application_choice.save!
 

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -25,7 +25,7 @@ class MakeOffer
 
           application_choice.current_course_option = course_option
           application_choice.offer = { 'conditions' => conditions }
-          UpdateOfferConditions.new(application_choice: application_choice).call
+          UpdateOfferConditions.new(application_choice: application_choice, conditions: conditions).call
           application_choice.offered_at = Time.zone.now
           application_choice.save!
 

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -36,7 +36,7 @@ class OfferValidations
   end
 
   def identical_to_existing_offer?
-    if application_choice.current_course_option == course_option && application_choice.offer['conditions'] == conditions
+    if application_choice.current_course_option == course_option && application_choice.offer.conditions.map(&:text).sort == conditions.sort
       raise IdenticalOfferError
     end
   end

--- a/app/services/support_interface/offer_conditions_export.rb
+++ b/app/services/support_interface/offer_conditions_export.rb
@@ -60,12 +60,12 @@ module SupportInterface
     end
 
     def conditions(choice)
-      choice.offer['conditions'].join(', ')
+      choice.offer.conditions.map(&:text).join(', ')
     end
 
     def relevant_choices
       ApplicationChoice
-        .where('offer IS NOT NULL')
+        .where.not(offered_at: nil)
         .order('offered_at asc')
     end
   end

--- a/app/services/update_accepted_offer_conditions.rb
+++ b/app/services/update_accepted_offer_conditions.rb
@@ -11,7 +11,7 @@ class UpdateAcceptedOfferConditions
         offer: { conditions: @conditions },
         audit_comment: "Change offer condition Zendesk request: #{@audit_comment_ticket}",
       )
-      UpdateOfferConditions.new(application_choice: @application_choice).call
+      UpdateOfferConditions.new(application_choice: @application_choice, conditions: @conditions).call
       if @conditions.empty?
         ApplicationStateChange.new(@application_choice).confirm_conditions_met!
         @application_choice.update!(recruited_at: Time.zone.now)

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -30,10 +30,10 @@
       <p class="govuk-body">If you need help, you can speak to our <%= govuk_link_to 'teacher training advisers', t('get_into_teaching.url_get_an_advisor') %>.</p>
 
       <%= f.govuk_radio_buttons_fieldset :response, legend: { text: t('decisions.response.legend'), size: 'm' } do %>
-        <% if @application_choice.offer&.dig('conditions')&.present? %>
-          <%= f.govuk_radio_button :response, 'accept', label: { text: t('decisions.response.accept.label') }, link_errors: true %>
-        <% else %>
+        <% if @application_choice.offer.conditions.none? %>
           <%= f.govuk_radio_button :response, 'accept', label: { text: t('decisions.response.accept_no_conditions.label') }, link_errors: true %>
+        <% else %>
+          <%= f.govuk_radio_button :response, 'accept', label: { text: t('decisions.response.accept.label') }, link_errors: true %>
         <% end %>
         <%= f.govuk_radio_button :response, 'decline', label: { text: t('decisions.response.decline.label') } %>
       <% end %>

--- a/app/views/provider_interface/offer/checks/edit.html.erb
+++ b/app/views/provider_interface/offer/checks/edit.html.erb
@@ -12,7 +12,7 @@
       <%= f.govuk_error_summary %>
       <%= render ProviderInterface::CompletedOfferSummaryComponent.new(application_choice: @application_choice,
                                                                        course_option: @wizard.course_option,
-                                                                       conditions: @wizard.conditions,
+                                                                       conditions: @wizard.conditions_to_render,
                                                                        course: @wizard.course_option.course,
                                                                        available_providers: @providers,
                                                                        available_courses: @courses,

--- a/app/views/provider_interface/offer/checks/new.html.erb
+++ b/app/views/provider_interface/offer/checks/new.html.erb
@@ -12,7 +12,7 @@
       <%= f.govuk_error_summary %>
       <%= render ProviderInterface::OfferSummaryComponent.new(application_choice: @application_choice,
                                                               course_option: @wizard.course_option,
-                                                              conditions: @wizard.conditions,
+                                                              conditions: @wizard.conditions_to_render,
                                                               course: @wizard.course_option.course,
                                                               available_providers: @providers,
                                                               available_courses: @courses,

--- a/app/views/provider_interface/offers/show.html.erb
+++ b/app/views/provider_interface/offers/show.html.erb
@@ -17,7 +17,7 @@
     <% if provider_user_can_make_decisions && @application_choice.offer? %>
       <%= render ProviderInterface::CompletedOfferSummaryComponent.new(application_choice: @application_choice,
                                                                        course_option: @application_choice.current_course_option,
-                                                                       conditions: @application_choice.offer['conditions'],
+                                                                       conditions: @application_choice.offer.conditions,
                                                                        course: @application_choice.current_course,
                                                                        available_providers: @providers,
                                                                        available_courses: @courses,

--- a/app/views/provider_interface/offers/show.html.erb
+++ b/app/views/provider_interface/offers/show.html.erb
@@ -26,7 +26,7 @@
     <% else %>
       <%= render ProviderInterface::ReadOnlyCompletedOfferSummaryComponent.new(application_choice: @application_choice,
                                                                                course_option: @application_choice.current_course_option,
-                                                                               conditions: @application_choice.offer['conditions'],
+                                                                               conditions: @application_choice.offer.conditions,
                                                                                course: @application_choice.current_course,
                                                                                available_providers: [],
                                                                                available_courses: [],

--- a/app/views/provider_interface/reconfirm_deferred_offers/conditions.html.erb
+++ b/app/views/provider_interface/reconfirm_deferred_offers/conditions.html.erb
@@ -15,7 +15,7 @@
         <%= render ProviderInterface::ConditionsComponent.new(application_choice: @wizard.modified_application_choice) %>
       </div>
 
-      <% met = @wizard.modified_application_choice.status == 'recruited' ? 'still met' : 'met' %>
+      <% met = @wizard.modified_application_choice.recruited? ? 'still met' : 'met' %>
 
       <%= f.govuk_radio_buttons_fieldset :conditions_status,
         legend: { text: "Has the candidate #{met} all of the conditions?", size: 'm' } do %>

--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -149,9 +149,10 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent do
 
   context 'when an offer has been made to a course choice' do
     it 'renders component with the status as offer when an offer has been made' do
+      conditions = [build(:offer_condition, text: 'DBS check'), build(:offer_condition, text: 'Get a haircut')]
       application_form = create_application_form_with_course_choices(statuses: %w[offer])
       application_choice = application_form.application_choices.first
-      application_choice.update!(offer: { conditions: ['DBS check', 'Get a haircut'] })
+      create(:offer, application_choice: application_choice, conditions: conditions)
 
       result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
 

--- a/spec/components/candidate_interface/offer_review_component_spec.rb
+++ b/spec/components/candidate_interface/offer_review_component_spec.rb
@@ -5,14 +5,13 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
 
   let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
   let(:application_form) { create(:application_form, submitted_at: Time.zone.now) }
+  let(:conditions) { [build(:offer_condition, text: 'Fitness to train to teach check'), build(:offer_condition, text: 'Be cool')] }
   let(:application_choice) do
-    create(
-      :application_choice,
-      status: 'offer',
-      offer: { 'conditions' => ['Fitness to train to teach check', 'Be cool'] },
-      course_option: course_option,
-      application_form: application_form,
-    )
+    create(:application_choice,
+           :with_offer,
+           offer: build(:offer, conditions: conditions),
+           course_option: course_option,
+           application_form: application_form)
   end
   let(:find_closes) { EndOfCycleTimetable::CYCLE_DATES.dig(Time.zone.now.year, :find_closes) }
 
@@ -69,13 +68,11 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
 
   context 'when there are no conditions' do
     let(:application_choice) do
-      create(
-        :application_choice,
-        status: 'offer',
-        offer: { 'conditions' => [] },
-        course_option: course_option,
-        application_form: application_form,
-      )
+      create(:application_choice,
+             :with_offer,
+             offer: build(:unconditional_offer),
+             course_option: course_option,
+             application_form: application_form)
     end
 
     it 'does not render a conditions row' do

--- a/spec/components/provider_interface/completed_offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/completed_offer_summary_component_spec.rb
@@ -1,7 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::CompletedOfferSummaryComponent do
-  let(:application_choice) { build_stubbed(:application_choice) }
+  let(:application_choice) do
+    build_stubbed(:application_choice,
+                  :with_offer,
+                  offer: build(:offer, conditions: conditions))
+  end
+  let(:conditions) do
+    [build(:offer_condition, text: 'condition 1'),
+     build(:offer_condition, text: 'condition 2')]
+  end
   let(:course_option) { build_stubbed(:course_option, course: course) }
   let(:providers) { [] }
   let(:course) { build_stubbed(:course, accredited_provider: build(:provider)) }
@@ -10,7 +18,7 @@ RSpec.describe ProviderInterface::CompletedOfferSummaryComponent do
   let(:render) do
     render_inline(described_class.new(application_choice: application_choice,
                                       course_option: course_option,
-                                      conditions: ['condition 1', 'condition 2'],
+                                      conditions: conditions,
                                       available_providers: providers,
                                       available_courses: courses,
                                       available_course_options: course_options,

--- a/spec/components/provider_interface/conditions_component_spec.rb
+++ b/spec/components/provider_interface/conditions_component_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe ProviderInterface::ConditionsComponent do
       offer = build(:offer, conditions: [build(:offer_condition, status: 'met')])
       application_with_conditions_met = build_stubbed(:application_choice,
                                                       :with_offer,
-                                                      :recruited)
-      allow(application_with_conditions_met).to receive(:offer).and_return(offer)
+                                                      :recruited,
+                                                      offer: offer)
 
       result = render_inline(described_class.new(application_choice: application_with_conditions_met))
 
@@ -37,8 +37,8 @@ RSpec.describe ProviderInterface::ConditionsComponent do
       application_with_conditions_met = build_stubbed(:application_choice,
                                                       :with_offer,
                                                       :offer_deferred,
-                                                      status_before_deferral: 'recruited')
-      allow(application_with_conditions_met).to receive(:offer).and_return(offer)
+                                                      status_before_deferral: 'recruited',
+                                                      offer: offer)
 
       result = render_inline(described_class.new(application_choice: application_with_conditions_met))
 

--- a/spec/components/provider_interface/conditions_component_spec.rb
+++ b/spec/components/provider_interface/conditions_component_spec.rb
@@ -2,34 +2,43 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::ConditionsComponent do
   describe 'rendered component' do
-    let(:conditions) { ['Fitness to teach check'] }
-
     it 'renders the conditions' do
-      application_with_conditions_met = build(:application_choice, status: 'recruited', offer: { 'conditions' => conditions })
+      application_with_conditions_met = build_stubbed(:application_choice,
+                                                      :with_offer,
+                                                      :recruited)
       result = render_inline(described_class.new(application_choice: application_with_conditions_met))
 
-      expect(result.to_html).to include('Fitness to teach check')
+      expect(result.to_html).to include(application_with_conditions_met.offer.conditions.first.text)
     end
 
     it 'indicates whether conditions are met' do
-      application_with_conditions_met = build(:application_choice, status: 'recruited', offer: { 'conditions' => conditions })
+      offer = build(:offer, conditions: [build(:offer_condition, status: 'met')])
+      application_with_conditions_met = build_stubbed(:application_choice,
+                                                      :with_offer,
+                                                      :recruited)
+      allow(application_with_conditions_met).to receive(:offer).and_return(offer)
+
       result = render_inline(described_class.new(application_choice: application_with_conditions_met))
 
       expect(result.css('.govuk-tag').text).to eq('Met')
     end
 
     it 'indicates whether conditions are pending' do
-      application_with_pending_conditions = build(:application_choice, status: 'awaiting_provider_decision', offer: { 'conditions' => conditions })
+      application_with_pending_conditions = build_stubbed(:application_choice,
+                                                          :with_offer,
+                                                          :awaiting_provider_decision)
       result = render_inline(described_class.new(application_choice: application_with_pending_conditions))
 
       expect(result.css('.govuk-tag').text).to eq('Pending')
     end
 
     it 'indicates whether conditions are met for deferred offers' do
-      application_with_conditions_met = build(:application_choice,
-                                              status: 'offer_deferred',
-                                              status_before_deferral: 'recruited',
-                                              offer: { 'conditions' => conditions })
+      offer = build(:offer, conditions: [build(:offer_condition, status: 'met')])
+      application_with_conditions_met = build_stubbed(:application_choice,
+                                                      :with_offer,
+                                                      :offer_deferred,
+                                                      status_before_deferral: 'recruited')
+      allow(application_with_conditions_met).to receive(:offer).and_return(offer)
 
       result = render_inline(described_class.new(application_choice: application_with_conditions_met))
 
@@ -37,10 +46,10 @@ RSpec.describe ProviderInterface::ConditionsComponent do
     end
 
     it 'indicates whether conditions are pending for deferred offers' do
-      application_with_pending_conditions = build(:application_choice,
-                                                  status: 'offer_deferred',
-                                                  status_before_deferral: 'pending_conditions',
-                                                  offer: { 'conditions' => conditions })
+      application_with_pending_conditions = build_stubbed(:application_choice,
+                                                          :with_offer,
+                                                          :offer_deferred,
+                                                          status_before_deferral: 'pending_conditions')
 
       result = render_inline(described_class.new(application_choice: application_with_pending_conditions))
 

--- a/spec/components/provider_interface/offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/offer_summary_component_spec.rb
@@ -3,7 +3,12 @@ require 'rails_helper'
 RSpec.describe ProviderInterface::OfferSummaryComponent do
   include Rails.application.routes.url_helpers
 
-  let(:application_choice) { build_stubbed(:application_choice) }
+  let(:application_choice) do
+    build_stubbed(:application_choice,
+                  :with_offer,
+                  offer: build(:offer, conditions: conditions))
+  end
+  let(:conditions) { [build(:offer_condition, text: 'condition 1')] }
   let(:course_option) { build_stubbed(:course_option) }
   let(:providers) { [] }
   let(:course) { build_stubbed(:course) }
@@ -11,8 +16,9 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
   let(:course_options) { [] }
   let(:editable) { true }
   let(:render) do
-    render_inline(described_class.new(application_choice: application_choice, course_option: course_option,
-                                      conditions: ['condition 1'],
+    render_inline(described_class.new(application_choice: application_choice,
+                                      course_option: course_option,
+                                      conditions: application_choice.offer.conditions,
                                       available_providers: providers,
                                       available_courses: courses,
                                       available_course_options: course_options,
@@ -121,30 +127,30 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
   end
 
   context 'when conditions are set' do
-    context 'when application is recruited' do
-      let(:application_choice) { build_stubbed(:application_choice, :with_recruited) }
+    context 'when status is set to met' do
+      let(:conditions) { [build(:offer_condition, :met)] }
 
       it 'renders conditions as met' do
         expect(render.css('.conditions-row .govuk-tag')[0].text).to eq('Met')
-        expect(render.css('.conditions-row .govuk-table__cell')[0].text).to eq('condition 1')
+        expect(render.css('.conditions-row .govuk-table__cell')[0].text).to eq(conditions.first.text)
       end
     end
 
-    context 'when application is on conditions_not_met' do
-      let(:application_choice) { build_stubbed(:application_choice, :with_conditions_not_met) }
+    context 'when status is set to unmet' do
+      let(:conditions) { [build(:offer_condition, :unmet)] }
 
       it 'renders conditions as met' do
         expect(render.css('.conditions-row .govuk-tag')[0].text).to eq('Not met')
-        expect(render.css('.conditions-row .govuk-table__cell')[0].text).to eq('condition 1')
+        expect(render.css('.conditions-row .govuk-table__cell')[0].text).to eq(conditions.first.text)
       end
     end
 
-    context 'when application is on offer state' do
-      let(:application_choice) { build_stubbed(:application_choice, :with_offer) }
+    context 'when status is set to pending' do
+      let(:conditions) { [build(:offer_condition, :pending)] }
 
       it 'renders conditions as met' do
         expect(render.css('.conditions-row .govuk-tag')[0].text).to eq('Pending')
-        expect(render.css('.conditions-row .govuk-table__cell')[0].text).to eq('condition 1')
+        expect(render.css('.conditions-row .govuk-table__cell')[0].text).to eq(conditions.first.text)
       end
     end
   end

--- a/spec/components/provider_interface/read_only_completed_offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/read_only_completed_offer_summary_component_spec.rb
@@ -3,7 +3,12 @@ require 'rails_helper'
 RSpec.describe ProviderInterface::ReadOnlyCompletedOfferSummaryComponent do
   include Rails.application.routes.url_helpers
 
-  let(:application_choice) { build_stubbed(:application_choice) }
+  let(:application_choice) do
+    build_stubbed(:application_choice,
+                  :with_offer,
+                  offer: build(:offer, conditions: conditions))
+  end
+  let(:conditions) { [build(:offer_condition, text: 'condition 1')] }
   let(:course_option) { build_stubbed(:course_option) }
   let(:providers) { [] }
   let(:course) { build_stubbed(:course) }
@@ -11,8 +16,9 @@ RSpec.describe ProviderInterface::ReadOnlyCompletedOfferSummaryComponent do
   let(:course_options) { [] }
   let(:editable) { false }
   let(:render) do
-    render_inline(described_class.new(application_choice: application_choice, course_option: course_option,
-                                      conditions: ['condition 1'],
+    render_inline(described_class.new(application_choice: application_choice,
+                                      course_option: course_option,
+                                      conditions: conditions,
                                       available_providers: providers,
                                       available_courses: courses,
                                       available_course_options: course_options,

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -67,7 +67,13 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
   end
 
   context 'Unconditional offer' do
-    let(:unconditional_offer) { create(:application_choice, :with_completed_application_form, :with_recruited, offer: { 'conditions' => [] }) }
+    let(:unconditional_offer) do
+      create(:application_choice,
+             :with_completed_application_form,
+             :with_offer,
+             :with_recruited,
+             offer: build(:unconditional_offer))
+    end
 
     it 'renders a link to the change the offered course choice when the `change_offered_course` flag is active' do
       FeatureFlag.activate(:support_user_change_offered_course)

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -162,14 +162,11 @@ FactoryBot.define do
       status { 'offer' }
       decline_by_default_at { 10.business_days.from_now }
       decline_by_default_days { 10 }
-      offer { { 'conditions' => ['Be cool'] } }
       offered_at { Time.zone.now }
 
-      after(:build) do |choice, _evaluator|
-        offer = create(:offer, application_choice: choice, conditions: [])
-        choice.offer['conditions'].each do |condition|
-          create(:offer_condition, text: condition, offer: offer)
-        end
+      after(:build) do |application_choice, _evaluator|
+        condition = build(:offer_condition, text: 'Be cool')
+        build(:offer, application_choice: application_choice, conditions: [condition])
       end
     end
 

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -168,6 +168,17 @@ FactoryBot.define do
         condition = build(:offer_condition, text: 'Be cool')
         build(:offer, application_choice: application_choice, conditions: [condition])
       end
+
+      after(:stub) do |application_choice, _evaluator|
+        condition = build(:offer_condition, text: 'Be cool')
+        offer = build(:offer, application_choice: application_choice, conditions: [condition])
+        allow(application_choice).to receive(:offer).and_return(offer)
+      end
+
+      after(:create) do |application_choice, _evaluator|
+        condition = build(:offer_condition, text: 'Be cool')
+        create(:offer, application_choice: application_choice, conditions: [condition])
+      end
     end
 
     trait :with_modified_offer do

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -169,10 +169,14 @@ FactoryBot.define do
         build(:offer, application_choice: application_choice, conditions: [condition])
       end
 
-      after(:stub) do |application_choice, _evaluator|
-        condition = build(:offer_condition, text: 'Be cool')
-        offer = build(:offer, application_choice: application_choice, conditions: [condition])
-        allow(application_choice).to receive(:offer).and_return(offer)
+      after(:stub) do |application_choice, evaluator|
+        if evaluator.offer.present?
+          allow(application_choice).to receive(:offer).and_return(evaluator.offer)
+        else
+          condition = build(:offer_condition, text: 'Be cool')
+          offer = build(:offer, application_choice: application_choice, conditions: [condition])
+          allow(application_choice).to receive(:offer).and_return(offer)
+        end
       end
 
       after(:create) do |application_choice, evaluator|

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -175,9 +175,14 @@ FactoryBot.define do
         allow(application_choice).to receive(:offer).and_return(offer)
       end
 
-      after(:create) do |application_choice, _evaluator|
-        condition = build(:offer_condition, text: 'Be cool')
-        create(:offer, application_choice: application_choice, conditions: [condition])
+      after(:create) do |application_choice, evaluator|
+        if evaluator.offer.present?
+          evaluator.offer.update(application_choice: application_choice)
+        else
+          condition = build(:offer_condition, text: 'Be cool')
+          create(:offer, application_choice: application_choice, conditions: [condition])
+        end
+        application_choice
       end
     end
 

--- a/spec/factories/offer.rb
+++ b/spec/factories/offer.rb
@@ -4,4 +4,8 @@ FactoryBot.define do
 
     conditions { [association(:offer_condition, offer: instance)] }
   end
+
+  factory :unconditional_offer, class: 'Offer' do
+    application_choice
+  end
 end

--- a/spec/factories/offer_condition.rb
+++ b/spec/factories/offer_condition.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     offer
 
     text { 'Evidence of being cool' }
+    status { 'pending' }
   end
 end

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -102,8 +102,11 @@ RSpec.describe ProviderInterface::OfferWizard do
   end
 
   describe '.build_from_application_choice' do
-    let(:application_choice) { create(:application_choice, offer: offer) }
-    let(:offer) { { 'conditions' => ['Fitness to train to teach check', 'Be cool'] } }
+    let(:application_choice) { create(:application_choice, :with_offer, offer: build(:offer, conditions: conditions)) }
+    let(:conditions) do
+      [build(:offer_condition, text: 'Fitness to train to teach check'),
+       build(:offer_condition, text: 'Be cool')]
+    end
     let(:options) { {} }
     let(:wizard) do
       described_class.build_from_application_choice(
@@ -135,7 +138,7 @@ RSpec.describe ProviderInterface::OfferWizard do
     end
 
     context 'when there is no offer present' do
-      let(:offer) { nil }
+      let(:application_choice) { create(:application_choice) }
 
       it 'populates the conditions with the standard ones' do
         expect(wizard).to be_valid

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
   describe '.changed_offer' do
     let(:email) { mailer.changed_offer(application_choices.first) }
-    let(:application_choice) { build_stubbed(:submitted_application_choice, course_option: course_option, current_course_option: other_option, decline_by_default_at: 10.business_days.from_now) }
+    let(:application_choice) { build_stubbed(:submitted_application_choice, :with_changed_offer, course_option: course_option, current_course_option: other_option, decline_by_default_at: 10.business_days.from_now) }
     let(:application_choices) { [application_choice] }
 
     it_behaves_like(

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -22,29 +22,26 @@ class CandidateMailerPreview < ActionMailer::Preview
 
   def changed_offer
     application_form = application_form_with_course_choices([application_choice_with_offer, application_choice_with_offer])
-    application_choice = FactoryBot.build_stubbed(
-      :submitted_application_choice,
-      course_option: course_option,
-      application_form: application_form,
-      current_course_option: course_option,
-      decline_by_default_at: 10.business_days.from_now,
-    )
+    application_choice = FactoryBot.build_stubbed(:submitted_application_choice,
+                                                  :with_offer,
+                                                  course_option: course_option,
+                                                  application_form: application_form,
+                                                  current_course_option: course_option,
+                                                  decline_by_default_at: 10.business_days.from_now)
 
     CandidateMailer.changed_offer(application_choice)
   end
 
   def changed_unconditional_offer
     application_form = application_form_with_course_choices([application_choice_with_offer, application_choice_with_offer])
-    application_choice = FactoryBot.build_stubbed(
-      :submitted_application_choice,
-      status: :offer,
-      offer: { 'conditions' => [] },
-      offered_at: Time.zone.now,
-      current_course_option: course_option,
-      course_option: course_option,
-      application_form: application_form,
-      decline_by_default_at: 10.business_days.from_now,
-    )
+    application_choice = FactoryBot.build_stubbed(:submitted_application_choice,
+                                                  :with_offer,
+                                                  offer: FactoryBot.build_stubbed(:unconditional_offer),
+                                                  offered_at: Time.zone.now,
+                                                  current_course_option: course_option,
+                                                  course_option: course_option,
+                                                  application_form: application_form,
+                                                  decline_by_default_at: 10.business_days.from_now)
 
     CandidateMailer.changed_offer(application_choice)
   end
@@ -105,49 +102,54 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def new_offer_single_offer
-    application_choice = application_form.application_choices.build(
-      course_option: course_option,
-      status: :offer,
-      offer: { conditions: ['DBS check', 'Pass exams'] },
-      offered_at: Time.zone.now,
-      current_course_option: course_option,
-      decline_by_default_at: 10.business_days.from_now,
-    )
+    conditions = [FactoryBot.build(:offer_condition, text: 'DBS check'),
+                  FactoryBot.build(:offer_condition, text: 'Pass exams')]
+    application_choice = FactoryBot.build_stubbed(:application_choice,
+                                                  :with_offer,
+                                                  application_form: application_form,
+                                                  course_option: course_option,
+                                                  offer: FactoryBot.build_stubbed(:offer, conditions: conditions),
+                                                  current_course_option: course_option,
+                                                  decline_by_default_at: 10.business_days.from_now)
     CandidateMailer.new_offer_single_offer(application_choice)
   end
 
   def new_offer_multiple_offers
     course_option = FactoryBot.build_stubbed(:course_option, site: site)
-    application_choice = application_form.application_choices.build(
-      course_option: course_option,
-      status: :offer,
-      offer: { conditions: ['DBS check', 'Pass exams'] },
-      offered_at: Time.zone.now,
-      current_course_option: course_option,
-      decline_by_default_at: 10.business_days.from_now,
-    )
+    conditions = [FactoryBot.build(:offer_condition, text: 'DBS check'),
+                  FactoryBot.build(:offer_condition, text: 'Pass exams')]
+    application_choice = FactoryBot.build_stubbed(:application_choice,
+                                                  :with_offer,
+                                                  application_form: application_form,
+                                                  course_option: course_option,
+                                                  offer: FactoryBot.build_stubbed(:offer, conditions: conditions),
+                                                  current_course_option: course_option,
+                                                  decline_by_default_at: 10.business_days.from_now)
+
     other_course_option = FactoryBot.build_stubbed(:course_option, site: site)
-    application_form.application_choices.build(
-      course_option: other_course_option,
-      status: :offer,
-      offer: { conditions: ['Get a degree'] },
-      offered_at: Time.zone.now,
-      current_course_option: other_course_option,
-      decline_by_default_at: 7.business_days.from_now,
-    )
+    conditions = [FactoryBot.build(:offer_condition, text: 'Get a degree')]
+    FactoryBot.build_stubbed(:application_choice,
+                             :with_offer,
+                             application_form: application_form,
+                             course_option: other_course_option,
+                             offer: FactoryBot.build_stubbed(:offer, conditions: conditions),
+                             current_course_option: other_course_option,
+                             decline_by_default_at: 7.business_days.from_now)
+
     CandidateMailer.new_offer_multiple_offers(application_choice)
   end
 
   def new_offer_decisions_pending
     course_option = FactoryBot.build_stubbed(:course_option, site: site)
-    application_choice = application_form.application_choices.build(
-      course_option: course_option,
-      status: :offer,
-      offer: { conditions: ['DBS check', 'Pass exams'] },
-      offered_at: Time.zone.now,
-      current_course_option: course_option,
-      decline_by_default_at: 10.business_days.from_now,
-    )
+    conditions = [FactoryBot.build(:offer_condition, text: 'DBS check'),
+                  FactoryBot.build(:offer_condition, text: 'Pass exams')]
+    application_choice = FactoryBot.build_stubbed(:application_choice,
+                                                  :with_offer,
+                                                  application_form: application_form,
+                                                  offer: FactoryBot.build_stubbed(:offer, conditions: conditions),
+                                                  current_course_option: course_option,
+                                                  decline_by_default_at: 10.business_days.from_now)
+
     other_course_option = FactoryBot.build_stubbed(:course_option, site: site)
     application_form.application_choices.build(
       course_option: other_course_option,
@@ -158,14 +160,13 @@ class CandidateMailerPreview < ActionMailer::Preview
 
   def new_unconditional_offer_decisions_pending
     course_option = FactoryBot.build_stubbed(:course_option, site: site)
-    application_choice = application_form.application_choices.build(
-      course_option: course_option,
-      status: :offer,
-      offer: { 'conditions' => [] },
-      offered_at: Time.zone.now,
-      current_course_option: course_option,
-      decline_by_default_at: 10.business_days.from_now,
-    )
+
+    application_choice = FactoryBot.build_stubbed(:application_choice,
+                                                  :with_offer,
+                                                  application_form: application_form,
+                                                  offer: FactoryBot.build_stubbed(:unconditional_offer),
+                                                  current_course_option: course_option,
+                                                  decline_by_default_at: 10.business_days.from_now)
     other_course_option = FactoryBot.build_stubbed(:course_option, site: site)
     application_form.application_choices.build(
       course_option: other_course_option,
@@ -562,7 +563,7 @@ class CandidateMailerPreview < ActionMailer::Preview
       :with_recruited,
       application_form: application_form,
       course_option: course_option,
-      offer: { 'conditions' => [] },
+      offer: FactoryBot.build_stubbed(:unconditional_offer),
       offer_deferred_at: Time.zone.local(2019, 10, 14),
     )
     CandidateMailer.reinstated_offer(application_choice)

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -247,9 +247,9 @@ RSpec.describe ApplicationChoice, type: :model do
 
     context 'recruited unconditionally' do
       it 'returns true' do
-        application_choice = build_stubbed(:application_choice, :with_recruited)
-        offer = build(:unconditional_offer)
-        allow(application_choice).to receive(:offer).and_return(offer)
+        application_choice = build_stubbed(:application_choice,
+                                           :with_recruited,
+                                           offer: build(:unconditional_offer))
 
         expect(application_choice.unconditional_offer?).to eq true
       end

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -247,7 +247,10 @@ RSpec.describe ApplicationChoice, type: :model do
 
     context 'recruited unconditionally' do
       it 'returns true' do
-        application_choice = build_stubbed(:application_choice, :with_recruited, offer: { 'conditions' => [] })
+        application_choice = build_stubbed(:application_choice, :with_recruited)
+        offer = build(:unconditional_offer)
+        allow(application_choice).to receive(:offer).and_return(offer)
+
         expect(application_choice.unconditional_offer?).to eq true
       end
     end

--- a/spec/requests/vendor_api/post_conditions_met_spec.rb
+++ b/spec/requests/vendor_api/post_conditions_met_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-conditio
   it_behaves_like 'an endpoint that requires metadata', '/confirm-conditions-met'
 
   it 'confirms the conditions have been met' do
-    application_choice = create_application_choice_for_currently_authenticated_provider(status: 'pending_conditions')
+    attributes = { status: 'pending_conditions', offered_at: Time.zone.now }
+    application_choice = create_application_choice_for_currently_authenticated_provider(attributes)
     create(:offer, application_choice: application_choice)
 
     post_api_request "/api/v1/applications/#{application_choice.id}/confirm-conditions-met"

--- a/spec/requests/vendor_api/post_conditions_not_met_spec.rb
+++ b/spec/requests/vendor_api/post_conditions_not_met_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/conditions-not-m
   it_behaves_like 'an endpoint that requires metadata', '/conditions-not-met'
 
   it 'confirms the conditions have not been met' do
-    application_choice = create_application_choice_for_currently_authenticated_provider(status: 'pending_conditions')
+    attributes = { status: 'pending_conditions', offered_at: Time.zone.now }
+    application_choice = create_application_choice_for_currently_authenticated_provider(attributes)
     create(:offer, application_choice: application_choice)
 
     post_api_request "/api/v1/applications/#{application_choice.id}/conditions-not-met"

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -374,8 +374,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       choice = create(:application_choice,
                       :with_completed_application_form,
                       :with_offer,
-                      course_option: course_option_for_provider(provider: currently_authenticated_provider),
-                      offer: { 'conditions' => ['DBS check'] })
+                      course_option: course_option_for_provider(provider: currently_authenticated_provider))
 
       request_body = {
         "data": {
@@ -386,24 +385,20 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
         },
       }
 
-      expect {
-        post_api_request "/api/v1/applications/#{choice.id}/offer", params: request_body
-      }.to(change { choice.reload.offer })
+      post_api_request "/api/v1/applications/#{choice.id}/offer", params: request_body
+      expect(choice.offer.conditions.map(&:text)).to eq(['Change your sheets', 'Wash your clothes'])
     end
 
     it 'returns 200 OK when sending the same offer & conditions repeatedly' do
       choice = create(:application_choice,
                       :with_completed_application_form,
                       :with_offer,
-                      course_option: course_option_for_provider(provider: currently_authenticated_provider),
-                      offer: { 'conditions' => ['DBS check'] })
+                      course_option: course_option_for_provider(provider: currently_authenticated_provider))
 
       request_body = {
         "data": {
-          "conditions": [
-            'DBS check',
-          ],
-          "course": course_option_to_course_payload(choice.current_course_option),
+          "conditions": choice.offer.conditions.map(&:text),
+          "course": course_option_to_course_payload(choice.course_option),
         },
       }
 

--- a/spec/services/accept_offer_spec.rb
+++ b/spec/services/accept_offer_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe AcceptOffer do
     end
 
     it 'sends a confirmation email to the candidate' do
-      application_choice = create(:application_choice, status: :offer)
+      application_choice = create(:application_choice, :with_offer)
 
       expect { described_class.new(application_choice: application_choice).save! }.to change { ActionMailer::Base.deliveries.count }.by(1)
       expect(ActionMailer::Base.deliveries.first.to).to eq [application_choice.application_form.candidate.email_address]

--- a/spec/services/accept_offer_spec.rb
+++ b/spec/services/accept_offer_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe AcceptOffer do
   it 'calls AcceptUnconditionalOffer when the feature is enabled and the offer is unconditional' do
     FeatureFlag.activate(:unconditional_offers_via_api)
 
-    application_choice = build(:application_choice, status: :offer, offer: { conditions: [] })
+    application_choice = create(:application_choice,
+                                :with_offer,
+                                offer: build(:unconditional_offer))
     allow(AcceptUnconditionalOffer).to receive(:new).and_call_original
 
     described_class.new(application_choice: application_choice).save!

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe ChangeOffer do
     end
     let(:course_option) { course_option_for_provider(provider: application_choice.course_option.provider) }
     let(:new_conditions) { [Faker::Lorem.sentence] }
+    let(:conditions) { [build(:offer_condition, text: 'DBS check')] }
     let(:application_choice) do
-      create(:application_choice, :with_offer, offer: { 'conditions' => ['DBS check'] })
+      create(:application_choice, :with_offer, offer: build(:offer, conditions: conditions))
     end
 
     describe 'if the actor is not authorised to perform this action' do

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe ChangeOffer do
             .to receive(:new).with(application_form: application_choice.application_form)
                     .and_return(set_declined_by_default)
         allow(UpdateOfferConditions)
-            .to receive(:new).with(application_choice: application_choice)
+            .to receive(:new).with(application_choice: application_choice, conditions: new_conditions)
                     .and_return(update_offer_conditions_service)
 
         change_offer.save!

--- a/spec/services/conditions_not_met_spec.rb
+++ b/spec/services/conditions_not_met_spec.rb
@@ -42,7 +42,9 @@ RSpec.describe ConditionsNotMet do
   end
 
   it 'creates an offer object if it does not exist' do
-    application_choice = create(:application_choice, offer: { conditions: ['Be cool'] }, status: :pending_conditions)
+    application_choice = create(:application_choice,
+                                :with_offer,
+                                :pending_conditions)
 
     described_class.new(
       actor: create(:support_user),

--- a/spec/services/confirm_offer_conditions_spec.rb
+++ b/spec/services/confirm_offer_conditions_spec.rb
@@ -47,7 +47,9 @@ RSpec.describe ConfirmOfferConditions do
   end
 
   it 'creates an offer object if it does not exist' do
-    application_choice = create(:application_choice, offer: { conditions: ['Be cool'] }, status: :pending_conditions)
+    application_choice = create(:application_choice,
+                                :with_offer,
+                                :pending_conditions)
 
     described_class.new(
       actor: create(:support_user),

--- a/spec/services/make_offer_spec.rb
+++ b/spec/services/make_offer_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe MakeOffer do
             .to receive(:new).with(application_choice: application_choice)
                     .and_return(send_new_offer_email_to_candidate)
         allow(UpdateOfferConditions)
-            .to receive(:new).with(application_choice: application_choice)
+            .to receive(:new).with(application_choice: application_choice, conditions: conditions)
                      .and_return(update_offer_conditions_service)
 
         make_offer.save!

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe OfferValidations, type: :model do
       context 'when the offer details are identical to the existing offer' do
         let(:application_choice) { build_stubbed(:application_choice, :with_offer) }
         let(:course_option) { application_choice.course_option }
-        let(:conditions) { application_choice.offer['conditions'] }
+        let(:conditions) { application_choice.offer.conditions.map(&:text) }
 
         it 'raises an IdenticalOfferError' do
           expect { offer.valid? }.to raise_error(IdenticalOfferError)
@@ -91,7 +91,7 @@ RSpec.describe OfferValidations, type: :model do
         let(:application_choice) { build_stubbed(:application_choice, :with_offer, current_course_option: current_course_option) }
         let(:current_course_option) { create(:course_option, :open_on_apply) }
         let(:course_option) { build(:course_option, :open_on_apply) }
-        let(:conditions) { application_choice.offer['conditions'] }
+        let(:conditions) { application_choice.offer.conditions.map(&:text) }
 
         it 'adds a :different_ratifying_provider error' do
           expect(offer).to be_invalid

--- a/spec/services/reinstate_conditions_met_spec.rb
+++ b/spec/services/reinstate_conditions_met_spec.rb
@@ -44,14 +44,14 @@ RSpec.describe ReinstateConditionsMet do
   end
 
   context 'when the application does not have an offer object associated' do
+    let(:conditions) { [build(:offer_condition, text: 'Be cool')] }
     let(:application_choice) do
-      create(
-        :application_choice,
-        offer: { conditions: ['Be cool'] },
-        status: :offer_deferred,
-        status_before_deferral: :pending_conditions,
-        course_option: previous_course_option,
-      )
+      create(:application_choice,
+             :with_offer,
+             :offer_deferred,
+             offer: build(:offer, conditions: conditions),
+             status_before_deferral: :pending_conditions,
+             course_option: previous_course_option)
     end
 
     it 'creates an offer object' do

--- a/spec/services/reinstate_pending_conditions_spec.rb
+++ b/spec/services/reinstate_pending_conditions_spec.rb
@@ -39,14 +39,14 @@ RSpec.describe ReinstatePendingConditions do
   end
 
   context 'when the application does not have an offer object associated' do
+    let(:conditions) { [build(:offer_condition, text: 'Be cool')] }
     let(:application_choice) do
-      create(
-        :application_choice,
-        offer: { conditions: ['Be cool'] },
-        status: :offer_deferred,
-        status_before_deferral: :pending_conditions,
-        course_option: previous_course_option,
-      )
+      create(:application_choice,
+             :with_offer,
+             :offer_deferred,
+             offer: build(:offer, conditions: conditions),
+             status_before_deferral: :pending_conditions,
+             course_option: previous_course_option)
     end
 
     it 'creates an offer object' do

--- a/spec/services/support_interface/offer_conditions_export_spec.rb
+++ b/spec/services/support_interface/offer_conditions_export_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe SupportInterface::OfferConditionsExport do
     end
 
     it 'returns phase information for each offer' do
-      unsuccessful_application_choices = [build(:application_choice, :with_declined_offer),
-                                          build(:application_choice, :withdrawn)]
+      unsuccessful_application_choices = [create(:application_choice, :with_declined_offer),
+                                          create(:application_choice, :withdrawn)]
       apply_1_form = create(:completed_application_form,
                             application_choices: unsuccessful_application_choices)
       apply_2_form = ApplyAgain.new(apply_1_form).call
@@ -133,7 +133,8 @@ RSpec.describe SupportInterface::OfferConditionsExport do
 
     it 'includes offer conditions' do
       choice = create(:application_choice, :with_modified_offer)
-      choice.update(offer: { 'conditions' => ['DBS Check', 'Be cool'] })
+      choice.offer.conditions = [build(:offer_condition, text: 'DBS Check'), build(:offer_condition, text: 'Be cool')]
+      choice.offer.save
 
       offers = described_class.new.offers
       expect(offers.first[:conditions]).to eq('DBS Check, Be cool')

--- a/spec/services/update_offer_conditions_spec.rb
+++ b/spec/services/update_offer_conditions_spec.rb
@@ -1,11 +1,12 @@
 require 'rails_helper'
 RSpec.describe UpdateOfferConditions do
   let(:conditions) { ['Test', 'Test but longer'] }
-  let(:application_choice) { create(:application_choice, offer: { conditions: conditions }) }
+  let(:application_choice) { create(:application_choice) }
 
   describe '#call' do
     it 'writes the conditions to the offer conditions model' do
-      described_class.new(application_choice: application_choice).call
+      described_class.new(application_choice: application_choice, conditions: conditions).call
+
       offer = Offer.find_by(application_choice: application_choice)
       expect(offer.conditions.count).to eq(2)
       expect(offer.conditions.first.text).to eq('Test')
@@ -16,7 +17,7 @@ RSpec.describe UpdateOfferConditions do
       let(:conditions) { nil }
 
       it 'does not create any offer conditions' do
-        described_class.new(application_choice: application_choice).call
+        described_class.new(application_choice: application_choice, conditions: conditions).call
 
         offer = Offer.find_by(application_choice: application_choice)
         expect(offer.conditions).to be_empty
@@ -46,13 +47,16 @@ RSpec.describe UpdateOfferConditions do
     end
 
     context 'when there is an existing offer' do
-      let!(:existing_offer) { create(:offer, application_choice: application_choice) }
+      let(:conditions) { [build(:offer_condition, text: 'Evidence of being cool')] }
+      let(:application_choice) { create(:application_choice, :with_offer, offer: build(:offer, conditions: conditions)) }
 
-      it 'overwrites the existing offer' do
+      it 'overwrites the existing offer conditions' do
         offer = Offer.find_by(application_choice: application_choice)
         expect(offer.conditions.count).to eq(1)
         expect(offer.conditions.first.text).to eq('Evidence of being cool')
-        described_class.new(application_choice: application_choice).call
+
+        described_class.new(application_choice: application_choice, conditions: ['Test', 'Test but longer']).call
+
         offer = Offer.find_by(application_choice: application_choice)
         expect(offer.conditions.count).to eq(2)
         expect(offer.conditions.first.text).to eq('Test')

--- a/spec/system/provider_interface/change_existing_offer_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_spec.rb
@@ -8,9 +8,14 @@ RSpec.feature 'Provider changes an existing offer' do
   let(:provider) { provider_user.providers.first }
   let(:ratifying_provider) { create(:provider) }
   let(:application_form) { build(:application_form, :minimum_info) }
+  let(:conditions) do
+    [build(:offer_condition, text: 'Fitness to train to teach check'),
+     build(:offer_condition, text: 'Be cool')]
+  end
   let!(:application_choice) do
-    create(:application_choice, :with_offer,
-           offer: { conditions: ['Fitness to train to teach check', 'Be cool'] },
+    create(:application_choice,
+           :with_offer,
+           offer: build(:offer, conditions: conditions),
            application_form: application_form,
            current_course_option: course_option)
   end

--- a/spec/system/support_interface/change_offer_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_conditions_spec.rb
@@ -43,9 +43,12 @@ RSpec.feature 'Add course to submitted application' do
         candidate: candidate,
       )
 
+      conditions = [build(:offer_condition, text: 'Be cool')]
       @application_choice = create(
         :application_choice,
+        :with_offer,
         :with_accepted_offer,
+        offer: build(:offer, conditions: conditions),
         application_form: @application_form,
       )
     end


### PR DESCRIPTION

## Context
Read offer data from Offer and OfferConditions in the Manage UI.

## Link to Trello card

https://trello.com/c/x9taO1pU/3731-%F0%9F%8F%88-start-reading-from-new-offer-and-conditions-tables

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
