### PR TITLE
Email candidate when an application is withdrawn at their request

### DIFF
--- a/app/services/concerns/candidate_applications.rb
+++ b/app/services/concerns/candidate_applications.rb
@@ -1,0 +1,25 @@
+module CandidateApplications
+  def applications_with_offer_and_awaiting_decision?
+    applications_with_offer_count == 1 && applications_awaiting_decision_count == 1
+  end
+
+  def applications_with_offers_only?
+    applications_with_offer_count.positive? && applications_awaiting_decision_count.zero?
+  end
+
+  def applications_awaiting_decision_only?
+    applications_awaiting_decision_count.positive? && applications_with_offer_count.zero?
+  end
+
+  def applications_awaiting_decision_count
+    @applications_pending_decision_count ||= candidate_applications.decision_pending.count
+  end
+
+  def applications_with_offer_count
+    @applications_with_offer_count ||= candidate_applications.offer.count
+  end
+
+  def candidate_applications
+    @candidate_applications ||= @application_choice.self_and_siblings
+  end
+end

--- a/app/services/provider_interface/decline_or_withdraw_application.rb
+++ b/app/services/provider_interface/decline_or_withdraw_application.rb
@@ -28,7 +28,7 @@ module ProviderInterface
         StateChangeNotifier.new(transition, @application_choice).application_outcome_notification
       end
 
-      # TODO: Email candidate.
+      SendCandidateWithdrawnOnRequestEmail.new(application_choice: application_choice).call
 
       ResolveUCASMatch.new(application_choice: @application_choice).call if resolve_ucas_match?
 

--- a/app/services/provider_interface/decline_or_withdraw_application.rb
+++ b/app/services/provider_interface/decline_or_withdraw_application.rb
@@ -16,10 +16,10 @@ module ProviderInterface
       ActiveRecord::Base.transaction do
         if declining?
           ApplicationStateChange.new(@application_choice).decline!
-          @application_choice.update!(declined_at: Time.zone.now)
+          @application_choice.update!(declined_at: Time.zone.now, audit_comment: 'Declined on behalf of the candidate')
         elsif withdrawing?
           ApplicationStateChange.new(@application_choice).withdraw!
-          @application_choice.update!(withdrawn_at: Time.zone.now)
+          @application_choice.update!(withdrawn_at: Time.zone.now, audit_comment: 'Withdrawn on behalf of the candidate')
           SetDeclineByDefault.new(application_form: @application_choice.application_form).call
         end
       end

--- a/app/services/provider_interface/send_candidate_withdrawn_on_request_email.rb
+++ b/app/services/provider_interface/send_candidate_withdrawn_on_request_email.rb
@@ -1,0 +1,23 @@
+module ProviderInterface
+  class SendCandidateWithdrawnOnRequestEmail
+    include CandidateApplications
+
+    attr_reader :application_choice, :helper
+
+    def initialize(application_choice:)
+      @application_choice = application_choice
+    end
+
+    def call
+      if candidate_applications.all?(&:withdrawn?)
+        CandidateMailer.application_withdrawn_on_request_all_applications_withdrawn(application_choice).deliver_later
+      elsif applications_with_offer_and_awaiting_decision?
+        CandidateMailer.application_withdrawn_on_request_one_offer_one_awaiting_decision(application_choice).deliver_later
+      elsif applications_awaiting_decision_only?
+        CandidateMailer.application_withdrawn_on_request_awaiting_decision_only(application_choice).deliver_later
+      elsif applications_with_offers_only?
+        CandidateMailer.application_withdrawn_on_request_offers_only(application_choice).deliver_later
+      end
+    end
+  end
+end

--- a/app/services/send_candidate_rejection_email.rb
+++ b/app/services/send_candidate_rejection_email.rb
@@ -1,4 +1,6 @@
 class SendCandidateRejectionEmail
+  include CandidateApplications
+
   attr_reader :application_choice
 
   def initialize(application_choice:)
@@ -15,31 +17,5 @@ class SendCandidateRejectionEmail
     elsif applications_with_offers_only?
       CandidateMailer.application_rejected_offers_only(application_choice).deliver_later
     end
