### PR TITLE
Fix test suite for reference_selection feature

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -207,11 +207,23 @@ private
       # The first reference is declined by the referee
       @application_form.application_references.feedback_requested.first.update!(feedback_status: 'feedback_refused')
 
-      # The 2 other of the outstanding references come in. However, only the
-      # first two are actually submitted, the last one is automatically cancelled.
-      @application_form.application_references.feedback_requested.each do |reference|
-        submit_reference!(reference.reload)
-        fast_forward
+      if FeatureFlag.active?(:reference_selection)
+        # Cancel 1 reference manually and receive feedback on the remaining 2.
+        # Select the two references with feedback.
+        @application_form.application_references.feedback_requested.first.cancelled!
+        @application_form.application_references.feedback_requested.each do |reference|
+          submit_reference!(reference.reload)
+          reference.update(selected: true)
+          fast_forward
+        end
+        @application_form.update!(references_completed: true)
+      else
+        # The 2 other of the outstanding references come in. However, only the
+        # first two are actually submitted, the last one is automatically cancelled.
+        @application_form.application_references.feedback_requested.each do |reference|
+          submit_reference!(reference.reload)
+          fast_forward
+        end
       end
 
       if states.include?(:unsubmitted_with_completed_references)

--- a/app/models/reference_feature_metrics.rb
+++ b/app/models/reference_feature_metrics.rb
@@ -43,7 +43,11 @@ private
   end
 
   def time_to_get_for(application, end_time)
-    return nil unless application.enough_references_have_been_provided?
+    if FeatureFlag.active?(:reference_selection)
+      return nil unless application.minimum_references_available_for_selection?
+    else
+      return nil unless application.enough_references_have_been_provided?
+    end
 
     times = application.application_references.feedback_provided.where(duplicate: false).map do |reference|
       [reference.requested_at, reference.feedback_provided_at]

--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -8,10 +8,6 @@ class SubmitReference
   end
 
   def save!
-    # Updating selected bool to true here will probably be done conditionally based
-    # on if enough references have been provided/the references section has been completed
-    # when we add in the new functionality
-
     if FeatureFlag.active?(:reference_selection)
       @reference.update!(feedback_status: :feedback_provided, feedback_provided_at: Time.zone.now, selected: false)
     else

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -278,22 +278,34 @@ RSpec.describe ApplicationForm do
   end
 
   describe '#too_many_complete_references?' do
-    it 'returns true if there are more than 2 references' do
-      application_form = create :application_form
-      references = []
-      3.times { references << create(:reference, :feedback_provided) }
-      application_form.application_references = references
+    context 'when reference_selection feature is on' do
+      before { FeatureFlag.activate(:reference_selection) }
 
-      expect(application_form.too_many_complete_references?).to be true
+      it 'returns false' do
+        application_form = create :application_form
+        create_list(:reference, 3, :feedback_provided, application_form: application_form)
+        expect(application_form.too_many_complete_references?).to be false
+      end
     end
 
-    it 'returns false if there are 2 or fewer references' do
-      application_form = create :application_form
-      expect(application_form.too_many_complete_references?).to be false
-      application_form.application_references << create(:reference)
-      expect(application_form.too_many_complete_references?).to be false
-      application_form.application_references << create(:reference)
-      expect(application_form.too_many_complete_references?).to be false
+    context 'when reference_selection feature is off' do
+      before { FeatureFlag.deactivate(:reference_selection) }
+
+      it 'returns true if there are more than 2 references' do
+        application_form = create :application_form
+        create_list(:reference, 3, :feedback_provided, application_form: application_form)
+
+        expect(application_form.too_many_complete_references?).to be true
+      end
+
+      it 'returns false if there are 2 or fewer references' do
+        application_form = create :application_form
+        expect(application_form.too_many_complete_references?).to be false
+        application_form.application_references << create(:reference)
+        expect(application_form.too_many_complete_references?).to be false
+        application_form.application_references << create(:reference)
+        expect(application_form.too_many_complete_references?).to be false
+      end
     end
   end
 

--- a/spec/services/reference_actions_policy_spec.rb
+++ b/spec/services/reference_actions_policy_spec.rb
@@ -8,18 +8,22 @@ RSpec.describe ReferenceActionsPolicy do
       expect(policy(reference).editable?).to eq true
     end
 
