### PR TITLE
Only incrementally sync Providers that have been updated since last sync

### DIFF
--- a/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
+++ b/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
@@ -12,8 +12,7 @@ module TeacherTrainingPublicAPI
         scope = scope.where(updated_since: TeacherTrainingPublicAPI::SyncCheck.updated_since) if incremental_sync
         response = scope.all
 
-        Rails.logger.info("Syncing #{response.count} Providers with the incremental sync set to #{incremental_sync}")
-        sync_providers(response, recruitment_cycle_year, incremental_sync: incremental_sync)
+        sync_providers(response, recruitment_cycle_year)
 
         is_last_page = true if response.links.links['next'].nil?
       end
@@ -23,12 +22,12 @@ module TeacherTrainingPublicAPI
       raise TeacherTrainingPublicAPI::SyncError
     end
 
-    def self.sync_providers(providers_from_api, recruitment_cycle_year, incremental_sync: true)
+    def self.sync_providers(providers_from_api, recruitment_cycle_year)
       providers_from_api.each do |provider_from_api|
         TeacherTrainingPublicAPI::SyncProvider.new(
           provider_from_api: provider_from_api,
           recruitment_cycle_year: recruitment_cycle_year,
-        ).call(incremental_sync: incremental_sync)
+        ).call
       end
     end
 

--- a/app/services/teacher_training_public_api/sync_provider.rb
+++ b/app/services/teacher_training_public_api/sync_provider.rb
@@ -5,7 +5,7 @@ module TeacherTrainingPublicAPI
       @recruitment_cycle_year = recruitment_cycle_year
     end
 
-    def call(run_in_background: true, force_sync_courses: false, incremental_sync: true)
+    def call(run_in_background: true, force_sync_courses: false)
       @force_sync_courses = force_sync_courses
 
       provider_attrs = if existing_provider
@@ -17,17 +17,15 @@ module TeacherTrainingPublicAPI
                        end
 
       provider = create_or_update_provider(provider_attrs)
-      sync_courses(run_in_background, provider, incremental_sync: incremental_sync)
+      sync_courses(run_in_background, provider)
     end
 
-    def sync_courses(run_in_background, provider, incremental_sync: true)
-      Rails.logger.info("Syncing Provider's (#{provider.code}) courses, with the incremental sync set to #{incremental_sync} and sync courses set to: #{sync_courses?}")
-
+    def sync_courses(run_in_background, provider)
       if sync_courses?
         if run_in_background
-          TeacherTrainingPublicAPI::SyncCourses.perform_async(provider.id, @recruitment_cycle_year, incremental_sync)
+          TeacherTrainingPublicAPI::SyncCourses.perform_async(provider.id, @recruitment_cycle_year)
         else
-          TeacherTrainingPublicAPI::SyncCourses.new.perform(provider.id, @recruitment_cycle_year, incremental_sync, run_in_background: false)
+          TeacherTrainingPublicAPI::SyncCourses.new.perform(provider.id, @recruitment_cycle_year, run_in_background: false)
         end
       end
     end

--- a/app/workers/teacher_training_public_api/sync_provider_worker.rb
+++ b/app/workers/teacher_training_public_api/sync_provider_worker.rb
@@ -10,7 +10,7 @@ module TeacherTrainingPublicAPI
         TeacherTrainingPublicAPI::SyncProvider.new(
           provider_from_api: provider_from_api,
           recruitment_cycle_year: ::RecruitmentCycle.current_year,
-        ).call(incremental_sync: false)
+        ).call
       end
     end
   end

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -31,13 +31,13 @@ task sync_dev_providers_and_open_courses: :environment do
 
     TeacherTrainingPublicAPI::SyncProvider.new(
       provider_from_api: provider_from_api, recruitment_cycle_year: RecruitmentCycle.previous_year,
-    ).call(run_in_background: false, force_sync_courses: true, incremental_sync: false)
+    ).call(run_in_background: false, force_sync_courses: true)
 
     Provider.find_by_code(code).courses.previous_cycle.exposed_in_find.update_all(open_on_apply: true, opened_on_apply_at: Time.zone.now)
 
     TeacherTrainingPublicAPI::SyncProvider.new(
       provider_from_api: provider_from_api, recruitment_cycle_year: RecruitmentCycle.current_year,
-    ).call(run_in_background: false, force_sync_courses: true, incremental_sync: false)
+    ).call(run_in_background: false, force_sync_courses: true)
   end
 
   puts 'Making all the courses open on Apply...'

--- a/spec/services/teacher_training_public_api/sync_all_providers_and_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_all_providers_and_courses_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCourses, sidekiq: tr
 
       before do
         allow(TeacherTrainingPublicAPI::SyncCheck).to receive(:updated_since).and_return(updated_since)
