### PR TITLE
Better formatting for JSON in Vendor API logs

### DIFF
--- a/app/components/support_interface/email_log_row_component.html.erb
+++ b/app/components/support_interface/email_log_row_component.html.erb
@@ -8,7 +8,7 @@
     <%= govuk_details(
       summary: 'Email body',
     ) do %>
-      <%= tag.pre(email.body) %>
+      <%= tag.pre(email.body, class: 'app-json-code-sample') %>
     <% end %>
   </td>
 </tr>

--- a/app/views/support_interface/vendor_api_requests/index.html.erb
+++ b/app/views/support_interface/vendor_api_requests/index.html.erb
@@ -20,18 +20,18 @@
               summary: 'Details',
             ) do %>
               <h3 class="govuk-!-margin-top-0">Headers</h3>
-              <%= tag.pre(JSON.pretty_generate(vendor_api_request.request_headers)) %>
+              <%= tag.pre(JSON.pretty_generate(vendor_api_request.request_headers), class: 'app-json-code-sample') %>
               <% if vendor_api_request.request_body.present? %>
                 <h3>Request <%= vendor_api_request.request_method == 'GET' ? 'params' : 'body' %></h3>
-                <%= tag.pre(JSON.pretty_generate(vendor_api_request.request_body)) %>
+                <%= tag.pre(JSON.pretty_generate(vendor_api_request.request_body), class: 'app-json-code-sample') %>
               <% end %>
               <% if vendor_api_request.response_headers.present? %>
                 <h3>Response headers</h3>
-                <%= tag.pre(JSON.pretty_generate(vendor_api_request.response_headers)) %>
+                <%= tag.pre(JSON.pretty_generate(vendor_api_request.response_headers), class: 'app-json-code-sample') %>
               <% end %>
               <% if vendor_api_request.response_body.present? %>
                 <h3>Response body</h3>
-                <%= tag.pre(JSON.pretty_generate(vendor_api_request.response_body)) %>
+                <%= tag.pre(JSON.pretty_generate(vendor_api_request.response_body), class: 'app-json-code-sample') %>
               <% end %>
             <% end %>
           </td>


### PR DESCRIPTION
These overflowed the container which caused other data to disappear

## Changes proposed in this pull request

**before**

<img width="830" alt="Screenshot 2021-06-15 at 16 23 38" src="https://user-images.githubusercontent.com/642279/122080288-1604e300-cdf6-11eb-8c78-f0cc6365e7e7.png">


**after**

<img width="818" alt="Screenshot 2021-06-15 at 16 22 56" src="https://user-images.githubusercontent.com/642279/122080307-18ffd380-cdf6-11eb-9f4f-7f9786938496.png">
