### PR TITLE
Add reference auto-response to all test environments

### DIFF
--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -77,6 +77,10 @@ module HostingEnvironment
     TEST_ENVIRONMENTS.include?(HostingEnvironment.environment_name)
   end
 
+  def self.use_refbots?
+    test_environment? || sandbox_mode?
+  end
+
   def self.dfe_signup_only?
     review? || qa? || staging?
   end

--- a/app/services/request_reference.rb
+++ b/app/services/request_reference.rb
@@ -13,7 +13,7 @@ class RequestReference
 private
 
   def auto_approve_reference_in_sandbox(reference)
-    auto_approve_reference(reference) if HostingEnvironment.sandbox_mode? && email_address_is_a_bot?(reference)
+    auto_approve_reference(reference) if HostingEnvironment.use_refbots? && email_address_is_a_bot?(reference)
   end
 
   def auto_approve_reference(reference)

--- a/app/views/candidate_interface/references/email_address/_shared_form.html.erb
+++ b/app/views/candidate_interface/references/email_address/_shared_form.html.erb
@@ -1,8 +1,8 @@
 <%= f.govuk_error_summary %>
 
-<% if HostingEnvironment.sandbox_mode? %>
+<% if HostingEnvironment.use_refbots? %>
   <%= render SandboxFeatureComponent.new(
-    description: 'Enter <code>refbot1@example.com</code> and <code>refbot2@example.com</code> as your referee email addresses to have the references automatically completed.',
+    description: 'Enter <code>refbot1@example.com</code> and <code>refbot2@example.com</code> as your referee email addresses to have the references automatically completed. Increment the number for each additional reference.',
   ) %>
 <% end %>
 


### PR DESCRIPTION
## Context

Adding a reference request with an email that matches one of the
REFEREE_BOT_EMAIL_ADDRESSES creates an automatic referee response. This
was used in sandbox for efficient testing of the reference workflow.

This would be useful in other test environments.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Expand this functionality to all test environments (`%w[development test qa review]`)

This is a quick change to get the functionality on QA and the new Research environment. I'll follow this with support for any number of reference bot email addresses.

For manual testing  — the refbot addresses should now work on the review app.

![Screenshot_20210610_215637](https://user-images.githubusercontent.com/519250/121596017-d1182f80-ca36-11eb-9b41-832eff046295.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
