### PR TITLE
Fix missing redirect in GCSE English grade edit action

### DIFF
--- a/app/controllers/candidate_interface/gcse/english/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/english/grade_controller.rb
@@ -38,9 +38,9 @@ module CandidateInterface
 
       if @gcse_grade_form.save
         if current_qualification.failed_required_gcse?
-          candidate_interface_gcse_details_edit_grade_explanation_path(@subject)
+          redirect_to candidate_interface_gcse_details_edit_grade_explanation_path(@subject)
         else
-          candidate_interface_gcse_review_path(@subject)
+          redirect_to candidate_interface_gcse_review_path(@subject)
         end
       else
         track_validation_error(@gcse_grade_form)

--- a/spec/system/candidate_interface/entering_details/candidate_entering_english_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_english_gcse_spec.rb
@@ -45,6 +45,9 @@ RSpec.feature 'Candidate entering GCSE English details' do
 
     when_i_click_to_change_my_grades
     then_i_see_the_grades_i_entered_in_the_form
+
+    when_i_enter_a_new_grade
+    then_i_see_my_new_grade_on_the_review_page
   end
 
   def given_i_am_signed_in
@@ -152,5 +155,16 @@ RSpec.feature 'Candidate entering GCSE English details' do
   def then_i_see_the_grades_i_entered_in_the_form
     expect(page).to have_selector("input[value='A*']")
     expect(page).to have_selector("input[value='Cockney rhyming slang']")
+  end
+
+  def when_i_enter_a_new_grade
+    within find('#candidate-interface-english-gcse-grade-form-english-gcses-other-english-gcse-conditional') do
+      fill_in('Grade', with: 'B')
+    end
+    and_i_click_save_and_continue
+  end
+
+  def then_i_see_my_new_grade_on_the_review_page
+    expect(page).to have_content('B (Cockney Rhyming Slang)')
   end
 end


### PR DESCRIPTION
## Context

Due to a couple of missing `redirect_to`s the `CandidateInterface::Gcse::English::GradeController#edit` stopped working due to a recent change. This PR attempts to fix the issue.

This only applies to editing English GCSE grades.

## Changes proposed in this pull request

The missing `redirect_to` means that this controller action does perform the desired update but rather than moving to the next page in the flow it re-renders the same view giving the appearance that nothing has happened.

- Add missing `redirect_to` and update the related system spec so that it covers this.

## Guidance to review

- Does this make sense?
- Anything I've missed? (I've checked the other controllers and the same pattern doesn't appear elsewhere).

## Link to Trello card

https://trello.com/c/hCOJY9St/3464-save-and-continue-not-moving-onto-next-requirement-when-changing-gcse-grade

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
