### PR TITLE
Redirect away from prefill form if there is already an application

### DIFF
--- a/app/controllers/candidate_interface/prefill_application_form_controller.rb
+++ b/app/controllers/candidate_interface/prefill_application_form_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class PrefillApplicationFormController < CandidateInterfaceController
+    before_action :redirect_if_application_form_present
+
     def new
       @prefill_application_or_not_form = PrefillApplicationOrNotForm.new
     end
@@ -21,6 +23,15 @@ module CandidateInterface
       end
     end
 
+  private
+
+    def redirect_if_application_form_present
+      application_form = current_candidate.application_forms.first
+      return if application_form.nil? || application_form.blank_application?
+
+      redirect_to candidate_interface_application_form_path
+    end
+
     def prefill_candidate_application_form
       example_application_choices = TestApplications.new.create_application(
         recruitment_cycle_year: RecruitmentCycle.current_year,
@@ -34,8 +45,6 @@ module CandidateInterface
       example_application_form = example_application_choices.first.application_form
       current_candidate.application_forms << example_application_form
     end
-
-  private
 
     def prefill_application_or_not_params
       params.fetch(:candidate_interface_prefill_application_or_not_form, {}).permit(:prefill)

--- a/spec/requests/candidate_interface/prefill_application_form_controller_spec.rb
+++ b/spec/requests/candidate_interface/prefill_application_form_controller_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::PrefillApplicationFormController, type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:candidate) { create(:candidate) }
+
+  before { sign_in candidate }
+
+  context 'when the candidate already has a non-blank application form' do
+    let!(:application_form) { create(:application_form, :minimum_info, candidate: candidate, created_at: 1.day.ago) }
+
+    it 'redirects to the application form page' do
+      get candidate_interface_prefill_path
+
+      expect(response.status).to eq(302)
+      expect(response.redirect_url).to eq(candidate_interface_application_form_url)
+    end
+  end
+
+  context 'when the candidate has a blank application form' do
+    let!(:application_form) { create(:application_form, :minimum_info, candidate: candidate) }
+
+    it 'does not redirect to the application form page' do
+      get candidate_interface_prefill_path
+
+      expect(response.status).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
## Context
During testing from an HEI, they noticed that there were multiple applications being generated for the same email address.


## Notes
Given that the candidate would be redirected to the form page from the after sign-in controller in this case anyway, we should redirect there from the prefill controller too. This prevents duplicate prefilled forms being created when the back button is used in the flow
