### PR TITLE
Enable non controversial new cops and resolve errors

### DIFF
--- a/app/controllers/candidate_interface/course_choices/ucas_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/ucas_controller.rb
@@ -2,12 +2,12 @@ module CandidateInterface
   module CourseChoices
     class UCASController < BaseController
       def no_courses
-        @provider = Provider.find_by!(id: params[:provider_id])
+        @provider = Provider.find(params[:provider_id])
       end
 
       def with_course
-        @provider = Provider.find_by!(id: params[:provider_id])
-        @course = Course.find_by!(id: params[:course_id])
+        @provider = Provider.find(params[:provider_id])
+        @course = Course.find(params[:course_id])
       end
     end
   end

--- a/app/forms/candidate_interface/english_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/english_gcse_grade_form.rb
@@ -97,7 +97,7 @@ module CandidateInterface
               english_literature
               english_studies_single_award english_studies_double_award
             ].exclude? k
-          } .first
+          }.first
 
           english_gcses << 'other_english_gcse' if other_english_gcse_name
           params[:english_gcses] = english_gcses

--- a/app/services/support_interface/structured_reasons_for_rejection_export.rb
+++ b/app/services/support_interface/structured_reasons_for_rejection_export.rb
@@ -1,8 +1,8 @@
 module SupportInterface
   class StructuredReasonsForRejectionExport
     def data_for_export
