### PR TITLE
Deny can_make_decisions? when relationship data is missing

### DIFF
--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -126,16 +126,20 @@ private
     permission_name = "training_provider_can_#{permission}"
     relationship = relationship_for course: course
 
+    return if relationship.blank?
+
     @actor.providers.include?(course.provider) &&
-      (relationship.blank? || relationship.send(permission_name))
+      relationship.send(permission_name)
   end
 
   def permission_as_ratifying_provider_user?(permission:, course:)
     permission_name = "ratifying_provider_can_#{permission}"
     relationship = relationship_for course: course
 
+    return if relationship.blank?
+
     @actor.providers.include?(course.accredited_provider) &&
-      (relationship.blank? || relationship.send(permission_name))
+      relationship.send(permission_name)
   end
 
   def full_authorisation?(permission:, course:)

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -101,6 +101,13 @@ RSpec.describe ProviderAuthorisation do
         expect(can_make_decisions?(actor: ratifying_provider_user)).to be_falsy
       end
 
+      it 'bad data: relationship record is missing' do
+        provider_relationship_permissions.destroy
+
+        expect(can_make_decisions?(actor: training_provider_user)).to be_falsy
+        expect(can_make_decisions?(actor: ratifying_provider_user)).to be_falsy
+      end
+
       it 'training_provider for self-ratified course can always decide' do
         for_self_ratified_course = create(
           :application_choice,


### PR DESCRIPTION
## Context

A subtle authorisation bug has appeared on sandbox because our `Test Provider` has courses ratified by other providers but the relevant provider relationship records have not been created. Because we assume relationships will be defined for all providers that ratify courses, and this is true because of our sync process, when the relationship record is missing our authorisation code essentially treats the course as a self-ratified course, meaning the authorisation result is determined by user-level permissions.

## Changes proposed in this pull request

Change this so that when a relationship record is missing (case of bad data), the default result in the authorisation logic is to deny permission, from an organisational permissions point of view. This doesn't affect self-ratified courses, which are still authorised based on user-level permissions only.

## Guidance to review

It is a small change but should fix things until the data backfill for `Test Provider` is ready. 

## Link to Trello card

https://trello.com/c/qfxhmbgB

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
