### PR TITLE
Stop writing to application_choice offer column

### DIFF
--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -24,7 +24,6 @@ class ChangeOffer
           update_conditions_service.save
 
           application_choice.current_course_option = course_option
-          application_choice.offer = { 'conditions' => update_conditions_service.conditions }
           application_choice.offer_changed_at = Time.zone.now
           application_choice.save!
 

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -26,7 +26,6 @@ class MakeOffer
           update_conditions_service.save
 
           application_choice.current_course_option = course_option
-          application_choice.offer = { 'conditions' => update_conditions_service.conditions }
           application_choice.offered_at = Time.zone.now
           application_choice.save!
 

--- a/app/services/update_accepted_offer_conditions.rb
+++ b/app/services/update_accepted_offer_conditions.rb
@@ -9,7 +9,6 @@ class UpdateAcceptedOfferConditions
     ActiveRecord::Base.transaction do
       conditions = @update_conditions_service.conditions
       @application_choice.update(
-        offer: { conditions: conditions },
         audit_comment: "Change offer condition Zendesk request: #{@audit_comment_ticket}",
       )
       @update_conditions_service.save


### PR DESCRIPTION
## Context
Now that we are no longer using the application_choice's offer column, we can stop writing to it so we can gradually transition to completely removing the column.

## Link to Trello card
https://trello.com/c/liORizFL/3759-stop-writing-to-applicationchoice-offer-column

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
