### PR TITLE
Hide Organisation permissions that have not been set up

### DIFF
--- a/app/components/provider_interface/organisation_list_component.html.erb
+++ b/app/components/provider_interface/organisation_list_component.html.erb
@@ -1,0 +1,32 @@
+<% ratifying_permissions.each do |permissions| %>
+  <div class="app-banner govuk-!-margin-bottom-4">
+    <div class="app-banner__message">
+      <% if permissions.setup_at.blank? %>
+        <p>
+          <%= permissions.training_provider.name %> have not set up permissions yet - only they can set up permissions. Contact them to do this.
+        </p>
+
+        <p>
+          Staff at <%= permissions.ratifying_provider.name %> can still view applications in the meantime.
+        </p>
+      <% else %>
+        Only <%= permissions.training_provider.name %> can change permissions because they run the courses. Contact them to change these settings.
+      <% end %>
+    </div>
+  </div>
+
+  <%= render ProviderInterface::ProviderRelationshipPermissionsListComponent.new(
+    permissions_model: permissions,
+    change_link_builder: ProviderInterface::ProviderRelationshipEditChangeLinkBuilder,
+    editable: false,
+  ) %>
+<% end %>
+
+<% training_permissions.each do |permissions| %>
+  <%= render ProviderInterface::ProviderRelationshipPermissionsListComponent.new(
+    permissions_model: permissions,
+    change_link_builder: ProviderInterface::ProviderRelationshipEditChangeLinkBuilder,
+    editable: current_provider_user.can_manage_organisations?,
+    heading_level: 2,
+  ) %>
+<% end %>

--- a/app/components/provider_interface/organisation_list_component.rb
+++ b/app/components/provider_interface/organisation_list_component.rb
@@ -1,0 +1,22 @@
+module ProviderInterface
+  class OrganisationListComponent < ViewComponent::Base
+    attr_accessor :training_permissions, :ratifying_permissions, :current_provider_user
+
+    def initialize(provider:,  current_provider_user:)
+      @current_provider_user = current_provider_user
+      @training_permissions = ProviderRelationshipPermissions.where(training_provider: provider)
+        .or(ProviderRelationshipPermissions.where(training_provider: all_manageable_providers, ratifying_provider: provider))
+        .where.not(setup_at: nil)
+        .includes(:training_provider)
+      @ratifying_permissions = ProviderRelationshipPermissions.where(ratifying_provider: provider)
+        .where.not(training_provider: all_manageable_providers)
+        .includes(:training_provider, :ratifying_provider)
+    end
+
+  private
+
+    def all_manageable_providers
+      current_provider_user.authorisation.providers_that_actor_can_manage_organisations_for
+    end
+  end
+end

--- a/app/controllers/provider_interface/organisations_controller.rb
+++ b/app/controllers/provider_interface/organisations_controller.rb
@@ -3,12 +3,13 @@ module ProviderInterface
     before_action :render_403_unless_organisation_valid_for_user, only: :show
 
     def index
-      @manageable_providers = current_provider_user.authorisation.providers_that_actor_can_manage_organisations_for(with_set_up_permissions: true)
+      @manageable_providers = manageable_providers
     end
 
     def show
       @training_permissions = ProviderRelationshipPermissions.where(training_provider_id: params[:id])
         .or(ProviderRelationshipPermissions.where(training_provider_id: manageable_providers, ratifying_provider_id: params[:id]))
+        .where.not(setup_at: nil)
         .includes(:training_provider)
 
       @ratifying_permissions = ProviderRelationshipPermissions.where(ratifying_provider_id: params[:id])
@@ -18,7 +19,7 @@ module ProviderInterface
   private
 
     def manageable_providers
-      @_manageable_providers ||= current_provider_user.authorisation.providers_that_actor_can_manage_organisations_for
+      @_manageable_providers ||= current_provider_user.authorisation.providers_that_actor_can_manage_organisations_for(with_set_up_permissions: true)
     end
 
     def render_403_unless_organisation_valid_for_user

--- a/app/controllers/provider_interface/organisations_controller.rb
+++ b/app/controllers/provider_interface/organisations_controller.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     before_action :render_403_unless_organisation_valid_for_user, only: :show
 
     def index
