### PR TITLE
Separate domain to service static assets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,8 +29,10 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  if ENV.key?('RAILS_ASSETS_HOST')
+    # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+    config.action_controller.asset_host = ENV['RAILS_ASSETS_HOST']
+  end
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -107,6 +107,12 @@ resource "cloudfoundry_route" "web_app_education_gov_uk_route" {
   hostname = local.service_gov_uk_host_names[var.app_environment]
 }
 
+resource "cloudfoundry_route" "web_app_assets_service_gov_uk_route" {
+  domain   = data.cloudfoundry_domain.apply_service_gov_uk.id
+  space    = data.cloudfoundry_space.space.id
+  hostname = local.assets_host_names[var.app_environment]
+}
+
 resource "cloudfoundry_service_instance" "postgres" {
   name         = local.postgres_service_name
   space        = data.cloudfoundry_space.space.id

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -55,7 +55,16 @@ locals {
     research = "research"
     prod     = "www"
   }
-  web_app_routes = [cloudfoundry_route.web_app_service_gov_uk_route, cloudfoundry_route.web_app_cloudapps_digital_route, cloudfoundry_route.web_app_education_gov_uk_route, cloudfoundry_route.web_app_internal_route]
+  assets_host_names = {
+    qa       = "qa-assets"
+    staging  = "staging-assets"
+    sandbox  = "sandbox-assets"
+    rollover = "rollover-assets"
+    research = "research-assets"
+    prod     = "assets"
+  }
+  web_app_routes = [cloudfoundry_route.web_app_service_gov_uk_route, cloudfoundry_route.web_app_cloudapps_digital_route,
+  cloudfoundry_route.web_app_education_gov_uk_route, cloudfoundry_route.web_app_internal_route, cloudfoundry_route.web_app_assets_service_gov_uk_route]
   app_environment_variables = merge(var.app_environment_variables,
     {
       BLAZER_DATABASE_URL = cloudfoundry_service_key.postgres-readonly-key.credentials.uri


### PR DESCRIPTION
## Context

Assets are currently not getting effectively cached by the CDN as
the request for the assets includes cookies and other headers,
which reduces the cache hit ratio for static assets.
Configuring a separate domain to serve assets which will
use a separate cdn-route that does not pass through any unnecessary headers

## Changes proposed in this pull request

Configure separate assets domain for serving assets.
This domain will be configured in a separate cdn-route than the main app.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
