### PR TITLE
Account for empty disability data in application forms

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -381,7 +381,7 @@ module VendorAPI
     end
 
     def other_disability_details(equality_and_diversity_data)
-      return unless equality_and_diversity_data['hesa_disabilities'].include?('96')
+      return unless equality_and_diversity_data['hesa_disabilities']&.include?('96')
 
       standard_disabilities = DisabilityHelper::STANDARD_DISABILITIES.map(&:last)
       (equality_and_diversity_data['disabilities'] - standard_disabilities).first.presence

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -118,6 +118,24 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       end
     end
 
+    context 'when the application choice has no disabilities or ethnicities' do
+      let(:equality_and_diversity) { {} }
+
+      it 'returns no the disability or ethnicity details' do
+        equality_and_diversity_data = application_choice.application_form.equality_and_diversity
+
+        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+
+        expect(response.dig(:attributes, :hesa_itt_data)).to eq(
+          disability: equality_and_diversity_data['hesa_disabilities'],
+          ethnicity: equality_and_diversity_data['hesa_ethnicity'],
+          sex: equality_and_diversity_data['hesa_sex'],
+          other_disability_details: nil,
+          other_ethnicity_details: nil,
+        )
+      end
+    end
+
     context 'when the application choice has other freetext ethnicity' do
       let(:ethnic_group) { 'White' }
       let(:ethnic_background) { 'Custom ethnic background' }


### PR DESCRIPTION
## Context

If an application form does not have any disability data we are seeing an error when attempting to surface API data: https://sentry.io/organizations/dfe-bat/issues/2442169894/events/0342584a199a4b9d8132220ab84dd3c3/?project=1765973

## Changes proposed in this pull request

Account for `nil` values in disability application form data when rendering application choices in the API

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
