### PR TITLE
Add invariant check for application forms with courses in a different cycle

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -173,15 +173,6 @@ class ApplicationChoice < ApplicationRecord
     offer.conditions.none?
   end
 
-  # To be removed after testing. This has been tested here
-  # remove_application_choices_in_the_incorrect_cycle_spec.rb
-
-  def self.return_application_choices_with_a_course_in_a_different_cycle
-    ApplicationChoice
-    .joins(:application_form, course_option: [:course])
-    .where('courses.recruitment_cycle_year != application_forms.recruitment_cycle_year')
-  end
-
 private
 
   def set_initial_status


### PR DESCRIPTION
## Context

**Do not merge until #4853 has been deployed**

 We've had a few issues with courses from previous recruitment cycles showing up on application forms in the current cycle

This adds a check to the detect invariant service for courses from different recruitment cycles being associated with application forms

## Changes proposed in this pull request

- Add check to detect invariants for application forms having courses from different recruitment cycles associated with them

## Guidance to review

Does this all seem reasonable?

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] This code does not rely on the addition/removal of Azure config environment variables in the same Pull Request
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
