### PR TITLE
Change condition statuses individually in Manage

### DIFF
--- a/app/components/provider_interface/individual_condition_status_form_component.html.erb
+++ b/app/components/provider_interface/individual_condition_status_form_component.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(
   model: form_object,
-  url: provider_interface_application_choice_confirm_update_conditions_path(application_choice),
+  url: confirm_provider_interface_condition_statuses_path(application_choice),
   method: :patch,
 ) do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/components/provider_interface/individual_condition_status_review_component.html.erb
+++ b/app/components/provider_interface/individual_condition_status_review_component.html.erb
@@ -14,7 +14,7 @@
   </p>
 <% end %>
 
-<%= govuk_button_to confirm_button_text, provider_interface_application_choice_update_conditions_path(application_choice), method: :patch, class: confirm_button_class %>
+<%= govuk_button_to confirm_button_text, provider_interface_condition_statuses_path(application_choice), method: :patch, class: confirm_button_class %>
 
 <p class="govuk-body">
   <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(application_choice), class: 'govuk-link--no-visited-state' %>

--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -7,7 +7,7 @@
   <% if editable %>
     <% if @application_choice.pending_conditions? %>
       <div class='govuk-body'>
-        <%= govuk_link_to 'Update status of conditions', provider_interface_application_choice_edit_conditions_path(@application_choice) %>
+        <%= govuk_link_to 'Update status of conditions', update_conditions_path %>
       </div>
     <% end %>
 

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -57,6 +57,14 @@ module ProviderInterface
       course.full_time_or_part_time? ? new_provider_interface_application_choice_offer_study_modes_path(application_choice) : nil
     end
 
+    def update_conditions_path
+      if FeatureFlag.active?(:individual_offer_conditions)
+        edit_provider_interface_condition_statuses_path(application_choice)
+      else
+        provider_interface_application_choice_edit_conditions_path(application_choice)
+      end
+    end
+
   private
 
     def accredited_body_details(course_option)

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
@@ -14,7 +14,7 @@
 
   <% if provider_can_respond %>
   <p class="govuk-body govuk-!-margin-bottom-4 govuk-!-display-none-print">
-    <%= govuk_link_to 'Update status of conditions', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-2 govuk-!-display-none-print' %>
+    <%= govuk_link_to 'Update status of conditions', update_conditions_path, class: 'govuk-!-margin-bottom-2 govuk-!-display-none-print' %>
   </p>
   <% end %>
 

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.rb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.rb
@@ -20,6 +20,14 @@ module ProviderInterface
       def rows
         course_rows(course_option: application_choice.current_course_option)
       end
+
+      def update_conditions_path
+        if FeatureFlag.active?(:individual_offer_conditions)
+          edit_provider_interface_condition_statuses_path(application_choice)
+        else
+          provider_interface_application_choice_edit_conditions_path(application_choice)
+        end
+      end
     end
   end
 end

--- a/app/controllers/provider_interface/condition_statuses_controller.rb
+++ b/app/controllers/provider_interface/condition_statuses_controller.rb
@@ -1,0 +1,84 @@
+module ProviderInterface
+  class ConditionStatusesController < ProviderInterfaceController
+    before_action :set_application_choice
+    before_action :redirect_unless_application_pending_conditions
+    before_action :requires_make_decisions_permission
+    before_action :redirect_unless_feature_flag_enabled
+
+    def edit
+      @form_object = ConfirmConditionsWizard.new(condition_statuses_store, offer: @application_choice.offer)
+      @form_object.save_state!
+    end
+
+    def confirm
+      @form_object = ConfirmConditionsWizard.new(condition_statuses_store, attributes_for_wizard)
+      @form_object.save_state!
+
+      unless @form_object.valid?
+        track_validation_error(@form_object)
+        render action: :edit
+      end
+    end
+
+    def update
+      @form_object = ConfirmConditionsWizard.new(condition_statuses_store, offer: @application_choice.offer)
+
+      if @form_object.valid?
+        handle_individual_status_transitions
+        flash[:success] = success_message
+
+        redirect_to provider_interface_application_choice_path(@application_choice)
+      else
+        track_validation_error(@form_object)
+        redirect_to action: :edit
+      end
+    end
+
+  private
+
+    def redirect_unless_application_pending_conditions
+      return if @application_choice.pending_conditions?
+
+      flash[:warning] = I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition')
+      redirect_to provider_interface_application_choice_path(@application_choice)
+    end
+
+    def redirect_unless_feature_flag_enabled
+      return if FeatureFlag.active?(:individual_offer_conditions)
+
+      redirect_to provider_interface_application_choice_path(@application_choice)
+    end
+
+    def attributes_for_wizard
+      condition_statuses_params.merge(offer: @application_choice.offer)
+    end
+
+    def condition_statuses_params
+      params
+        .require(:provider_interface_confirm_conditions_wizard)
+        .permit(statuses: {})
+    end
+
+    def condition_statuses_store
+      key = "condition_statuses_store_#{current_provider_user.id}_#{@application_choice.id}"
+      WizardStateStores::RedisStore.new(key: key)
+    end
+
+    def handle_individual_status_transitions
+      ProviderInterface::SaveConditionStatuses.new(
+        actor: current_provider_user,
+        application_choice: @application_choice,
+      ).save!
+    end
+
+    def success_message
+      if @form_object.all_conditions_met?
+        'Conditions marked as met'
+      elsif @form_object.any_condition_not_met?
+        'Conditions marked as not met'
+      else
+        'Status of conditions updated'
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/condition_statuses_controller.rb
+++ b/app/controllers/provider_interface/condition_statuses_controller.rb
@@ -68,7 +68,7 @@ module ProviderInterface
       ProviderInterface::SaveConditionStatuses.new(
         actor: current_provider_user,
         application_choice: @application_choice,
-        conditions: @form_object.conditions,
+        statuses_form_object: @form_object,
       ).save!
     end
 

