### PR TITLE
Mark send_notifications as an ignored column

### DIFF
--- a/app/controllers/provider_interface/notifications_controller.rb
+++ b/app/controllers/provider_interface/notifications_controller.rb
@@ -11,12 +11,6 @@ module ProviderInterface
 
   private
 
-    def notification_params
-      return ActionController::Parameters.new unless params.key?(:provider_user)
-
-      params.require(:provider_user).permit(:send_notifications)
-    end
-
     def notification_preferences_params
       return ActionController::Parameters.new unless params.key?(:provider_user_notification_preferences)
 

--- a/app/controllers/support_interface/provider_user_notification_preferences_controller.rb
+++ b/app/controllers/support_interface/provider_user_notification_preferences_controller.rb
@@ -1,12 +1,5 @@
 module SupportInterface
   class ProviderUserNotificationPreferencesController < SupportInterfaceController
-    def toggle_notifications
-      provider_user_notifications_service.backfill_notification_preferences!(send_notifications: !provider_user.send_notifications)
-
-      flash[:success] = 'Provider user updated'
-      redirect_to support_interface_provider_user_path(provider_user)
-    end
-
     def update_notifications
       provider_user_notifications_service.update_all_notification_preferences!(notification_preferences_params: notification_preferences_params)
 

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -1,6 +1,8 @@
 class ProviderUser < ApplicationRecord
   include AuthenticatedUsingMagicLinks
 
+  self.ignored_columns = %w[send_notifications]
+
   has_many :provider_permissions, dependent: :destroy
   has_many :providers, through: :provider_permissions
   has_many :notes, dependent: :destroy

--- a/app/services/provider_interface/save_provider_user_service.rb
+++ b/app/services/provider_interface/save_provider_user_service.rb
@@ -55,9 +55,7 @@ module ProviderInterface
     end
 
     def create_notification_preferences!(user)
-      SaveProviderUserNotificationPreferences
-        .new(provider_user: user)
-        .backfill_notification_preferences!(send_notifications: user.send_notifications)
+      ProviderUserNotificationPreferences.create!(provider_user: user)
     end
 
     def create_provider_permissions!(user)

--- a/app/services/save_provider_user.rb
+++ b/app/services/save_provider_user.rb
@@ -7,17 +7,17 @@ class SaveProviderUser
 
   def call!
     @provider_user.save!
-    save_provider_user_notification_preferences!
+    save_notification_preferences!
     update_provider_permissions!
     @provider_user.reload
   end
 
 private
 
-  def save_provider_user_notification_preferences!
-    SaveProviderUserNotificationPreferences
-      .new(provider_user: @provider_user)
-      .backfill_notification_preferences!(send_notifications: @provider_user.send_notifications)
+  def save_notification_preferences!
+    return if ProviderUserNotificationPreferences.exists?(provider_user: @provider_user)
+
+    ProviderUserNotificationPreferences.create!(provider_user: @provider_user)
   end
 
   def update_provider_permissions!

--- a/app/services/save_provider_user_notification_preferences.rb
+++ b/app/services/save_provider_user_notification_preferences.rb
@@ -5,45 +5,16 @@ class SaveProviderUserNotificationPreferences
     @provider_user = provider_user
   end
 
-  def backfill_notification_preferences!(send_notifications:)
-    return false if send_notifications.nil?
-
-    ActiveRecord::Base.transaction do
-      provider_user_notification_preferences.update_all_preferences(send_notifications)
-      update_provider_user!(send_notifications)
-    end
-  end
-
   def update_all_notification_preferences!(notification_preferences_params: {})
     return false if notification_preferences_params.empty?
 
-    ActiveRecord::Base.transaction do
-      update_provider_user!(send_notifications_from_notificaion_prefernces(notification_preferences_params))
-      provider_user_notification_preferences.update!(notification_preferences_params)
-    end
+    provider_user_notification_preferences.update!(notification_preferences_params)
   end
 
 private
 
-  def update_provider_user!(send_notifications)
-    provider_user.assign_attributes(send_notifications: send_notifications)
-
-    provider_user.save! if provider_user.send_notifications_changed?
-  end
-
   def provider_user_notification_preferences
     @provider_user_notification_preferences ||= provider_user.notification_preferences ||
       ProviderUserNotificationPreferences.create!(provider_user: provider_user)
-  end
-
-  def send_notifications_from_notificaion_prefernces(notification_preferences_params)
-    values =
-      notification_preferences_params
-        .values
-        .uniq
-
-    return true if values.count > 1
-
-    values.first
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1029,7 +1029,6 @@ Rails.application.routes.draw do
 
       resources :provider_users, only: %i[show index new create edit update], path: :provider do
         get '/audits' => 'provider_users#audits'
-        patch '/toggle-notifications' => 'provider_user_notification_preferences#toggle_notifications', as: :toggle_notifications
         put '/update-notifications' => 'provider_user_notification_preferences#update_notifications', as: :update_notifications
         post '/impersonate' => 'provider_users#impersonate', as: :impersonate
       end

