### PR TITLE
Add components and UI for individual conditions

### DIFF
--- a/app/components/provider_interface/conditions_list_component.html.erb
+++ b/app/components/provider_interface/conditions_list_component.html.erb
@@ -1,0 +1,16 @@
+<% if conditions.any? %>
+  <dl class="govuk-summary-list app-conditions-list govuk-!-margin-bottom-0">
+    <% conditions.each_with_index do |condition, index| %>
+      <div class="govuk-summary-list__row<%= ' govuk-summary-list__row--no-border' if index == conditions.length - 1 %>">
+        <dt class="govuk-summary-list__key">
+          <%= condition.text %>
+        </dt>
+        <dd class="govuk-summary-list__value app-conditions-list__tag">
+          <%= render ProviderInterface::ConditionStatusTagComponent.new(condition) %>
+        </dd>
+      </div>
+    <% end %>
+  </dl>
+<% else %>
+  <p class="govuk-body">No conditions have been set for this offer.</p>
+<% end %>

--- a/app/components/provider_interface/conditions_list_component.rb
+++ b/app/components/provider_interface/conditions_list_component.rb
@@ -1,0 +1,9 @@
+module ProviderInterface
+  class ConditionsListComponent < ViewComponent::Base
+    attr_reader :conditions
+
+    def initialize(conditions)
+      @conditions = conditions
+    end
+  end
+end

--- a/app/components/provider_interface/individual_condition_status_form_component.html.erb
+++ b/app/components/provider_interface/individual_condition_status_form_component.html.erb
@@ -1,0 +1,30 @@
+<%= form_with(
+  model: form_object,
+  url: provider_interface_application_choice_confirm_update_conditions_path(application_choice),
+  method: :patch,
+) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l"><%= application_choice.application_form.full_name %></span>
+  <h1 class="govuk-heading-l">Update status of conditions</h1>
+
+  <div class="app-box govuk-!-margin-bottom-7">
+    <%= render ProviderInterface::ConditionsListComponent.new(application_choice.offer.conditions) %>
+  </div>
+
+  <% form_object.conditions.each do |condition| %>
+    <%= f.fields_for 'statuses[]', condition do |sf| %>
+      <%= sf.govuk_radio_buttons_fieldset :status, legend: { text: "Status of ‘#{condition.text.truncate_words(6)}’", size: 'm' } do %>
+        <%= sf.govuk_radio_button :status, 'pending', label: { text: 'Pending' }, link_errors: true %>
+        <%= sf.govuk_radio_button :status, 'unmet', label: { text: 'Not met' } %>
+        <%= sf.govuk_radio_button :status, 'met', label: { text: 'Met' } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit t('continue') %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(application_choice), class: 'govuk-link--no-visited-state' %>
+  </p>
+<% end %>

--- a/app/components/provider_interface/individual_condition_status_form_component.rb
+++ b/app/components/provider_interface/individual_condition_status_form_component.rb
@@ -1,0 +1,10 @@
+module ProviderInterface
+  class IndividualConditionStatusFormComponent < ViewComponent::Base
+    attr_reader :form_object, :application_choice
+
+    def initialize(form_object:, application_choice:)
+      @form_object = form_object
+      @application_choice = application_choice
+    end
+  end
+end

--- a/app/components/provider_interface/individual_condition_status_review_component.html.erb
+++ b/app/components/provider_interface/individual_condition_status_review_component.html.erb
@@ -1,0 +1,21 @@
+<span class="govuk-caption-l"><%= application_choice.application_form.full_name %></span>
+<h1 class="govuk-heading-l"><%= page_heading %></h1>
+
+<%= render ProviderInterface::ReadOnlyCompletedOfferSummaryComponent.new(
+  application_choice: application_choice,
+  course_option: application_choice.current_course_option,
+  conditions: form_object.conditions,
+  course: application_choice.current_course,
+) %>
+
+<% if form_object.any_condition_not_met? %>
+  <p class="govuk-body">
+    The candidate will be told that their application was unsuccessful.
+  </p>
+<% end %>
+
+<%= govuk_button_to confirm_button_text, provider_interface_application_choice_update_conditions_path(application_choice), method: :patch, class: confirm_button_class %>
+
+<p class="govuk-body">
+  <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(application_choice), class: 'govuk-link--no-visited-state' %>
+</p>

