### PR TITLE
Reload application offer before rendering in the API response

### DIFF
--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -67,7 +67,7 @@ module VendorAPI
     end
 
     def render_application
-      render json: { data: SingleApplicationPresenter.new(application_choice.reload).as_json }
+      render json: { data: SingleApplicationPresenter.new(application_choice).as_json }
     end
 
     def respond_to_decision(decision)

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -353,7 +353,7 @@ module VendorAPI
       return nil if application_choice.offer.nil?
 
       {
-        conditions: application_choice.offer.conditions.map(&:text),
+        conditions: application_choice.offer.reload.conditions.map(&:text),
         offer_made_at: application_choice.offered_at,
         offer_accepted_at: application_choice.accepted_at,
         offer_declined_at: application_choice.declined_at,

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -386,6 +386,17 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       }
 
       post_api_request "/api/v1/applications/#{choice.id}/offer", params: request_body
+
+      expect(parsed_response['data']['attributes']['offer']).to eq(
+        'conditions' => [
+          'Change your sheets',
+          'Wash your clothes',
+        ],
+        'course' => course_option_to_course_payload(choice.course_option),
+        'offer_made_at' => Time.zone.now.iso8601(3),
+        'offer_accepted_at' => nil,
+        'offer_declined_at' => nil,
+      )
       expect(choice.offer.conditions.map(&:text)).to eq(['Change your sheets', 'Wash your clothes'])
     end
 


### PR DESCRIPTION
## Context
Make offer in the API does the right thing in the DB, but we render the old offer

## Changes proposed in this pull request
reload the offer - this shouldn't be necessary when we set up the proper association


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