-      @manageable_providers = manageable_providers
+      @manageable_providers = current_provider_user.authorisation.providers_that_actor_can_manage_organisations_for(with_set_up_permissions: true)
     end
 
     def show

--- a/app/controllers/provider_interface/organisations_controller.rb
+++ b/app/controllers/provider_interface/organisations_controller.rb
@@ -6,15 +6,7 @@ module ProviderInterface
       @manageable_providers = manageable_providers
     end
 
-    def show
-      @training_permissions = ProviderRelationshipPermissions.where(training_provider_id: params[:id])
-        .or(ProviderRelationshipPermissions.where(training_provider_id: manageable_providers, ratifying_provider_id: params[:id]))
-        .where.not(setup_at: nil)
-        .includes(:training_provider)
-
-      @ratifying_permissions = ProviderRelationshipPermissions.where(ratifying_provider_id: params[:id])
-        .includes(:training_provider, :ratifying_provider) - @training_permissions
-    end
+    def show; end
 
   private
 

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -23,15 +23,14 @@ class ProviderAuthorisation
   def providers_that_actor_can_manage_organisations_for(with_set_up_permissions: false)
     scope = ProviderRelationshipPermissions
      .where(training_provider: @actor.providers)
-     .or(
-       ProviderRelationshipPermissions.where(
-         ratifying_provider_id: @actor.providers,
-       ),
-     )
 
     scope = scope.where.not(setup_at: nil) if with_set_up_permissions
 
-    provider_ids = scope.pluck(:ratifying_provider_id, :training_provider_id).flatten
+    provider_ids = scope.or(
+      ProviderRelationshipPermissions.where(
+        ratifying_provider_id: @actor.providers,
+      ),
+    ).pluck(:ratifying_provider_id, :training_provider_id).flatten
 
     manageable_provider_ids = ProviderPermissions
       .where(provider_id: provider_ids, provider_user: @actor, manage_organisations: true)

--- a/app/views/provider_interface/account/show.html.erb
+++ b/app/views/provider_interface/account/show.html.erb
@@ -38,7 +38,7 @@
       </ul>
     <% end %>
 
-    <% if current_provider_user.authorisation.can_manage_organisations_for_at_least_one_provider? %>
+    <% if current_provider_user.authorisation.can_manage_organisations_for_at_least_one_setup_provider? %>
       <h2 class="govuk-heading-m">
         <%= govuk_link_to t('page_titles.provider.org_permissions'), provider_interface_organisations_path %>
       </h2>

--- a/app/views/provider_interface/organisations/show.html.erb
+++ b/app/views/provider_interface/organisations/show.html.erb
@@ -12,37 +12,6 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l"><%= t('page_titles.provider.org_permissions') %></span>
     <h1 class="govuk-heading-l"><%= @provider.name %></h1>
-    <% @ratifying_permissions.each do |permissions| %>
-      <div class="app-banner govuk-!-margin-bottom-4">
-        <div class="app-banner__message">
-          <% if permissions.setup_at.blank? %>
-            <p>
-              <%= permissions.training_provider.name %> have not set up permissions yet - only they can set up permissions. Contact them to do this.
-            </p>
-
-            <p>
-              Staff at <%= permissions.ratifying_provider.name %> can still view applications in the meantime.
-            </p>
-          <% else %>
-            Only <%= permissions.training_provider.name %> can change permissions because they run the courses. Contact them to change these settings.
-          <% end %>
-        </div>
-      </div>
-
-      <%= render ProviderInterface::ProviderRelationshipPermissionsListComponent.new(
-        permissions_model: permissions,
-        change_link_builder: ProviderInterface::ProviderRelationshipEditChangeLinkBuilder,
-        editable: false,
-      ) %>
-    <% end %>
-
-    <% @training_permissions.each do |permissions| %>
-      <%= render ProviderInterface::ProviderRelationshipPermissionsListComponent.new(
-        permissions_model: permissions,
-        change_link_builder: ProviderInterface::ProviderRelationshipEditChangeLinkBuilder,
-        editable: current_provider_user.can_manage_organisations?,
-        heading_level: 2,
-      ) %>
-    <% end %>
+    <%= render ProviderInterface::OrganisationListComponent.new(provider: @provider, current_provider_user: current_provider_user) %>
   </div>
 </div>

