### PR TITLE
Create custom methods with field name that contain error value

### DIFF
--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -210,7 +210,10 @@ module ProviderInterface
 
       condition_models.each do |model|
         model.errors.each do |error|
-          errors.add("further_conditions[#{model.id}][#{error.attribute}]", error.message)
+          field_name = "further_conditions[#{model.id}][#{error.attribute}]"
+          create_method(field_name) { error.message }
+
+          errors.add(field_name, error.message)
         end
       end
     end
@@ -226,6 +229,10 @@ module ProviderInterface
         attrs.merge!(study_mode: nil, course_option_id: nil)
       end
       attrs
+    end
+
+    def create_method(name, &block)
+      self.class.send(:define_method, name, &block)
     end
   end
 end

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe ProviderInterface::OfferWizard do
         expect(wizard.errors[:"further_conditions[1][text]"]).to contain_exactly('Condition 2 must be 255 characters or fewer')
         expect(wizard.errors[:"further_conditions[2][text]"]).to be_blank
       end
+
+      it 'creates custom methods with the field name that contain the error value' do
+        expect(wizard.valid?(:conditions)).to eq(false)
+
+        expect(wizard.public_send('further_conditions[0][text]')).to eq('Condition 1 must be 255 characters or fewer')
+      end
     end
 
     context 'if the offer has too many conditions' do


### PR DESCRIPTION

## Context

Currently attempting to track further condition validation errors results in an error as ValidateError is attempting to retrieve the error message using the field name, which does not exist on the offer model.

This PR resolves this issue by dynamically generating methods that returns the appropriate value as part of checking for the validity of further conditions.

## Link to Trello card

https://trello.com/c/c1sITh3T/3786-tracking-validation-errors-on-offer-conditions

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
