### PR TITLE
Raise exception when attempting to check authorisation with no permissions

### DIFF
--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -108,6 +108,7 @@ class ProviderAuthorisation
   end
 
   class NotAuthorisedError < StandardError; end
+  class RelationshipNotPresent < StandardError; end
 
 private
 
@@ -126,16 +127,20 @@ private
     permission_name = "training_provider_can_#{permission}"
     relationship = relationship_for course: course
 
+    raise RelationshipNotPresent if relationship.blank?
+
     @actor.providers.include?(course.provider) &&
-      (relationship.blank? || relationship.send(permission_name))
+      relationship.send(permission_name)
   end
 
   def permission_as_ratifying_provider_user?(permission:, course:)
     permission_name = "ratifying_provider_can_#{permission}"
     relationship = relationship_for course: course
 
+    raise RelationshipNotPresent if relationship.blank?
+
     @actor.providers.include?(course.accredited_provider) &&
-      (relationship.blank? || relationship.send(permission_name))
+      relationship.send(permission_name)
   end
 
   def full_authorisation?(permission:, course:)

--- a/spec/components/provider_interface/diversity_information_component_spec.rb
+++ b/spec/components/provider_interface/diversity_information_component_spec.rb
@@ -124,9 +124,12 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
       end
 
       context 'when provider user does not have permissions to view diversity information and the application is accepted' do
+        before do
+          provider_relationship_permissions
+        end
+
         it 'displays the correct text' do
-          provider_user.provider_permissions.find_by(provider: training_provider)
-            .update!(view_diversity_information: false)
+          provider_user.provider_permissions.find_by(provider: training_provider).update!(view_diversity_information: false)
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
           expect(result.text).to include('The candidate disclosed information in the optional equality and diversity questionnaire.')
@@ -172,6 +175,10 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
       end
 
       context 'when provider user does not have permissions to view diversity information' do
+        before do
+          provider_relationship_permissions
+        end
+
         it 'displays the correct text' do
           provider_user.provider_permissions.find_by(provider: training_provider)
             .update!(view_diversity_information: false)
@@ -219,6 +226,10 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
       end
 
       context 'when provider user does not have permissions to view diversity information' do
+        before do
+          provider_relationship_permissions
+        end
+
         it 'displays the correct text with correct offer context' do
           provider_user.provider_permissions.find_by(provider: training_provider)
             .update!(view_diversity_information: false)

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -101,6 +101,13 @@ RSpec.describe ProviderAuthorisation do
         expect(can_make_decisions?(actor: ratifying_provider_user)).to be_falsy
       end
 
+      it 'bad data: relationship record is missing' do
+        provider_relationship_permissions.destroy
+
+        expect { can_make_decisions?(actor: training_provider_user) }.to raise_error(ProviderAuthorisation::RelationshipNotPresent)
+        expect { can_make_decisions?(actor: ratifying_provider_user) }.to raise_error(ProviderAuthorisation::RelationshipNotPresent)
+      end
+
       it 'training_provider for self-ratified course can always decide' do
         for_self_ratified_course = create(
           :application_choice,

--- a/spec/support/test_helpers/course_option_helpers.rb
+++ b/spec/support/test_helpers/course_option_helpers.rb
@@ -13,7 +13,7 @@ module CourseOptionHelpers
   end
 
   def course_option_for_accredited_provider(provider:, accredited_provider:, recruitment_cycle_year: RecruitmentCycle.current_year)
-    course = create(:course, :open_on_apply, provider: provider, accredited_provider: accredited_provider, recruitment_cycle_year: recruitment_cycle_year)
+    course = create(:course, :open_on_apply, :with_provider_relationship_permissions, provider: provider, accredited_provider: accredited_provider, recruitment_cycle_year: recruitment_cycle_year)
     site = create(:site, provider: provider)
     create(:course_option, course: course, site: site)
   end


### PR DESCRIPTION
## Context

The authorisation service always assumes all `provider_permissions` exist, and they may have been setup, or still need to be verified. The reason we expect to exist is because it is part of syncing courses

## Changes proposed in this pull request

Raise error if the provider relationship is missing

## Link to Trello card

https://trello.com/c/xY7mPZr1/3770-raise-exception-when-attempting-to-check-authorisation-with-no-permissions
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
