### PR TITLE
Enable Style/RedundantBegin and Style/FormatString cops

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -160,7 +160,7 @@ module SupportInterface
     end
 
     def rejection_reasons_text
-      @_rejection_reasons_text ||= begin
+      @_rejection_reasons_text ||=
         if application_choice.structured_rejection_reasons.present?
           render(
             ReasonsForRejectionComponent.new(
@@ -172,7 +172,6 @@ module SupportInterface
         elsif application_choice.rejection_reason.present?
           application_choice.rejection_reason
         end
-      end
     end
 
     def visible_over_vendor_api?

--- a/app/controllers/candidate_interface/degrees/grade_controller.rb
+++ b/app/controllers/candidate_interface/degrees/grade_controller.rb
@@ -61,12 +61,10 @@ module CandidateInterface
 
       def set_page_title
         @page_title =
-          begin
-            if current_degree.international?
-              current_degree.completed? ? t('page_titles.degree_grade_international') : t('page_titles.degree_grade_international_predicted')
-            else
-              current_degree.completed? ? t('page_titles.degree_grade') : t('page_titles.degree_grade_predicted')
-            end
+          if current_degree.international?
+            current_degree.completed? ? t('page_titles.degree_grade_international') : t('page_titles.degree_grade_international_predicted')
+          else
+            current_degree.completed? ? t('page_titles.degree_grade') : t('page_titles.degree_grade_predicted')
           end
       end
     end

--- a/app/forms/candidate_interface/pick_course_form.rb
+++ b/app/forms/candidate_interface/pick_course_form.rb
@@ -10,9 +10,7 @@ module CandidateInterface
     DropdownOption = Struct.new(:id, :name)
 
     def radio_available_courses
-      @radio_available_courses ||= begin
-        courses_for_current_cycle.exposed_in_find.order(:name).includes(:course_options)
-      end
+      @radio_available_courses ||= courses_for_current_cycle.exposed_in_find.order(:name).includes(:course_options)
     end
 
     def dropdown_available_courses

--- a/app/forms/candidate_interface/pick_provider_form.rb
+++ b/app/forms/candidate_interface/pick_provider_form.rb
@@ -10,9 +10,7 @@ module CandidateInterface
     end
 
     def available_providers
-      @available_providers ||= begin
-        Provider.all.order(:name)
-      end
+      @available_providers ||= Provider.all.order(:name)
     end
   end
 end

--- a/app/forms/provider_interface/provider_user_providers_form.rb
+++ b/app/forms/provider_interface/provider_user_providers_form.rb
@@ -12,9 +12,7 @@ module ProviderInterface
     end
 
     def providers_that_actor_can_manage_users_for
-      @providers_that_actor_can_manage_users_for ||= begin
-        current_provider_user.authorisation.providers_that_actor_can_manage_users_for
-      end
+      @providers_that_actor_can_manage_users_for ||= current_provider_user.authorisation.providers_that_actor_can_manage_users_for
     end
 
     def persisted?

--- a/app/forms/support_interface/edit_single_provider_user_form.rb
+++ b/app/forms/support_interface/edit_single_provider_user_form.rb
@@ -48,12 +48,11 @@ module SupportInterface
     end
 
     def possible_permissions
-      @possible_permissions ||= begin
+      @possible_permissions ||=
         Provider.where(sync_courses: true).order(:name).map do |provider|
-          provider_permissions = all_possible_permissions.find { |existing_permission| existing_permission.provider_id == provider.id }
+          provider_permissions = all_possible_permissions.find { |permission| permission.provider_id == provider.id }
           provider_permissions || ProviderPermissions.new(provider: provider)
         end
-      end
     end
   end
 end

--- a/app/helpers/geocode_helper.rb
+++ b/app/helpers/geocode_helper.rb
@@ -23,7 +23,7 @@ private
     return 'n/a' if number.blank? && with_units
     return '' if number.blank?
 
-    rounded = sprintf('%.1f', number)
+    rounded = format('%.1f', number)
     with_units ? "#{rounded} miles" : rounded
   end
 end

--- a/app/models/ucas_matched_application.rb
+++ b/app/models/ucas_matched_application.rb
@@ -110,11 +110,11 @@ class UCASMatchedApplication
   end
 
   def application_choice
-    @application_choice ||= begin
+    @application_choice ||=
       ApplicationChoice.includes(:application_form)
-        .where('application_forms.candidate_id = ?', @matching_data['Apply candidate ID']).references(:application_forms)
-        .find_by(course_option: course.course_options)
-    end
+      .where('application_forms.candidate_id = ?', @matching_data['Apply candidate ID'])
+      .references(:application_forms)
+      .find_by(course_option: course.course_options)
   end
 
 private

--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -15,11 +15,10 @@ class DetectInvariants
   end
 
   def detect_application_choices_in_old_states
-    choices_in_wrong_state = begin
+    choices_in_wrong_state =
       ApplicationChoice
-        .where("status IN ('awaiting_references', 'application_complete')")
-        .map(&:id).sort
-    end
+      .where("status IN ('awaiting_references', 'application_complete')")
+      .map(&:id).sort
 
     if choices_in_wrong_state.any?
       urls = choices_in_wrong_state.map { |application_choice_id| helpers.support_interface_application_choice_url(application_choice_id) }

--- a/config/rubocop/config/style.yml
+++ b/config/rubocop/config/style.yml
@@ -60,8 +60,6 @@ Style/Documentation:
 
 Style/FormatStringToken:
   EnforcedStyle: template
-  Exclude:
-    - app/helpers/geocode_helper.rb
 
 Style/Alias:
   Enabled: false
@@ -81,8 +79,7 @@ Style/ClassAndModuleChildren:
   Enabled: false
 
 Style/FormatString:
-  Exclude:
-    - app/helpers/geocode_helper.rb
+  Enabled: true
 
 Style/AccessorGrouping:
   Enabled: false

--- a/config/rubocop/config/style.yml
+++ b/config/rubocop/config/style.yml
@@ -121,7 +121,7 @@ Style/SingleArgumentDig:
   Enabled: false
 
 Style/RedundantBegin:
-  Enabled: false
+  Enabled: true
 
 Style/HashAsLastArrayItem:
   Enabled: false

--- a/spec/components/support_interface/audit_trail_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_component_spec.rb
@@ -10,13 +10,12 @@ RSpec.describe SupportInterface::AuditTrailComponent, with_audited: true do
   end
 
   def application_form
-    @application_form ||= begin
+    @application_form ||=
       Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
         Audited.audit_class.as_user(candidate) do
           create(:application_form, candidate: candidate, first_name: 'Robert')
         end
       end
-    end
   end
 
   subject(:component) { described_class.new(audited_thing: application_form) }

--- a/spec/components/support_interface/feature_audit_trail_component_spec.rb
+++ b/spec/components/support_interface/feature_audit_trail_component_spec.rb
@@ -17,13 +17,10 @@ RSpec.describe SupportInterface::FeatureAuditTrailComponent, with_audited: true 
 
   context 'with a feature that was created with a false value' do
     def feature
-      @feature ||= begin
+      @feature ||=
         Timecop.freeze(Time.zone.local(2020, 5, 1, 12, 0, 0)) do
-          Audited.audit_class.as_user(bob_support_user) do
-            create(:feature)
-          end
+          Audited.audit_class.as_user(bob_support_user) { create(:feature) }
         end
-      end
     end
 
     it 'renders the create audit entry' do
@@ -34,11 +31,8 @@ RSpec.describe SupportInterface::FeatureAuditTrailComponent, with_audited: true 
 
   context 'with a feature that was created with a true value and updated to false' do
     def feature
-      @feature ||= begin
-        Timecop.freeze(Time.zone.local(2020, 5, 1, 12, 0, 0)) do
-          create(:feature, active: true)
-        end
-      end
+      @feature ||= Timecop.freeze(Time.zone.local(2020, 5, 1, 12, 0, 0)) { create(:feature, active: true) }
+
       Timecop.freeze(Time.zone.local(2020, 5, 3, 15, 30, 0)) do
         Audited.audit_class.as_user(alice_support_user) do
           @feature.update!(active: false)


### PR DESCRIPTION
## Context
- Enable Style/RedundantBegin cop
- Enable Style/FormatString cop

## Link to Trello card
https://trello.com/c/I6JiD7cR/1564-rubocop-cleanup

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
