### PR TITLE
Add yabeda config for Rails metrics graphing in Grafana

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,14 @@ gem 'holidays'
 gem 'okcomputer'
 gem 'skylight'
 
+gem 'prometheus-client'
+gem 'yabeda-rails'
+gem 'yabeda-puma-plugin'
+gem 'yabeda-gc'
+gem 'yabeda-sidekiq'
+gem 'yabeda-http_requests'
+gem 'yabeda-prometheus'
+
 # Logging
 gem 'request_store_rails'
 gem 'request_store-sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,18 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    actioncable (6.1.3.2)
+      actionpack (= 6.1.3.2)
+      activesupport (= 6.1.3.2)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (6.1.3.2)
+      actionpack (= 6.1.3.2)
+      activejob (= 6.1.3.2)
+      activerecord (= 6.1.3.2)
+      activestorage (= 6.1.3.2)
+      activesupport (= 6.1.3.2)
+      mail (>= 2.7.1)
     actionmailer (6.1.3.2)
       actionpack (= 6.1.3.2)
       actionview (= 6.1.3.2)
@@ -22,12 +34,22 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (6.1.3.2)
+      actionpack (= 6.1.3.2)
+      activerecord (= 6.1.3.2)
+      activestorage (= 6.1.3.2)
+      activesupport (= 6.1.3.2)
+      nokogiri (>= 1.8.5)
     actionview (6.1.3.2)
       activesupport (= 6.1.3.2)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_attr (0.15.3)
+      actionpack (>= 3.0.2, < 7.0)
+      activemodel (>= 3.0.2, < 7.0)
+      activesupport (>= 3.0.2, < 7.0)
     active_hash (3.1.0)
       activesupport (>= 5.0.0)
     activejob (6.1.3.2)
@@ -40,6 +62,13 @@ GEM
       activesupport (= 6.1.3.2)
     activerecord-cte (0.1.3)
       activerecord
