### PR TITLE
Fix bug on SatisfactionSurveyFeatureMetrics

### DIFF
--- a/app/models/satisfaction_survey_feature_metrics.rb
+++ b/app/models/satisfaction_survey_feature_metrics.rb
@@ -38,8 +38,8 @@ private
         recruitment_cycle_year: RecruitmentCycle.current_year,
       )
       .where('application_forms.submitted_at BETWEEN ? AND ?', start_time, end_time)
-      .where.not(feedback_satisfaction_level: '').where.not(feedback_suggestions: '')
-      .where(recruitment_cycle_year: RecruitmentCycle.current_year)
+      .where.not(feedback_satisfaction_level: '')
+      .where(recruitment_cycle_year: RecruitmentCycle.current_year).select(:candidate_id).distinct
   end
 
   def application_forms_with_no_feedback(start_time, end_time)
@@ -49,7 +49,6 @@ private
       )
       .where('application_forms.submitted_at BETWEEN ? AND ?', start_time, end_time)
       .where(feedback_satisfaction_level: nil).or(ApplicationForm.where(feedback_satisfaction_level: ''))
-      .where(feedback_suggestions: nil).or(ApplicationForm.where(feedback_suggestions: ''))
-      .where(recruitment_cycle_year: RecruitmentCycle.current_year)
+      .where(recruitment_cycle_year: RecruitmentCycle.current_year).select(:candidate_id).distinct
   end
 end

--- a/app/models/satisfaction_survey_feature_metrics.rb
+++ b/app/models/satisfaction_survey_feature_metrics.rb
@@ -39,7 +39,7 @@ private
       )
       .where('application_forms.submitted_at BETWEEN ? AND ?', start_time, end_time)
       .where.not(feedback_satisfaction_level: '')
-      .where(recruitment_cycle_year: RecruitmentCycle.current_year).select(:candidate_id).distinct
+      .where(recruitment_cycle_year: RecruitmentCycle.current_year)
   end
 
   def application_forms_with_no_feedback(start_time, end_time)
@@ -49,6 +49,6 @@ private
       )
       .where('application_forms.submitted_at BETWEEN ? AND ?', start_time, end_time)
       .where(feedback_satisfaction_level: nil).or(ApplicationForm.where(feedback_satisfaction_level: ''))
-      .where(recruitment_cycle_year: RecruitmentCycle.current_year).select(:candidate_id).distinct
+      .where(recruitment_cycle_year: RecruitmentCycle.current_year)
   end
 end

--- a/spec/models/satisfaction_survey_feature_metrics_spec.rb
+++ b/spec/models/satisfaction_survey_feature_metrics_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SatisfactionSurveyFeatureMetrics, with_audited: true do
   end
 
   def create_application_with_feedback
-    create(:completed_application_form, :with_feedback_completed, submitted_at: Time.zone.now)
+    create(:completed_application_form, feedback_satisfaction_level: 'very_satisfied', submitted_at: Time.zone.now)
   end
 
   describe '#formatted_response_rate' do


### PR DESCRIPTION
## Context
It was noticed that the info on the Feature Metrics Dashboard for Satisfaction Survey
did not represent stats. 

## Changes proposed in this pull request

This PR corrects the scope of the query to only look for the
presence of feedback_atisfaction_level for unique candidates.

## Guidance to review

check the scope of the query makes sense.

## Link to Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
