### PR TITLE
Correct spelling of DfE Sign-in

### DIFF
--- a/adr/0012-extra-security-for-support.md
+++ b/adr/0012-extra-security-for-support.md
@@ -4,12 +4,12 @@ Date: 2020-03-30
 
 ## Context
 
-Members of the Apply team have access to a section of the service called [Support](https://www.apply-for-teacher-training.service.gov.uk/support). It exposes a lot of data and allows make changes to the site. We use DfE Signin for access to the support interface.
+Members of the Apply team have access to a section of the service called [Support](https://www.apply-for-teacher-training.service.gov.uk/support). It exposes a lot of data and allows make changes to the site. We use DfE Sign-in for access to the support interface.
 
 There are 2 concerns around the security of Support:
 
-- DfE Signin uses a username and password for sign in. It does not offer 2 factor authentication. This means that an attacker could steal or guess a password and gain access to Support.
-- We do not have an automated leavers process that revokes access to DfE Signin when people leave. This leaves open the possibility that former staff retain access to Support.
+- DfE Sign-in uses a username and password for sign in. It does not offer 2 factor authentication. This means that an attacker could steal or guess a password and gain access to Support.
+- We do not have an automated leavers process that revokes access to DfE Sign-in when people leave. This leaves open the possibility that former staff retain access to Support.
 
 As part of proactive security work we’ve looked into improving the security of Support.
 
@@ -21,7 +21,7 @@ The solution we intend to build works by requiring Support users to confirm that
 
 The technical implementation:
 
-When a support user visits the site they sign in as usual using DfE Signin. When they return to Apply, we check if they have a valid “email\_confirmed” cookie set. If not, they’ll see a screen saying that they’ve received an email with a confirmation link. If they click the link, we’ll set the “email\_confirmed” cookie and allow them access to the site.
+When a support user visits the site they sign in as usual using DfE Sign-in. When they return to Apply, we check if they have a valid “email\_confirmed” cookie set. If not, they’ll see a screen saying that they’ve received an email with a confirmation link. If they click the link, we’ll set the “email\_confirmed” cookie and allow them access to the site.
 
 The “email\_confirmed” cookie is [signed to avoid tampering](https://apidock.com/rails/v6.0.0/ActionDispatch/Cookies/ChainedCookieJars/signed). It contains the user ID of the user (so it cannot be shared) and an expiry date 7 days in the future (so that emails have to be reconfirmed every 7 days).
 
@@ -37,6 +37,6 @@ All options have their trade-offs. We’ve chosen to go with the Email confirmat
 | B. SMS | On successful login with password, the user gets an SMS with a one-time code | Easy for users to understand. Easy integration with GOV.UK Notify. Could be re-used for provider users. Does not require a smartphone. | Does not prove that the user still works at DfE. SMS is considered not secure enough for 2FA by some security experts. We do not have people’s phone numbers, so we’d have to get them. |
 | C. Authenticator app | Use an integration via a gem, users scan a QR code using their app (e.g. Authy, Google Authenticator, etc) and then whenever they login we ask them for the latest auto-generated code | Widely used. Could be re-used for provider users. | Not everyone has a smartphone. Corporate phones might prevent app installs. It’s a bit of a faff to set up for users. Does not prove that the user still works at DfE. |
 | D. Hardware key (Yubikey) | Support users plug in a Yubi key and prove their identity | Easy to use once set up. Plenty of hardware options available | Cost and procurement. We’d need a lot of processes to provide new devices, revoke old devices, and manage lost. Will not work for provider users. Does not prove that the user still works at DfE. |
-| E. Replace DfE Signin with magic links | A lot of emails already have 2FA / MFA - we could get rid of passwords and just use magic links. Only if we mandate support users use \*.education.gov.uk addresses, which have 2FA | Could be used to provide fallback when DfE Signin is down. Proves user works at DfE. | Will not work as 2FA for provider users as we cannot prove that their email has 2FA |
-| F. DfE Signin | DfE Signin has some form of 2FA built into it | We do not have to do anything. Works for provider users. | Investigated by Claim team, it’s apparently not production ready |
-| G. Using Google SSO for Support login | Use Google Apps SSO for digital.education.gov.uk for login | Gets rid of the DfE Signin requirement for support users. No additional login step for DfE users already signed into their email accounts. Minimal changes to our app (we use omniauth)Proves user works at DfE. | Not everyone has @digital.education.gov.uk email address, some civil servants only have a @education.gov.uk address. Will not work for provider users. |
+| E. Replace DfE Sign-in with magic links | A lot of emails already have 2FA / MFA - we could get rid of passwords and just use magic links. Only if we mandate support users use \*.education.gov.uk addresses, which have 2FA | Could be used to provide fallback when DfE Sign-in is down. Proves user works at DfE. | Will not work as 2FA for provider users as we cannot prove that their email has 2FA |
+| F. DfE Sign-in | DfE Sign-in has some form of 2FA built into it | We do not have to do anything. Works for provider users. | Investigated by Claim team, it’s apparently not production ready |
+| G. Using Google SSO for Support login | Use Google Apps SSO for digital.education.gov.uk for login | Gets rid of the DfE Sign-in requirement for support users. No additional login step for DfE users already signed into their email accounts. Minimal changes to our app (we use omniauth)Proves user works at DfE. | Not everyone has @digital.education.gov.uk email address, some civil servants only have a @education.gov.uk address. Will not work for provider users. |

--- a/app/views/provider_interface/sessions/authentication_fallback.html.erb
+++ b/app/views/provider_interface/sessions/authentication_fallback.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_notification_banner(title: t('notification_banner.info')) do |notification_banner| %>
       <%= notification_banner.slot(:heading, text: 'Temporary login') %>
-      <p class="govuk-body">DfE Sign In is experiencing problems. You need to sign in using your email address.</p>
+      <p class="govuk-body">DfE Sign-in is experiencing problems. You need to sign in using your email address.</p>
     <% end %>
 
     <h1 class="govuk-heading-xl">

--- a/app/views/support_interface/sessions/authentication_fallback.html.erb
+++ b/app/views/support_interface/sessions/authentication_fallback.html.erb
@@ -3,10 +3,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
     <%= govuk_notification_banner(title: t('notification_banner.info')) do |notification_banner| %>
       <%= notification_banner.slot(:heading, text: 'Temporary login') %>
-      <p class="govuk-body">DfE Sign In is experiencing problems. You need to sign in using your email address.</p>
+      <p class="govuk-body">DfE Sign-in is experiencing problems. You need to sign in using your email address.</p>
     <% end %>
 
     <p class="govuk-body-l">You must sign in to your account to use the support console.</p>

--- a/azure/template.json
+++ b/azure/template.json
@@ -310,13 +310,13 @@
         "dfeSignInClientId": {
             "type": "string",
             "metadata": {
-                "description": "The DfE Sign-in client ID, obtained from the DfE Sign in management interface"
+                "description": "The DfE Sign-in client ID, obtained from the DfE Sign-in management interface"
             }
         },
         "dfeSignInSecret": {
             "type": "string",
             "metadata": {
-                "description": "The DfE Sign-in secret, obtained from the DfE sign-in management interface"
+                "description": "The DfE Sign-in secret, obtained from the DfE Sign-in management interface"
             }
         },
         "dfeSignInIssuer": {


### PR DESCRIPTION
## Context

‘DfE Sign-in’ is incorrectly spelt on the fallback sign in pages. Mis-spellings also appear in some docs and other places. Have done a quick find and replace to standardise on the correct spelling/capitalisation.