### PR TITLE
Minor improvements to reference testing in system specs

### DIFF
--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -29,6 +29,8 @@ FactoryBot.define do
       transient do
         references_state { :feedback_provided }
       end
+
+      references_completed { true }
     end
 
     trait :with_feedback_completed do

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -93,10 +93,6 @@ module CandidateHelper
   end
 
   def candidate_submits_application
-    receive_references
-    if FeatureFlag.active?(:reference_selection)
-      select_references_and_complete_section
-    end
     click_link 'Check and submit your application'
     click_link t('continue')
     choose 'No'

--- a/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_to_new_cycle_spec.rb
@@ -38,6 +38,7 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
 
     when_i_add_another_course
     and_i_complete_the_section
+    and_i_receive_references
     and_i_submit_my_application
     then_my_application_is_awaiting_provider_decision
   end
@@ -181,6 +182,13 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
     click_button t('continue')
     choose t('application_form.completed_radio')
     click_button t('continue')
+  end
+
+  def and_i_receive_references
+    receive_references
+    if FeatureFlag.active?(:reference_selection)
+      select_references_and_complete_section
+    end
   end
 
   def and_i_submit_my_application

--- a/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
@@ -33,6 +33,7 @@ RSpec.feature 'Manually carry over unsubmitted applications that do not have cou
 
     and_i_select_a_course
     and_i_complete_the_section
+    and_i_receive_references
     and_i_submit_my_application
     and_my_application_is_awaiting_provider_decision
   end
@@ -146,6 +147,13 @@ RSpec.feature 'Manually carry over unsubmitted applications that do not have cou
     click_button t('continue')
     choose t('application_form.completed_radio')
     click_button t('continue')
+  end
+
+  def and_i_receive_references
+    receive_references
+    if FeatureFlag.active?(:reference_selection)
+      select_references_and_complete_section
+    end
   end
 
   def and_i_submit_my_application


### PR DESCRIPTION

## Context

As part of implementing the 'reference selection' feature, Apply Again needed a review to check if any changes were needed. The only changes identified were these minor spec improvements.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Make testing of reference behaviour a little clearer with the following
changes:

- Make the `candidate_submits_application` helper deal only with app
  submission, requiring reference-related changes to be called
  explicitly by the spec.
- Update the application_form factory trait `with_completed_references`
  so that it includes the `references_completed` boolean set to true.

These changes have the following effects:

- The apply again spec for a completed application does not need to do
  anything with references to successfully submit the apply_2
  application.
- The apply again specs for an unsubmitted application now need to
  receive references within the spec body in order to successfully
  submit.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
na
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/hZVGCcxd
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