-      data_for_export = application_choices.order(:id).find_each(batch_size: 100).map do |application_choice|
-        output = {
+      application_choices.order(:id).find_each(batch_size: 100).map do |application_choice|
+        {
           candidate_id: application_choice.application_form_id,
           application_choice_id: application_choice.id,
           recruitment_cycle_year: application_choice.course.recruitment_cycle_year,
@@ -11,11 +11,7 @@ module SupportInterface
           course_code: application_choice.course.code,
           rejected_at: application_choice.rejected_at.strftime('%d/%m/%Y'),
         }.merge!(FlatReasonsForRejectionPresenter.build_from_structured_rejection_reasons(ReasonsForRejection.new(application_choice.structured_rejection_reasons)))
-
-        output
       end
-
-      data_for_export
     end
 
   private

--- a/app/views/support_interface/validation_errors/user/index.html.erb
+++ b/app/views/support_interface/validation_errors/user/index.html.erb
@@ -10,4 +10,4 @@
 
 <p class="govuk-body"><%= govuk_link_to 'Validation error summary', [:support_interface, :validation_errors, @user_type, :summary] %></p>
 
-<%= render SupportInterface:: ValidationErrorsListComponent.new(distinct_errors_with_counts: @list_of_distinct_errors_with_counts, grouped_counts: @grouped_counts, scoped_error_object: :form_object, source_name: @user_type, grouped_counts_label: 'Form') %>
+<%= render SupportInterface::ValidationErrorsListComponent.new(distinct_errors_with_counts: @list_of_distinct_errors_with_counts, grouped_counts: @grouped_counts, scoped_error_object: :form_object, source_name: @user_type, grouped_counts_label: 'Form') %>

--- a/config/rubocop/config/layout.yml
+++ b/config/rubocop/config/layout.yml
@@ -31,4 +31,4 @@ Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: false
 
 Layout/SpaceAroundMethodCallOperator:
-  Enabled: false
+  Enabled: true

--- a/config/rubocop/config/rails.yml
+++ b/config/rubocop/config/rails.yml
@@ -52,7 +52,7 @@ Rails/AfterCommitOverride:
   Enabled: true
 
 Rails/FindById:
-  Enabled: false
+  Enabled: true
 
 Rails/Inquiry:
   Enabled: true

--- a/config/rubocop/config/style.yml
+++ b/config/rubocop/config/style.yml
@@ -92,7 +92,7 @@ Style/ExponentialNotation:
   Enabled: true
 
 Style/RedundantAssignment:
-  Enabled: false
+  Enabled: true
 
 Style/RedundantFetchBlock:
   Enabled: true

--- a/spec/forms/candidate_interface/english_foreign_language/ielts_form_spec.rb
+++ b/spec/forms/candidate_interface/english_foreign_language/ielts_form_spec.rb
@@ -18,21 +18,21 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::IeltsForm, type: :mod
       form = valid_form.tap { |f| f.trf_number = nil }
 
       expect(form).not_to be_valid
-      expect(form.errors.full_messages) .to eq ['Trf number Enter your TRF number']
+      expect(form.errors.full_messages).to eq ['Trf number Enter your TRF number']
     end
 
     it 'is invalid if given an invalid year' do
       form = valid_form.tap { |f| f.award_year = 111 }
 
       expect(form).not_to be_valid
-      expect(form.errors.full_messages) .to eq ['Award year Enter a real award year']
+      expect(form.errors.full_messages).to eq ['Award year Enter a real award year']
     end
 
     it 'is is future year if given a future year' do
       form = valid_form.tap { |f| f.award_year = Time.zone.today.year.to_i + 1 }
 
       expect(form).not_to be_valid
-      expect(form.errors.full_messages) .to eq ['Award year Assessment year must be this year or a previous year']
+      expect(form.errors.full_messages).to eq ['Award year Assessment year must be this year or a previous year']
     end
 
     context 'user inputs single digit band_score' do

--- a/spec/forms/candidate_interface/english_foreign_language/other_efl_qualification_form_spec.rb
+++ b/spec/forms/candidate_interface/english_foreign_language/other_efl_qualification_form_spec.rb
@@ -18,21 +18,21 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::OtherEflQualification
       form = valid_form.tap { |f| f.name = nil }
 
       expect(form).not_to be_valid
-      expect(form.errors.full_messages) .to eq ['Name Enter assessment name']
+      expect(form.errors.full_messages).to eq ['Name Enter assessment name']
     end
 
     it 'is invalid if given an invalid year' do
       form = valid_form.tap { |f| f.award_year = 111 }
 
       expect(form).not_to be_valid
-      expect(form.errors.full_messages) .to eq ['Award year Enter a real award year']
+      expect(form.errors.full_messages).to eq ['Award year Enter a real award year']
     end
 
     it 'is is future year if given a future year' do
       form = valid_form.tap { |f| f.award_year = Time.zone.today.year.to_i + 1 }
 
       expect(form).not_to be_valid
-      expect(form.errors.full_messages) .to eq ['Award year Assessment year must be this year or a previous year']
+      expect(form.errors.full_messages).to eq ['Award year Assessment year must be this year or a previous year']
     end
   end
 

--- a/spec/forms/candidate_interface/english_foreign_language/toefl_form_spec.rb
+++ b/spec/forms/candidate_interface/english_foreign_language/toefl_form_spec.rb
@@ -18,21 +18,21 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::ToeflForm, type: :mod
       form = valid_form.tap { |f| f.registration_number = nil }
 
       expect(form).not_to be_valid
-      expect(form.errors.full_messages) .to eq ['Registration number Enter your registration number']
+      expect(form.errors.full_messages).to eq ['Registration number Enter your registration number']
     end
 
     it 'is invalid if given an invalid year' do
       form = valid_form.tap { |f| f.award_year = 111 }
 
       expect(form).not_to be_valid
-      expect(form.errors.full_messages) .to eq ['Award year Enter a real award year']
+      expect(form.errors.full_messages).to eq ['Award year Enter a real award year']
     end
 
     it 'is is future year if given a future year' do
       form = valid_form.tap { |f| f.award_year = Time.zone.today.year.to_i + 1 }
 
       expect(form).not_to be_valid
-      expect(form.errors.full_messages) .to eq ['Award year Assessment year must be this year or a previous year']
+      expect(form.errors.full_messages).to eq ['Award year Assessment year must be this year or a previous year']
     end
   end
 

--- a/spec/models/apply_again_feature_metrics_spec.rb
+++ b/spec/models/apply_again_feature_metrics_spec.rb
@@ -6,12 +6,10 @@ RSpec.describe ApplyAgainFeatureMetrics, with_audited: true do
   def create_apply_again_application(
     original_application = create(:completed_application_form)
   )
-    apply_again_application_form = DuplicateApplication.new(
+    DuplicateApplication.new(
       original_application,
       target_phase: 'apply_2',
     ).duplicate
-
-    apply_again_application_form
   end
 
   def make_offer_for(application_form)

--- a/spec/models/carry_over_feature_metrics_spec.rb
+++ b/spec/models/carry_over_feature_metrics_spec.rb
@@ -14,13 +14,11 @@ RSpec.describe CarryOverFeatureMetrics, with_audited: true do
   def create_carry_over_application(
     original_application = create_unsuccessful_application_from_last_cycle
   )
-    carry_over_application_form = DuplicateApplication.new(
+    DuplicateApplication.new(
       original_application,
       target_phase: 'apply_1',
       recruitment_cycle_year: RecruitmentCycle.current_year,
     ).duplicate
-
-    carry_over_application_form
   end
 
   describe '#carry_over_count' do


### PR DESCRIPTION
## Context

Enable the following cops and resolve errors:
- Style/RedundantAssignmentCop
- Rails/FindByID and
- Layout/SpaceAroundMethodCAllOperator 

## Link to Trello card
https://trello.com/c/I6JiD7cR/1564-rubocop-cleanup
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
