### PR TITLE
Ignore applications with statuses not in outcome list in slack notifier

### DIFF
--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -103,8 +103,9 @@ private
     applications.inject(APPLICATION_OUTCOME_EVENTS.index_with { |_| [] }) do |grouped, application|
       status = :rejected_by_default if application.rejected? && application.rejected_by_default?
       status = :declined_by_default if application.declined? && application.declined_by_default?
+      status ||= application.status.to_sym
 
-      grouped[status || application.status.to_sym] << application
+      grouped[status] << application if grouped.key?(status)
       grouped
     end
   end


### PR DESCRIPTION
## Context

If a candidate has multiple applications with statuses not in the slack notifier list, an error is raised when attempting to group applications using the accepted statuses in the following list: `['declined', 'declined_by_default', 'withdrawn', 'rejected' 'rejected_by_default', 'recruited']`.

## Changes proposed in this pull request

Ignore and do not attempt to group applications with statuses not included in notifier list

## Guidance to review

I've went with ignoring the other applications for now as they could be in any state. Maybe we should revisit to add messages for any other pending statuses?

## Link to Trello card

https://trello.com/c/wibkPNFR/3748-error-when-rejecting-applications-by-default

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
