### PR TITLE
Backfill values for candidate_api_updated_at

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -18,6 +18,10 @@ class Candidate < ApplicationRecord
   has_many :application_references, through: :application_forms
   belongs_to :course_from_find, class_name: 'Course', optional: true
 
+  after_create do
+    self.candidate_api_updated_at = Time.zone.now
+  end
+
   def self.for_email(email)
     find_or_initialize_by(email_address: email.downcase) if email
   end

--- a/app/services/data_migrations/backfill_candidate_api_updated_at.rb
+++ b/app/services/data_migrations/backfill_candidate_api_updated_at.rb
@@ -1,0 +1,12 @@
+module DataMigrations
+  class BackfillCandidateAPIUpdatedAt
+    TIMESTAMP = 20210615140317
+    MANUAL_RUN = false
+
+    def change
+      Candidate
+        .where('candidate_api_updated_at IS NULL')
+        .each { |candidate| candidate.update!(candidate_api_updated_at: candidate.created_at) }
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillCandidateAPIUpdatedAt',
   'DataMigrations::BackfillNoneHesaDisabilitiesCodes',
   'DataMigrations::SetMissingProviderRelationshipPermissions',
   'DataMigrations::RemoveApplicationChoicesInTheIncorrectCycle',

--- a/spec/services/data_migrations/backfill_candidate_api_updated_at_spec.rb
+++ b/spec/services/data_migrations/backfill_candidate_api_updated_at_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillCandidateAPIUpdatedAt do
+  describe '#change' do
+    it 'backfills candidate_api_updated_at with the created_at date if nil' do
+      candidate = create(:candidate, candidate_api_updated_at: nil)
+
+      described_class.new.change
+
+      expect(candidate.reload.candidate_api_updated_at).to eq candidate.created_at
+    end
+  end
+end


### PR DESCRIPTION
## Context

Following on from the migration in [#4952](https://github.com/DFE-Digital/apply-for-teacher-training/pull/4952) this is to backfill it using the created_at value. This will be modified later on to update when specific attributes are changed.

## Changes proposed in this pull request

- Add an `after_create` callback to populate the `candidate_api_updated_at` attribute with the creation date.
- Add a backfill to populate `candidate_api_updated_at` with the `created_at` value.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ncl7SeXN

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
