### PR TITLE
Disable test generation in Sandbox from Support tasks

### DIFF
--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -65,7 +65,7 @@
   </section>
 <% end %>
 
-<% unless HostingEnvironment.production? %>
+<% if HostingEnvironment.test_environment? %>
   <section class="app-section app-section--with-top-border">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Context

Now that we have the Publish sandbox workflow for adding providers and the test generation API endpoint, we no longer need to allow this from the support console.

## Changes proposed in this pull request

Disable the creation of fake providers as well as applications on Sandbox

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/KAuhpobH/3769-remove-ability-to-generate-test-providers-through-support-on-sandbox

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
