### PR TITLE
Update docs to mark regenerate endpoint as deprecated

### DIFF
--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,7 @@
+## 15th June
+
+Documentation has been amended to mark the following endpoint as deprecated: `/test-data/regenerate`.
+
 ## 3rd June
 
 `HESAITTData` now includes the following optional fields:

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -305,16 +305,16 @@ paths:
     post:
       tags:
       - Testing
-      summary: Regenerate test data
+      summary: Regenerate test data (DEPRECATED)
       description: |
-        Deletes all applications and generates 100 new applications. Only
-        available on the Sandbox.
+        This endpoint has been deprecated and will return an error. Please use `/test-data/clear` and `/test-data/generate`.
       parameters:
       - name: count
         description: How many items to generate (max 100)
         in: query
         schema:
           type: integer
+      deprecated: true
       responses:
         '200':
           "$ref": "#/components/responses/OK"


### PR DESCRIPTION
## Context

Integrated providers are attempting to use a deprecated endpoint and are getting confused when getting an error.

## Changes proposed in this pull request

Mark regenerate endpoint as deprecated to avoid confusion

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
