### PR TITLE
Begin adopting govuk_summary_list component

### DIFF
--- a/app/components/api_docs/property_list_component.html.erb
+++ b/app/components/api_docs/property_list_component.html.erb
@@ -1,55 +1,46 @@
-<dl class="govuk-summary-list">
+<%= govuk_summary_list do |component| %>
   <% properties.each do |property| %>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <code><%= property.name %></code>
-      </dt>
+    <% content_for :value, flush: true do %>
+      <p class="govuk-body">
+        <% if !property.object_schema_name %>
+          <%= property.type_description %>
+        <% elsif property.type == 'array' %>
+          Array of <%= govuk_link_to property.object_schema_name, "##{property.object_schema_name.parameterize}-object" %> objects
+        <% else %>
+          <%= govuk_link_to property.object_schema_name, "##{property.object_schema_name.parameterize}-object" %> object
+        <% end %>
+      </p>
 
-      <dd class="govuk-summary-list__value">
-        <p class="app-api-metadata">
-          <% if !property.object_schema_name %>
-            <%= property.type_description %>
-          <% elsif property.type == 'array' %>
-            Array of <%= govuk_link_to property.object_schema_name, "##{property.object_schema_name.parameterize}-object" %> objects
-          <% else %>
-            <%= govuk_link_to property.object_schema_name, "##{property.object_schema_name.parameterize}-object" %> object
+      <% if property.nullable? %>
+        <p class="govuk-body">Optional</p>
+      <% end %>
+
+      <% if property.deprecated? %>
+        <p class="govuk-body"><%= govuk_tag(text: 'Deprecated', colour: 'red') %></p>
+      <% end %>
+
+      <% if property.attributes.description %>
+        <%= markdown_to_html property.attributes.description %>
+      <% end %>
+
+      <% if property.example %>
+        <p class="govuk-body">Example: <code><%= property.example.is_a?(Array) ? json_code_sample(property.example) : property.example.inspect %></code></p>
+      <% end %>
+
+      <% if property.enum %>
+        <p class="govuk-body">Possible values:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <% property.enum.each do |item| %>
+            <li><code><%= item.inspect %></code></li>
           <% end %>
-        </p>
+        </ul>
+      <% end %>
+    <% end %>
 
-        <% if property.nullable? %>
-          <p class="app-api-metadata">
-            Optional
-          </p>
-        <% end %>
-
-        <% if property.deprecated? %>
-          <p class="app-api-metadata govuk-!-font-weight-bold">
-            DEPRECATED
-          </p>
-        <% end %>
-
-        <% if property.attributes.description %>
-          <%= markdown_to_html property.attributes.description %>
-        <% end %>
-
-        <% if property.example %>
-          <p class="govuk-body">
-            Example: <code><%= property.example.is_a?(Array) ? json_code_sample(property.example) : property.example.inspect %></code>
-          </p>
-        <% end %>
-
-        <% if property.enum %>
-          <p class="govuk-body">
-            Possible values:
-          </p>
-
-          <ul class="govuk-list govuk-list--bullet">
-            <% property.enum.each do |item| %>
-              <li><code><%= item.inspect %></code></li>
-            <% end %>
-          </ul>
-        <% end %>
-      </dd>
-    </div>
+    <%= component.slot(
+      :row,
+      key: "<code>#{property.name}</code>".html_safe,
+      value: content_for(:value),
+    ) %>
   <% end %>
-</dl>
+<% end %>

--- a/app/frontend/styles/_syntax-highlighting.scss
+++ b/app/frontend/styles/_syntax-highlighting.scss
@@ -22,12 +22,6 @@ $code-0f: #c92424; // Deprecated, opening/closing embedded language tags e.g. <?
 $code-insert-bg: #def8ca;
 $code-delete-bg: #fadddd;
 
-.app-api-metadata {
-  color: $govuk-secondary-text-colour;
-  margin: 0;
-  font-weight: normal;
-}
-
 .app-json-code-sample {
   background: $code-00;
   color: $code-05;

--- a/app/views/candidate_interface/submitted_application_form/review_submitted.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/review_submitted.html.erb
@@ -6,15 +6,8 @@
   <%= t('page_titles.submitted_application') %>
 </h1>
 
-<dl class="govuk-summary-list app-summary">
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      Date submitted
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <%= submitted_at_date %>
-    </dd>
-  </div>
-</dl>
+<%= govuk_summary_list do |component| %>
+  <%= component.slot(:row, key: 'Date submitted', value: submitted_at_date) %>
+<% end %>
 
 <%= render 'candidate_interface/application_form/review', application_form: @application_form, editable: false %>


### PR DESCRIPTION
## Context

Split off from #4760 — further commits on that PR need more work, but these two commits are standalone improvements

## Changes proposed in this pull request

Adopt `govuk_summary_list` for the application-submitted page and the API property list, eg https://www.apply-for-teacher-training.service.gov.uk/api-docs/reference#candidate-object

## Guidance to review

Is it equivalent to what was there before (except the nice new red `DEPRECATED` badge)

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
