### PR TITLE
Add Cayman Islands to countries list

### DIFF
--- a/config/initializers/countries.rb
+++ b/config/initializers/countries.rb
@@ -33,6 +33,7 @@ COUNTRIES = {
   'CM' => 'Cameroon',
   'CA' => 'Canada',
   'CV' => 'Cape Verde',
+  'KY' => 'Cayman Islands',
   'CF' => 'Central African Republic',
   'TD' => 'Chad',
   'CL' => 'Chile',


### PR DESCRIPTION
A candidate needs to add a non-uk qualification which they obtained in
the Cayman Islands. Our countries list doesn't contain this currently.

A review of the countries/nationalities list is planned, in the meantime
add the missing country in.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/oTk7WiDE
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