--- a/app/components/provider_interface/individual_condition_status_review_component.rb
+++ b/app/components/provider_interface/individual_condition_status_review_component.rb
@@ -1,0 +1,34 @@
+module ProviderInterface
+  class IndividualConditionStatusReviewComponent < ViewComponent::Base
+    attr_reader :form_object, :application_choice
+
+    def initialize(form_object:, application_choice:)
+      @form_object = form_object
+      @application_choice = application_choice
+    end
+
+    def page_heading
+      if form_object.all_conditions_met?
+        'Check your changes and mark conditions as met'
+      elsif form_object.any_condition_not_met?
+        'Check your changes and mark conditions as not met'
+      else
+        'Check and update status of conditions'
+      end
+    end
+
+    def confirm_button_text
+      if form_object.all_conditions_met?
+        'Mark conditions as met and tell candidate'
+      elsif form_object.any_condition_not_met?
+        'Mark conditions as not met'
+      else
+        'Update status'
+      end
+    end
+
+    def confirm_button_class
+      'govuk-button--warning' if form_object.any_condition_not_met?
+    end
+  end
+end

--- a/app/frontend/styles/_box.scss
+++ b/app/frontend/styles/_box.scss
@@ -1,0 +1,19 @@
+.app-box {
+  border: 5px solid govuk-colour('mid-grey');
+  padding: govuk-spacing(4);
+  margin-bottom: govuk-spacing(4);
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+
+  .govuk-summary-list:last-child {
+    margin-bottom: 0;
+  }
+
+  .govuk-summary-list__row:last-child .govuk-summary-list__key,
+  .govuk-summary-list__row:last-child .govuk-summary-list__value,
+  .govuk-summary-list__row:last-child .govuk-summary-list__actions {
+    border-bottom: none;
+  }
+}

