### PR TITLE
Handle state changes when a new reference is received

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -148,7 +148,8 @@ class CandidateMailer < ApplicationMailer
 
   def reference_received(reference)
     @reference = reference
-
+    @selected_references = reference.application_form.application_references.select(&:selected)
+    @provided_references = reference.application_form.application_references.select(&:feedback_provided?)
     email_for_candidate(
       reference.application_form,
       subject: I18n.t!('candidate_mailer.reference_received.subject', referee_name: @reference.name),

--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -1,6 +1,16 @@
 # You have a reference from <%= @reference.name %>
 
-<% if @application_form.enough_references_have_been_provided? %>
+<% if FeatureFlag.active?(:reference_selection) && @selected_references.count >= ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
+You have enough references to send your application to training providers.
+
+You’ve selected 2 references to send with your application already, but you can change your selection if you want.
+
+Sign in to complete your application:
+<% elsif FeatureFlag.active?(:reference_selection) && @provided_references.count >= ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
+You have enough references to send your application to training providers.
+
+Sign in to complete your application:
+<% elsif @application_form.enough_references_have_been_provided? %>
 You’ve got 2 references back now.
 
 When you’re ready, you can send your application to training providers.

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -392,6 +392,34 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.reference_received(reference)
   end
 
+  def reference_received_and_can_now_send_to_providers
+    application_form_with_provided_references = FactoryBot.build_stubbed(
+      :application_form,
+      application_references: [
+        FactoryBot.build_stubbed(:reference, feedback_status: :feedback_provided),
+        FactoryBot.build_stubbed(:reference, feedback_status: :feedback_provided),
+      ],
+    )
+
+    new_reference = FactoryBot.build_stubbed(:reference, application_form: application_form_with_provided_references)
+
+    CandidateMailer.reference_received(new_reference)
+  end
+
+  def reference_received_after_selection
+    application_form_with_selected_references = FactoryBot.build_stubbed(
+      :application_form,
+      application_references: [
+        FactoryBot.build_stubbed(:reference, selected: true, feedback_status: :feedback_provided),
+        FactoryBot.build_stubbed(:reference, selected: true, feedback_status: :feedback_provided),
+      ],
+    )
+
+    new_reference = FactoryBot.build_stubbed(:reference, application_form: application_form_with_selected_references)
+
+    CandidateMailer.reference_received(new_reference)
+  end
+
   def offer_withdrawn
     candidate = FactoryBot.build_stubbed(:candidate)
     application_choice = FactoryBot.build_stubbed(


### PR DESCRIPTION
## Context

Follow on from [#4852](https://github.com/DFE-Digital/apply-for-teacher-training/pull/4852). This PR covers how we handle state changes when a candidate receives a new reference.

## Changes proposed in this pull request
The copy of the email will conditionally change depending on how many references the candidate currently has and if they've selected any.

|Candidate receives their first reference|Candidate receives a reference, taking their total to (at least a minimum of) 2, but has not yet selected any|Candidate has selected two references and then receives another|
|---|---|---|
|![image](https://user-images.githubusercontent.com/47917431/121020312-27b40e00-c798-11eb-8a61-b394c7a5b22b.png)|![image](https://user-images.githubusercontent.com/47917431/121226169-2828d380-c882-11eb-8197-6a4ba3cee4ca.png)|![image](https://user-images.githubusercontent.com/47917431/121227133-29a6cb80-c883-11eb-8638-8540e7f06606.png)|


## Guidance to review

There are two previews of the emails that get sent in the Documentation section of the review app:
- [Receiving a new reference](https://apply-for-te-3378-5-sta-9xitig.herokuapp.com/rails/mailers/candidate_mailer/reference_received)
- [Receiving a new reference after you've selected two](https://apply-for-te-3378-5-sta-9xitig.herokuapp.com/rails/mailers/candidate_mailer/reference_received_after_selection)
- [Enough references received to send the application to providers](https://apply-for-te-3378-5-sta-9xitig.herokuapp.com/rails/mailers/candidate_mailer/reference_received_and_can_now_send_to_providers)

In terms of testing the actual functionality – you can see which version of the email the candidate has received by going into the email logs section, under support:
![image](https://user-images.githubusercontent.com/47917431/121009024-9048be00-c78b-11eb-9f91-a76728a82e77.png)


## Link to Trello card

https://trello.com/c/hZVGCcxd

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
