### PR TITLE
Rubocop Cop configuration - part 1

### DIFF
--- a/app/forms/candidate_interface/english_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/english_gcse_grade_form.rb
@@ -139,7 +139,7 @@ module CandidateInterface
         self.grade_other_english_gcse = params[:grade_other_english_gcse]
       else
         self.grade = params[:grade]
-        self.other_grade = params [:other_grade]
+        self.other_grade = params[:other_grade]
       end
       self
     end

--- a/app/forms/referee_interface/questionnaire_form.rb
+++ b/app/forms/referee_interface/questionnaire_form.rb
@@ -66,7 +66,7 @@ module RefereeInterface
     end
 
     def consent_to_be_contacted_response
-      "#{consent_to_be_contacted} | #{(consent_to_be_contacted_details if consent_to_be_contacted == 'true')}"
+      "#{consent_to_be_contacted} | #{consent_to_be_contacted_details if consent_to_be_contacted == 'true'}"
     end
   end
 end

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -1,15 +1,18 @@
 class TestApplications
   class NotEnoughCoursesError < RuntimeError; end
+
   class ZeroCoursesPerApplicationError < RuntimeError
     def message
       'You cannot have zero courses per application'
     end
   end
+
   class CourseAndStateNumbersDoNotMatchError < RuntimeError
     def message
       'The number of states and courses must be equal'
     end
   end
+
   class OnlyOneCourseWhenApplyingAgainError < RuntimeError
     def message
       'You can only apply to one course when applying again'

--- a/config/rubocop/config/layout.yml
+++ b/config/rubocop/config/layout.yml
@@ -34,7 +34,8 @@ Layout/SpaceAroundMethodCallOperator:
   Enabled: true
 
 Layout/EmptyLineBetweenDefs:
-  Enabled: false
+  AllowAdjacentOneLineDefs: true
+  Enabled: true
 
 Layout/SpaceBeforeBrackets:
   Enabled: true

--- a/config/rubocop/config/layout.yml
+++ b/config/rubocop/config/layout.yml
@@ -37,4 +37,4 @@ Layout/EmptyLineBetweenDefs:
   Enabled: false
 
 Layout/SpaceBeforeBrackets:
-  Enabled: false
+  Enabled: true

--- a/config/rubocop/config/lint.yml
+++ b/config/rubocop/config/lint.yml
@@ -32,4 +32,4 @@ Lint/DuplicateBranch:
   Enabled: false
 
 Lint/EmptyBlock:
-  Enabled: false
+  Enabled: true

--- a/config/rubocop/config/lint.yml
+++ b/config/rubocop/config/lint.yml
@@ -17,7 +17,7 @@ Lint/StructNewOverride:
   Enabled: true
 
 Lint/EmptyFile:
-  Enabled: false
+  Enabled: true
 
 Lint/MissingSuper:
   Enabled: false

--- a/config/rubocop/config/style.yml
+++ b/config/rubocop/config/style.yml
@@ -146,7 +146,7 @@ Style/SoleNestedConditional:
   Enabled: false
 
 Style/RedundantParentheses:
-  Enabled: false
+  Enabled: true
 
 Style/QuotedSymbols:
   Enabled: false

--- a/spec/components/provider_interface/status_box_components/recruited_component_spec.rb
+++ b/spec/components/provider_interface/status_box_components/recruited_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ProviderInterface::StatusBoxComponents::RecruitedComponent do
   subject(:component) { described_class.new(application_choice: build_stubbed(:application_choice, :with_recruited), options: options) }
 
   let(:result) { render_inline(component) }
-  let(:options) {}
+  let(:options) { {} }
 
   context 'when :provider_can_respond' do
     let(:options) { { provider_can_respond: true } }

--- a/spec/forms/support_interface/application_forms/reinstate_declined_offer_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/reinstate_declined_offer_form_spec.rb
@@ -16,11 +16,6 @@ RSpec.describe SupportInterface::ApplicationForms::ReinstateDeclinedOfferForm, t
     end
   end
 
-  describe '.build_from_course_choice' do
-    it 'creates an object based on the provided ApplicationChoice' do
-    end
-  end
-
   describe '#save' do
     let(:zendesk_ticket) { 'www.becomingateacher.zendesk.com/agent/tickets/example' }
 


### PR DESCRIPTION
## Context
Configures and resolves errors for the following cops

- Style/RedundantParentheses 
- Lint/EmptyFile
- Lint/EmptyBlock
- Layout/SpaceBeforeBrackets 
- Layout/EmptyLineBetweenDefs (configure to not require empty lnes between single line definitions)

## Link to Trello card
https://trello.com/c/I6JiD7cR/1564-rubocop-cleanup

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
