### PR TITLE
Replace rubocop-govuk with rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,9 @@
 inherit_from: .rubocop_todo.yml
 
-inherit_gem:
-  rubocop-govuk:
-    - config/default.yml
-    - config/rails.yml
-
 require:
 - rubocop-rspec
+- rubocop-rails
+- rubocop-rake
 - ./lib/rubocop/cop/govuk/govuk_button_to.rb
 - ./lib/rubocop/cop/govuk/govuk_link_to.rb
 - ./lib/rubocop/cop/govuk/govuk_submit.rb
@@ -175,6 +172,9 @@ Style/NumericLiterals:
 Style/NegatedIf:
   Enabled: false
 
+Layout/LineLength:
+  Enabled: false
+
 # Disable these cops because they do not allow reasonable code like splitting
 # `attr_reader :bla, :foo` over 2 lines.
 Layout/MultilineArrayLineBreaks:
@@ -202,3 +202,106 @@ Rails/Output:
 
 Style/SafeNavigation:
   Enabled: true
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Rails/SkipsModelValidations:
+  Enabled: false
+
+Layout/AccessModifierIndentation:
+  EnforcedStyle: outdent
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Naming/AccessorMethodName:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Enabled: false
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Style/Documentation:
+  Enabled: false
+
+Style/FormatStringToken:
+  EnforcedStyle: template
+  Exclude:
+    - app/helpers/geocode_helper.rb
+
+Style/Alias:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+  EnforcedStyle: mixed
+  AllowInnerSlashes: true
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Rails/OutputSafety:
+  Enabled: false
+
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+
+Layout/MultilineOperationIndentation:
+  Enabled: false
+
+Rails/InverseOf:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Naming/PredicateName:
+  Enabled: false
+
+Style/FormatString:
+  Exclude:
+    - app/helpers/geocode_helper.rb
+
+Metrics/BlockNesting:
+  Exclude:
+    - app/services/provider_authorisation.rb
+    - app/helpers/geocode_helper.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,16 @@
-inherit_from: .rubocop_todo.yml
+inherit_from:
+  - .rubocop_todo.yml
+  - ./config/rubocop/config/rspec.yml
+  - ./config/rubocop/config/rails.yml
+  - ./config/rubocop/config/rake.yml
+  - ./config/rubocop/config/style.yml
+  - ./config/rubocop/config/layout.yml
+  - ./config/rubocop/config/metrics.yml
 
 require:
-- rubocop-rspec
-- rubocop-rails
-- rubocop-rake
-- ./lib/rubocop/cop/govuk/govuk_button_to.rb
-- ./lib/rubocop/cop/govuk/govuk_link_to.rb
-- ./lib/rubocop/cop/govuk/govuk_submit.rb
+  - ./lib/rubocop/cop/govuk/govuk_button_to.rb
+  - ./lib/rubocop/cop/govuk/govuk_link_to.rb
+  - ./lib/rubocop/cop/govuk/govuk_submit.rb
 
 AllCops:
   Exclude:
@@ -20,76 +24,13 @@ AllCops:
     - 'features/support/env.rb'
     - 'vendor/**/*'
 
-Rails/BulkChangeTable:
-  Enabled: false
-
-Style/AndOr:
-  EnforcedStyle: conditionals
-
-Style/StringLiterals:
-  Enabled: true
-  EnforcedStyle: single_quotes
-
 Bundler/OrderedGems:
   Enabled: false
-
-Metrics/BlockLength:
-  Enabled: false
-
-RSpec/NestedGroups:
-  Enabled: true
-  Max: 4
-  Exclude:
-    - 'spec/forms/provider_interface/offer_wizard_spec.rb'
-
-RSpec/ExampleLength:
-  Enabled: false
-
-RSpec/MultipleExpectations:
-  Enabled: false
-
-RSpec/ContextWording:
-  Enabled: false
-
-# we have a property called "subject" in some factories
-RSpec/EmptyLineAfterSubject:
-  Exclude:
-    - 'spec/factories/*.rb'
-
-RSpec/LetSetup:
-  Enabled: false
-
-Naming/MethodParameterName:
-  AllowedNames:
-    - e
-    - to
 
 Capybara/FeatureMethods:
   EnabledMethods:
     - feature
     - scenario