--- a/app/controllers/provider_interface/condition_statuses_controller.rb
+++ b/app/controllers/provider_interface/condition_statuses_controller.rb
@@ -68,6 +68,7 @@ module ProviderInterface
       ProviderInterface::SaveConditionStatuses.new(
         actor: current_provider_user,
         application_choice: @application_choice,
+        conditions: @form_object.conditions,
       ).save!
     end
 

--- a/app/controllers/provider_interface/conditions_controller.rb
+++ b/app/controllers/provider_interface/conditions_controller.rb
@@ -3,6 +3,7 @@ module ProviderInterface
     before_action :set_application_choice
     before_action :redirect_back_if_application_terminated
     before_action :requires_make_decisions_permission
+    before_action :redirect_if_new_feature_flag_enabled
 
     def edit
       @form_object = ConfirmConditionsForm.new
@@ -48,9 +49,17 @@ module ProviderInterface
       end
     end
 
+  private
+
     def redirect_back_if_application_terminated
       if ApplicationStateChange::TERMINAL_STATES.include?(@application_choice.status.to_sym)
         redirect_back(fallback_location: provider_interface_application_choice_path(@application_choice))
+      end
+    end
+
+    def redirect_if_new_feature_flag_enabled
+      if FeatureFlag.active?(:individual_offer_conditions)
+        redirect_to provider_interface_application_choice_path(@application_choice)
       end
     end
   end

--- a/app/forms/provider_interface/confirm_conditions_wizard.rb
+++ b/app/forms/provider_interface/confirm_conditions_wizard.rb
@@ -13,18 +13,11 @@ module ProviderInterface
     end
 
     def conditions
-      copied_conditions = offer.conditions.map do |condition|
-        updated_condition = condition.dup
-        updated_condition.id = condition.id
-        updated_condition
-      end
+      duplicate_conditions = offer.conditions.map { |condition| duplicate_condition_with_id(condition) }
 
-      return copied_conditions if statuses.blank?
+      return duplicate_conditions if statuses.blank?
 
-      copied_conditions.each do |condition|
-        new_status = statuses&.dig(condition.id.to_s, 'status')
-        condition.status = new_status
-      end
+      duplicate_conditions.each { |condition| update_status_for(condition) }
     end
 
     def all_conditions_met?
@@ -44,6 +37,17 @@ module ProviderInterface
     end
 
   private
+
+    def duplicate_condition_with_id(condition)
+      condition.dup.tap do |duplicate_condition|
+        duplicate_condition.id = condition.id
+      end
+    end
+
+    def update_status_for(condition)
+      new_status = statuses&.dig(condition.id.to_s, 'status')
+      condition.status = new_status
+    end
 
     def all_conditions_have_a_status_selected
       conditions.each do |condition|

--- a/app/forms/provider_interface/confirm_conditions_wizard.rb
+++ b/app/forms/provider_interface/confirm_conditions_wizard.rb
@@ -1,0 +1,44 @@
+module ProviderInterface
+  class ConfirmConditionsWizard
+    include ActiveModel::Model
+
+    attr_accessor :statuses, :offer
+
+    def initialize(state_store, attrs = {})
+      @state_store = state_store
+
+      super(last_saved_state.merge(attrs))
+    end
+
+    def conditions
+      conditions = offer.conditions
+      return conditions if statuses.blank?
+
+      conditions.each do |condition|
+        new_status = statuses.dig(condition.id.to_s, 'status')
+        condition.status = new_status
+      end
+    end
+
+    def save_state!
+      @state_store.write(state)
+    end
+
+    def clear_state!
+      @state_store.delete
+    end
+
+  private
+
+    def last_saved_state
+      saved_state = @state_store.read
+      saved_state ? JSON.parse(saved_state) : {}
+    end
+
+    def state
+      as_json(
+        except: %w[state_store errors validation_context],
+      ).to_json
+    end
+  end
+end

--- a/app/forms/provider_interface/confirm_conditions_wizard.rb
+++ b/app/forms/provider_interface/confirm_conditions_wizard.rb
@@ -13,10 +13,15 @@ module ProviderInterface
     end
 
     def conditions
-      conditions = offer.conditions
-      return conditions if statuses.blank?
+      copied_conditions = offer.conditions.map do |condition|
+        updated_condition = condition.dup
+        updated_condition.id = condition.id
+        updated_condition
+      end
 
-      conditions.each do |condition|
+      return copied_conditions if statuses.blank?
+
+      copied_conditions.each do |condition|
         new_status = statuses&.dig(condition.id.to_s, 'status')
         condition.status = new_status
       end

--- a/app/forms/provider_interface/confirm_conditions_wizard.rb
+++ b/app/forms/provider_interface/confirm_conditions_wizard.rb
@@ -20,6 +20,14 @@ module ProviderInterface
       end
     end
 
+    def all_conditions_met?
+      conditions.all?(&:met?)
+    end
+
+    def any_condition_not_met?
+      conditions.any?(&:unmet?)
+    end
+
     def save_state!
       @state_store.write(state)
     end

--- a/app/models/offer_condition.rb
+++ b/app/models/offer_condition.rb
@@ -12,6 +12,8 @@ class OfferCondition < ApplicationRecord
     unmet: 'unmet',
   }
 
+  validates :status, presence: true
+
   def standard_condition?
     STANDARD_CONDITIONS.include?(text)
   end

