### PR TITLE
Add created_at column to candidate api migration

### DIFF
--- a/app/services/data_migrations/backfill_candidate_api_updated_at.rb
+++ b/app/services/data_migrations/backfill_candidate_api_updated_at.rb
@@ -4,7 +4,7 @@ module DataMigrations
     MANUAL_RUN = false
 
     def change
-      candidates = Candidate.select(:candidate_api_updated_at).where(candidate_api_updated_at: nil)
+      candidates = Candidate.where(candidate_api_updated_at: nil)
 
       candidates.find_in_batches(batch_size: 10) do |batch|
         batch.each { |candidate| candidate.update!(candidate_api_updated_at: candidate.created_at) }

--- a/spec/factories/candidate.rb
+++ b/spec/factories/candidate.rb
@@ -2,5 +2,16 @@ FactoryBot.define do
   factory :candidate do
     email_address { "#{SecureRandom.hex(5)}@example.com" }
     sign_up_email_bounced { false }
+
+    transient do
+      skip_candidate_api_updated_at { false }
+    end
+
+    callback(:after_create) do |candidate, evaluator|
+      if evaluator.skip_candidate_api_updated_at
+        candidate.candidate_api_updated_at = nil
+        candidate.save
+      end
+    end
   end
 end

--- a/spec/services/data_migrations/backfill_candidate_api_updated_at_spec.rb
+++ b/spec/services/data_migrations/backfill_candidate_api_updated_at_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 RSpec.describe DataMigrations::BackfillCandidateAPIUpdatedAt do
   describe '#change' do
     it 'backfills candidate_api_updated_at with the created_at date if nil' do
-      candidate = create(:candidate, candidate_api_updated_at: nil)
+      candidate = create(:candidate, skip_candidate_api_updated_at: true)
+
+      expect(candidate.reload.candidate_api_updated_at).to be_nil
 
       described_class.new.change
 


### PR DESCRIPTION
## Context

After [#4989](https://github.com/DFE-Digital/apply-for-teacher-training/pull/4989) was updated, it was referencing the `created_at` column without selecting it.

## Changes proposed in this pull request

- Candidate factory has been updated with the option to skip setting the `candidate_api_updated_at` value
- The backfill no longer references specific columns

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