-  end
-
-private
-
-  def applications_with_offer_and_awaiting_decision?
-    applications_with_offer_count == 1 && applications_awaiting_decision_count == 1
-  end
-
-  def applications_with_offers_only?
-    applications_with_offer_count.positive? && applications_awaiting_decision_count.zero?
-  end
-
-  def applications_awaiting_decision_only?
-    applications_awaiting_decision_count.positive? && applications_with_offer_count.zero?
-  end
-
-  def applications_awaiting_decision_count
-    @applications_pending_decision_count ||= candidate_applications.decision_pending.count
-  end
-
-  def applications_with_offer_count
-    @applications_with_offer_count ||= candidate_applications.offer.count
-  end
-
-  def candidate_applications
-    @candidate_applications ||= application_choice.self_and_siblings
   end
 end

--- a/app/views/candidate_mailer/application_withdrawn_on_request_all_applications_withdrawn.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_all_applications_withdrawn.text.erb
@@ -1,0 +1,19 @@
+Dear <%= @application_form.first_name %>,
+
+# Update on your application
+
+At your request, <%= @course.provider.name %> has withdrawn your application to study <%= @course.name_and_code %>.
+
+If you did not ask them to withdraw the application, contact a Get Into Teaching adviser:
+
+https://getintoteaching.education.gov.uk/#talk-to-us
+
+You can also call for free on 0800 389 2500, Monday to Friday, 8.30am to 5pm (except public holidays).
+
+# You can apply again
+
+<% if @multiple_applications %>
+  You’ve now had decisions about all the courses you applied for. You did not get any offers, so you can apply again.
+<% end %>
+
+<%= render 'still_interested_content' %>

--- a/app/views/candidate_mailer/application_withdrawn_on_request_awaiting_decision_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_awaiting_decision_only.text.erb
@@ -1,0 +1,31 @@
+Dear <%= @application_form.first_name %>,
+
+# Update on your application
+
+At your request, <%= @course.provider.name %> has withdrawn your application to study <%= @course.name_and_code %>.
+
+If you did not ask them to withdraw the application, contact a Get Into Teaching adviser:
+
+https://getintoteaching.education.gov.uk/#talk-to-us
+
+You can also call for free on 0800 389 2500, Monday to Friday, 8.30am to 5pm (except public holidays).
+
+<% if @awaiting_decision.length == 1 %>
+
+# You’re waiting for a decision
+
+You’re waiting for <%= @awaiting_decision.first.course_option.course.provider.name %> to make a decision about your application to study <%= @awaiting_decision.first.course_option.course.name %>. They should do this by <%= @awaiting_decision.first.reject_by_default_at.to_s(:govuk_date) %>.
+
+<% else %>
+
+# You’re waiting for decisions
+
+You're waiting for decisions about your applications to:
+
+<% @awaiting_decision.each do |awaiting_decision| %>
+  - <%= awaiting_decision.course_option.course.provider.name %> to study <%= awaiting_decision.course_option.course.name %>
+<% end %>
+
+They should make their decisions by <%= @awaiting_decisions_by %>.
+
+<% end %>

--- a/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
@@ -1,0 +1,35 @@
+Dear <%= @application_form.first_name %>,
+
+# Update on your application
+
+At your request, <%= @course.provider.name %> has withdrawn your application to study <%= @course.name_and_code %>.
+
+If you did not ask them to withdraw the application, contact a Get Into Teaching adviser:
+
+https://getintoteaching.education.gov.uk/#talk-to-us
+
+You can also call for free on 0800 389 2500, Monday to Friday, 8.30am to 5pm (except public holidays).
+
+# Respond to your <%= 'offer'.pluralize(@offers.length) %> by <%= @respond_by_date %>
+
+<% if @offers.length == 1 %>
+
+You’ve received an offer from <%= @offers.first.course_option.course.provider.name %> to study <%= @offers.first.course_option.course.name %>. You’re not waiting for any other decisions.
+
+<% else %>
+
+You’ve received offers from:
+
+<% @offers.each do |offer| %>
+  - <%= offer.course_option.course.provider.name %> to study <%= offer.course_option.course.name %>
+<% end %>
+
+You’re not waiting for any other decisions.
+
+<% end %>
+
+The <%= 'offer'.pluralize(@offers.length) %> will automatically be withdrawn if you do not respond by <%= @respond_by_date %>.
+
+Sign in to your account to respond:
+
+<%= @candidate_magic_link %>

