### PR TITLE
Create a new flow for bulk creation of provider users

### DIFF
--- a/app/components/support_interface/permissions_list_review_component.html.erb
+++ b/app/components/support_interface/permissions_list_review_component.html.erb
@@ -1,0 +1,31 @@
+<ul class="govuk-list">
+  <% if permissions['manage_organisations'] %>
+    <li><%= render IconComponent.new(type: 'check') %> Manage organisational permissions</li>
+  <% else %>
+    <li><%= render IconComponent.new(type: 'cross') %> Manage organisational permissions</li>
+  <% end %>
+
+  <% if permissions['manage_users'] %>
+    <li><%= render IconComponent.new(type: 'check') %> Manage users</li>
+  <% else %>
+    <li><%= render IconComponent.new(type: 'cross') %> Manage users</li>
+  <% end %>
+
+  <% if permissions['make_decisions'] %>
+    <li><%= render IconComponent.new(type: 'check') %> Make decisions</li>
+  <% else %>
+    <li><%= render IconComponent.new(type: 'cross') %> Make decisions</li>
+  <% end %>
+
+  <% if permissions['view_safeguarding_information'] %>
+    <li><%= render IconComponent.new(type: 'check') %> Access safeguarding information</li>
+  <% else %>
+    <li><%= render IconComponent.new(type: 'cross') %> Access safeguarding information</li>
+  <% end %>
+
+  <% if permissions['view_diversity_information'] %>
+    <li><%= render IconComponent.new(type: 'check') %> Access diversity information</li>
+  <% else %>
+    <li><%= render IconComponent.new(type: 'cross') %> Access diversity information</li>
+  <% end %>
+</ul>

--- a/app/components/support_interface/permissions_list_review_component.rb
+++ b/app/components/support_interface/permissions_list_review_component.rb
@@ -1,0 +1,9 @@
+module SupportInterface
+  class PermissionsListReviewComponent < ViewComponent::Base
+    attr_reader :permissions
+
+    def initialize(permissions)
+      @permissions = permissions
+    end
+  end
+end

--- a/app/controllers/support_interface/bulk_upload/checks_controller.rb
+++ b/app/controllers/support_interface/bulk_upload/checks_controller.rb
@@ -1,0 +1,25 @@
+module SupportInterface
+  module BulkUpload
+    class ChecksController < SupportInterfaceController
+      def show
+        @provider = Provider.find(provider_id_param)
+        @wizard = MultipleProviderUsersWizard.new(
+          state_store: multiple_provider_user_store,
+          provider_id: provider_id_param,
+        )
+        @backlink_path = edit_support_interface_bulk_upload_permissions_path(position: @wizard.provider_user_count)
+      end
+
+    private
+
+      def provider_id_param
+        params[:provider_id].to_i
+      end
+
+      def multiple_provider_user_store
+        key = "multiple_provider_user_store_#{provider_id_param}"
+        WizardStateStores::RedisStore.new(key: key)
+      end
+    end
+  end
+end

