### PR TITLE
Update Support and Manage for reference selection feature

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -18,6 +18,7 @@ module SupportInterface
     def rows
       [
         status_row,
+        selected_row,
         date_rows,
         name_row,
         email_address_row,
@@ -40,6 +41,13 @@ module SupportInterface
       {
         key: 'Reference status',
         value: govuk_tag(text: t("support_interface.reference_status.#{feedback_status}"), colour: feedback_status_colour(reference)),
+      }
+    end
+
+    def selected_row
+      {
+        key: 'Selected?',
+        value: reference.selected? ? '✅' : '❌',
       }
     end
 

--- a/app/views/provider_interface/application_choices/_references.html.erb
+++ b/app/views/provider_interface/application_choices/_references.html.erb
@@ -1,7 +1,7 @@
 <section class="app-section govuk-!-width-two-thirds">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="references">References</h2>
 
-  <% @application_choice.application_form.application_references.selected.each_with_index do |reference, i| %>
+  <% selected_references.each_with_index do |reference, i| %>
     <%= render ProviderInterface::ReferenceWithFeedbackComponent.new(reference: reference, index: i) %>
   <% end %>
 </section>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -52,8 +52,8 @@
 
 <%= render PersonalStatementComponent.new(application_form: @application_choice.application_form) %>
 
-<% if @application_choice.application_form.application_references.feedback_provided.any? %>
-  <%= render 'references' %>
+<% if @application_choice.application_form.selected_references.any? %>
+  <%= render 'references', selected_references: @application_choice.application_form.selected_references %>
 <% end %>
 
 <%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>

--- a/spec/components/support_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/support_interface/reference_with_feedback_component_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
+  include CandidateHelper
+
   describe 'Undo refusal link' do
     it 'is present when the reference is refused' do
       reference = create(:reference, feedback_status: 'feedback_refused')
@@ -34,6 +36,26 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
       render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
 
       expect(rendered_component).to include("##{reference.id}")
+    end
+  end
+
+  describe 'selected row' do
+    it 'indicates selected when the reference is selected' do
+      reference = create(:reference, selected: true)
+      render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
+
+      within_summary_row('Selected?') do
+        expect(page).to include '✅'
+      end
+    end
+
+    it 'indicates not selected when the reference is not selected' do
+      reference = create(:reference, selected: false)
+      render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
+
+      within_summary_row('Selected?') do
+        expect(page).to include '❌'
+      end
     end
   end
 end

--- a/spec/system/support_interface/editing_reference_spec.rb
+++ b/spec/system/support_interface/editing_reference_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Editing reference' do
   include DfESignInHelpers
+  include CandidateHelper
 
   scenario 'Support user edits reference', with_audited: true do
     given_i_am_a_support_user
@@ -48,7 +49,11 @@ RSpec.feature 'Editing reference' do
   end
 
   def and_i_click_the_change_link_next_to_referee_name
-    all('.govuk-summary-list__actions')[12].click_link 'Change'
+    within_summary_card("reference ##{@form.application_references.first.id}") do
+      within_summary_row('Name') do
+        click_link 'Change'
+      end
+    end
   end
 
   def then_i_should_see_a_prepopulated_details_form
@@ -90,7 +95,9 @@ RSpec.feature 'Editing reference' do
   end
 
   def and_i_click_the_change_link_next_to_feedback
-    all('.govuk-summary-list__actions')[15].click_link 'Change'
+    within_summary_card("reference ##{@form.application_references.first.id}") do
+      click_link 'Change feedback'
+    end
   end
 
   def then_i_should_see_the_feedback_form


### PR DESCRIPTION
## Context

We have a new reference selection feature. Some minor updates are required in Support and Manage to reflect how this feature works.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Use `selected_references` method when rendering application in Manage
- Indicate selected state when rendering references in support

<!-- If there are UI changes, please include Before and After screenshots. -->
![Screenshot_20210616_092709-1](https://user-images.githubusercontent.com/519250/122185512-100a1300-ce85-11eb-8d1c-51f12df92102.png)
![Screenshot_20210616_092734](https://user-images.githubusercontent.com/519250/122185592-1f895c00-ce85-11eb-98d6-d87af17cbc85.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- Support update can be manually tested by viewing an application in the support interface
- Manage update is just a code change—no change in behaviour or UI.

## Link to Trello card
https://trello.com/c/hZVGCcxd
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
