### PR TITLE
Add new data migration service for removing all application choices in the incorrect cycle

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -169,6 +169,15 @@ class ApplicationChoice < ApplicationRecord
     offer&.fetch('conditions', []).blank?
   end
 
+  # To be removed after testing. This has been tested here
+  # remove_application_choices_in_the_incorrect_cycle_spec.rb
+
+  def self.return_application_choices_with_a_course_in_a_different_cycle
+    ApplicationChoice
+    .joins(:application_form, course_option: [:course])
+    .where('courses.recruitment_cycle_year != application_forms.recruitment_cycle_year')
+  end
+
 private
 
   def set_initial_status

--- a/app/services/data_migrations/remove_application_choices_in_the_incorrect_cycle.rb
+++ b/app/services/data_migrations/remove_application_choices_in_the_incorrect_cycle.rb
@@ -1,0 +1,18 @@
+module DataMigrations
+  class RemoveApplicationChoicesInTheIncorrectCycle
+    TIMESTAMP = 20210609084557
+    MANUAL_RUN = true
+
+    def change
+      ApplicationChoice
+      .joins(:application_form, course_option: [:course])
+      .where('courses.recruitment_cycle_year != application_forms.recruitment_cycle_year')
+      .find_each(batch_size: 100) do |application_choice|
+        application_choice.application_form.update!(
+          audit_comment: "Application_choice ##{application_choice.id} was deleted due to being associated with a course from another recruitment cycle",
+        )
+        application_choice.destroy
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveApplicationChoicesInTheIncorrectCycle',
   'DataMigrations::DeleteUuidlessCourses',
   'DataMigrations::RemovePreviousCyclesCoursesFromApplicationsInTheCurrentCycle',
   'DataMigrations::BackfillRestucturedWorkHistoryBoolean',

--- a/spec/services/data_migrations/remove_application_choices_in_the_incorrect_cycle_spec.rb
+++ b/spec/services/data_migrations/remove_application_choices_in_the_incorrect_cycle_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveApplicationChoicesInTheIncorrectCycle do
+  it 'removes course choices from the previous cycle from application forms in the current cycle', with_audited: true do
+    application_form_from_current_cycle = create(:application_form)
+    application_form_from_previous_cycle = create(:application_form, recruitment_cycle_year: RecruitmentCycle.previous_year)
+
+    course_from_previous_cycle = create(:course, recruitment_cycle_year: RecruitmentCycle.previous_year)
+    course_from_current_cycle = create(:course, recruitment_cycle_year: RecruitmentCycle.current_year)
+
+    old_course_option = create(:course_option, course: course_from_previous_cycle)
+    new_course_option = create(:course_option, course: course_from_current_cycle)
+
+    invalid_application_choice1 = create(:application_choice, course_option: old_course_option, application_form: application_form_from_current_cycle)
+    valid_application_choice1 = create(:application_choice, course_option: new_course_option, application_form: application_form_from_current_cycle)
+
+    invalid_application_choice2 = create(:application_choice, course_option: new_course_option, application_form: application_form_from_previous_cycle)
+    valid_application_choice2 = create(:application_choice, course_option: old_course_option, application_form: application_form_from_previous_cycle)
+
+    described_class.new.change
+
+    expect(application_form_from_current_cycle.reload.application_choices).to match_array [valid_application_choice1]
+    expect(application_form_from_current_cycle.audits.last.comment).to eq "Application_choice ##{invalid_application_choice1.id} was deleted due to being associated with a course from another recruitment cycle"
+    expect(application_form_from_previous_cycle.reload.application_choices).to match_array [valid_application_choice2]
+    expect(application_form_from_previous_cycle.audits.last.comment).to eq "Application_choice ##{invalid_application_choice2.id} was deleted due to being associated with a course from another recruitment cycle"
+  end
+end


### PR DESCRIPTION
## Context

Before we can merge in the invariant check in #4854, we need to do some data cleanup of invalid application_choices.

This PR tweaks a data migration service to delete application choices that are associated with an application form that is in a different cycle.

Previously it was scoped to the application form being in the current cycle and the course being in the previous cycle.

## Changes proposed in this pull request

- Rename and rework the `RemovePreviousCyclesCoursesFromApplicationsInTheCurrentCycle` to be cycle agnostic

## Guidance to review

Does renaming the service and tweaking the timestamp cause any issues? Maybe i should have just deleted it and created a new migration?

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
