### PR TITLE
Handle state changes when a selected reference is deleted

### DIFF
--- a/app/controllers/candidate_interface/references/review_controller.rb
+++ b/app/controllers/candidate_interface/references/review_controller.rb
@@ -62,7 +62,7 @@ module CandidateInterface
           redirect_to_review_page and return
         end
 
-        @reference.destroy!
+        DeleteReference.new.call(reference: @reference)
         redirect_to_review_page
       end
 

--- a/app/services/delete_reference.rb
+++ b/app/services/delete_reference.rb
@@ -1,0 +1,10 @@
+class DeleteReference
+  def call(reference:)
+    raise 'Application has been sent to providers' if reference.application_form.submitted?
+
+    if FeatureFlag.active?(:reference_selection) && reference.selected
+      reference.application_form.update!(references_completed: false)
+    end
+    reference.destroy!
+  end
+end

--- a/app/views/candidate_interface/references/review/confirm_destroy_reference.html.erb
+++ b/app/views/candidate_interface/references/review/confirm_destroy_reference.html.erb
@@ -8,10 +8,21 @@
       url: candidate_interface_destroy_reference_path(@reference),
       method: :delete,
     ) do |f| %>
-      <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl"><%= @reference.name %></span>
-        <%= t('page_titles.references_delete_reference') %>
-      </h1>
+      <% if FeatureFlag.active?(:reference_selection) && @reference.selected %>
+        <h1 class="govuk-heading-xl">
+          <span class="govuk-caption-xl"><%= @reference.name %></span>
+          <%= t('page_titles.references_delete_selected_reference') %>
+        </h1>
+
+        <p class="govuk-body">
+          You’ve selected this reference, deleting it means you’ll need to select another.
+        </p>
+      <% else %>
+        <h1 class="govuk-heading-xl">
+          <span class="govuk-caption-xl"><%= @reference.name %></span>
+          <%= t('page_titles.references_delete_reference') %>
+        </h1>
+      <% end %>
 
       <%= f.govuk_submit t('application_form.references.delete_reference.confirm'), warning: true %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -156,6 +156,7 @@ en:
     references_delete_request: Are you sure you want to delete this reference request?
     references_delete_referee: Are you sure you want to delete this referee?
     references_delete_reference: Are you sure you want to delete this reference?
+    references_delete_selected_reference: Are you sure you want to delete this selected reference?
     references_send_reminder: Would you like to send a reminder to this referee?
     references_select: Which 2 references do you want to include in your application?
     references_review: Review your references

--- a/spec/services/delete_reference_spec.rb
+++ b/spec/services/delete_reference_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe DeleteReference do
+  let(:completed_application_form) do
+    create(
+      :completed_application_form,
+      application_choices_count: 3,
+      work_experiences_count: 2,
+      volunteering_experiences_count: 2,
+      references_count: 2,
+      full_work_history: true,
+    )
+  end
+  let(:reference) { create(:reference, :feedback_provided, application_form: completed_application_form) }
+
+  describe '#call' do
+    it 'raises error if application has been submitted to providers' do
+      application_choice = completed_application_form.application_choices.first
+      SendApplicationToProvider.call(application_choice)
+      expect { described_class.new.call(reference: reference) }.to raise_error('Application has been sent to providers')
+    end
+
+    it 'deletes the reference' do
+      application_form = create(:application_form)
+      reference_to_delete = create(:reference, :feedback_provided, application_form: application_form)
+      create(:reference, :feedback_provided, application_form: application_form)
+
+      described_class.new.call(reference: reference_to_delete)
+
+      expect { reference_to_delete.reload }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find ApplicationReference with 'id'=#{reference_to_delete.id}")
+      expect(application_form.application_references.count).to eq 1
+    end
+
+    it 'marks the section as incomplete' do
+      FeatureFlag.activate(:reference_selection)
+
+      application_form = create(:application_form, references_completed: true)
+      create_list(:reference, 2, :feedback_provided, selected: true, application_form: application_form)
+
+      described_class.new.call(reference: application_form.application_references.first)
+
+      expect(application_form.reload.references_completed).to eq false
+    end
+  end
+end

