### PR TITLE
Link conditions to DB entries in the frontend to enable better auditing

### DIFF
--- a/app/controllers/provider_interface/offer/conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/conditions_controller.rb
@@ -36,7 +36,7 @@ module ProviderInterface
       end
 
       def remove_condition_param
-        params[:remove_condition]&.to_i
+        params[:remove_condition]
       end
 
       def add_another_condition?
@@ -44,11 +44,9 @@ module ProviderInterface
       end
 
       def attributes_for_wizard
-        attributes = conditions_params
-
-        further_conditions = conditions_params.fetch('further_conditions', {}).values.map { |hash| hash['text'] }
-
-        attributes.merge!(further_conditions: further_conditions, current_step: 'conditions')
+        attrs = conditions_params
+        attrs['further_condition_attrs'] = attrs.delete('further_conditions') || {}
+        attrs.merge!(current_step: 'conditions')
       end
 
       def conditions_params
@@ -72,7 +70,7 @@ module ProviderInterface
         if remove_condition_param.present?
           'further-conditions-heading'
         elsif add_another_condition?
-          "provider-interface-offer-wizard-further-conditions-#{@wizard.further_conditions.length - 1}-text-field"
+          "provider-interface-offer-wizard-further-conditions-#{@wizard.further_condition_attrs.length - 1}-text-field"
         end
       end
     end

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -16,7 +16,7 @@ module ProviderInterface
         MakeOffer.new(actor: current_provider_user,
                       application_choice: @application_choice,
                       course_option: @wizard.course_option,
-                      update_conditions_service: update_conditions_service(@wizard.conditions)).save!
+                      update_conditions_service: update_conditions_service).save!
         @wizard.clear_state!
 
         flash[:success] = t('.success')
@@ -55,7 +55,7 @@ module ProviderInterface
         ChangeOffer.new(actor: current_provider_user,
                         application_choice: @application_choice,
                         course_option: @wizard.course_option,
-                        update_conditions_service: update_conditions_service(@wizard.conditions)).save!
+                        update_conditions_service: update_conditions_service).save!
         @wizard.clear_state!
 
         flash[:success] = t('.success')
@@ -110,10 +110,11 @@ module ProviderInterface
       )
     end
 
-    def update_conditions_service(conditions)
-      UpdateOfferConditions.new(
+    def update_conditions_service
+      SaveOfferConditionsFromParams.new(
         application_choice: @application_choice,
-        conditions: conditions,
+        standard_conditions: @wizard.standard_conditions,
+        further_condition_attrs: @wizard.further_condition_attrs,
       )
     end
 

--- a/app/forms/provider_interface/offer_condition_field.rb
+++ b/app/forms/provider_interface/offer_condition_field.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   class OfferConditionField
     include ActiveModel::Model
 
-    attr_accessor :id, :text
+    attr_accessor :id, :text, :condition_id
 
     validates :text, length: { maximum: 255, too_long: ->(c, _) { "Condition #{c.id + 1} must be %{count} characters or fewer" } }
   end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -7,7 +7,7 @@ module ProviderInterface
     MAX_FURTHER_CONDITIONS = OfferValidations::MAX_CONDITIONS_COUNT - MakeOffer::STANDARD_CONDITIONS.length
 
     attr_accessor :provider_id, :course_id, :course_option_id, :study_mode,
-                  :standard_conditions, :further_conditions, :current_step, :decision,
+                  :standard_conditions, :further_condition_attrs, :current_step, :decision,
                   :action, :path_history, :wizard_path_history,
                   :provider_user_id, :application_choice_id
 
@@ -38,14 +38,14 @@ module ProviderInterface
         study_mode: course_option.study_mode,
         decision: :default,
         standard_conditions: standard_conditions_from(application_choice.offer),
-        further_conditions: further_conditions_from(application_choice.offer),
+        further_condition_attrs: further_condition_attrs_from(application_choice.offer),
       }.merge(options)
 
       new(state_store, attrs)
     end
 
     def conditions
-      @conditions = (standard_conditions + further_conditions).reject(&:blank?)
+      @conditions = (standard_conditions + condition_models.map(&:text)).reject(&:blank?)
     end
 
     def conditions_to_render