-
-# It's better to be explicit about the class that's being tested
-RSpec/DescribedClass:
-  Enabled: false
-
-# This cop wants us to use `expect().to change(Candidate, :count)` instead
-# of `expect().to change { Candidate.count }`, which does not seem better.
-RSpec/ExpectChange:
-  Enabled: false
-
-RSpec/LeadingSubject:
-  Enabled: false
-
-# In acceptance tests it's often handy to user instance variables to keep track of state
-RSpec/InstanceVariable:
-  Enabled: false
-
-RSpec/PredicateMatcher:
-  Enabled: false
-
-RSpec/DescribeClass:
-  Enabled: false
 
 Lint/AmbiguousBlockAssociation:
   Exclude:
@@ -97,32 +38,20 @@ Lint/AmbiguousBlockAssociation:
     - 'spec/system/support_interface/daily_report_spec.rb'
     - 'spec/requests/vendor_api/api_authentication_spec.rb'
 
-# We do not want to subclass from ApplicationController. This enables separation
-# between the namespaces, and allows subclassing from ActionController::API in
-# the Vendor API.
-Rails/ApplicationController:
-  Enabled: false
-
-# Rails does not actually allow "dynamic find_by", so this cop yields false positives
-# like `VendorApiToken.find_by_unhashed_token` (which we implement ourselves)
-Rails/DynamicFindBy:
-  Enabled: false
-
-# Not all rake tasks need :environment
-Rails/RakeEnvironment:
-  Enabled: false
-
-# This cop demands a default value for not-null columns, which is not possible
-# when dealing with references
-Rails/NotNullColumn:
-  Enabled: false
+Naming/MethodParameterName:
+  AllowedNames:
+    - e
+    - to
 
 Naming/MemoizedInstanceVariableName:
   Enabled: false
 
-# sometimes reduce is fine
-Style/EachWithObject:
+Naming/AccessorMethodName:
   Enabled: false
+
+Naming/PredicateName:
+  Enabled: false
+
 
 Govuk:
   Include:
@@ -148,160 +77,3 @@ Govuk/GovukLinkTo:
     # link_to for kaminari pagination links
     - 'app/views/kaminari/_next_page.html.erb'
     - 'app/views/kaminari/_prev_page.html.erb'
-
-# Pending cops
-# These will be enabled by default at Rubocop 1.0
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true
-
-Rake/Desc:
-  Exclude:
-    - 'lib/tasks/reset_qa.rake'
-
-# This cop has too many false positives (it also requires underscores for things that are not numbers)
-Style/NumericLiterals:
-  Enabled: false
-
-# Sometimes it's easier to think about a negated if, for example `render_error if !model.valid?` vs `render_error unless model.valid?`
-Style/NegatedIf:
-  Enabled: false
-
-Layout/LineLength:
-  Enabled: false
-
-# Disable these cops because they do not allow reasonable code like splitting
-# `attr_reader :bla, :foo` over 2 lines.
-Layout/MultilineArrayLineBreaks:
-  Enabled: false
-
-Layout/MultilineHashKeyLineBreaks:
-  Enabled: false
-
-Layout/MultilineMethodArgumentLineBreaks:
-  Enabled: false
-
-Layout/FirstMethodArgumentLineBreak:
-  Enabled: false
-
-# 🤷‍♂️
-Style/AsciiComments:
-  Enabled: false
-
-Style/ConditionalAssignment:
-  Enabled: false
-
-Rails/Output:
-  Exclude:
-    - config/initializers/console.rb
-
-Style/SafeNavigation:
-  Enabled: true
-
-Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: comma
-
-Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: comma
-
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Layout/FirstHashElementIndentation:
-  EnforcedStyle: consistent
-
-Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: comma
-
-Layout/MultilineMethodCallIndentation:
-  Enabled: false
-
-Metrics/MethodLength:
-  Enabled: false
-
-Metrics/AbcSize:
-  Enabled: false
-
-Rails/SkipsModelValidations:
-  Enabled: false
-
-Layout/AccessModifierIndentation:
-  EnforcedStyle: outdent
-
-Metrics/ParameterLists:
-  Enabled: false
-
-Naming/AccessorMethodName:
-  Enabled: false
-
-Metrics/ModuleLength:
-  Enabled: false
-
-Style/BlockDelimiters:
-  Enabled: false
-
-Layout/FirstArrayElementIndentation:
-  EnforcedStyle: consistent
-
-Style/Documentation:
-  Enabled: false
-
-Style/FormatStringToken:
-  EnforcedStyle: template
-  Exclude:
-    - app/helpers/geocode_helper.rb
-
-Style/Alias:
-  Enabled: false
-
-Metrics/CyclomaticComplexity:
-  Enabled: false
-
-Style/RegexpLiteral:
-  Enabled: false
-  EnforcedStyle: mixed
-  AllowInnerSlashes: true
-
-Style/IfUnlessModifier:
-  Enabled: false
-
-Metrics/ClassLength:
-  Enabled: false
-
-Style/GuardClause:
-  Enabled: false
-
-Metrics/PerceivedComplexity:
-  Enabled: false
-
-Rails/OutputSafety:
-  Enabled: false
-
-Rails/HasManyOrHasOneDependent:
-  Enabled: false
-
-Layout/MultilineOperationIndentation:
-  Enabled: false
-
-Rails/InverseOf:
-  Enabled: false
-
-Style/ClassAndModuleChildren:
-  Enabled: false
-
-Naming/PredicateName:
-  Enabled: false
-
-Style/FormatString:
-  Exclude:
-    - app/helpers/geocode_helper.rb
-
-Metrics/BlockNesting:
-  Exclude:
-    - app/services/provider_authorisation.rb
-    - app/helpers/geocode_helper.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,18 @@ Lint/AmbiguousBlockAssociation:
     - 'spec/system/support_interface/daily_report_spec.rb'
     - 'spec/requests/vendor_api/api_authentication_spec.rb'
 
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
 Naming/MethodParameterName:
   AllowedNames:
     - e

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ inherit_from:
   - ./config/rubocop/config/rake.yml
   - ./config/rubocop/config/style.yml
   - ./config/rubocop/config/layout.yml