--- a/app/services/provider_interface/save_condition_statuses.rb
+++ b/app/services/provider_interface/save_condition_statuses.rb
@@ -2,10 +2,10 @@ module ProviderInterface
   class SaveConditionStatuses
     include ImpersonationAuditHelper
 
-    def initialize(actor:, application_choice:, conditions:)
+    def initialize(actor:, application_choice:, statuses_form_object:)
       @auth = ProviderAuthorisation.new(actor: actor)
       @application_choice = application_choice
-      @conditions = conditions
+      @statuses_form_object = statuses_form_object
     end
 
     def save!
@@ -20,24 +20,16 @@ module ProviderInterface
 
   private
 
-    attr_reader :auth, :application_choice, :conditions
+    attr_reader :auth, :application_choice, :statuses_form_object
 
     def save_conditions_and_update_application!
-      if conditions_met?
+      if statuses_form_object.all_conditions_met?
         transition_to_conditions_met!
-      elsif conditions_not_met?
+      elsif statuses_form_object.any_condition_not_met?
         transition_to_conditions_not_met!
       else
         save_conditions
       end
-    end
-
-    def conditions_met?
-      conditions.all?(&:met?)
-    end
-
-    def conditions_not_met?
-      conditions.any?(&:unmet?)
     end
 
     def transition_to_conditions_met!
@@ -56,7 +48,7 @@ module ProviderInterface
     end
 
     def save_conditions
-      conditions.each do |condition|
+      statuses_form_object.conditions.each do |condition|
         application_choice.offer.conditions.find(condition.id).update!(status: condition.status)
       end
     end

--- a/app/services/provider_interface/save_condition_statuses.rb
+++ b/app/services/provider_interface/save_condition_statuses.rb
@@ -2,9 +2,10 @@ module ProviderInterface
   class SaveConditionStatuses
     include ImpersonationAuditHelper
 
-    def initialize(actor:, application_choice:)
+    def initialize(actor:, application_choice:, conditions:)
       @auth = ProviderAuthorisation.new(actor: actor)
       @application_choice = application_choice
+      @conditions = conditions
     end
 
     def save!
@@ -19,7 +20,7 @@ module ProviderInterface
 
   private
 
-    attr_reader :auth, :application_choice
+    attr_reader :auth, :application_choice, :conditions
 
     def save_conditions_and_update_application!
       if conditions_met?
@@ -32,11 +33,11 @@ module ProviderInterface
     end
 
     def conditions_met?
-      application_choice.offer.conditions.all?(&:met?)
+      conditions.all?(&:met?)
     end
 
     def conditions_not_met?
-      application_choice.offer.conditions.any?(&:unmet?)
+      conditions.any?(&:unmet?)
     end
 
     def transition_to_conditions_met!
@@ -55,7 +56,9 @@ module ProviderInterface
     end
 
     def save_conditions
-      application_choice.offer.conditions.each(&:save!)
+      conditions.each do |condition|
+        application_choice.offer.conditions.find(condition.id).update!(status: condition.status)
+      end
     end
   end
 end

--- a/app/services/provider_interface/save_condition_statuses.rb
+++ b/app/services/provider_interface/save_condition_statuses.rb
@@ -1,0 +1,61 @@
+module ProviderInterface
+  class SaveConditionStatuses
+    include ImpersonationAuditHelper
+
+    def initialize(actor:, application_choice:)
+      @auth = ProviderAuthorisation.new(actor: actor)
+      @application_choice = application_choice
+    end
+
+    def save!
+      auth.assert_can_make_decisions!(application_choice: application_choice, course_option: application_choice.current_course_option)
+
+      audit(auth.actor) do
+        ActiveRecord::Base.transaction do
+          save_conditions_and_update_application!
+        end
+      end
+    end
+
+  private
+
+    attr_reader :auth, :application_choice
+
+    def save_conditions_and_update_application!
+      if conditions_met?
+        transition_to_conditions_met!
+      elsif conditions_not_met?
+        transition_to_conditions_not_met!
+      else
+        save_conditions
+      end
+    end
+
+    def conditions_met?
+      application_choice.offer.conditions.all?(&:met?)
+    end
+
+    def conditions_not_met?
+      application_choice.offer.conditions.any?(&:unmet?)
+    end
+
+    def transition_to_conditions_met!
+      ApplicationStateChange.new(application_choice).confirm_conditions_met!
+      application_choice.update!(recruited_at: Time.zone.now)
+      save_conditions
+      CandidateMailer.conditions_met(application_choice).deliver_later
+      StateChangeNotifier.new(:recruited, application_choice).application_outcome_notification
+    end
+
+    def transition_to_conditions_not_met!
+      ApplicationStateChange.new(application_choice).conditions_not_met!
+      application_choice.update!(conditions_not_met_at: Time.zone.now)
+      save_conditions
+      CandidateMailer.conditions_not_met(application_choice).deliver_later
+    end
+
+    def save_conditions
+      application_choice.offer.conditions.each(&:save!)
+    end
+  end
+end

