### PR TITLE
Update candidate API migration to use batching

### DIFF
--- a/app/services/data_migrations/backfill_candidate_api_updated_at.rb
+++ b/app/services/data_migrations/backfill_candidate_api_updated_at.rb
@@ -4,9 +4,11 @@ module DataMigrations
     MANUAL_RUN = false
 
     def change
-      Candidate
-        .where('candidate_api_updated_at IS NULL')
-        .each { |candidate| candidate.update!(candidate_api_updated_at: candidate.created_at) }
+      candidates = Candidate.select(:candidate_api_updated_at).where(candidate_api_updated_at: nil)
+
+      candidates.find_in_batches(batch_size: 10) do |batch|
+        batch.each { |candidate| candidate.update!(candidate_api_updated_at: candidate.created_at) }
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

Original migration in PR [#4954](https://github.com/DFE-Digital/apply-for-teacher-training/pull/4954) is timing out due to the size of the request.

## Changes proposed in this pull request

Update the `change` method to use `find_in_batches`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
