### PR TITLE
Update provider service guidance

### DIFF
--- a/app/views/content/service_guidance_provider.md
+++ b/app/views/content/service_guidance_provider.md
@@ -221,7 +221,7 @@ You can make these changes, and also amend conditions, even if the offer has alr
 
 The candidate will receive a formal notification of the changed offer, but you should also explain and agree any changes with them directly via email or phone.
 
-Once the candidate has accepted your offer, you cannot change the terms of the offer without their permission.
+Once the candidate has accepted your offer, you cannot change the terms of it within the service. You'll need to get the candidate's permission to make the change, then email us at <becomingateacher@digital.education.gov.uk>.
 
 ### Confirming the conditions of an offer
 


### PR DESCRIPTION
## Context

Update Manage service guidance to help users know that they can only change an accepted offer with the candidate's permission.

## Changes proposed in this pull request

### Before
<img width="711" alt="service-guidance-before" src="https://user-images.githubusercontent.com/159200/119743336-9385a500-be81-11eb-8838-1798f5f777c0.png">

### After
<img width="709" alt="service-guidance-after" src="https://user-images.githubusercontent.com/159200/119743222-502b3680-be81-11eb-823f-d9c0944ea47c.png">

## Link to Trello card

https://trello.com/c/RfyUKuUw/3732-update-manage-service-guidance-to-help-users-know-that-they-can-only-change-an-accepted-offer-with-the-candidates-permission

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
