### PR TITLE
Add data migration to remove surplus reference selections

### DIFF
--- a/app/services/data_migrations/remove_surplus_reference_selections.rb
+++ b/app/services/data_migrations/remove_surplus_reference_selections.rb
@@ -1,0 +1,25 @@
+module DataMigrations
+  class RemoveSurplusReferenceSelections
+    TIMESTAMP = 20210616160559
+    MANUAL_RUN = false
+
+    def change
+      selected_reference_counts =
+        ApplicationForm.joins(:application_references)
+        .where(references: { selected: true })
+        .group('id')
+        .select('"application_forms".id, COUNT("references".id) AS ref_count')
+
+      applications_with_surplus_selections =
+        ApplicationForm.where(
+          id: selected_reference_counts.select { |c| c.ref_count > 2 }.map(&:id),
+        )
+
+      applications_with_surplus_selections.each do |application|
+        selected_references = application.application_references.selected
+        surplus_count = selected_references.size - 2
+        selected_references.limit(surplus_count).update_all(selected: false)
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveSurplusReferenceSelections',
   'DataMigrations::BackfillCandidateAPIUpdatedAt',
   'DataMigrations::BackfillNoneHesaDisabilitiesCodes',
   'DataMigrations::RemoveApplicationChoicesInTheIncorrectCycle',

--- a/spec/services/data_migrations/remove_surplus_reference_selections_spec.rb
+++ b/spec/services/data_migrations/remove_surplus_reference_selections_spec.rb
@@ -1,15 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe DataMigrations::RemoveSurplusReferenceSelections do
-  it 'removes surplus references selections so that applications have a maximum of 2 selected references' do
-    application_form1 = create(:completed_application_form, references_count: 4, references_state: :feedback_provided)
-    application_form2 = create(:completed_application_form, references_count: 2, references_state: :feedback_provided)
-    application_form3 = create(:completed_application_form, references_count: 1, references_state: :feedback_provided)
+  it 'removes surplus reference selections so that applications have a maximum of 2 selected references' do
+    application_form1 = create(:completed_application_form, application_choices: [build(:submitted_application_choice)], references_count: 4, references_state: :feedback_provided)
+    application_form2 = create(:completed_application_form, application_choices: [build(:submitted_application_choice)], references_count: 2, references_state: :feedback_provided)
+    application_form3 = create(:completed_application_form, application_choices: [build(:submitted_application_choice)], references_count: 1, references_state: :feedback_provided)
+    [application_form1, application_form2, application_form3].each do |app|
+      app.application_references.update_all(selected: true)
+    end
 
     described_class.new.change
 
     expect(application_form1.application_references.selected.size).to eq 2
     expect(application_form2.application_references.selected.size).to eq 2
     expect(application_form3.application_references.selected.size).to eq 1
+  end
+
+  it 'removes all selections from unsubmitted apps' do
+    submitted_app = create(:completed_application_form, references_count: 4, references_state: :feedback_provided, application_choices: [build(:submitted_application_choice)])
+    unsubmitted_app = create(:completed_application_form, references_count: 4, references_state: :feedback_provided)
+    [submitted_app, unsubmitted_app].each do |app|
+      app.application_references.update_all(selected: true)
+    end
+
+    described_class.new.change
+
+    expect(submitted_app.application_references.selected.size).to eq 2
+    expect(unsubmitted_app.application_references.selected.size).to eq 0
   end
 end

--- a/spec/services/data_migrations/remove_surplus_reference_selections_spec.rb
+++ b/spec/services/data_migrations/remove_surplus_reference_selections_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveSurplusReferenceSelections do
+  it 'removes surplus references selections so that applications have a maximum of 2 selected references' do
+    application_form1 = create(:completed_application_form, references_count: 4, references_state: :feedback_provided)
+    application_form2 = create(:completed_application_form, references_count: 2, references_state: :feedback_provided)
+    application_form3 = create(:completed_application_form, references_count: 1, references_state: :feedback_provided)
+
+    described_class.new.change
+
+    expect(application_form1.application_references.selected.size).to eq 2
+    expect(application_form2.application_references.selected.size).to eq 2
+    expect(application_form3.application_references.selected.size).to eq 1
+  end
+end


### PR DESCRIPTION


## Context
To prepare Apply for the reference selection feature, a prior data
migration (a1ca03f5fb) set `selected: true` for all `feedback_provided`
references. Prior to the introduction of reference selection, we
expected there to be a maximum of 2 provided references per application.
Historic bugs in the service, however, mean that we have some
applications (90 in total) with more than 2 `feedback_provided`
references.

This means that those references are now also selected. It would be
useful to have an invariant check that warns us about surplus selections on
an ongoing basis. This data migration removes existing surplus
selections in preparation for such a check.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

The migration:

- Looks for all applications with a selected reference count of > 2
- Sets `selected: false` on all surplus selections
- Does not care particularly about which references get de-selected
  (which shouldn't be an issue as this migration will be run prior to
  the reference selection feature going live)
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Does the rationale make sense?
- Is the test adequate?
- Is there anything else I haven't factored in?
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/hZVGCcxd
## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
