### PR TITLE
Add action views to withdraw application at candidates request

### DIFF
--- a/app/controllers/provider_interface/decline_or_withdraw_controller.rb
+++ b/app/controllers/provider_interface/decline_or_withdraw_controller.rb
@@ -1,0 +1,27 @@
+module ProviderInterface
+  class DeclineOrWithdrawController < ProviderInterfaceController
+    before_action :render_404_unless_feature_flag_active
+    before_action :set_application_choice
+    before_action :requires_make_decisions_permission
+
+    def edit; end
+
+    def update
+      service = DeclineOrWithdrawApplication.new(actor: current_provider_user, application_choice: @application_choice)
+
+      if service.save!
+        flash[:success] = 'Application withdrawn'
+        redirect_to provider_interface_application_choice_path(@application_choice)
+      else
+        flash[:warning] = 'Could not withdraw application'
+        render :edit
+      end
+    end
+
+  private
+
+    def render_404_unless_feature_flag_active
+      render_404 unless FeatureFlag.active?(:withdraw_at_candidates_request)
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -35,6 +35,7 @@ class FeatureFlag
     [:reference_selection, 'Allow candidates to receive multiple references and then select which two are added to their application', 'Malcolm Baig'],
     [:new_provider_user_flow, 'New flow for creating or updating a single ProviderUser and adding Provider users in bulk', 'Toby Retallick'],
     [:individual_offer_conditions, 'Enables individual offer condition management', 'Despo Pentara'],