--- a/app/controllers/support_interface/bulk_upload/permissions_controller.rb
+++ b/app/controllers/support_interface/bulk_upload/permissions_controller.rb
@@ -1,0 +1,83 @@
+module SupportInterface
+  module BulkUpload
+    class PermissionsController < SupportInterfaceController
+      def edit
+        multiple_provider_users_wizard = MultipleProviderUsersWizard.new(
+          state_store: multiple_provider_user_store,
+          provider_id: provider_id_param,
+          index: index,
+        )
+
+        @provider = Provider.find(provider_id_param)
+        @form = multiple_provider_users_wizard.single_provider_user_form(index)
+        @position_and_count = multiple_provider_users_wizard.position_and_count
+        @backlink_path = backlink_path
+      end
+
+      def update
+        multiple_provider_users_wizard = MultipleProviderUsersWizard.new(
+          state_store: multiple_provider_user_store,
+          provider_id: provider_id_param,
+          index: provider_user_params[:index],
+        )
+
+        @provider = Provider.find(provider_id_param)
+        @position_and_count = multiple_provider_users_wizard.position_and_count
+        @form = CreateSingleProviderUserForm.new(
+          provider_user_params.merge(provider_permissions: provider_permissions_params),
+        )
+
+        if @form.valid?
+          multiple_provider_users_wizard.save_user_to_state_store!(@form)
+
+          if multiple_provider_users_wizard.more_users_to_process?
+            redirect_to edit_support_interface_bulk_upload_permissions_path(position: multiple_provider_users_wizard.next_position)
+          else
+            redirect_to support_interface_bulk_upload_checks_path
+          end
+        else
+          render :edit
+        end
+      end
+
+    private
+
+      def multiple_provider_user_store
+        key = "multiple_provider_user_store_#{provider_id_param}"
+        WizardStateStores::RedisStore.new(key: key)
+      end
+
+      def provider_id_param
+        params[:provider_id].to_i
+      end
+
+      def position_param
+        params[:position]&.to_i
+      end
+
+      def index
+        position_param - 1
+      end
+
+      def provider_user_params
+        params.require(:support_interface_create_single_provider_user_form)
+              .permit(:email_address, :first_name, :last_name, :provider_id, :index)
+      end
+
+      def provider_permissions_params
+        params.require(:support_interface_create_single_provider_user_form)
+              .permit(provider_permissions_form: {})
+              .fetch(:provider_permissions_form, {})
+              .to_h
+      end
+
+      def backlink_path
+        if index.zero?
+          new_support_interface_bulk_upload_provider_users_details_path
+        else
+          edit_support_interface_bulk_upload_permissions_path(position: index)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/support_interface/bulk_upload/provider_users_controller.rb
+++ b/app/controllers/support_interface/bulk_upload/provider_users_controller.rb
@@ -1,0 +1,62 @@
+module SupportInterface
+  module BulkUpload
+    class ProviderUsersController < SupportInterfaceController
+      def create
+        @wizard = MultipleProviderUsersWizard.new(
+          state_store: multiple_provider_user_store,
+          provider_id: provider_id_param,
+        )
+
+        if save_to_db_and_invite!(@wizard)
+          flash[:success] = success_message(@wizard)
+          @wizard.clear_state!
+          redirect_to support_interface_provider_user_list_path
+        else
+          flash[:error] = 'Something went wrong'
+          redirect_to support_interface_bulk_upload_checks_path unless @wizard.save_to_db_and_invite!
+        end
+      end
+
+    private
+
+      def save_to_db_and_invite!(wizard)
+        forms = wizard.all_single_provider_user_forms
+        services = save_and_invite_provider_user_services(forms)
+
+        services.each(&:call)
+      end
+
+      def save_and_invite_provider_user_services(forms)
+        forms.map do |form|
+          provider_user = form.build
+
+          SaveAndInviteProviderUser.new(
+            form: form,
+            save_service: SaveProviderUser.new(
+              provider_user: provider_user,
+              provider_permissions: [form.provider_permissions],
+            ),
+            invite_service: InviteProviderUser.new(provider_user: provider_user),
+          )
+        end
+      end
+
+      def multiple_provider_user_store
+        key = "multiple_provider_user_store_#{provider_id_param}"
+        WizardStateStores::RedisStore.new(key: key)
+      end
+
+      def provider_id_param
+        params[:provider_id].to_i
+      end
+
+      def success_message(wizard)
+        if wizard.provider_user_count > 1
+          "#{wizard.provider_user_count} users added"
+        else
+          "User #{wizard.provider_user_name} added"
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/support_interface/bulk_upload/provider_users_details_controller.rb
+++ b/app/controllers/support_interface/bulk_upload/provider_users_details_controller.rb
@@ -1,0 +1,50 @@
+module SupportInterface
+  module BulkUpload
+    class ProviderUsersDetailsController < SupportInterfaceController
+      def new
+        @provider = Provider.find(provider_id_param)
+        @wizard = MultipleProviderUsersWizard.build(
+          state_store: multiple_provider_user_store,
+          provider_id: provider_id_param,
+        )
+      end
+
+      def create
+        @provider = Provider.find(provider_id_param)
+        @wizard = MultipleProviderUsersWizard.new(
+          state_store: multiple_provider_user_store,
+          provider_users: form_params[:provider_users],
+          provider_id: form_params[:provider_id],
+        )
+
+        if @wizard.valid?
+          @wizard.save_users_to_state_store!
+
+          redirect_to edit_support_interface_bulk_upload_permissions_path(position: 1)
+        else
+          track_validation_error(@wizard)
+          render :new
+        end
+      end
+
+    private
+
+      def form_params
+        params.require(:support_interface_multiple_provider_users_wizard).permit(:provider_users)
+      end
+
+      def provider_id_param
+        params[:provider_id].to_i
+      end
+
+      def position_param
+        params[:position].to_i
+      end
+
+      def multiple_provider_user_store
+        key = "multiple_provider_user_store_#{provider_id_param}"
+        WizardStateStores::RedisStore.new(key: key)
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/create_single_provider_user_form.rb
+++ b/app/forms/support_interface/create_single_provider_user_form.rb
@@ -4,7 +4,7 @@ module SupportInterface
     include ActiveModel::Validations
 
     attr_accessor :first_name, :last_name, :provider_user, :provider_id
-    attr_reader :provider_permissions, :email_address
+    attr_reader :provider_permissions, :email_address, :index
 
     validates :first_name, :last_name, :email_address, presence: true
     validates :email_address, valid_for_notify: true
@@ -20,7 +20,11 @@ module SupportInterface
     end
 
     def email_address=(raw_email_address)
-      @email_address = raw_email_address.downcase.strip
+      @email_address = raw_email_address.downcase.strip if raw_email_address
+    end
+
+    def index=(index)
+      @index = index.to_i
     end
 
     def provider_permissions=(attributes)