+    activestorage (6.1.3.2)
+      actionpack (= 6.1.3.2)
+      activejob (= 6.1.3.2)
+      activerecord (= 6.1.3.2)
+      activesupport (= 6.1.3.2)
+      marcel (~> 1.0.0)
+      mini_mime (~> 1.0.2)
     activesupport (6.1.3.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
@@ -49,6 +78,8 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
+    anyway_config (2.1.0)
+      ruby-next-core (>= 0.11.0)
     ar-sequence (0.1.2)
       activerecord
     archive-zip (0.12.0)
@@ -134,6 +165,7 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    dry-initializer (3.0.4)
     erb_lint (0.0.37)
       activesupport
       better_html (~> 1.0.7)
@@ -238,6 +270,7 @@ GEM
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     io-like (0.3.1)
+    json (2.5.1)
     json-jwt (1.13.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -285,20 +318,21 @@ GEM
       activesupport (>= 5.2.4.3)
       notifications-ruby-client (~> 5.1)
       rack (>= 2.1.4)
+    marcel (1.0.1)
     memoist (0.16.2)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mini_mime (1.1.0)
-    mini_portile2 (2.5.1)
+    mini_mime (1.0.3)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     nenv (0.3.0)
     netrc (0.11.0)
     nio4r (2.5.7)
-    nokogiri (1.11.4)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -342,6 +376,7 @@ GEM
       optimist (~> 3.0)
     pdfkit (0.8.5)
     pg (1.2.3)
+    prometheus-client (2.1.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -366,6 +401,21 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rails (6.1.3.2)
+      actioncable (= 6.1.3.2)
+      actionmailbox (= 6.1.3.2)
+      actionmailer (= 6.1.3.2)
+      actionpack (= 6.1.3.2)
+      actiontext (= 6.1.3.2)
+      actionview (= 6.1.3.2)
+      activejob (= 6.1.3.2)
+      activemodel (= 6.1.3.2)
+      activerecord (= 6.1.3.2)
+      activestorage (= 6.1.3.2)
+      activesupport (= 6.1.3.2)
+      bundler (>= 1.15.0)
+      railties (= 6.1.3.2)
+      sprockets-rails (>= 2.0.0)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -472,6 +522,7 @@ GEM
     ruby-jmeter (3.1.08)
       nokogiri
       rest-client
+    ruby-next-core (0.12.0)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.4)
     rubyzip (2.3.0)
@@ -509,6 +560,9 @@ GEM
     skylight (5.1.1)
       activesupport (>= 5.2.0)
     smart_properties (1.15.0)
+    sniffer (0.4.0)
+      active_attr (>= 0.10.2)
+      anyway_config (>= 1.0)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
@@ -573,10 +627,36 @@ GEM
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
     webrick (1.7.0)
+    websocket-driver (0.7.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
     wkhtmltopdf-binary (0.12.6.3)
     workflow (2.0.2)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yabeda (0.9.0)
+      concurrent-ruby
+      dry-initializer
+    yabeda-gc (0.1.1)
+      yabeda (~> 0.6)
+    yabeda-http_requests (0.2.0)
+      sniffer
+      yabeda
+    yabeda-prometheus (0.6.1)
+      prometheus-client (>= 0.10, < 3.0)
+      rack
+      yabeda (~> 0.5)
+    yabeda-puma-plugin (0.6.0)
+      json
+      puma
+      yabeda (~> 0.5)
+    yabeda-rails (0.7.2)
+      rails
+      yabeda (~> 0.8)
+    yabeda-sidekiq (0.8.0)
+      anyway_config (>= 1.3, < 3)
+      sidekiq
+      yabeda (~> 0.6)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -635,6 +715,7 @@ DEPENDENCIES
   parallel_tests
   pdfkit
   pg (~> 1.2.3)
+  prometheus-client
   pry
   pry-byebug
   pry-rails
@@ -670,6 +751,12 @@ DEPENDENCIES
   webpacker
   wkhtmltopdf-binary
   workflow
+  yabeda-gc
+  yabeda-http_requests
+  yabeda-prometheus
+  yabeda-puma-plugin
+  yabeda-rails
+  yabeda-sidekiq
 
 RUBY VERSION
    ruby 2.7.2p137

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -4,6 +4,8 @@ Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
     chain.add Workers::AuditTrailAttributionMiddleware
   end
+
+  Yabeda::Prometheus::Exporter.start_metrics_server!
 end
 
 require 'sidekiq/web'

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,3 +36,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
+
+# For Yabeda monitoring
+activate_control_app
+plugin :yabeda

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1084,6 +1084,8 @@ Rails.application.routes.draw do
   get '/check', to: 'healthcheck#show'
   get '/check/version', to: 'healthcheck#version'
 
+  mount Yabeda::Prometheus::Exporter => '/metrics'
+
   scope via: :all do
     match '/404', to: 'errors#not_found'
     match '/406', to: 'errors#not_acceptable'


### PR DESCRIPTION
## Context

We already monitor the app via Skylight, but would like to start graphing more metrics via Prometheus/Grafana. Skylight is great for troubleshooting the here and now, but grafana integration will make it easier to inspect data for specific date/time ranges and correlate application metrics with other infrastructure graphs (e.g. memory, cpu, database).

## Changes proposed in this pull request

Add 
```
gem 'yabeda-rails'
gem 'yabeda-puma-plugin'
gem 'yabeda-gc'
gem 'yabeda-sidekiq'
gem 'yabeda-http_requests'
gem 'yabeda-prometheus'
```

Expose these metrics at `/metrics'. Another PR will import these into our metrics stack.

## Guidance to review

Should `/metrics` be protected? It is currently public.

~~Installing `yabeda-rails` has confused my rvm environment. Please check yours, too!~~

~~`bundle exec rails s` has stopped working. Error: `LoadError: cannot load such file -- rake/rdoctask`~~
~~`bundle exec bin/rails s` works fine.~~

This was because `yabeda-rails` introduces a dependency on `rails`, and bundler somehow satisfied it with rails 0.9.5! Once I upgraded this to 6.1.3.2, everything went back to normal. Weirdly we don't currently have that dependency, perhaps to avoid parts of Rails we don't use, such as actioncable.

~~Not entirely sure how sidekiq metrics will be collected, as the sidekiq process does not expose any web pages, so no `/metrics` to poll. Maybe we need a different way to ship metrics for sidekiq, pushing the data rather than polling~~ Figured it out... the worker process exposes a WEBrick-based `/metrics` on port 9394 cc @vigneshmsft @saliceti 

Apparently, we may also do:

> `Yabeda::Prometheus.push_gateway.add(Yabeda::Prometheus.registry)`
> Address of push gateway is configured with PROMETHEUS_PUSH_GATEWAY env variable.
 
... for short-lived rake tasks, data migrations, but will leave this out for now (do we have a push gateway?)

Example output:

```
# TYPE puma_backlog gauge
# HELP puma_backlog Number of established but unaccepted connections in the backlog
puma_backlog{index="0"} 0.0
# TYPE puma_running gauge
# HELP puma_running Number of running worker threads
puma_running{index="0"} 5.0
# TYPE puma_pool_capacity gauge
# HELP puma_pool_capacity Number of allocatable worker threads
puma_pool_capacity{index="0"} 4.0
# TYPE puma_max_threads gauge
# HELP puma_max_threads Maximum number of worker threads
puma_max_threads{index="0"} 5.0
# TYPE gc_count gauge
# HELP gc_count Count of all GCs
gc_count 73.0
# TYPE gc_compact_count gauge
# HELP gc_compact_count Count of all GC compactions
gc_compact_count 0.0
# TYPE gc_minor_gc_count gauge
# HELP gc_minor_gc_count Count of minor GCs
gc_minor_gc_count 56.0
# TYPE gc_major_gc_count gauge
# HELP gc_major_gc_count Count of major GCs
gc_major_gc_count 17.0
# TYPE gc_heap_allocated_pages gauge
# HELP gc_heap_allocated_pages Total number of pages allocated for the heap
gc_heap_allocated_pages 3497.0
# TYPE gc_heap_sorted_length gauge
# HELP gc_heap_sorted_length Length of the sorted heap
gc_heap_sorted_length 3593.0
...

# TYPE rails_requests_total counter
# HELP rails_requests_total A counter of the total number of HTTP requests rails processed.
rails_requests_total{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get"} 1.0
rails_requests_total{controller="provider_interface/application_choices",action="show",status="200",format="html",method="get"} 2.0
rails_requests_total{controller="provider_interface/offers",action="show",status="200",format="html",method="get"} 1.0
rails_requests_total{controller="provider_interface/application_choices",action="timeline",status="200",format="html",method="get"} 1.0
rails_requests_total{controller="provider_interface/activity_log",action="index",status="200",format="html",method="get"} 1.0
rails_requests_total{controller="provider_interface/interview_schedules",action="show",status="200",format="html",method="get"} 1.0
# TYPE rails_request_duration_seconds histogram
# HELP rails_request_duration_seconds A histogram of the response latency.
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="0.005"} 0.0
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="0.01"} 0.0
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="0.025"} 0.0
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="0.05"} 0.0
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="0.1"} 0.0
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="0.25"} 0.0
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="0.5"} 0.0
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="1"} 0.0
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="2.5"} 1.0
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="5"} 1.0
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="10"} 1.0
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="30"} 1.0
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="60"} 1.0
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="120"} 1.0
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="300"} 1.0
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="600"} 1.0
rails_request_duration_seconds_bucket{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get",le="+Inf"} 1.0
rails_request_duration_seconds_sum{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get"} 1.334
rails_request_duration_seconds_count{controller="provider_interface/application_choices",action="index",status="200",format="html",method="get"} 1.0
...
```

The sidekiq process reports similar things (note the stats on outgoing API requests!):

```
# TYPE sidekiq_jobs_waiting_count gauge
# HELP sidekiq_jobs_waiting_count The number of jobs waiting to process in sidekiq.
sidekiq_jobs_waiting_count{queue="mailers"} 0.0
sidekiq_jobs_waiting_count{queue="low_priority"} 0.0
sidekiq_jobs_waiting_count{queue="default"} 0.0
# TYPE sidekiq_active_workers_count gauge
# HELP sidekiq_active_workers_count The number of currently running machines with sidekiq workers.
sidekiq_active_workers_count 0.0
# TYPE sidekiq_jobs_scheduled_count gauge
# HELP sidekiq_jobs_scheduled_count The number of jobs scheduled for later execution.
sidekiq_jobs_scheduled_count 0.0
# TYPE sidekiq_jobs_retry_count gauge
# HELP sidekiq_jobs_retry_count The number of failed jobs waiting to be retried
sidekiq_jobs_retry_count 12.0
# TYPE sidekiq_jobs_dead_count gauge
# HELP sidekiq_jobs_dead_count The number of jobs exceeded their retry count.
sidekiq_jobs_dead_count 0.0
# TYPE sidekiq_active_processes gauge
# HELP sidekiq_active_processes The number of active Sidekiq worker processes.
sidekiq_active_processes 1.0
# TYPE sidekiq_queue_latency gauge
# HELP sidekiq_queue_latency The queue latency, the difference in seconds since the oldest job in the queue was enqueued
sidekiq_queue_latency{queue="default"} 0.0
sidekiq_queue_latency{queue="low_priority"} 0.0
sidekiq_queue_latency{queue="mailers"} 0.0
# TYPE http_request_total counter
# HELP http_request_total A counter of the total number of external HTTP \\\n                         requests.
http_request_total{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET"} 2.0
# TYPE http_response_total counter
# HELP http_response_total A counter of the total number of external HTTP \\\n                         responses.
http_response_total{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200"} 2.0
# TYPE http_response_duration_milliseconds histogram
# HELP http_response_duration_milliseconds A histogram of the response                                                duration (milliseconds).
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="0.5"} 0.0
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="1"} 0.0
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="2.5"} 0.0
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="5"} 0.0
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="10"} 0.0
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="25"} 0.0
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="50"} 0.0
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="100"} 2.0
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="250"} 2.0
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="500"} 2.0
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="1000"} 2.0
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="30000"} 2.0
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="60000"} 2.0
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="120000"} 2.0
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="300000"} 2.0
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="600000"} 2.0
http_response_duration_milliseconds_bucket{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200",le="+Inf"} 2.0
http_response_duration_milliseconds_sum{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200"} 135.0
http_response_duration_milliseconds_count{host="api.publish-teacher-training-courses.service.gov.uk",port="443",method="GET",status="200"} 2.0
```

## Link to Trello card

General monitoring / Preparing for load-testing

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
