### PR TITLE
Add offer association to applicationchoice model

### DIFF
--- a/app/components/candidate_interface/application_dashboard_course_choices_component.rb
+++ b/app/components/candidate_interface/application_dashboard_course_choices_component.rb
@@ -205,6 +205,7 @@ module CandidateInterface
       @application_form
         .application_choices
         .includes(:course, :site, :provider, :current_course, :current_course_option, :interviews)
+        .includes(offer: :conditions)
         .order(id: :asc)
         .select { |ac| ac.status.to_sym.in?(ApplicationStateChange::ACCEPTED_STATES) }
     end
@@ -213,6 +214,7 @@ module CandidateInterface
       @application_form
         .application_choices
         .includes(:course, :site, :provider, :current_course, :current_course_option, :interviews)
+        .includes(offer: :conditions)
         .order(id: :asc)
     end
 

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -24,6 +24,7 @@ module VendorAPI
           providers: current_provider,
           vendor_api: true,
           includes: [
+            :offer,
             application_form: %i[candidate application_qualifications application_work_experiences application_work_history_breaks application_volunteering_experiences english_proficiency],
             course_option: [{ course: %i[provider] }, :site],
             current_course_option: [{ course: %i[provider] }, :site],

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -17,6 +17,7 @@ class ApplicationChoice < ApplicationRecord
   has_one :current_course, through: :current_course_option, source: :course
   has_one :current_provider, through: :current_course, source: :provider
   has_one :current_accredited_provider, through: :current_course, source: :accredited_provider
+  has_one :offer
 
   has_many :notes, dependent: :destroy
   has_many :interviews, dependent: :destroy
@@ -76,10 +77,6 @@ class ApplicationChoice < ApplicationRecord
     if offer? && dbd && dbd > Time.zone.now
       ((dbd - Time.zone.now) / 1.day).floor
     end
-  end
-
-  def offer
-    @offer ||= Offer.find_by(application_choice: self)
   end
 
   delegate :course_not_available?, to: :course_option

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -353,7 +353,7 @@ module VendorAPI
       return nil if application_choice.offer.nil?
 
       {
-        conditions: application_choice.offer.reload.conditions_text,
+        conditions: application_choice.offer.conditions_text,
         offer_made_at: application_choice.offered_at,
         offer_accepted_at: application_choice.accepted_at,
         offer_declined_at: application_choice.declined_at,

--- a/app/services/save_offer_conditions_from_text.rb
+++ b/app/services/save_offer_conditions_from_text.rb
@@ -1,14 +1,12 @@
 class SaveOfferConditionsFromText
-  attr_reader :application_choice, :conditions
+  attr_reader :offer, :conditions
 
   def initialize(application_choice:, conditions:)
-    @application_choice = application_choice
+    @offer = application_choice.offer || application_choice.build_offer
     @conditions = conditions
   end
 
   def save
-    offer = Offer.find_or_create_by(application_choice: application_choice)
-
     offer_conditions = conditions.map do |condition_text|
       offer.conditions.find_or_initialize_by(text: condition_text)
     end

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -165,31 +165,18 @@ FactoryBot.define do
       decline_by_default_at { 10.business_days.from_now }
       decline_by_default_days { 10 }
       offered_at { Time.zone.now }
-
-      after(:build) do |application_choice, _evaluator|
-        condition = build(:offer_condition, text: 'Be cool')
-        build(:offer, application_choice: application_choice, conditions: [condition])
-      end
+      association :offer
 
       after(:stub) do |application_choice, evaluator|
         if evaluator.offer.present?
           allow(application_choice).to receive(:offer).and_return(evaluator.offer)
+          allow(evaluator.offer).to receive(:conditions_text).and_return(evaluator.offer.conditions.map(&:text))
         else
           condition = build(:offer_condition, text: 'Be cool')
           offer = build(:offer, application_choice: application_choice, conditions: [condition])
           allow(application_choice).to receive(:offer).and_return(offer)
           allow(offer).to receive(:conditions_text).and_return(offer.conditions.map(&:text))
         end
-      end
-
-      after(:create) do |application_choice, evaluator|
-        if evaluator.offer.present?
-          evaluator.offer.update(application_choice: application_choice)
-        else
-          condition = build(:offer_condition, text: 'Be cool')
-          create(:offer, application_choice: application_choice, conditions: [condition])
-        end
-        application_choice
       end
     end
 

--- a/spec/factories/ucas_match.rb
+++ b/spec/factories/ucas_match.rb
@@ -67,7 +67,7 @@ FactoryBot.define do
     trait :with_multiple_acceptances do
       scheme { %w[U D] }
       application_form do
-        create(:completed_application_form, application_choices: [create(:application_choice, :with_accepted_offer)])
+        create(:completed_application_form, application_choices: [create(:application_choice, :pending_conditions)])
       end
       ucas_status { :pending_conditions }
     end

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe CandidateMailer, type: :mailer do
   let(:site) { build_stubbed(:site, name: 'Aquaria') }
   let(:other_option) { build_stubbed(:course_option, course: other_course, site: site) }
 
-  let(:offer) { build_stubbed(:application_choice, :with_offer, course_option: course_option) }
+  let(:offer) { build(:offer, conditions: [build(:offer_condition, text: 'Be cool')]) }
+  let(:other_offer) { build(:offer, conditions: [build(:offer_condition, text: 'Be even cooler')]) }
+  let(:application_choice_with_offer) { build_stubbed(:application_choice, :with_offer, offer: offer, course_option: course_option) }
   let(:awaiting_decision) { build_stubbed(:application_choice, :awaiting_provider_decision, course_option: other_option, current_course_option: other_option) }
   let(:interviewing) { build_stubbed(:application_choice, :awaiting_provider_decision, status: :interviewing, course_option: other_option, current_course_option: other_option) }
 
@@ -36,10 +38,10 @@ RSpec.describe CandidateMailer, type: :mailer do
 
   describe '.new_offer_single_offer' do
     let(:email) { mailer.new_offer_single_offer(application_choices.first) }
-    let(:application_choices) { [offer] }
+    let(:application_choices) { [application_choice_with_offer] }
 
     before do
-      allow(CourseOption).to receive(:find_by).with(id: offer.current_course_option_id).and_return(offer.current_course_option)
+      allow(CourseOption).to receive(:find_by).with(id: application_choice_with_offer.current_course_option_id).and_return(application_choice_with_offer.current_course_option)
     end
 
     it_behaves_like(
@@ -54,7 +56,7 @@ RSpec.describe CandidateMailer, type: :mailer do
     context 'when the provider offers the candidate a different course option' do
       let(:other_course) { build_stubbed(:course, name: 'Computer Science', code: 'X0FO', provider: other_provider) }
       let(:other_option) { build_stubbed(:course_option, course: other_course) }
-      let(:offer) { build_stubbed(:application_choice, :with_offer, current_course_option_id: other_option.id, course_option: course_option, current_course_option: other_option) }
+      let(:application_choice_with_offer) { build_stubbed(:application_choice, :with_offer, offer: offer, current_course_option_id: other_option.id, course_option: course_option, current_course_option: other_option) }
 
       it_behaves_like(
         'a mail with subject and content',
@@ -69,8 +71,8 @@ RSpec.describe CandidateMailer, type: :mailer do
 
   describe '.new_offer_multiple_offers' do
     let(:email) { mailer.new_offer_multiple_offers(application_choices.first) }
-    let(:other_offer) { build_stubbed(:application_choice, :with_offer, course_option: other_option) }
-    let(:application_choices) { [offer, other_offer] }
+    let(:application_choice_with_other_offer) { build_stubbed(:application_choice, :with_offer, offer: other_offer, course_option: other_option) }
+    let(:application_choices) { [application_choice_with_offer, application_choice_with_other_offer] }
 
     it_behaves_like(
       'a mail with subject and content',
@@ -86,7 +88,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
   describe '.new_offer_decisions_pending' do
     let(:email) { mailer.new_offer_decisions_pending(application_choices.first) }
-    let(:application_choices) { [offer, awaiting_decision] }
+    let(:application_choices) { [application_choice_with_offer, awaiting_decision] }
 
     it_behaves_like(
       'a mail with subject and content',
@@ -150,7 +152,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       let(:email) { mailer.application_rejected_one_offer_one_awaiting_decision(application_choices.first) }
 
       context 'with an awaiting decision application' do
-        let(:application_choices) { [rejected, offer, awaiting_decision] }
+        let(:application_choices) { [rejected, application_choice_with_offer, awaiting_decision] }
 
         it_behaves_like(
           'a mail with subject and content',
@@ -168,7 +170,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       end
 
       context 'with an interviewing application' do
-        let(:application_choices) { [rejected, offer, interviewing] }
+        let(:application_choices) { [rejected, application_choice_with_offer, interviewing] }
 
         it_behaves_like(
           'a mail with subject and content',
@@ -204,7 +206,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     describe '.application_rejected_offers_only' do
       let(:email) { mailer.application_rejected_offers_only(application_choices.first) }
-      let(:application_choices) { [rejected, offer, offer] }
+      let(:application_choices) { [rejected, application_choice_with_offer, application_choice_with_offer] }
 
       it_behaves_like(
         'a mail with subject and content',
@@ -235,7 +237,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
   describe '.deferred_offer' do
     let(:email) { mailer.deferred_offer(application_choices.first) }
-    let(:application_choices) { [offer] }
+    let(:application_choices) { [application_choice_with_offer] }
 
     before do
       magic_link_stubbing(application_form.candidate)
@@ -254,7 +256,7 @@ RSpec.describe CandidateMailer, type: :mailer do
   describe '.reinstated_offer' do
     let(:email) { mailer.reinstated_offer(application_choices.first) }
     let(:application_choices) { [application_choice] }
-    let(:application_choice) { build_stubbed(:application_choice, :with_deferred_offer, course_option: other_option, current_course_option: other_option, offer_deferred_at: Time.zone.local(2019, 10, 3)) }
+    let(:application_choice) { build_stubbed(:application_choice, :with_deferred_offer, offer: offer, course_option: other_option, current_course_option: other_option, offer_deferred_at: Time.zone.local(2019, 10, 3)) }
     let(:other_course) do
       build_stubbed :course, name: 'Forensic Science',
                              code: 'E0FO',

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -397,7 +397,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
         'offer_accepted_at' => nil,
         'offer_declined_at' => nil,
       )
-      expect(choice.offer.conditions.map(&:text)).to eq(['Change your sheets', 'Wash your clothes'])
+      expect(choice.offer.reload.conditions_text).to eq(['Change your sheets', 'Wash your clothes'])
     end
 
     it 'returns 200 OK when sending the same offer & conditions repeatedly' do
@@ -408,7 +408,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       request_body = {
         "data": {
-          "conditions": choice.offer.conditions.map(&:text),
+          "conditions": choice.offer.conditions_text,
           "course": course_option_to_course_payload(choice.course_option),
         },
       }

--- a/spec/services/provider_interface/sort_application_choices_spec.rb
+++ b/spec/services/provider_interface/sort_application_choices_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe ProviderInterface::SortApplicationChoices do
         # --- 999
         create(:application_choice, :offer, status: 'offer_withdrawn'),
         # --- 10
-        create(:application_choice, :with_deferred_offer),
+        create(:application_choice, :offer_deferred),
         # --- 9
         create(:application_choice, :recruited),
         # --- 8
@@ -135,7 +135,7 @@ RSpec.describe ProviderInterface::SortApplicationChoices do
         create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 5.business_days.from_now),
         create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 5.business_days.from_now), # has more recent updated_at, will appear first
         # --- 1
-        create(:application_choice, :with_deferred_offer, :previous_year),
+        create(:application_choice, :offer_deferred, :previous_year),
       ]
     end
 


### PR DESCRIPTION
## Context
Add and utilise `offer` association on application_choice

Removing the `offer` column at the moment is a bit problematic as we use it as a placeholder in order to enable easier factory creation. Doing this task prior to dropping the column enables us to achieve that easier.

## Changes proposed in this pull request
- Add `offer` association to `application_choice`
- Resolve broken specs

## Link to Trello card

https://trello.com/c/Cn4e6z2P/3814-add-offer-association-to-applicationchoice-model

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