--- a/spec/components/provider_user_notification_preferences_component_spec.rb
+++ b/spec/components/provider_user_notification_preferences_component_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ProviderUserNotificationPreferencesComponent do
-  let(:provider_user) { create(:provider_user, send_notifications: true) }
+  let(:provider_user) { create(:provider_user) }
   let(:notification_preferences) { provider_user.notification_preferences }
 
   it 'renders correct labels for notification preferences' do

--- a/spec/components/support_interface/provider_user_summary_component_spec.rb
+++ b/spec/components/support_interface/provider_user_summary_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportInterface::ProviderUserSummaryComponent do
   let(:provider_user) do
     create(:provider_user,
-           :with_notification_preferences_enabled,
+           :with_notifications_enabled,
            first_name: 'John',
            last_name: 'Smith',
            email_address: 'provider@example.com',

--- a/spec/components/support_interface/provider_user_summary_component_spec.rb
+++ b/spec/components/support_interface/provider_user_summary_component_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.describe SupportInterface::ProviderUserSummaryComponent do
   let(:provider_user) do
     create(:provider_user,
+           :with_notification_preferences_enabled,
            first_name: 'John',
            last_name: 'Smith',
            email_address: 'provider@example.com',
            dfe_sign_in_uid: 'ABC-UID',
            last_signed_in_at: Time.zone.local(2021, 0o3, 15, 10, 45, 0),
-           providers: [create(:provider, name: 'The Provider')],
-           send_notifications: true)
+           providers: [create(:provider, name: 'The Provider')])
   end
 
   subject(:rendered_component) do

--- a/spec/factories/provider_user.rb
+++ b/spec/factories/provider_user.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     email_address { "#{Faker::Name.first_name.downcase}-#{SecureRandom.hex}@example.com" }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
-    send_notifications { Faker::Boolean.boolean(true_ratio: 0.5) }
 
     transient do
       create_notification_preference { true }
@@ -12,7 +11,7 @@ FactoryBot.define do
 
     after(:create) do |user, evaluator|
       if evaluator.create_notification_preference
-        user.send_notifications ? create(:provider_user_notification_preferences, provider_user: user) : create(:provider_user_notification_preferences, :all_off, provider_user: user)
+        create(:provider_user_notification_preferences, :all_off, provider_user: user)
       end
     end
 
@@ -63,6 +62,12 @@ FactoryBot.define do
     trait :with_view_diversity_information do
       after(:create) do |user, _evaluator|
         user.provider_permissions.update_all(view_diversity_information: true)
+      end
+    end
+
+    trait :with_notification_preferences_enabled do
+      after(:create) do |user, _evaluator|
+        user.notification_preferences.update_all_preferences(true)
       end
     end
   end

--- a/spec/factories/provider_user.rb
+++ b/spec/factories/provider_user.rb
@@ -65,7 +65,7 @@ FactoryBot.define do
       end
     end
 
-    trait :with_notification_preferences_enabled do
+    trait :with_notifications_enabled do
       after(:create) do |user, _evaluator|
         user.notification_preferences.update_all_preferences(true)
       end

--- a/spec/services/accept_offer_spec.rb
+++ b/spec/services/accept_offer_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe AcceptOffer do
   describe 'emails', sidekiq: true do
     it 'sends a notification email to the training provider and ratifying provider' do
       training_provider = create(:provider)
-      training_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [training_provider])
+      training_provider_user = create(:provider_user, :with_notifications_enabled, providers: [training_provider])
 
       ratifying_provider = create(:provider)
-      ratifying_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [ratifying_provider])
+      ratifying_provider_user = create(:provider_user, :with_notifications_enabled, providers: [ratifying_provider])
 
       course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
       application_choice = create(:application_choice, :with_offer, course_option: course_option)

--- a/spec/services/accept_offer_spec.rb
+++ b/spec/services/accept_offer_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe AcceptOffer do
   describe 'emails', sidekiq: true do
     it 'sends a notification email to the training provider and ratifying provider' do
       training_provider = create(:provider)
-      training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+      training_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [training_provider])
 
       ratifying_provider = create(:provider)
-      ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+      ratifying_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [ratifying_provider])
 
       course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
       application_choice = create(:application_choice, :with_offer, course_option: course_option)

--- a/spec/services/accept_unconditional_offer_spec.rb
+++ b/spec/services/accept_unconditional_offer_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe AcceptUnconditionalOffer do
 
     it 'sends a notification email to the training provider and ratifying provider' do
       training_provider = create(:provider)
-      training_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [training_provider])
+      training_provider_user = create(:provider_user, :with_notifications_enabled, providers: [training_provider])
 
       ratifying_provider = create(:provider)
-      ratifying_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [ratifying_provider])
+      ratifying_provider_user = create(:provider_user, :with_notifications_enabled, providers: [ratifying_provider])
 
       course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
       application_choice = build(:application_choice, :with_offer, course_option: course_option)

