### PR TITLE
Add a reference_selection system spec for reviewing references

### DIFF
--- a/spec/factories/reference.rb
+++ b/spec/factories/reference.rb
@@ -74,7 +74,6 @@ FactoryBot.define do
       feedback_provided_at { Time.zone.now }
       safeguarding_concerns { '' }
       relationship_correction { '' }
-      selected { true }
     end
 
     trait :feedback_provided_with_completed_referee_questionnaire do
@@ -91,6 +90,10 @@ FactoryBot.define do
       end
       safeguarding_concerns { '' }
       relationship_correction { '' }
+    end
+
+    factory :selected_reference do
+      feedback_provided
       selected { true }
     end
   end

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -685,15 +685,13 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
     it 'returns only references with feedback which were selected by the candidate' do
       with_feedback_and_selected = create(
-        :reference,
-        :feedback_provided,
+        :selected_reference,
         application_form: application_choice.application_form,
       )
 
       with_feedback_but_not_selected = create(
         :reference,
         :feedback_provided,
-        selected: false,
         application_form: application_choice.application_form,
       )
 
@@ -711,8 +709,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
     it 'returns application references with their respective ids' do
       reference = create(
-        :reference,
-        :feedback_provided,
+        :selected_reference,
         application_form: application_choice.application_form,
       )
       presenter = VendorAPI::SingleApplicationPresenter.new(application_choice)
@@ -721,15 +718,13 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
     it 'includes safeguarding concerns' do
       create(
-        :reference,
-        :feedback_provided,
+        :selected_reference,
         safeguarding_concerns_status: 'has_safeguarding_concerns_to_declare',
         application_form: application_choice.application_form,
       )
 
       create(
-        :reference,
-        :feedback_provided,
+        :selected_reference,
         safeguarding_concerns_status: 'no_safeguarding_concerns_to_declare',
         application_form: application_choice.application_form,
       )

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -137,8 +137,8 @@ module CandidateHelper
     visit candidate_interface_application_form_path
     click_link 'Select your references'
     application_form = ApplicationForm.last
-    first_reference = application_form.application_references.first
-    second_reference = application_form.application_references.second
+    first_reference = application_form.application_references.feedback_provided.first
+    second_reference = application_form.application_references.feedback_provided.second
     check first_reference.name
     check second_reference.name
     click_button t('save_and_continue')

--- a/spec/system/candidate_interface/apply_again/candidate_reviews_rejection_reasons_from_previous_applications_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_reviews_rejection_reasons_from_previous_applications_spec.rb
@@ -34,6 +34,7 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
       references_count: 2,
       candidate: @candidate,
     )