--- a/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
@@ -1,0 +1,21 @@
+Dear <%= @application_form.first_name %>,
+
+# Update on your application
+
+At your request, <%= @course.provider.name %> has withdrawn your application to study <%= @course.name_and_code %>.
+
+If you did not ask them to withdraw the application, contact a Get Into Teaching adviser:
+
+https://getintoteaching.education.gov.uk/#talk-to-us
+
+You can also call for free on 0800 389 2500, Monday to Friday, 8.30am to 5pm (except public holidays).
+
+# You have an offer and are waiting for a decision about another course
+
+You have an offer from <%= @offer.course_option.course.provider.name %> to study <%= @offer.course_option.course.name %>.
+
+<%= @awaiting_decision.course_option.course.provider.name %> has until <%= @awaiting_decision_by %> to make a decision about your application to study <%= @awaiting_decision.course_option.course.name %>.
+
+You can wait until you’ve received both decisions before you respond. Alternatively you can sign in to your account and accept the offer you’ve already got:
+
+<%= @candidate_magic_link %>

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -234,9 +234,13 @@ en:
       name: Candidate withdraws
       by: candidate
       description: |
-        The candidate makes a withdrawal decision to inform the provider that they no longer want their application to be considered. The candidate can withdraw an application at any time.
+        The candidate makes a withdrawal decision to inform the provider that they no longer want their application to be considered. The candidate can withdraw an application at any time or ask the provider to withdraw the application on their behalf.
       emails:
         - provider_mailer-application_withdrawn
+        - candidate_mailer-application_withdrawn_on_request_all_applications_withdrawn
+        - candidate_mailer-application_withdrawn_on_request_awaiting_decision_only
+        - candidate_mailer-application_withdrawn_on_request_offers_only
+        - candidate_mailer-application_withdrawn_on_request_one_offer_one_awaiting_decision
 
     awaiting_provider_decision-reject_by_default:
       name: Rejected by default
@@ -279,9 +283,13 @@ en:
       name: Candidate withdraws
       by: candidate
       description: |
-        The candidate makes a withdrawal decision to inform the provider that they no longer want their application to be considered. The candidate can withdraw an application at any time.
+        The candidate makes a withdrawal decision to inform the provider that they no longer want their application to be considered. The candidate can withdraw an application at any time or ask a provider to withdraw an application on their behalf.
       emails:
         - provider_mailer-application_withdrawn
+        - candidate_mailer-application_withdrawn_on_request_all_applications_withdrawn
+        - candidate_mailer-application_withdrawn_on_request_awaiting_decision_only
+        - candidate_mailer-application_withdrawn_on_request_offers_only
+        - candidate_mailer-application_withdrawn_on_request_one_offer_one_awaiting_decision
 
     interviewing-reject_by_default:
       name: Rejected by default
@@ -355,9 +363,13 @@ en:
     offer-decline:
       name: Candidate declines offer
       by: candidate
-      description: The candidate can decline the offer.
+      description: The candidate can decline the offer or ask the provider to withdraw the offered application on their behalf.
       emails:
         - provider_mailer-declined
+        - candidate_mailer-application_withdrawn_on_request_all_applications_withdrawn
+        - candidate_mailer-application_withdrawn_on_request_awaiting_decision_only
+        - candidate_mailer-application_withdrawn_on_request_offers_only
+        - candidate_mailer-application_withdrawn_on_request_one_offer_one_awaiting_decision
 
     pending_conditions-confirm_conditions_met:
       name: Provider confirms conditions are met
@@ -376,16 +388,24 @@ en:
     pending_conditions-withdraw:
       name: Candidate withdraws
       by: candidate
-      description: Candidates can withdraw at any time.
+      description: Candidates can withdraw at any time or ask the provider to withdraw the application on their behalf.
       emails:
         - provider_mailer-application_withdrawn