+  - ./config/rubocop/config/lint.yml
   - ./config/rubocop/config/metrics.yml
 
 require:
@@ -31,24 +32,6 @@ Capybara/FeatureMethods:
   EnabledMethods:
     - feature
     - scenario
-
-Lint/AmbiguousBlockAssociation:
-  Exclude:
-    - 'spec/support/slack_notifications.rb'
-    - 'spec/system/support_interface/daily_report_spec.rb'
-    - 'spec/requests/vendor_api/api_authentication_spec.rb'
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true
 
 Naming/MethodParameterName:
   AllowedNames:

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,10 @@ gem 'mail-notify'
 gem 'govuk_markdown'
 
 # Linting
-gem 'rubocop-govuk'
+gem 'rubocop'
+gem 'rubocop-rspec'
+gem 'rubocop-rails'
+gem 'rubocop-rake'
 gem 'erb_lint', require: false
 
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -501,12 +501,6 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.8.0)
       parser (>= 2.7.1.5)
-    rubocop-govuk (3.17.2)
-      rubocop (= 0.87.1)
-      rubocop-ast (= 0.8.0)
-      rubocop-rails (= 2.8.1)
-      rubocop-rake (= 0.5.1)
-      rubocop-rspec (= 1.42.0)
     rubocop-rails (2.8.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
@@ -728,7 +722,10 @@ DEPENDENCIES
   rouge
   rspec-rails
   rspec_junit_formatter
-  rubocop-govuk
+  rubocop
+  rubocop-rails
+  rubocop-rake
+  rubocop-rspec
   ruby-graphviz
   ruby-jmeter
   selenium-webdriver

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -161,13 +161,11 @@ private
         if [training_provider_can, ratifying_provider_can].none?
           add_error(permission, :requires_training_or_ratifying_provider_permission)
         # Check org-level and user-level permissions match for ratifying provider
-        elsif !training_provider_can
-          add_error(permission, :requires_provider_user_permission) unless
-            user_level_can?(permission: permission, provider: ratifying_provider)
+        elsif !training_provider_can && !user_level_can?(permission: permission, provider: ratifying_provider)
+          add_error(permission, :requires_provider_user_permission)
         # Same for training provider
-        elsif !ratifying_provider_can
-          add_error(permission, :requires_provider_user_permission) unless
-            user_level_can?(permission: permission, provider: training_provider)
+        elsif !ratifying_provider_can && !user_level_can?(permission: permission, provider: training_provider)
+          add_error(permission, :requires_provider_user_permission)
         end
         # No additional checks if both providers have org-level access
       elsif @actor.providers.include?(ratifying_provider)

--- a/config/rubocop/config/layout.yml
+++ b/config/rubocop/config/layout.yml
@@ -1,0 +1,28 @@
+Layout/LineLength:
+  Enabled: false
+
+# Disable these cops because they do not allow reasonable code like splitting
+# `attr_reader :bla, :foo` over 2 lines.
+Layout/MultilineArrayLineBreaks:
+  Enabled: false
+
+Layout/MultilineHashKeyLineBreaks:
+  Enabled: false
+
+Layout/MultilineMethodArgumentLineBreaks:
+  Enabled: false
+
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: false
+
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+
+Layout/AccessModifierIndentation:
+  EnforcedStyle: outdent
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent

--- a/config/rubocop/config/layout.yml
+++ b/config/rubocop/config/layout.yml
@@ -26,3 +26,9 @@ Layout/AccessModifierIndentation:
 
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: false
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: false

--- a/config/rubocop/config/lint.yml
+++ b/config/rubocop/config/lint.yml
@@ -1,0 +1,17 @@
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - 'spec/support/slack_notifications.rb'
+    - 'spec/system/support_interface/daily_report_spec.rb'
+    - 'spec/requests/vendor_api/api_authentication_spec.rb'
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true

--- a/config/rubocop/config/metrics.yml
+++ b/config/rubocop/config/metrics.yml
@@ -1,0 +1,28 @@
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Exclude:
+    - app/services/provider_authorisation.rb
+    - app/helpers/geocode_helper.rb

--- a/config/rubocop/config/metrics.yml
+++ b/config/rubocop/config/metrics.yml
@@ -21,8 +21,3 @@ Metrics/ClassLength:
 
 Metrics/PerceivedComplexity:
   Enabled: false
-
-Metrics/BlockNesting:
-  Exclude:
-    - app/services/provider_authorisation.rb
-    - app/helpers/geocode_helper.rb

--- a/config/rubocop/config/rails.yml
+++ b/config/rubocop/config/rails.yml
@@ -44,3 +44,48 @@ Rails/InverseOf:
 
 Rails/HttpStatus:
   Enabled: false
+
+Rails/ActiveRecordCallbacksOrder:
+  Enabled: true
+
+Rails/AfterCommitOverride:
+  Enabled: true
+
+Rails/FindById:
+  Enabled: false
+
+Rails/Inquiry:
+  Enabled: true
+
+Rails/MailerName:
+  Enabled: true
+
+Rails/MatchRoute:
+  Enabled: false
+
+Rails/NegateInclude:
+  Enabled: false
+
+Rails/Pluck:
+  Enabled: false
+
+Rails/PluckInWhere:
+  Enabled: true
+
+Rails/RenderInline:
+  Enabled: true
+
+Rails/RenderPlainText:
+  Enabled: true
+
+Rails/ShortI18n:
+  Enabled: true
+
+Rails/SquishedSQLHeredocs:
+  Enabled: false
+
+Rails/WhereExists:
+  Enabled: true
+
+Rails/WhereNot:
+  Enabled: false

--- a/config/rubocop/config/rails.yml
+++ b/config/rubocop/config/rails.yml
@@ -1,0 +1,46 @@
+require: rubocop-rails
+
+Rails/BulkChangeTable:
+  Enabled: false
+
+# We do not want to subclass from ApplicationController. This enables separation
+# between the namespaces, and allows subclassing from ActionController::API in
+# the Vendor API.
+Rails/ApplicationController:
+  Enabled: false
+
+# Rails does not actually allow "dynamic find_by", so this cop yields false positives
+# like `VendorApiToken.find_by_unhashed_token` (which we implement ourselves)
+Rails/DynamicFindBy:
+  Enabled: false
+
+# Not all rake tasks need :environment
+Rails/RakeEnvironment:
+  Enabled: false
+
+# This cop demands a default value for not-null columns, which is not possible
+# when dealing with references
+Rails/NotNullColumn:
+  Enabled: false
+
+Rails/Output:
+  Exclude:
+    - config/initializers/console.rb
+
+Rails/SkipsModelValidations:
+  Enabled: false
+
+Rails/OutputSafety:
+  Enabled: false
+
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+
+Layout/MultilineOperationIndentation:
+  Enabled: false
+
+Rails/InverseOf:
+  Enabled: false
+
+Rails/HttpStatus:
+  Enabled: false

--- a/config/rubocop/config/rake.yml
+++ b/config/rubocop/config/rake.yml
@@ -1,0 +1,5 @@
+require: rubocop-rake
+
+Rake/Desc:
+  Exclude:
+    - 'lib/tasks/reset_qa.rake'

--- a/config/rubocop/config/rspec.yml
+++ b/config/rubocop/config/rspec.yml
@@ -1,0 +1,46 @@
+require: rubocop-rspec
+
+RSpec/NestedGroups:
+  Enabled: true
+  Max: 4
+  Exclude:
+    - 'spec/forms/provider_interface/offer_wizard_spec.rb'
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/ContextWording:
+  Enabled: false
+
+# we have a property called "subject" in some factories
+RSpec/EmptyLineAfterSubject:
+  Exclude:
+    - 'spec/factories/*.rb'
+
+RSpec/LetSetup:
+  Enabled: false
+
+# It's better to be explicit about the class that's being tested
+RSpec/DescribedClass:
+  Enabled: false
+
+# This cop wants us to use `expect().to change(Candidate, :count)` instead
+# of `expect().to change { Candidate.count }`, which does not seem better.
+RSpec/ExpectChange:
+  Enabled: false
+
+RSpec/LeadingSubject:
+  Enabled: false
+
+# In acceptance tests it's often handy to user instance variables to keep track of state
+RSpec/InstanceVariable:
+  Enabled: false
+
+RSpec/PredicateMatcher:
+  Enabled: false
+
+RSpec/DescribeClass:
+  Enabled: false

--- a/config/rubocop/config/style.yml
+++ b/config/rubocop/config/style.yml
@@ -1,0 +1,83 @@
+Style/AndOr:
+  EnforcedStyle: conditionals
+
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: single_quotes
+
+# sometimes reduce is fine
+Style/EachWithObject:
+  Enabled: false
+
+# Pending cops
+# These will be enabled by default at Rubocop 1.0
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+# This cop has too many false positives (it also requires underscores for things that are not numbers)
+Style/NumericLiterals:
+  Enabled: false
+
+# Sometimes it's easier to think about a negated if, for example `render_error if !model.valid?` vs `render_error unless model.valid?`
+Style/NegatedIf:
+  Enabled: false
+
+# 🤷‍♂️
+Style/AsciiComments:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Style/SafeNavigation:
+  Enabled: true
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+Style/BlockDelimiters:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/FormatStringToken:
+  EnforcedStyle: template
+  Exclude:
+    - app/helpers/geocode_helper.rb
+
+Style/Alias:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+  EnforcedStyle: mixed
+  AllowInnerSlashes: true
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/FormatString:
+  Exclude:
+    - app/helpers/geocode_helper.rb

--- a/config/rubocop/config/style.yml
+++ b/config/rubocop/config/style.yml
@@ -81,3 +81,27 @@ Style/ClassAndModuleChildren:
 Style/FormatString:
   Exclude:
     - app/helpers/geocode_helper.rb
+
+Style/AccessorGrouping:
+  Enabled: false
+
+Style/BisectedAttrAccessor:
+  Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/RedundantAssignment:
+  Enabled: false
+
+Style/RedundantFetchBlock:
+  Enabled: true
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
+  Enabled: false
+
+Style/SlicingWithRange:
+  Enabled: true


### PR DESCRIPTION
## Context
This PR removes rubocop-govuk and disables a number of cops to match its configuration and avoid having to make a lot of changes across the codebase, so we are able to tackle each cop that we want to re-enable in separate PRs. (Except Metrics/BlockNesting which only resulted in 2 errors that I addressed as part of this PR).

## Changes proposed in this pull request

- Replace rubocop-govuk with rubocop, rubocop-rspec, rubocop-rake and rubocop-rails
- Disable cops to match rubocop-govuk configuration
- Group cop configuration per area they tackle, e.g. rspec.yml, metrics.yml etc

## Link to Trello card
https://trello.com/c/XANNLBur/432-should-we-continue-using-rubocop-govuk
https://trello.com/c/I6JiD7cR/1564-rubocop-cleanup

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
