### PR TITLE
Add the `provider_made_decision` column to the E&D export

### DIFF
--- a/app/exports/equality_and_diversity_export.yml
+++ b/app/exports/equality_and_diversity_export.yml
@@ -37,6 +37,10 @@ custom_columns:
       - ended_without_success
       - unknown_state
 
+  provider_made_decision:
+    type: boolean
+    description: Returns true if a provider took an affirmative action by offering or rejecting any application choice
+
   application_choice_1_subject:
     type: string
     description: The name of a course

--- a/app/services/support_interface/equality_and_diversity_export.rb
+++ b/app/services/support_interface/equality_and_diversity_export.rb
@@ -13,6 +13,7 @@ module SupportInterface
           ethnic_group: application_form.equality_and_diversity['ethnic_group'],
           ethnic_background: application_form.equality_and_diversity['ethnic_background'],
           application_status: I18n.t!("candidate_flow_application_states.#{ProcessState.new(application_form).state}.name"),
+          provider_made_decision: provider_made_decision_on_any_application_choice?(application_form),
           application_choice_1_subject: application_choices[0]&.course&.name,
           application_choice_2_subject: application_choices[1]&.course&.name,
           application_choice_3_subject: application_choices[2]&.course&.name,
@@ -44,6 +45,13 @@ module SupportInterface
       ApplicationForm
         .includes(:application_choices)
         .where.not(equality_and_diversity: nil)
+    end
+
+    def provider_made_decision_on_any_application_choice?(application_form)
+      application_form.application_choices.any? do |application_choice|
+        application_choice.status.in?(%w[offer pending_conditions recruited rejected declined conditions_not_met offer_deferred]) &&
+          !application_choice.rejected_by_default
+      end
     end
   end
 end

--- a/spec/services/support_interface/equality_and_diversity_export_spec.rb
+++ b/spec/services/support_interface/equality_and_diversity_export_spec.rb
@@ -63,10 +63,25 @@ RSpec.describe SupportInterface::EqualityAndDiversityExport do
           honesty_and_professionalism_y_n: 'Yes',
           honesty_and_professionalism_concerns: %w[references],
         },
+        rejected_by_default: false,
         application_form: application_form_two,
       )
 
-      application_choice2 = create(:application_choice, :with_rejection, rejection_reason: 'Absence of English GCSE.', application_form: application_form_three)
+      application_choice2 = create(
+        :application_choice,
+        :with_rejection,
+        rejection_reason: 'Absence of English GCSE.',
+        rejected_by_default: false,
+        application_form: application_form_three,
+      )
+
+      application_choice3 = create(
+        :application_choice,
+        :with_rejection,
+        rejection_reason: 'Absence of Maths GCSE.',
+        rejected_by_default: true,
+        application_form: application_form_one,
+      )
 
       expect(described_class.new.data_for_export).to contain_exactly(
         {
@@ -77,6 +92,7 @@ RSpec.describe SupportInterface::EqualityAndDiversityExport do
           ethnic_group: application_form_three.equality_and_diversity['ethnic_group'],
           ethnic_background: application_form_three.equality_and_diversity['ethnic_background'],
           application_status: 'Ended without success',
+          provider_made_decision: true,
           application_choice_1_subject: application_choice2.course.name,
           application_choice_2_subject: nil,
           application_choice_3_subject: nil,
@@ -97,11 +113,12 @@ RSpec.describe SupportInterface::EqualityAndDiversityExport do
           sex: application_form_one.equality_and_diversity['sex'],
           ethnic_group: application_form_one.equality_and_diversity['ethnic_group'],
           ethnic_background: application_form_one.equality_and_diversity['ethnic_background'],
-          application_status: 'Have not started form',
-          application_choice_1_subject: nil,
+          application_status: 'Ended without success',
+          provider_made_decision: false,
+          application_choice_1_subject: application_choice3.course.name,
           application_choice_2_subject: nil,
           application_choice_3_subject: nil,
-          application_choice_1_unstructured_rejection_reasons: nil,
+          application_choice_1_unstructured_rejection_reasons: 'Absence of Maths GCSE.',
           application_choice_2_unstructured_rejection_reasons: nil,
           application_choice_3_unstructured_rejection_reasons: nil,
           application_choice_1_structured_rejection_reasons: nil,
@@ -118,6 +135,7 @@ RSpec.describe SupportInterface::EqualityAndDiversityExport do
           ethnic_group: application_form_two.equality_and_diversity['ethnic_group'],
           ethnic_background: application_form_two.equality_and_diversity['ethnic_background'],
           application_status: 'Ended without success',
+          provider_made_decision: true,
           application_choice_1_subject: application_choice1.course.name,
           application_choice_2_subject: nil,
           application_choice_3_subject: nil,


### PR DESCRIPTION
## Context

The ApplicationChoiceExport has functionality that the E&D export is missing.

Milan is doing some research on how many candidates have received either an offer or rejection (non rbd) from a provider.

This column returns true if they have and false if they haven't.

## Changes proposed in this pull request

- Add new provider_made_decision column to the E&D export

## Guidance for review 

This contains all the states for which a provider had to take an affirmative actions, but excludes an rejections via RBD

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
