### PR TITLE
Expose free text equality and diversity data in Vendor API

### DIFF
--- a/app/forms/candidate_interface/equality_and_diversity/disabilities_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/disabilities_form.rb
@@ -2,10 +2,6 @@ module CandidateInterface
   class EqualityAndDiversity::DisabilitiesForm
     include ActiveModel::Model
 
-    DISABILITIES = %w[blind deaf learning long_standing mental physical social].map { |disability|
-      [disability, I18n.t("equality_and_diversity.disabilities.#{disability}.label")]
-    }.freeze
-
     attr_accessor :disabilities, :other_disability
 
     validates :disabilities, presence: true
@@ -13,7 +9,7 @@ module CandidateInterface
     def self.build_from_application(application_form)
       return new(disabilities: nil) if application_form.equality_and_diversity.nil?
 
-      list_of_disabilities = DISABILITIES.map { |_, disability| disability } << 'Other'
+      list_of_disabilities = DisabilityHelper::STANDARD_DISABILITIES.map { |_, disability| disability } << 'Other'
       listed, other = application_form.equality_and_diversity['disabilities'].partition { |d| list_of_disabilities.include?(d) }
 
       if other.any?

--- a/app/forms/candidate_interface/equality_and_diversity/ethnic_background_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/ethnic_background_form.rb
@@ -16,7 +16,7 @@ module CandidateInterface
         new(ethnic_background: application_form.equality_and_diversity['ethnic_background'])
       else
         new(
-          ethnic_background: EthnicBackgroundHelper::OTHER_ETHNIC_BACKGROUNDS[group].first,
+          ethnic_background: OTHER_ETHNIC_BACKGROUNDS[group],
           other_background: application_form.equality_and_diversity['ethnic_background'],
         )
       end
@@ -27,7 +27,7 @@ module CandidateInterface
 
       group = application_form.equality_and_diversity['ethnic_group']
 
-      other_background_present = ethnic_background == EthnicBackgroundHelper::OTHER_ETHNIC_BACKGROUNDS[group].first && other_background.present?
+      other_background_present = ethnic_background == OTHER_ETHNIC_BACKGROUNDS[group] && other_background.present?
 
       background = other_background_present ? other_background : ethnic_background
 
@@ -46,7 +46,7 @@ module CandidateInterface
     end
 
     def self.listed_ethnic_background?(group, background)
-      EthnicBackgroundHelper::ETHNIC_BACKGROUNDS[group].include?(background) || EthnicBackgroundHelper::OTHER_ETHNIC_BACKGROUNDS[group].include?(background)
+      ETHNIC_BACKGROUNDS[group].include?(background) || OTHER_ETHNIC_BACKGROUNDS[group] == background
     end
 
   private

--- a/app/helpers/checkbox_options_helper.rb
+++ b/app/helpers/checkbox_options_helper.rb
@@ -1,6 +1,6 @@
 module CheckboxOptionsHelper
   def disabilities_checkboxes
