### PR TITLE
OfferCondition model improvements

### DIFF
--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -127,9 +127,7 @@ module ProviderInterface
     def self.further_condition_attrs_from(offer)
       return {} if offer.blank?
 
-      further_conditions = offer.conditions.reject do |condition|
-        OfferCondition::STANDARD_CONDITIONS.include?(condition.text)
-      end
+      further_conditions = offer.conditions.reject(&:standard_condition?)
 
       further_conditions.each_with_index.to_h do |condition, index|
         [index.to_s, { 'text' => condition.text, 'condition_id' => condition.id }]

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -4,7 +4,7 @@ module ProviderInterface
 
     STEPS = { make_offer: %i[select_option conditions check],
               change_offer: %i[select_option providers courses study_modes locations conditions check] }.freeze
-    MAX_FURTHER_CONDITIONS = OfferValidations::MAX_CONDITIONS_COUNT - MakeOffer::STANDARD_CONDITIONS.length
+    MAX_FURTHER_CONDITIONS = OfferValidations::MAX_CONDITIONS_COUNT - OfferCondition::STANDARD_CONDITIONS.length
 
     attr_accessor :provider_id, :course_id, :course_option_id, :study_mode,
                   :standard_conditions, :further_condition_attrs, :current_step, :decision,
@@ -116,10 +116,10 @@ module ProviderInterface
   private
 
     def self.standard_conditions_from(offer)
-      return MakeOffer::STANDARD_CONDITIONS if offer.blank?
+      return OfferCondition::STANDARD_CONDITIONS if offer.blank?
 
       conditions = offer.conditions_text
-      conditions & MakeOffer::STANDARD_CONDITIONS
+      conditions & OfferCondition::STANDARD_CONDITIONS
     end
 
     private_class_method :standard_conditions_from
@@ -128,7 +128,7 @@ module ProviderInterface
       return {} if offer.blank?
 
       further_conditions = offer.conditions.reject do |condition|
-        MakeOffer::STANDARD_CONDITIONS.include?(condition.text)
+        OfferCondition::STANDARD_CONDITIONS.include?(condition.text)
       end
 
       further_conditions.each_with_index.to_h do |condition, index|

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -79,7 +79,7 @@ module SupportInterface
       return [] if offer.blank?
 
       conditions = offer.conditions_text
-      conditions & MakeOffer::STANDARD_CONDITIONS
+      conditions & OfferCondition::STANDARD_CONDITIONS
     end
 
     def self.further_condition_attrs_from(offer)

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -85,9 +85,7 @@ module SupportInterface
     def self.further_condition_attrs_from(offer)
       return {} if offer.blank?
 
-      further_conditions = offer.conditions.reject do |condition|
-        MakeOffer::STANDARD_CONDITIONS.include?(condition.text)
-      end
+      further_conditions = offer.conditions.reject(&:standard_condition?)
 
       further_conditions.each_with_index.to_h do |condition, index|
         [index.to_s, { 'text' => condition.text, 'condition_id' => condition.id }]

--- a/app/helpers/checkbox_options_helper.rb
+++ b/app/helpers/checkbox_options_helper.rb
@@ -10,7 +10,7 @@ module CheckboxOptionsHelper
   end
 
   def standard_conditions_checkboxes
-    MakeOffer::STANDARD_CONDITIONS.map do |condition|
+    OfferCondition::STANDARD_CONDITIONS.map do |condition|
       OpenStruct.new(
         id: condition,
         name: condition,

--- a/app/models/offer_condition.rb
+++ b/app/models/offer_condition.rb
@@ -1,5 +1,4 @@
 class OfferCondition < ApplicationRecord
-
   STANDARD_CONDITIONS = ['Fitness to train to teach check', 'Disclosure and Barring Service (DBS) check'].freeze
 
   belongs_to :offer
@@ -12,4 +11,8 @@ class OfferCondition < ApplicationRecord
     met: 'met',
     unmet: 'unmet',
   }
+
+  def standard_condition?
+    STANDARD_CONDITIONS.include?(text)
+  end
 end

--- a/app/models/offer_condition.rb
+++ b/app/models/offer_condition.rb
@@ -1,4 +1,7 @@
 class OfferCondition < ApplicationRecord
+
+  STANDARD_CONDITIONS = ['Fitness to train to teach check', 'Disclosure and Barring Service (DBS) check'].freeze
+
   belongs_to :offer
   has_one :application_choice, through: :offer
 

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -1,8 +1,6 @@
 class MakeOffer
   include ImpersonationAuditHelper
 