--- a/app/views/provider_interface/condition_statuses/confirm.html.erb
+++ b/app/views/provider_interface/condition_statuses/confirm.html.erb
@@ -1,0 +1,8 @@
+<% content_for :browser_title, title_with_error_prefix('Confirm conditions', @form_object.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(edit_provider_interface_condition_statuses_path(@application_choice)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render ProviderInterface::IndividualConditionStatusReviewComponent.new(form_object: @form_object, application_choice: @application_choice) %>
+  </div>
+</div>

--- a/app/views/provider_interface/condition_statuses/edit.html.erb
+++ b/app/views/provider_interface/condition_statuses/edit.html.erb
@@ -1,0 +1,8 @@
+<% content_for :browser_title, title_with_error_prefix('Confirm conditions', @form_object.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render ProviderInterface::IndividualConditionStatusFormComponent.new(form_object: @form_object, application_choice: @application_choice) %>
+  </div>
+</div>

--- a/config/locales/provider_interface/offer_conditions.yml
+++ b/config/locales/provider_interface/offer_conditions.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        offer_condition:
+          attributes:
+            status:
+              blank: Select a status

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -666,6 +666,10 @@ Rails.application.routes.draw do
       patch '/conditions/confirm' => 'conditions#confirm_update', as: :application_choice_confirm_update_conditions
       patch '/conditions' => 'conditions#update', as: :application_choice_update_conditions
 
+      resource :condition_statuses, only: %i[edit update], path: 'condition-statuses' do
+        patch :confirm, on: :collection
+      end
+
       get '/offer/new_withdraw' => redirect('/offer/withdraw')
       post '/offer/confirm_withdraw' => redirect('/offer/confirm-withdraw')
       get '/offer/withdraw' => 'decisions#new_withdraw_offer', as: :application_choice_new_withdraw_offer

--- a/spec/components/provider_interface/offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/offer_summary_component_spec.rb
@@ -170,8 +170,16 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
       context 'when application is in condititions_pending state' do
         let(:application_choice) { build_stubbed(:application_choice, :with_accepted_offer) }
 
-        it 'displays the update condition link' do
+        it 'displays the update condition link when the individual_conditions feature flag is off' do
+          FeatureFlag.deactivate(:individual_offer_conditions)
+
           expect(render.css('.govuk-body').css('a').first.attr('href')).to eq(provider_interface_application_choice_edit_conditions_path(application_choice))
+        end
+
+        it 'displays the update condition link when the individual_conditions feature flag is on' do
+          FeatureFlag.activate(:individual_offer_conditions)
+
+          expect(render.css('.govuk-body').css('a').first.attr('href')).to eq(edit_provider_interface_condition_statuses_path(application_choice))
         end
       end
     end

--- a/spec/forms/provider_interface/confirm_conditions_wizard_spec.rb
+++ b/spec/forms/provider_interface/confirm_conditions_wizard_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ConfirmConditionsWizard do
+  let(:store) { instance_double(WizardStateStores::RedisStore) }
+  let(:conditions) { [build_stubbed(:offer_condition, status: :met), build_stubbed(:offer_condition)] }
+  let(:offer) { build_stubbed(:offer, conditions: conditions) }
+  let(:statuses) { nil }
+
+  let(:wizard) do
+    described_class.new(
+      store,
+      offer: offer,
+      statuses: statuses,
+    )
+  end
+
+  before { allow(store).to receive(:read) }
+
+  describe '#conditions' do
+    context 'when built from an offer' do
+      it 'returns the conditions of the offer' do
+        expect(wizard.conditions).to eq(conditions)
+      end
+    end
+
+    context 'when built from status params' do
+      let(:statuses) do
+        conditions.to_h do |condition|
+          [condition.id.to_s, { 'status' => %w[pending met unmet].sample }]
+        end
+      end
+
+      it 'returns the conditions of the offer with modified statuses' do
+        modified_conditions = wizard.conditions
+
+        expect(modified_conditions.first.status).to eq(statuses[modified_conditions.first.id.to_s]['status'])
+        expect(modified_conditions.last.status).to eq(statuses[modified_conditions.last.id.to_s]['status'])
+      end
+
+      context 'if unknown condition ids are given' do
+        let(:statuses) do
+          {
+            'not_an_id' => { 'status' => 'unmet' },
+            conditions.last.id.to_s => { 'status' => 'met' },
+          }
+        end
+
+        it 'only modifies the statuses of the conditions in the offer' do
+          modified_conditions = wizard.conditions
+
+          expect(modified_conditions.first.status).to eq(nil)
+          expect(modified_conditions.last.status).to eq('met')
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/provider_interface/confirm_conditions_wizard_spec.rb
+++ b/spec/forms/provider_interface/confirm_conditions_wizard_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::ConfirmConditionsWizard do
   let(:store) { instance_double(WizardStateStores::RedisStore) }
-  let(:conditions) { [build_stubbed(:offer_condition, status: :met), build_stubbed(:offer_condition)] }
-  let(:offer) { build_stubbed(:offer, conditions: conditions) }
+  let(:offer) { create(:offer, conditions: [create(:offer_condition, status: :met), create(:offer_condition)]) }
+  let(:conditions) { offer.conditions }
   let(:statuses) { nil }
 
   let(:wizard) do

--- a/spec/forms/provider_interface/confirm_conditions_wizard_spec.rb
+++ b/spec/forms/provider_interface/confirm_conditions_wizard_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe ProviderInterface::ConfirmConditionsWizard do
 
   before { allow(store).to receive(:read) }
 
+  describe 'validations' do
+    let(:statuses) { { conditions.last.id.to_s => { 'status' => 'met' } } }
+
+    it 'validates that all conditions have a status set' do
+      expect(wizard).to be_invalid
+      expect(wizard.errors.first.message).to eq('Select a status')
+    end
+  end
+
   describe '#conditions' do
     context 'when built from an offer' do
       it 'returns the conditions of the offer' do

--- a/spec/forms/provider_interface/confirm_conditions_wizard_spec.rb
+++ b/spec/forms/provider_interface/confirm_conditions_wizard_spec.rb
@@ -54,4 +54,58 @@ RSpec.describe ProviderInterface::ConfirmConditionsWizard do
       end
     end
   end
+
+  describe '#all_conditions_met?' do
+    context 'all of the conditions are marked as met' do
+      let(:statuses) do
+        conditions.to_h do |condition|
+          [condition.id.to_s, { 'status' => 'met' }]
+        end
+      end
+
+      it 'returns true' do
+        expect(wizard.all_conditions_met?).to eq(true)
+      end
+    end
+
+    context 'one of the conditions is not marked as met' do
+      let(:statuses) do
+        {
+          conditions.first.id.to_s => { 'status' => 'pending' },
+          conditions.last.id.to_s => { 'status' => 'met' },
+        }
+      end
+
+      it 'returns false' do
+        expect(wizard.all_conditions_met?).to eq(false)
+      end
+    end
+  end
+
+  describe '#any_condition_not_met?' do
+    context 'at least one of the conditions is marked as not met' do
+      let(:statuses) do
+        {
+          conditions.first.id.to_s => { 'status' => %w[pending met unmet].sample },
+          conditions.last.id.to_s => { 'status' => 'unmet' },
+        }
+      end
+
+      it 'returns true' do
+        expect(wizard.any_condition_not_met?).to eq(true)
+      end
+    end
+
+    context 'none of the conditions are marked as not met' do
+      let(:statuses) do
+        conditions.to_h do |condition|
+          [condition.id.to_s, { 'status' => %w[pending met].sample }]
+        end
+      end
+
+      it 'returns false' do
+        expect(wizard.any_condition_not_met?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/models/offer_condition_spec.rb
+++ b/spec/models/offer_condition_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe OfferCondition do
     end
   end
 
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:status) }
+  end
+
   describe '#conditions_text' do
     it 'returns an array with the text of all the offer conditions' do
       conditions = build_list(:offer_condition, 4)

--- a/spec/requests/provider_interface/condition_statuses_controller_spec.rb
+++ b/spec/requests/provider_interface/condition_statuses_controller_spec.rb
@@ -61,4 +61,32 @@ RSpec.describe ProviderInterface::ConditionStatusesController, type: :request do
       end
     end
   end
+
+  describe 'validation errors' do
+    let!(:application_choice) do
+      create(:application_choice, :with_accepted_offer,
+             application_form: application_form,
+             course_option: course_option)
+    end
+
+    it 'tracks errors on confirm_update' do
+      condition_id = application_choice.offer.conditions.first.id.to_s
+      expect {
+        patch(
+          confirm_provider_interface_condition_statuses_path(application_choice),
+          params: { provider_interface_confirm_conditions_wizard: { statuses: { condition_id => { test: :test } } } },
+        )
+      }.to change(ValidationError, :count).by(1)
+    end
+
+    it 'tracks errors on update' do
+      condition_id = application_choice.offer.conditions.first.id.to_s
+      expect {
+        patch(
+          provider_interface_condition_statuses_path(application_choice),
+          params: { provider_interface_confirm_conditions_wizard: { statuses: { condition_id => { test: :test } } } },
+        )
+      }.to change(ValidationError, :count).by(1)
+    end
+  end
 end

--- a/spec/requests/provider_interface/condition_statuses_controller_spec.rb
+++ b/spec/requests/provider_interface/condition_statuses_controller_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ConditionStatusesController, type: :request do
+  include DfESignInHelpers
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions) }
+  let(:provider) { provider_user.providers.first }
+  let(:application_form) { build(:application_form, :minimum_info) }
+  let(:course) { build(:course, :open_on_apply, provider: provider) }
+  let(:course_option) { build(:course_option, course: course) }
+
+  before do
+    allow(ProviderUser).to receive(:load_from_session).and_return(provider_user)
+    FeatureFlag.activate(:individual_offer_conditions)
+  end
+
+  describe 'if application choice is in a recruited state' do
+    let!(:application_choice) do
+      create(:application_choice, :recruited,
+             application_form: application_form,
+             course_option: course_option)
+    end
+    let(:referer) { "http://www.example.com/provider/applications/#{application_choice.id}" }
+
+    context 'GET edit' do
+      it 'redirects back' do
+        get(
+          edit_provider_interface_condition_statuses_path(application_choice),
+          params: nil,
+          headers: { 'HTTP_REFERER' => referer },
+        )
+
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(referer)
+      end
+    end
+
+    context 'PATCH confirm_update' do
+      it 'redirects back' do
+        patch(
+          confirm_provider_interface_condition_statuses_path(application_choice),
+          params: {},
+          headers: { 'HTTP_REFERER' => referer },
+        )
+
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(referer)
+      end
+    end
+
+    context 'PATCH update' do
+      it 'redirects back' do
+        patch(
+          provider_interface_condition_statuses_path(application_choice),
+          params: {},
+          headers: { 'HTTP_REFERER' => referer },
+        )
+
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(referer)
+      end
+    end
+  end
+end