-    CandidateInterface::EqualityAndDiversity::DisabilitiesForm::DISABILITIES.map do |id, disability|
+    DisabilityHelper::STANDARD_DISABILITIES.map do |id, disability|
       OpenStruct.new(
         id: id,
         name: disability,

--- a/app/helpers/disability_helper.rb
+++ b/app/helpers/disability_helper.rb
@@ -1,0 +1,5 @@
+module DisabilityHelper
+  STANDARD_DISABILITIES = %w[blind deaf learning long_standing mental physical social].map { |disability|
+    [disability, I18n.t("equality_and_diversity.disabilities.#{disability}.label")]
+  }.freeze
+end

--- a/app/helpers/ethnic_background_helper.rb
+++ b/app/helpers/ethnic_background_helper.rb
@@ -1,26 +1,10 @@
 module EthnicBackgroundHelper
-  ETHNIC_GROUPS = [
-    'Asian or Asian British',
-    'Black, African, Black British or Caribbean',
-    'Mixed or multiple ethnic groups',
-    'White',
-    'Another ethnic group',
-  ].freeze
-
-  ETHNIC_BACKGROUNDS = {
-    'Asian or Asian British' => %w[Bangladeshi Chinese Indian Pakistani],
-    'Black, African, Black British or Caribbean' => %w[African Caribbean],
-    'Mixed or multiple ethnic groups' => ['Asian and White', 'Black African and White', 'Black Caribbean and White'],
-    'White' => ['British, English, Northern Irish, Scottish, or Welsh', 'Irish', 'Irish Traveller or Gypsy'],
-    'Another ethnic group' => %w[Arab],
-  }.freeze
-
-  OTHER_ETHNIC_BACKGROUNDS = {
-    'Asian or Asian British' => ['Another Asian background', 'Your Asian background (optional)'],
-    'Black, African, Black British or Caribbean' => ['Another Black background', 'Your Black background (optional)'],
-    'Mixed or multiple ethnic groups' => ['Another Mixed background', 'Your Mixed background (optional)'],
-    'White' => ['Another White background', 'Your White background (optional)'],
-    'Another ethnic group' => ['Another ethnic background', 'Describe your ethnic background (optional)'],
+  ETHNIC_BACKGROUND_TEXTFIELD_LABELS = {
+    EthnicGroup::ASIAN => 'Your Asian background (optional)',
+    EthnicGroup::BLACK => 'Your Black background (optional)',
+    EthnicGroup::MIXED => 'Your Mixed background (optional)',
+    EthnicGroup::WHITE => 'Your White background (optional)',
+    EthnicGroup::OTHER => 'Describe your ethnic background (optional)',
   }.freeze
 
   def ethnic_backgrounds(group)
@@ -31,7 +15,8 @@ module EthnicBackgroundHelper
       )
     end
 
-    button_label, textfield_label = OTHER_ETHNIC_BACKGROUNDS[group]
+    button_label = OTHER_ETHNIC_BACKGROUNDS[group]
+    textfield_label = ETHNIC_BACKGROUND_TEXTFIELD_LABELS[group]
 
     ethnic_backgrounds << OpenStruct.new(
       label: button_label,
@@ -49,7 +34,7 @@ module EthnicBackgroundHelper
   # used in the factory for generating sensible combinations in test data
   def all_combinations
     combos = []
-    ETHNIC_GROUPS.each do |group|
+    EthnicGroup.all.each do |group|
       ETHNIC_BACKGROUNDS[group].each do |bg|
         combos << [group, bg]
       end

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -369,8 +369,29 @@ module VendorAPI
           sex: equality_and_diversity_data['hesa_sex'],
           disability: equality_and_diversity_data['hesa_disabilities'],
           ethnicity: equality_and_diversity_data['hesa_ethnicity'],
-        }
+        }.merge(additional_hesa_itt_data(equality_and_diversity_data))
       end
+    end
+
+    def additional_hesa_itt_data(equality_and_diversity_data)
+      {
+        other_disability_details: other_disability_details(equality_and_diversity_data),
+        other_ethnicity_details: other_ethnicity_details(equality_and_diversity_data),
+      }
+    end
+
+    def other_disability_details(equality_and_diversity_data)
+      return unless equality_and_diversity_data['hesa_disabilities'].include?('96')
+
+      standard_disabilities = DisabilityHelper::STANDARD_DISABILITIES.map(&:last)
+      (equality_and_diversity_data['disabilities'] - standard_disabilities).first.presence
+    end
+
+    def other_ethnicity_details(equality_and_diversity_data)
+      known_ethnic_backgrounds = OTHER_ETHNIC_BACKGROUNDS.values + ETHNIC_BACKGROUNDS.values.flatten + ['Prefer not to say']
+      return if known_ethnic_backgrounds.include?(equality_and_diversity_data['ethnic_background'])
+
+      equality_and_diversity_data['ethnic_background']
     end
 
     def work_history_breaks

--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,10 @@
+## 3rd June
+
+`HESAITTData` now includes the following optional fields:
+
+- `other_disability_details` will contain the candidate’s description of their disability if they selected “Other” and entered a value. This corresponds to HESA disability code `96`
+- `other_ethnicity_details` will contain the candidate’s description of their ethnicity if they selected “Other” and entered a value.
+
 ## 5th May
 
 The following experimental/sandbox endpoint has been updated:

--- a/config/initializers/ethnicities.rb
+++ b/config/initializers/ethnicities.rb
@@ -1,0 +1,27 @@
+module EthnicGroup
+  ASIAN = 'Asian or Asian British'.freeze
+  BLACK = 'Black, African, Black British or Caribbean'.freeze
+  MIXED = 'Mixed or multiple ethnic groups'.freeze
+  WHITE = 'White'.freeze
+  OTHER = 'Another ethnic group'.freeze
+
+  def self.all
+    [ASIAN, BLACK, MIXED, WHITE, OTHER]
+  end
+end
+
+ETHNIC_BACKGROUNDS = {
+  EthnicGroup::ASIAN => %w[Bangladeshi Chinese Indian Pakistani],
+  EthnicGroup::BLACK => %w[African Caribbean],
+  EthnicGroup::MIXED => ['Asian and White', 'Black African and White', 'Black Caribbean and White'],
+  EthnicGroup::WHITE => ['British, English, Northern Irish, Scottish, or Welsh', 'Irish', 'Irish Traveller or Gypsy'],
+  EthnicGroup::OTHER => %w[Arab],
+}.freeze
+
+OTHER_ETHNIC_BACKGROUNDS = {
+  EthnicGroup::ASIAN => 'Another Asian background',
+  EthnicGroup::BLACK => 'Another Black background',
+  EthnicGroup::MIXED => 'Another Mixed background',
+  EthnicGroup::WHITE => 'Another White background',
+  EthnicGroup::OTHER => 'Another ethnic background',
+}.freeze

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -1175,6 +1175,16 @@ components:
           - "80"
           - "90"
           - "98"