--- a/spec/services/accept_unconditional_offer_spec.rb
+++ b/spec/services/accept_unconditional_offer_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe AcceptUnconditionalOffer do
 
     it 'sends a notification email to the training provider and ratifying provider' do
       training_provider = create(:provider)
-      training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+      training_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [training_provider])
 
       ratifying_provider = create(:provider)
-      ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+      ratifying_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [ratifying_provider])
 
       course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
       application_choice = build(:application_choice, :with_offer, course_option: course_option)

--- a/spec/services/decline_offer_by_default_spec.rb
+++ b/spec/services/decline_offer_by_default_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe DeclineOfferByDefault do
 
   it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do
     training_provider = create(:provider)
-    training_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [training_provider])
+    training_provider_user = create(:provider_user, :with_notifications_enabled, providers: [training_provider])
 
     ratifying_provider = create(:provider)
-    ratifying_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [ratifying_provider])
+    ratifying_provider_user = create(:provider_user, :with_notifications_enabled, providers: [ratifying_provider])
 
     course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
     application_choice = create(:application_choice, status: :offer, course_option: course_option)

--- a/spec/services/decline_offer_by_default_spec.rb
+++ b/spec/services/decline_offer_by_default_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe DeclineOfferByDefault do
 
   it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do
     training_provider = create(:provider)
-    training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+    training_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [training_provider])
 
     ratifying_provider = create(:provider)
-    ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+    ratifying_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [ratifying_provider])
 
     course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
     application_choice = create(:application_choice, status: :offer, course_option: course_option)

--- a/spec/services/decline_offer_spec.rb
+++ b/spec/services/decline_offer_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe DeclineOffer do
 
   it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do
     training_provider = create(:provider)
-    training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+    training_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [training_provider])
 
     ratifying_provider = create(:provider)
-    ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+    ratifying_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [ratifying_provider])
 
     course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
     application_choice = create(:application_choice, status: :offer, course_option: course_option)

--- a/spec/services/decline_offer_spec.rb
+++ b/spec/services/decline_offer_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe DeclineOffer do
 
   it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do
     training_provider = create(:provider)
-    training_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [training_provider])
+    training_provider_user = create(:provider_user, :with_notifications_enabled, providers: [training_provider])
 
     ratifying_provider = create(:provider)
-    ratifying_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [ratifying_provider])
+    ratifying_provider_user = create(:provider_user, :with_notifications_enabled, providers: [ratifying_provider])
 
     course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
     application_choice = create(:application_choice, status: :offer, course_option: course_option)

--- a/spec/services/notifications_list_spec.rb
+++ b/spec/services/notifications_list_spec.rb
@@ -2,52 +2,44 @@ require 'rails_helper'
 
 RSpec.describe NotificationsList do
   describe '.for' do
-    context 'when the configurable provider notifications feature flag is on' do
-      it 'raises an error for an undefined type of event' do
-        application_choice = build(:application_choice)
+    it 'raises an error for an undefined type of event' do
+      application_choice = build(:application_choice)
 
-        expect { NotificationsList.for(application_choice, event: 'application_exploded') }.to raise_error('Undefined type of notification event')
-      end
+      expect { NotificationsList.for(application_choice, event: 'application_exploded') }.to raise_error('Undefined type of notification event')
+    end
 
-      it 'returns training provider users for the application choice for a given type of event' do
-        application_choice = create(:application_choice)
+    it 'returns training provider users for the application choice for a given type of event' do
+      application_choice = create(:application_choice)
+      provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [application_choice.course.provider])
 
-        create(:provider_user_notification_preferences, :all_off, provider_user: create(:provider_user, send_notifications: false, providers: [application_choice.course.provider]))
-        create(:provider_user_notification_preferences)
+      create(:provider_user_notification_preferences, :all_off, provider_user: create(:provider_user, providers: [application_choice.course.provider]))
 
-        provider_user = create(:provider_user, send_notifications: true, providers: [application_choice.course.provider])
+      expect(NotificationsList.for(application_choice, event: :offer_accepted).to_a).to eql([provider_user])
+    end
 
-        expect(NotificationsList.for(application_choice, event: :offer_accepted).to_a).to eql([provider_user])
-      end
+    it 'returns training and ratifying provider users for the application choice for a given type of event' do
+      ratifying_provider = create(:provider)
+      ratifying_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [ratifying_provider])
 
-      it 'returns training and ratifying provider users for the application choice for a given type of event' do
-        ratifying_provider = create(:provider)
-        ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+      application_choice = create(:application_choice, course_option: create(:course_option, course: create(:course, accredited_provider: ratifying_provider)))
 
-        application_choice = create(:application_choice, course_option: create(:course_option, course: create(:course, accredited_provider: ratifying_provider)))
+      training_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [application_choice.course.provider])
 
-        training_provider_user = create(:provider_user, send_notifications: true, providers: [application_choice.course.provider])
+      create(:provider_user_notification_preferences, :all_off, provider_user: create(:provider_user, providers: [application_choice.course.provider]))
+      expect(NotificationsList.for(application_choice, include_ratifying_provider: true, event: :offer_accepted).to_a).to match_array([training_provider_user, ratifying_provider_user])
+    end
 