--- a/spec/system/candidate_interface/references/reference_selection/candidate_deletes_a_selected_reference_spec.rb
+++ b/spec/system/candidate_interface/references/reference_selection/candidate_deletes_a_selected_reference_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.feature 'References' do
+  include CandidateHelper
+
+  scenario 'the candidate deletes their selected references' do
+    given_i_am_signed_in
+    and_the_reference_selection_feature_flag_is_active
+
+    given_i_receive_my_references_and_have_selected_two_of_them
+    and_i_have_completed_the_section
+
+    when_i_delete_one_of_the_selected_references
+    then_i_am_redirected_to_the_references_review_page
+    and_the_section_is_not_marked_as_completed
+
+    when_i_select_my_other_reference
+    and_complete_the_section
+    then_the_section_is_marked_as_completed
+
+    when_i_delete_one_of_the_selected_references
+    then_i_am_redirected_to_the_references_review_page
+    and_the_section_is_not_marked_as_completed
+
+    when_i_visit_the_select_references_page
+    then_i_am_presented_with_the_guidance
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+    @application = @candidate.current_application
+  end
+
+  def and_the_reference_selection_feature_flag_is_active
+    FeatureFlag.activate('reference_selection')
+  end
+
+  def given_i_receive_my_references_and_have_selected_two_of_them
+    create_list(:reference, 3, feedback_status: :feedback_provided, application_form: @application)
+    @application.application_references[0..1].each { |reference| reference.update!(selected: true) }
+  end
+
+  def and_i_have_completed_the_section
+    @application.update!(references_completed: true)
+  end
+
+  def when_i_delete_one_of_the_selected_references
+    visit candidate_interface_references_review_path
+    click_on "Delete reference #{@application.application_references.feedback_provided.first.name}"
+    click_on I18n.t('application_form.references.delete_reference.confirm')
+  end
+
+  def then_i_am_redirected_to_the_references_review_page
+    expect(page).to have_current_path candidate_interface_references_review_path
+  end
+
+  def and_the_section_is_not_marked_as_completed
+    visit candidate_interface_application_form_path
+    expect(page).to have_css('#selected-references-badge-id', text: 'Incomplete')
+  end
+
+  def when_i_select_my_other_reference
+    visit candidate_interface_select_references_path
+    check @application.application_references.feedback_provided.first.name
+    check @application.application_references.feedback_provided.second.name
+    click_button 'Save and continue'
+  end
+
+  def and_complete_the_section
+    choose t('application_form.completed_radio')
+    click_button 'Save and continue'
+  end
+
+  def then_the_section_is_marked_as_completed
+    expect(page).to have_css('#selected-references-badge-id', text: 'Completed')
+  end
+
+  def when_i_visit_the_select_references_page
+    visit candidate_interface_select_references_path
+  end
+
+  def then_i_am_presented_with_the_guidance
+    expect(page).to have_current_path candidate_interface_select_references_path
+    expect(page).to have_content 'Once 2 or more references have been given, you can then select which you want to include'
+  end
+end


### PR DESCRIPTION
## Context

This PR adds a `DeleteReference` service that is used as part of the new reference section design.

## Changes proposed in this pull request

Deleting a reference has been moved into its own service but will still function as before, however, if the candidate deletes a 'selected' reference they will encounter a different confirmation message:

|Deleting a selected reference|
|---|
|![image](https://user-images.githubusercontent.com/47917431/120326596-cfd15f00-c2e0-11eb-8d63-987e986a00ef.png)|

The section will also be marked as incomplete if they proceed.

Additionally, the service will raise an error if it's used to delete a reference that is attached to a submitted application.

## Guidance to review

Scenarios to consider:

1. Candidate has received three (or more) references, selected two of them and then deletes one -> Can still use the reference selection section.
2. Candidate has two references, selected both of them and then deletes one -> Can no longer use the reference selection section.

## Link to Trello card

https://trello.com/c/hZVGCcxd

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
