### PR TITLE
Throw an exception when trying to mark a stale application changed

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -32,14 +32,17 @@ class TestApplications
       courses_to_choose_from: courses_to_apply_to,
       course_full: course_full,
     )
-    create_application_to_courses(
-      recruitment_cycle_year: recruitment_cycle_year,
-      states: states,
-      courses: courses,
-      apply_again: apply_again,
-      carry_over: carry_over,
-      candidate: candidate,
-    )
+
+    ApplicationForm.with_unsafe_application_choice_touches do
+      create_application_to_courses(
+        recruitment_cycle_year: recruitment_cycle_year,
+        states: states,
+        courses: courses,
+        apply_again: apply_again,
+        carry_over: carry_over,
+        candidate: candidate,
+      )
+    end
   end
 
 private

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -93,11 +93,21 @@ class ApplicationForm < ApplicationRecord
 
   before_save do |form|
     if (form.changed & PUBLISHED_FIELDS).any?
-      application_choices.touch_all
+      touch_choices
     end
   end
 
   after_commit :geocode_address_if_required
+
+  def touch_choices
+    return unless application_choices.any?
+
+    if recruitment_cycle_year < RecruitmentCycle.current_year
+      raise 'Tried to mark an application choice from a previous cycle as changed'
+    end
+
+    application_choices.touch_all
+  end
 
   def submitted?
     submitted_at.present?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -102,7 +102,8 @@ class ApplicationForm < ApplicationRecord
   def touch_choices
     return unless application_choices.any?
 
-    if recruitment_cycle_year < RecruitmentCycle.current_year
+    if recruitment_cycle_year < RecruitmentCycle.current_year && \
+        !RequestStore.store[:allow_unsafe_application_choice_touches]
       raise 'Tried to mark an application choice from a previous cycle as changed'
     end
 
@@ -409,6 +410,16 @@ class ApplicationForm < ApplicationRecord
 
   def reviewable?(section)
     apply_2? && previous_application_rejection_reason(section).present?
+  end
+
+  def self.with_unsafe_application_choice_touches
+    prior_state = RequestStore.store[:allow_unsafe_application_choice_touches].presence || false
+
+    RequestStore.store[:allow_unsafe_application_choice_touches] = true
+    return_value = yield
+    RequestStore.store[:allow_unsafe_application_choice_touches] = prior_state
+
+    return_value
   end
 
 private

--- a/app/models/concerns/published_in_api.rb
+++ b/app/models/concerns/published_in_api.rb
@@ -3,7 +3,7 @@ module PublishedInAPI
 
   included do
     after_commit do
-      application_form.application_choices.touch_all
+      application_form.touch_choices
     end
   end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -39,6 +39,17 @@ RSpec.describe ApplicationForm do
         expect { application_form.update(first_name: 'Maria') }
           .not_to raise_error
       end
+
+      context 'when we allow unsafe touches' do
+        it 'does not throw an exception' do
+          application_form = create(:completed_application_form, recruitment_cycle_year: RecruitmentCycle.previous_year, application_choices_count: 1)
+
+          ApplicationForm.with_unsafe_application_choice_touches do
+            expect { application_form.update(first_name: 'Maria') }
+              .not_to raise_error
+          end
+        end
+      end
     end
   end
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -24,6 +24,22 @@ RSpec.describe ApplicationForm do
       expect { application_form.update(latitude: '0.12343') }
         .not_to(change { application_form.application_choices.first.updated_at })
     end
+
+    context 'when the form belongs to a previous recruitment cycle' do
+      it 'throws an exception rather than touch an application choice' do
+        application_form = create(:completed_application_form, recruitment_cycle_year: RecruitmentCycle.previous_year, application_choices_count: 1)
+
+        expect { application_form.update(first_name: 'Maria') }
+          .to raise_error('Tried to mark an application choice from a previous cycle as changed')
+      end
+
+      it 'does nothing when there are no application choices' do
+        application_form = create(:completed_application_form, recruitment_cycle_year: RecruitmentCycle.previous_year, application_choices_count: 0)
+
+        expect { application_form.update(first_name: 'Maria') }
+          .not_to raise_error
+      end
+    end
   end
 
   describe 'after_touch' do

