### PR TITLE
Fix carry over test applications

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -104,10 +104,11 @@ private
       last_name = candidate.current_application.last_name
       previous_application_form = candidate.current_application
     elsif carry_over
+      courses_from_last_year = Course.open_on_apply.in_cycle(recruitment_cycle_year - 1).sample(rand(1..3))
       create_application_to_courses(
         recruitment_cycle_year: recruitment_cycle_year - 1,
-        courses: courses,
-        states: courses.count.times.map { %i[declined rejected].sample },
+        courses: courses_from_last_year,
+        states: courses_from_last_year.count.times.map { %i[declined rejected].sample },
         candidate: candidate,
       )
 

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -150,6 +150,23 @@ RSpec.describe TestApplications do
     end
   end
 
+  describe 'carried over' do
+    it 'generates an application to courses from the year before' do
+      create(:course_option, course: create(:course, :open_on_apply))
+      create(:course_option, course: create(:course, :open_on_apply, :previous_year))
+
+      TestApplications.new.create_application(recruitment_cycle_year: RecruitmentCycle.current_year, states: %i[awaiting_provider_decision], courses_to_apply_to: Course.current_cycle, carry_over: true)
+
+      previous_form = ApplicationForm.where(recruitment_cycle_year: RecruitmentCycle.previous_year).first
+      new_form = ApplicationForm.current_cycle.first
+
+      expect(previous_form).not_to be_nil
+      expect(previous_form.application_choices.first.course.recruitment_cycle_year).to eq(RecruitmentCycle.previous_year)
+      expect(new_form).not_to be_nil
+      expect(new_form.application_choices.first.course.recruitment_cycle_year).to eq(RecruitmentCycle.current_year)
+    end
+  end
+
   it 'marks any submitted application choices as just updated', with_audited: true do
     create(:course_option, course: create(:course, :open_on_apply))
 


### PR DESCRIPTION
## Context
We are getting warnings about courses from the wrong cycle on applications in test environments

## Changes proposed in this pull request
Generate a fake application to courses in the previous cycle when carry_over is true

## Guidance to review


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