-        create(:provider_user_notification_preferences, :all_off, provider_user: create(:provider_user, send_notifications: false, providers: [application_choice.course.provider]))
-        create(:provider_user_notification_preferences)
+    it 'returns a provider user who is a member of the training and ratifying providers without duplicates' do
+      ratifying_provider = create(:provider)
+      training_provider = create(:provider)
+      provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [training_provider, ratifying_provider])
+      application_choice = create(:application_choice, course_option: create(:course_option, course: create(:course, provider: training_provider, accredited_provider: ratifying_provider)))
 
-        expect(NotificationsList.for(application_choice, include_ratifying_provider: true, event: :offer_accepted).to_a).to match_array([training_provider_user, ratifying_provider_user])
-      end
-
-      it 'returns a provider user who is a member of the training and ratifying providers without duplicates' do
-        ratifying_provider = create(:provider)
-        training_provider = create(:provider)
-        provider_user = create(:provider_user, send_notifications: true, providers: [training_provider, ratifying_provider])
-        application_choice = create(:application_choice, course_option: create(:course_option, course: create(:course, provider: training_provider, accredited_provider: ratifying_provider)))
-
-        create(:provider_user_notification_preferences, provider_user: provider_user)
-
-        expect(NotificationsList.for(
-          application_choice,
-          include_ratifying_provider: true,
-          event: :offer_accepted,
-        ).to_a).to match_array([provider_user])
-      end
+      expect(NotificationsList.for(
+        application_choice,
+        include_ratifying_provider: true,
+        event: :offer_accepted,
+      ).to_a).to match_array([provider_user])
     end
   end
 end

--- a/spec/services/notifications_list_spec.rb
+++ b/spec/services/notifications_list_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe NotificationsList do
 
     it 'returns training provider users for the application choice for a given type of event' do
       application_choice = create(:application_choice)
-      provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [application_choice.course.provider])
+      provider_user = create(:provider_user, :with_notifications_enabled, providers: [application_choice.course.provider])
 
       create(:provider_user_notification_preferences, :all_off, provider_user: create(:provider_user, providers: [application_choice.course.provider]))
 
@@ -19,11 +19,11 @@ RSpec.describe NotificationsList do
 
     it 'returns training and ratifying provider users for the application choice for a given type of event' do
       ratifying_provider = create(:provider)
-      ratifying_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [ratifying_provider])
+      ratifying_provider_user = create(:provider_user, :with_notifications_enabled, providers: [ratifying_provider])
 
       application_choice = create(:application_choice, course_option: create(:course_option, course: create(:course, accredited_provider: ratifying_provider)))
 
-      training_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [application_choice.course.provider])
+      training_provider_user = create(:provider_user, :with_notifications_enabled, providers: [application_choice.course.provider])
 
       create(:provider_user_notification_preferences, :all_off, provider_user: create(:provider_user, providers: [application_choice.course.provider]))
       expect(NotificationsList.for(application_choice, include_ratifying_provider: true, event: :offer_accepted).to_a).to match_array([training_provider_user, ratifying_provider_user])
@@ -32,7 +32,7 @@ RSpec.describe NotificationsList do
     it 'returns a provider user who is a member of the training and ratifying providers without duplicates' do
       ratifying_provider = create(:provider)
       training_provider = create(:provider)