-        allow(sync_provider).to receive(:call).with(incremental_sync: true)
+        allow(sync_provider).to receive(:call)
         allow(TeacherTrainingPublicAPI::SyncProvider)
           .to receive(:new)
             .with(provider_from_api: anything, recruitment_cycle_year: recruitment_cycle_year)
@@ -55,10 +55,10 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCourses, sidekiq: tr
         )
       end
 
-      it "calls sync provider with incremental sync 'true'" do
+      it 'calls sync provider' do
         described_class.call(incremental_sync: true)
 
-        expect(sync_provider).to have_received(:call).with(incremental_sync: true)
+        expect(sync_provider).to have_received(:call)
       end
     end
   end

--- a/spec/support/test_helpers/teacher_training_public_api_helper.rb
+++ b/spec/support/test_helpers/teacher_training_public_api_helper.rb
@@ -32,10 +32,10 @@ module TeacherTrainingPublicAPIHelper
     )
   end
 
-  def stub_teacher_training_api_course_with_site(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, course_code:, site_code:, vacancy_status: 'full_time_vacancies', course_attributes: [], site_attributes: [], filter_option: nil)
+  def stub_teacher_training_api_course_with_site(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, course_code:, site_code:, vacancy_status: 'full_time_vacancies', course_attributes: [], site_attributes: [])
     course_attributes = course_attributes.any? ? [course_attributes.first.merge(code: course_code)] : [{ code: course_code }]
     site_attributes = site_attributes.any? ? [site_attributes.first.merge(code: site_code)] : [{ code: site_code }]
-    stub_teacher_training_api_courses(recruitment_cycle_year: recruitment_cycle_year, provider_code: provider_code, specified_attributes: course_attributes, filter_option: filter_option)
+    stub_teacher_training_api_courses(recruitment_cycle_year: recruitment_cycle_year, provider_code: provider_code, specified_attributes: course_attributes)
     stub_teacher_training_api_sites(recruitment_cycle_year: recruitment_cycle_year, provider_code: provider_code, course_code: course_code, specified_attributes: site_attributes, vacancy_status: vacancy_status)
   end
 
@@ -44,9 +44,9 @@ module TeacherTrainingPublicAPIHelper
     stub_teacher_training_single_api_request("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses/#{course_code}", response_body)
   end
 
-  def stub_teacher_training_api_courses(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, specified_attributes: [], filter_option: nil)
+  def stub_teacher_training_api_courses(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, specified_attributes: [])
     response_body = build_response_body('course_list_response.json', specified_attributes)
-    stub_teacher_training_list_api_request("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses", response_body, filter_option: filter_option)
+    stub_teacher_training_list_api_request("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses", response_body)
   end
 
   def stub_teacher_training_api_sites(recruitment_cycle_year: RecruitmentCycle.current_year, provider_code:, course_code:, specified_attributes: [], vacancy_status: 'full_time_vacancies')
@@ -104,15 +104,13 @@ private
     )
   end
 
-  def stub_teacher_training_list_api_request(url, response_body, filter_option: nil)
+  def stub_teacher_training_list_api_request(url, response_body)
     scope = stub_request(
       :get,
       url,
     ).with(
       query: { page: { per_page: 500 } },
     )
-
-    scope = scope.with(query: filter_option) if filter_option
 
     scope.to_return(
       status: 200,

--- a/spec/system/find_sync/syncing_providers_spec.rb
+++ b/spec/system/find_sync/syncing_providers_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe 'Syncing providers', sidekiq: true do
     stub_teacher_training_api_courses(
       provider_code: 'ABC',
       specified_attributes: [{ code: 'ABC1', accredited_body_code: nil, subject_codes: %w[08], uuid: @course_uuid }],
-      filter_option: { 'filter[updated_since]' => @updated_since },
     )
     stub_teacher_training_api_sites(
       provider_code: 'ABC',

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -131,19 +131,16 @@ RSpec.feature 'Providers and courses' do
                                                course_code: 'ABC1',
                                                course_attributes: [{ accredited_body_code: 'XYZ', qualifications: %w[qts pgce], name: 'Primary' }],
                                                site_code: 'X',
-                                               site_attributes: [{ name: 'Main site' }],
-                                               filter_option: { 'filter[updated_since]' => @updated_since })
+                                               site_attributes: [{ name: 'Main site' }])
 
     stub_teacher_training_api_course_with_site(provider_code: 'DEF',
                                                course_code: 'DEF1',
                                                course_attributes: [{ accredited_body_code: 'ABC' }],
-                                               filter_option: { 'filter[updated_since]' => @updated_since },
                                                site_code: 'Y')
 
     stub_teacher_training_api_course_with_site(provider_code: 'GHI',
                                                course_code: 'GHI1',
                                                course_attributes: [{ accredited_body_code: 'GHI' }],
-                                               filter_option: { 'filter[updated_since]' => @updated_since },
                                                site_code: 'C')
 
     Sidekiq::Testing.inline! do