+        other_disability_details:
+          type: string
+          nullable: true
+          description: The candidate’s description of their disability, if they selected “Other” and entered a value. This corresponds to HESA disability code `96`.
+          example: "My disability is..."
+        other_ethnicity_details:
+          type: string
+          nullable: true
+          description: The candidate’s description of their ethnicity, if they selected “Other” and entered a value.
+          example: "My ethnicity is..."
     Attribution:
       type: object
       additionalProperties: false

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
       equality_and_diversity do
         ethnicity = Class.new.extend(EthnicBackgroundHelper).all_combinations.sample
         other_disability = 'Acquired brain injury'
-        all_disabilities = CandidateInterface::EqualityAndDiversity::DisabilitiesForm::DISABILITIES.map(&:second) << other_disability
+        all_disabilities = DisabilityHelper::STANDARD_DISABILITIES.map(&:second) << other_disability
         disabilities = rand < 0.85 ? all_disabilities.sample([*0..3].sample) : ['Prefer not to say']
         hesa_sex = %w[1 2 3].sample
         hesa_disabilities = disabilities ? [HESA_DISABILITIES.map(&:first).sample] : %w[00]

--- a/spec/helpers/checkbox_options_helper_spec.rb
+++ b/spec/helpers/checkbox_options_helper_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe CheckboxOptionsHelper, type: :helper do
   describe '#disabilities_checkboxes' do
     it 'return a stuctured list of all listed disabilities' do
