### PR TITLE
 🏈 refactor move offer related concerns from application choice to the offer class

### DIFF
--- a/app/components/candidate_interface/application_dashboard_course_choices_component.rb
+++ b/app/components/candidate_interface/application_dashboard_course_choices_component.rb
@@ -115,7 +115,7 @@ module CandidateInterface
         key: 'Condition'.pluralize(application_choice.offer.conditions.count),
         value: render(
           OfferConditionsReviewComponent.new(
-            conditions: application_choice.offer.conditions.map(&:text),
+            conditions: application_choice.offer.conditions_text,
             provider: application_choice.current_course.provider.name,
           ),
         ),

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -42,7 +42,7 @@ module CandidateInterface
     def conditions_row
       {
         key: 'Conditions',
-        value: render(OfferConditionsReviewComponent.new(conditions: @course_choice.offer.conditions.map(&:text), provider: @course_choice.current_course.provider.name)),
+        value: render(OfferConditionsReviewComponent.new(conditions: @course_choice.offer.conditions_text, provider: @course_choice.current_course.provider.name)),
       }
     end
 

--- a/app/components/support_interface/application_choice_component.html.erb
+++ b/app/components/support_interface/application_choice_component.html.erb
@@ -1,6 +1,6 @@
 <%= render SummaryCardComponent.new(rows: rows) do %>
   <%= render SummaryCardHeaderComponent.new(title: title, heading_level: 3, anchor: anchor) do %>
-    <% if FeatureFlag.active?(:support_user_change_offered_course) && (application_choice.pending_conditions? || application_choice.unconditional_offer?) %>
+    <% if FeatureFlag.active?(:support_user_change_offered_course) && (application_choice.pending_conditions? || application_choice.unconditional_offer_pending_recruitment?) %>
       <div class="app-summary-card__actions">
         <ul class="app-summary-card__actions-list">
           <div class="app-summary-card__actions">

--- a/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
+++ b/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
@@ -84,7 +84,7 @@ module SupportInterface
           redirect_to support_interface_application_form_path(@application_form.id) unless FeatureFlag.active?(:support_user_change_offered_course) &&
             (
               @application_choice.pending_conditions? ||
-              @application_choice.unconditional_offer?
+              @application_choice.unconditional_offer_pending_recruitment?
             )
         end
       end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -115,7 +115,7 @@ module ProviderInterface
     def self.standard_conditions_from(offer)
       return MakeOffer::STANDARD_CONDITIONS if offer.blank?
 
-      conditions = offer.conditions.map(&:text)
+      conditions = offer.conditions_text
       conditions & MakeOffer::STANDARD_CONDITIONS
     end
 
@@ -124,7 +124,7 @@ module ProviderInterface
     def self.further_conditions_from(offer)
       return [] if offer.blank?
 
-      conditions = offer.conditions.map(&:text)
+      conditions = offer.conditions_text
       conditions - MakeOffer::STANDARD_CONDITIONS
     end
 

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -53,14 +53,14 @@ module SupportInterface
     def self.standard_conditions_from(offer)
       return [] if offer.blank?
 
-      conditions = offer.conditions.map(&:text)
+      conditions = offer.conditions_text
       conditions & MakeOffer::STANDARD_CONDITIONS
     end
 
     def self.further_conditions_from(offer)
       return [] if offer.blank?
 
-      conditions = offer.conditions.map(&:text)
+      conditions = offer.conditions_text
       conditions - MakeOffer::STANDARD_CONDITIONS
     end
 

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -218,7 +218,7 @@ class CandidateMailer < ApplicationMailer
 
   def changed_offer(application_choice)
     @application_choice = application_choice
-    @conditions = @application_choice.offer.conditions.map(&:text)
+    @conditions = @application_choice.offer.conditions_text
 
     @course_option = @application_choice.course_option
     @current_course_option = @application_choice.current_course_option
