### PR TITLE
Cascade delete offer/offer condition foreign keys

### DIFF
--- a/db/migrate/20210615043247_cascade_delete_offers_and_offer_conditions.rb
+++ b/db/migrate/20210615043247_cascade_delete_offers_and_offer_conditions.rb
@@ -1,0 +1,9 @@
+class CascadeDeleteOffersAndOfferConditions < ActiveRecord::Migration[6.1]
+  def change
+    remove_foreign_key 'offers', 'application_choices'
+    add_foreign_key 'offers', 'application_choices', on_delete: :cascade, validate: false
+
+    remove_foreign_key 'offer_conditions', 'offers'
+    add_foreign_key 'offer_conditions', 'offers', on_delete: :cascade, validate: false
+  end
+end

--- a/db/migrate/20210615043807_validate_offers_and_offer_conditions_foreign_keys.rb
+++ b/db/migrate/20210615043807_validate_offers_and_offer_conditions_foreign_keys.rb
@@ -1,0 +1,6 @@
+class ValidateOffersAndOfferConditionsForeignKeys < ActiveRecord::Migration[6.1]
+  def change
+    validate_foreign_key 'offers', 'application_choices'
+    validate_foreign_key 'offer_conditions', 'offers'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_03_152817) do
+ActiveRecord::Schema.define(version: 2021_06_15_043807) do
 
   create_sequence "application_choices_id_seq"
   create_sequence "application_experiences_id_seq"
@@ -792,8 +792,8 @@ ActiveRecord::Schema.define(version: 2021_06_03_152817) do
   add_foreign_key "interviews", "providers", on_delete: :cascade
   add_foreign_key "notes", "application_choices", on_delete: :cascade
   add_foreign_key "notes", "provider_users", on_delete: :cascade
-  add_foreign_key "offer_conditions", "offers"
-  add_foreign_key "offers", "application_choices"
+  add_foreign_key "offer_conditions", "offers", on_delete: :cascade
+  add_foreign_key "offers", "application_choices", on_delete: :cascade
   add_foreign_key "provider_agreements", "provider_users"
   add_foreign_key "provider_agreements", "providers"
   add_foreign_key "provider_relationship_permissions", "providers", column: "ratifying_provider_id"

--- a/spec/services/vendor_api/clear_application_data_for_provider_spec.rb
+++ b/spec/services/vendor_api/clear_application_data_for_provider_spec.rb
@@ -39,6 +39,26 @@ RSpec.describe VendorAPI::ClearApplicationDataForProvider do
       expect { described_class.call(provider) }.to change { ApplicationChoice.count }.from(1).to(0)
     end
 
+    it 'deletes all associated offers to the candidate' do
+      create(
+        :application_choice,
+        :with_offer,
+        course_option: course_option_for_provider(provider: provider),
+      )
+
+      expect { described_class.call(provider) }.to change { Offer.count }.from(1).to(0)
+    end
+
+    it 'deletes all associated offer conditions to the candidate' do
+      create(
+        :application_choice,
+        :with_offer,
+        course_option: course_option_for_provider(provider: provider),
+      )
+
+      expect { described_class.call(provider) }.to change { OfferCondition.count }.from(1).to(0)
+    end
+
     it 'deletes all associated application forms to the candidate' do
       create(
         :application_choice,


### PR DESCRIPTION
## Context

Our endpoint to clear data from sandbox deletes application choices. When attempting to delete an application choice, we have started getting an error because we now have a new offer/offer condition record with a foreign key to the application choice. 
https://sentry.io/organizations/dfe-bat/issues/2441678779/events/cb1e0e65c27940019507dd5ca963931e/?environment=sandbox&project=1765973

## Changes proposed in this pull request

Add a foreign key cascade delete for both offer and offer conditions. To avoid locking the table add the validation in a subsequent migration.

## Guidance to review

Does it make sense?

## Link to Trello card

https://trello.com/c/MxtqcSTO/3829-fix-clear-application-data-endpoint

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
