### PR TITLE
Implement the Candidate API

### DIFF
--- a/app/controllers/candidate_api/candidates_controller.rb
+++ b/app/controllers/candidate_api/candidates_controller.rb
@@ -23,8 +23,8 @@ module CandidateAPI
       render json: { errors: [{ error: 'ParameterInvalid', message: e }] }, status: :unprocessable_entity
     end
 
-    def statement_timeout(e)
-      render json: { errors: [{ error: 'QueryCanceled', message: e }] }, status: :internal_server_error
+    def statement_timeout
+      render json: { errors: [{ error: 'QueryCanceled', message: 'There is a problem with the service' }] }, status: :internal_server_error
     end
 
   private
@@ -34,7 +34,7 @@ module CandidateAPI
 
       candidates.map do |candidate|
         {
-          id: "C#{candidate.id}",
+          id: candidate.public_id,
           type: 'candidate',
           attributes: {
             email_address: candidate.email_address,
@@ -46,7 +46,16 @@ module CandidateAPI
     end
 
     def updated_since_params
-      params.require(:updated_since)
+      updated_since_value = params.require(:updated_since)
+
+      begin
+        date = Time.zone.iso8601(updated_since_value)
+        raise ParameterInvalid, 'Parameter is invalid (date is nonsense): updated_since' unless date.year.positive?
+
+        date
+      rescue ArgumentError, KeyError
+        raise ParameterInvalid, 'Parameter is invalid (should be ISO8601): updated_since'
+      end
     end
   end
 end

--- a/app/controllers/candidate_api/candidates_controller.rb
+++ b/app/controllers/candidate_api/candidates_controller.rb
@@ -1,0 +1,52 @@
+module CandidateAPI
+  class CandidatesController < ActionController::API
+    include ServiceAPIUserAuthentication
+
+    rescue_from ActionController::ParameterMissing, with: :parameter_missing
+    rescue_from ParameterInvalid, with: :parameter_invalid
+
+    # Makes PG::QueryCanceled statement timeout errors appear in Skylight
+    # against the controller action that triggered them
+    # instead of bundling them with every other ErrorsController#internal_server_error
+    rescue_from ActiveRecord::QueryCanceled, with: :statement_timeout
+
+    def index
+      render json: { data: serialized_candidates }
+    end
+
+    def parameter_missing(e)
+      error_message = e.message.split("\n").first
+      render json: { errors: [{ error: 'ParameterMissing', message: error_message }] }, status: :unprocessable_entity
+    end
+
+    def parameter_invalid(e)
+      render json: { errors: [{ error: 'ParameterInvalid', message: e }] }, status: :unprocessable_entity
+    end
+
+    def statement_timeout(e)
+      render json: { errors: [{ error: 'QueryCanceled', message: e }] }, status: :internal_server_error
+    end
+
+  private
+
+    def serialized_candidates
+      candidates = Candidate.where('candidate_api_updated_at > ?', updated_since_params)
+
+      candidates.map do |candidate|
+        {
+          id: "C#{candidate.id}",
+          type: 'candidate',
+          attributes: {
+            email_address: candidate.email_address,
+            created_at: candidate.created_at,
+            updated_at: candidate.candidate_api_updated_at,
+          },
+        }
+      end
+    end
+
+    def updated_since_params
+      params.require(:updated_since)
+    end
+  end
+end

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -19,7 +19,7 @@ class Candidate < ApplicationRecord
   belongs_to :course_from_find, class_name: 'Course', optional: true
 
   after_create do
-    self.candidate_api_updated_at = Time.zone.now
+    update!(candidate_api_updated_at: Time.zone.now)
   end
 
   def self.for_email(email)

--- a/app/models/service_api_user.rb
+++ b/app/models/service_api_user.rb
@@ -13,6 +13,7 @@ class ServiceAPIUser < ActiveHash::Base
     { id: 1, name: 'User for testing, not used in production', authorized_api: 'TestAPI' },
     { id: 2, name: 'DfE TAD', authorized_api: 'DataAPI' },
     { id: 3, name: 'DfE Register', authorized_api: 'RegisterAPI' },
+    { id: 4, name: 'DfE Candidate', authorized_api: 'CandidateAPI' },
   ]
 
   def self.test_data_user
@@ -25,6 +26,10 @@ class ServiceAPIUser < ActiveHash::Base
 
   def self.register_user
     find(3)
+  end
+
+  def self.candidate_user
+    find(4)
   end
 
   # Fix a bug in ActiveHash that causes the user_type in a AuthenticationToken to

--- a/config/candidate-api.yml
+++ b/config/candidate-api.yml
@@ -36,7 +36,7 @@ paths:
         '401':
           "$ref": "#/components/responses/Unauthorized"
         '422':
-          "$ref": "#/components/responses/ParameterMissing"
+          "$ref": "#/components/responses/UnprocessableEntity"
 components:
   responses:
     Unauthorized:
@@ -45,12 +45,15 @@ components:
         application/json:
           schema:
             "$ref": "#/components/schemas/UnauthorizedResponse"
-    ParameterMissing:
-      description: A required URL parameter was empty or missing
+    UnprocessableEntity:
+      description: Returned when the request body was missing data or contained invalid
+        data
       content:
         application/json:
           schema:
-            "$ref": "#/components/schemas/ParameterMissingResponse"
+            oneOf:
+              - "$ref": "#/components/schemas/ParameterMissingResponse"
+              - "$ref": "#/components/schemas/ParameterInvalidResponse"
   schemas:
     CandidateList:
       type: object
@@ -127,6 +130,20 @@ components:
           example:
           - error: ParameterMissing
             message: "param is missing or the value is empty: updated_since"
+    ParameterInvalidResponse:
+      type: object
+      required:
+      - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: ParameterInvalid
+            message: "Parameter is invalid: updated_since"
     Error:
       type: object
       additionalProperties: false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -623,6 +623,10 @@ Rails.application.routes.draw do
     get '/applications' => 'applications#index'
   end
 
+  namespace :candidate_api, path: 'candidate-api' do
+    get '/candidates' => 'candidates#index'
+  end
+
   namespace :provider_interface, path: '/provider' do
     get '/' => 'start_page#show'
 

--- a/spec/requests/candidate_api/get_candidates_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_spec.rb
@@ -51,4 +51,28 @@ RSpec.describe 'GET /candidate-api/candidates', type: :request do
     expect(response).to have_http_status(401)
     expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
   end
+
+  it 'returns HTTP status 422 given an unparseable `updated_since` date value' do
+    get_api_request '/candidate-api/candidates?updated_since=17/07/2020T12:00:42Z', token: candidate_api_token
+
+    expect(response).to have_http_status(422)
+    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): updated_since')
+    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
+  end
+
+  it 'returns HTTP status 422 when encountering a KeyError from ActiveSupport::TimeZone' do
+    get_api_request '/candidate-api/candidates?updated_since=12936', token: candidate_api_token
+
+    expect(response).to have_http_status(422)
+    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): updated_since')
+    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
+  end
+
+  it 'returns HTTP status 422 given a parseable but nonsensensical `updated_since` date value' do
+    get_api_request '/candidate-api/candidates?updated_since=-004713-03-23T11:52:19.448Z', token: candidate_api_token
+
+    expect(response).to have_http_status(422)
+    expect(error_response['message']).to eql('Parameter is invalid (date is nonsense): updated_since')
+    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
+  end
 end