--- a/spec/requests/provider_interface/condition_statuses_controller_spec.rb
+++ b/spec/requests/provider_interface/condition_statuses_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::ConditionStatusesController, type: :request do
   include DfESignInHelpers
+  include ModelWithErrorsStubHelper
 
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions) }
   let(:provider) { provider_user.providers.first }
@@ -80,11 +81,12 @@ RSpec.describe ProviderInterface::ConditionStatusesController, type: :request do
     end
 
     it 'tracks errors on update' do
-      condition_id = application_choice.offer.conditions.first.id.to_s
+      stub_model_instance_with_errors(ProviderInterface::ConfirmConditionsWizard, { valid?: false })
+
       expect {
         patch(
           provider_interface_condition_statuses_path(application_choice),
-          params: { provider_interface_confirm_conditions_wizard: { statuses: { condition_id => { test: :test } } } },
+          params: {},
         )
       }.to change(ValidationError, :count).by(1)
     end

--- a/spec/requests/provider_interface/conditions_controller_spec.rb
+++ b/spec/requests/provider_interface/conditions_controller_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe ProviderInterface::ConditionsController, type: :request do
   let(:course) { build(:course, :open_on_apply, provider: provider) }
   let(:course_option) { build(:course_option, course: course) }
 
-  before { allow(ProviderUser).to receive(:load_from_session).and_return(provider_user) }
+  before do
+    allow(ProviderUser).to receive(:load_from_session).and_return(provider_user)
+    FeatureFlag.deactivate(:individual_offer_conditions)
+  end
 
   describe 'if application choice is in a recruited state' do
     let!(:application_choice) do