--- a/app/frontend/styles/_conditions-list.scss
+++ b/app/frontend/styles/_conditions-list.scss
@@ -1,0 +1,34 @@
+.app-conditions-list {
+  .govuk-summary-list__key {
+    @include govuk-media-query($from: tablet) {
+      width: 60%;
+    }
+    font-weight: normal;
+  }
+
+  .govuk-summary-list__value {
+    @include govuk-media-query($from: tablet) {
+      width: 15%;
+    }
+  }
+
+  .govuk-summary-list__actions {
+    @include govuk-media-query($from: tablet) {
+      width: 25%;
+    }
+  }
+}
+
+.app-condition-list--combined {
+  .govuk-summary-list__row dd:last-of-type {
+    @include govuk-media-query($from: tablet) {
+      text-align: right;
+    }
+  }
+}
+
+.app-conditions-list__tag {
+  @include govuk-media-query($from: tablet) {
+    text-align: right;
+  }
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -41,6 +41,7 @@ $moj-images-path: "~@ministryofjustice/frontend/moj/assets/images/";
 @import "application-card";
 @import "autocomplete";
 @import "banner";
+@import "box";
 @import "notification_banner";
 @import "card";
 @import "conditions-list";

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -43,6 +43,7 @@ $moj-images-path: "~@ministryofjustice/frontend/moj/assets/images/";
 @import "banner";
 @import "notification_banner";
 @import "card";
+@import "conditions-list";
 @import "contents-list";
 @import "diagram";
 @import "feedback";

--- a/spec/components/previews/provider_interface/conditions_list_component_preview.rb
+++ b/spec/components/previews/provider_interface/conditions_list_component_preview.rb
@@ -1,0 +1,14 @@
+module ProviderInterface
+  class ConditionsListComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
+    def empty_conditions
+      render ConditionsListComponent.new([])
+    end
+
+    def conditions_list
+      conditions = rand(1..3).times.map { FactoryBot.build_stubbed(:offer_condition, status: %w[pending met unmet].sample) }
+      render ConditionsListComponent.new(conditions)
+    end
+  end
+end

--- a/spec/components/provider_interface/conditions_list_component_spec.rb
+++ b/spec/components/provider_interface/conditions_list_component_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ConditionsListComponent do
+  let(:render) { render_inline(described_class.new(conditions)) }
+
+  context 'when there are no conditions' do
+    let(:conditions) { [] }
+
+    it 'renders text' do
+      expect(render.css('p').text).to eq('No conditions have been set for this offer.')
+    end
+  end
+
+  context 'when there are conditions' do
+    let(:conditions) do
+      [
+        build_stubbed(:offer_condition),
+        build_stubbed(:offer_condition, status: 'met'),
+      ]
+    end
+
+    it 'renders a list of conditions with their statuses' do
+      expect(render.css('.govuk-summary-list__key').first.text.squish).to eq(conditions.first.text)
+      expect(render.css('.govuk-summary-list__value').first.text.squish).to eq('Pending')
+
+      expect(render.css('.govuk-summary-list__key').last.text.squish).to eq(conditions.last.text)
+      expect(render.css('.govuk-summary-list__value').last.text.squish).to eq('Met')
+    end
+  end
+end

--- a/spec/components/provider_interface/individual_condition_status_review_component_spec.rb
+++ b/spec/components/provider_interface/individual_condition_status_review_component_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::IndividualConditionStatusReviewComponent do
+  let(:all_conditions_met) { false }
+  let(:any_condition_not_met) { false }
+  let(:form_object) { double }
+
+  let(:render) { render_inline(described_class.new(form_object: form_object, application_choice: create(:application_choice, :with_offer))) }
+
+  before do
+    allow(form_object).to receive(:all_conditions_met?).and_return(all_conditions_met)
+    allow(form_object).to receive(:any_condition_not_met?).and_return(any_condition_not_met)
+    allow(form_object).to receive(:conditions).and_return([])
+  end
+
+  context 'when conditions are not all met or unmet' do
+    it 'shows the correct title' do
+      expect(render.css('h1').text).to eq('Check and update status of conditions')
+    end
+
+    it 'shows the correct button text without the warning class' do
+      expect(render.css('input .govuk-button--warning')).to be_empty
+      expect(render.css('input[type="submit"]').first['value']).to eq('Update status')
+    end
+  end
+
+  context 'when all conditions are met' do
+    let(:all_conditions_met) { true }
+
+    it 'shows the correct title' do
+      expect(render.css('h1').text).to eq('Check your changes and mark conditions as met')
+    end
+
+    it 'shows the correct button text without the warning class' do
+      expect(render.css('input .govuk-button--warning')).to be_empty
+      expect(render.css('input[type="submit"]').first['value']).to eq('Mark conditions as met and tell candidate')
+    end
+  end
+
+  context 'when a condition is not met' do
+    let(:any_condition_not_met) { true }
+
+    it 'shows the correct title' do
+      expect(render.css('h1').text).to eq('Check your changes and mark conditions as not met')
+    end
+
+    it 'shows the correct button text with the warning class' do
+      expect(render.css('.govuk-button--warning').css('input[type="submit"]').first['value']).to eq('Mark conditions as not met')
+    end
+
+    it 'shows the information text about the status of the application' do
+      expect(render.text).to include('The candidate will be told that their application was unsuccessful.')
+    end
+  end
+end


### PR DESCRIPTION
## Context
There are new components required for the individual conditions flow

## Changes proposed in this pull request
- Add a conditions list component with the correct HTML from the. prototype
- Add a form page for selecting condition statuses
- Add a check answers page

## Guidance to review
Per commit

## Link to Trello card
https://trello.com/c/4keyF4am/3791-implement-individual-conditions-ui-in-manage-for-non-deferred-offers

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
