### PR TITLE
Push setting sync `updated_since` two hours in the past

### DIFF
--- a/app/models/teacher_training_public_api/sync_check.rb
+++ b/app/models/teacher_training_public_api/sync_check.rb
@@ -16,9 +16,9 @@ module TeacherTrainingPublicAPI
 
     def self.updated_since
       if last_sync.present?
-        Time.zone.parse(last_sync) - 1.hour
+        Time.zone.parse(last_sync) - 2.hours
       else
-        Time.zone.now - 1.hour
+        Time.zone.now - 2.hours
       end
     end
 


### PR DESCRIPTION
## Context

We currently set an `updated_at` timestamp in Redis to help with our incremental syncs of the TTAPI. We set this timestamp to 1 hour behind the current time.

However the teacher training API is 1 hour behind. Since we kick off subsequent jobs for syncing providers then courses then sites, and we reset the `updated_at` after syncing providers only, we actually were never using the correct timestamp to query for courses, and always missing the 10 minute window.

## Changes proposed in this pull request

Set the `updated_at` timestamp to 2 hours to avoid issue for now (as it was previously)

## Guidance to review

This is a quick fix, I think we need a better solution around setting the `updated_at` timestamp to happen after the sync is complete to avoid any issues we might face with changing the time.

## Link to Trello card

https://trello.com/c/59TtliPE/3776-incremental-sync-not-adding-new-courses

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