-    it 'is not editable when the application form has enough references' do
-      reference = create(:reference, :not_requested_yet)
-      create(:reference, :feedback_provided, application_form: reference.application_form)
-      create(:reference, :feedback_provided, application_form: reference.application_form)
-
-      expect(policy(reference).editable?).to eq false
-    end
-
     it 'is not editable in any other other state' do
       reference = build(:reference, :feedback_provided)
 
       expect(policy(reference).editable?).to eq false
+    end
+
+    context 'with reference_selection feature off' do
+      before { FeatureFlag.deactivate(:reference_selection) }
+
+      it 'is not editable when the application form has enough references' do
+        reference = create(:reference, :not_requested_yet)
+        create(:reference, :feedback_provided, application_form: reference.application_form)
+        create(:reference, :feedback_provided, application_form: reference.application_form)
+
+        expect(policy(reference).editable?).to eq false
+      end
     end
   end
 

--- a/spec/services/submit_reference_spec.rb
+++ b/spec/services/submit_reference_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SubmitReference do
   describe '#save!' do
-    it 'updates the reference to "feedback_provided", sets `feedback_provided_at` to the current time and selected to true' do
+    it 'updates the reference to "feedback_provided" and sets `feedback_provided_at` to the current time' do
       Timecop.freeze do
         application_choice = create(:application_choice, status: :unsubmitted)
         application_form = application_choice.application_form
@@ -14,10 +14,15 @@ RSpec.describe SubmitReference do
 
         expect(reference_one).to be_feedback_provided
         expect(reference_one.feedback_provided_at).to eq Time.zone.now
-        expect(reference_one.selected).to eq true
         expect(reference_two).to be_feedback_provided
         expect(reference_two.feedback_provided_at).to eq Time.zone.now
-        expect(reference_two.selected).to eq true
+        if FeatureFlag.active?(:reference_selection)
+          expect(reference_one.selected).to eq false
+          expect(reference_two.selected).to eq false
+        else
+          expect(reference_one.selected).to eq true
+          expect(reference_two.selected).to eq true
+        end
         expect(application_form.reload.application_choices).to all(be_unsubmitted)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,12 +107,6 @@ RSpec.configure do |config|
 
   config.before { Redis.new.flushdb }
 
-  # Temporarily disable the reference_selection feature. This flag will be
-  # selectively enabled as the feature is being built out. The line below will
-  # be removed prior to switching the feature on in production. See:
-  # https://trello.com/c/hZVGCcxd
-  config.before { FeatureFlag.deactivate(:reference_selection) }
-
   # If running tests in parallel, use a unique Redis database per test process.
   # This allocates databases from 1 onwards, as it's assumed that 0 is the
   # development database.

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -77,7 +77,6 @@ module CandidateHelper
       candidate_provides_two_referees
       receive_references
       if FeatureFlag.active?(:reference_selection)
-        click_link 'Selected references'
         select_references_and_complete_section
       end
     end
@@ -87,6 +86,9 @@ module CandidateHelper
 
   def candidate_submits_application
     receive_references
+    if FeatureFlag.active?(:reference_selection)
+      select_references_and_complete_section
+    end
     click_link 'Check and submit your application'
     click_link t('continue')
     choose 'No'
@@ -124,6 +126,8 @@ module CandidateHelper
   end
 
   def select_references_and_complete_section
+    visit candidate_interface_application_form_path
+    click_link 'Selected references'
     application_form = ApplicationForm.last
     first_reference = application_form.application_references.first
     second_reference = application_form.application_references.second

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -22,6 +22,14 @@ module CandidateHelper
     login_as(current_candidate)
   end
 
+  def application_form_sections
+    if FeatureFlag.active?(:reference_selection)
+      APPLICATION_FORM_SECTIONS - [:references_provided] + [:references_selected]
+    else
+      APPLICATION_FORM_SECTIONS
+    end
+  end
+
   def candidate_completes_application_form(with_referees: true)
     FeatureFlag.deactivate(:restructured_work_history)
     given_courses_exist

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -15,7 +15,7 @@ module CandidateHelper
     becoming_a_teacher
     subject_knowledge
     interview_preferences
-    references_provided
+    references_selected
   ].freeze
 
   def create_and_sign_in_candidate
@@ -24,9 +24,9 @@ module CandidateHelper
 
   def application_form_sections
     if FeatureFlag.active?(:reference_selection)
-      APPLICATION_FORM_SECTIONS - [:references_provided] + [:references_selected]
-    else
       APPLICATION_FORM_SECTIONS
