### PR TITLE
Add support for multiple refbot email addresses

### DIFF
--- a/app/services/request_reference.rb
+++ b/app/services/request_reference.rb
@@ -1,6 +1,4 @@
 class RequestReference
-  REFEREE_BOT_EMAIL_ADDRESSES = ['refbot1@example.com', 'refbot2@example.com'].freeze
-
   def call(reference)
     policy = ReferenceActionsPolicy.new(reference)
     raise "ApplicationReference##{reference.id} can't be requested" unless policy.can_request?
@@ -31,6 +29,6 @@ private
   end
 
   def email_address_is_a_bot?(reference)
-    REFEREE_BOT_EMAIL_ADDRESSES.include?(reference.email_address)
+    /^refbot(\d+)@example.com/ =~ reference.email_address
   end
 end

--- a/spec/system/candidate_interface/references/candidate_adding_referees_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adding_referees_in_sandbox_spec.rb
@@ -40,8 +40,8 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
     click_button t('continue')
 
     candidate_fills_in_referee(
-      name: 'Refbot Two',
-      email_address: 'refbot2@example.com',
+      name: 'Refbot Three',
+      email_address: 'refbot3@example.com',
       relationship: 'Second boss',
     )
     choose 'Yes, send a reference request now'


### PR DESCRIPTION
Allow any number of refbot emails to support testing of the new
`reference_selection` feature, where the expected workflow involves
obtaining any number of references before selecting the ones to add to
the application.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Can test in review app - `refbot2000@example.com` should automatically provide reference feedback.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
