### PR TITLE
change permissions prompt to scope on open courses

### DIFF
--- a/app/services/provider_setup.rb
+++ b/app/services/provider_setup.rb
@@ -28,6 +28,12 @@ class ProviderSetup
 
   def relationships_pending
     auth = ProviderAuthorisation.new(actor: @provider_user)
-    auth.training_provider_relationships_that_actor_can_manage_organisations_for.select { |prp| prp.setup_at.blank? || prp.invalid? }
+    auth.training_provider_relationships_that_actor_can_manage_organisations_for.select do |relationship|
+      (relationship.setup_at.blank? || relationship.invalid?) && has_open_course_for_relationship?(relationship)
+    end
+  end
+
+  def has_open_course_for_relationship?(relationship)
+    Course.current_cycle.open_on_apply.exists?(provider: relationship.training_provider, accredited_provider: relationship.ratifying_provider)
   end
 end

--- a/spec/requests/provider_interface/provider_relationship_permissions_request_spec.rb
+++ b/spec/requests/provider_interface/provider_relationship_permissions_request_spec.rb
@@ -68,16 +68,18 @@ RSpec.describe 'ProviderRelationshipPermissions', type: :request do
   end
 
   describe 'validation errors' do
+    let(:ratifying_provider) { create(:provider) }
     let(:permissions) do
       permissions = create(
         :provider_relationship_permissions,
-        ratifying_provider: create(:provider),
+        ratifying_provider: ratifying_provider,
         training_provider: provider,
         setup_at: nil,
       )
       provider_user.provider_permissions.update_all(manage_organisations: true)
       permissions
     end
+    let!(:course) { create(:course, :open_on_apply, provider: provider, accredited_provider: ratifying_provider) }
 
     it 'tracks validation errors on save_permissions' do
       stub_model_instance_with_errors(

--- a/spec/system/provider_interface/provider_accepts_data_sharing_agreement_spec.rb
+++ b/spec/system/provider_interface/provider_accepts_data_sharing_agreement_spec.rb
@@ -66,8 +66,11 @@ RSpec.feature 'Accept data sharing agreement' do
   def and_i_need_to_set_up_organisation_permissions
     provider_user = ProviderUser.find_by_dfe_sign_in_uid 'DFE_SIGN_IN_UID'
     provider = Provider.find_by_code('ABC')
+    ratifying_provider = create(:provider, :with_signed_agreement)
+    ratifying_provider.provider_users << provider_user
+    create(:course, :open_on_apply, provider: provider, accredited_provider: ratifying_provider)
     provider_user.provider_permissions.where(provider: provider).update_all(manage_organisations: true)
-    create(:provider_relationship_permissions, setup_at: nil, training_provider: provider)
+    create(:provider_relationship_permissions, setup_at: nil, training_provider: provider, ratifying_provider: ratifying_provider)
   end
 
   def when_i_navigate_to_the_provider_interface

--- a/spec/system/provider_interface/setup_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/setup_provider_relationship_permissions_spec.rb
@@ -54,6 +54,7 @@ RSpec.feature 'Setting up provider relationship permissions' do
       training_provider_can_view_diversity_information: false,
       setup_at: nil,
     )
+    create(:course, :open_on_apply, provider: @training_provider, accredited_provider: @ratifying_provider)
 
     create(
       :provider_relationship_permissions,
@@ -64,6 +65,7 @@ RSpec.feature 'Setting up provider relationship permissions' do
       training_provider_can_view_diversity_information: false,
       setup_at: nil,
     )
+    create(:course, :open_on_apply, provider: @another_training_provider, accredited_provider: @another_ratifying_provider)
   end
 
   alias_method :when_i_sign_in_to_the_provider_interface, :and_i_sign_in_to_the_provider_interface


### PR DESCRIPTION
Restrict relationships pending to relationships where the setup is nil or the relationship is invalid and the providers in the relationship have a course open on apply in the current recruitment cycle.

## Link to Trello card

https://trello.com/c/ROdYaLcX/3811-change-organisation-relationship-setup-prompt
## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
