### PR TITLE
Add pre-translated error messages

### DIFF
--- a/app/forms/provider_interface/reasons_for_rejection_wizard.rb
+++ b/app/forms/provider_interface/reasons_for_rejection_wizard.rb
@@ -2,6 +2,8 @@ module ProviderInterface
   class ReasonsForRejectionWizard
     include ActiveModel::Model
 
+    TRANSLATION_KEY_PREFIX = 'activemodel.errors.models.provider_interface/reasons_for_rejection_wizard.attributes'.freeze
+
     class NestedAnswerValidator < ActiveModel::EachValidator
       def validate_each(record, attribute, value)
         return unless options.key?(:collection_name) && options.key?(:selected_option)
@@ -9,20 +11,22 @@ module ProviderInterface
         top_level_question = options[:top_level_question]
         top_level_answer = record.send(top_level_question)
 
-        record.errors.add(top_level_question, :blank) if top_level_answer.blank?
-        record.errors.add(top_level_question, :inclusion) unless %w[Yes No].include?(top_level_answer)
+        if top_level_answer.blank?
+          record.errors.add(top_level_question, I18n.t("#{TRANSLATION_KEY_PREFIX}.#{top_level_question}.blank"))
+        end
 
-        return unless record.send(top_level_question) == 'Yes'
+        return unless top_level_answer == 'Yes'
 
-        collection_values = record.send(options[:collection_name])
+        collection_name = options[:collection_name]
+        collection_values = record.send(collection_name)
         if collection_values.blank?
-          record.errors.add(options[:collection_name], :blank)
+          record.errors.add(collection_name, I18n.t("#{TRANSLATION_KEY_PREFIX}.#{collection_name}.blank"))
           return
         end
 
         if collection_values.include?(options[:selected_option])
-          record.errors.add(attribute, :blank) if value.blank?
-          record.errors.add(attribute, :too_long) if record.excessive_word_count?(value)
+          record.errors.add(attribute, I18n.t("#{TRANSLATION_KEY_PREFIX}.#{attribute}.blank")) if value.blank?
+          record.errors.add(attribute, I18n.t("#{TRANSLATION_KEY_PREFIX}.#{attribute}.too_long")) if record.excessive_word_count?(value)
         end
       end
     end
@@ -169,8 +173,8 @@ module ProviderInterface
                  end
 
         if record.send(method) == 'Yes'
-          record.errors.add(attr, :blank) if value.blank?
-          record.errors.add(attr, :too_long) if record.excessive_word_count?(value)
+          record.errors.add(attr, I18n.t("#{TRANSLATION_KEY_PREFIX}.#{attr}.blank")) if value.blank?
+          record.errors.add(attr, I18n.t("#{TRANSLATION_KEY_PREFIX}.#{attr}.too_long")) if record.excessive_word_count?(value)
         end
       end
     end

--- a/spec/forms/provider_interface/reasons_for_rejection_wizard_spec.rb
+++ b/spec/forms/provider_interface/reasons_for_rejection_wizard_spec.rb
@@ -142,7 +142,22 @@ RSpec.describe ProviderInterface::ReasonsForRejectionWizard do
           ],
         )
 
-        expect(wizard.errors.details.values.flatten.map { |v| v[:error] }.uniq).to eq(%i[too_long])
+        expect(wizard.errors.details.values.flatten.map { |v| v[:error] }).to eq([
+          'Details about candidate behaviour must be 100 words or fewer',
+          'Details about how the candidate can improve their behaviour must be 100 words or fewer',
+          'Details about the quality of their application must be 100 words or fewer',
+          'Details about how they can improve their application must be 100 words or fewer',
+          'Details about the problem with their qualifications must be 100 words or fewer',
+          'Details about inaccurate or false information in the application must be 100 words or fewer',
+          'The details about evidence of plagiarism in the application must be 100 words or fewer',
+          'Details about references not supporting the application must be 100 words or fewer',
+          'Details about the candidate’s honesty and professionalism must be 100 words or fewer',
+          'Details about the information the candidate disclosed must be 100 words or fewer',
+          'Details about the information found by your vetting process which makes the candidate unsuitable to work with children must be 100 words or fewer',
+          'Details about safeguarding must be 100 words or fewer',
+          'Details about how they can improve their performance at interview must be 100 words or fewer',
+          'Details about the place offered on another course must be 100 words or fewer',
+        ])
       end
     end
 


### PR DESCRIPTION
## Context

ActiveModel's `error.messages` will call `Error.generate_message` and this in turn will automatically attempt to interpolate
the translation which is proving very costly with response times as much as 20 seconds. 

![slow](https://user-images.githubusercontent.com/93511/120472971-6fa0f280-c39e-11eb-93d8-018cb034665f.png)


[Adding the error messages as Strings bypasses this mechanism](https://github.com/rails/rails/blob/75ac626c4e21129d8296d4206a1960563cc3d4aa/activemodel/lib/active_model/error.rb#L134-L141) and reduces the response time significantly.

![image](https://user-images.githubusercontent.com/93511/120473577-12f20780-c39f-11eb-96fe-a456cf0c9081.png)

It's likely that there's still an issue lurking, possibly too much recursion in the wizard validation or that the many calls to `@wizard.errors.messages` are not performant (ie they generate messages on each call). 

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Performs i18n translation as part of the nested validation in the wizard.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Currently if you submit the R4R questionnaire without filling or checking any items the response time is around 12-16 seconds (in dev environment)

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/NpbCJA8l/3744-slow-rejection-reasons-page
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
