### PR TITLE
Update candidate mailer copy to improve clarity

### DIFF
--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -6,7 +6,11 @@ You have enough references to send your application to training providers.
 You’ve selected 2 references to submit with your application already, but you can change your selection if you want.
 
 Sign in to complete your application:
-<% elsif FeatureFlag.active?(:reference_selection) && @provided_references.count >= ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
+<% elsif FeatureFlag.active?(:reference_selection) && @provided_references.count > ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
+You have more than enough references to send your application to training providers.
+
+Sign in to complete your application:
+<% elsif FeatureFlag.active?(:reference_selection) && @provided_references.count == ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
 You have enough references to send your application to training providers.
 
 Sign in to complete your application:

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       )
     end
 
-    context 'when an additional reference is received but none are selected' do
+    context 'when a second reference is received but none are selected' do
       let(:email) { mailer.send(:reference_received, reference) }
 
       let(:application_form) { build(:application_form) }
@@ -82,6 +82,26 @@ RSpec.describe CandidateMailer, type: :mailer do
         'a mail with subject and content',
         'You have a reference from Scott Knowles',
         'request other' => 'You have enough references to send your application to training providers.',
+      )
+    end
+
+    context 'when a third reference is received but none are selected' do
+      let(:email) { mailer.send(:reference_received, reference) }
+
+      let(:application_form) { build(:application_form) }
+      let(:reference) { build(:reference, :feedback_provided, name: 'Scott Knowles', application_form: application_form) }
+      let(:second_reference) { build(:reference, :feedback_provided, name: 'William Adama', application_form: application_form) }
+      let(:third_reference) { build(:reference, :feedback_provided, name: 'Kara Thrace', application_form: application_form) }
+
+      before do
+        application_form.application_references = [reference, second_reference, third_reference]
+        FeatureFlag.activate(:reference_selection)
+      end
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'You have a reference from Scott Knowles',
+        'request other' => 'You have more than enough references to send your application to training providers.',
       )
     end
 

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -393,10 +393,25 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.reference_received(reference)
   end
 
-  def reference_received_and_can_now_send_to_providers
+  def two_references_received
     application_form_with_provided_references = FactoryBot.build_stubbed(
       :application_form,
       application_references: [
+        FactoryBot.build_stubbed(:reference, feedback_status: :feedback_provided),
+        FactoryBot.build_stubbed(:reference, feedback_status: :feedback_provided),
+      ],
+    )
+
+    new_reference = FactoryBot.build_stubbed(:reference, application_form: application_form_with_provided_references)
+
+    CandidateMailer.reference_received(new_reference)
+  end
+
+  def three_or_more_references_received
+    application_form_with_provided_references = FactoryBot.build_stubbed(
+      :application_form,
+      application_references: [
+        FactoryBot.build_stubbed(:reference, feedback_status: :feedback_provided),
         FactoryBot.build_stubbed(:reference, feedback_status: :feedback_provided),
         FactoryBot.build_stubbed(:reference, feedback_status: :feedback_provided),
       ],


### PR DESCRIPTION
## Context

Following the initial round of user research, both participants gave feedback around the clarity of the emails. They assumed it wasn't until they got their third reference back that they had enough, when they actually only need two.

## Changes proposed in this pull request

Minor copy change to make it clearer that the candidate can send their references off once they've received two.

|Two references received|Three or more references received|
|---|---|
|![image](https://user-images.githubusercontent.com/47917431/122732747-7f607800-d274-11eb-9c15-071352429457.png)|![image](https://user-images.githubusercontent.com/47917431/122732702-72dc1f80-d274-11eb-8787-9e80b2048250.png)|

## Guidance to review

Two mailer previews available in the support UI:
![image](https://user-images.githubusercontent.com/47917431/122733003-afa81680-d274-11eb-9ed8-b8da447ec9db.png)


## Link to Trello card

https://trello.com/c/hZVGCcxd

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
