### PR TITLE
Fix validation so you can choose not to complete the GCSE section

### DIFF
--- a/app/controllers/candidate_interface/degrees/review_controller.rb
+++ b/app/controllers/candidate_interface/degrees/review_controller.rb
@@ -10,9 +10,10 @@ module CandidateInterface
         @application_form = current_application
         @section_complete_form = SectionCompleteForm.new(application_form_params)
 
-        if @application_form.incomplete_degree_information?
+        if @application_form.incomplete_degree_information? &&
+            ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
           flash[:warning] = 'You cannot mark this section complete with incomplete degree information.'
-          render :show
+          redirect_to candidate_interface_degrees_review_path
         elsif @section_complete_form.save(current_application, :degrees_completed)
           redirect_to candidate_interface_application_form_path
         else

--- a/app/controllers/candidate_interface/gcse/review_controller.rb
+++ b/app/controllers/candidate_interface/gcse/review_controller.rb
@@ -16,9 +16,11 @@ module CandidateInterface
       @application_qualification = current_qualification
       @section_complete_form = SectionCompleteForm.new(completed: application_form_params[:completed])
 
-      if @application_qualification.incomplete_gcse_information? && !@application_qualification.missing_qualification?
+      if @application_qualification.incomplete_gcse_information? &&
+          !@application_qualification.missing_qualification? &&
+          ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
         flash[:warning] = 'You cannot mark this section complete with incomplete GCSE information.'
-        render :show
+        redirect_to candidate_interface_gcse_review_path(subject: @subject)
       elsif @section_complete_form.save(current_application, @field_name.to_sym)
         redirect_to candidate_interface_application_form_path
       else

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
@@ -53,6 +53,16 @@ RSpec.feature 'Candidate entering GCSE details' do
     when_i_mark_the_section_as_completed
     and_click_continue
     then_i_see_the_maths_gcse_is_completed
+
+    when_i_click_on_the_english_gcse_link
+    then_i_see_the_add_gcse_english_page
+
+    when_i_select_gcse_option
+    and_i_click_save_and_continue
+    then_i_see_add_english_grade_page
+
+    when_i_choose_to_return_later
+    then_i_am_returned_to_the_application_form
   end
 
   def given_i_am_signed_in
@@ -185,5 +195,31 @@ RSpec.feature 'Candidate entering GCSE details' do
 
   def when_i_click_continue
     and_click_continue
+  end
+
+  def when_i_click_on_the_english_gcse_link
+    click_on 'English GCSE or equivalent'
+  end
+
+  def then_i_see_add_english_grade_page
+    expect(page).to have_content t('multiple_gcse_edit_grade.page_title')
+  end
+
+  def then_i_see_the_add_gcse_english_page
+    expect(page).to have_content 'Add English GCSE grade 4 (C) or above, or equivalent'
+  end
+
+  def when_i_choose_to_return_later
+    visit candidate_interface_gcse_review_path(subject: 'english')
+    and_i_mark_the_section_as_incomplete
+    and_click_continue
+  end
+
+  def and_i_mark_the_section_as_incomplete
+    choose t('application_form.incomplete_radio')
+  end
+
+  def then_i_am_returned_to_the_application_form
+    expect(page).to have_current_path candidate_interface_application_form_path
   end
 end

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
@@ -26,8 +26,9 @@ RSpec.feature 'Deleting and replacing a degree' do
     then_i_can_only_see_my_undergraduate_degree
 
     when_i_add_another_degree_type_only
-    and_return_to_the_application_review_page
-    then_i_should_see_the_form_and_the_section_is_not_completed
+    and_i_choose_to_return_later
+    then_i_am_returned_to_the_application_form
+    and_i_should_see_the_form_and_the_section_is_not_completed
   end
 
   def given_i_am_signed_in
@@ -116,6 +117,7 @@ RSpec.feature 'Deleting and replacing a degree' do
     expect(page).to have_content(t('page_titles.application_form'))
     expect(page).not_to have_css('#degree-badge-id', text: 'Completed')
   end
+  alias_method :and_i_should_see_the_form_and_the_section_is_not_completed, :then_i_should_see_the_form_and_the_section_is_not_completed
 
   def when_i_add_my_degree_back_in
     when_i_choose_uk_degree
@@ -205,7 +207,13 @@ RSpec.feature 'Deleting and replacing a degree' do
     and_i_click_on_save_and_continue
   end
 
-  def and_return_to_the_application_review_page
-    visit candidate_interface_application_form_path
+  def and_i_choose_to_return_later
+    visit candidate_interface_degrees_review_path
+    and_i_mark_the_section_as_incomplete
+    and_i_click_on_continue
+  end
+
+  def then_i_am_returned_to_the_application_form
+    expect(page).to have_current_path candidate_interface_application_form_path
   end
 end


### PR DESCRIPTION
## Context

If a GCSE is incomplete you should not be able to set the section to the completed state. However there is a bug that prevents you from leaving it incomplete.

## Changes proposed in this pull request

- Check that the validation is only applied when candidate selects the _I have completed this section_ radio button.
- Use a redirect rather than render when the validation is applied to prevent double render of message.
- Repeat for the degree section.

## Guidance to review

- Per commit (there's only 2)

## Link to Trello card

https://trello.com/c/qwPoYnt3/3457-you-cant-choose-not-to-complete-the-section-unless-all-gcse-fields-are-complete

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
