### PR TITLE
Give the remaining backlinks explicit targets

### DIFF
--- a/app/controllers/candidate_interface/safeguarding_controller.rb
+++ b/app/controllers/candidate_interface/safeguarding_controller.rb
@@ -7,6 +7,21 @@ module CandidateInterface
       @section_complete_form = SectionCompleteForm.new(completed: current_application.safeguarding_issues_completed)
     end
 
+    def new
+      @safeguarding_form = SafeguardingIssuesDeclarationForm.build_from_application(current_application)
+    end
+
+    def create
+      @safeguarding_form = SafeguardingIssuesDeclarationForm.new(safeguarding_params)
+
+      if @safeguarding_form.save(current_application)
+        redirect_to candidate_interface_review_safeguarding_path
+      else
+        track_validation_error(@safeguarding_form)
+        render :new
+      end
+    end
+
     def edit
       @safeguarding_form = SafeguardingIssuesDeclarationForm.build_from_application(current_application)
     end

--- a/app/controllers/candidate_interface/volunteering/role_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/role_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class Volunteering::RoleController < Volunteering::BaseController
     def new
+      set_previous_path
       @volunteering_role = VolunteeringRoleForm.new
     end
 
@@ -10,6 +11,7 @@ module CandidateInterface
       if @volunteering_role.save(current_application)
         redirect_to candidate_interface_review_volunteering_path
       else
+        set_previous_path
         track_validation_error(@volunteering_role)
         render :new
       end
@@ -55,6 +57,14 @@ module CandidateInterface
           .transform_keys { |key| start_date_field_to_attribute(key) }
           .transform_keys { |key| end_date_field_to_attribute(key) },
       )
+    end
+
+    def set_previous_path
+      @previous_path = if current_application.application_volunteering_experiences.present?
+                         candidate_interface_review_volunteering_path
+                       else
+                         candidate_interface_volunteering_experience_path
+                       end
     end
   end
 end

--- a/app/views/candidate_interface/course_choices/site_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/site_selection/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.which_location'), @pick_site.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_course_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/decisions/accept_offer.html.erb
+++ b/app/views/candidate_interface/decisions/accept_offer.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.decisions.accept_offer') %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_offer_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/decisions/decline_offer.html.erb
+++ b/app/views/candidate_interface/decisions/decline_offer.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.decisions.decline_offer') %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_offer_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.decisions.offer'), @respond_to_offer.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_complete_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_complete_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/decisions/withdraw.html.erb
+++ b/app/views/candidate_interface/decisions/withdraw.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.decisions.withdraw') %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_complete_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/english_foreign_language/ielts/edit.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/ielts/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.ielts'), @ielts_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_english_foreign_language_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/english_foreign_language/ielts/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/ielts/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.ielts'), @ielts_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_english_foreign_language_type_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/english_foreign_language/other_efl_qualification/edit.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/other_efl_qualification/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.other'), @other_qualification_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_english_foreign_language_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/english_foreign_language/other_efl_qualification/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/other_efl_qualification/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.other'), @other_qualification_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_english_foreign_language_type_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/english_foreign_language/review/show.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/review/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.efl.review') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_english_foreign_language_complete_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/english_foreign_language/start/edit.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/start/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.start'), @start_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_english_foreign_language_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/english_foreign_language/start/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/start/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.start'), @start_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/english_foreign_language/toefl/edit.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/toefl/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.toefl'), @toefl_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_english_foreign_language_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/english_foreign_language/toefl/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/toefl/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.toefl'), @toefl_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_english_foreign_language_type_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/english_foreign_language/type/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/type/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.type'), @type_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_english_foreign_language_start_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/other_qualifications/details/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.qualification_details'), @form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_other_qualification_type_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, other_qualifications_title(@application_form) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_complete_other_qualifications_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/other_qualifications/type/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(other_qualifications_title(current_application), @form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_review_other_qualifications_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/other_qualifications/type/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/new.html.erb
@@ -1,8 +1,8 @@
 <% content_for :title, title_with_error_prefix(other_qualifications_title(current_application), @form.errors.any?) %>
 <% if current_application.application_qualifications.other.blank? && !current_application.no_other_qualifications %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+  <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 <% else %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_review_other_qualifications_path, 'Back') %>