--- a/app/forms/support_interface/multiple_provider_users_wizard.rb
+++ b/app/forms/support_interface/multiple_provider_users_wizard.rb
@@ -1,0 +1,153 @@
+module SupportInterface
+  class MultipleProviderUsersWizard
+    include ActiveModel::Model
+    include ActiveModel::Validations
+
+    attr_accessor :provider_id,
+                  :state_store,
+                  :provider_users
+
+    attr_reader :index
+
+    validates :provider_users, presence: true
+
+    class << self
+      def build(state_store:, provider_id:)
+        new(
+          state_store: state_store,
+          provider_id: provider_id,
+          provider_users: provider_users(state_store),
+        )
+      end
+
+    private
+
+      def provider_users(state_store)
+        state = state_store.read
+        stored_provider_users = JSON.parse(state)['provider_users'] if state
+        create_csv_row = ->(pu) { [pu['first_name'], pu['last_name'], pu['email_address']].compact.join(',') + "\n" }
+        stored_provider_users&.map { |pu| create_csv_row.call(pu) }&.join
+      end
+    end
+
+    def index=(index)
+      @index = index.to_i
+    end
+
+    def clear_state!
+      @state_store.delete
+    end
+
+    def save_users_to_state_store!
+      state_store.write(prepare_provider_users_for_state_store)
+    end
+
+    def save_user_to_state_store!(single_provider_user_form)
+      state_store.write(prepare_provider_user_for_state_store(single_provider_user_form))
+    end
+
+    def all_single_provider_user_forms
+      provider_users = read_state['provider_users']
+
+      provider_users.map.with_index do |provider_user, index|
+        SupportInterface::CreateSingleProviderUserForm.new(
+          index: index,
+          provider_id: provider_id,
+          first_name: provider_user['first_name'],
+          last_name: provider_user['last_name'],
+          email_address: provider_user['email_address'],
+          provider_permissions: {
+            provider_permission: provider_user['permissions'].symbolize_keys,
+          },
+        )
+      end
+    end
+
+    def stored_provider_users
+      read_state['provider_users']
+    end
+
+    def provider_user_count
+      read_state['provider_users'].length
+    end
+
+    def position_and_count
+      {
+        position: index + 1,
+        count: provider_user_count,
+      }
+    end
+
+    def next_position
+      index + 2
+    end
+
+    def more_users_to_process?
+      read_state['provider_users'].select { |pu| pu['complete'] == false }.present?
+    end
+
+    def single_provider_user_form(index)
+      provider_user = read_state['provider_users'][index]
+      form = SupportInterface::CreateSingleProviderUserForm.new(
+        index: index,
+        provider_id: provider_id,
+        first_name: provider_user['first_name'],
+        last_name: provider_user['last_name'],
+        email_address: provider_user['email_address'],
+      )
+
+      if provider_user['permissions']
+        form.provider_permissions = { provider_permission: provider_user['permissions'].symbolize_keys }
+      end
+
+      form
+    end
+
+    def provider_user_name
+      state = read_state
+      provider_user = state['provider_users'].first
+
+      "#{provider_user['first_name']} #{provider_user['last_name']}"
+    end
+
+  private
+
+    def prepare_provider_users_for_state_store
+      provider_user_array_hash = provider_users
+        .split("\r\n")
+        .map { |row| row.split(/[\t,]+/) }
+        .map do |provider_user|
+        {
+          first_name: provider_user[0],
+          last_name: provider_user[1],
+          email_address: provider_user[2],
+          complete: false,
+        }
+      end
+
+      {
+        provider_users: provider_user_array_hash,
+      }.to_json
+    end
+
+    def prepare_provider_user_for_state_store(form)
+      state = read_state
+      updated_user_details = {
+        first_name: form.first_name,
+        last_name: form.last_name,
+        email_address: form.email_address,
+        permissions: form.permission_form.provider_permission,
+        complete: true,
+      }
+
+      state['provider_users'][form.index] = updated_user_details
+
+      clear_state!
+      state.to_json
+    end
+
+    def read_state
+      JSON.parse(state_store.read)
+    end
+  end
+end

