### PR TITLE
Generate documentation for GIT API

### DIFF
--- a/app/controllers/api_docs/candidate_api_docs/open_api_controller.rb
+++ b/app/controllers/api_docs/candidate_api_docs/open_api_controller.rb
@@ -1,0 +1,9 @@
+module APIDocs
+  module CandidateAPIDocs
+    class OpenAPIController < APIDocsController
+      def spec
+        render plain: CandidateAPISpecification.as_yaml, content_type: 'text/yaml'
+      end
+    end
+  end
+end

--- a/app/controllers/api_docs/candidate_api_docs/reference_controller.rb
+++ b/app/controllers/api_docs/candidate_api_docs/reference_controller.rb
@@ -1,0 +1,9 @@
+module APIDocs
+  module CandidateAPIDocs
+    class ReferenceController < APIDocsController
+      def reference
+        @api_reference = APIReference.new(CandidateAPISpecification.as_hash)
+      end
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,6 +47,8 @@ module ApplicationHelper
       'data_api_docs'
     elsif section == 'register-api'
       'register_api_docs'
+    elsif section == 'candidate-api'
+      'candidate_api_docs'
     elsif section.present?
       "#{section}_interface"
     end

--- a/app/lib/candidate_api_specification.rb
+++ b/app/lib/candidate_api_specification.rb
@@ -1,0 +1,13 @@
+class CandidateAPISpecification
+  def self.as_yaml
+    spec.to_yaml
+  end
+
+  def self.as_hash
+    spec
+  end
+
+  def self.spec
+    YAML.load_file('config/candidate-api.yml')
+  end
+end

--- a/app/views/api_docs/candidate_api_docs/reference/reference.html.erb
+++ b/app/views/api_docs/candidate_api_docs/reference/reference.html.erb
@@ -1,0 +1,59 @@
+<h1 class="govuk-heading-xl"><%= t('page_titles.api_docs.candidate_api.reference') %></h1>
+
+<p class="govuk-body">This is API documentation for the Apply for teacher training candidate API. This API provides candidate information to other services.</p>
+
+<h2 class="app-contents-list__title">Contents</h2>
+
+<ol class="app-contents-list__list">
+  <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'Developing on the API', '#developing', class: 'app-contents-list__link' %></li>
+  <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+    <%= govuk_link_to 'Endpoints', '#endpoints', class: 'app-contents-list__link' %>
+
+    <ol class="app-contents-list__nested-list">
+    <% @api_reference.operations.each do |operation| %>
+      <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+        <%= govuk_link_to operation.name, "##{operation.anchor}", class: 'app-contents-list__link' %>
+      </li>
+    <% end %>
+    </ol>
+  </li>
+  <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+    <%= govuk_link_to 'Objects', '#objects', class: 'app-contents-list__link' %>
+
+    <ol class="app-contents-list__nested-list">
+      <% @api_reference.schemas.each do |schema| %>
+        <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+          <%= govuk_link_to schema.name, "##{schema.anchor}", class: 'app-contents-list__link' %>
+        </li>
+      <% end %>
+    </ol>
+  </li>
+</ol>
+
+<hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
+
+<h2 class="govuk-heading-l" id="developing">Developing on the API</h2>
+
+<p class="govuk-body">
+  The OpenAPI spec from which this documentation is generated is <%= govuk_link_to 'available in YAML format', api_docs_candidate_api_docs_spec_url %>.
+</p>
+
+<h3 id="authentication" class="govuk-heading-m">Authentication</h3>
+
+<p class="govuk-body">
+  All requests must be accompanied by an <code>Authorization</code> request header in the following format:
+</p>
+
+<p class="govuk-body">
+  <code>
+    Authorization: Bearer {token}
+  </code>
+</p>
+
+<p class="govuk-body">You can get a token by writing to <%= bat_contact_mail_to %></p>
+
+<h3 class="govuk-heading-m">Testing</h3>
+
+<p class="govuk-body">To get familiar with our system and perform testing, you can use <%= govuk_link_to 'our sandbox environment', 'https://sandbox.apply-for-teacher-training.service.gov.uk' %>.</p>
+
+<%= render(APIDocs::APIReferenceComponent.new(@api_reference)) %>

--- a/config/candidate-api.yml
+++ b/config/candidate-api.yml
@@ -2,7 +2,7 @@
 openapi: 3.0.0
 info:
   version: v1
-  title: Apply candidates API
+  title: Apply candidate API
   contact:
     name: DfE
     email: becomingateacher@digital.education.gov.uk
@@ -10,9 +10,9 @@ info:
     API for candidates from DfE’s Apply for teacher training service.
 servers:
 - description: Sandbox (test environment)
-  url: https://sandbox.apply-for-teacher-training.service.gov.uk/candidates-api
+  url: https://sandbox.apply-for-teacher-training.service.gov.uk/candidate-api
 - description: Production
-  url: https://www.apply-for-teacher-training.service.gov.uk/candidates-api
+  url: https://www.apply-for-teacher-training.service.gov.uk/candidate-api
 paths:
   "/candidates":
     get:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -180,6 +180,8 @@ en:
       withdraw: Are you sure you want to withdraw this course choice?
       withdrawal_feedback: Course choice withdrawn
     api_docs:
+      candidate_api:
+        reference: Apply for teacher training candidate API
       data_api:
         reference: Apply for teacher training data API
       vendor_api_docs:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1080,6 +1080,11 @@ Rails.application.routes.draw do
       get '/spec.yml' => 'open_api#spec', as: :spec
       get '/release-notes' => 'pages#release_notes', as: :release_notes
     end
+
+    namespace :candidate_api_docs, path: '/candidate-api' do
+      get '/' => 'reference#reference', as: :home
+      get '/spec.yml' => 'open_api#spec', as: :spec
+    end
   end
 
   get '/check', to: 'healthcheck#show'

--- a/spec/system/candidate_api/candidate_api_docs_spec.rb
+++ b/spec/system/candidate_api/candidate_api_docs_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate API docs' do
+  scenario 'User visits Candidate API docs' do
+    when_i_visit_the_candidate_api_docs
+    then_i_can_see_the_docs
+  end
+
+  def when_i_visit_the_candidate_api_docs
+    visit '/candidate-api'
+  end
+
+  def then_i_can_see_the_docs
+    expect(page).to have_content 'Apply for teacher training candidate API'
+  end
+end


### PR DESCRIPTION


## Context
As part of intial work to build the GIT Bat Data Sharing API we need to generate docs for review by GiT

## Changes proposed in this pull request

This PR adds a lightweight mvc for the API Docs and defines a
 route at which these can be viewed. The structure of mirros that of the
data api docs.

<img width="1440" alt="Screenshot 2021-06-09 at 16 35 55" src="https://user-images.githubusercontent.com/62567622/121385180-cbd8b900-c940-11eb-8ca9-4379a2ded503.png">

## Guidance to review

Check all is okay in the review app.

## Link to Trello card

https://trello.com/c/X8VGziRz/3491-generate-documentation-for-git-api

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