+  <% content_for :before_content, govuk_back_link_to(candidate_interface_review_other_qualifications_path) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/references/request/new.html.erb
+++ b/app/views/candidate_interface/references/request/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, t('page_titles.references_send_request') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_references_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/references/retry_request/new.html.erb
+++ b/app/views/candidate_interface/references/retry_request/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.references_retry_request') %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_references_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/references/review/confirm_cancel.html.erb
+++ b/app/views/candidate_interface/references/review/confirm_cancel.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.references_cancel_request') %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_references_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/references/review/confirm_destroy_referee.html.erb
+++ b/app/views/candidate_interface/references/review/confirm_destroy_referee.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.references_delete_referee') %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_references_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/references/review/confirm_destroy_reference.html.erb
+++ b/app/views/candidate_interface/references/review/confirm_destroy_reference.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.references_delete_reference') %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_references_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/references/review/confirm_destroy_reference_request.html.erb
+++ b/app/views/candidate_interface/references/review/confirm_destroy_reference_request.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.references_delete_request') %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_references_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.references'), @too_many_references) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <% if @too_many_references %>
   <div class="govuk-error-summary" tabindex="-1" role="alert" data-module="govuk-error-summary" aria-labelledby="error-summary-title">

--- a/app/views/candidate_interface/references/review/show_for_reference_selection.html.erb
+++ b/app/views/candidate_interface/references/review/show_for_reference_selection.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.references') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/restructured_work_history/break/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/break/confirm_destroy.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.destroy_work_history_break') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_restructured_work_history_review_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_restructured_work_history_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/restructured_work_history/job/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/job/confirm_destroy.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.restructured_work_history_destroy') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_restructured_work_history_review_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_restructured_work_history_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/restructured_work_history/job/new.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/job/new.html.erb
@@ -2,7 +2,7 @@
 <% if current_application.application_work_experiences.present? %>
   <% content_for :before_content, govuk_back_link_to(candidate_interface_restructured_work_history_review_path) %>
 <% else %>
-  <% content_for :before_content, govuk_back_link_to %>
+  <% content_for :before_content, govuk_back_link_to(candidate_interface_restructured_work_history_path) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.work_history') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_restructured_work_history_complete_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/restructured_work_history/start/choice.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/start/choice.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.work_history'), @choice_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/safeguarding/_form.html.erb
+++ b/app/views/candidate_interface/safeguarding/_form.html.erb
@@ -1,0 +1,39 @@
+<%= f.govuk_error_summary %>
+
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.suitability_to_work_with_children') %>
+</h1>
+
+<p class="govuk-body">
+  Teacher training providers need to check that it’s safe for you to work
+  with children and young people.
+</p>
+
+<p class="govuk-body">
+  As well as confirming your identity and your right to work in the UK,
+  providers will check:
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>your criminal record in the UK (they’ll do an enhanced <%= govuk_link_to 'Disclosure and Barring Service check', 'https://www.gov.uk/government/organisations/disclosure-and-barring-service/about#dbs-checks', target: '_blank' %>) and abroad where relevant</li>
+  <li>whether you’ve been banned from teaching or working with children</li>
+  <li>your professional behaviour, such as whether you’ve been removed from teacher training and what your referees say about you</li>
+</ul>
+
+<p class="govuk-body">
+  Tell your provider about any potential safeguarding issues, such as
+  offences, cautions, reprimands and final warnings. They can give advice
+  about whether this will affect your application.
+</p>
+
+<p class="govuk-body">It will not necessarily stop you becoming a teacher.</p>
+
+<%= f.govuk_radio_buttons_fieldset :share_safeguarding_issues, legend: { text: 'Do you want to share any safeguarding issues?', size: 'm' } do %>
+  <%= f.govuk_radio_button :share_safeguarding_issues, 'Yes', label: { text: 'Yes, I want to share something' }, hint: { text: 'After you have submitted your application, your provider may be in touch to discuss the information you shared. If you prefer, you can contact your provider directly.' }, link_errors: true do %>
+    <%= f.govuk_text_area :safeguarding_issues, rows: 8, label: { text: 'Give any relevant information', size: 's' }, max_words: 400 %>
+  <% end %>
+
+  <%= f.govuk_radio_button :share_safeguarding_issues, 'No', label: { text: 'No' } %>
+<% end %>
+
+<%= f.govuk_submit t('continue') %>