@@ -61,7 +64,7 @@ RSpec.describe ProviderInterface::ConditionsController, type: :request do
 
   describe 'validation errors' do
     let!(:application_choice) do
-      create(:application_choice, :pending_conditions,
+      create(:application_choice, :with_accepted_offer,
              application_form: application_form,
              course_option: course_option)
     end

--- a/spec/services/provider_interface/save_condition_statuses_spec.rb
+++ b/spec/services/provider_interface/save_condition_statuses_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::SaveConditionStatuses do
+  let(:application_choice) { create(:application_choice, :with_accepted_offer, offer: offer) }
+  let(:offer) { create(:offer, conditions: conditions) }
+  let(:conditions) { create_list(:offer_condition, 3, status: :pending) }
+
+  let(:provider_user) { create(:provider_user, :with_make_decisions, providers: [application_choice.current_course.provider]) }
+
+  let(:service) { described_class.new(actor: provider_user, application_choice: application_choice) }
+
+  describe 'save!' do
+    context 'provider user does not have make_decisions' do
+      let(:provider_user) { create(:provider_user, providers: [application_choice.current_course.provider]) }
+
+      it 'raises an error' do
+        expect { service.save! }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
+      end
+    end
+
+    context 'when a condition status is changed' do
+      before { application_choice.offer.conditions.each { |condition| condition.status = 'met' } }
+
+      it 'attributes audits to the actor', with_audited: true do
+        expect { service.save! }.to change(offer.conditions.last.audits, :count).by(1)
+        expect(offer.conditions.last.audits.last.user).to eq(provider_user)
+      end
+    end
+
+    context 'when none of the conditions are marked as unmet' do
+      context 'when all conditions are met' do
+        before { application_choice.offer.conditions.each { |condition| condition.status = 'met' } }
+
+        it 'transitions the application to the recruited state' do
+          Timecop.freeze do
+            expect { service.save! }.to change(application_choice, :status).from('pending_conditions').to('recruited')
+                                    .and change(application_choice, :recruited_at).to(Time.zone.now)
+          end
+        end
+
+        it 'sends an email to the candidate', sidekiq: true do
+          service.save!
+          expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('conditions_met')
+        end
+
+        # rubocop:disable RSpec/NestedGroups
+        context 'when the application is not in the pending_conditions state' do
+          let(:application_choice) { create(:application_choice, :with_recruited, offer: offer) }
+
+          it 'raises a Workflow::NoTransitionAllowed error' do
+            expect { service.save! }.to raise_error(Workflow::NoTransitionAllowed)
+          end
+        end
+        # rubocop:enable RSpec/NestedGroups
+      end
+
+      context 'when one conditions is still pending' do
+        before do
+          application_choice.offer.conditions.each_with_index do |condition, index|
+            condition.status = index.zero? ? 'pending' : 'met'
+          end
+        end
+
+        it 'keeps the application in the pending_conditions state' do
+          expect { service.save! }.not_to change(application_choice, :status)
+        end
+
+        it 'does not send an email to the candidate', sidekiq: true do
+          service.save!
+          expect(ActionMailer::Base.deliveries).to be_empty
+        end
+      end
+    end
+
+    context 'when one of the conditions is marked as unmet' do
+      before do
+        application_choice.offer.conditions.each_with_index do |condition, index|
+          condition.status = index.zero? ? 'unmet' : 'pending'
+        end
+      end
+
+      it 'transitions the application to the conditions_not_met state' do
+        Timecop.freeze do
+          expect { service.save! }.to change(application_choice, :status).from('pending_conditions').to('conditions_not_met')
+                                  .and change(application_choice, :conditions_not_met_at).to(Time.zone.now)
+        end
+      end
+
+      it 'sends an email to the candidate', sidekiq: true do
+        service.save!
+        expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('conditions_not_met')
+      end
+
+      context 'when the application is not in the pending_conditions state' do
+        let(:application_choice) { create(:application_choice, :with_conditions_not_met, offer: offer) }
+
+        it 'raises a Workflow::NoTransitionAllowed error' do
+          expect { service.save! }.to raise_error(Workflow::NoTransitionAllowed)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/provider_interface/save_condition_statuses_spec.rb
+++ b/spec/services/provider_interface/save_condition_statuses_spec.rb
@@ -6,9 +6,20 @@ RSpec.describe ProviderInterface::SaveConditionStatuses do
   let(:conditions) { create_list(:offer_condition, 3, status: :pending) }
   let(:new_conditions) { conditions }
 
+  let(:statuses_form_object) do
+    all_conditions_met = new_conditions.all?(&:met?)
+    any_condition_not_met = new_conditions.any?(&:unmet?)
+    instance_double(
+      ProviderInterface::ConfirmConditionsWizard,
+      conditions: new_conditions,
+      all_conditions_met?: all_conditions_met,
+      any_condition_not_met?: any_condition_not_met,
+    )
+  end
+
   let(:provider_user) { create(:provider_user, :with_make_decisions, providers: [application_choice.current_course.provider]) }
 
-  let(:service) { described_class.new(actor: provider_user, application_choice: application_choice, conditions: new_conditions) }
+  let(:service) { described_class.new(actor: provider_user, application_choice: application_choice, statuses_form_object: statuses_form_object) }
 
   describe 'save!' do
     context 'provider user does not have make_decisions' do

--- a/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
@@ -5,6 +5,8 @@ RSpec.feature 'Confirm conditions met' do
   include DfESignInHelpers
   include ProviderUserPermissionsHelper
 
+  before { FeatureFlag.deactivate(:individual_offer_conditions) }
+
   scenario 'Provider user confirms offer conditions have been met by the candidate' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_an_authorised_provider_user

--- a/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
@@ -5,6 +5,8 @@ RSpec.feature 'Confirm conditions not met' do
   include DfESignInHelpers
   include ProviderUserPermissionsHelper
 
+  before { FeatureFlag.deactivate(:individual_offer_conditions) }
+
   scenario 'Provider user confirms offer conditions have not been met by the candidate' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_an_authorised_provider_user

--- a/spec/system/provider_interface/provider_edits_condition_statuses_spec.rb
+++ b/spec/system/provider_interface/provider_edits_condition_statuses_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+RSpec.feature 'Confirm conditions met' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+
+  before { FeatureFlag.activate(:individual_offer_conditions) }
+
+  scenario 'Provider user confirms offer conditions have been met by the candidate' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_an_authorised_provider_user
+    and_i_can_access_the_provider_interface
+
+    when_i_navigate_to_an_offer_accepted_by_the_candidate
+    and_i_navigate_to_the_offer_tab
+    and_click_on_confirm_conditions
+    then_i_should_see_a_summary_of_the_conditions
+
+    when_i_change_the_status_of_one_of_the_conditions
+    and_confirm_my_selection_in_the_next_page
+
+    then_i_get_feedback_that_my_action_succeeded
+    and_i_am_back_on_the_application_page
+    and_the_candidate_is_still_pending_conditions
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_am_an_authorised_provider_user
+    @provider = create(:provider, :with_signed_agreement)
+    create(:provider_user, providers: [@provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    permit_make_decisions!
+  end
+
+  def and_i_can_access_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+    visit provider_interface_applications_path
+    expect(page).to have_current_path provider_interface_applications_path
+  end
+
+  def when_i_navigate_to_an_offer_accepted_by_the_candidate
+    course_option = course_option_for_provider_code(provider_code: @provider.code)
+    @application_form = create(
+      :completed_application_form,
+      first_name: 'John',
+      last_name: 'Smith',
+    )
+    @conditions = create_list(:offer_condition, 3)
+    @application_choice = create(
+      :application_choice,
+      :with_accepted_offer,
+      offer: create(:offer, conditions: @conditions),
+      current_course_option: course_option,
+      application_form: @application_form,
+    )
+    visit provider_interface_application_choice_path(@application_choice)
+  end
+
+  def and_i_navigate_to_the_offer_tab
+    click_on 'Offer'
+  end
+
+  def and_click_on_confirm_conditions
+    click_on 'Update status of conditions'
+  end
+
+  def then_i_should_see_a_summary_of_the_conditions
+    within '.app-box' do
+      @conditions.each do |condition|
+        expect(page).to have_content(condition.text)
+      end
+    end
+  end
+
+  def when_i_change_the_status_of_one_of_the_conditions
+    within_fieldset(@conditions.sample.text) do
+      choose 'Met'
+    end
+
+    click_on t('continue')
+  end
+
+  def and_confirm_my_selection_in_the_next_page
+    click_on 'Update status'
+  end
+
+  def then_i_get_feedback_that_my_action_succeeded
+    expect(page).to have_content 'Status of conditions updated'
+  end
+
+  def and_i_am_back_on_the_application_page
+    expect(page).to have_current_path provider_interface_application_choice_path(@application_choice)
+  end
+
+  def and_the_candidate_is_still_pending_conditions
+    expect(@application_choice.reload.pending_conditions?).to be_truthy
+    expect(page).to have_content 'Accepted'
+  end
+end

--- a/spec/system/provider_interface/provider_marks_conditions_as_met_spec.rb
+++ b/spec/system/provider_interface/provider_marks_conditions_as_met_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.feature 'Confirm conditions met' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+
+  before { FeatureFlag.activate(:individual_offer_conditions) }
+
+  scenario 'Provider user confirms offer conditions have been met by the candidate' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_an_authorised_provider_user
+    and_i_can_access_the_provider_interface
+
+    when_i_navigate_to_an_offer_accepted_by_the_candidate
+    and_i_navigate_to_the_offer_tab
+    and_click_on_confirm_conditions
+    then_i_should_see_a_summary_of_the_conditions
+
+    when_i_select_they_have_met_all_the_conditions
+    and_confirm_my_selection_in_the_next_page
+
+    then_i_get_feedback_that_my_action_succeeded
+    and_i_am_back_on_the_application_page
+    and_the_candidate_is_recruited
+    and_the_candidate_receives_an_email_notification
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_am_an_authorised_provider_user
+    @provider = create(:provider, :with_signed_agreement)
+    create(:provider_user, providers: [@provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    permit_make_decisions!
+  end
+
+  def and_i_can_access_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+    visit provider_interface_applications_path
+    expect(page).to have_current_path provider_interface_applications_path
+  end
+
+  def when_i_navigate_to_an_offer_accepted_by_the_candidate
+    course_option = course_option_for_provider_code(provider_code: @provider.code)
+    @application_form = create(
+      :completed_application_form,
+      first_name: 'John',
+      last_name: 'Smith',
+    )
+    @conditions = create_list(:offer_condition, 3)
+    @application_choice = create(
+      :application_choice,
+      :with_accepted_offer,
+      offer: create(:offer, conditions: @conditions),
+      current_course_option: course_option,
+      application_form: @application_form,
+    )
+    visit provider_interface_application_choice_path(@application_choice)
+  end
+
+  def and_i_navigate_to_the_offer_tab
+    click_on 'Offer'
+  end
+
+  def and_click_on_confirm_conditions
+    click_on 'Update status of conditions'
+  end
+
+  def then_i_should_see_a_summary_of_the_conditions
+    within '.app-box' do
+      @conditions.each do |condition|
+        expect(page).to have_content(condition.text)
+      end
+    end
+  end
+
+  def when_i_select_they_have_met_all_the_conditions
+    @conditions.each do |condition|
+      within_fieldset(condition.text) do
+        choose 'Met'
+      end
+    end
+
+    click_on t('continue')
+  end
+
+  def and_confirm_my_selection_in_the_next_page
+    click_on 'Mark conditions as met and tell candidate'
+  end
+
+  def then_i_get_feedback_that_my_action_succeeded
+    expect(page).to have_content 'Conditions marked as met'
+  end
+
+  def and_i_am_back_on_the_application_page
+    expect(page).to have_current_path provider_interface_application_choice_path(@application_choice)
+  end
+
+  def and_the_candidate_is_recruited
+    expect(@application_choice.reload.recruited?).to be_truthy
+    expect(page).to have_content 'Conditions met'
+  end
+
+  def and_the_candidate_receives_an_email_notification
+    open_email(@application_choice.application_form.candidate.email_address)
+    expect(current_email.subject).to have_content 'You have met your conditions for'
+  end
+end

--- a/spec/system/provider_interface/provider_marks_conditions_as_not_met_spec.rb
+++ b/spec/system/provider_interface/provider_marks_conditions_as_not_met_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.feature 'Confirm conditions met' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+
+  before { FeatureFlag.activate(:individual_offer_conditions) }
+
+  scenario 'Provider user confirms offer conditions have been met by the candidate' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_an_authorised_provider_user
+    and_i_can_access_the_provider_interface
+
+    when_i_navigate_to_an_offer_accepted_by_the_candidate
+    and_i_navigate_to_the_offer_tab
+    and_click_on_confirm_conditions
+    then_i_should_see_a_summary_of_the_conditions
+
+    when_i_select_they_have_not_met_one_of_the_conditions
+    and_confirm_my_selection_in_the_next_page
+
+    then_i_get_feedback_that_my_action_succeeded
+    and_i_am_back_on_the_application_page
+    and_the_candidate_is_conditions_not_met
+    and_the_candidate_receives_an_email_notification
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_am_an_authorised_provider_user
+    @provider = create(:provider, :with_signed_agreement)
+    create(:provider_user, providers: [@provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    permit_make_decisions!
+  end
+
+  def and_i_can_access_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+    visit provider_interface_applications_path
+    expect(page).to have_current_path provider_interface_applications_path
+  end
+
+  def when_i_navigate_to_an_offer_accepted_by_the_candidate
+    course_option = course_option_for_provider_code(provider_code: @provider.code)
+    @application_form = create(
+      :completed_application_form,
+      first_name: 'John',
+      last_name: 'Smith',
+    )
+    @conditions = create_list(:offer_condition, 3)
+    @application_choice = create(
+      :application_choice,
+      :with_accepted_offer,
+      offer: create(:offer, conditions: @conditions),
+      current_course_option: course_option,
+      application_form: @application_form,
+    )
+    visit provider_interface_application_choice_path(@application_choice)
+  end
+
+  def and_i_navigate_to_the_offer_tab
+    click_on 'Offer'
+  end
+
+  def and_click_on_confirm_conditions
+    click_on 'Update status of conditions'
+  end
+
+  def then_i_should_see_a_summary_of_the_conditions
+    within '.app-box' do
+      @conditions.each do |condition|
+        expect(page).to have_content(condition.text)
+      end
+    end
+  end
+
+  def when_i_select_they_have_not_met_one_of_the_conditions
+    within_fieldset(@conditions.sample.text) do
+      choose 'Not met'
+    end
+
+    click_on t('continue')
+  end
+
+  def and_confirm_my_selection_in_the_next_page
+    click_on 'Mark conditions as not met'
+  end
+
+  def then_i_get_feedback_that_my_action_succeeded
+    expect(page).to have_content 'Conditions marked as not met'
+  end
+
+  def and_i_am_back_on_the_application_page
+    expect(page).to have_current_path provider_interface_application_choice_path(@application_choice)
+  end
+
+  def and_the_candidate_is_conditions_not_met
+    expect(@application_choice.reload.conditions_not_met?).to be_truthy
+    expect(page).to have_content 'Conditions not met'
+  end
+
+  def and_the_candidate_receives_an_email_notification
+    open_email(@application_choice.application_form.candidate.email_address)
+    expect(current_email.subject).to have_content 'You have not met your conditions for'
+  end
+end


### PR DESCRIPTION
## Context
At the moment, condition status is managed in bulk by providers, which is not that user friendly because they have to track conditions off the system.

This PR connects the existing UI to a new controller and logic so that condition statuses can be individually changed in Manage

## Changes proposed in this pull request
- Add a wizard to back the new flow
- Add service that saves the result of the wizard

## Guidance to review
This should be tested thoroughly with the feature flag on and off.

## Link to Trello card
https://trello.com/c/4keyF4am/3791-implement-individual-conditions-ui-in-manage-for-non-deferred-offers

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
