### PR TITLE
Audit RBD date change in test generation

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -223,9 +223,9 @@ private
         @application_form.application_choices.each do |choice|
           choice.update_columns(
             sent_to_provider_at: time,
-            reject_by_default_at: time + rand(3..30).days,
             updated_at: time,
           )
+
           choice.audits.last&.update_columns(created_at: time)
         end
 


### PR DESCRIPTION
## Context

To avoid confusion around test applications generated automatically, audit changing the RBD date to a random value that isn't 40 days. 

## Changes proposed in this pull request

- Audit RBD random change in test application generation
- Change range for RBD to 10 to 40 days to allow providers more time to test applications

## Guidance to review

Maybe we should default to the standard 40 days instead of a range?

## Link to Trello card

https://trello.com/c/CH7njRAZ/3775-brighton-seeing-rbdd-in-sandbox-but-the-applications-have-a-submission-date-of-27th-may

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