+    else
+      APPLICATION_FORM_SECTIONS - [:references_selected] + [:references_provided]
     end
   end
 

--- a/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_between_cycles_spec.rb
@@ -92,7 +92,11 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
   end
 
   def when_i_view_referees
-    click_on 'Manage your references'
+    if FeatureFlag.active?(:reference_selection)
+      click_on 'Review your references'
+    else
+      click_on 'Manage your references'
+    end
   end
 
   def then_i_can_see_the_referees_i_previously_added

--- a/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_to_new_cycle_spec.rb
@@ -113,7 +113,11 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
   end
 
   def when_i_view_referees
-    click_on 'Manage your references'
+    if FeatureFlag.active?(:reference_selection)
+      click_on 'Review your references'
+    else
+      click_on 'Manage your references'
+    end
   end
 
   def then_i_can_see_the_referees_i_previously_added

--- a/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
@@ -103,7 +103,11 @@ RSpec.feature 'Manually carry over unsubmitted applications that do not have cou
   end
 
   def when_i_view_referees
-    click_on 'Manage your references'
+    if FeatureFlag.active?(:reference_selection)
+      click_on 'Review your references'
+    else
+      click_on 'Manage your references'
+    end
   end
 
   def then_i_can_see_the_referees_i_previously_added

--- a/spec/system/candidate_interface/apply_again/candidate_reviews_rejection_reasons_from_previous_applications_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_reviews_rejection_reasons_from_previous_applications_spec.rb
@@ -52,6 +52,12 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
 
     click_link 'Choose your course'
     candidate_fills_in_apply_again_course_choice
+
+    if FeatureFlag.active?(:reference_selection)
+      click_link 'Selected references'
+      choose 'Yes, I have completed this section'
+      click_button t('save_and_continue')
+    end
   end
 
   def then_subject_knowledge_needs_review

--- a/spec/system/candidate_interface/feedback/candidate_provides_feedback_while_completing_their_application_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_provides_feedback_while_completing_their_application_spec.rb
@@ -27,7 +27,11 @@ RSpec.feature 'Candidate provides feedback during the application process' do
   end
 
   def and_i_click_on_the_references_section
-    click_link 'Add your references'
+    if FeatureFlag.active?(:reference_selection)
+      click_link 'Review your references'
+    else
+      click_link 'Add your references'
+    end
   end
 
   def and_i_click_there_is_an_issue_with_the_section

--- a/spec/system/candidate_interface/references/backlinks_spec.rb
+++ b/spec/system/candidate_interface/references/backlinks_spec.rb
@@ -82,7 +82,11 @@ RSpec.feature 'References' do
   end
 
   def and_i_click_add_your_references
-    click_link 'Add your references'
+    if FeatureFlag.active?(:reference_selection)
+      click_link 'Review your references'
+    else
+      click_link 'Add your references'
+    end
   end
 
   def and_i_click_to_add_a_reference

--- a/spec/system/candidate_interface/references/candidate_adds_a_new_reference_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adds_a_new_reference_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'References' do
     when_i_visit_the_site
     then_i_should_see_the_references_section
 
-    when_i_click_add_you_references
+    when_i_click_through_to_add_my_references
     then_i_see_the_start_page
 
     when_i_click_continue
@@ -110,8 +110,12 @@ RSpec.feature 'References' do
     expect(page).to have_content 'It takes 8 days to get a reference on average.'
   end
 
-  def when_i_click_add_you_references
-    click_link 'Add your references'
+  def when_i_click_through_to_add_my_references
+    if FeatureFlag.active?(:reference_selection)
+      click_link 'Review your references'
+    else
+      click_link 'Add your references'
+    end
   end
 
   def then_i_see_the_start_page

--- a/spec/system/candidate_interface/references/candidate_has_too_many_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_has_too_many_references_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'References' do
   include CandidateHelper
 
+  before { FeatureFlag.deactivate(:reference_selection) }
+
   # We now take steps to prevent more than two references being provided. This
   # wasn't the case historically, however, and a candidate might end up in the
   # following state if they Apply Again from a previous application that had

--- a/spec/system/candidate_interface/references/candidate_receives_feedback_from_their_reference_requests_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_receives_feedback_from_their_reference_requests_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'References' do
   include CandidateHelper
 
+  before { FeatureFlag.deactivate(:reference_selection) }
+
   scenario 'The candidate receives feedback from two of their four referees' do
     given_i_am_signed_in
     and_i_have_provided_my_name

