### PR TITLE
Ensure we set '00' hesa_disabilities code

### DIFF
--- a/app/forms/candidate_interface/equality_and_diversity/disability_status_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/disability_status_form.rb
@@ -18,18 +18,15 @@ module CandidateInterface
     def save(application_form)
       return false unless valid?
 
-      if application_form.equality_and_diversity.nil?
-        application_form.update(equality_and_diversity: {
-          'disabilities' => [],
-          'hesa_disabilities' => [hesa_code].compact,
-        })
-      elsif reset_disabilities?(application_form)
+      application_form.equality_and_diversity = {} if application_form.equality_and_diversity.nil?
+
+      if application_form.equality_and_diversity['disabilities'].nil? || reset_disabilities?(application_form)
         application_form.equality_and_diversity['disabilities'] = []
-        reset_hesa_disabilities(application_form)
+        application_form.equality_and_diversity['hesa_disabilities'] = [hesa_code].compact
         application_form.save
       elsif disability_status == 'Prefer not to say'
         application_form.equality_and_diversity['disabilities'] = ['Prefer not to say']
-        reset_hesa_disabilities(application_form)
+        application_form.equality_and_diversity['hesa_disabilities'] = []
         application_form.save
       else
         true
@@ -47,13 +44,8 @@ module CandidateInterface
     end
 
     def reset_disabilities?(application_form)
-      application_form.equality_and_diversity['disabilities'].nil? ||
-        disability_status == 'no' ||
+      disability_status == 'no' ||
         application_form.equality_and_diversity['disabilities'].include?('Prefer not to say')
-    end
-
-    def reset_hesa_disabilities(application_form)
-      application_form.equality_and_diversity['hesa_disabilities'] = [] if application_form.equality_and_diversity['hesa_disabilities'].present?
     end
   end
 end

--- a/app/forms/candidate_interface/equality_and_diversity/disability_status_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/disability_status_form.rb
@@ -18,7 +18,7 @@ module CandidateInterface
     def save(application_form)
       return false unless valid?
 
-      application_form.equality_and_diversity = {} if application_form.equality_and_diversity.nil?
+      application_form.equality_and_diversity ||= {}
 
       if application_form.equality_and_diversity['disabilities'].nil? || reset_disabilities?(application_form)
         application_form.equality_and_diversity['disabilities'] = []

--- a/spec/forms/candidate_interface/equality_and_diversity/disability_status_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/disability_status_form_spec.rb
@@ -72,13 +72,27 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
         )
       end
 
+      it 'amends the equality and diversity information on the application form' do
+        application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male' })
+        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'no')
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq(
+          'sex' => 'male',
+          'disabilities' => [],
+          'hesa_disabilities' => %w[00],
+        )
+      end
+
       it 'updates the existing record of equality and diversity information' do
         application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male' })
         form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'yes')
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
-          'sex' => 'male', 'disabilities' => [],
+          'sex' => 'male',
+          'disabilities' => [],
+          'hesa_disabilities' => [],
         )
       end
 
@@ -88,7 +102,8 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
-          'sex' => 'male', 'disabilities' => %w[Blind],
+          'sex' => 'male',
+          'disabilities' => %w[Blind],
         )
       end
 
@@ -98,7 +113,9 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
-          'sex' => 'male', 'disabilities' => [],
+          'sex' => 'male',
+          'disabilities' => [],
+          'hesa_disabilities' => %w[00],
         )
       end
 
@@ -120,7 +137,9 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
-          'sex' => 'male', 'disabilities' => [],
+          'sex' => 'male',
+          'disabilities' => [],
+          'hesa_disabilities' => [],
         )
       end
     end


### PR DESCRIPTION
## Context

If the candidate has already answered some of the equality and diversity questions but answers 'no' to disability status we still need to populate the appropriate `00` HESA code.
The code was previously expecting the equality_and_diversity field to be nil.

Similarly if a candidate changes their answer to 'no' for an application
with existing disabilities data we should set the appropriate '00' code.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Ensures we set the `00` no disabilities HESA code when there is existing equality and diversity data (ie when the candidate has already answered other parts of the questionnaire).
 
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/cQurakCV/3772-tribal-select-no-disability-returns-blank-should-be-00
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