--- a/spec/components/provider_interface/organisation_list_component_spec.rb
+++ b/spec/components/provider_interface/organisation_list_component_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::OrganisationListComponent do
+  let(:provider) { create(:provider) }
+  let(:providers_user_belongs_to) { [] }
+  let(:provider_user) { create(:provider_user, providers: providers_user_belongs_to) }
+  let(:render) { render_inline(described_class.new(provider: provider, current_provider_user: provider_user)) }
+
+  context 'user cannot manage organisations' do
+    context 'with set up ratifying providers permissions' do
+      let!(:permission) do
+        create(
+          :provider_relationship_permissions,
+          ratifying_provider: provider,
+        )
+      end
+
+      it 'renders text for uneditable permissions' do
+        expect(render.text).to include("Only #{permission.training_provider.name} can change permissions")
+      end
+    end
+
+    context 'with ratifying providers not set up' do
+      let!(:permission) do
+        create(
+          :provider_relationship_permissions,
+          ratifying_provider: provider,
+          setup_at: nil,
+        )
+      end
+
+      it 'renders text for non set up permissions' do
+        expect(render.text).to include("#{permission.training_provider.name} have not set up permissions yet")
+      end
+    end
+  end
+
+  context 'user can manage organisations' do
+    let(:provider_user) { create(:provider_user, :with_manage_organisations, providers: providers_user_belongs_to) }
+
+    context 'with set up training providers' do
+      let(:providers_user_belongs_to) { [provider] }
+      let!(:permission) do
+        create(
+          :provider_relationship_permissions,
+          training_provider: provider,
+        )
+      end
+
+      it 'renders text for editable permissions' do
+        expect(render.text).to include("#{permission.training_provider.name} and #{permission.ratifying_provider.name}")
+      end
+    end
+
+    context 'with set up ratifying providers' do
+      let(:providers_user_belongs_to) { [provider, training_provider] }
+      let(:training_provider) { create(:provider) }
+      let!(:permission) do
+        create(
+          :provider_relationship_permissions,
+          training_provider: training_provider,
+          ratifying_provider: provider,
+        )
+      end
+
+      it 'renders text for editable permissions' do
+        expect(render.text).to include("#{permission.training_provider.name} and #{permission.ratifying_provider.name}")
+      end
+
+      it 'does not render text for non editable permissions' do
+        expect(render.text).not_to include("Only #{permission.training_provider.name} can change permissions")
+      end
+    end
+
+    context 'with training providers not set up' do
+      let(:providers_user_belongs_to) { [provider] }
+      let!(:permission) do
+        create(
+          :provider_relationship_permissions,
+          training_provider: provider,
+          setup_at: nil,
+        )
+      end
+
+      it 'does not render text for editable permissions' do
+        expect(render.text).not_to include("#{permission.training_provider.name} and #{permission.ratifying_provider.name}")
+      end
+    end
+
+    context 'with ratifying providers not set up' do
+      let(:providers_user_belongs_to) { [provider, training_provider] }
+      let(:training_provider) { create(:provider) }
+      let!(:permission) do
+        create(
+          :provider_relationship_permissions,
+          training_provider: training_provider,
+          ratifying_provider: provider,
+          setup_at: nil,
+        )
+      end
+
+      it 'does not render text for editable permissions' do
+        expect(render.text).not_to include("#{permission.training_provider.name} and #{permission.ratifying_provider.name}")
+      end
+
+      it 'does not render text for non set up permissions' do
+        expect(render.text).not_to include("#{permission.training_provider.name} have not set up permissions yet")
+      end
+    end
+  end
+end

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -521,21 +521,11 @@ RSpec.describe ProviderAuthorisation do
     end
 
     context 'when filtering out training provider permissions that have not been set up' do
+      let(:training_provider) { create(:provider) }
+      let(:ratifying_provider) { create(:provider) }
+
       it 'only returns providers with permissions that do not have setup_at set to nil' do