--- a/spec/system/support_interface/feature_metrics_dashboard_spec.rb
+++ b/spec/system/support_interface/feature_metrics_dashboard_spec.rb
@@ -96,41 +96,43 @@ RSpec.feature 'Feature metrics dashboard' do
   end
 
   def and_there_are_candidates_and_application_forms_in_the_system
-    allow(EndOfCycleTimetable).to receive(:apply_reopens).and_return(60.days.ago)
-    Timecop.freeze(@today - 65.days) do
-      @previous_application_form = create_application_form_with_references(recruitment_cycle_year: 2020).first
-    end
-    Timecop.freeze(@today - 50.days) do
-      @application_form1, @references1 = create_application_form_with_references
-      @application_form2, @references2 = create_application_form_with_references
-      create(:authentication_token, user: @application_form1.candidate, hashed_token: '0987654321')
-      create(:authentication_token, user: @application_form1.candidate, hashed_token: '9876543210')
-      create(:authentication_token, user: @application_form2.candidate, hashed_token: '8765432109')
-      start_work_history(@application_form1)
-    end
-    Timecop.freeze(@today - 40.days) do
-      @application_form3, @references3 = create_application_form_with_references
-      provide_references(@references1)
-      start_work_history(@application_form2)
-      complete_work_history(@application_form1)
-      reject_application(@application_form1.application_choices.first)
-    end
-    Timecop.freeze(@today - 21.days) do
-      @application_form4, @references4 = create_application_form_with_references
-      provide_references(@references2)
-      complete_work_history(@application_form2)
-      start_work_history(@application_form3)
-      start_work_history(@application_form4)
-    end
-    Timecop.freeze(@today - 2.days) do
-      provide_references(@references3)
-      provide_references(@references4)
-      complete_work_history(@application_form3)
-      complete_work_history(@application_form4)
-      reject_application(@application_form2.application_choices.first)
-      apply_again_and_reject_application(@application_form1)
-      apply_again_and_offer_application(@application_form2)
-      carry_over_application(@previous_application_form)
+    ApplicationForm.with_unsafe_application_choice_touches do
+      allow(EndOfCycleTimetable).to receive(:apply_reopens).and_return(60.days.ago)
+      Timecop.freeze(@today - 65.days) do
+        @previous_application_form = create_application_form_with_references(recruitment_cycle_year: 2020).first
+      end
+      Timecop.freeze(@today - 50.days) do
+        @application_form1, @references1 = create_application_form_with_references
+        @application_form2, @references2 = create_application_form_with_references
+        create(:authentication_token, user: @application_form1.candidate, hashed_token: '0987654321')
+        create(:authentication_token, user: @application_form1.candidate, hashed_token: '9876543210')
+        create(:authentication_token, user: @application_form2.candidate, hashed_token: '8765432109')
+        start_work_history(@application_form1)
+      end
+      Timecop.freeze(@today - 40.days) do
+        @application_form3, @references3 = create_application_form_with_references
+        provide_references(@references1)
+        start_work_history(@application_form2)
+        complete_work_history(@application_form1)
+        reject_application(@application_form1.application_choices.first)
+      end
+      Timecop.freeze(@today - 21.days) do
+        @application_form4, @references4 = create_application_form_with_references
+        provide_references(@references2)
+        complete_work_history(@application_form2)
+        start_work_history(@application_form3)
+        start_work_history(@application_form4)
+      end
+      Timecop.freeze(@today - 2.days) do
+        provide_references(@references3)
+        provide_references(@references4)
+        complete_work_history(@application_form3)
+        complete_work_history(@application_form4)
+        reject_application(@application_form2.application_choices.first)
+        apply_again_and_reject_application(@application_form1)
+        apply_again_and_offer_application(@application_form2)
+        carry_over_application(@previous_application_form)
+      end
     end
   end
 


### PR DESCRIPTION
Provider systems can't deal with application choices from the last cycle
being marked as changed - they come back over the API and have to be
manually removed. Throw an exception rather than touch them by accident.

## Context

We have had application choices resurface in the API (and Manage, though that's less bad) as a result of data migrations, eg https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1622217278224900.

## Changes proposed in this pull request

Before we accidentally touch an application choice in the wrong cycle, bail out with an error.



## Link to Trello card

https://trello.com/c/ies4qkcs/3766-blow-up-when-trying-to-touch-an-application-choice-from-a-previous-recruitment-cycle

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