--- a/app/views/candidate_interface/safeguarding/new.html.erb
+++ b/app/views/candidate_interface/safeguarding/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.suitability_to_work_with_children'), @safeguarding_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_review_safeguarding_path) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -213,7 +213,7 @@
           <%= render(TaskListItemComponent.new(
             text: t('page_titles.suitability_to_work_with_children'),
             completed: @application_form_presenter.safeguarding_completed?,
-            path: @application_form_presenter.safeguarding_valid? ? candidate_interface_review_safeguarding_path : candidate_interface_edit_safeguarding_path,
+            path: @application_form_presenter.safeguarding_valid? ? candidate_interface_review_safeguarding_path : candidate_interface_new_safeguarding_path,
           )) %>
         </li>
       </ol>

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.volunteering.short') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_complete_volunteering_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/volunteering/role/edit.html.erb
+++ b/app/views/candidate_interface/volunteering/role/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.edit_volunteering_role'), @volunteering_role.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_review_volunteering_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/volunteering/role/new.html.erb
+++ b/app/views/candidate_interface/volunteering/role/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.add_volunteering_role'), @volunteering_role.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(@previous_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/volunteering/start/show.html.erb
+++ b/app/views/candidate_interface/volunteering/start/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.volunteering.long'), @volunteering_experience_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(:back) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <div class="govuk-grid-row">
   <%= form_with model: @volunteering_experience_form, url: candidate_interface_volunteering_experience_path do |f| %>

--- a/app/views/candidate_interface/work_history/break/edit.html.erb
+++ b/app/views/candidate_interface/work_history/break/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.work_history_break'), @work_break.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_show_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/work_history/edit/edit.html.erb
+++ b/app/views/candidate_interface/work_history/edit/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.edit_job'), @work_experience_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_show_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/work_history/edit/new.html.erb
+++ b/app/views/candidate_interface/work_history/edit/new.html.erb
@@ -2,7 +2,7 @@
 <% if current_application.application_work_experiences.present? %>
   <% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_show_path) %>
 <% else %>
-  <% content_for :before_content, govuk_back_link_to %>
+  <% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_length_path) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/work_history/edit/new.html.erb
+++ b/app/views/candidate_interface/work_history/edit/new.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.add_job'), @work_experience_form.errors.any?) %>
-<% if current_application.application_work_experiences.present? %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_show_path) %>
-<% else %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_length_path) %>
-<% end %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_show_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/work_history/explanation/show.html.erb
+++ b/app/views/candidate_interface/work_history/explanation/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.work_history_explanation'), @work_explanation_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_length_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/work_history/explanation/show.html.erb
+++ b/app/views/candidate_interface/work_history/explanation/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.work_history_explanation'), @work_explanation_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_length_path) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_show_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/work_history/length/show.html.erb
+++ b/app/views/candidate_interface/work_history/length/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.work_history'), @work_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/work_history/review/show.html.erb
+++ b/app/views/candidate_interface/work_history/review/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.work_history') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_work_history_complete_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -527,8 +527,10 @@ Rails.application.routes.draw do
       end
 
       scope '/safeguarding' do
-        get '/' => 'safeguarding#edit', as: :edit_safeguarding
-        post '/' => 'safeguarding#update'
+        get '/' => 'safeguarding#new', as: :new_safeguarding
+        patch '/' => 'safeguarding#create'
+        get '/edit' => 'safeguarding#edit', as: :edit_safeguarding
+        patch '/edit' => 'safeguarding#update'
         get '/review' => 'safeguarding#show', as: :review_safeguarding
         post '/complete' => 'safeguarding#complete', as: :complete_safeguarding
       end


### PR DESCRIPTION
## Context

 This is the last PR for giving all of our backlinks explicit targets and all if cost was my sanity.

It covers the following:

1.  work history section 
2.  volunteering 
3. safeguarding
4. restructured work history
5. other quals
6. EFL
7. decisions
8. site selection
9. references (just the view about deleting/resending etc.)

## Changes proposed in this pull request

Pass explicit backlink targets to *all* remaining sections of the application form

## Guidance to review

- Per commit will be easiest 

## Link to Trello card

https://trello.com/c/GuiJ30Jg/3397-catch-all-give-back-links-explicit-targets

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
