### PR TITLE
Disable condition editing for non-pending conditions

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -100,12 +100,17 @@ module SupportInterface
       conditions = application_choice.offer.conditions
       return if conditions.empty?
 
-      {
+      conditions_row = {
         key: 'Conditions',
         value: render(SupportInterface::ConditionsComponent.new(conditions: conditions)),
+      }
+
+      return conditions_row if application_choice.offer.has_non_pending_conditions?
+
+      conditions_row.merge({
         action: 'conditions',
         change_path: support_interface_edit_application_choice_conditions_path(application_choice_id: @application_choice.id),
-      }
+      })
     end
 
     def sent_to_provider_at_row

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -11,6 +11,10 @@ class Offer < ApplicationRecord
     conditions.none?
   end
 
+  def has_non_pending_conditions?
+    conditions.not_pending.any?
+  end
+
   def conditions_text
     conditions.pluck(:text)
   end

--- a/app/services/save_offer_conditions_from_params.rb
+++ b/app/services/save_offer_conditions_from_params.rb
@@ -11,6 +11,8 @@ class SaveOfferConditionsFromParams
     ActiveRecord::Base.transaction do
       @offer = Offer.find_or_create_by(application_choice: application_choice)
 
+      raise ValidationException, 'Cannot edit conditions of offer when they are not all pending' if @offer.has_non_pending_conditions?
+
       serialize_standard_conditions
       serialize_further_conditions
     end

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -64,6 +64,30 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
       expect(page).not_to have_selector '.app-summary-card__actions a'
       expect(page).not_to have_text 'Change offered course'
     end
+
+    it 'renders a link to change conditions' do
+      result = render_inline(described_class.new(accepted_choice))
+
+      expect(result.css('.app-summary-card .govuk-summary-list__actions a').first.text.squish).to eq 'Change conditions'
+    end
+
+    context 'when one of the conditions is met' do
+      let(:conditions) { [build(:offer_condition, status: 'met'), build(:offer_condition)] }
+      let(:accepted_choice) do
+        create(
+          :application_choice,
+          :with_completed_application_form,
+          :with_accepted_offer,
+          offer: build(:offer, conditions: conditions),
+        )
+      end
+
+      it 'does not render a link to the change the offered course choice  when the`change_offered_course` flag is not active' do
+        result = render_inline(described_class.new(accepted_choice))
+
+        expect(result.css('.app-summary-card .govuk-summary-list__actions a').text.squish).not_to include 'Change conditions'
+      end
+    end
   end
 
   context 'Unconditional offer' do

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -28,6 +28,26 @@ RSpec.describe Offer do
     end
   end
 
+  describe '#has_non_pending_conditions?' do
+    it 'returns false when there are no conditions' do
+      offer = create(:unconditional_offer)
+
+      expect(offer.has_non_pending_conditions?).to be false
+    end
+
+    it 'returns false if all conditions are pending' do
+      offer = create(:offer, conditions: [build(:offer_condition), build(:offer_condition)])
+
+      expect(offer.has_non_pending_conditions?).to be false
+    end
+
+    it 'returns true if there is a non-pending condition' do
+      offer = create(:offer, conditions: [build(:offer_condition, status: :met), build(:offer_condition)])
+
+      expect(offer.has_non_pending_conditions?).to be true
+    end
+  end
+
   context 'delegators' do
     let(:offer) { create(:offer, course_option: create(:course_option)) }
 

--- a/spec/services/save_offer_conditions_from_params_spec.rb
+++ b/spec/services/save_offer_conditions_from_params_spec.rb
@@ -44,6 +44,19 @@ RSpec.describe SaveOfferConditionsFromParams do
       end
     end
 
+    context 'when there is an existing offer with non-pending conditions' do
+      let!(:application_choice) { create(:application_choice, :with_offer, offer: offer) }
+      let(:offer) do
+        build(:offer, conditions: [build(:offer_condition, text: MakeOffer::STANDARD_CONDITIONS.first, status: :met),
+                                   build(:offer_condition, text: 'Red hair')])
+      end
+
+      it 'raises a validation error' do
+        expect { service.save }.to raise_error(ValidationException)
+                                     .and change(offer.conditions, :count).by(0)
+      end
+    end
+
     context 'when we have standard and further conditions' do
       context 'when we make changes to further conditions' do
         let!(:application_choice) { create(:application_choice, :with_offer, offer: offer) }


### PR DESCRIPTION
## Context
- Conditions can be edited in Support after the offer has been accepted
- We are making changes so that condition statuses can be managed separately, so an application choice can be `pending_conditions` but some of the conditions are `met`.

The two points above mean that there is a risk we edit condition text after they have been marked as met. This might become confusing and isn't a required support feature for now.

## Changes proposed in this pull request
- Hide the change link for conditions in support if any of the conditions are not pending.
- Raise an error in the save conditions service if conditions are edited when any are non-pending.

## Guidance to review
Does this make sense?

We decided to go with "block editing if any condition is non-pending" rather than "block editing of any non-pending conditions". The latter option would require UI work and there hasn't been a specific support need for this yet (mainly because it isn't currently possible to get into the problem state).

## Link to Trello card
https://trello.com/c/pzCQobQX/3823-support-interface-do-not-allow-editing-of-non-pending-conditions

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
