### PR TITLE
Paas internal routes

### DIFF
--- a/terraform/modules/paas/data.tf
+++ b/terraform/modules/paas/data.tf
@@ -11,6 +11,10 @@ data "cloudfoundry_domain" "london_cloudapps_digital" {
   name = "london.cloudapps.digital"
 }
 
+data "cloudfoundry_domain" "internal" {
+  name = "apps.internal"
+}
+
 data "cloudfoundry_domain" "apply_service_gov_uk" {
   name = "apply-for-teacher-training.service.gov.uk"
 }

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -83,6 +83,12 @@ resource "cloudfoundry_app" "worker" {
   }
 }
 
+resource "cloudfoundry_route" "web_app_internal_route" {
+  domain   = data.cloudfoundry_domain.internal.id
+  space    = data.cloudfoundry_space.space.id
+  hostname = local.web_app_name
+}
+
 resource "cloudfoundry_route" "web_app_cloudapps_digital_route" {
   domain   = data.cloudfoundry_domain.london_cloudapps_digital.id
   space    = data.cloudfoundry_space.space.id

--- a/terraform/modules/paas/network-policies.tf
+++ b/terraform/modules/paas/network-policies.tf
@@ -1,0 +1,31 @@
+/*
+This configuration is only for a prometheus app hosted inside the same space as the Apply app.
+prometheus-bat-qa -> apply-qa (bat-qa space)
+prometheus-bat -> apply-prod and apply-sandbox (bat-prod space)
+We don't have prometheus stack deployed in bat-staging and hence the use of count to not deploy the policy in staging.
+*/
+locals {
+  configure_prometheus_network_policy = var.prometheus_app == null ? 0 : 1
+}
+
+data "cloudfoundry_app" "apply_web_app" {
+  depends_on = [cloudfoundry_app.web_app]
+  name_or_id = cloudfoundry_app.web_app.name
+  space      = data.cloudfoundry_space.space.id
+}
+
+data "cloudfoundry_app" "prometheus_app" {
+  count      = local.configure_prometheus_network_policy
+  name_or_id = var.prometheus_app
+  space      = data.cloudfoundry_space.space.id
+}
+
+resource "cloudfoundry_network_policy" "apply_prometheus_policy" {
+  depends_on = [data.cloudfoundry_app.apply_web_app]
+  count      = local.configure_prometheus_network_policy
+  policy {
+    source_app      = data.cloudfoundry_app.prometheus_app[0].id
+    destination_app = data.cloudfoundry_app.apply_web_app.id
+    port            = "8080"
+  }
+}

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -34,6 +34,8 @@ variable "worker_app_instances" {}
 
 variable "logstash_url" {}
 
+variable "prometheus_app" { default = null }
+
 locals {
   web_app_name          = "apply-${var.app_environment}"
   clock_app_name        = "apply-clock-${var.app_environment}"

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -52,7 +52,7 @@ locals {
     rollover = "rollover"
     prod     = "www"
   }
-  web_app_routes = [cloudfoundry_route.web_app_service_gov_uk_route, cloudfoundry_route.web_app_cloudapps_digital_route, cloudfoundry_route.web_app_education_gov_uk_route]
+  web_app_routes = [cloudfoundry_route.web_app_service_gov_uk_route, cloudfoundry_route.web_app_cloudapps_digital_route, cloudfoundry_route.web_app_education_gov_uk_route, cloudfoundry_route.web_app_internal_route]
   app_environment_variables = merge(var.app_environment_variables,
     {
       BLAZER_DATABASE_URL = cloudfoundry_service_key.postgres-readonly-key.credentials.uri

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -36,6 +36,7 @@ module "paas" {
   cf_user_password          = local.infra_secrets.CF_PASSWORD
   cf_sso_passcode           = var.paas_sso_code
   cf_space                  = var.paas_cf_space
+  prometheus_app            = var.prometheus_app
   docker_credentials        = local.docker_credentials
   web_app_instances         = var.paas_web_app_instances
   web_app_memory            = var.paas_web_app_memory

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,6 +23,8 @@ variable "paas_clock_app_instances" { default = 1 }
 
 variable "paas_worker_app_instances" { default = 1 }
 
+variable "prometheus_app" { default = null }
+
 # Key Vault variables
 variable "azure_credentials" { default = null }
 
@@ -35,7 +37,10 @@ variable "key_vault_infra_secret_name" {}
 variable "key_vault_app_secret_name" {}
 
 # StatusCake variables
-variable "statuscake_alerts" { type = map(any) }
+variable "statuscake_alerts" {
+  type    = map(any)
+  default = {}
+}
 
 locals {
   cf_api_url        = "https://api.london.cloud.service.gov.uk"

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -15,6 +15,9 @@ key_vault_name              = "s121p01-shared-kv-01"
 key_vault_app_secret_name   = "APPLY-APP-SECRETS-PRODUCTION"
 key_vault_infra_secret_name = "BAT-INFRA-SECRETS-PRODUCTION"
 
+# Network Policy
+prometheus_app = "prometheus-bat"
+
 # StatusCake
 statuscake_alerts = {
   apply-prod = {

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -12,6 +12,9 @@ key_vault_name              = "s121d01-shared-kv-01"
 key_vault_app_secret_name   = "APPLY-APP-SECRETS-QA"
 key_vault_infra_secret_name = "BAT-INFRA-SECRETS-QA"
 
+# Network Policy
+prometheus_app = "prometheus-bat-qa"
+
 # StatusCake
 statuscake_alerts = {
   apply-qa = {

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -14,6 +14,9 @@ key_vault_name              = "s121p01-shared-kv-01"
 key_vault_app_secret_name   = "APPLY-APP-SECRETS-SANDBOX"
 key_vault_infra_secret_name = "BAT-INFRA-SECRETS-SANDBOX"
 
+# Network Policy
+prometheus_app = "prometheus-bat"
+
 # StatusCake
 statuscake_alerts = {
   apply-sandbox = {


### PR DESCRIPTION
## Context

To allow prometheus to scrap metrics from each app instance (from `/metrics` endpoint ).


## Changes proposed in this pull request

Configure a internal route for the web app,
Add a network policy between app web app and prometheus app.


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