+    [:withdraw_at_candidates_request, "Allows providers to withdraw an application at the candidate's request", 'Steve Laing'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/services/provider_interface/decline_or_withdraw_application.rb
+++ b/app/services/provider_interface/decline_or_withdraw_application.rb
@@ -1,0 +1,56 @@
+module ProviderInterface
+  class DeclineOrWithdrawApplication
+    def initialize(actor:, application_choice:)
+      @actor = actor
+      @application_choice = application_choice
+      @resolve_ucas_match = withdrawing?
+    end
+
+    def save!
+      return false unless declining? || withdrawing?
+
+      auth.assert_can_make_decisions!(application_choice: @application_choice, course_option: @application_choice.course_option)
+
+      transition = declining? ? :declined : :withdrawn
+
+      ActiveRecord::Base.transaction do
+        if declining?
+          ApplicationStateChange.new(@application_choice).decline!
+          @application_choice.update!(declined_at: Time.zone.now)
+        elsif withdrawing?
+          ApplicationStateChange.new(@application_choice).withdraw!
+          @application_choice.update!(withdrawn_at: Time.zone.now)
+          SetDeclineByDefault.new(application_form: @application_choice.application_form).call
+        end
+      end
+
+      if @application_choice.application_form.ended_without_success?
+        StateChangeNotifier.new(transition, @application_choice).application_outcome_notification
+      end
+
+      # TODO: Email candidate.
+
+      ResolveUCASMatch.new(application_choice: @application_choice).call if resolve_ucas_match?
+    end
+
+  private
+
+    attr_reader :application_choice
+
+    def declining?
+      application_choice.offer?
+    end
+
+    def withdrawing?
+      ApplicationStateChange.new(application_choice).can_withdraw?
+    end
+
+    def resolve_ucas_match?
+      @resolve_ucas_match
+    end
+
+    def auth
+      @auth ||= ProviderAuthorisation.new(actor: @actor)
+    end
+  end
+end

--- a/app/services/provider_interface/decline_or_withdraw_application.rb
+++ b/app/services/provider_interface/decline_or_withdraw_application.rb
@@ -9,7 +9,7 @@ module ProviderInterface
     def save!
       return false unless declining? || withdrawing?
 
-      auth.assert_can_make_decisions!(application_choice: @application_choice, course_option: @application_choice.course_option)
+      auth.assert_can_make_decisions!(application_choice: @application_choice, course_option: @application_choice.current_course_option)
 
       transition = declining? ? :declined : :withdrawn
 
@@ -31,6 +31,8 @@ module ProviderInterface
       # TODO: Email candidate.
 
       ResolveUCASMatch.new(application_choice: @application_choice).call if resolve_ucas_match?
+
+      true
     end
 
   private

--- a/app/services/resolve_ucas_match.rb
+++ b/app/services/resolve_ucas_match.rb
@@ -1,0 +1,13 @@
+class ResolveUCASMatch
+  def initialize(application_choice:)
+    @application_choice = application_choice
+  end
+
+  def call
+    match = UCASMatches::RetrieveForApplicationChoice.new(@application_choice).call
+
+    if match&.ready_to_resolve? && match&.duplicate_applications_withdrawn_from_apply?
+      UCASMatches::ResolveOnApply.new(match).call
+    end
+  end
+end

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -17,7 +17,7 @@ class WithdrawApplication
 
     send_email_notification_to_provider_users(application_choice)
 
-    resolve_ucas_match(application_choice)
+    ResolveUCASMatch.new(application_choice: application_choice).call
   end
 
 private
@@ -27,14 +27,6 @@ private
   def send_email_notification_to_provider_users(application_choice)
     NotificationsList.for(application_choice, event: :application_withdrawn, include_ratifying_provider: true).each do |provider_user|
       ProviderMailer.application_withdrawn(provider_user, application_choice).deliver_later
-    end
-  end
-
-  def resolve_ucas_match(application_choice)
-    match = UCASMatches::RetrieveForApplicationChoice.new(application_choice).call
-
-    if match&.ready_to_resolve? && match&.duplicate_applications_withdrawn_from_apply?
-      UCASMatches::ResolveOnApply.new(match).call
     end
   end
 end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -11,6 +11,13 @@
     <%= render ProviderInterface::ApplicationSummaryComponent.new(application_form: @application_choice.application_form) %>
 
     <p class="govuk-body govuk-!-display-none-print">
+      <% if FeatureFlag.active?(:withdraw_at_candidates_request) && @provider_can_respond %>
+        <%= govuk_link_to(
+          "Withdraw at candidate's request",
+          provider_interface_decline_or_withdraw_edit_path(@application_choice),
+          class: 'govuk-!-margin-right-2',
+        ) %>
+      <% end %>
       <%= govuk_link_to(
         'Download application (PDF)',
         provider_interface_application_choice_path(@application_choice.id, format: :pdf),

--- a/app/views/provider_interface/decline_or_withdraw/edit.html.erb
+++ b/app/views/provider_interface/decline_or_withdraw/edit.html.erb
@@ -1,0 +1,15 @@
+<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
+    <h1 class="govuk-heading-l">Confirm that the candidate wants to withdraw their application</h1>
+
+    <p class="govuk-body">The candidate will be told that their application has been withdrawn.</p>
+
+    <%= form_with url: provider_interface_decline_or_withdraw_update_path(@application_choice), method: :put do |f| %>
+      <%= f.govuk_submit 'Withdraw application' %>
+    <% end %>
+    <p class="govuk-body"><%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice) %></p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -691,6 +691,9 @@ Rails.application.routes.draw do
       get '/rejection-reasons/check' => 'reasons_for_rejection#check', as: :reasons_for_rejection_check
       post '/rejection-reasons/commit' => 'reasons_for_rejection#commit', as: :reasons_for_rejection_commit
 
+      get '/decline-or-withdraw' => 'decline_or_withdraw#edit', as: :decline_or_withdraw_edit
+      put '/decline-or-withdraw' => 'decline_or_withdraw#update', as: :decline_or_withdraw_update
+
       resources :notes, only: %i[index show new create], as: :application_choice_notes
 
       resources :interviews, only: %i[new edit index], as: :application_choice_interviews do

--- a/spec/services/provider_interface/decline_or_withdraw_application_spec.rb
+++ b/spec/services/provider_interface/decline_or_withdraw_application_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::DeclineOrWithdrawApplication do
+  describe '#save!' do
+    let(:resolver) { instance_double(ResolveUCASMatch, call: true) }
+
+    before { allow(ResolveUCASMatch).to receive(:new).and_return(resolver) }
+
+    it 'declines applications which are under offer' do
+      application_choice = create(:application_choice, :with_offer)
+      provider = application_choice.course_option.provider
+      permitted_user = create(:provider_user, :with_make_decisions, providers: [provider])
+
+      expect(described_class.new(application_choice: application_choice, actor: permitted_user).save!).to be true
+
+      expect(application_choice.reload.declined_at).not_to be nil
+      expect(application_choice).to be_declined
+      expect(application_choice).not_to be_withdrawn
+      expect(ResolveUCASMatch).not_to have_received(:new)
+    end
+
+    it 'withdraws applications which are withdrawable' do
+      application_choice = create(:application_choice, :awaiting_provider_decision)
+      provider = application_choice.course_option.provider
+      permitted_user = create(:provider_user, :with_make_decisions, providers: [provider])
+
+      expect(described_class.new(application_choice: application_choice, actor: permitted_user).save!).to be true
+
+      expect(application_choice.reload.withdrawn_at).not_to be nil
+      expect(application_choice).to be_withdrawn
+      expect(application_choice).not_to be_declined
+    end
+
+    it 'resolves UCAS matches when withdrawing' do
+      application_choice = create(:application_choice, :awaiting_provider_decision)
+      provider = application_choice.course_option.provider
+      permitted_user = create(:provider_user, :with_make_decisions, providers: [provider])
+
+      described_class.new(application_choice: application_choice, actor: permitted_user).save!
+
+      expect(ResolveUCASMatch).to have_received(:new).with(application_choice: application_choice)
+      expect(resolver).to have_received(:call)
+    end
+
+    it 'returns false when the application is not under offer and is not withdrawable' do
+      application_choice = create(:application_choice, :withdrawn)
+      provider = application_choice.course_option.provider
+      permitted_user = create(:provider_user, :with_make_decisions, providers: [provider])
+
+      expect(described_class.new(application_choice: application_choice, actor: permitted_user).save!).to be false
+    end
+
+    it 'raises when the provider user cannot make decisions' do
+      application_choice = create(:application_choice, :awaiting_provider_decision)
+      provider = application_choice.course_option.provider
+      user = create(:provider_user, providers: [provider])
+
+      expect {
+        described_class.new(application_choice: application_choice, actor: user).save!
+      }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
+    end
+  end
+end

--- a/spec/services/resolve_ucas_match_spec.rb
+++ b/spec/services/resolve_ucas_match_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe ResolveUCASMatch do
+  describe '#call' do
+    let(:application_choice) { build_stubbed(:application_choice) }
+    let(:ucas_match) do
+      instance_double(
+        UCASMatch,
+        ready_to_resolve?: ready_to_resolve,
+        duplicate_applications_withdrawn_from_apply?: duplicate_applications_withdrawn,
+      )
+    end
+    let(:ucas_match_retriever) { instance_double(UCASMatches::RetrieveForApplicationChoice, call: ucas_match) }
+    let(:ucas_match_resolver) { instance_double(UCASMatches::ResolveOnApply, call: true) }
+    let(:ready_to_resolve) { true }
+    let(:duplicate_applications_withdrawn) { true }
+
+    before do
+      allow(UCASMatches::RetrieveForApplicationChoice).to receive(:new).and_return(ucas_match_retriever)
+      allow(UCASMatches::ResolveOnApply).to receive(:new).and_return(ucas_match_resolver)
+    end
+
+    it 'retrieves a UCAS Match for the application choice and resolves on apply' do
+      described_class.new(application_choice: application_choice).call
+
+      expect(UCASMatches::RetrieveForApplicationChoice).to have_received(:new).with(application_choice)
+      expect(ucas_match_retriever).to have_received(:call)
+
+      expect(UCASMatches::ResolveOnApply).to have_received(:new).with(ucas_match)
+      expect(ucas_match_resolver).to have_received(:call)
+    end
+
+    context 'when the ucas match does not need resolving' do
+      let(:ready_to_resolve) { false }
+
+      it 'does not call the resolving service' do
+        described_class.new(application_choice: application_choice).call
+
+        expect(ucas_match_resolver).not_to have_received(:call)
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/withdraw_an_application_at_candidates_request_spec.rb
+++ b/spec/system/provider_interface/withdraw_an_application_at_candidates_request_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe "withdrawing an application at the candidate's request", type: :feature do
+  include DfESignInHelpers
+  include CourseOptionHelpers
+
+  scenario 'A provider user withdraws an application at the request of a candidate' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_the_withdraw_at_candidates_request_feature_flag_is_enabled
+    and_i_am_permitted_to_make_decisions_for_my_provider
+    and_my_organisation_has_received_an_application
+    and_i_sign_in_to_the_provider_interface
+    when_i_visit_a_submitted_application
+    and_i_click_a_link_to_withdraw_at_candidates_request
+    and_i_confirm_the_withdrawal
+    then_i_see_a_message_confirming_that_the_application_has_been_withdrawn
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_the_withdraw_at_candidates_request_feature_flag_is_enabled
+    FeatureFlag.activate(:withdraw_at_candidates_request)
+  end
+
+  def and_i_am_permitted_to_make_decisions_for_my_provider
+    @provider = create(:provider, :with_signed_agreement)
+    @provider_user = create(:provider_user, :with_make_decisions, providers: [@provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+  end
+
+  def and_my_organisation_has_received_an_application
+    course_option = course_option_for_provider_code(provider_code: @provider.code)
+    @application_choice = create(:submitted_application_choice, :with_completed_application_form, course_option: course_option)
+  end
+
+  def and_i_sign_in_to_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def when_i_visit_a_submitted_application
+    visit provider_interface_application_choice_path(@application_choice)
+  end
+
+  def and_i_click_a_link_to_withdraw_at_candidates_request
+    click_on "Withdraw at candidate's request"
+  end
+
+  def and_i_confirm_the_withdrawal
+    expect(page).to have_content('Confirm that the candidate wants to withdraw their application')
+
+    click_on 'Withdraw application'
+  end
+
+  def then_i_see_a_message_confirming_that_the_application_has_been_withdrawn
+    expect(page).to have_current_path(provider_interface_application_choice_path(@application_choice))
+    expect(page).to have_content('Application withdrawn')
+  end
+end


### PR DESCRIPTION
## Context

We would like to allow provider users to decline or withdraw applications at the candidates request.

## Changes proposed in this pull request

A new link has been added on the application details page allowing permitted users to withdraw or decline applications at the candidates request. The link takes them to a confirmation screen which they must confirm before the withdrawal is complete. They are then redirected back to the application details page. 

## TODO

Emails will be completed in a subsequent PR.

## Link to Trello card

https://trello.com/c/1Dar5Ny0/3836-add-action-views-to-allow-providers-to-withdraw-application-on-candidates-request

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
