### PR TITLE
Move offer association creation in after(:build) to avoid creating mu…

### DIFF
--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -165,7 +165,10 @@ FactoryBot.define do
       decline_by_default_at { 10.business_days.from_now }
       decline_by_default_days { 10 }
       offered_at { Time.zone.now }
-      association :offer
+
+      after(:build) do |application_choice, evaluator|
+        application_choice.offer = build(:offer, application_choice: application_choice) if evaluator.offer.blank?
+      end
 
       after(:stub) do |application_choice, evaluator|
         if evaluator.offer.present?

--- a/spec/system/support_interface/managing_users_v2/bulk_upload_a_single_provider_user_spec.rb
+++ b/spec/system/support_interface/managing_users_v2/bulk_upload_a_single_provider_user_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'bulk upload provider users' do
   end
 
   def given_dfe_signin_is_configured
-    set_dsi_api_response(success: true)
+    dsi_api_response(success: true)
   end
 
   def and_i_am_a_support_user

--- a/spec/system/support_interface/managing_users_v2/bulk_upload_multiple_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_users_v2/bulk_upload_multiple_provider_users_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'bulk upload provider users' do
   end
 
   def given_dfe_signin_is_configured
-    set_dsi_api_response(success: true)
+    dsi_api_response(success: true)
   end
 
   def and_i_am_a_support_user


### PR DESCRIPTION
…ltiple application_choices

## Context

Resolves issue with offer related flaky specs by ensuring that offer association is build after the application choice as the current setup creaets duplicate entries of the application_choice, which seems to be causing the failures.