--- a/spec/system/candidate_interface/references/review_references_spec.rb
+++ b/spec/system/candidate_interface/references/review_references_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Review references' do
   include CandidateHelper
 
+  before { FeatureFlag.deactivate(:reference_selection) }
+
   scenario 'Candidate submits and reviews references' do
     given_i_am_signed_in
 

--- a/spec/system/candidate_interface/references/submitting_an_application_spec.rb
+++ b/spec/system/candidate_interface/references/submitting_an_application_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Submitting an application' do
   include CandidateHelper
 
+  before { FeatureFlag.deactivate(:reference_selection) }
+
   scenario 'Candidate submits complete application' do
     given_i_am_signed_in
     and_i_have_completed_my_application

--- a/spec/system/candidate_interface/submitting/candidate_reviewing_an_incomplete_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviewing_an_incomplete_application_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Candidate reviewing an incomplete application' do
   end
 
   def then_i_should_be_able_to_click_through_and_complete_each_required_section
-    (CandidateHelper::APPLICATION_FORM_SECTIONS - %i[science_gcse efl]).each do |section|
+    (application_form_sections - %i[science_gcse efl]).each do |section|
       within "#incomplete-#{section}-error" do
         expect(page).to have_selector("a[data-qa='incomplete-#{section}']")
       end

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -139,13 +139,17 @@ RSpec.feature 'Candidate submits the application' do
   end
 
   def and_i_can_see_my_referees
-    expect(page).to have_content 'Terri Tudor'
-    expect(page).to have_content 'terri@example.com'
-    expect(page).to have_content 'Tutor'
-
-    expect(page).to have_content 'Anne Other'
-    expect(page).to have_content 'anne@other.com'
-    expect(page).to have_content 'First boss'
+    if FeatureFlag.active?(:reference_selection)
+      within_summary_row('Selected references') do
+        expect(page).to have_content 'Terri Tudor'
+        expect(page).to have_content 'Anne Other'
+      end
+    else
+      expect(page).to have_content 'terri@example.com'
+      expect(page).to have_content 'Tutor'
+      expect(page).to have_content 'anne@other.com'
+      expect(page).to have_content 'First boss'
+    end
   end
 
   def and_i_visit_the_application_form_page

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature 'Candidate submits the application' do
   end
 
   def then_i_should_see_all_sections_are_complete
-    CandidateHelper::APPLICATION_FORM_SECTIONS.each do |section|
+    application_form_sections.each do |section|
       expect(page).not_to have_selector "[data-qa='incomplete-#{section}']"
     end
   end

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -141,7 +141,7 @@ RSpec.feature 'International candidate submits the application' do
   end
 
   def then_i_should_see_all_sections_are_complete
-    CandidateHelper::APPLICATION_FORM_SECTIONS.each do |section|
+    application_form_sections.each do |section|
       expect(page).not_to have_selector "[data-qa='incomplete-#{section}']"
     end
   end

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -110,6 +110,9 @@ RSpec.feature 'International candidate submits the application' do
 
     candidate_provides_two_referees
     receive_references
+    if FeatureFlag.active?(:reference_selection)
+      select_references_and_complete_section
+    end
   end
 
   def when_i_review_my_application

--- a/spec/system/referee_interface/referee_cannot_provide_reference_if_two_already_received_spec.rb
+++ b/spec/system/referee_interface/referee_cannot_provide_reference_if_two_already_received_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'Referee is not required to submit a reference' do
   # We believe this is a false positive so will disable Bullet for this spec for now
 
   before do
+    FeatureFlag.deactivate(:reference_selection)
     Bullet.raise = false
   end
 


### PR DESCRIPTION
## Context

In the early stages of the `reference_selection` feature, we disabled its flag across the entire test suite. This allowed us to build out an initial version of it without having to fix a large number of tests that relied on the existing reference behaviour.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This PR:

- Fixes all breaking tests so that they pass when `reference_selection` is active
- Removes the piece of config that disabled the feature by default across the suite


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Per-commit highly recommended. There are a large number of commits, but each one is fairly small and fixes a specific kind of failure. Changes are a mix of:

- Disabling the feature in the spec, with a view to writing a `reference_selection` equivalent before the feature goes live
- Inline conditional checks, to either take different steps in a system spec or expect different results in unit tests.
- Updates to helpers and supporting code to accommodate the behaviour of the new feature.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/hZVGCcxd
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