--- a/spec/requests/candidate_api/get_candidates_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /candidate-api/candidates', type: :request do
+  include CandidateAPISpecHelper
+
+  it 'does not allow access to the API from other data users' do
+    api_token = ServiceAPIUser.test_data_user.create_magic_link_token!
+    get_api_request "/candidate-api/candidates?updated_since=#{CGI.escape((Time.zone.now - 1.month).iso8601)}", token: api_token
+    expect(response).to have_http_status(:unauthorized)
+    expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
+  end
+
+  it 'allows access to the API for Candidate users' do
+    get_api_request "/candidate-api/candidates?updated_since=#{CGI.escape((Time.zone.now - 1.month).iso8601)}", token: candidate_api_token
+
+    expect(response).to have_http_status(:success)
+    expect(parsed_response).to be_valid_against_openapi_schema('CandidateList')
+  end
+
+  it 'returns an error if the `updated_since` parameter is missing' do
+    get_api_request '/candidate-api/candidates', token: candidate_api_token
+
+    expect(response).to have_http_status(422)
+    expect(error_response['message']).to eql('param is missing or the value is empty: updated_since')
+    expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse')
+  end
+
+  it 'returns applications filtered with `updated_since`' do
+    Timecop.travel(Time.zone.now - 2.days) do
+      create(:candidate)
+    end
+
+    create(:candidate)
+
+    get_api_request "/candidate-api/candidates?updated_since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}", token: candidate_api_token
+
+    expect(response).to have_http_status(200)
+    expect(parsed_response['data'].size).to eq(1)
+  end
+
+  it 'returns an error if the token is incorrect' do
+    get "/candidate-api/candidates?updated_since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}", headers: { "Authorization": 'invalid-token' }
+
+    expect(response).to have_http_status(401)
+    expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
+  end
+
+  it 'returns an error if no API token is present' do
+    get "/candidate-api/candidates?updated_since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}", headers: { "Authorization": nil }
+
+    expect(response).to have_http_status(401)
+    expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
+  end
+end

--- a/spec/services/data_migrations/backfill_candidate_api_updated_at_spec.rb
+++ b/spec/services/data_migrations/backfill_candidate_api_updated_at_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DataMigrations::BackfillCandidateAPIUpdatedAt do
 
       described_class.new.change
 
-      expect(candidate.reload.candidate_api_updated_at).to eq candidate.created_at
+      expect(candidate.reload.candidate_api_updated_at).to be_within(1.second).of(candidate.created_at)
     end
   end
 end

--- a/spec/support/candidate_api/candidate_api_spec_helper.rb
+++ b/spec/support/candidate_api/candidate_api_spec_helper.rb
@@ -1,0 +1,27 @@
+module CandidateAPISpecHelper
+  def get_api_request(url, token:, options: {})
+    headers_and_params = {
+      headers: {
+        'Authorization' => "Bearer #{token}",
+      },
+    }.deep_merge(options)
+
+    get url, **headers_and_params
+  end
+
+  def candidate_api_token
+    @candidate_api_token ||= ServiceAPIUser.candidate_user.create_magic_link_token!
+  end
+
+  def parsed_response
+    JSON.parse(response.body)
+  end
+
+  def error_response
+    parsed_response['errors'].first
+  end
+
+  def be_valid_against_openapi_schema(expected)
+    ValidAgainstOpenAPISchemaMatcher.new(expected, CandidateAPISpecification.as_hash)
+  end
+end


### PR DESCRIPTION
## Context

Following on from [#4917](https://github.com/DFE-Digital/apply-for-teacher-training/pull/4917) this is the implementation of the Candidate API

## Changes proposed in this pull request

- Implement the `/candidates` endpoint

- Add a `ParameterInvalidResponse` to the spec:

![image](https://user-images.githubusercontent.com/47917431/122227952-4c526900-ceaf-11eb-85d3-c8ff2b7f7240.png)


## Guidance to review

Only testing for a missing parameter, not an invalid one. Should that really be covered as well?

## Link to Trello card

https://trello.com/c/ncl7SeXN/

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
