### PR TITLE
Handle IdenticalOfferError gracefully in ChangeOffer flow

### DIFF
--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -52,13 +52,17 @@ module ProviderInterface
     def update
       @wizard = OfferWizard.new(offer_store)
       if @wizard.valid?(:save)
-        ChangeOffer.new(actor: current_provider_user,
-                        application_choice: @application_choice,
-                        course_option: @wizard.course_option,
-                        update_conditions_service: update_conditions_service).save!
-        @wizard.clear_state!
-
-        flash[:success] = t('.success')
+        begin
+          ChangeOffer.new(actor: current_provider_user,
+                          application_choice: @application_choice,
+                          course_option: @wizard.course_option,
+                          update_conditions_service: update_conditions_service).save!
+          @wizard.clear_state!
+          flash[:success] = t('.success')
+        rescue IdenticalOfferError
+          @wizard.clear_state!
+          flash[:success] = t('.success')
+        end
       else
         @wizard.clear_state!
         track_validation_error(@wizard)

--- a/spec/system/provider_interface/change_existing_offer_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_spec.rb
@@ -66,6 +66,14 @@ RSpec.feature 'Provider changes an existing offer' do
 
     when_i_send_the_offer
     then_i_see_that_the_offer_was_successfully_updated
+
+    when_i_choose_to_change_the_conditions
+    and_i_click_continue
+
+    then_the_review_page_is_loaded
+    when_i_send_the_offer
+
+    then_i_see_that_the_offer_was_successfully_updated
   end
 
   def given_i_am_a_provider_user
@@ -209,5 +217,9 @@ RSpec.feature 'Provider changes an existing offer' do
     within('.govuk-notification-banner--success') do
       expect(page).to have_content('New offer sent')
     end
+  end
+
+  def when_i_choose_to_change_the_conditions
+    click_on 'Add or change conditions'
   end
 end


### PR DESCRIPTION
## Context

Handle `IdenticalOfferError` in Change Offer Flow

## Changes proposed in this pull request

Handle exception and display succesful update error, as suggested by Adam, to replicate the behavior that existed in the previous flow, as we don't want to

## Guidance to review

Go through the Change offer flow without making any changes and `Send offer`. It should not result in an error.

## Link to Trello card

https://trello.com/c/MzR1qpjZ/3824-attempting-to-make-an-identical-offer-in-the-change-offer-flow-results-in-application-error

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
