### PR TITLE
Ensure the SignInCandidate only adds courses from the current cycle

### DIFF
--- a/app/services/candidate_interface/sign_in_candidate.rb
+++ b/app/services/candidate_interface/sign_in_candidate.rb
@@ -35,14 +35,18 @@ module CandidateInterface
   private
 
     def update_course_from_find(candidate)
-      course_from_find = Provider
-        .find_by(code: params[:providerCode])
-        &.courses
-        &.find_by(code: params[:courseCode])
+      return nil if provider.blank?
 
-      if course_from_find
-        candidate.update!(course_from_find_id: course_from_find.id)
-      end
+      course = provider
+        .courses
+        .current_cycle
+        .find_by(code: params[:courseCode])
+
+      candidate.update!(course_from_find_id: course.id) if course.present?
+    end
+
+    def provider
+      @_provider ||= Provider.find_by(code: params[:providerCode])
     end
   end
 end

--- a/spec/services/candidate_interface/sign_in_candidate_spec.rb
+++ b/spec/services/candidate_interface/sign_in_candidate_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::SignInCandidate do
+  let(:controller_double) do
+    instance_double(
+      CandidateInterface::SignInController,
+      params: {
+        providerCode: course.provider.code,
+        courseCode: course.code,
+      },
+      set_user_context: true,
+      candidate_interface_check_email_sign_in_path: true,
+      redirect_to: true,
+    )
+  end
+
+  context 'course is in the current cycle' do
+    let(:course) { create(:course, recruitment_cycle_year: RecruitmentCycle.current_year) }
+
+    it 'is sets the candidates `course_from_find_id` to the course.id' do
+      candidate = create(:candidate)
+      create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, candidate: candidate)
+
+      described_class.new(candidate.email_address, controller_double).call
+
+      expect(candidate.reload.course_from_find_id).to eq course.id
+    end
+  end
+
+  context 'course is in the previous cycle' do
+    let(:course) {  create(:course, recruitment_cycle_year: RecruitmentCycle.previous_year) }
+
+    it 'is does not set the candidates `course_from_find_id` if the course is not in the current cycle' do
+      candidate = create(:candidate)
+      create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, candidate: candidate)
+
+      described_class.new(candidate.email_address, controller_double).call
+
+      expect(candidate.reload.course_from_find_id).to eq nil
+    end
+  end
+end


### PR DESCRIPTION
## Context

At the moment, we're not scoping adding a course with params from Find to the current cycle.

This can cause applications from the current cycle to a course form the previous cycle added to it.

## Changes proposed in this pull request

- Scope the db hit to courses for the current cycle
- Add some tests 

## Guidance to review

Does this approach seem sound

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