+    application.application_references.update_all(selected: true)
     choice = create(:application_choice, :with_structured_rejection_reasons, application_form: application)
 
     choice.update!(

--- a/spec/system/candidate_interface/references/reference_selection/candidate_reviews_references_spec.rb
+++ b/spec/system/candidate_interface/references/reference_selection/candidate_reviews_references_spec.rb
@@ -1,0 +1,163 @@
+require 'rails_helper'
+
+RSpec.feature 'Review references' do
+  include CandidateHelper
+
+  before { FeatureFlag.activate(:reference_selection) }
+
+  scenario 'Candidate submits and reviews references' do
+    given_i_am_signed_in
+
+    when_i_have_no_references_and_try_to_visit_the_review_page
+    then_i_am_redirected_to_the_start_page
+
+    when_i_view_my_application
+    then_the_references_section_is_incomplete
+
+    when_i_have_added_references
+    then_the_references_section_is_still_incomplete
+
+    when_enough_references_have_been_provided_and_selected
+    and_i_mark_the_section_complete
+    then_the_references_section_is_complete
+    and_i_can_review_my_references_before_submission
+    and_i_can_delete_a_reference
+    and_i_can_delete_a_reference_request
+    and_i_can_cancel_a_sent_reference
+    and_referee_receives_email_about_reference_cancellation
+    and_i_can_return_to_the_application_page
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_have_no_references_and_try_to_visit_the_review_page
+    visit candidate_interface_references_review_path
+  end
+
+  def then_i_am_redirected_to_the_start_page
+    expect(page).to have_current_path candidate_interface_references_start_path
+  end
+
+  def when_i_view_my_application
+    visit candidate_interface_application_form_path
+  end
+
+  def then_the_references_section_is_incomplete
+    when_i_view_my_application
+    within '#select-your-references-badge-id' do
+      expect(page).to have_content 'Incomplete'
+    end
+  end
+
+  def then_the_references_section_is_still_incomplete
+    when_i_view_my_application
+    within '#select-your-references-badge-id' do
+      expect(page).to have_content 'Incomplete'
+    end
+  end
+
+  def when_i_have_added_references
+    application_form = current_candidate.current_application
+    @complete_reference = create(:reference, :feedback_provided, application_form: application_form)
+    @not_sent_reference = create(:reference, :not_requested_yet, application_form: application_form)
+    @requested_reference = create(:reference, :feedback_requested, application_form: application_form)
+    @refused_reference = create(:reference, :feedback_refused, application_form: application_form)
+    @cancelled_reference = create(:reference, :cancelled, application_form: application_form)
+    @bounced_reference = create(:reference, :cancelled, application_form: application_form)
+  end
+
+  def when_enough_references_have_been_provided_and_selected
+    create(:reference, :feedback_provided, application_form: current_candidate.current_application)
+  end
+
+  def and_i_mark_the_section_complete
+    when_i_view_my_application
+    click_link 'Select your references'
+    choose 'Yes'
+    click_button t('save_and_continue')
+  end
+
+  def then_the_references_section_is_complete
+    when_i_view_my_application
+    within '#select-your-references-badge-id' do
+      expect(page).to have_content 'Complete'
+    end
+  end
+
+  def and_i_can_review_my_references_before_submission
+    click_link 'Review your references'
+    expect(page).to have_current_path candidate_interface_references_review_path
+
+    within '#references_given' do
+      expect(page).to have_content @complete_reference.email_address
+      expect(page).not_to have_link 'Change'
+      expect(page).to have_link 'Delete reference'
+    end
+
+    within '#references_waiting_to_be_sent' do
+      expect(page).to have_content @not_sent_reference.email_address
+      expect(page).to have_link 'Change'
+      expect(page).to have_link 'Delete referee'
+    end
+
+    within '#references_sent' do
+      expect(all('.app-summary-card')[0].text).to have_content @requested_reference.email_address
+      expect(all('.app-summary-card')[0]).not_to have_link 'Change'
+      expect(all('.app-summary-card')[0]).not_to have_link 'Delete'
+      expect(all('.app-summary-card')[1].text).to have_content @refused_reference.email_address
+      expect(all('.app-summary-card')[1]).not_to have_link 'Change'
+      expect(all('.app-summary-card')[1]).to have_link 'Delete request'
+      expect(all('.app-summary-card')[2].text).to have_content @cancelled_reference.email_address
+      expect(all('.app-summary-card')[2]).not_to have_link 'Change'
+      expect(all('.app-summary-card')[2]).to have_link 'Delete request'
+      expect(all('.app-summary-card')[3].text).to have_content @bounced_reference.email_address
+      expect(all('.app-summary-card')[3]).not_to have_link 'Change'
+      expect(all('.app-summary-card')[3]).to have_link 'Delete request'
+    end
+  end
+
+  def and_i_can_delete_a_reference
+    within '#references_waiting_to_be_sent' do
+      click_link 'Delete referee'
+    end
+    click_button 'Yes I’m sure'
+
+    expect(page).to have_current_path candidate_interface_references_review_path
+    expect(page).not_to have_css('#references_waiting_to_be_sent')
+  end
+
+  def and_i_can_delete_a_reference_request
+    within '#references_sent' do
+      click_link 'Delete request', match: :first
+    end
+    click_button 'Yes I’m sure'
+
+    expect(page).to have_current_path candidate_interface_references_review_path
+    expect(page).not_to have_content @refused_reference.name
+  end
+
+  def and_i_can_cancel_a_sent_reference
+    within '#references_sent' do
+      click_link 'Cancel request'
+    end
+    click_button 'Yes I’m sure'
+
+    expect(page).to have_current_path candidate_interface_references_review_path
+    expect(page).to have_content("Reference request cancelled for #{@requested_reference.name}")
+    expect(page).to have_content('Request cancelled')
+  end
+
+  def and_referee_receives_email_about_reference_cancellation
+    open_email(@requested_reference.email_address)
+
+    expect(current_email.subject).to include 'Reference request cancelled by'
+    expect(current_email.text).to include 'The candidate has cancelled their request.'
+  end
+
+  def and_i_can_return_to_the_application_page
+    click_link t('continue')
+    expect(page).to have_current_path candidate_interface_application_form_path
+  end
+end

--- a/spec/system/candidate_interface/references/reference_selection/candidate_reviews_references_spec.rb
+++ b/spec/system/candidate_interface/references/reference_selection/candidate_reviews_references_spec.rb
@@ -70,6 +70,7 @@ RSpec.feature 'Review references' do
 
   def when_enough_references_have_been_provided_and_selected
     create(:reference, :feedback_provided, application_form: current_candidate.current_application)
+    select_references_and_complete_section
   end
 
   def and_i_mark_the_section_complete

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -135,15 +135,14 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
            start_date: 10.months.ago,
            end_date: nil)
 
-    create(:reference,
-           :feedback_provided,
+    create(:selected_reference,
            application_form: application_form,
            name: 'R2D2',
            email_address: 'r2d2@rebellion.org',
            relationship: 'Astromech droid',
            feedback: 'beep boop beep')
 
-    create(:reference,
+    create(:selected_reference,
            :feedback_provided,
            application_form: application_form,
            name: 'C3PO',


### PR DESCRIPTION


## Context

Part of an effort to ensure we maintain the existing level of references system test coverage for the new reference_selection feature.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Add new system spec for reviewing references. Based on an equivalent spec in the parent folder, but adjusted to test
the reference_selection version of the same behaviour.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Is the test clear? Does anything need removing/adding?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/hZVGCcxd
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