--- a/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
+++ b/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Sync from Teacher Training API' do
 
   scenario 'a courses study mode changes between syncs' do
     given_there_is_a_full_time_course_on_the_teacher_training_api
-    and_the_last_sync_was_two_hours_ago
 
     when_sync_provider_is_called
     then_the_correct_course_option_is_created_on_apply
@@ -22,18 +21,12 @@ RSpec.describe 'Sync from Teacher Training API' do
   end
 
   def given_there_is_a_full_time_course_on_the_teacher_training_api
-    @updated_since = Time.zone.now - 2.hours
     @provider = create :provider, code: 'ABC', sync_courses: true
     stub_teacher_training_api_course_with_site(provider_code: 'ABC',
                                                course_code: 'ABC1',
                                                course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
-                                               filter_option: { 'filter[updated_since]' => @updated_since },
                                                site_code: 'A',
                                                vacancy_status: 'full_time_vacancies')
-  end
-
-  def and_the_last_sync_was_two_hours_ago
-    allow(TeacherTrainingPublicAPI::SyncCheck).to receive(:updated_since).and_return(@updated_since)
   end
 
   def when_sync_provider_is_called
@@ -59,7 +52,6 @@ RSpec.describe 'Sync from Teacher Training API' do
     stub_teacher_training_api_course_with_site(provider_code: 'ABC',
                                                course_code: 'ABC1',
                                                course_attributes: [{ accredited_body_code: nil, study_mode: 'both' }],
-                                               filter_option: { 'filter[updated_since]' => @updated_since },
                                                site_code: 'A',
                                                vacancy_status: 'both_full_time_and_part_time_vacancies')
   end
@@ -74,7 +66,6 @@ RSpec.describe 'Sync from Teacher Training API' do
     stub_teacher_training_api_course_with_site(provider_code: 'ABC',
                                                course_code: 'ABC1',
                                                course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
-                                               filter_option: { 'filter[updated_since]' => @updated_since },
                                                site_code: 'A',
                                                vacancy_status: 'full_time_vacancies')
   end

--- a/spec/system/teacher_training_public_api/sync_course_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_course_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe 'Sync courses', sidekiq: true do
                                qualifications: %w[qts pgce],
                                accredited_body_code: 'DEF',
                              }],
-      filter_option: { 'filter[updated_since]' => @updated_since },
     )
     stub_teacher_training_api_sites(
       provider_code: 'ABC',

--- a/spec/system/teacher_training_public_api/sync_site_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_site_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe 'Sync sites', sidekiq: true do
         study_mode: 'both',
         uuid: @course_uuid,
       }],
-      filter_option: { 'filter[updated_since]' => @updated_since },
     )
     stub_teacher_training_api_sites(
       provider_code: 'ABC',


### PR DESCRIPTION
## Context

The current process of our incremental TTAPI sync which runs every 10 minutes is as follows:
- Query the API for the providers updated since our last sync 
- Update or create providers from the list
- update the last sync timestamp to current time - 1 hour
- Trigger course sync jobs for the provider list retrieved 
- Query the API for the courses updated since the new timestamp (the one just updated) for the provider
- Update or create the courses from the list
- Trigger subsequent sites sync

Querying the courses changed since with the **updated** timestamp meant we were not actually ever getting the updated courses because the TTAPI being one hour behind, meant that we actually missed 10 minutes each time the course sync jobs ran, missing our window to retrieve the correct courses.

A quick fix was merged yesterday to set the last sync timestamp to two hours behind https://github.com/DFE-Digital/apply-for-teacher-training/pull/4904 to factor in the courses that could come in even when we update the last sync time

However a robust solution would be to use the same `updated_since` across all sync jobs. After a discussion with @duncanjbrown the suggestion was to pass the old `updated_since` to every job we trigger.

I started going down this path but realised the complexity we are adding with introducing yet more parameters to pass around between different jobs. Instead I resurrected https://github.com/DFE-Digital/apply-for-teacher-training/pull/4765 which removes any syncing from courses/sites and only retains it for the provider list we pull in.

## Changes proposed in this pull request

- Remove incremental syncing from courses
- Remove unnecessary logging now we found the issue


## Guidance to review

The price for syncing all courses for updated providers is small to reduce complexity/chance of bugs in the sync. Are there any issues we foresee in the future around this, where we will be syncing a higher number of courses per provider?

## Link to Trello card

https://trello.com/c/59TtliPE/3776-incremental-sync-not-adding-new-courses

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