-      id, name = CandidateInterface::EqualityAndDiversity::DisabilitiesForm::DISABILITIES.sample
+      id, name = DisabilityHelper::STANDARD_DISABILITIES.sample
 
       expect(disabilities_checkboxes).to include(
         OpenStruct.new(

--- a/spec/helpers/ethnic_background_helper_spec.rb
+++ b/spec/helpers/ethnic_background_helper_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe EthnicBackgroundHelper, type: :helper do
   describe '#ethnic_backgrounds' do
-    let(:group) { EthnicBackgroundHelper::ETHNIC_GROUPS.sample }
+    let(:group) { EthnicGroup.all.sample }
 
     it 'return a stuctured list of all listed ethnic backgrounds' do
-      expected_background = EthnicBackgroundHelper::ETHNIC_BACKGROUNDS[group].sample
+      expected_background = ETHNIC_BACKGROUNDS[group].sample
 
       expect(ethnic_backgrounds(group)).to include(
         OpenStruct.new(
@@ -16,12 +16,13 @@ RSpec.describe EthnicBackgroundHelper, type: :helper do
     end
 
     it 'includes a label for the contextual other ethnic background descreption textfield' do
-      expected_other_background = EthnicBackgroundHelper::OTHER_ETHNIC_BACKGROUNDS[group]
+      expected_other_background = OTHER_ETHNIC_BACKGROUNDS[group]
+      expected_textfield_label = EthnicBackgroundHelper::ETHNIC_BACKGROUND_TEXTFIELD_LABELS[group]
 
       expect(ethnic_backgrounds(group)).to include(
         OpenStruct.new(
-          label: expected_other_background.first,
-          textfield_label: expected_other_background.second,
+          label: expected_other_background,
+          textfield_label: expected_textfield_label,
         ),
       )
     end
@@ -46,9 +47,9 @@ RSpec.describe EthnicBackgroundHelper, type: :helper do
 
     it 'has an entry for each combination of group and background' do
       result = all_combinations
-      EthnicBackgroundHelper::ETHNIC_GROUPS.each do |group|
+      EthnicGroup.all.each do |group|
         sorted_backgrounds = result.select { |e| e.first == group }.map(&:last).sort
-        expect(sorted_backgrounds).to eq(EthnicBackgroundHelper::ETHNIC_BACKGROUNDS[group].sort)
+        expect(sorted_backgrounds).to eq(ETHNIC_BACKGROUNDS[group].sort)
       end
     end
   end

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -63,14 +63,27 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
   end
 
   describe 'attributes.hesa_itt_data' do
-    context 'when an application choice has had an accepted offer' do
-      let(:application_choice) do
-        application_form = create(:application_form,
-                                  :minimum_info,
-                                  :with_equality_and_diversity_data)
-        create(:application_choice, :with_accepted_offer, application_form: application_form)
-      end
+    let(:disabilities) { %w[Deaf] }
+    let(:hesa_disabilities) { %w[57] }
+    let(:ethnic_group) { 'White' }
+    let(:ethnic_background) { 'Irish' }
+    let(:equality_and_diversity) do
+      {
+        ethnic_group: ethnic_group,
+        ethnic_background: ethnic_background,
+        disabilities: disabilities,
+        hesa_disabilities: hesa_disabilities,
+        hesa_sex: '1',
+      }
+    end
+    let(:application_choice) do
+      application_form = create(:application_form,
+                                :minimum_info,
+                                equality_and_diversity: equality_and_diversity)
+      create(:application_choice, :with_accepted_offer, application_form: application_form)
+    end
 
+    context 'when an application choice has had an accepted offer' do
       it 'returns the hesa_itt_data attribute of an application' do
         equality_and_diversity_data = application_choice.application_form.equality_and_diversity
 
@@ -80,6 +93,84 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
           disability: equality_and_diversity_data['hesa_disabilities'],
           ethnicity: equality_and_diversity_data['hesa_ethnicity'],
           sex: equality_and_diversity_data['hesa_sex'],
+          other_disability_details: nil,
+          other_ethnicity_details: nil,
+        )
+      end
+    end
+
+    context 'when the application choice has other disabilities' do
+      let(:disabilities) { ['Deaf', 'A very specific thing'] }
+      let(:hesa_disabilities) { %w[57 96] }
+
+      it 'returns the other disability in the other_disability_details field' do
+        equality_and_diversity_data = application_choice.application_form.equality_and_diversity
+
+        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+
+        expect(response.dig(:attributes, :hesa_itt_data)).to eq(
+          disability: equality_and_diversity_data['hesa_disabilities'],
+          ethnicity: equality_and_diversity_data['hesa_ethnicity'],
+          sex: equality_and_diversity_data['hesa_sex'],
+          other_disability_details: 'A very specific thing',
+          other_ethnicity_details: nil,
+        )
+      end
+    end
+
+    context 'when the application choice has other freetext ethnicity' do
+      let(:ethnic_group) { 'White' }
+      let(:ethnic_background) { 'Custom ethnic background' }
+
+      it 'returns the other ethnicity in the other_ethnicity_details field' do
+        equality_and_diversity_data = application_choice.application_form.equality_and_diversity
+
+        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+
+        expect(response.dig(:attributes, :hesa_itt_data)).to eq(
+          disability: equality_and_diversity_data['hesa_disabilities'],
+          ethnicity: equality_and_diversity_data['hesa_ethnicity'],
+          sex: equality_and_diversity_data['hesa_sex'],
+          other_disability_details: nil,
+          other_ethnicity_details: 'Custom ethnic background',
+        )
+      end
+    end
+
+    context 'when the application choice has other non-freetext ethnicity' do
+      let(:ethnic_group) { 'Another ethnic group' }
+      let(:ethnic_background) { 'Another ethnic background' }
+
+      it 'does not return the other ethnicity in the other_ethnicity_details field' do
+        equality_and_diversity_data = application_choice.application_form.equality_and_diversity
+
+        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+
+        expect(response.dig(:attributes, :hesa_itt_data)).to eq(
+          disability: equality_and_diversity_data['hesa_disabilities'],
+          ethnicity: equality_and_diversity_data['hesa_ethnicity'],
+          sex: equality_and_diversity_data['hesa_sex'],
+          other_disability_details: nil,
+          other_ethnicity_details: nil,
+        )
+      end
+    end
+
+    context 'when the application choice has set prefer not to say as the ethnic background' do
+      let(:ethnic_group) { 'Another ethnic group' }
+      let(:ethnic_background) { 'Prefer not to say' }
+
+      it 'does not return the other ethnicity in the other_ethnicity_details field' do
+        equality_and_diversity_data = application_choice.application_form.equality_and_diversity
+
+        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+
+        expect(response.dig(:attributes, :hesa_itt_data)).to eq(
+          disability: equality_and_diversity_data['hesa_disabilities'],
+          ethnicity: equality_and_diversity_data['hesa_ethnicity'],
+          sex: equality_and_diversity_data['hesa_sex'],
+          other_disability_details: nil,
+          other_ethnicity_details: nil,
         )
       end
     end


### PR DESCRIPTION
## Context
We have been asked to expose this data since Vendors will need more information than just "Other" if we have it.

## Link to Trello card
https://trello.com/c/lVL9xKPU/3742-tribal-selected-disability-other-and-populated-textbox-the-text-is-not-sent-in-the-api

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
