### PR TITLE
Add further sanitization to the Science GCSE form mk2

### DIFF
--- a/app/forms/candidate_interface/science_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/science_gcse_grade_form.rb
@@ -203,7 +203,9 @@ module CandidateInterface
     end
 
     def sanitize(grade)
-      if DOUBLE_GCSE_GRADES.exclude?(grade)
+      if ALL_GCSE_GRADES.exclude?(grade) && grade_contains_number?(grade)
+        grade&.gsub(/[^%\d]/, '')&.insert(1, '-')
+      elsif DOUBLE_GCSE_GRADES.exclude?(grade)
         grade&.gsub(/[^*\w]/, '')&.upcase
       else
         grade
@@ -242,6 +244,12 @@ module CandidateInterface
       return true unless qualification.pass_gcse?
 
       qualification.update(missing_explanation: nil)
+    end
+
+    def grade_contains_number?(grade)
+      return false if grade.nil?
+
+      grade.count('0-9').positive?
     end
   end
 end

--- a/app/forms/candidate_interface/science_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/science_gcse_grade_form.rb
@@ -203,10 +203,10 @@ module CandidateInterface
     end
 
     def sanitize(grade)
-      if ALL_GCSE_GRADES.exclude?(grade) && grade_contains_number?(grade)
-        grade&.gsub(/[^%\d]/, '')&.insert(1, '-')
+      if ALL_GCSE_GRADES.exclude?(grade) && grade_contains_two_numbers?(grade)
+        remove_special_characters_and_add_dash_between_numbers(grade)
       elsif DOUBLE_GCSE_GRADES.exclude?(grade)
-        grade&.gsub(/[^*\w]/, '')&.upcase
+        remove_special_characters_and_upcase(grade)
       else
         grade
       end
@@ -246,10 +246,18 @@ module CandidateInterface
       qualification.update(missing_explanation: nil)
     end
 
-    def grade_contains_number?(grade)
+    def grade_contains_two_numbers?(grade)
       return false if grade.nil?
 
-      grade.count('0-9').positive?
+      grade.count('0-9') == 2
+    end
+
+    def remove_special_characters_and_add_dash_between_numbers(grade)
+      grade&.gsub(/[^%\d]/, '')&.insert(1, '-')
+    end
+
+    def remove_special_characters_and_upcase(grade)
+      grade&.gsub(/[^*\w]/, '')&.upcase
     end
   end
 end

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -154,7 +154,7 @@ class ApplicationQualification < ApplicationRecord
     details.strip if details.present?
   end
 
-  GCSE_PASS_GRADES = %w[A* A B C A*A* A*A AA AB BB BC CC CD 9 8 7 6 5 4 99 98 88 87 77 76 66 65 55 54 44 43].freeze
+  GCSE_PASS_GRADES = %w[A* A B C A*A* A*A AA AB BB BC CC CD 9 8 7 6 5 4 9-9 9-8 8-8 8-7 7-7 7-6 6-6 6-5 5-5 5-4 4-4 4-3].freeze
   def failed_required_gcse?
     return true if required_gcse? && all_grades.present? && !pass_gcse?
 

--- a/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
@@ -302,6 +302,24 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
         expect(qualification.grade).to eq('A*A*')
       end
 
+      it 'stores a sanitized grade when it is a numerical double award' do
+        application_form = build(:application_form)
+        qualification = ApplicationQualification.create(
+          level: 'gcse',
+          application_form: application_form,
+        )
+
+        details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+
+        details_form.subject = ApplicationQualification::SCIENCE_DOUBLE_AWARD
+        details_form.grade = '43'
+
+        details_form.save
+        qualification.reload
+
+        expect(qualification.grade).to eq('4-3')
+      end
+
       it 'stores sanitized grades when it is a triple award' do
         application_form = build(:application_form)
         qualification = ApplicationQualification.create(

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -302,5 +302,13 @@ RSpec.describe ApplicationQualification, type: :model do
       grades = { english_language: { grade: 'E', public_id: 120282 }, english_literature: { grade: 'D', public_id: 120283 } }
       expect(build(:gcse_qualification, :multiple_english_gcses, constituent_grades: grades).failed_required_gcse?).to be true
     end
+
+    it 'returns false if the qualification is Double Award GCSE and has a numerical pass grade' do
+      expect(build(:gcse_qualification, grade: '4-3').failed_required_gcse?).to be false
+    end
+
+    it 'returns true if the qualification is Double Award GCSE and has a numerical fail grade' do
+      expect(build(:gcse_qualification, grade: '3-3').failed_required_gcse?).to be true
+    end
   end
 end


### PR DESCRIPTION
## Context

Paul retested the GCSE form and found that grades in the following format thre errors and were not sanitised: 4/4, 4/3  & 4,4, 4,3 

44, 43 also throw a validation error, we should update all numbers including the above to be separated by a dash i.e. 4-4 and 4-3

He also found that the 'You need a science GCSE at grade 4 (C) or above, or equivalent page' rendered whenever you enter a any numbered grade – it should only show if you enter a grade that isn’t a pass grade (this is shown if entering a valid double grade for both English and Maths double award subjects)

## Changes proposed in this pull request

Adding another clause that inserts '-' between numerical a double award grade in
the '44' format. This also strips numerical grades of any mistyped non
numeric characters before doing this (I have made an exception in the
case of '%' as this will now just return a validation error. 

Also, I found that numerical grades were all being tagged as failures by the
failed_required_gcse? method as the pass grades array had been incorrectly
input.

## Guidance to review

Test the above examples in the review app. Are there any loose ends? Also would appreciate thoughts on any other symbols to exclude from the sanitize method.

## Link to Trello card

https://trello.com/c/ajbpi20L/3394-double-gcse-grades

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
