### PR TITLE
Add logging to TTAPI provider/course sync

### DIFF
--- a/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
+++ b/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
@@ -12,6 +12,7 @@ module TeacherTrainingPublicAPI
         scope = scope.where(updated_since: TeacherTrainingPublicAPI::SyncCheck.updated_since) if incremental_sync
         response = scope.all
 
+        Rails.logger.info("Syncing #{response.count} Providers with the incremental sync set to #{incremental_sync}")
         sync_providers(response, recruitment_cycle_year, incremental_sync: incremental_sync)
 
         is_last_page = true if response.links.links['next'].nil?

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -17,6 +17,7 @@ module TeacherTrainingPublicAPI
       scope = scope.where(updated_since: TeacherTrainingPublicAPI::SyncCheck.updated_since) if incremental_sync
 
       scope.each do |course_from_api|
+        Rails.logger.info("Syncing Course (#{course_from_api.code}) from Provider (#{provider.code}), with the incremental sync set to #{incremental_sync}")
         ActiveRecord::Base.transaction do
           create_or_update_course(course_from_api, recruitment_cycle_year)
         end

--- a/app/services/teacher_training_public_api/sync_provider.rb
+++ b/app/services/teacher_training_public_api/sync_provider.rb
@@ -21,6 +21,8 @@ module TeacherTrainingPublicAPI
     end
 
     def sync_courses(run_in_background, provider, incremental_sync: true)
+      Rails.logger.info("Syncing Provider's (#{provider.code}) courses, with the incremental sync set to #{incremental_sync} and sync courses set to: #{sync_courses?}")
+
       if sync_courses?
         if run_in_background
           TeacherTrainingPublicAPI::SyncCourses.perform_async(provider.id, @recruitment_cycle_year, incremental_sync)


### PR DESCRIPTION
## Context

We aren't syncing courses correctly through the incremental TTAPI sync. Add logging to help with debugging the issue.

## Changes proposed in this pull request

Add logging when attempting to sync a provider and their courses

## Guidance to review

This is just the initial step in helping to determine why we are missing courses through the incremental step but not the full sync

## Link to Trello card

https://trello.com/c/59TtliPE/3776-incremental-sync-not-adding-new-courses

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