@@ -85,29 +85,32 @@ module ProviderInterface
     delegate :previous_step, to: :wizard_path_history
 
     def condition_models
-      @_condition_models ||= further_conditions.map.with_index do |further_condition, index|
-        OfferConditionField.new(id: index, text: further_condition)
+      @_condition_models ||= further_condition_attrs.map do |index, params|
+        OfferConditionField.new(id: index.to_i, text: params['text'], condition_id: params['condition_id'])
       end
     end
 
     def has_max_number_of_further_conditions?
-      further_conditions.length >= MAX_FURTHER_CONDITIONS
+      further_condition_attrs.length >= MAX_FURTHER_CONDITIONS
     end
 
     def add_empty_condition
       return if has_max_number_of_further_conditions?
 
-      further_conditions << ''
+      further_condition_attrs.merge!(further_condition_attrs.length.to_s => { 'text' => '' })
       save_state!
     end
 
     def remove_condition(condition_id)
-      further_conditions.delete_at(condition_id)
+      further_condition_attrs.delete(condition_id)
+      further_condition_attrs.transform_keys!.with_index { |_, index| index.to_s }
       save_state!
     end
 
     def remove_empty_conditions!
-      further_conditions.reject!(&:blank?)
+      further_condition_attrs.reject! { |_, condition| condition['text'].blank? }
+      further_condition_attrs.transform_keys!.with_index { |_, index| index.to_s }
+      save_state!
     end
 
   private
@@ -121,14 +124,19 @@ module ProviderInterface
 
     private_class_method :standard_conditions_from
 
-    def self.further_conditions_from(offer)
-      return [] if offer.blank?
+    def self.further_condition_attrs_from(offer)
+      return {} if offer.blank?
 
-      conditions = offer.conditions_text
-      conditions - MakeOffer::STANDARD_CONDITIONS
+      further_conditions = offer.conditions.reject do |condition|
+        MakeOffer::STANDARD_CONDITIONS.include?(condition.text)
+      end
+
+      further_conditions.each_with_index.to_h do |condition, index|
+        [index.to_s, { 'text' => condition.text, 'condition_id' => condition.id }]
+      end
     end
 
