### PR TITLE
Do not allow ClearApplicationDataForProvider to run in prod

### DIFF
--- a/app/services/vendor_api/clear_application_data_for_provider.rb
+++ b/app/services/vendor_api/clear_application_data_for_provider.rb
@@ -1,6 +1,8 @@
 module VendorAPI
   class ClearApplicationDataForProvider
     def self.call(provider)
+      raise 'This is not meant to be run in production' if HostingEnvironment.production?
+
       scope = Candidate.joins(application_forms: { application_choices: { course_option: :course } })
       scope.where("courses.accredited_provider": provider).or(scope.where("courses.provider": provider))
         .delete_all

--- a/app/services/vendor_api/generate_test_applications_for_provider.rb
+++ b/app/services/vendor_api/generate_test_applications_for_provider.rb
@@ -14,6 +14,7 @@ module VendorAPI
     end
 
     def call
+      raise 'This is not meant to be run in production' if HostingEnvironment.production?
       raise ParameterInvalid, 'Parameter is invalid (cannot be zero): courses_per_application' if courses_per_application.zero?
 
       application_count.times do

--- a/spec/services/vendor_api/clear_application_data_for_provider_spec.rb
+++ b/spec/services/vendor_api/clear_application_data_for_provider_spec.rb
@@ -68,5 +68,11 @@ RSpec.describe VendorAPI::ClearApplicationDataForProvider do
 
       expect { described_class.call(provider) }.to change { ApplicationForm.count }.from(1).to(0)
     end
+
+    it 'does not work in production' do
+      ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'production' do
+        expect { described_class.call(provider) }.to raise_error('This is not meant to be run in production')
+      end
+    end
   end
 end

--- a/spec/services/vendor_api/generate_test_applications_for_provider_spec.rb
+++ b/spec/services/vendor_api/generate_test_applications_for_provider_spec.rb
@@ -134,6 +134,14 @@ RSpec.describe VendorAPI::GenerateTestApplicationsForProvider, sidekiq: true do
           ).call
         }.to raise_error ParameterInvalid, 'Parameter is invalid (cannot be greater than number of available courses): courses_per_application'
       end
+
+      it 'when the service is run in production' do
+        ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'production' do
+          expect {
+            described_class.new(service_params).call
+          }.to raise_error('This is not meant to be run in production')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

It would be quite bad if we ran this in production