@@ -257,7 +257,7 @@ class CandidateMailer < ApplicationMailer
   def reinstated_offer(application_choice)
     @application_choice = application_choice
     @course_option = @application_choice.current_course_option
-    @conditions = @application_choice.offer.conditions.map(&:text)
+    @conditions = @application_choice.offer.conditions_text
 
     email_for_candidate(
       @application_choice.application_form,
@@ -430,7 +430,7 @@ private
     course_option = CourseOption.find_by(id: @application_choice.current_course_option_id) || @application_choice.course_option
     @provider_name = course_option.course.provider.name
     @course_name = course_option.course.name_and_code
-    @conditions = @application_choice.offer.conditions.map(&:text)
+    @conditions = @application_choice.offer.conditions_text
     @offers = @application_choice.self_and_siblings.select(&:offer?).map do |offer|
       "#{offer.course_option.course.name_and_code} at #{offer.course_option.course.provider.name}"
     end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -168,9 +168,13 @@ class ApplicationChoice < ApplicationRecord
   end
 
   def unconditional_offer?
+    offer&.unconditional?
+  end
+
+  def unconditional_offer_pending_recruitment?
     return false unless recruited?
 
-    offer&.unconditional?
+    unconditional_offer?
   end
 
 private

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -170,7 +170,7 @@ class ApplicationChoice < ApplicationRecord
   def unconditional_offer?
     return false unless recruited?
 
-    offer.conditions.none?
+    offer&.unconditional?
   end
 
 private

--- a/app/models/course_option.rb
+++ b/app/models/course_option.rb
@@ -5,6 +5,7 @@ class CourseOption < ApplicationRecord
 
   audited associated_with: :provider
   delegate :provider, to: :course
+  delegate :accredited_provider, to: :course
   delegate :name, :full_address, to: :site, prefix: true
 
   validates :vacancy_status, presence: true

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -2,6 +2,10 @@ class Offer < ApplicationRecord
   belongs_to :application_choice
   has_many :conditions, class_name: 'OfferCondition', dependent: :destroy
 
+  has_one :course_option, through: :application_choice, source: :current_course_option
+
+  delegate :course, :site, :provider, :accredited_provider, to: :course_option
+
   def unconditional?
     conditions.none?
   end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -5,6 +5,7 @@ class Offer < ApplicationRecord
   has_one :course_option, through: :application_choice, source: :current_course_option
 
   delegate :course, :site, :provider, :accredited_provider, to: :course_option
+  delegate :offered_at, to: :application_choice
 
   def unconditional?
     conditions.none?

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -10,4 +10,8 @@ class Offer < ApplicationRecord
   def unconditional?
     conditions.none?
   end
+
+  def conditions_text
+    conditions.pluck(:text)
+  end
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,4 +1,8 @@
 class Offer < ApplicationRecord
   belongs_to :application_choice
   has_many :conditions, class_name: 'OfferCondition', dependent: :destroy
+
+  def unconditional?
+    conditions.none?
+  end
 end

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -353,7 +353,7 @@ module VendorAPI
       return nil if application_choice.offer.nil?
 
       {
-        conditions: application_choice.offer.reload.conditions.map(&:text),
+        conditions: application_choice.offer.reload.conditions_text,
         offer_made_at: application_choice.offered_at,
         offer_accepted_at: application_choice.accepted_at,
         offer_declined_at: application_choice.declined_at,

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -1,16 +1,18 @@
 class AcceptOffer
+  attr_reader :application_choice
+
   def initialize(application_choice:)
     @application_choice = application_choice
   end
 
   def save!
     if FeatureFlag.active?(:unconditional_offers_via_api) && unconditional_offer?
-      return AcceptUnconditionalOffer.new(application_choice: @application_choice).save!
+      return AcceptUnconditionalOffer.new(application_choice: application_choice).save!
     end
 
     ActiveRecord::Base.transaction do
-      ApplicationStateChange.new(@application_choice).accept!
-      @application_choice.update!(accepted_at: Time.zone.now)
+      ApplicationStateChange.new(application_choice).accept!
+      application_choice.update!(accepted_at: Time.zone.now)
 
       StateChangeNotifier.disable_notifications do
         other_application_choices_with_offers.each do |application_choice|
@@ -23,29 +25,27 @@ class AcceptOffer
       end
     end
 
-    NotificationsList.for(@application_choice, event: :offer_accepted, include_ratifying_provider: true).each do |provider_user|
-      ProviderMailer.offer_accepted(provider_user, @application_choice).deliver_later
+    NotificationsList.for(application_choice, event: :offer_accepted, include_ratifying_provider: true).each do |provider_user|
+      ProviderMailer.offer_accepted(provider_user, application_choice).deliver_later
     end
 
-    CandidateMailer.offer_accepted(@application_choice).deliver_later
+    CandidateMailer.offer_accepted(application_choice).deliver_later
   end
 
 private
 
   def other_application_choices_with_offers
-    @application_choice
+    application_choice
       .self_and_siblings
       .offer
-      .where.not(id: @application_choice.id)
+      .where.not(id: application_choice.id)
   end
 
   def application_choices_awaiting_provider_decision
-    @application_choice
+    application_choice
       .self_and_siblings
       .decision_pending
   end
 
-  def unconditional_offer?
-    @application_choice.offer.conditions.none?
-  end
+  delegate :unconditional_offer?, to: :application_choice
 end

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -36,7 +36,7 @@ class OfferValidations
   end
 
   def identical_to_existing_offer?
-    if application_choice.current_course_option == course_option && application_choice.offer.conditions.map(&:text).sort == conditions.sort
+    if application_choice.current_course_option == course_option && application_choice.offer.conditions_text.sort == conditions.sort
       raise IdenticalOfferError
     end
   end

--- a/app/services/support_interface/offer_conditions_export.rb
+++ b/app/services/support_interface/offer_conditions_export.rb
@@ -60,7 +60,7 @@ module SupportInterface
     end
 
     def conditions(choice)
-      choice.offer.conditions.map(&:text).join(', ')
+      choice.offer.conditions_text.join(', ')
     end
 
     def relevant_choices

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -30,7 +30,7 @@
       <p class="govuk-body">If you need help, you can speak to our <%= govuk_link_to 'teacher training advisers', t('get_into_teaching.url_get_an_advisor') %>.</p>
 
       <%= f.govuk_radio_buttons_fieldset :response, legend: { text: t('decisions.response.legend'), size: 'm' } do %>
-        <% if @application_choice.offer.conditions.none? %>
+        <% if @application_choice.unconditional_offer? %>
           <%= f.govuk_radio_button :response, 'accept', label: { text: t('decisions.response.accept_no_conditions.label') }, link_errors: true %>
         <% else %>
           <%= f.govuk_radio_button :response, 'accept', label: { text: t('decisions.response.accept.label') }, link_errors: true %>

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -178,6 +178,7 @@ FactoryBot.define do
           condition = build(:offer_condition, text: 'Be cool')
           offer = build(:offer, application_choice: application_choice, conditions: [condition])
           allow(application_choice).to receive(:offer).and_return(offer)
+          allow(offer).to receive(:conditions_text).and_return(offer.conditions.map(&:text))
         end
       end
 

--- a/spec/factories/offer_condition.rb
+++ b/spec/factories/offer_condition.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :offer_condition do
     offer
 
-    text { 'Evidence of being cool' }
+    text { Faker::Lorem.sentence }
     status { 'pending' }
   end
 end

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe SupportInterface::ConditionsForm do
       )
       expect(form.save).to be(false)
       expect(form.errors.full_messages).to include('Audit comment ticket Enter a Zendesk ticket URL')
-      expect(application_choice.offer.conditions.map(&:text)).to eq([
+      expect(application_choice.offer.conditions_text).to eq([
         'Fitness to train to teach check',
         'Get a haircut',
       ])
@@ -112,7 +112,7 @@ RSpec.describe SupportInterface::ConditionsForm do
       )
       form.save
 
-      expect(application_choice.offer.reload.conditions.map(&:text)).to eq([
+      expect(application_choice.offer.reload.conditions_text).to eq([
         'Fitness to train to teach check',
         'Disclosure and Barring Service (DBS) check',
         'Get a haircut',
@@ -141,7 +141,7 @@ RSpec.describe SupportInterface::ConditionsForm do
       form.save
 
       offer = Offer.find_by(application_choice: application_choice)
-      expect(offer.conditions.map(&:text)).to eq(
+      expect(offer.conditions_text).to eq(
         [
           'Fitness to train to teach check',
           'Disclosure and Barring Service (DBS) check',
@@ -169,7 +169,7 @@ RSpec.describe SupportInterface::ConditionsForm do
         'audit_comment_ticket' => 'https://becomingateacher.zendesk.com/agent/tickets/12345',
       )
       form.save
-      expect(application_choice.offer.reload.conditions.map(&:text)).to eq(
+      expect(application_choice.offer.reload.conditions_text).to eq(
         [
           'Disclosure and Barring Service (DBS) check',
           'Wear a tie',

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -237,11 +237,11 @@ RSpec.describe ApplicationChoice, type: :model do
     end
   end
 
-  describe '#unconditional_offer?' do
+  describe '#unconditional_offer_pending_recruitment?' do
     context 'recruited with conditions' do
       it 'returns false' do
         application_choice = build_stubbed(:application_choice, :with_recruited)
-        expect(application_choice.unconditional_offer?).to eq false
+        expect(application_choice.unconditional_offer_pending_recruitment?).to eq false
       end
     end
 
@@ -249,7 +249,7 @@ RSpec.describe ApplicationChoice, type: :model do
       it 'returns true' do
         application_choice = build_stubbed(:application_choice, :with_recruited, offer: create(:unconditional_offer))
 
-        expect(application_choice.unconditional_offer?).to eq true
+        expect(application_choice.unconditional_offer_pending_recruitment?).to eq true
       end
     end
 
@@ -259,8 +259,26 @@ RSpec.describe ApplicationChoice, type: :model do
 
         statuses.each do |status|
           application_choice = build_stubbed(:application_choice, status: status)
-          expect(application_choice.unconditional_offer?).to eq false
+          expect(application_choice.unconditional_offer_pending_recruitment?).to eq false
         end
+      end
+    end
+  end
+
+  describe '#unconditional_offer' do
+    context 'when the offer has no conditions' do
+      it 'returns true' do
+        application_choice = build_stubbed(:application_choice, :with_recruited, offer: create(:unconditional_offer))
+
+        expect(application_choice.unconditional_offer?).to be true
+      end
+    end
+
+    context 'when the offer has conditions' do
+      it 'returns false' do
+        application_choice = build_stubbed(:application_choice, :with_offer, offer: create(:offer))
+
+        expect(application_choice.unconditional_offer?).to be false
       end
     end
   end

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -247,9 +247,7 @@ RSpec.describe ApplicationChoice, type: :model do
 
     context 'recruited unconditionally' do
       it 'returns true' do
-        application_choice = build_stubbed(:application_choice,
-                                           :with_recruited,
-                                           offer: build(:unconditional_offer))
+        application_choice = build_stubbed(:application_choice, :with_recruited, offer: create(:unconditional_offer))
 
         expect(application_choice.unconditional_offer?).to eq true
       end

--- a/spec/models/offer_condition_spec.rb
+++ b/spec/models/offer_condition_spec.rb
@@ -8,4 +8,13 @@ RSpec.describe OfferCondition do
       expect(offer_condition.application_choice).not_to be_nil
     end
   end
+
+  describe '#conditions_text' do
+    it 'returns an array with the text of all the offer conditions' do
+      conditions = build_list(:offer_condition, 4)
+      offer = create(:offer, conditions: conditions)
+
+      expect(offer.conditions_text).to eq(conditions.map(&:text))
+    end
+  end
 end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -54,5 +54,14 @@ RSpec.describe Offer do
         expect(offer.accredited_provider).to eq(offer.course_option.accredited_provider)
       end
     end
+
+    describe '#offered_at' do
+      let(:application_choice) { create(:application_choice) }
+      let(:offer) { create(:offer, application_choice: application_choice) }
+
+      it 'returns the offered_at related to the application_choice' do
+        expect(offer.offered_at).to eq(offer.course_option.accredited_provider)
+      end
+    end
   end
 end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -9,6 +9,15 @@ RSpec.describe Offer do
 
       expect(offer.conditions.map(&:text)).to contain_exactly('Provide evidence of degree qualification', 'Do a backflip and send us a video')
     end
+
+    describe '#course_option' do
+      it 'returns the application choice current_course_option' do
+        application_choice = create(:application_choice, current_course_option: create(:course_option))
+        offer = create(:offer, application_choice: application_choice)
+
+        expect(offer.course_option).to eq(application_choice.reload.current_course_option)
+      end
+    end
   end
 
   describe '#unconditional' do
@@ -16,6 +25,34 @@ RSpec.describe Offer do
       offer = create(:unconditional_offer)
 
       expect(offer.unconditional?).to be true
+    end
+  end
+
+  context 'delegators' do
+    let(:offer) { create(:offer, course_option: create(:course_option)) }
+
+    describe '#course' do
+      it 'returns the course related to the course_option' do
+        expect(offer.course).to eq(offer.course_option.course)
+      end
+    end
+
+    describe '#site' do
+      it 'returns the site related to the course_option' do
+        expect(offer.site).to eq(offer.course_option.site)
+      end
+    end
+
+    describe '#provider' do
+      it 'returns the provider related to the course_option' do
+        expect(offer.provider).to eq(offer.course_option.provider)
+      end
+    end
+
+    describe '#accredited_provider' do
+      it 'returns the accredited_provider related to the course_option' do
+        expect(offer.accredited_provider).to eq(offer.course_option.accredited_provider)
+      end
     end
   end
 end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -10,4 +10,12 @@ RSpec.describe Offer do
       expect(offer.conditions.map(&:text)).to contain_exactly('Provide evidence of degree qualification', 'Do a backflip and send us a video')
     end
   end
+
+  describe '#unconditional' do
+    it 'returns true when there are no conditions' do
+      offer = create(:unconditional_offer)
+
+      expect(offer.unconditional?).to be true
+    end
+  end
 end

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe OfferValidations, type: :model do
       context 'when the offer details are identical to the existing offer' do
         let(:application_choice) { build_stubbed(:application_choice, :with_offer) }
         let(:course_option) { application_choice.course_option }
-        let(:conditions) { application_choice.offer.conditions.map(&:text) }
+        let(:conditions) { application_choice.offer.conditions_text }
 
         it 'raises an IdenticalOfferError' do
           expect { offer.valid? }.to raise_error(IdenticalOfferError)
@@ -91,7 +91,7 @@ RSpec.describe OfferValidations, type: :model do
         let(:application_choice) { build_stubbed(:application_choice, :with_offer, current_course_option: current_course_option) }
         let(:current_course_option) { create(:course_option, :open_on_apply) }
         let(:course_option) { build(:course_option, :open_on_apply) }
-        let(:conditions) { application_choice.offer.conditions.map(&:text) }
+        let(:conditions) { application_choice.offer.conditions_text }
 
         it 'adds a :different_ratifying_provider error' do
           expect(offer).to be_invalid


### PR DESCRIPTION
## Context

Move offer related content to `Offer` model by using has through associations and `delegate`

## Link to Trello card

https://trello.com/c/jEnBoj4Y/3721-%F0%9F%8F%88-refactor-move-offer-related-concerns-from-application-choice-to-the-offer-class

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