-      provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [training_provider, ratifying_provider])
+      provider_user = create(:provider_user, :with_notifications_enabled, providers: [training_provider, ratifying_provider])
       application_choice = create(:application_choice, course_option: create(:course_option, course: create(:course, provider: training_provider, accredited_provider: ratifying_provider)))
 
       expect(NotificationsList.for(

--- a/spec/services/save_provider_user_notification_preferences_spec.rb
+++ b/spec/services/save_provider_user_notification_preferences_spec.rb
@@ -2,75 +2,9 @@ require 'rails_helper'
 
 RSpec.describe SaveProviderUserNotificationPreferences do
   let(:create_notification_preference) { false }
-  let(:send_notifications) { false }
-  let!(:provider_user) { create(:provider_user, create_notification_preference: create_notification_preference, send_notifications: send_notifications) }
+  let!(:provider_user) { create(:provider_user, create_notification_preference: create_notification_preference) }
 
   subject(:service) { described_class.new(provider_user: provider_user) }
-
-  describe 'backfill_notification_preferences!' do
-    it 'returns false if no value for #send_notifications is set' do
-      expect(service.backfill_notification_preferences!(send_notifications: nil)).to be(false)
-    end
-
-    context 'when no notification preferences exist for a provider user' do
-      it 'updates #send_notifications for a provider user' do
-        service.backfill_notification_preferences!(send_notifications: true)
-
-        expect(provider_user.send_notifications).to be(true)
-      end
-
-      it 'creates the #notification_preferences for the provider user' do
-        expect { service.backfill_notification_preferences!(send_notifications: true) }.to change(ProviderUserNotificationPreferences, :count).by(1)
-      end
-
-      it 'sets the correct value for the #notification_preferences for a provider user' do
-        service.backfill_notification_preferences!(send_notifications: true)
-
-        ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |preference|
-          expect(provider_user.reload.notification_preferences.send(preference)).to be(true)
-        end
-      end
-    end
-
-    context 'when notification preferences exist for a user' do
-      let(:create_notification_preference) { true }
-
-      it 'updates #send_notifications for a provider user' do
-        service.backfill_notification_preferences!(send_notifications: true)
-
-        expect(provider_user.send_notifications).to be(true)
-      end
-
-      it 'does not create #notification_preferences for a provider user' do
-        expect { service.backfill_notification_preferences!(send_notifications: true) }.not_to change(ProviderUserNotificationPreferences, :count)
-      end
-
-      it 'sets the correct value for the #notification_preferences for a provider user' do
-        service.backfill_notification_preferences!(send_notifications: true)
-
-        ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |preference|
-          expect(provider_user.reload.notification_preferences.send(preference)).to be(true)
-        end
-      end
-    end
-
-    context 'when send notification preference is unchanged' do
-      let(:send_notifications) { false }
-
-      it 'does not update #send_notifications for a provider user' do
-        expect { service.backfill_notification_preferences!(send_notifications: false) }.not_to change(provider_user, :send_notifications)
-        expect(provider_user.send_notifications).to be(false)
-      end
-
-      it 'sets the correct value for the #notification_preferences for a provider user' do
-        service.backfill_notification_preferences!(send_notifications: false)
-
-        ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |preference|
-          expect(provider_user.reload.notification_preferences.send(preference)).to be(false)
-        end
-      end
-    end
-  end
 
   describe 'update_all_notification_preferences!' do
     it 'returns false if no value for #notification_preferences_params is set' do
@@ -78,7 +12,6 @@ RSpec.describe SaveProviderUserNotificationPreferences do
     end
 
     context 'when all #notification_preferences_params values are the same' do
-      let(:send_notifications) { true }
       let(:notification_preferences_params) do
         {
           application_received: false,
@@ -87,12 +20,6 @@ RSpec.describe SaveProviderUserNotificationPreferences do
           offer_accepted: false,
           offer_declined: false,
         }
-      end
-
-      it 'updates #send_notifications for a provider user' do
-        service.update_all_notification_preferences!(notification_preferences_params: notification_preferences_params)
-
-        expect(provider_user.send_notifications).to be(false)
       end
 
       it 'sets the correct value for the #notification_preferences for a provider user' do
@@ -113,12 +40,6 @@ RSpec.describe SaveProviderUserNotificationPreferences do
           offer_accepted: true,
           offer_declined: false,
         }
-      end
-
-      it 'updates #send_notifications for a provider user' do
-        service.update_all_notification_preferences!(notification_preferences_params: notification_preferences_params)
-
-        expect(provider_user.send_notifications).to be(true)
       end
 
       it 'sets the correct value for the #notification_preferences for a provider user' do

--- a/spec/services/save_provider_user_spec.rb
+++ b/spec/services/save_provider_user_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SaveProviderUser do
   let(:provider) { create(:provider) }
   let(:another_provider) { create(:provider) }
   let(:new_provider) { create(:provider) }
-  let(:provider_user) { create(:provider_user, create_notification_preference: false, providers: [provider, another_provider]) }
+  let(:provider_user) { create(:provider_user, providers: [provider, another_provider]) }
   let(:provider_ids) { { selected: [another_provider.id], deselected: [provider.id] } }
   let(:deselected_provider_permissions) { provider_user.provider_permissions.where(provider: provider) }
   let(:provider_permissions) do

--- a/spec/services/send_application_to_provider_spec.rb
+++ b/spec/services/send_application_to_provider_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe SendApplicationToProvider do
   end
 
   it 'emails the provider’s provider users', sidekiq: true do
-    user = create(:provider_user, :with_notification_preferences_enabled)
+    user = create(:provider_user, :with_notifications_enabled)
 
     application_choice.provider.provider_users = [user]
 

--- a/spec/services/send_application_to_provider_spec.rb
+++ b/spec/services/send_application_to_provider_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe SendApplicationToProvider do
   end
 
   it 'emails the provider’s provider users', sidekiq: true do
-    user = create(:provider_user, send_notifications: true)
+    user = create(:provider_user, :with_notification_preferences_enabled)
+
     application_choice.provider.provider_users = [user]
 
     expect {

--- a/spec/services/send_new_application_email_to_provider_spec.rb
+++ b/spec/services/send_new_application_email_to_provider_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe SendNewApplicationEmailToProvider, sidekiq: true do
 
   it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do
     training_provider = create(:provider)
-    training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+    training_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [training_provider])
 
     ratifying_provider = create(:provider)
-    ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+    ratifying_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [ratifying_provider])
 
     course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
     application_choice = create(:application_choice, :with_completed_application_form, :awaiting_provider_decision, course_option: course_option)
