### PR TITLE
Invariant check for incorrect number of selected references on a submitted application

### DIFF
--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -12,6 +12,7 @@ class DetectInvariants
     detect_course_sync_not_succeeded_for_an_hour
     detect_high_sidekiq_retries_queue_length
     detect_application_choices_with_courses_from_the_incorrect_cycle
+    detect_submitted_applications_with_more_than_two_selected_references
   end
 
   def detect_application_choices_in_old_states
@@ -185,6 +186,29 @@ class DetectInvariants
     end
   end
 
+  def detect_submitted_applications_with_more_than_two_selected_references
+    applications_with_more_than_two_selected_references = ApplicationForm
+    .joins(:application_references)
+    .where.not(submitted_at: nil)
+    .where(references: { selected: true })
+    .group('references.application_form_id')
+    .having('COUNT("references".id) > 2')
+    .pluck(:application_form_id).uniq
+    .sort
+
+    if applications_with_more_than_two_selected_references.any?
+      urls = applications_with_more_than_two_selected_references.map { |application_form_id| helpers.support_interface_application_form_url(application_form_id) }
+
+      message = <<~MSG
+        The following applications have been submitted with more than two selected references
+
+        #{urls.join("\n")}
+      MSG
+
+      Raven.capture_exception(ApplicationSubmittedWithMoreThanTwoSelectedReferences.new(message))
+    end
+  end
+
   class ApplicationInRemovedState < StandardError; end
   class OutstandingReferencesOnSubmittedApplication < StandardError; end
   class ApplicationEditedByWrongCandidate < StandardError; end
@@ -194,6 +218,7 @@ class DetectInvariants
   class CourseSyncNotSucceededForAnHour < StandardError; end
   class SidekiqRetriesQueueHigh < StandardError; end
   class ApplicationWithADifferentCyclesCourse < StandardError; end
+  class ApplicationSubmittedWithMoreThanTwoSelectedReferences < StandardError; end
 
 private
 


### PR DESCRIPTION
## Context

Once the new reference selection feature goes live, all applications are expected to have 2 selected references. We want to be made aware if bugs in the system are allowing apps to be submitted with more or less than this number.

## Changes proposed in this pull request

Add a new DetectInvariant check that will look for submitted application that don't have two selected references.

## Guidance to review

Any suggestions to an alternative name for `ApplicationSubmittedWithAnIncorrectNumberOfSelectedReferences` ?

## Link to Trello card

https://trello.com/c/hPsPC4VY

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