+        - candidate_mailer-application_withdrawn_on_request_all_applications_withdrawn
+        - candidate_mailer-application_withdrawn_on_request_awaiting_decision_only
+        - candidate_mailer-application_withdrawn_on_request_offers_only
+        - candidate_mailer-application_withdrawn_on_request_one_offer_one_awaiting_decision
 
     recruited-withdraw:
       name: Candidate withdraws
       by: candidate
-      description: Candidates can withdraw at any time.
+      description: Candidates can withdraw at any time or ask the provider to withdraw the application on their behalf.
       emails:
         - provider_mailer-application_withdrawn
+        - candidate_mailer-application_withdrawn_on_request_all_applications_withdrawn
+        - candidate_mailer-application_withdrawn_on_request_awaiting_decision_only
+        - candidate_mailer-application_withdrawn_on_request_offers_only
+        - candidate_mailer-application_withdrawn_on_request_one_offer_one_awaiting_decision
 
     rejected-give_feedback_for_application_rejected_by_default:
       name: Provider gives feedback for application rejected by default
@@ -564,4 +584,9 @@ en:
     offer_deferred-withdraw:
       name: Withdraw
       by: candidate
-      description: Candidates can withdraw at any time.
+      description: Candidates can withdraw at any time or ask the provider to withdraw the application on their behalf.
+      emails:
+        - candidate_mailer-application_withdrawn_on_request_all_applications_withdrawn
+        - candidate_mailer-application_withdrawn_on_request_awaiting_decision_only
+        - candidate_mailer-application_withdrawn_on_request_offers_only
+        - candidate_mailer-application_withdrawn_on_request_one_offer_one_awaiting_decision

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -59,6 +59,14 @@ en:
       subject: Update on your application
     application_rejected_offers_only:
       subject: Update on your application - respond by %{date}
+    application_withdrawn_on_request_all_applications_withdrawn:
+      subject: Update on your application - all decisions now made
+    application_withdrawn_on_request_one_offer_one_awaiting_decision:
+      subject: Update on your application - decide what to do
+    application_withdrawn_on_request_awaiting_decision_only:
+      subject: Update on your application
+    application_withdrawn_on_request_offers_only:
+      subject: Update on your application - respond by %{date}
     application_withdrawn:
       subject:
         one: "You’ve withdrawn your application: next steps"