-    private_class_method :further_conditions_from
+    private_class_method :further_condition_attrs_from
 
     def course_option_details
       OfferedCourseOptionDetailsCheck.new(provider_id: provider_id,

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -200,7 +200,8 @@ module ProviderInterface
 
     def last_saved_state
       saved_state = @state_store.read
-      saved_state ? JSON.parse(saved_state) : {}
+      state_hash = saved_state ? JSON.parse(saved_state) : {}
+      state_hash.except('further_conditions')
     end
 
     def state

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -45,7 +45,7 @@ module ProviderInterface
     end
 
     def conditions
-      @conditions = (standard_conditions + condition_models.map(&:text)).reject(&:blank?)
+      @conditions = (standard_conditions + further_condition_models.map(&:text)).reject(&:blank?)
     end
 
     def conditions_to_render
@@ -84,8 +84,8 @@ module ProviderInterface
 
     delegate :previous_step, to: :wizard_path_history
 
-    def condition_models
-      @_condition_models ||= further_condition_attrs.map do |index, params|
+    def further_condition_models
+      @_further_condition_models ||= further_condition_attrs.map do |index, params|
         OfferConditionField.new(id: index.to_i, text: params['text'], condition_id: params['condition_id'])
       end
     end
@@ -206,7 +206,7 @@ module ProviderInterface
 
     def state
       as_json(
-        except: %w[state_store errors validation_context query_service wizard_path_history _condition_models],
+        except: %w[state_store errors validation_context query_service wizard_path_history _further_condition_models],
       ).to_json
     end
 
@@ -219,9 +219,9 @@ module ProviderInterface
     end
 
     def further_conditions_valid
-      condition_models.map(&:valid?).all?
+      further_condition_models.map(&:valid?).all?
 
-      condition_models.each do |model|
+      further_condition_models.each do |model|
         model.errors.each do |error|
           field_name = "further_conditions[#{model.id}][#{error.attribute}]"
           create_method(field_name) { error.message }
@@ -232,7 +232,7 @@ module ProviderInterface
     end
 
     def max_conditions_length
-      return unless (condition_models.count + standard_conditions.compact_blank.length) > OfferValidations::MAX_CONDITIONS_COUNT
+      return unless (further_condition_models.count + standard_conditions.compact_blank.length) > OfferValidations::MAX_CONDITIONS_COUNT
 
       errors.add(:base, :exceeded_max_conditions, count: OfferValidations::MAX_CONDITIONS_COUNT)
     end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -23,7 +23,7 @@ module ProviderInterface
       @state_store = state_store
       attrs = sanitize_parameters(attrs)
 
-      super(last_saved_state.deep_merge(attrs))
+      super(last_saved_state.merge(attrs))
       update_path_history(attrs)
     end
 
@@ -153,7 +153,7 @@ module ProviderInterface
       attrs = { study_mode: available_study_modes.first } if step.eql?(:study_modes)
       attrs = { course_option_id: available_course_options.first.id } if step.eql?(:locations)
 
-      assign_attributes(last_saved_state.deep_merge(attrs))
+      assign_attributes(last_saved_state.merge(attrs))
       save_state!
 
       next_step(step)

--- a/app/frontend/packs/further_conditions/assignIndexBasedValues.js
+++ b/app/frontend/packs/further_conditions/assignIndexBasedValues.js
@@ -4,16 +4,26 @@ const assignIndexBasedValues = (element, index) => {
   element.className = ITEM_CSS_CLASS
   element.removeAttribute('id')
 
+  setHiddenIdInputProperties(element, index)
   setTextAreaProperties(element, index)
   setLabelProperties(element, index)
   setRemoveButtonProperties(element, index)
 }
 
+const setHiddenIdInputProperties = (element, index) => {
+  const idInput = element.querySelector('input')
+  setInputProperties(idInput, index)
+}
+
 const setTextAreaProperties = (element, index) => {
   const textArea = element.querySelector('textarea')
-  replaceExistingAttribute(textArea, 'id', index)
-  replaceExistingAttribute(textArea, 'name', index)
-  textArea.removeAttribute('disabled')
+  setInputProperties(textArea, index)
+}
+
+const setInputProperties = (inputElement, index) => {
+  replaceExistingAttribute(inputElement, 'id', index)
+  replaceExistingAttribute(inputElement, 'name', index)
+  inputElement.removeAttribute('disabled')
 }
 
 const setLabelProperties = (element, index) => {

--- a/app/frontend/packs/further_conditions/index.spec.js
+++ b/app/frontend/packs/further_conditions/index.spec.js
@@ -5,6 +5,7 @@ const setupBodyWithConditions = (count) => {
     <fieldset>
       <legend id="further-conditions-heading" tabindex="-1">Further conditions</legend>
       <div id="add-another-item-placeholder">
+        <input disabled="disabled" type="hidden" name="provider_interface_offer_wizard[further_conditions][placeholder][condition_id]" id="provider_interface_offer_wizard_further_conditions_placeholder_condition_id">
         <div>
           <label for="provider-interface-offer-wizard-further-conditions-placeholder-text-field">Condition placeholder</label>
           <textarea id="provider-interface-offer-wizard-further-conditions-placeholder-text-field" disabled="disabled" name="provider_interface_offer_wizard[further_conditions][placeholder][text]"></textarea>
@@ -32,6 +33,7 @@ const conditionFieldList = (count) => {
 const conditionFieldWithId = (id) => {
   return `
     <div class="app-add-condition__item" >
+      <input disabled="disabled" type="hidden" name="provider_interface_offer_wizard[further_conditions][${id}][condition_id]" id="provider_interface_offer_wizard_further_conditions_${id}_condition_id">
       <div>
         <label for="provider-interface-offer-wizard-further-conditions-${id}-text-field">Condition ${id + 1}</label>
         <textarea id="provider-interface-offer-wizard-further-conditions-${id}-text-field" name="provider_interface_offer_wizard[further_conditions][${id}][text]"></textarea>

--- a/app/services/save_offer_conditions_from_params.rb
+++ b/app/services/save_offer_conditions_from_params.rb
@@ -1,0 +1,64 @@
+class SaveOfferConditionsFromParams
+  attr_reader :application_choice, :standard_conditions, :further_condition_attrs
+
+  def initialize(application_choice:, standard_conditions:, further_condition_attrs:)
+    @application_choice = application_choice
+    @standard_conditions = standard_conditions & MakeOffer::STANDARD_CONDITIONS
+    @further_condition_attrs = further_condition_attrs
+  end
+
+  def save
+    @offer = Offer.find_or_create_by(application_choice: application_choice)
+
+    serialize_standard_conditions
+    serialize_further_conditions
+  end
+
+  def conditions
+    further_condition_attrs.values.map { |hash| hash['text'] } + standard_conditions
+  end
+
+private
+
+  def serialize_standard_conditions
+    existing_standard_conditions = @offer.conditions.where(text: MakeOffer::STANDARD_CONDITIONS)
+
+    standard_conditions.each do |text|
+      existing_standard_conditions.find_or_create_by(text: text)
+    end
+    conditions_to_destroy = existing_standard_conditions.where.not(text: standard_conditions)
+    conditions_to_destroy.destroy_all
+  end
+
+  def serialize_further_conditions
+    new_conditions = further_condition_attrs.each_value.map do |params|
+      create_or_update_condition(params)
+    end
+
+    remove_deleted_conditions(new_conditions)
+  end
+
+  def remove_deleted_conditions(new_conditions)
+    existing_condition_ids = further_condition_attrs.values.inject(new_conditions.map(&:id)) do |conditions, hash|
+      conditions << hash['condition_id']
+    end
+
+    offer_further_conditions.where.not(id: existing_condition_ids).destroy_all
+  end
+
+  def create_or_update_condition(params)
+    existing_condition = offer_further_conditions.find_by(id: params['condition_id'])
+
+    if existing_condition.blank?
+      existing_condition = offer_further_conditions.create(text: params['text'])
+    else
+      existing_condition.update(text: params['text'])
+    end
+
+    existing_condition
+  end
+
+  def offer_further_conditions
+    @offer_further_conditions ||= @offer.conditions.where.not(text: MakeOffer::STANDARD_CONDITIONS)
+  end
+end

--- a/app/views/provider_interface/offer/conditions/_form.html.erb
+++ b/app/views/provider_interface/offer/conditions/_form.html.erb
@@ -26,7 +26,7 @@
 
         <%= render 'provider_interface/offer/conditions/further_condition', form: f, model: OpenStruct.new(id: 'placeholder'), label_text: 'placeholder', disabled: true %>
 
-        <% form_object.condition_models.each do |model| %>
+        <% form_object.further_condition_models.each do |model| %>
           <%= render 'provider_interface/offer/conditions/further_condition', form: f, model: model, label_text: model.id + 1, disabled: false %>
         <% end %>
 

--- a/app/views/provider_interface/offer/conditions/_further_condition.html.erb
+++ b/app/views/provider_interface/offer/conditions/_further_condition.html.erb
@@ -1,5 +1,6 @@
 <%= form.fields_for 'further_conditions[]', model do |condition_field| %>
   <div class="<%= disabled ? 'govuk-!-display-none' : 'app-add-condition__item' %>" <%= 'id=add-another-item-placeholder' if disabled %>>
+    <%= condition_field.hidden_field :condition_id, disabled: disabled %>
     <%= condition_field.govuk_text_area :text, label: { text: t('.condition', id: label_text), size: 's' }, rows: 3, disabled: disabled %>
     <%= form.button name: 'remove_condition', value: model.id, class: 'govuk-button govuk-button--secondary app-add-condition__remove-button' do %>
       <%= t('.remove') %> <span class="govuk-visually-hidden"> <%= t('.condition', id: label_text).downcase %></span>

--- a/spec/components/provider_interface/conditions_form_component_spec.rb
+++ b/spec/components/provider_interface/conditions_form_component_spec.rb
@@ -5,21 +5,21 @@ RSpec.describe ProviderInterface::ConditionsFormComponent do
   let(:form_object_class) do
     Class.new do
       include ActiveModel::Model
-      attr_accessor :standard_conditions, :condition_models, :has_max_number_of_further_conditions
+      attr_accessor :standard_conditions, :further_condition_models, :has_max_number_of_further_conditions
 
       alias_method :has_max_number_of_further_conditions?, :has_max_number_of_further_conditions
     end
   end
 
   let(:further_conditions) { [] }
-  let(:condition_models) do
+  let(:further_condition_models) do
     further_conditions.map.with_index do |condition, index|
       OpenStruct.new(id: index, text: condition)
     end
   end
   let(:max_conditions) { false }
 
-  let(:form_object) { FormObjectClass.new(condition_models: condition_models, has_max_number_of_further_conditions: max_conditions) }
+  let(:form_object) { FormObjectClass.new(further_condition_models: further_condition_models, has_max_number_of_further_conditions: max_conditions) }
 
   let(:component) do
     described_class.new(

--- a/spec/requests/provider_interface/offers_controller_spec.rb
+++ b/spec/requests/provider_interface/offers_controller_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe ProviderInterface::OffersController, type: :request do
 
     context 'POST to (conditions) create' do
       let(:trait) { :awaiting_provider_decision }
-      let(:wizard_attrs) { { previous_step: :locations, standard_conditions: [], persisted?: true, condition_models: [], has_max_number_of_further_conditions?: false } }
+      let(:wizard_attrs) { { previous_step: :locations, standard_conditions: [], persisted?: true, further_condition_models: [], has_max_number_of_further_conditions?: false } }
 
       subject do
         post provider_interface_application_choice_offer_conditions_path(application_choice),
@@ -141,7 +141,7 @@ RSpec.describe ProviderInterface::OffersController, type: :request do
     end
 
     context 'PATCH to (conditions) update' do
-      let(:wizard_attrs) { { previous_step: :locations, standard_conditions: [], persisted?: true, condition_models: [], has_max_number_of_further_conditions?: false } }
+      let(:wizard_attrs) { { previous_step: :locations, standard_conditions: [], persisted?: true, further_condition_models: [], has_max_number_of_further_conditions?: false } }
 
       subject do
         patch provider_interface_application_choice_offer_conditions_path(application_choice),

--- a/spec/services/save_offer_conditions_from_params_spec.rb
+++ b/spec/services/save_offer_conditions_from_params_spec.rb
@@ -1,0 +1,173 @@
+require 'rails_helper'
+
+RSpec.describe SaveOfferConditionsFromParams do
+  subject(:service) do
+    described_class.new(application_choice: application_choice,
+                        standard_conditions: standard_conditions,
+                        further_condition_attrs: further_condition_attrs)
+  end
+
+  let(:standard_conditions) { [] }
+  let(:further_condition_attrs) { {} }
+  let(:application_choice) { build(:application_choice) }
+
+  describe '#conditions' do
+    let(:standard_conditions) { [MakeOffer::STANDARD_CONDITIONS.sample] }
+    let(:further_condition_attrs) do
+      {
+        0 => {
+          'text' => 'You must have a driving license',
+        },
+        1 => {
+          'text' => 'Blue hair',
+        },
+      }
+    end
+
+    it 'returns a text array of all serialized conditions' do
+      expect(service.conditions).to contain_exactly(standard_conditions.first, 'You must have a driving license', 'Blue hair')
+    end
+  end
+
+  describe '#save' do
+    context 'when there is no offer for the application_choice' do
+      it 'create an offer when one does not exist' do
+        expect { service.save }.to change(Offer, :count).by(1)
+      end
+    end
+
+    context 'when there is an existing offer for the application_choice' do
+      let!(:application_choice) { create(:application_choice, :with_offer) }
+
+      it 'create an offer when one does not exist' do
+        expect { service.save }.to change(Offer, :count).by(0)
+      end
+    end
+
+    context 'when we have standard and further conditions' do
+      context 'when we make changes to further conditions' do
+        let!(:application_choice) { create(:application_choice, :with_offer, offer: offer) }
+        let(:offer) do
+          build(:offer, conditions: [build(:offer_condition, text: MakeOffer::STANDARD_CONDITIONS.first),
+                                     build(:offer_condition, text: MakeOffer::STANDARD_CONDITIONS.last),
+                                     build(:offer_condition, text: 'Red hair')])
+        end
+
+        let(:standard_conditions) { [MakeOffer::STANDARD_CONDITIONS.sample] }
+        let(:further_condition_attrs) do
+          {
+            0 => {
+              'text' => 'You must have a driving license',
+            },
+            1 => {
+              'condition_id' => offer.conditions.last,
+              'text' => 'Blue hair',
+            },
+          }
+        end
+
+        it 'returns the expected results' do
+          service.save
+
+          expect(offer.reload.conditions.map(&:text)).to contain_exactly(standard_conditions.first,
+                                                                         'You must have a driving license',
+                                                                         'Blue hair')
+        end
+      end
+    end
+
+    context 'standard_conditions' do
+      let!(:application_choice) { create(:application_choice, :with_offer, offer: offer) }
+      let(:standard_conditions) { [MakeOffer::STANDARD_CONDITIONS.sample] }
+
+      context 'when they dont already exist on the offer' do
+        let(:offer) { build(:unconditional_offer) }
+
+        it 'the service creates them' do
+          expect { service.save }.to change(offer.conditions, :count).by(1)
+        end
+      end
+
+      context 'when they do exist on the offer' do
+        let(:offer) { build(:offer, conditions: [build(:offer_condition, text: standard_conditions.first)]) }
+
+        it 'the service does nothing' do
+          expect { service.save }.to change(offer.conditions, :count).by(0)
+        end
+      end
+
+      context 'when they are removed' do
+        let(:offer) { build(:offer, conditions: [build(:offer_condition, text: MakeOffer::STANDARD_CONDITIONS.first)]) }
+        let(:standard_conditions) { [] }
+
+        it 'the service deletes the existing entries' do
+          expect { service.save }.to change(offer.conditions, :count).by(-1)
+        end
+      end
+    end
+
+    context 'further_conditions' do
+      let!(:application_choice) { create(:application_choice, :with_offer, offer: offer) }
+      let(:further_condition_attrs) do
+        {
+          0 => {
+            'text' => 'You must have a driving license',
+          },
+        }
+      end
+
+      context 'when they dont already exist on the offer' do
+        let(:offer) { build(:unconditional_offer) }
+
+        it 'the service creates them' do
+          expect { service.save }.to change(offer.conditions, :count).by(1)
+          expect(offer.conditions.first.text).to eq('You must have a driving license')
+        end
+      end
+
+      context 'when they do exist on the offer' do
+        let(:offer) { build(:offer, conditions: [build(:offer_condition, text: 'You must have a driving license')]) }
+        let(:further_condition_attrs) do
+          {
+            0 => {
+              'condition_id' => offer.conditions.first.id,
+              'text' => 'You must have a driving license',
+            },
+          }
+        end
+
+        it 'the service does nothing' do
+          expect { service.save }.to change(offer.conditions, :count).by(0)
+        end
+      end
+
+      context 'when they are removed' do
+        let(:offer) { build(:offer, conditions: [build(:offer_condition, text: 'You must have a driving license')]) }
+        let(:further_condition_attrs) { {} }
+
+        it 'the service deletes the existing entries' do
+          expect { service.save }.to change(offer.conditions, :count).by(-1)
+        end
+      end
+
+      context 'when they are updated' do
+        let!(:application_choice) { create(:application_choice, :with_offer, offer: offer) }
+        let(:offer) { build(:offer, conditions: [build(:offer_condition, text: 'You must have a driving license')]) }
+        let(:further_condition_attrs) do
+          {
+            0 => {
+              'condition_id' => offer.conditions.first.id,
+              'text' => 'You must NOT have a driving license',
+            },
+          }
+        end
+
+        it 'the service updates the existing entries' do
+          expect { service.save }
+            .to change(offer.conditions, :count).by(0)
+            .and change { offer.conditions.first.reload.text }.to('You must NOT have a driving license')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
The UpdateOfferConditions service is a bit heavy handed, and we wish to turn on OfferCondition auditing.

## Changes proposed in this pull request
This update allows us to detect when conditions are being updated so we don't have to delete and recreate all conditions

- Send back the condition_id in the form params
- Update condition text based on provided ID
- Update JS to correctly produce the required hidden id field

Paired on with @despo

## Link to Trello card
https://trello.com/c/zOkJlJFl/3805-%F0%9F%8F%88-update-offer-condition-forms-to-include-condition-id

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
