### PR TITLE
Support interface conditions form passes condition ids in params

### DIFF
--- a/app/views/support_interface/application_choice_conditions/edit.html.erb
+++ b/app/views/support_interface/application_choice_conditions/edit.html.erb
@@ -33,6 +33,7 @@
 
         <% @form.further_condition_models.each do |model| %>
           <%= f.fields_for 'further_conditions[]', model do |fc| %>
+            <%= fc.hidden_field :condition_id %>
             <%= fc.govuk_text_area :text, label: { text: "Condition #{model.id.to_i + 1}", size: 's' }, rows: 3 %>
           <% end %>
         <% end %>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -68,12 +68,11 @@ en:
               blank: Please specify a provider
         support_interface/conditions_form:
           attributes:
+            base:
+              exceeded_max_conditions: 'You can only have %{count} conditions or fewer'
             audit_comment_ticket:
               blank: Enter a Zendesk ticket URL
               invalid: Enter a valid Zendesk ticket URL
-            further_conditions:
-              too_long: 'Condition %{index} must be %{limit} characters or fewer'
-              too_many: 'You can only have %{limit} conditions or fewer'
         support_interface/conditions_form/offer_condition_field:
           attributes:
             text:

--- a/spec/system/support_interface/change_offer_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_conditions_spec.rb
@@ -96,9 +96,10 @@ RSpec.feature 'Add course to submitted application' do
 
   def then_i_see_the_new_condition_as_well_as_the_original_ones
     expect(page).to have_current_path(support_interface_application_form_path(@application_choice.application_form_id))
-    expect(page).to have_content(
-      "Conditions\nFitness to train to teach check Be cool Learn to play piano",
-    )
+    expect(page).to have_content('Conditions')
+    expect(page).to have_content('Fitness to train to teach check')
+    expect(page).to have_content('Be cool')
+    expect(page).to have_content('Learn to play piano')
   end
 
   def and_i_remove_all_conditions_and_click_update_conditions


### PR DESCRIPTION
## Context
Using the UpdateOfferConditions service results in deleting and recreating conditions when that is not what the user actioned

## Changes proposed in this pull request
This update allows us to detect when conditions are being updated so we don't have to delete and recreate all conditions

- Send back the condition_id in the form params
- Update condition text based on provided ID

Spotted and fixed a slight bug that the change link is rendered when it shouldn't be.

## Guidance to review
Give it a test in the review app.

I've tested locally with auditing switched on and it made sensible audits for conditions.

## Link to Trello card
https://trello.com/c/OTT7se7y/3807-support-interface-update-offer-condition-form-to-include-condition-id

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