@@ -24,7 +24,7 @@ RSpec.describe SendNewApplicationEmailToProvider, sidekiq: true do
 
   it 'sends a different email when the candidate supplied safeguarding information' do
     provider = create(:provider)
-    create(:provider_user, send_notifications: true, providers: [provider])
+    create(:provider_user, :with_notification_preferences_enabled, providers: [provider])
     option = course_option_for_provider(provider: provider)
 
     form = create(:completed_application_form, :with_safeguarding_issues_disclosed)

--- a/spec/services/send_new_application_email_to_provider_spec.rb
+++ b/spec/services/send_new_application_email_to_provider_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe SendNewApplicationEmailToProvider, sidekiq: true do
 
   it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do
     training_provider = create(:provider)
-    training_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [training_provider])
+    training_provider_user = create(:provider_user, :with_notifications_enabled, providers: [training_provider])
 
     ratifying_provider = create(:provider)
-    ratifying_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [ratifying_provider])
+    ratifying_provider_user = create(:provider_user, :with_notifications_enabled, providers: [ratifying_provider])
 
     course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
     application_choice = create(:application_choice, :with_completed_application_form, :awaiting_provider_decision, course_option: course_option)
@@ -24,7 +24,7 @@ RSpec.describe SendNewApplicationEmailToProvider, sidekiq: true do
 
   it 'sends a different email when the candidate supplied safeguarding information' do
     provider = create(:provider)
-    create(:provider_user, :with_notification_preferences_enabled, providers: [provider])
+    create(:provider_user, :with_notifications_enabled, providers: [provider])
     option = course_option_for_provider(provider: provider)
 
     form = create(:completed_application_form, :with_safeguarding_issues_disclosed)

--- a/spec/services/send_reject_by_default_email_to_provider_spec.rb
+++ b/spec/services/send_reject_by_default_email_to_provider_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SendRejectByDefaultEmailToProvider do
 
   it 'sends a notification email to the training provider', sidekiq: true do
     training_provider = create(:provider)
-    training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+    training_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [training_provider])
 
     application_choice = create(:application_choice, :with_rejection_by_default, application_form: create(:application_form, :minimum_info), course_option: course_option_for_provider(provider: training_provider))
 

--- a/spec/services/send_reject_by_default_email_to_provider_spec.rb
+++ b/spec/services/send_reject_by_default_email_to_provider_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SendRejectByDefaultEmailToProvider do
 
   it 'sends a notification email to the training provider', sidekiq: true do
     training_provider = create(:provider)
-    training_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [training_provider])
+    training_provider_user = create(:provider_user, :with_notifications_enabled, providers: [training_provider])
 
     application_choice = create(:application_choice, :with_rejection_by_default, application_form: create(:application_form, :minimum_info), course_option: course_option_for_provider(provider: training_provider))
 

--- a/spec/services/withdraw_application_spec.rb
+++ b/spec/services/withdraw_application_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe WithdrawApplication do
 
     it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do
       training_provider = create(:provider)
-      training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+      training_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [training_provider])
 
       ratifying_provider = create(:provider)
-      ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+      ratifying_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [ratifying_provider])
 
       course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
       application_choice = create(:submitted_application_choice, course_option: course_option)

--- a/spec/services/withdraw_application_spec.rb
+++ b/spec/services/withdraw_application_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe WithdrawApplication do
 
     it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do
       training_provider = create(:provider)
-      training_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [training_provider])
+      training_provider_user = create(:provider_user, :with_notifications_enabled, providers: [training_provider])
 
       ratifying_provider = create(:provider)
-      ratifying_provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [ratifying_provider])
+      ratifying_provider_user = create(:provider_user, :with_notifications_enabled, providers: [ratifying_provider])
 
       course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
       application_choice = create(:submitted_application_choice, course_option: course_option)

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -34,7 +34,7 @@ module DfESignInHelpers
     provider_one = create(:provider, :with_signed_agreement, code: 'ABC', name: 'Example Provider')
     provider_two = create(:provider, :with_signed_agreement, code: 'DEF', name: 'Another Provider')
     create(:provider_user,
-           :with_notification_preferences_enabled,
+           :with_notifications_enabled,
            providers: [provider_one, provider_two],
            dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
            email_address: email_address)

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -30,14 +30,14 @@ module DfESignInHelpers
     support_user_signs_in_using_dfe_sign_in
   end
 
-  def provider_user_exists_in_apply_database(email_address: 'email@provider.ac.uk', send_notifications: true)
+  def provider_user_exists_in_apply_database(email_address: 'email@provider.ac.uk')
     provider_one = create(:provider, :with_signed_agreement, code: 'ABC', name: 'Example Provider')
     provider_two = create(:provider, :with_signed_agreement, code: 'DEF', name: 'Another Provider')
     create(:provider_user,
+           :with_notification_preferences_enabled,
            providers: [provider_one, provider_two],
            dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
-           email_address: email_address,
-           send_notifications: send_notifications)
+           email_address: email_address)
   end
 
   def provider_user_exists_in_apply_database_with_multiple_providers

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature 'Candidate accepts an offer' do
     @course_option = course_option_for_provider_code(provider_code: 'ABC')
     other_course_option = course_option_for_provider_code(provider_code: 'DEF')
 
