### PR TITLE
Backfill providerrelationshippermissions on test environments

### DIFF
--- a/app/services/data_migrations/set_missing_provider_relationship_permissions.rb
+++ b/app/services/data_migrations/set_missing_provider_relationship_permissions.rb
@@ -1,0 +1,16 @@
+module DataMigrations
+  class SetMissingProviderRelationshipPermissions
+    TIMESTAMP = 20210607134802
+    MANUAL_RUN = true
+
+    def change
+      Course.all.each do |course|
+        next if ProviderRelationshipPermissions.exists?(training_provider: course.provider,
+                                                        ratifying_provider: course.accredited_provider)
+
+        ProviderRelationshipPermissions.new(training_provider: course.provider,
+                                            ratifying_provider: course.accredited_provider).save!
+      end
+    end
+  end
+end

--- a/app/services/data_migrations/set_missing_provider_relationship_permissions.rb
+++ b/app/services/data_migrations/set_missing_provider_relationship_permissions.rb
@@ -5,12 +5,22 @@ module DataMigrations
 
     def change
       Course.all.each do |course|
-        next if ProviderRelationshipPermissions.exists?(training_provider: course.provider,
-                                                        ratifying_provider: course.accredited_provider)
+        next if ratified_by_provider?(course) || provider_relationship_permissions_exist?(course)
 
         ProviderRelationshipPermissions.new(training_provider: course.provider,
                                             ratifying_provider: course.accredited_provider).save!
       end
+    end
+
+  private
+
+    def ratified_by_provider?(course)
+      !course.accredited_provider || course.accredited_provider == course.provider
+    end
+
+    def provider_relationship_permissions_exist?(course)
+      ProviderRelationshipPermissions.exists?(training_provider: course.provider,
+                                              ratifying_provider: course.accredited_provider)
     end
   end
 end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::SetMissingProviderRelationshipPermissions',
   'DataMigrations::RemoveApplicationChoicesInTheIncorrectCycle',
   'DataMigrations::DeleteUuidlessCourses',
   'DataMigrations::RemovePreviousCyclesCoursesFromApplicationsInTheCurrentCycle',

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -25,6 +25,16 @@ FactoryBot.define do
       accredited_provider { create(:provider) }
     end
 
+    trait :with_provider_relationship_permissions do
+      with_accredited_provider
+
+      after(:build) do |_, evaluator|
+        create(:provider_relationship_permissions,
+               training_provider: evaluator.provider,
+               ratifying_provider: evaluator.accredited_provider)
+      end
+    end
+
     trait :ucas_only do
       open_on_apply { false }
       exposed_in_find { true }

--- a/spec/services/data_migrations/set_missing_provider_relationship_permissions_spec.rb
+++ b/spec/services/data_migrations/set_missing_provider_relationship_permissions_spec.rb
@@ -18,4 +18,14 @@ RSpec.describe DataMigrations::SetMissingProviderRelationshipPermissions do
       described_class.new.change
     }.to change(ProviderRelationshipPermissions, :count).by(0)
   end
+
+  it 'does nothing if the course has no accredited provider or a match provider and accredited provider' do
+    provider = build(:provider)
+    create(:course, provider: provider, accredited_provider: provider)
+    create(:course, provider: provider, accredited_provider: nil)
+
+    expect {
+      described_class.new.change
+    }.to change(ProviderRelationshipPermissions, :count).by(0)
+  end
 end

--- a/spec/services/data_migrations/set_missing_provider_relationship_permissions_spec.rb
+++ b/spec/services/data_migrations/set_missing_provider_relationship_permissions_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::SetMissingProviderRelationshipPermissions do
+  it 'creates missing provider_relationship_permission' do
+    courses_with_no_provider_relationships = create_list(:course, 3, :with_accredited_provider)
+    create(:course, :with_provider_relationship_permissions)
+
+    expect {
+      described_class.new.change
+    }.to change(ProviderRelationshipPermissions, :count).by(courses_with_no_provider_relationships.count)
+  end
+
+  it 'does nothing if all courses have provider_relationship_permissions correctly setup' do
+    create(:course, :with_provider_relationship_permissions)
+    create(:course, :with_provider_relationship_permissions)
+
+    expect {
+      described_class.new.change
+    }.to change(ProviderRelationshipPermissions, :count).by(0)
+  end
+end


### PR DESCRIPTION
## Context
The authorisation service always assumes all `provider_permissions` exist, and they may have been setup, or still need to be verified. The reason we expect to exist is because it is part of syncing courses (see here: https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/services/teacher_training_public_api/sync_courses.rb#L99)

However when generating test data for test providers and courses, we aren't creating the expected `ProviderRelationshipPermissions` as seen in when syncing courses.

Since generating test data is used on Sandbox, QA and locally for development, when attempting to make offers  as seen in https://docs.google.com/document/d/1BtftTNmCpf_CXR5f1JY6jhVuMKI60F9S/edit

## Changes proposed in this pull request

Backfill all `ProviderRelationshipPermissions` similar to when we sync courses. 

## Link to Trello card

https://trello.com/c/JS7u2s7d/3768-backfill-providerrelationshippermissions-on-test-environments

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