--- a/app/views/support_interface/bulk_upload/checks/show.html.erb
+++ b/app/views/support_interface/bulk_upload/checks/show.html.erb
@@ -1,0 +1,40 @@
+<% content_for :browser_title, title_with_error_prefix('Check details and add users', @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(@backlink_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= @provider.name %></span> Check details and add users
+    </h1>
+
+    <%= form_with model: @wizard, url: support_interface_bulk_upload_provider_users_path do |f| %>
+      <% f.object.stored_provider_users.each_with_index do |provider_user, index| %>
+        <%= render SummaryCardComponent.new(editable: true, border: true, rows: [
+          {
+            key: 'First name',
+            value: provider_user['first_name'],
+          },
+          {
+            key: 'Last name',
+            value: provider_user['last_name'],
+          },
+          {
+            key: 'Email address',
+            value: provider_user['email_address'],
+          },
+          {
+            key: 'Permissions',
+            value: render(SupportInterface::PermissionsListReviewComponent.new(provider_user['permissions'])),
+          },
+        ].compact) do %>
+          <%= render SummaryCardHeaderComponent.new(title: "User #{index + 1}", heading_level: 2) do %>
+            <div class="app-summary-card__actions">
+              <%= govuk_link_to 'Change', edit_support_interface_bulk_upload_permissions_path(position: index + 1) %>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>
+      <%= f.govuk_submit 'Add users' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/bulk_upload/permissions/_provider_permissions.html.erb
+++ b/app/views/support_interface/bulk_upload/permissions/_provider_permissions.html.erb
@@ -1,0 +1,41 @@
+<%= f.fields_for :provider_permissions_form, f.object.permission_form do |pf| %>
+  <%= pf.fields_for :provider_permission, f.object.permission_form.provider_permission do |ppf| %>
+    <%= ppf.govuk_check_boxes_fieldset :permissions,
+      legend: {
+        text: 'Permissions (optional)', size: 's'
+},
+      hint: { text: 'The user will be able to view applications. You can also give them additional permissions.' } do %>
+      <%= ppf.govuk_check_box(
+            :manage_users,
+            true,
+            multiple: false,
+            label: { text: 'Manage users' },
+            link_errors: true,
+          ) %>
+      <%= ppf.govuk_check_box(
+            :manage_organisations,
+            true,
+            multiple: false,
+            label: { text: 'Manage organisational permissions' },
+          ) %>
+      <%= ppf.govuk_check_box(
+            :make_decisions,
+            true,
+            multiple: false,
+            label: { text: 'Make decisions' },
+          ) %>
+      <%= ppf.govuk_check_box(
+            :view_safeguarding_information,
+            true,
+            multiple: false,
+            label: { text: 'Access safeguarding information' },
+          ) %>
+      <%= ppf.govuk_check_box(
+            :view_diversity_information,
+            true,
+            multiple: false,
+            label: { text: 'Access diversity information' },
+          ) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/support_interface/bulk_upload/permissions/edit.html.erb
+++ b/app/views/support_interface/bulk_upload/permissions/edit.html.erb
@@ -1,0 +1,27 @@
+<% content_for :browser_title,
+  title_with_error_prefix("Add user (#{@position_and_count[:position]} of #{@position_and_count[:count]})",
+    @form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(@backlink_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: support_interface_bulk_upload_permissions_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @provider.name %></span>
+        Add user (<%= @position_and_count[:position] %> of <%= @position_and_count[:count] %>)
+      </h1>
+
+      <%= f.govuk_text_field :first_name, label: { text: 'First name', size: 's' }, class: 'govuk-!-width-two-thirds' %>
+      <%= f.govuk_text_field :last_name, label: { text: 'Last name', size: 's' }, class: 'govuk-!-width-two-thirds' %>
+      <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 's' }, class: 'govuk-!-width-two-thirds' %>
+      <%= f.hidden_field :provider_id %>
+      <%= f.hidden_field :index %>
+
+      <%= render 'provider_permissions', f: f %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/bulk_upload/provider_users_details/new.html.erb
+++ b/app/views/support_interface/bulk_upload/provider_users_details/new.html.erb
@@ -1,0 +1,20 @@
+<% content_for :browser_title, title_with_error_prefix("Add users to #{@provider.name}", @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_provider_user_list_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @wizard, url: support_interface_bulk_upload_provider_users_details_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class='govuk-heading-l'>Add users to <%= @provider.name %></h1>
+
+      <%= f.govuk_text_area :provider_users,
+        rows: 5,
+        label: { text: 'Users’ details', size: 's' },
+        hint: { text: 'Enter first name, last name and email address. Separate them with a tab or comma and use a new line for each user. You can also copy and paste directly from a spreadsheet.' } %>
+      <%= f.hidden_field :provider_id %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/providers/users.html.erb
+++ b/app/views/support_interface/providers/users.html.erb
@@ -1,7 +1,8 @@
 <%= render 'provider_navigation', title: 'Users' %>
 
 <% if FeatureFlag.active?(:new_provider_user_flow) %>
-   <%= govuk_link_to 'Add user', support_interface_new_single_provider_user_path, button: true %>
+  <%= govuk_link_to 'Add user', support_interface_new_single_provider_user_path, button: true %>
+  <%= govuk_link_to 'Add multiple users', new_support_interface_bulk_upload_provider_users_details_path, button: true, class: 'govuk-button--secondary' %>
 <% else %>
   <%= govuk_link_to 'Add provider user', new_support_interface_provider_user_path, button: true %>
 <% end %>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -66,6 +66,10 @@ en:
               blank: Enter a last name
             provider_permissions:
               blank: Please specify a provider
+        support_interface/multiple_provider_users_wizard:
+          attributes:
+            provider_users:
+              blank: Enter the users' details
         support_interface/conditions_form:
           attributes:
             base:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -927,6 +927,13 @@ Rails.application.routes.draw do
       get '/user/new' => 'single_provider_users#new', as: :new_single_provider_user
       post '/user' => 'single_provider_users#create', as: :create_single_provider_user
 
+      namespace :bulk_upload, path: '/bulk-upload' do
+        resource :provider_users_details, path: '/provider-users-details', only: %i[new create]
+        resource :permissions, only: %i[edit update]
+        resource :checks, only: %i[show]
+        resource :provider_users, path: '/provider-users', only: %i[create]
+      end
+
       post '' => 'providers#open_all_courses'
       post '/enable_course_syncing' => redirect('/enable-course-syncing')
       post '/enable-course-syncing' => 'providers#enable_course_syncing', as: :enable_provider_course_syncing

--- a/spec/components/support_interface/permissions_list_review_component_spec.rb
+++ b/spec/components/support_interface/permissions_list_review_component_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::PermissionsListReviewComponent do
+  let(:tick_svg_path_shape) { 'M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z' }
+  let(:cross_svg_path_shape) { 'M100 0a100 100 0 110 200 100 100 0 010-200zm30 50l-30 30-30-30-20 20 30 30-30 30 20 20 30-30 30 30 20-20-30-30 30-30-20-20z' }
+
+  context 'Manage organisational permissions' do
+    it 'displays permission has been assigned' do
+      permissions = { 'manage_organisations' => true }
+
+      result = render_inline(described_class.new(permissions))
+
+      expect(result.css('li').text).to include('Manage organisational permissions')
+      expect(result.css('path')[0].attribute('d').value).to eq(tick_svg_path_shape)
+    end
+
+    it 'does not display that permission has been assigned' do
+      permissions = {}
+
+      result = render_inline(described_class.new(permissions))
+
+      expect(result.css('li').text).to include('Manage users')
+      expect(result.css('path')[0].attribute('d').value).to eq(cross_svg_path_shape)
+    end
+  end
+
+  context 'Manage other users' do
+    it 'displays permission has been assigned' do
+      permissions = { 'manage_users' => true }
+
+      result = render_inline(described_class.new(permissions))
+
+      expect(result.css('li').text).to include('Manage users')
+      expect(result.css('path')[1].attribute('d').value).to eq(tick_svg_path_shape)
+    end
+
+    it 'does not display that permission has been assigned' do
+      permissions = {}
+
+      result = render_inline(described_class.new(permissions))
+
+      expect(result.css('li').text).to include('Manage users')
+      expect(result.css('path')[1].attribute('d').value).to eq(cross_svg_path_shape)
+    end
+  end
+
+  context 'Make decisions' do
+    it 'displays permission has been assigned' do
+      permissions = { 'make_decisions' => true }
+
+      result = render_inline(described_class.new(permissions))
+
+      expect(result.css('li').text).to include('Make decisions')
+      expect(result.css('path')[2].attribute('d').value).to eq(tick_svg_path_shape)
+    end
+
+    it 'does not display that permission has been assigned' do
+      permissions = {}
+
+      result = render_inline(described_class.new(permissions))
+
+      expect(result.css('li').text).to include('Make decisions')
+      expect(result.css('path')[2].attribute('d').value).to eq(cross_svg_path_shape)
+    end
+  end
+
+  context 'Access safeguarding information' do
+    it 'displays permission has been assigned' do
+      permissions = { 'view_safeguarding_information' => true }
+
+      result = render_inline(described_class.new(permissions))
+
+      expect(result.css('li').text).to include('Access safeguarding information')
+      expect(result.css('path')[3].attribute('d').value).to eq(tick_svg_path_shape)
+    end
+
+    it 'does not display that permission has been assigned' do
+      permissions = {}
+
+      result = render_inline(described_class.new(permissions))
+
+      expect(result.css('li').text).to include('Access safeguarding information')
+      expect(result.css('path')[3].attribute('d').value).to eq(cross_svg_path_shape)
+    end
+  end
+
+  context 'Access diversity information' do
+    it 'displays permission has been assigned' do
+      permissions = { 'view_diversity_information' => true }
+
+      result = render_inline(described_class.new(permissions))
+
+      expect(result.css('li').text).to include('Access diversity information')
+      expect(result.css('path')[4].attribute('d').value).to eq(tick_svg_path_shape)
+    end
+
+    it 'does not display that permission has been assigned' do
+      permissions = {}
+
+      result = render_inline(described_class.new(permissions))
+
+      expect(result.css('li').text).to include('Access diversity information')
+      expect(result.css('path')[4].attribute('d').value).to eq(cross_svg_path_shape)
+    end
+  end
+end

--- a/spec/forms/support_interface/multiple_provider_users_wizard_spec.rb
+++ b/spec/forms/support_interface/multiple_provider_users_wizard_spec.rb
@@ -1,0 +1,230 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::MultipleProviderUsersWizard do
+  subject(:form) do
+    described_class.new(state_store: store)
+  end
+
+  let(:store) { instance_double(WizardStateStores::RedisStore) }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:provider_users) }
+  end
+
+  describe '.build' do
+    it 'returns a form with correct attributes' do
+      provider_id = 1
+      stored_users = {
+        provider_users: [
+          {
+            'first_name' => 'Bob',
+            'last_name' => 'Smith',
+            'email_address' => 'bob@foo.com',
+            'complete' => false,
+          },
+          {
+            'first_name' => 'Fred',
+            'last_name' => 'Jones',
+            'email_address' => 'fred@bar.com',
+            'complete' => false,
+          },
+        ],
+      }
+
+      allow(store).to receive(:read).and_return(stored_users.to_json)
+
+      form = described_class.build(state_store: store, provider_id: provider_id)
+      expected_attributes = {
+        state_store: store,
+        provider_id: provider_id,
+        stored_provider_users: stored_users[:provider_users],
+        provider_users: "Bob,Smith,bob@foo.com\nFred,Jones,fred@bar.com\n",
+      }
+
+      expect(form).to have_attributes(expected_attributes)
+    end
+  end
+
+  describe '#all_single_provider_user_forms' do
+    it 'converts provider users from state store to CreateSingleProviderUserForms' do
+      stored_users = {
+        provider_users: [
+          {
+            first_name: 'Bob',
+            last_name: 'Smith',
+            email_address: 'bob@foo.com',
+            complete: false,
+            permissions: { manage_users: 'true' },
+          },
+        ],
+      }
+
+      provider = create(:provider)
+
+      allow(store).to receive(:read).and_return(stored_users.to_json)
+
+      forms = described_class.build(
+        state_store: store,
+        provider_id: provider.id,
+      ).all_single_provider_user_forms
+
+      form = forms.first
+
+      expect(form).to be_kind_of(SupportInterface::CreateSingleProviderUserForm)
+      expect(form.first_name).to eq('Bob')
+      expect(form.last_name).to eq('Smith')
+      expect(form.email_address).to eq('bob@foo.com')
+
+      provider_permissions = form.provider_permissions
+      expect(provider_permissions).to be_kind_of(ProviderPermissions)
+      expect(provider_permissions.provider_id).to eq(provider.id)
+      expect(provider_permissions.manage_users).to be(true)
+    end
+  end
+
+  describe '#provider_user_count' do
+    it 'returns the provider user count' do
+      stored_users = {
+        provider_users: [
+          {
+            first_name: 'Bob',
+            last_name: 'Smith',
+            email_address: 'bob@foo.com',
+            complete: false,
+            permissions: { manage_users: true },
+          },
+        ],
+      }
+
+      allow(store).to receive(:read).and_return(stored_users.to_json)
+
+      expect(described_class.new(state_store: store).provider_user_count).to eq(1)
+    end
+  end
+
+  describe '#position_and_count' do
+    it "returns provider users' position and count" do
+      stored_users = {
+        provider_users: [
+          {
+            first_name: 'Bob',
+            last_name: 'Smith',
+            email_address: 'bob@foo.com',
+            complete: false,
+          },
+          {
+            first_name: 'Fred',
+            last_name: 'Jones',
+            email_address: 'fred@bar.com',
+            complete: false,
+          },
+        ],
+      }
+
+      allow(store).to receive(:read).and_return(stored_users.to_json)
+
+      expect(described_class.new(state_store: store, index: 0).position_and_count).to eq(
+        {
+          position: 1,
+          count: 2,
+        },
+      )
+    end
+  end
+
+  describe '#provider_user_name' do
+    it "returns the provider user's name" do
+      stored_users = {
+        provider_users: [
+          {
+            first_name: 'Bob',
+            last_name: 'Smith',
+            email_address: 'bob@foo.com',
+            complete: false,
+          },
+        ],
+      }
+
+      allow(store).to receive(:read).and_return(stored_users.to_json)
+
+      expect(described_class.new(state_store: store).provider_user_name).to eq('Bob Smith')
+    end
+  end
+
+  describe '#more_users_to_process?' do
+    context 'there are more users to process' do
+      it 'returns true' do
+        stored_users = {
+          provider_users: [
+            {
+              first_name: 'Bob',
+              last_name: 'Smith',
+              email_address: 'bob@foo.com',
+              complete: false,
+            },
+          ],
+        }
+
+        allow(store).to receive(:read).and_return(stored_users.to_json)
+
+        expect(
+          described_class.new(state_store: store).more_users_to_process?,
+        )
+        .to eq(true)
+      end
+    end
+
+    context 'there are no more users to process' do
+      it 'returns false' do
+        stored_users = {
+          provider_users: [
+            {
+              first_name: 'Bob',
+              last_name: 'Smith',
+              email_address: 'bob@foo.com',
+              complete: true,
+            },
+          ],
+        }
+
+        allow(store).to receive(:read).and_return(stored_users.to_json)
+
+        expect(
+          described_class.new(state_store: store).more_users_to_process?,
+        ).to eq(false)
+      end
+    end
+  end
+
+  describe '#single_provider_user_form' do
+    it 'returns an instance of CreateSingleProviderUserForm' do
+      first_name = 'Bob'
+      last_name = 'Smith'
+      email_address = 'bob@foo.com'
+      index = 0
+      stored_users = {
+        provider_users: [
+          {
+            first_name: first_name,
+            last_name: last_name,
+            email_address: email_address,
+            complete: false,
+          },
+        ],
+      }
+
+      allow(store).to receive(:read).and_return(stored_users.to_json)
+
+      single_provider_user_form = described_class.new(state_store: store, provider_id: 1).single_provider_user_form(index)
+      expected_attributes = {
+        first_name: first_name,
+        last_name: last_name,
+        email_address: email_address,
+        provider_id: 1,
+      }
+
+      expect(single_provider_user_form).to be_an_instance_of(SupportInterface::CreateSingleProviderUserForm)
+      expect(single_provider_user_form).to have_attributes(expected_attributes)
+    end
+  end
+end

--- a/spec/system/support_interface/managing_users_v2/bulk_upload_a_single_provider_user_spec.rb
+++ b/spec/system/support_interface/managing_users_v2/bulk_upload_a_single_provider_user_spec.rb
@@ -1,0 +1,179 @@
+require 'rails_helper'
+
+RSpec.feature 'bulk upload provider users' do
+  include DfESignInHelpers
+  include DsiAPIHelper
+
+  scenario 'bulk upload a single provider user', with_audited: true do
+    FeatureFlag.activate(:new_provider_user_flow)
+
+    given_dfe_signin_is_configured
+    and_i_am_a_support_user
+    and_a_provider_exists
+
+    when_i_visit_the_providers_page
+    and_i_click_on_users
+    and_i_click_add_multiple_users
+    then_i_should_see_the_add_multiple_user_form
+
+    when_i_click_continue
+    then_i_should_see_a_user_details_form_validation_error
+
+    when_i_enter_the_provider_users_details
+    and_i_click_continue
+    then_i_should_see_the_permissions_form_for_the_provider_user
+
+    when_i_click_back
+    then_i_should_see_the_add_multiple_user_form
+
+    when_i_click_continue
+    then_i_should_see_the_permissions_form_for_the_provider_user
+
+    when_i_remove_the_provider_users_first_name
+    and_i_click_continue
+    then_i_should_see_a_first_name_blank_validation_error
+
+    when_i_enter_a_new_email_address_for_the_first_user
+    and_i_add_permissions_for_the_first_user
+    and_i_click_continue
+    then_i_can_see_the_check_users_page
+
+    when_i_click_back
+    then_i_should_see_the_permissions_form_for_the_provider_user
+
+    when_i_click_continue
+    then_i_can_see_the_check_users_page
+
+    when_i_click_change_within_the_provider_user_summary
+    then_i_should_see_the_permissions_form_for_the_provider_user
+    and_the_permissions_i_selected_are_checked
+
+    when_i_edit_permissions_for_the_first_user
+    and_i_click_continue
+    then_i_can_see_the_check_users_page
+
+    when_i_click_add_users
+    then_i_see_the_provider_users_page
+    and_i_see_the_user_has_been_successfully_created
+  end
+
+  def given_dfe_signin_is_configured
+    set_dsi_api_response(success: true)
+  end
+
+  def and_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_a_provider_exists
+    @provider = create(:provider, name: 'Gorse SCITT', code: 'ABC')
+
+    create(:course, :open_on_apply, provider: @provider)
+  end
+
+  def when_i_visit_the_providers_page
+    visit support_interface_provider_path(@provider)
+  end
+
+  def and_i_click_on_users
+    click_on 'Users'
+  end
+
+  def and_i_click_add_multiple_users
+    click_on 'Add multiple users'
+  end
+
+  def then_i_should_see_the_add_multiple_user_form
+    expect(page).to have_content("Add users to #{@provider.name}")
+  end
+
+  def when_i_enter_the_provider_users_details
+    user_details = 'Natasha,Smith,natasha@smith.com'
+    fill_in 'support_interface_multiple_provider_users_wizard[provider_users]', with: user_details
+  end
+
+  def when_i_remove_the_provider_users_first_name
+    fill_in 'support_interface_create_single_provider_user_form[first_name]', with: nil
+  end
+
+  def then_i_should_see_a_first_name_blank_validation_error
+    expect(page).to have_content('Enter a first name')
+  end
+
+  def and_i_click_continue
+    click_on 'Continue'
+  end
+
+  def when_i_click_continue
+    and_i_click_continue
+  end
+
+  def then_i_should_see_a_user_details_form_validation_error
+    expect(page).to have_content("Enter the users' details")
+  end
+
+  def then_i_should_see_the_permissions_form_for_the_provider_user
+    expect(page).to have_content('Add user (1 of 1)')
+    expect(page).to have_content(@provider.name)
+    expect(page).to have_field('support_interface_create_single_provider_user_form[last_name]', with: 'Smith')
+  end
+
+  def and_i_add_permissions_for_the_first_user
+    check 'Manage users'
+    check 'Manage organisational permissions'
+    check 'Access safeguarding information'
+    check 'Make decisions'
+    check 'Access diversity information'
+  end
+
+  def when_i_enter_a_new_email_address_for_the_first_user
+    fill_in('First name', with: 'Henry')
+  end
+
+  def when_i_edit_permissions_for_the_first_user
+    check 'Manage users'
+    check 'Manage organisational permissions'
+  end
+
+  def when_i_click_back
+    click_on 'Back'
+  end
+
+  def then_i_should_see_the_provider_user_review_page
+    expect(page).to have_content("#{@provder_name} Check details and add users")
+    expect(page).to have_content('first_name_one')
+    expect(page).to have_content('first_name_two')
+  end
+
+  def and_i_click_add_users
+    click_on 'Add users'
+  end
+
+  def when_i_click_add_users
+    click_on 'Add users'
+  end
+
+  def and_the_permissions_i_selected_are_checked
+    expect(find_field('Manage users')).to be_checked
+    expect(find_field('Manage organisational permissions')).to be_checked
+    expect(find_field('Access safeguarding information')).to be_checked
+    expect(find_field('Make decisions')).to be_checked
+    expect(find_field('Access diversity information')).to be_checked
+  end
+
+  def then_i_see_the_provider_users_page
+    expect(page).to have_content(@provider.name_and_code.to_s)
+  end
+
+  def then_i_can_see_the_check_users_page
+    expect(page).to have_content('Check details and add users')
+  end
+
+  def when_i_click_change_within_the_provider_user_summary
+    all(:css, '.govuk-link').last.click
+  end
+
+  def and_i_see_the_user_has_been_successfully_created
+    expect(page).to have_content('User Henry Smith added')
+  end
+end

--- a/spec/system/support_interface/managing_users_v2/bulk_upload_multiple_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_users_v2/bulk_upload_multiple_provider_users_spec.rb
@@ -1,0 +1,189 @@
+require 'rails_helper'
+
+RSpec.feature 'bulk upload provider users' do
+  include DfESignInHelpers
+  include DsiAPIHelper
+
+  scenario 'bulk upload multiple provider users', with_audited: true do
+    FeatureFlag.activate(:new_provider_user_flow)
+
+    given_dfe_signin_is_configured
+    and_i_am_a_support_user
+    and_a_provider_exists
+
+    when_i_visit_the_providers_page
+    and_i_click_on_users
+    and_i_click_add_multiple_users
+    then_i_should_see_the_add_multiple_user_form
+
+    when_i_click_continue
+    then_i_should_see_a_form_validation_error
+
+    when_i_enter_the_users_details
+    and_i_click_continue
+    then_i_should_see_the_permissions_form_for_the_first_user
+
+    when_i_click_back
+    then_i_should_see_the_add_multiple_user_form
+
+    when_i_click_continue
+    and_i_edit_the_email_address_for_the_first_user
+    and_i_add_permissions_for_the_first_user
+    and_i_click_continue
+    then_i_should_see_the_permissions_form_for_the_second_user
+
+    when_i_click_back
+    then_i_should_see_the_permissions_form_for_the_first_user
+
+    when_i_click_continue
+    and_i_add_permissions_for_the_second_user
+    and_i_click_continue
+    then_i_should_see_the_provider_user_review_page
+
+    when_i_click_back
+    then_i_should_see_the_permissions_form_for_the_second_user
+
+    when_i_click_continue
+    then_i_can_see_the_check_users_page
+
+    when_i_click_change_within_the_second_user_summary
+    then_i_should_see_the_edit_permissions_form_for_the_second_user
+    and_the_permissions_i_selected_are_checked
+
+    when_i_edit_permissions_for_the_second_user
+    and_i_click_continue
+    then_i_can_see_the_check_users_page
+
+    when_i_click_add_users
+    then_i_see_the_provider_users_page
+    and_i_see_two_users_have_been_successfully_created
+  end
+
+  def given_dfe_signin_is_configured
+    set_dsi_api_response(success: true)
+  end
+
+  def and_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_a_provider_exists
+    @provider = create(:provider, name: 'Gorse SCITT', code: 'ABC')
+
+    create(:course, :open_on_apply, provider: @provider)
+  end
+
+  def when_i_visit_the_providers_page
+    visit support_interface_provider_path(@provider)
+  end
+
+  def and_i_click_on_users
+    click_on 'Users'
+  end
+
+  def and_i_click_add_multiple_users
+    click_on 'Add multiple users'
+  end
+
+  def then_i_should_see_the_add_multiple_user_form
+    expect(page).to have_content("Add users to #{@provider.name}")
+  end
+
+  def when_i_enter_the_users_details
+    user_details = "first_name_one,last_name_one,first_name_one@foo.com\nfirst_name_two\tlast_name_two\tfirst_name_two@foo.com"
+    fill_in 'support_interface_multiple_provider_users_wizard[provider_users]', with: user_details
+  end
+
+  def and_i_click_continue
+    click_on 'Continue'
+  end
+
+  def when_i_click_continue
+    and_i_click_continue
+  end
+
+  def then_i_should_see_a_form_validation_error
+    expect(page).to have_content("Enter the users' details")
+  end
+
+  def then_i_should_see_the_permissions_form_for_the_first_user
+    expect(page).to have_content('Add user (1 of 2)')
+    expect(page).to have_content(@provider.name)
+    expect(page).to have_field('support_interface_create_single_provider_user_form[first_name]', with: 'first_name_one')
+  end
+
+  def and_i_add_permissions_for_the_first_user
+    check 'Manage users'
+    check 'Manage organisational permissions'
+    check 'Access safeguarding information'
+    check 'Make decisions'
+    check 'Access diversity information'
+  end
+
+  def then_i_should_see_the_permissions_form_for_the_second_user
+    expect(page).to have_content('Add user (2 of 2)')
+    expect(page).to have_content(@provider.name)
+    expect(page).to have_field('support_interface_create_single_provider_user_form[last_name]', with: 'last_name_two')
+  end
+
+  def then_i_should_see_the_edit_permissions_form_for_the_second_user
+    expect(page).to have_content('Add user (2 of 2)')
+    expect(page).to have_content(@provider.name)
+    expect(page).to have_field('support_interface_create_single_provider_user_form[last_name]', with: 'last_name_two')
+  end
+
+  def and_i_edit_the_email_address_for_the_first_user
+    fill_in('Email address', with: 'superfoo@superbar.com')
+  end
+
+  def and_i_add_permissions_for_the_second_user
+    and_i_add_permissions_for_the_first_user
+  end
+
+  def when_i_edit_permissions_for_the_second_user
+    check 'Manage users'
+    check 'Manage organisational permissions'
+  end
+
+  def when_i_click_back
+    click_on 'Back'
+  end
+
+  def then_i_should_see_the_provider_user_review_page
+    expect(page).to have_content("#{@provder_name} Check details and add users")
+    expect(page).to have_content('first_name_one')
+    expect(page).to have_content('first_name_two')
+  end
+
+  def and_i_click_add_users
+    click_on 'Add users'
+  end
+
+  def when_i_click_add_users
+    click_on 'Add users'
+  end
+
+  def and_the_permissions_i_selected_are_checked
+    expect(find_field('Manage users')).to be_checked
+    expect(find_field('Manage organisational permissions')).to be_checked
+    expect(find_field('Access safeguarding information')).to be_checked
+    expect(find_field('Make decisions')).to be_checked
+    expect(find_field('Access diversity information')).to be_checked
+  end
+
+  def then_i_see_the_provider_users_page
+    expect(page).to have_content(@provider.name_and_code.to_s)
+  end
+
+  def then_i_can_see_the_check_users_page
+    expect(page).to have_content('Check details and add users')
+  end
+
+  def when_i_click_change_within_the_second_user_summary
+    all(:css, '.govuk-link').last.click
+  end
+
+  def and_i_see_two_users_have_been_successfully_created
+    expect(page).to have_content('2 users added')
+  end
+end


### PR DESCRIPTION
## Context

As part of the Transition team's provider onboarding process, they need to be able to add users in bulk. The process is currently managed via a spreadsheet and the team inputs user details one-by-one. This is inefficient.

## Changes proposed in this pull request

-  Add new flow for bulk adding of ProviderUsers

## Guidance to review

- In the support interface, click on the 'users' tab for any provider (`/support/providers/PROVIDER_ID/users`), then click 'add multiple users'
- Enter user details in CVS format in the text field and make you way through the form
- The flow makes use of a Redis store in order to temporarily store users whilst permissions are added to each ProviderUser. Once all permissions are added, the ProviderUser details (and their permissions are  saved to the database)
- [Support prototype](https://support-for-apply-prototype.herokuapp.com/providers/T92/users)

## Link to Trello card

https://trello.com/c/LYQBq8At/3400-%E2%9B%B5%EF%B8%8F-epic-bulk-add-provider-users

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