--- a/spec/mailers/candidate_mailer_withdrawn_on_request_spec.rb
+++ b/spec/mailers/candidate_mailer_withdrawn_on_request_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe CandidateMailer, type: :mailer do
+  include TestHelpers::MailerSetupHelper
+
+  subject(:mailer) { described_class }
+
+  let(:candidate) { build_stubbed(:candidate) }
+  let!(:application_form) { build_stubbed(:application_form, first_name: 'Fred', candidate: candidate, application_choices: application_choices) }
+  let(:provider) { build_stubbed(:provider, name: 'Arithmetic College') }
+  let(:site) { build_stubbed(:site, name: 'Aquaria') }
+  let(:course) { build_stubbed(:course, name: 'Mathematics', code: 'M101', provider: provider) }
+  let(:course_option) { build_stubbed(:course_option, course: course) }
+
+  let(:other_provider) { build_stubbed(:provider, name: 'Falconholt Technical College', code: 'X100') }
+  let(:other_course) { build_stubbed(:course, name: 'Forensic Science', code: 'E0FO', provider: other_provider) }
+  let(:other_option) { build_stubbed(:course_option, course: other_course, site: site) }
+
+  let(:application_choices) { [] }
+
+  before do
+    magic_link_stubbing(candidate)
+  end
+
+  describe '.application_withdrawn_on_request_all_applications_withdrawn' do
+    let(:email) { mailer.application_withdrawn_on_request_all_applications_withdrawn(application_choices.first) }
+    let(:application_choices) { [build_stubbed(:application_choice, :rejected, course_option: course_option)] }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      I18n.t!('candidate_mailer.application_withdrawn_on_request_all_applications_withdrawn.subject', provider_name: 'Arithmetic College'),
+      'heading' => 'Dear Fred',
+      'withdrawn sentence' => 'At your request, Arithmetic College has withdrawn your application to study Mathematics (M101)',
+      'link to support' => 'https://getintoteaching.education.gov.uk/#talk-to-us',
+      'apply again' => 'You can apply again',
+    )
+  end
+
+  describe '.application_withdrawn_on_request_awaiting_decision_only' do
+    let(:email) { mailer.application_withdrawn_on_request_awaiting_decision_only(application_choices.first) }
+    let(:application_choices) { [build_stubbed(:application_choice, :awaiting_provider_decision, course_option: course_option)] }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      I18n.t!('candidate_mailer.application_withdrawn_on_request_awaiting_decision_only.subject', provider_name: 'Arithmetic College'),
+      'heading' => 'Dear Fred',
+      'withdrawn sentence' => 'At your request, Arithmetic College has withdrawn your application to study Mathematics (M101)',
+      'link to support' => 'https://getintoteaching.education.gov.uk/#talk-to-us',
+      'awaiting decision content' => 'You’re waiting for Arithmetic College to make a decision about your application to study Mathematics.',
+    )
+  end
+
+  describe '.application_withdrawn_on_request_offers_only' do
+    let(:email) { mailer.application_withdrawn_on_request_offers_only(application_choices.first) }
+    let(:application_choices) { [build_stubbed(:application_choice, :with_offer, course_option: course_option, decline_by_default_at: Time.zone.local(2021, 6, 22))] }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      I18n.t!('candidate_mailer.application_withdrawn_on_request_offers_only.subject', provider_name: 'Arithmetic College', date: Time.zone.local(2021, 6, 22).to_s(:govuk_date)),
+      'heading' => 'Dear Fred',
+      'withdrawn sentence' => 'At your request, Arithmetic College has withdrawn your application to study Mathematics (M101)',
+      'link to support' => 'https://getintoteaching.education.gov.uk/#talk-to-us',
+      'offer content' => 'You’ve received an offer from Arithmetic College to study Mathematics',
+    )
+  end
+
+  describe '.application_withdrawn_on_request_one_offer_one_awaiting_decision' do
+    let(:email) { mailer.application_withdrawn_on_request_one_offer_one_awaiting_decision(application_choices.first) }
+    let(:application_choices) do
+      [
+        build_stubbed(:application_choice, :with_offer, course_option: course_option, decline_by_default_at: Time.zone.local(2021, 6, 22)),
+        build_stubbed(:application_choice, :awaiting_provider_decision, course_option: other_option, reject_by_default_at: Time.zone.local(2021, 7, 1)),
+      ]
+    end
+
+    it_behaves_like(
+      'a mail with subject and content',
+      I18n.t!('candidate_mailer.application_withdrawn_on_request_one_offer_one_awaiting_decision.subject', provider_name: 'Arithmetic College'),
+      'heading' => 'Dear Fred',
+      'withdrawn sentence' => 'At your request, Arithmetic College has withdrawn your application to study Mathematics (M101)',
+      'link to support' => 'https://getintoteaching.education.gov.uk/#talk-to-us',
+      'offer content' => 'You have an offer from Arithmetic College to study Mathematics.',
+      'awaiting decision content' => 'Falconholt Technical College has until 1 July 2021 to make a decision about your application to study Forensic Science.',
+    )
+  end
+end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -395,21 +395,21 @@ class CandidateMailerPreview < ActionMailer::Preview
       last_name: 'Wellick',
       candidate: candidate,
       application_choices: [
-        FactoryBot.build_stubbed(
+        FactoryBot.build(
           :application_choice,
           application_form: application_form,
           course_option: course_option,
           status: :withdrawn,
           withdrawn_at: Time.zone.now,
         ),
-        FactoryBot.build_stubbed(
+        FactoryBot.build(
           :application_choice,
           :with_offer,
           application_form: application_form,
           reject_by_default_at: 7.days.since,
           course_option: course_option,
         ),
-        FactoryBot.build_stubbed(
+        FactoryBot.build(
           :application_choice,
           application_form: application_form,
           reject_by_default_at: 9.days.since,
@@ -461,21 +461,21 @@ class CandidateMailerPreview < ActionMailer::Preview
       last_name: 'Wellick',
       candidate: candidate,
       application_choices: [
-        FactoryBot.build_stubbed(
+        FactoryBot.build(
           :application_choice,
           application_form: application_form,
           course_option: course_option,
           status: :withdrawn,
           withdrawn_at: Time.zone.now,
         ),
-        FactoryBot.build_stubbed(
+        FactoryBot.build(
           :application_choice,
           :with_offer,
           application_form: application_form,
           decline_by_default_at: 3.days.from_now,
           course_option: course_option,
         ),
-        FactoryBot.build_stubbed(
+        FactoryBot.build(
           :application_choice,
           :with_offer,
           application_form: application_form,

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -377,6 +377,116 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.application_rejected_offers_only(application_form.application_choices.first)
   end
 
+  def application_withdrawn_on_request_all_applications_withdrawn
+    application_choice = FactoryBot.build_stubbed(
+      :application_choice,
+      application_form: application_form,
+      course_option: course_option,
+      status: :withdrawn,
+      withdrawn_at: Time.zone.now,
+    )
+    CandidateMailer.application_withdrawn_on_request_all_applications_withdrawn(application_choice)
+  end
+
+  def application_withdrawn_on_request_one_offer_one_awaiting_decision
+    application_form = FactoryBot.build_stubbed(
+      :application_form,
+      first_name: 'Tyrell',
+      last_name: 'Wellick',
+      candidate: candidate,
+      application_choices: [
+        FactoryBot.build_stubbed(
+          :application_choice,
+          application_form: application_form,
+          course_option: course_option,
+          status: :withdrawn,
+          withdrawn_at: Time.zone.now,
+        ),
+        FactoryBot.build_stubbed(
+          :application_choice,
+          :with_offer,
+          application_form: application_form,
+          reject_by_default_at: 7.days.since,
+          course_option: course_option,
+        ),
+        FactoryBot.build_stubbed(
+          :application_choice,
+          application_form: application_form,
+          reject_by_default_at: 9.days.since,
+          status: :awaiting_provider_decision,
+          course_option: course_option,
+        ),
+      ],
+    )
+    CandidateMailer.application_withdrawn_on_request_one_offer_one_awaiting_decision(application_form.application_choices.first)
+  end
+
+  def application_withdrawn_on_request_awaiting_decision_only
+    application_form = FactoryBot.build_stubbed(
+      :application_form,
+      first_name: 'Tyrell',
+      last_name: 'Wellick',
+      candidate: candidate,
+      application_choices: [
+        FactoryBot.build_stubbed(
+          :application_choice,
+          application_form: application_form,
+          course_option: course_option,
+          status: :withdrawn,
+          withdrawn_at: Time.zone.now,
+        ),
+        FactoryBot.build_stubbed(
+          :application_choice,
+          status: :awaiting_provider_decision,
+          application_form: application_form,
+          reject_by_default_at: 3.days.from_now,
+          course_option: course_option,
+        ),
+        FactoryBot.build_stubbed(
+          :application_choice,
+          application_form: application_form,
+          reject_by_default_at: 2.days.from_now,
+          status: :awaiting_provider_decision,
+          course_option: course_option,
+        ),
+      ],
+    )
+    CandidateMailer.application_withdrawn_on_request_awaiting_decision_only(application_form.application_choices.first)
+  end
+
+  def application_withdrawn_on_request_offers_only
+    application_form = FactoryBot.build_stubbed(
+      :application_form,
+      first_name: 'Tyrell',
+      last_name: 'Wellick',
+      candidate: candidate,
+      application_choices: [
+        FactoryBot.build_stubbed(
+          :application_choice,
+          application_form: application_form,
+          course_option: course_option,
+          status: :withdrawn,
+          withdrawn_at: Time.zone.now,
+        ),
+        FactoryBot.build_stubbed(
+          :application_choice,
+          :with_offer,
+          application_form: application_form,
+          decline_by_default_at: 3.days.from_now,
+          course_option: course_option,
+        ),
+        FactoryBot.build_stubbed(
+          :application_choice,
+          :with_offer,
+          application_form: application_form,
+          decline_by_default_at: 2.days.from_now,
+          course_option: course_option,
+        ),
+      ],
+    )
+    CandidateMailer.application_withdrawn_on_request_offers_only(application_form.application_choices.first)
+  end
+
   def feedback_received_for_application_rejected_by_default
     application_choice =
       FactoryBot.build(

--- a/spec/services/provider_interface/send_candidate_withdrawn_on_request_email_spec.rb
+++ b/spec/services/provider_interface/send_candidate_withdrawn_on_request_email_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::SendCandidateWithdrawnOnRequestEmail do
+  describe '#call' do
+    let(:mailer) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+    it 'calls CandidateMailer.application_withdrawn_on_request_all_applications_withdrawn when all applications are withdrawn' do
+      allow(CandidateMailer).to receive(:application_withdrawn_on_request_all_applications_withdrawn).and_return(mailer)
+
+      described_class.new(application_choice: create(:application_choice, :withdrawn)).call
+
+      expect(CandidateMailer).to have_received(:application_withdrawn_on_request_all_applications_withdrawn)
+    end
+
+    it 'calls CandidateMailer.application_withdrawn_on_request_awaiting_decision_only when all applications are awaiting decision' do
+      allow(CandidateMailer).to receive(:application_withdrawn_on_request_awaiting_decision_only).and_return(mailer)
+
+      described_class.new(application_choice: create(:application_choice, :awaiting_provider_decision)).call
+
+      expect(CandidateMailer).to have_received(:application_withdrawn_on_request_awaiting_decision_only)
+    end
+
+    it 'calls CandidateMailer.application_withdrawn_on_request_offers_only when all applications have offers' do
+      allow(CandidateMailer).to receive(:application_withdrawn_on_request_offers_only).and_return(mailer)
+
+      described_class.new(application_choice: create(:application_choice, :with_offer)).call
+
+      expect(CandidateMailer).to have_received(:application_withdrawn_on_request_offers_only)
+    end
+
+    it 'calls CandidateMailer.application_withdrawn_on_request_one_offer_one_awaiting_decision when one application has an offer and another is awaiting decision' do
+      allow(CandidateMailer).to receive(:application_withdrawn_on_request_one_offer_one_awaiting_decision).and_return(mailer)
+      offered = create(:application_choice, :with_offer)
+      create(:application_choice, :awaiting_provider_decision, application_form: offered.application_form)
+
+      described_class.new(application_choice: offered).call
+
+      expect(CandidateMailer).to have_received(:application_withdrawn_on_request_one_offer_one_awaiting_decision)
+    end
+  end
+end

--- a/spec/system/provider_interface/withdraw_an_application_at_candidates_request_spec.rb
+++ b/spec/system/provider_interface/withdraw_an_application_at_candidates_request_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "withdrawing an application at the candidate's request", type: :f
     and_i_click_a_link_to_withdraw_at_candidates_request
     and_i_confirm_the_withdrawal
     then_i_see_a_message_confirming_that_the_application_has_been_withdrawn
+    and_the_candidate_receives_an_email_about_the_withdrawal
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -55,5 +56,10 @@ RSpec.describe "withdrawing an application at the candidate's request", type: :f
   def then_i_see_a_message_confirming_that_the_application_has_been_withdrawn
     expect(page).to have_current_path(provider_interface_application_choice_path(@application_choice))
     expect(page).to have_content('Application withdrawn')
+  end
+
+  def and_the_candidate_receives_an_email_about_the_withdrawal
+    open_email(@application_choice.application_form.candidate.email_address)
+    expect(current_email.subject).to have_content 'Update on your application - all decisions now made'
   end
 end


### PR DESCRIPTION
## Context

Providers will be able to withdraw applications at the candidate's request. Candidates will be notified via a suitable email about the withdrawal.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds a service to handle emailing the candidate the appropriate notification based on the status of their applications.
- Adds email templates for custom notifications.
- Moves some common logic around candidate applications into a helper.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Design for emails : https://bat-design-history.netlify.app/manage-teacher-training-applications/withdrawing-an-application-iteration-2/#emails

Having spoken with content design we don't think it necessary to distinguish between 'decline' and 'withdraw' in terms of notifying the candidate.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/4sWEdC5j/3837-email-candidate-when-application-is-withdrawn-at-their-request
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
