### PR TITLE
add migration to delete courses with no uuid

### DIFF
--- a/app/services/data_migrations/delete_uuidless_courses.rb
+++ b/app/services/data_migrations/delete_uuidless_courses.rb
@@ -1,0 +1,17 @@
+module DataMigrations
+  class DeleteUuidlessCourses
+    TIMESTAMP = 20210601155313
+    MANUAL_RUN = true
+
+    def change
+      courses_without_uuid = Course.where(uuid: nil)
+      raise 'Cannot delete courses with outstanding applications' if courses_without_uuid.flat_map(&:application_choices).any?
+
+      course_options_without_uuid = courses_without_uuid.flat_map(&:course_options)
+      course_subjects_without_uuid = courses_without_uuid.flat_map(&:course_subjects)
+      course_subjects_without_uuid.each(&:destroy)
+      course_options_without_uuid.each(&:destroy)
+      courses_without_uuid.each(&:destroy)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::DeleteUuidlessCourses',
   'DataMigrations::RemovePreviousCyclesCoursesFromApplicationsInTheCurrentCycle',
   'DataMigrations::BackfillRestucturedWorkHistoryBoolean',
   'DataMigrations::BackfillValidationErrorsServiceColumn',

--- a/spec/services/data_migrations/delete_uuidless_courses_spec.rb
+++ b/spec/services/data_migrations/delete_uuidless_courses_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::DeleteUuidlessCourses do
+  context 'when uuid is nil' do
+    let!(:course) { create(:course, uuid: nil) }
+    let!(:course_option) { create(:course_option, course: course) }
+
+    it 'deletes courses without uuids and associated course options and subjects' do
+      expect { described_class.new.change }.to change(course.course_subjects, :count).by(-1)
+                                           .and change(course.course_options, :count).by(-1)
+                                           .and change(Course, :count).by(-1)
+    end
+  end
+
+  context 'when a course has an outstanding application' do
+    let!(:course) { create(:course, uuid: nil) }
+    let!(:application_choice) { create(:application_choice, course: course) }
+
+    it 'raises an Error and doesnt delete the course' do
+      expect { described_class.new.change }.to raise_error('Cannot delete courses with outstanding applications')
+                                           .and change(Course, :count).by(0)
+    end
+  end
+
+  context 'when uuid is not nil' do
+    let!(:course) { create(:course, uuid: SecureRandom.uuid) }
+    let!(:course_option) { create(:course_option, course: course) }
+
+    it 'doesnt deletes courses with uuids or their associated course options and subjects' do
+      expect { described_class.new.change }.to change(course.course_subjects, :count).by(0)
+                                           .and change(course.course_options, :count).by(0)
+                                           .and change(Course, :count).by(0)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Migration to remove courses on apply with no UUIDs present, these courses arnt on the TTAPI and so should be removed. None of these courses have any applications associated with them.

## Link to Trello card

https://trello.com/c/XggXgsa7/3710-investigate-courses-with-no-uuids

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
