### PR TITLE
Add redirect to GCSE controller if GCSE is missing

### DIFF
--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class Gcse::TypeController < Gcse::BaseController
     include Gcse::ResolveGcseEditPathConcern
+    before_action :redirect_to_application_form_if_current_qualification_missing, only: %i[edit update]
 
     def new
       @type_form = if current_qualification
@@ -65,6 +66,12 @@ module CandidateInterface
 
     def non_uk_qualification?
       current_qualification.qualification_type == 'non_uk'
+    end
+
+    def redirect_to_application_form_if_current_qualification_missing
+      if current_qualification.blank?
+        redirect_to candidate_interface_application_form_path
+      end
     end
   end
 end

--- a/spec/requests/candidate_interface/gcse/type_controller_spec.rb
+++ b/spec/requests/candidate_interface/gcse/type_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'CandidateInterface::GCSE::TypeController', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:candidate) { create :candidate }
+
+  before { sign_in candidate }
+
+  describe 'edit' do
+    it 'redirects if qualification not created yet' do
+      %w[maths english science].each do |subject|
+        get "/candidate/application/gcse/#{subject}/edit"
+
+        expect(response).to redirect_to candidate_interface_application_form_path
+      end
+    end
+  end
+
+  describe 'update' do
+    it 'redirects if qualification not created yet' do
+      %w[maths english science].each do |subject|
+        patch "/candidate/application/gcse/#{subject}/edit"
+
+        expect(response).to redirect_to candidate_interface_application_form_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
For the edit/update actions in the GCSE TypeController, redirect to the
application form if the GCSE doesn't exist.

This fixes a bug seen in production
https://sentry.io/organizations/dfe-bat/issues/2438946737/

It's unclear how a candidate would navigate to the edit action normally
without first creating the GCSE, however manual URL manipulation is
plausible.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