-        a_provider = create(:provider)
-        training_provider = create(:provider)
-        ratifying_provider = create(:provider)
-
-        provider_user = create(:provider_user, providers: [training_provider, ratifying_provider, a_provider])
-
-        # The user will have manage_organisations for a_provider but it has
-        # no relationships so it should not be returned.
-        ProviderPermissions.find_by(
-          provider_user: provider_user,
-          provider: a_provider,
-        ).update!(
-          manage_organisations: true,
-        )
+        provider_user = create(:provider_user, providers: [training_provider])
 
         # there is a relationship to manage between these two providers...
         create(:provider_relationship_permissions,
@@ -556,9 +546,6 @@ RSpec.describe ProviderAuthorisation do
       end
 
       it 'does not filter out ratifying provider relationships which are not set up' do
-        training_provider = create(:provider)
-        ratifying_provider = create(:provider)
-
         provider_user = create(:provider_user, providers: [ratifying_provider])
 
         ProviderPermissions.find_by(

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -520,38 +520,62 @@ RSpec.describe ProviderAuthorisation do
         .to eq([training_provider])
     end
 
-    it 'only returns permissions that do not have setup_at set to nil' do
-      a_provider = create(:provider)
-      training_provider = create(:provider)
-      ratifying_provider = create(:provider)
+    context 'when filtering out training provider permissions that have not been set up' do
+      it 'only returns providers with permissions that do not have setup_at set to nil' do
+        a_provider = create(:provider)
+        training_provider = create(:provider)
+        ratifying_provider = create(:provider)
 
-      provider_user = create(:provider_user, providers: [training_provider, ratifying_provider, a_provider])
+        provider_user = create(:provider_user, providers: [training_provider, ratifying_provider, a_provider])
 
-      # The user will have manage_organisations for a_provider but it has
-      # no relationships so it should not be returned.
-      ProviderPermissions.find_by(
-        provider_user: provider_user,
-        provider: a_provider,
+        # The user will have manage_organisations for a_provider but it has
+        # no relationships so it should not be returned.
+        ProviderPermissions.find_by(
+          provider_user: provider_user,
+          provider: a_provider,
         ).update!(
-        manage_organisations: true,
+          manage_organisations: true,
         )
 
-      # there is a relationship to manage between these two providers...
-      create(:provider_relationship_permissions,
-             training_provider: training_provider,
-             ratifying_provider: ratifying_provider,
-             setup_at: nil)
+        # there is a relationship to manage between these two providers...
+        create(:provider_relationship_permissions,
+               training_provider: training_provider,
+               ratifying_provider: ratifying_provider,
+               setup_at: nil)
 
-      # ...but the user only has manage_organisations permissions for the training_provider.
-      ProviderPermissions.find_by(
-        provider_user: provider_user,
-        provider: training_provider,
+        # ...but the user only has manage_organisations permissions for the training_provider.
+        ProviderPermissions.find_by(
+          provider_user: provider_user,
+          provider: training_provider,
         ).update!(
-        manage_organisations: true,
+          manage_organisations: true,
         )
 
-      expect(ProviderAuthorisation.new(actor: provider_user).providers_that_actor_can_manage_organisations_for(with_set_up_permissions: true))
-        .to eq([])
+        expect(ProviderAuthorisation.new(actor: provider_user).providers_that_actor_can_manage_organisations_for(with_set_up_permissions: true))
+          .to eq([])
+      end
+
+      it 'does not filter out ratifying provider relationships which are not set up' do
+        training_provider = create(:provider)
+        ratifying_provider = create(:provider)
+
+        provider_user = create(:provider_user, providers: [ratifying_provider])
+
+        ProviderPermissions.find_by(
+          provider_user: provider_user,
+          provider: ratifying_provider,
+        ).update!(
+          manage_organisations: true,
+        )
+
+        create(:provider_relationship_permissions,
+               training_provider: training_provider,
+               ratifying_provider: ratifying_provider,
+               setup_at: nil)
+
+        expect(ProviderAuthorisation.new(actor: provider_user).providers_that_actor_can_manage_organisations_for(with_set_up_permissions: true))
+          .to eq([ratifying_provider])
+      end
     end
   end
 end

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -545,7 +545,7 @@ RSpec.describe ProviderAuthorisation do
           .to eq([])
       end
 
-      it 'does not filter out ratifying provider relationships which are not set up' do
+      it 'filters out ratifying provider relationships which are not set up' do
         provider_user = create(:provider_user, providers: [ratifying_provider])
 
         ProviderPermissions.find_by(
@@ -561,7 +561,7 @@ RSpec.describe ProviderAuthorisation do
                setup_at: nil)
 
         expect(ProviderAuthorisation.new(actor: provider_user).providers_that_actor_can_manage_organisations_for(with_set_up_permissions: true))
-          .to eq([ratifying_provider])
+          .to eq([])
       end
     end
   end

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -519,5 +519,39 @@ RSpec.describe ProviderAuthorisation do
       expect(ProviderAuthorisation.new(actor: provider_user).providers_that_actor_can_manage_organisations_for)
         .to eq([training_provider])
     end
+
+    it 'only returns permissions that do not have setup_at set to nil' do
+      a_provider = create(:provider)
+      training_provider = create(:provider)
+      ratifying_provider = create(:provider)
+
+      provider_user = create(:provider_user, providers: [training_provider, ratifying_provider, a_provider])
+
+      # The user will have manage_organisations for a_provider but it has
+      # no relationships so it should not be returned.
+      ProviderPermissions.find_by(
+        provider_user: provider_user,
+        provider: a_provider,
+        ).update!(
+        manage_organisations: true,
+        )
+
+      # there is a relationship to manage between these two providers...
+      create(:provider_relationship_permissions,
+             training_provider: training_provider,
+             ratifying_provider: ratifying_provider,
+             setup_at: nil)
+
+      # ...but the user only has manage_organisations permissions for the training_provider.
+      ProviderPermissions.find_by(
+        provider_user: provider_user,
+        provider: training_provider,
+        ).update!(
+        manage_organisations: true,
+        )
+
+      expect(ProviderAuthorisation.new(actor: provider_user).providers_that_actor_can_manage_organisations_for(with_set_up_permissions: true))
+        .to eq([])
+    end
   end
 end

--- a/spec/system/provider_interface/viewing_organisational_permissions.rb
+++ b/spec/system/provider_interface/viewing_organisational_permissions.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.feature 'Viewing organisational permissions' do
+  include DfESignInHelpers
+
+  scenario 'Provider user uses their account page with various permissions' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+
+    and_i_sign_in_to_the_provider_interface
+
+    given_i_can_manage_multiple_organisations_that_do_not_have_permissions_set_up
+
+    when_i_go_to_my_account
+    then_i_cannot_see_organisational_permissions
+
+    when_i_set_up_permissions_for_a_provider
+    and_i_go_to_my_account
+    then_i_can_see_organisational_permissions
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_user_exists_in_apply_database
+  end
+
+  def then_i_cannot_see_organisational_permissions
+    expect(page).to have_content(t('page_titles.provider.notifications'))
+    expect(page).not_to have_content(t('page_titles.provider.org_permissions'))
+  end
+
+  def then_i_can_see_organisational_permissions
+    expect(page).to have_content(t('page_titles.provider.org_permissions'))
+  end
+
+  def given_i_can_manage_multiple_organisations_that_do_not_have_permissions_set_up
+    @provider_user = ProviderUser.last
+
+    training_provider = Provider.find_by(code: 'ABC')
+    ratifying_provider = Provider.find_by(code: 'DEF')
+    another_ratifying_provider = create(:provider, :with_signed_agreement, code: 'GHI', name: 'Example Provider')
+    @provider_user.providers << another_ratifying_provider
+
+    @permission_one = create(
+      :provider_relationship_permissions,
+      training_provider: training_provider,
+      ratifying_provider: ratifying_provider,
+      setup_at: nil,
+      )
+
+    @permission_two = create(
+      :provider_relationship_permissions,
+      training_provider: training_provider,
+      ratifying_provider: another_ratifying_provider,
+      setup_at: nil,
+      )
+
+    @provider_user.provider_permissions.update_all(manage_organisations: true)
+  end
+
+  def when_i_set_up_permissions_for_a_provider
+    @permission_one.update(setup_at: Time.zone.now)
+  end
+
+  def when_i_go_to_my_account
+    click_on t('page_titles.provider.account')
+  end
+
+  alias_method :and_i_go_to_my_account, :when_i_go_to_my_account
+end

--- a/spec/system/provider_interface/viewing_organisational_permissions.rb
+++ b/spec/system/provider_interface/viewing_organisational_permissions.rb
@@ -16,6 +16,9 @@ RSpec.feature 'Viewing organisational permissions' do
     when_i_set_up_permissions_for_a_provider
     and_i_go_to_my_account
     then_i_can_see_organisational_permissions
+
+    when_i_go_to_organisational_permissions
+    then_i_can_see_organisations_with_setup_permissions
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -35,26 +38,32 @@ RSpec.feature 'Viewing organisational permissions' do
   def given_i_can_manage_multiple_organisations_that_do_not_have_permissions_set_up
     @provider_user = ProviderUser.last
 
-    training_provider = Provider.find_by(code: 'ABC')
-    ratifying_provider = Provider.find_by(code: 'DEF')
-    another_ratifying_provider = create(:provider, :with_signed_agreement, code: 'GHI', name: 'Example Provider')
-    @provider_user.providers << another_ratifying_provider
+    @training_provider = Provider.find_by(code: 'ABC')
+    @ratifying_provider = Provider.find_by(code: 'DEF')
+    @another_ratifying_provider = create(:provider, :with_signed_agreement, code: 'GHI', name: 'Another Example Provider')
+    @provider_user.providers << @another_ratifying_provider
 
     @permission_one = create(
       :provider_relationship_permissions,
-      training_provider: training_provider,
-      ratifying_provider: ratifying_provider,
+      training_provider: @training_provider,
+      ratifying_provider: @ratifying_provider,
       setup_at: nil,
       )
 
     @permission_two = create(
       :provider_relationship_permissions,
-      training_provider: training_provider,
-      ratifying_provider: another_ratifying_provider,
+      training_provider: @training_provider,
+      ratifying_provider: @another_ratifying_provider,
       setup_at: nil,
       )
 
     @provider_user.provider_permissions.update_all(manage_organisations: true)
+  end
+
+  def then_i_can_see_organisations_with_setup_permissions
+    expect(page).to have_content("#{@training_provider.name}")
+    expect(page).to have_content("#{@ratifying_provider.name}")
+    expect(page).not_to have_content("#{@another_ratifying_provider.name}")
   end
 
   def when_i_set_up_permissions_for_a_provider
@@ -63,6 +72,10 @@ RSpec.feature 'Viewing organisational permissions' do
 
   def when_i_go_to_my_account
     click_on t('page_titles.provider.account')
+  end
+
+  def when_i_go_to_organisational_permissions
+    click_on 'Organisational permissions'
   end
 
   alias_method :and_i_go_to_my_account, :when_i_go_to_my_account

--- a/spec/system/provider_interface/viewing_organisational_permissions_spec.rb
+++ b/spec/system/provider_interface/viewing_organisational_permissions_spec.rb
@@ -22,6 +22,10 @@ RSpec.feature 'Viewing organisational permissions' do
 
     when_i_go_to_the_training_provider_permissions
     then_i_can_only_see_permissions_that_have_been_set_up
+
+    when_i_go_to_organisational_permissions
+    then_i_go_to_the_ratifying_provider_permissions
+    then_i_can_only_see_permissions_that_have_been_set_up
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -35,7 +39,7 @@ RSpec.feature 'Viewing organisational permissions' do
     @another_ratifying_provider = create(:provider, :with_signed_agreement, code: 'GHI')
     create(:provider_user,
            :with_notifications_enabled,
-           providers: [@training_provider],
+           providers: [@training_provider, @ratifying_provider],
            dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
            email_address: 'email@provider.ac.uk')
   end
@@ -71,6 +75,7 @@ RSpec.feature 'Viewing organisational permissions' do
 
   def then_i_can_see_organisations_with_setup_permissions
     expect(page).to have_content(@training_provider.name.to_s)
+    expect(page).to have_content(@ratifying_provider.name.to_s)
   end
 
   def when_i_set_up_permissions_for_a_provider
@@ -87,6 +92,10 @@ RSpec.feature 'Viewing organisational permissions' do
 
   def when_i_go_to_the_training_provider_permissions
     click_on @training_provider.name.to_s
+  end
+
+  def then_i_go_to_the_ratifying_provider_permissions
+    click_on @ratifying_provider.name.to_s
   end
 
   def then_i_can_only_see_permissions_that_have_been_set_up

--- a/spec/system/provider_interface/viewing_organisational_permissions_spec.rb
+++ b/spec/system/provider_interface/viewing_organisational_permissions_spec.rb
@@ -19,11 +19,25 @@ RSpec.feature 'Viewing organisational permissions' do
 
     when_i_go_to_organisational_permissions
     then_i_can_see_organisations_with_setup_permissions
+
+    when_i_go_to_the_training_provider_permissions
+    then_i_can_only_see_permissions_that_have_been_set_up
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
-    provider_user_exists_in_apply_database
+    provider_user_is_associated_with_a_training_provider
+  end
+
+  def provider_user_is_associated_with_a_training_provider
+    @training_provider = create(:provider, :with_signed_agreement, code: 'ABC')
+    @ratifying_provider = create(:provider, :with_signed_agreement, code: 'DEF')
+    @another_ratifying_provider = create(:provider, :with_signed_agreement, code: 'GHI')
+    create(:provider_user,
+           :with_notifications_enabled,
+           providers: [@training_provider],
+           dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
+           email_address: 'email@provider.ac.uk')
   end
 
   def then_i_cannot_see_organisational_permissions
@@ -38,32 +52,25 @@ RSpec.feature 'Viewing organisational permissions' do
   def given_i_can_manage_multiple_organisations_that_do_not_have_permissions_set_up
     @provider_user = ProviderUser.last
 
-    @training_provider = Provider.find_by(code: 'ABC')
-    @ratifying_provider = Provider.find_by(code: 'DEF')
-    @another_ratifying_provider = create(:provider, :with_signed_agreement, code: 'GHI', name: 'Another Example Provider')
-    @provider_user.providers << @another_ratifying_provider
-
     @permission_one = create(
       :provider_relationship_permissions,
       training_provider: @training_provider,
       ratifying_provider: @ratifying_provider,
       setup_at: nil,
-      )
+    )
 
     @permission_two = create(
       :provider_relationship_permissions,
       training_provider: @training_provider,
       ratifying_provider: @another_ratifying_provider,
       setup_at: nil,
-      )
+    )
 
     @provider_user.provider_permissions.update_all(manage_organisations: true)
   end
 
   def then_i_can_see_organisations_with_setup_permissions
-    expect(page).to have_content("#{@training_provider.name}")
-    expect(page).to have_content("#{@ratifying_provider.name}")
-    expect(page).not_to have_content("#{@another_ratifying_provider.name}")
+    expect(page).to have_content(@training_provider.name.to_s)
   end
 
   def when_i_set_up_permissions_for_a_provider
@@ -76,6 +83,15 @@ RSpec.feature 'Viewing organisational permissions' do
 
   def when_i_go_to_organisational_permissions
     click_on 'Organisational permissions'
+  end
+
+  def when_i_go_to_the_training_provider_permissions
+    click_on @training_provider.name.to_s
+  end
+
+  def then_i_can_only_see_permissions_that_have_been_set_up
+    expect(page).to have_content("#{@training_provider.name} and #{@ratifying_provider.name}")
+    expect(page).not_to have_content("#{@training_provider.name} and #{@another_ratifying_provider.name}")
   end
 
   alias_method :and_i_go_to_my_account, :when_i_go_to_my_account


### PR DESCRIPTION
## Context

Providers currently will only be able to set up their permissions if they have the field setup_at as nil and also if they have at least one course open on apply.

Adding the second requirement for courses means that providers can now access their account and see empty providers, where previously they would have been redirected to the set up permissions prompt.

To avoid providers getting access to permissions they have not already set up through the usual prompt, hide all those permissions until they have at least one course open on apply.

## Changes proposed in this pull request

Organisations a provider can manage:

- Only show the organisation permissions section if the provider user has at least one permission set up
- Only show the list of organisations in the permissions section with permissions set up.
- In the organisation specific section, only show the permission details for those that have been set up

Ratifying organisations a provider belongs to, but cannot manage:
They can see this organisation as read only. If this organisation has not been set up there is dedicated content to explain that.

We chose not to amend this logic as it stands as this will be revamped in the next iteration of permissions.

We have also moved the logic to a component to test all edgecases to avoid multiple system specs

## Guidance to review

Did we miss any more cases?

## Link to Trello card

https://trello.com/c/3VWjgvgA/3812-hide-organisational-permissions-for-relationships

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
