### PR TITLE
Add service to withdraw at candidates request

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -35,6 +35,7 @@ class FeatureFlag
     [:reference_selection, 'Allow candidates to receive multiple references and then select which two are added to their application', 'Malcolm Baig'],
     [:new_provider_user_flow, 'New flow for creating or updating a single ProviderUser and adding Provider users in bulk', 'Toby Retallick'],
     [:individual_offer_conditions, 'Enables individual offer condition management', 'Despo Pentara'],
+    [:withdraw_at_candidates_request, "Allows providers to withdraw an application at the candidate's request", 'Steve Laing'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/services/provider_interface/decline_or_withdraw_application.rb
+++ b/app/services/provider_interface/decline_or_withdraw_application.rb
@@ -1,0 +1,56 @@
+module ProviderInterface
+  class DeclineOrWithdrawApplication
+    def initialize(actor:, application_choice:)
+      @actor = actor
+      @application_choice = application_choice
+      @resolve_ucas_match = withdrawing?
+    end
+
+    def save!
+      return false unless declining? || withdrawing?
+
+      auth.assert_can_make_decisions!(application_choice: @application_choice, course_option: @application_choice.course_option)
+
+      transition = declining? ? :declined : :withdrawn
+
+      ActiveRecord::Base.transaction do
+        if declining?
+          ApplicationStateChange.new(@application_choice).decline!
+          @application_choice.update!(declined_at: Time.zone.now)
+        elsif withdrawing?
+          ApplicationStateChange.new(@application_choice).withdraw!
+          @application_choice.update!(withdrawn_at: Time.zone.now)
+          SetDeclineByDefault.new(application_form: @application_choice.application_form).call
+        end
+      end
+
+      if @application_choice.application_form.ended_without_success?
+        StateChangeNotifier.new(transition, @application_choice).application_outcome_notification
+      end
+
+      # TODO: Email candidate.
+
+      ResolveUCASMatch.new(application_choice: @application_choice).call if resolve_ucas_match?
+    end
+
+  private
+
+    attr_reader :application_choice
+
+    def declining?
+      application_choice.offer?
+    end
+
+    def withdrawing?
+      ApplicationStateChange.new(application_choice).can_withdraw?
+    end
+
+    def resolve_ucas_match?
+      @resolve_ucas_match
+    end
+
+    def auth
+      @auth ||= ProviderAuthorisation.new(actor: @actor)
+    end
+  end
+end

--- a/app/services/resolve_ucas_match.rb
+++ b/app/services/resolve_ucas_match.rb
@@ -1,0 +1,13 @@
+class ResolveUCASMatch
+  def initialize(application_choice:)
+    @application_choice = application_choice
+  end
+
+  def call
+    match = UCASMatches::RetrieveForApplicationChoice.new(@application_choice).call
+
+    if match&.ready_to_resolve? && match&.duplicate_applications_withdrawn_from_apply?
+      UCASMatches::ResolveOnApply.new(match).call
+    end
+  end
+end

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -17,7 +17,7 @@ class WithdrawApplication
 
     send_email_notification_to_provider_users(application_choice)
 
-    resolve_ucas_match(application_choice)
+    ResolveUCASMatch.new(application_choice: application_choice).call
   end
 
 private
@@ -27,14 +27,6 @@ private
   def send_email_notification_to_provider_users(application_choice)
     NotificationsList.for(application_choice, event: :application_withdrawn, include_ratifying_provider: true).each do |provider_user|
       ProviderMailer.application_withdrawn(provider_user, application_choice).deliver_later
-    end
-  end
-
-  def resolve_ucas_match(application_choice)
-    match = UCASMatches::RetrieveForApplicationChoice.new(application_choice).call
-
-    if match&.ready_to_resolve? && match&.duplicate_applications_withdrawn_from_apply?
-      UCASMatches::ResolveOnApply.new(match).call
     end
   end
 end

--- a/spec/services/provider_interface/decline_or_withdraw_application_spec.rb
+++ b/spec/services/provider_interface/decline_or_withdraw_application_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::DeclineOrWithdrawApplication do
+  describe '#save!' do
+    let(:resolver) { instance_double(ResolveUCASMatch, call: true) }
+
+    before { allow(ResolveUCASMatch).to receive(:new).and_return(resolver) }
+
+    it 'declines applications which are under offer' do
+      application_choice = create(:application_choice, :with_offer)
+      provider = application_choice.course_option.provider
+      permitted_user = create(:provider_user, :with_make_decisions, providers: [provider])
+
+      described_class.new(application_choice: application_choice, actor: permitted_user).save!
+
+      expect(application_choice.reload.declined_at).not_to be nil
+      expect(application_choice).to be_declined
+      expect(application_choice).not_to be_withdrawn
+      expect(ResolveUCASMatch).not_to have_received(:new)
+    end
+
+    it 'withdraws applications which are withdrawable' do
+      application_choice = create(:application_choice, :awaiting_provider_decision)
+      provider = application_choice.course_option.provider
+      permitted_user = create(:provider_user, :with_make_decisions, providers: [provider])
+
+      described_class.new(application_choice: application_choice, actor: permitted_user).save!
+
+      expect(application_choice.reload.withdrawn_at).not_to be nil
+      expect(application_choice).to be_withdrawn
+      expect(application_choice).not_to be_declined
+    end
+
+    it 'resolves UCAS matches when withdrawing' do
+      application_choice = create(:application_choice, :awaiting_provider_decision)
+      provider = application_choice.course_option.provider
+      permitted_user = create(:provider_user, :with_make_decisions, providers: [provider])
+
+      described_class.new(application_choice: application_choice, actor: permitted_user).save!
+
+      expect(ResolveUCASMatch).to have_received(:new).with(application_choice: application_choice)
+      expect(resolver).to have_received(:call)
+    end
+
+    it 'returns false when the application is not under offer and is not withdrawable' do
+      application_choice = create(:application_choice, :withdrawn)
+      provider = application_choice.course_option.provider
+      permitted_user = create(:provider_user, :with_make_decisions, providers: [provider])
+
+      expect(described_class.new(application_choice: application_choice, actor: permitted_user).save!).to be false
+    end
+
+    it 'raises when the provider user cannot make decisions' do
+      application_choice = create(:application_choice, :awaiting_provider_decision)
+      provider = application_choice.course_option.provider
+      user = create(:provider_user, providers: [provider])
+
+      expect {
+        described_class.new(application_choice: application_choice, actor: user).save!
+      }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
+    end
+  end
+end

--- a/spec/services/resolve_ucas_match_spec.rb
+++ b/spec/services/resolve_ucas_match_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe ResolveUCASMatch do
+  describe '#call' do
+    let(:application_choice) { build_stubbed(:application_choice) }
+    let(:ucas_match) do
+      instance_double(
+        UCASMatch,
+        ready_to_resolve?: ready_to_resolve,
+        duplicate_applications_withdrawn_from_apply?: duplicate_applications_withdrawn,
+      )
+    end
+    let(:ucas_match_retriever) { instance_double(UCASMatches::RetrieveForApplicationChoice, call: ucas_match) }
+    let(:ucas_match_resolver) { instance_double(UCASMatches::ResolveOnApply, call: true) }
+    let(:ready_to_resolve) { true }
+    let(:duplicate_applications_withdrawn) { true }
+
+    before do
+      allow(UCASMatches::RetrieveForApplicationChoice).to receive(:new).and_return(ucas_match_retriever)
+      allow(UCASMatches::ResolveOnApply).to receive(:new).and_return(ucas_match_resolver)
+    end
+
+    it 'retrieves a UCAS Match for the application choice and resolves on apply' do
+      described_class.new(application_choice: application_choice).call
+
+      expect(UCASMatches::RetrieveForApplicationChoice).to have_received(:new).with(application_choice)
+      expect(ucas_match_retriever).to have_received(:call)
+
+      expect(UCASMatches::ResolveOnApply).to have_received(:new).with(ucas_match)
+      expect(ucas_match_resolver).to have_received(:call)
+    end
+
+    context 'when the ucas match does not need resolving' do
+      let(:ready_to_resolve) { false }
+
+      it 'does not call the resolving service' do
+        described_class.new(application_choice: application_choice).call
+
+        expect(ucas_match_resolver).not_to have_received(:call)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/48E7VUrb/3835-add-withdraw-application-on-candidates-request-service

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
