### PR TITLE
Add notifications preferences data export

### DIFF
--- a/app/exports/notifications_export.yml
+++ b/app/exports/notifications_export.yml
@@ -1,0 +1,29 @@
+common_columns:
+- provider_code
+- provider_user_id
+
+custom_columns:
+  notification_application_received:
+    type: boolean
+    description: Receive notifications when an application is received.
+    example: true
+  notification_application_withdrawn:
+    type: boolean
+    description: Receive notifications when an application is withdrawn.
+    example: true
+  notification_application_rbd:
+    type: boolean
+    description: Receive notifications when an application is rejected by default.
+    example: true
+  notification_offer_accepted:
+    type: boolean
+    description: Receive notifications when an offer is accepted.
+    example: true
+  notification_offer_declined:
+    type: boolean
+    description: Receive notifications when an offer is declined.
+    example: true
+  permissions_make_decisions:
+    type: boolean
+    description: Whether the provider user has 'make decisions' permissions within their organisation.
+    example: false

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -90,6 +90,12 @@ class DataExport < ApplicationRecord
       description: 'Changes to notification preferences for provider users.',
       class: SupportInterface::NotificationPreferencesExport,
     },
+    notifications_export: {
+      name: 'Notification preferences',
+      export_type: 'notifications_export',
+      description: 'Notification preferences for each provider user within each provider organisation.',
+      class: SupportInterface::NotificationsExport,
+    },
     offer_conditions: {
       name: 'Offer conditions',
       export_type: 'offer_conditions',

--- a/app/services/support_interface/notifications_export.rb
+++ b/app/services/support_interface/notifications_export.rb
@@ -1,0 +1,26 @@
+module SupportInterface
+  class NotificationsExport
+    LABELS = %i[
+      provider_user_id notification_application_received notification_application_withdrawn notification_application_rbd
+      notification_offer_accepted notification_offer_declined permissions_make_decisions provider_code
+    ].freeze
+
+    def data_for_export
+      ProviderUserNotificationPreferences
+        .joins('LEFT JOIN provider_users_providers ON provider_users_providers.provider_user_id = provider_user_notifications.provider_user_id')
+        .joins('LEFT JOIN providers ON provider_users_providers.provider_id = providers.id')
+        .order('provider_users_providers.provider_user_id, providers.code')
+        .pluck(
+          'provider_users_providers.provider_user_id',
+          'provider_user_notifications.application_received',
+          'provider_user_notifications.application_withdrawn',
+          'provider_user_notifications.application_rejected_by_default',
+          'provider_user_notifications.offer_accepted',
+          'provider_user_notifications.offer_declined',
+          'provider_users_providers.make_decisions',
+          'providers.code',
+        )
+        .map { |row| Hash[LABELS.zip(row)] }
+    end
+  end
+end

--- a/spec/services/support_interface/notifications_export_spec.rb
+++ b/spec/services/support_interface/notifications_export_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::NotificationsExport do
+  describe '#data_for_export' do
+    let(:provider1) { create(:provider, code: 'ABC') }
+    let(:provider2) { create(:provider, code: 'XYZ') }
+    let(:provider_user1) { create(:provider_user, create_notification_preference: false, providers: [provider1, provider2]) }
+    let(:provider_user2) { create(:provider_user, create_notification_preference: false, providers: [provider1, provider2]) }
+
+    before do
+      create(
+        :provider_user_notification_preferences,
+        provider_user: provider_user1,
+        application_received: false,
+        application_withdrawn: true,
+        application_rejected_by_default: false,
+        offer_accepted: true,
+        offer_declined: false,
+      )
+
+      create(
+        :provider_user_notification_preferences,
+        provider_user: provider_user2,
+        application_received: true,
+        application_withdrawn: false,
+        application_rejected_by_default: true,
+        offer_accepted: false,
+        offer_declined: true,
+      )
+
+      provider_user1.provider_permissions.where(provider: provider1).update(make_decisions: true)
+    end
+
+    it_behaves_like 'a data export'
+
+    it 'exports notification preferences for provider users per organisation' do
+      results = described_class.new.data_for_export
+
+      expect(results.size).to eq(4)
+      expect(results).to eq([
+        {
+          provider_user_id: provider_user1.id,
+          notification_application_received: false,
+          notification_application_withdrawn: true,
+          notification_application_rbd: false,
+          notification_offer_accepted: true,
+          notification_offer_declined: false,
+          permissions_make_decisions: true,
+          provider_code: provider1.code,
+        },
+        {
+          provider_user_id: provider_user1.id,
+          notification_application_received: false,
+          notification_application_withdrawn: true,
+          notification_application_rbd: false,
+          notification_offer_accepted: true,
+          notification_offer_declined: false,
+          permissions_make_decisions: false,
+          provider_code: provider2.code,
+        },
+        {
+          provider_user_id: provider_user2.id,
+          notification_application_received: true,
+          notification_application_withdrawn: false,
+          notification_application_rbd: true,
+          notification_offer_accepted: false,
+          notification_offer_declined: true,
+          permissions_make_decisions: false,
+          provider_code: provider1.code,
+        },
+        {
+          provider_user_id: provider_user2.id,
+          notification_application_received: true,
+          notification_application_withdrawn: false,
+          notification_application_rbd: true,
+          notification_offer_accepted: false,
+          notification_offer_declined: true,
+          permissions_make_decisions: false,
+          provider_code: provider2.code,
+        },
+      ])
+    end
+  end
+end


### PR DESCRIPTION
## Context

This is a replacement for the old notifications export now that we've moved over to finer grained provider notification preferences.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds notifications export based on values from `ProviderUserNotificationPreferences` model

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ZdF7V6nM/3739-creation-of-new-notification-snapshot-data-export
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
