### PR TITLE
Destroy application choices with a course from the previous cycle

### DIFF
--- a/app/services/data_migrations/remove_previous_cycles_courses_from_applications_in_the_current_cycle.rb
+++ b/app/services/data_migrations/remove_previous_cycles_courses_from_applications_in_the_current_cycle.rb
@@ -1,0 +1,19 @@
+module DataMigrations
+  class RemovePreviousCyclesCoursesFromApplicationsInTheCurrentCycle
+    TIMESTAMP = 20210528131818
+    MANUAL_RUN = false
+
+    def change
+      ApplicationChoice
+      .joins(:application_form, course_option: [:course])
+      .where(course: { recruitment_cycle_year: RecruitmentCycle.previous_year })
+      .where(application_form: { recruitment_cycle_year: RecruitmentCycle.current_year })
+      .find_each(batch_size: 100) do |application_choice|
+        application_choice.application_form.update!(
+          audit_comment: "Application_choice ##{application_choice.id} was deleted due to being associated with a course from last years recruitment cycle",
+        )
+        application_choice.destroy
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,6 +1,7 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
   'DataMigrations::BackfillOfferData',
+  'DataMigrations::RemovePreviousCyclesCoursesFromApplicationsInTheCurrentCycle',
   'DataMigrations::BackfillRestucturedWorkHistoryBoolean',
   'DataMigrations::BackfillValidationErrorsServiceColumn',
   'DataMigrations::BackfillSelectedBoolean',

--- a/spec/services/data_migrations/remove_previous_cycles_courses_from_applications_in_the_current_cycle_spec.rb
+++ b/spec/services/data_migrations/remove_previous_cycles_courses_from_applications_in_the_current_cycle_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemovePreviousCyclesCoursesFromApplicationsInTheCurrentCycle do
+  it 'removes course choices from the previous cycle from application forms in the current cycle', with_audited: true do
+    application_form = create(:application_form)
+    course_from_previous_cycle = create(:course, recruitment_cycle_year: RecruitmentCycle.previous_year)
+    course_from_current_cycle = create(:course, recruitment_cycle_year: RecruitmentCycle.current_year)
+
+    old_course_option = create(:course_option, course: course_from_previous_cycle)
+    new_course_option = create(:course_option, course: course_from_current_cycle)
+
+    invalid_application_choice = create(:application_choice, course_option: old_course_option, application_form: application_form)
+    valid_application_choice = create(:application_choice, course_option: new_course_option, application_form: application_form)
+
+    described_class.new.change
+
+    expect(application_form.reload.application_choices).to eq [valid_application_choice]
+    expect(application_form.audits.last.comment).to eq "Application_choice ##{invalid_application_choice.id} was deleted due to being associated with a course from last years recruitment cycle"
+  end
+end


### PR DESCRIPTION
## Context

In this commit https://github.com/DFE-Digital/apply-for-teacher training/commit/17387c9b17a7c216566116712dcd9f0964017099 Steve L did some work to stop old courses being duplicated onto new application forms. This services does the clean up work to cleanse the data.

It destroys any application choices with a course from last years cycle.

## Changes proposed in this pull request

- Return any application choices where the course is from last cycle
- Add an audit comment to the application form explaining why they application_choices have been deleted
- destroy the choices


## Guidance to review

Does the query do what it should be doing?


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