-    @provider_user = create(:provider_user, send_notifications: true, providers: [@course_option.course.provider])
+    @provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [@course_option.course.provider])
 
     @application_choice = create(
       :application_choice,

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature 'Candidate accepts an offer' do
     @course_option = course_option_for_provider_code(provider_code: 'ABC')
     other_course_option = course_option_for_provider_code(provider_code: 'DEF')
 
-    @provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [@course_option.course.provider])
+    @provider_user = create(:provider_user, :with_notifications_enabled, providers: [@course_option.course.provider])
 
     @application_choice = create(
       :application_choice,

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_declines_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_declines_offer_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'Candidate declines an offer' do
       application_form: @application_form,
     )
 
-    @provider_user = create(:provider_user, send_notifications: true, providers: [@application_choice.provider])
+    @provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [@application_choice.provider])
   end
 
   def when_i_visit_the_application_dashboard

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_declines_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_declines_offer_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'Candidate declines an offer' do
       application_form: @application_form,
     )
 
-    @provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [@application_choice.provider])
+    @provider_user = create(:provider_user, :with_notifications_enabled, providers: [@application_choice.provider])
   end
 
   def when_i_visit_the_application_dashboard

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'A candidate withdraws her application' do
     form = create(:completed_application_form, :with_completed_references, candidate: current_candidate)
     @application_choice = create(:application_choice, :awaiting_provider_decision, application_form: form)
     @application_choice2 = create(:application_choice, :awaiting_provider_decision, application_form: form)
-    @provider_user = create(:provider_user, :with_notification_preferences_enabled)
+    @provider_user = create(:provider_user, :with_notifications_enabled)
     create(:provider_permissions, provider_id: @application_choice.provider.id, provider_user_id: @provider_user.id)
   end
 

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'A candidate withdraws her application' do
     form = create(:completed_application_form, :with_completed_references, candidate: current_candidate)
     @application_choice = create(:application_choice, :awaiting_provider_decision, application_form: form)
     @application_choice2 = create(:application_choice, :awaiting_provider_decision, application_form: form)
-    @provider_user = create(:provider_user, send_notifications: true)
+    @provider_user = create(:provider_user, :with_notification_preferences_enabled)
     create(:provider_permissions, provider_id: @application_choice.provider.id, provider_user_id: @provider_user.id)
   end
 

--- a/spec/system/decline_by_default_spec.rb
+++ b/spec/system/decline_by_default_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature 'Decline by default' do
     @application_form = create(:completed_application_form, first_name: 'Harry', last_name: 'Potter')
     @application_choice = create(:application_choice, status: :offer, application_form: @application_form, sent_to_provider_at: Time.zone.now, decline_by_default_at: Time.zone.now + 10.days)
 
-    @provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [@application_choice.provider])
+    @provider_user = create(:provider_user, :with_notifications_enabled, providers: [@application_choice.provider])
   end
 
   def and_the_time_limit_before_decline_by_default_date_has_been_exceeded

--- a/spec/system/decline_by_default_spec.rb
+++ b/spec/system/decline_by_default_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature 'Decline by default' do
     @application_form = create(:completed_application_form, first_name: 'Harry', last_name: 'Potter')
     @application_choice = create(:application_choice, status: :offer, application_form: @application_form, sent_to_provider_at: Time.zone.now, decline_by_default_at: Time.zone.now + 10.days)
 
-    @provider_user = create(:provider_user, send_notifications: true, providers: [@application_choice.provider])
+    @provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [@application_choice.provider])
   end
 
   def and_the_time_limit_before_decline_by_default_date_has_been_exceeded

--- a/spec/system/reject_by_default_spec.rb
+++ b/spec/system/reject_by_default_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Reject by default' do
 
   scenario 'An application is rejected by default', with_audited: true do
     given_there_is_a_provider_user_for_the_provider_course
-    and_the_provider_user_has_send_notifications_enabled
+    and_the_provider_user_has_notifications_enabled
     and_there_is_a_candidate
     and_an_application_is_ready_to_reject_by_default
 
@@ -22,8 +22,7 @@ RSpec.feature 'Reject by default' do
     @provider_user = Provider.find_by(code: 'ABC').provider_users.first
   end
 
-  def and_the_provider_user_has_send_notifications_enabled
-    @provider_user.update(send_notifications: true)
+  def and_the_provider_user_has_notifications_enabled
     create(:provider_user_notification_preferences, provider_user: @provider_user)
   end
 

--- a/spec/system/support_interface/managing_provider_user_notification_preferences_spec.rb
+++ b/spec/system/support_interface/managing_provider_user_notification_preferences_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Managing provider user notification preferences' do
   end
 
   def and_a_provider_user_exist
