### PR TITLE
Show course choices on previous applications

### DIFF
--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -4,7 +4,7 @@
 
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.courses') %></h2>
-  <% if !CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(@application_form) %>
+  <% if !@application_form.submitted? && !CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(@application_form) %>
     <p class="govuk-body">
       You’ll be able to find courses in <%= days_until_find_reopens %> <%= 'day'.pluralize(days_until_find_reopens) %>
       (<%= EndOfCycleTimetable.find_reopens.to_s(:govuk_date) %>).
@@ -17,6 +17,7 @@
         editable: editable,
         heading_level: 3,
         show_incomplete: true,
+        show_status: @application_form.submitted?,
         missing_error: missing_error,
         application_choice_error: application_choice_error,
       ),

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -24,7 +24,7 @@
       <% if @application_form.candidate_has_previously_applied? && @application_form.previous_application_form.application_choices.rejected.any? %>
         <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @application_form.previous_application_form)) %>
       <% end %>
-      <% if  @application_form.candidate_has_previously_applied? && @application_form.apply_2? %>
+      <% if @application_form.candidate_has_previously_applied? && @application_form.apply_2? %>
         <%= render(CandidateInterface::ApplicationFormCourseChoiceComponent.new(
           completed: @application_form_presenter.course_choices_completed?,
         )) %>

--- a/spec/system/candidate_interface/apply_again/carry_over_unsuccessful_application_spec.rb
+++ b/spec/system/candidate_interface/apply_again/carry_over_unsuccessful_application_spec.rb
@@ -28,6 +28,9 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
 
     when_i_visit_the_carry_over_page_again
     then_i_am_redirected_to_my_existing_application
+
+    when_i_view_my_previous_application
+    then_i_can_see_my_previous_course_options
   end
 
   def given_i_am_signed_in
@@ -36,7 +39,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_have_an_application_with_a_rejection
-    @application_form = create(:completed_application_form, :with_completed_references, candidate: @candidate)
+    @application_form = create(:completed_application_form, :with_completed_references, :with_gcses, candidate: @candidate)
     create(:application_choice, :with_rejection, application_form: @application_form)
   end
 
@@ -98,5 +101,15 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
 
   def then_i_am_redirected_to_my_existing_application
     then_i_can_see_application_details
+  end
+
+  def when_i_view_my_previous_application
+    click_link 'First application'
+  end
+
+  def then_i_can_see_my_previous_course_options
+    expect(page).not_to have_content('You’ll be able to find courses in')
+    expect(page).to have_content("Course #{@application_form.application_choices.first.course.name_and_code}")
+    expect(page).to have_content("Status #{t("candidate_application_states.#{@application_form.application_choices.first.status}")}")
   end
 end


### PR DESCRIPTION
## Context

When navigating back to an application in an earlier cycle that has since been carried over the candidate sees a fairly meaningless message about courses re-opening in (minus) n days. We should (I think) be displaying the courses that the candidate picked in their earlier application together with the status.

## Changes proposed in this pull request

Before:
<img width="865" alt="image" src="https://user-images.githubusercontent.com/450843/120720851-b5f07180-c4c4-11eb-8de6-cb0e46d2a06d.png">

After:
<img width="865" alt="image" src="https://user-images.githubusercontent.com/450843/120720813-a53ffb80-c4c4-11eb-90b6-30c69cd059f8.png">

## Guidance to review

- Does this make sense from a UX point of view?
- Is it reasonable to show course choices including the status?

## Link to Trello card

https://trello.com/c/em7RBXpl/3266-fix-message-about-adding-courses-to-old-applications

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
