### PR TITLE
Audit changes to the provider user’s notification preferences

### DIFF
--- a/app/models/provider_user_notification_preferences.rb
+++ b/app/models/provider_user_notification_preferences.rb
@@ -1,6 +1,8 @@
 class ProviderUserNotificationPreferences < ApplicationRecord
   belongs_to :provider_user
 
+  audited associated_with: :provider_user, on: [:update]
+
   self.table_name = :provider_user_notifications
 
   NOTIFICATION_PREFERENCES = %i[

--- a/spec/models/provider_user_notification_preferences_spec.rb
+++ b/spec/models/provider_user_notification_preferences_spec.rb
@@ -27,4 +27,16 @@ RSpec.describe ProviderUserNotificationPreferences do
       expect(described_class.notification_preference_exists?(:application_exploded)).to eq(false)
     end
   end
+
+  describe 'auditing' do
+    it 'updating adds an audit entry related to the provider_user', with_audited: true do
+      notification_preferences = create(:provider_user_notification_preferences)
+      notification_preferences.update(application_withdrawn: false)
+
+      audit = notification_preferences.provider_user.associated_audits.last
+
+      expect(notification_preferences.provider_user.associated_audits.count).to eq(1)
+      expect(audit.audited_changes['application_withdrawn']).to eq([true, false])
+    end
+  end
 end


### PR DESCRIPTION
## Context
Audit changes to the provider user's notification settings to enable tracking changes over time

## Guidance to review
1. Login as provider user
2. Update notification settings
3. Login to support
4. Check history for provider user


## Link to Trello card

https://trello.com/c/TQJBfGhT/3740-adding-changes-to-provider-user-notification-settings-to-the-audit-table

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
