### PR TITLE
Add export of notification preferences changes over time

### DIFF
--- a/app/exports/notification_preferences_export.yml
+++ b/app/exports/notification_preferences_export.yml
@@ -1,0 +1,22 @@
+common_columns:
+- provider_user_id
+- provider_code
+
+custom_columns:
+  permissions_make_decisions:
+    type: boolean
+    description: Whether this provider user can make decisions on applications within their organisation
+    example: true
+  changed_at:
+    type: string
+    description: The date and time when the change was made
+    format: datetime
+    example: 2020-11-01T00:00:00+00:00
+  notifications_added:
+    type: string
+    description: The events this user enabled notifications for
+    example: application_withdrawn offer_declined
+  notifications_removed:
+    type: string
+    description: The events this user disabled notifications for
+    example: application_withdrawn offer_declined

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -84,6 +84,12 @@ class DataExport < ApplicationRecord
       description: 'Data related to notes made on applications by providers.',
       class: SupportInterface::NotesExport,
     },
+    notification_preferences_export: {
+      name: 'Notification preferences changes',
+      export_type: 'notification_preferences_export',
+      description: 'Changes to notification preferences for provider users.',
+      class: SupportInterface::NotificationPreferencesExport,
+    },
     offer_conditions: {
       name: 'Offer conditions',
       export_type: 'offer_conditions',
@@ -210,6 +216,7 @@ class DataExport < ApplicationRecord
     find_feedback: 'find_feedback',
     interviews_export: 'interview_export',
     notifications_export: 'notifications_export',
+    notification_preferences_export: 'notification_preferences_export',
     notes_export: 'notes_export',
     offer_conditions: 'offer_conditions',
     organisation_permissions: 'organisation_permissions',

--- a/app/services/support_interface/notification_preferences_export.rb
+++ b/app/services/support_interface/notification_preferences_export.rb
@@ -1,0 +1,42 @@
+module SupportInterface
+  class NotificationPreferencesExport
+    LABELS = %i[
+      provider_user_id
+      provider_code
+      permissions_make_decisions
+      changed_at
+      notifications_added
+      notifications_removed
+    ].freeze
+
+    def data_for_export
+      rows = Audited::Audit
+        .where(auditable_type: 'ProviderUserNotificationPreferences', action: 'update')
+        .joins('JOIN provider_user_notifications ON auditable_id = provider_user_notifications.id')
+        .joins('JOIN provider_users ON provider_user_notifications.provider_user_id = provider_users.id')
+        .joins('JOIN provider_users_providers ON provider_users.id = provider_users_providers.provider_user_id')
+        .joins('JOIN providers ON providers.id = provider_users_providers.provider_id')
+        .order(:created_at)
+        .pluck(
+          'provider_users.id',
+          'providers.code',
+          'provider_users_providers.make_decisions',
+          'audits.created_at',
+          'audits.audited_changes',
+        )
+
+      rows.map do |row|
+        notifications_added, notifications_removed = group_audit_changes(row.pop)
+        row[3] = row[3].iso8601
+        row << notifications_added << notifications_removed
+        Hash[LABELS.zip(row)]
+      end
+    end
+
+  private
+
+    def group_audit_changes(changes)
+      changes.partition { |_, v| v == [false, true] }.map { |ary| ary.map(&:first).sort.join(', ') }
+    end
+  end
+end

--- a/spec/factories/audit.rb
+++ b/spec/factories/audit.rb
@@ -58,4 +58,23 @@ FactoryBot.define do
       audit.audited_changes = evaluator.changes
     end
   end
+
+  factory :provider_user_notification_preferences_audit, class: 'Audited::Audit' do
+    action { 'update' }
+    user { create(:provider_user) }
+    version { 1 }
+    request_uuid { SecureRandom.uuid }
+    created_at { Time.zone.now }
+
+    transient do
+      notification_preferences { build_stubbed(:provider_user_notification_preferences) }
+      changes { {} }
+    end
+
+    after(:build) do |audit, evaluator|
+      audit.auditable_type = 'ProviderUserNotificationPreferences'
+      audit.auditable_id = evaluator.notification_preferences.id
+      audit.audited_changes = evaluator.changes
+    end
+  end
 end

--- a/spec/services/support_interface/notification_preferences_export_spec.rb
+++ b/spec/services/support_interface/notification_preferences_export_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::NotificationPreferencesExport do
+  let(:provider1) { create(:provider) }
+  let(:provider2) { create(:provider) }
+  let(:provider_user1) { create(:provider_user, providers: [provider1, provider2]) }
+  let(:provider_user2) { create(:provider_user, providers: [provider2]) }
+
+  before do
+    provider_user1.provider_permissions.where(provider: provider2).update(make_decisions: true)
+    create(:provider_user_notification_preferences, provider_user: provider_user1)
+    provider_user2.provider_permissions.where(provider: provider2).update(make_decisions: true)
+    create(:provider_user_notification_preferences, provider_user: provider_user2)
+
+    create(:provider_user_notification_preferences_audit, notification_preferences: provider_user1.notification_preferences, changes: {
+      'application_received' => [true, false], 'offer_accepted' => [false, true], 'offer_declined' => [true, false]
+    })
+    create(:provider_user_notification_preferences_audit, notification_preferences: provider_user2.notification_preferences, changes: {
+      'application_withdrawn' => [true, false], 'application_rejected_by_default' => [false, true], 'offer_accepted' => [true, false]
+    })
+    create(:provider_user_notification_preferences_audit, notification_preferences: provider_user2.notification_preferences, changes: {
+      'application_received' => [true, false], 'offer_accepted' => [true, false]
+    })
+  end
+
+  it_behaves_like 'a data export'
+
+  describe '#data_for_export' do
+    it 'exports changes to provider user notification preferences' do
+      expect(described_class.new.data_for_export).to match_array([
+        {
+          provider_user_id: provider_user1.id,
+          provider_code: provider1.code,
+          permissions_make_decisions: false,
+          changed_at: anything,
+          notifications_added: 'offer_accepted',
+          notifications_removed: 'application_received, offer_declined',
+        },
+        {
+          provider_user_id: provider_user1.id,
+          provider_code: provider2.code,
+          permissions_make_decisions: true,
+          changed_at: anything,
+          notifications_added: 'offer_accepted',
+          notifications_removed: 'application_received, offer_declined',
+        },
+        {
+          provider_user_id: provider_user2.id,
+          provider_code: provider2.code,
+          permissions_make_decisions: true,
+          changed_at: anything,
+          notifications_added: '',
+          notifications_removed: 'application_received, offer_accepted',
+        },
+        {
+          provider_user_id: provider_user2.id,
+          provider_code: provider2.code,
+          permissions_make_decisions: true,
+          changed_at: anything,
+          notifications_added: 'application_rejected_by_default',
+          notifications_removed: 'application_withdrawn, offer_accepted',
+        },
+      ])
+    end
+  end
+end


### PR DESCRIPTION
## Context

We've moved to notification preferences for providers based on specific events.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds an export of notification preference changes per provider user and provider.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/NaVZK2sw/3758-creation-of-new-notification-data-export-tracking-changes-over-time
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