-  STANDARD_CONDITIONS = ['Fitness to train to teach check', 'Disclosure and Barring Service (DBS) check'].freeze
-
   attr_reader :actor, :application_choice, :course_option, :update_conditions_service
 
   def initialize(actor:,

--- a/app/services/save_offer_conditions_from_params.rb
+++ b/app/services/save_offer_conditions_from_params.rb
@@ -3,7 +3,7 @@ class SaveOfferConditionsFromParams
 
   def initialize(application_choice:, standard_conditions:, further_condition_attrs:)
     @application_choice = application_choice
-    @standard_conditions = standard_conditions & MakeOffer::STANDARD_CONDITIONS
+    @standard_conditions = standard_conditions & OfferCondition::STANDARD_CONDITIONS
     @further_condition_attrs = further_condition_attrs
   end
 
@@ -27,7 +27,7 @@ class SaveOfferConditionsFromParams
 private
 
   def serialize_standard_conditions
-    existing_standard_conditions = @offer.conditions.where(text: MakeOffer::STANDARD_CONDITIONS)
+    existing_standard_conditions = @offer.conditions.where(text: OfferCondition::STANDARD_CONDITIONS)
 
     standard_conditions.each do |text|
       existing_standard_conditions.find_or_create_by(text: text)
@@ -65,6 +65,6 @@ private
   end
 
   def offer_further_conditions
-    @offer_further_conditions ||= @offer.conditions.where.not(text: MakeOffer::STANDARD_CONDITIONS)
+    @offer_further_conditions ||= @offer.conditions.where.not(text: OfferCondition::STANDARD_CONDITIONS)
   end
 end

--- a/spec/components/previews/provider_interface/offer_summary_component_preview.rb
+++ b/spec/components/previews/provider_interface/offer_summary_component_preview.rb
@@ -5,7 +5,7 @@ module ProviderInterface
     def offer_summary
       application_choice = ApplicationChoice.limit(5).sample
       course_option = CourseOption.limit(10).sample
-      conditions =  MakeOffer::STANDARD_CONDITIONS + ['Driving license']
+      conditions =  OfferCondition::STANDARD_CONDITIONS + ['Driving license']
 
       render ProviderInterface::OfferSummaryComponent.new(application_choice: application_choice,
                                                           course_option: course_option,

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ProviderInterface::OfferWizard do
   let(:course_option_id) { nil }
   let(:study_mode) { nil }
   let(:application_choice_id) { create(:application_choice).id }
-  let(:standard_conditions) { MakeOffer::STANDARD_CONDITIONS }
+  let(:standard_conditions) { OfferCondition::STANDARD_CONDITIONS }
   let(:further_condition_1) { '' }
   let(:further_condition_2) { '' }
   let(:further_condition_3) { '' }
@@ -154,7 +154,7 @@ RSpec.describe ProviderInterface::OfferWizard do
 
       it 'populates the conditions with the standard ones' do
         expect(wizard).to be_valid
-        expect(wizard.standard_conditions).to match_array(MakeOffer::STANDARD_CONDITIONS)
+        expect(wizard.standard_conditions).to match_array(OfferCondition::STANDARD_CONDITIONS)
         expect(wizard.further_condition_attrs).to eq({})
       end
     end
@@ -318,12 +318,12 @@ RSpec.describe ProviderInterface::OfferWizard do
   end
 
   describe '#conditions' do
-    let(:standard_conditions) { ['', MakeOffer::STANDARD_CONDITIONS.last] }
+    let(:standard_conditions) { ['', OfferCondition::STANDARD_CONDITIONS.last] }
     let(:further_condition_1) { 'Receiving an A* on their Maths A Level' }
     let(:further_condition_3) { 'They must graduate from their current course with an Honors' }
 
     it 'constructs an array with the offer conditions' do
-      expect(wizard.conditions).to eq([MakeOffer::STANDARD_CONDITIONS.last,
+      expect(wizard.conditions).to eq([OfferCondition::STANDARD_CONDITIONS.last,
                                        further_condition_1,
                                        further_condition_3])
     end

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe SupportInterface::ConditionsForm do
     end
 
     it 'reads standard and further conditions' do
-      conditions = [build(:offer_condition, text: MakeOffer::STANDARD_CONDITIONS.sample),
+      conditions = [build(:offer_condition, text: OfferCondition::STANDARD_CONDITIONS.sample),
                     build(:offer_condition, text: 'Get a haircut')]
       application_choice = create(:application_choice,
                                   :with_offer,

--- a/spec/helpers/checkbox_options_helper_spec.rb
+++ b/spec/helpers/checkbox_options_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CheckboxOptionsHelper, type: :helper do
 
   describe '#standard_conditions_checkboxes' do
     it 'returns structured data for standard offer conditions' do
-      expected = MakeOffer::STANDARD_CONDITIONS.map do |condition|
+      expected = OfferCondition::STANDARD_CONDITIONS.map do |condition|
         OpenStruct.new(id: condition, name: condition)
       end
 

--- a/spec/models/offer_condition_spec.rb
+++ b/spec/models/offer_condition_spec.rb
@@ -17,4 +17,18 @@ RSpec.describe OfferCondition do
       expect(offer.conditions_text).to eq(conditions.map(&:text))
     end
   end
+
+  describe '#standard_condition?' do
+    it 'returns true if the condition is part of the standard conditions' do
+      condition = build(:offer_condition, text: 'Fitness to train to teach check')
+
+      expect(condition.standard_condition?).to be true
+    end
+
+    it 'returns false if the condition is part of the standard conditions' do
+      condition = build(:offer_condition, text: 'You must receive your deegree')
+
+      expect(condition.standard_condition?).to be false
+    end
+  end
 end

--- a/spec/services/save_offer_conditions_from_params_spec.rb
+++ b/spec/services/save_offer_conditions_from_params_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SaveOfferConditionsFromParams do
   let(:application_choice) { build(:application_choice) }
 
   describe '#conditions' do
-    let(:standard_conditions) { [MakeOffer::STANDARD_CONDITIONS.sample] }
+    let(:standard_conditions) { [OfferCondition::STANDARD_CONDITIONS.sample] }
     let(:further_condition_attrs) do
       {
         0 => {
@@ -47,7 +47,7 @@ RSpec.describe SaveOfferConditionsFromParams do
     context 'when there is an existing offer with non-pending conditions' do
       let!(:application_choice) { create(:application_choice, :with_offer, offer: offer) }
       let(:offer) do
-        build(:offer, conditions: [build(:offer_condition, text: MakeOffer::STANDARD_CONDITIONS.first, status: :met),
+        build(:offer, conditions: [build(:offer_condition, text: OfferCondition::STANDARD_CONDITIONS.first, status: :met),
                                    build(:offer_condition, text: 'Red hair')])
       end
 
@@ -61,12 +61,12 @@ RSpec.describe SaveOfferConditionsFromParams do
       context 'when we make changes to further conditions' do
         let!(:application_choice) { create(:application_choice, :with_offer, offer: offer) }
         let(:offer) do
-          build(:offer, conditions: [build(:offer_condition, text: MakeOffer::STANDARD_CONDITIONS.first),
-                                     build(:offer_condition, text: MakeOffer::STANDARD_CONDITIONS.last),
+          build(:offer, conditions: [build(:offer_condition, text: OfferCondition::STANDARD_CONDITIONS.first),
+                                     build(:offer_condition, text: OfferCondition::STANDARD_CONDITIONS.last),
                                      build(:offer_condition, text: 'Red hair')])
         end
 
-        let(:standard_conditions) { [MakeOffer::STANDARD_CONDITIONS.sample] }
+        let(:standard_conditions) { [OfferCondition::STANDARD_CONDITIONS.sample] }
         let(:further_condition_attrs) do
           {
             0 => {
@@ -91,7 +91,7 @@ RSpec.describe SaveOfferConditionsFromParams do
 
     context 'standard_conditions' do
       let!(:application_choice) { create(:application_choice, :with_offer, offer: offer) }
-      let(:standard_conditions) { [MakeOffer::STANDARD_CONDITIONS.sample] }
+      let(:standard_conditions) { [OfferCondition::STANDARD_CONDITIONS.sample] }
 
       context 'when they dont already exist on the offer' do
         let(:offer) { build(:unconditional_offer) }
@@ -110,7 +110,7 @@ RSpec.describe SaveOfferConditionsFromParams do
       end
 
       context 'when they are removed' do
-        let(:offer) { build(:offer, conditions: [build(:offer_condition, text: MakeOffer::STANDARD_CONDITIONS.first)]) }
+        let(:offer) { build(:offer, conditions: [build(:offer_condition, text: OfferCondition::STANDARD_CONDITIONS.first)]) }
         let(:standard_conditions) { [] }
 
         it 'the service deletes the existing entries' do


### PR DESCRIPTION
## Context

- Move STANDARD_CONDITIONS to OfferCondition
- Enable OfferCondition to check if it's part of standard conditions. This should enable us to simplify checks run by other services.

## Link to Trello card

https://trello.com/c/ZbXOjpKS/3827-refactor-offercondition-model-improvements

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
