### PR TITLE
Substitute calls to `UpdateOfferConditions` service with bulk updates…

### DIFF
--- a/app/services/conditions_not_met.rb
+++ b/app/services/conditions_not_met.rb
@@ -2,19 +2,21 @@ class ConditionsNotMet
   include ActiveModel::Validations
   include ImpersonationAuditHelper
 
+  attr_reader :auth, :application_choice
+
   def initialize(actor:, application_choice:)
     @auth = ProviderAuthorisation.new(actor: actor)
     @application_choice = application_choice
   end
 
   def save
-    @auth.assert_can_make_decisions!(application_choice: @application_choice, course_option_id: @application_choice.current_course_option.id)
+    auth.assert_can_make_decisions!(application_choice: application_choice, course_option_id: application_choice.current_course_option.id)
 
-    audit(@auth.actor) do
-      ApplicationStateChange.new(@application_choice).conditions_not_met!
-      @application_choice.update!(conditions_not_met_at: Time.zone.now)
-      UpdateOfferConditions.new(application_choice: @application_choice).call
-      CandidateMailer.conditions_not_met(@application_choice).deliver_later
+    audit(auth.actor) do
+      ApplicationStateChange.new(application_choice).conditions_not_met!
+      application_choice.update!(conditions_not_met_at: Time.zone.now)
+      application_choice.offer.conditions.each(&:unmet!)
+      CandidateMailer.conditions_not_met(application_choice).deliver_later
     end
   rescue Workflow::NoTransitionAllowed
     errors.add(

--- a/app/services/confirm_offer_conditions.rb
+++ b/app/services/confirm_offer_conditions.rb
@@ -2,20 +2,22 @@ class ConfirmOfferConditions
   include ActiveModel::Validations
   include ImpersonationAuditHelper
 
+  attr_reader :auth, :application_choice
+
   def initialize(actor:, application_choice:)
     @auth = ProviderAuthorisation.new(actor: actor)
     @application_choice = application_choice
   end
 
   def save
-    @auth.assert_can_make_decisions!(application_choice: @application_choice, course_option_id: @application_choice.current_course_option.id)
+    auth.assert_can_make_decisions!(application_choice: application_choice, course_option_id: application_choice.current_course_option.id)
 
-    audit(@auth.actor) do
-      ApplicationStateChange.new(@application_choice).confirm_conditions_met!
-      @application_choice.update!(recruited_at: Time.zone.now)
-      UpdateOfferConditions.new(application_choice: @application_choice).call
-      CandidateMailer.conditions_met(@application_choice).deliver_later
-      StateChangeNotifier.new(:recruited, @application_choice).application_outcome_notification
+    audit(auth.actor) do
+      ApplicationStateChange.new(application_choice).confirm_conditions_met!
+      application_choice.update!(recruited_at: Time.zone.now)
+      application_choice.offer.conditions.each(&:met!)
+      CandidateMailer.conditions_met(application_choice).deliver_later
+      StateChangeNotifier.new(:recruited, application_choice).application_outcome_notification
     end
   rescue Workflow::NoTransitionAllowed
     errors.add(


### PR DESCRIPTION
… to change conditions status

## Context

Calling the service is no longer necessary as all we need is to update the condition status and will not be performing any other operations such as editing or deleting conditions, which the service will be handling moving forward.

## Link to Trello card

https://trello.com/c/efGPIEnA/3822-manage-condition-statuses-in-bulk-for-confirmconditionsnotmet-and-confirmofferconditions

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