-    @provider_user = create(:provider_user, :with_notification_preferences_enabled)
+    @provider_user = create(:provider_user, :with_notifications_enabled)
   end
 
   def when_i_visit_the_support_console

--- a/spec/system/support_interface/managing_provider_user_notification_preferences_spec.rb
+++ b/spec/system/support_interface/managing_provider_user_notification_preferences_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Managing provider user notification preferences' do
   end
 
   def and_a_provider_user_exist
-    @provider_user = create(:provider_user, send_notifications: true)
+    @provider_user = create(:provider_user, :with_notification_preferences_enabled)
   end
 
   def when_i_visit_the_support_console

--- a/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
+++ b/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
 
   def given_there_is_a_new_match
     @not_previously_matched = Candidate.create_with(email_address: 'not_previously_matched@abc.com').find_or_create_by(id: 999213)
-    @provider_user = create(:provider_user, :with_notification_preferences_enabled)
+    @provider_user = create(:provider_user, :with_notifications_enabled)
     course = create(:course, code: 'XYZ', provider: create(:provider, code: 'XX', provider_users: [@provider_user]))
     course_option = create(:course_option, course: course)
     application_choice = create(:submitted_application_choice, course_option: course_option)
@@ -36,7 +36,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
 
   def and_there_is_a_previous_match_with_dual_application_we_emailed_about
     @previously_matched_changed = Candidate.create_with(email_address: 'previously_matched_changed@abc.com').find_or_create_by(id: 99944)
-    @provider_user1 = create(:provider_user, :with_notification_preferences_enabled)
+    @provider_user1 = create(:provider_user, :with_notifications_enabled)
     course = create(:course, code: 'LMN', provider: create(:provider, code: '2FF', provider_users: [@provider_user1]))
     course_option = create(:course_option, course: course)
     application_choice = create(:submitted_application_choice, course_option: course_option)

--- a/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
+++ b/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
 
   def given_there_is_a_new_match
     @not_previously_matched = Candidate.create_with(email_address: 'not_previously_matched@abc.com').find_or_create_by(id: 999213)
-    @provider_user = create(:provider_user, send_notifications: true)
+    @provider_user = create(:provider_user, :with_notification_preferences_enabled)
     course = create(:course, code: 'XYZ', provider: create(:provider, code: 'XX', provider_users: [@provider_user]))
     course_option = create(:course_option, course: course)
     application_choice = create(:submitted_application_choice, course_option: course_option)
@@ -36,7 +36,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
 
   def and_there_is_a_previous_match_with_dual_application_we_emailed_about
     @previously_matched_changed = Candidate.create_with(email_address: 'previously_matched_changed@abc.com').find_or_create_by(id: 99944)
-    @provider_user1 = create(:provider_user, send_notifications: true)
+    @provider_user1 = create(:provider_user, :with_notification_preferences_enabled)
     course = create(:course, code: 'LMN', provider: create(:provider, code: '2FF', provider_users: [@provider_user1]))
     course_option = create(:course_option, course: course)
     application_choice = create(:submitted_application_choice, course_option: course_option)

--- a/spec/system/vendor_api/vendor_makes_unconditional_offer_spec.rb
+++ b/spec/system/vendor_api/vendor_makes_unconditional_offer_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'Vendor makes unconditional offer' do
 
     @application_choice = @application.application_choices.first
     @course_option = @application_choice.course_option
-    @provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [@provider])
+    @provider_user = create(:provider_user, :with_notifications_enabled, providers: [@provider])
     uri = "/api/v1/applications/#{@application_choice.id}/offer"
 
     @api_response = page.driver.post(uri, unconditional_offer_payload)

--- a/spec/system/vendor_api/vendor_makes_unconditional_offer_spec.rb
+++ b/spec/system/vendor_api/vendor_makes_unconditional_offer_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'Vendor makes unconditional offer' do
 
     @application_choice = @application.application_choices.first
     @course_option = @application_choice.course_option
-    @provider_user = create(:provider_user, send_notifications: true, providers: [@provider])
+    @provider_user = create(:provider_user, :with_notification_preferences_enabled, providers: [@provider])
     uri = "/api/v1/applications/#{@application_choice.id}/offer"
 
     @api_response = page.driver.post(uri, unconditional_offer_payload)


### PR DESCRIPTION
## Context

Strong migrations ensures the column is ignored before it's physically removed.
This column will be removed in a subsequent migration.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Ignore `ProviderUser#send_notifications` column.
- Stop backfilling `ProviderUserNotificationPreferences` from `ProviderUser#send_notifications` value, just create the record when a user is created.
- Updates specs to setup with notification preferences instead of `send_notifications`

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

There's an implementation change here in that we were previously creating `ProviderUserNotificationPreferences` based on the value of `ProviderUser#send_notifications` but as this field will be removed we now just create a `ProviderUserNotificationPreferences` record associated with the provider user. See https://github.com/DFE-Digital/apply-for-teacher-training/pull/4879/commits/f122910ffdac6ce55151ebbc699a643f0d0d907e for this change.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/04BJzJlM/3757-remove-old-notifications-from-database
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
