### PR TITLE
Allow CORS requests to our own hostname

### DIFF
--- a/config/initializers/asset_cache_headers.rb
+++ b/config/initializers/asset_cache_headers.rb
@@ -1,3 +1,4 @@
 Rails.application.config.public_file_server.headers = {
   'Cache-Control' => 'max-age=31536000, public, immutable',
+  'Access-Control-Allow-Origin' => "https://#{ENV['CUSTOM_HOSTNAME']}",
 }


### PR DESCRIPTION
Chrome requires CORS permission for font files - when we're addressing
the app via RAILS_ASSETS_HOST we need to permit the current domain in
Access-Control-Allow-Origin

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
