### PR TITLE
remove dependency on updateofferservice from reinstate services

### DIFF
--- a/app/services/reinstate_conditions_met.rb
+++ b/app/services/reinstate_conditions_met.rb
@@ -25,7 +25,7 @@ class ReinstateConditionsMet
         ActiveRecord::Base.transaction do
           ApplicationStateChange.new(application_choice).reinstate_conditions_met!
           application_choice.update(attrs)
-          UpdateOfferConditions.new(application_choice: application_choice).call
+          application_choice.offer.conditions.each(&:met!)
           CandidateMailer.reinstated_offer(application_choice).deliver_later
         end
       end

--- a/app/services/reinstate_pending_conditions.rb
+++ b/app/services/reinstate_pending_conditions.rb
@@ -21,7 +21,7 @@ class ReinstatePendingConditions
       if valid?
         ActiveRecord::Base.transaction do
           ApplicationStateChange.new(application_choice).reinstate_pending_conditions!
-          UpdateOfferConditions.new(application_choice: application_choice).call
+          application_choice.offer.conditions.each(&:pending!)
           @application_choice.update(
             current_course_option_id: course_option.id,
             recruited_at: nil,


### PR DESCRIPTION
## Context

Modify the ReinstateConditionsMet and ReinstatePendingConditions services to remove the dependency on UpdateOfferConditions.

## Link to Trello card

https://trello.com/c/Pu8s7seA/3808-manage-condition-statuses-in-bulk-for-reinstating-deferred-offers

