### PR TITLE
Export path in Dockerfile to avoid having to type full path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,8 @@ WORKDIR /app
 
 COPY --from=assets-precompile /app /app
 COPY --from=assets-precompile /usr/local/bundle/ /usr/local/bundle/
+RUN echo export PATH=/usr/local/bin:\$PATH > /root/.ashrc
+ENV ENV="/root/.ashrc"
 
 RUN echo ${VERSION} > public/check
 


### PR DESCRIPTION
## Context

We currently have to include the full path to run `/usr/local/bin/bundle exec` when sshing into the container

## Changes proposed in this pull request

Export path in Dockerfile when building the container

## Guidance to review

There are multiple ways to do this:
```
ENV PATH="/usr/local/bin:$PATH"
```
However it seems this doesn't work with everyone as might be overwritten. We could also just run the export path but also might face the same problem.

Let me know your thoughts. I went with examples from: https://github.com/DFE-Digital/register-trainee-teachers/blob/ee3d92b6e66465f8462562dac32a4abca1cf08b1/Dockerfile#L28
and https://github.com/DFE-Digital/teaching-vacancies/blob/master/Dockerfile#L50

Maybe one of the other options works better/is more idiomatic in the Dockerfile.

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
