### PR TITLE
Refactor the end of cycle calendar

### DIFF
--- a/app/components/candidate_interface/apply_again_call_to_action_component.rb
+++ b/app/components/candidate_interface/apply_again_call_to_action_component.rb
@@ -18,7 +18,7 @@ module CandidateInterface
     end
 
     def render?
-      !EndOfCycleTimetable.between_cycles_apply_2? &&
+      !CycleTimetableQuery.between_cycles_apply_2? &&
         application_form.recruitment_cycle_year == RecruitmentCycle.current_year
     end
 

--- a/app/components/candidate_interface/carry_over_banner_component.rb
+++ b/app/components/candidate_interface/carry_over_banner_component.rb
@@ -15,7 +15,7 @@ module CandidateInterface
     end
 
     def between_cycles?
-      EndOfCycleTimetable.between_cycles_apply_2?
+      CycleTimetableQuery.between_cycles_apply_2?
     end
 
     def start_path

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -111,7 +111,7 @@ module CandidateInterface
     end
 
     def course_row_value(application_choice)
-      if EndOfCycleTimetable.find_down?
+      if CycleTimetableQuery.find_down?
         "#{application_choice.current_course.name} (#{application_choice.current_course.code})"
       else
         govuk_link_to("#{application_choice.current_course.name} (#{application_choice.current_course.code})", application_choice.current_course.find_url, target: '_blank', rel: 'noopener')

--- a/app/components/candidate_interface/deadline_banner_component.rb
+++ b/app/components/candidate_interface/deadline_banner_component.rb
@@ -19,13 +19,13 @@ private
 
   def show_apply_1_deadline_banner?
     apply_1? &&
-      EndOfCycleTimetable.show_apply_1_deadline_banner? &&
+      CycleTimetableQuery.show_apply_1_deadline_banner? &&
       FeatureFlag.active?(:deadline_notices)
   end
 
   def show_apply_2_deadline_banner?
     apply_2? &&
-      EndOfCycleTimetable.show_apply_2_deadline_banner? &&
+      CycleTimetableQuery.show_apply_2_deadline_banner? &&
       FeatureFlag.active?(:deadline_notices)
   end
 
@@ -38,10 +38,10 @@ private
   end
 
   def apply_1_deadline
-    EndOfCycleTimetable.date(:apply_1_deadline).strftime('%d %B')
+    CycleTimetableQuery.date(:apply_1_deadline).strftime('%d %B')
   end
 
   def apply_2_deadline
-    EndOfCycleTimetable.date(:apply_2_deadline).strftime('%d %B')
+    CycleTimetableQuery.date(:apply_2_deadline).strftime('%d %B')
   end
 end

--- a/app/components/candidate_interface/grouped_provider_courses_component.html.erb
+++ b/app/components/candidate_interface/grouped_provider_courses_component.html.erb
@@ -1,4 +1,4 @@
-<% find_down = EndOfCycleTimetable.find_down? %>
+<% find_down = CycleTimetableQuery.find_down? %>
 
 <% courses_by_provider_and_region.each do |region_code, courses_by_provider| %>
   <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-8"><%= label_for(region_code) %></h2>

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -47,7 +47,7 @@ module CandidateInterface
     end
 
     def course_row_value
-      if EndOfCycleTimetable.find_down?
+      if CycleTimetableQuery.find_down?
         tag.p(@course_choice.current_course.name_and_code, class: 'govuk-!-margin-bottom-0') +
           tag.p(@course_choice.current_course.description, class: 'govuk-body')
       else

--- a/app/components/candidate_interface/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons_component.rb
@@ -28,7 +28,7 @@ module CandidateInterface
     end
 
     def course_details_row_value(application_choice)
-      if EndOfCycleTimetable.find_down?
+      if CycleTimetableQuery.find_down?
         tag.p(application_choice.current_course.name_and_code, class: 'govuk-!-margin-bottom-0') + tag.p(application_choice.course.description, class: 'govuk-body')
       else
         govuk_link_to(application_choice.current_course.name_and_code,

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -15,12 +15,12 @@ private
 
   def show_apply_1_reopen_banner?
     apply_1? &&
-      EndOfCycleTimetable.between_cycles_apply_1?
+      CycleTimetableQuery.between_cycles_apply_1?
   end
 
   def show_apply_2_reopen_banner?
     apply_2? &&
-      EndOfCycleTimetable.between_cycles_apply_2?
+      CycleTimetableQuery.between_cycles_apply_2?
   end
 
   def apply_1?
@@ -32,6 +32,6 @@ private
   end
 
   def reopen_date
-    EndOfCycleTimetable.date(:apply_reopens).to_s(:govuk_date)
+    CycleTimetableQuery.date(:apply_reopens).to_s(:govuk_date)
   end
 end

--- a/app/controllers/candidate_interface/carry_over_controller.rb
+++ b/app/controllers/candidate_interface/carry_over_controller.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     before_action :redirect_if_already_carried_over
 
     def start
-      if EndOfCycleTimetable.between_cycles_apply_2?
+      if CycleTimetableQuery.between_cycles_apply_2?
         render current_application.submitted? ? :start_between_cycles : :start_between_cycles_unsubmitted
       else
         render :start

--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -5,13 +5,13 @@ module CandidateInterface
     before_action :show_pilot_holding_page_if_not_open
 
     def new
-      redirect_to candidate_interface_applications_closed_path and return if EndOfCycleTimetable.between_cycles_apply_1?
+      redirect_to candidate_interface_applications_closed_path and return if CycleTimetableQuery.between_cycles_apply_1?
 
       @sign_up_form = CandidateInterface::SignUpForm.new
     end
 
     def create
-      redirect_to candidate_interface_applications_closed_path and return if EndOfCycleTimetable.between_cycles_apply_1?
+      redirect_to candidate_interface_applications_closed_path and return if CycleTimetableQuery.between_cycles_apply_1?
 
       @sign_up_form = CandidateInterface::SignUpForm.new(candidate_sign_up_form_params)
 

--- a/app/controllers/candidate_interface/submitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/submitted_application_form_controller.rb
@@ -19,7 +19,7 @@ module CandidateInterface
     end
 
     def start_carry_over
-      render EndOfCycleTimetable.between_cycles_apply_2? ? :start_carry_over_between_cycles : :start_carry_over
+      render CycleTimetableQuery.between_cycles_apply_2? ? :start_carry_over_between_cycles : :start_carry_over
     end
 
     def carry_over

--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -54,7 +54,7 @@ module CandidateInterface
     end
 
     def redirect_to_application_if_between_cycles
-      if EndOfCycleTimetable.between_cycles?(current_application.phase)
+      if CycleTimetableQuery.between_cycles?(current_application.phase)
         redirect_to candidate_interface_application_form_path and return false
       end
 

--- a/app/forms/support_interface/change_cycle_form.rb
+++ b/app/forms/support_interface/change_cycle_form.rb
@@ -3,7 +3,7 @@ module SupportInterface
     include ActiveModel::Model
 
     def cycle_schedule_name
-      EndOfCycleTimetable.current_cycle_schedule
+      CycleTimetableQuery.current_cycle_schedule
     end
   end
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -113,7 +113,7 @@ module ViewHelper
   end
 
   def days_until_find_reopens
-    (EndOfCycleTimetable.find_reopens - Time.zone.today).to_i
+    (CycleTimetableQuery.find_reopens - Time.zone.today).to_i
   end
 
   def percent_of(numerator, denominator)

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -530,8 +530,8 @@ private
       earliest_date = 20.days.ago.to_date
       latest_date = Time.zone.now.to_date
     else
-      earliest_date = EndOfCycleTimetable::CYCLE_DATES[recruitment_cycle_year][:apply_reopens]
-      latest_date = EndOfCycleTimetable::CYCLE_DATES[recruitment_cycle_year + 1][:apply_1_deadline]
+      earliest_date = CycleTimetableQuery::CYCLE_DATES[recruitment_cycle_year][:apply_reopens]
+      latest_date = CycleTimetableQuery::CYCLE_DATES[recruitment_cycle_year + 1][:apply_1_deadline]
     end
 
     @time = rand(earliest_date..latest_date)

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -530,8 +530,8 @@ private
       earliest_date = 20.days.ago.to_date
       latest_date = Time.zone.now.to_date
     else
-      earliest_date = CycleTimetableQuery::CYCLE_DATES[recruitment_cycle_year][:apply_reopens]
-      latest_date = CycleTimetableQuery::CYCLE_DATES[recruitment_cycle_year + 1][:apply_1_deadline]
+      earliest_date = RealCycleSchedule.new(CycleTimetableQuery::RECRUITMENT_CYCLE_YEAR).cycle_dates[:apply_reopens]
+      latest_date = RealCycleSchedule.new(CycleTimetableQuery::RECRUITMENT_CYCLE_YEAR + 1).cycle_dates[:apply_reopens]
     end
 
     @time = rand(earliest_date..latest_date)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -209,9 +209,9 @@ class ApplicationForm < ApplicationRecord
 
   def must_be_carried_over?
     if ended_without_success?
-      recruitment_cycle_year < RecruitmentCycle.current_year || EndOfCycleTimetable.between_cycles_apply_2?
+      recruitment_cycle_year < RecruitmentCycle.current_year || CycleTimetableQuery.between_cycles_apply_2?
     elsif !submitted?
-      recruitment_cycle_year < RecruitmentCycle.current_year && !EndOfCycleTimetable.between_cycles_apply_1?
+      recruitment_cycle_year < RecruitmentCycle.current_year && !CycleTimetableQuery.between_cycles_apply_1?
     end
   end
 

--- a/app/models/feature_metrics_dashboard.rb
+++ b/app/models/feature_metrics_dashboard.rb
@@ -75,7 +75,7 @@ private
   def load_avg_time_to_get_references
     write_metric(
       :avg_time_to_get_references,
-      reference_statistics.average_time_to_get_references(EndOfCycleTimetable.apply_reopens.beginning_of_day),
+      reference_statistics.average_time_to_get_references(CycleTimetableQuery.apply_reopens.beginning_of_day),
     )
     write_metric(
       :avg_time_to_get_references_this_month,
@@ -93,7 +93,7 @@ private
     write_metric(
       :pct_references_completed_within_30_days,
       reference_statistics.percentage_references_within(
-        30, EndOfCycleTimetable.apply_reopens.beginning_of_day
+        30, CycleTimetableQuery.apply_reopens.beginning_of_day
       ),
     )
     write_metric(
@@ -113,7 +113,7 @@ private
   def load_avg_time_to_complete_work_history
     write_metric(
       :avg_time_to_complete_work_history,
-      work_history_statistics.average_time_to_complete(EndOfCycleTimetable.apply_reopens.beginning_of_day),
+      work_history_statistics.average_time_to_complete(CycleTimetableQuery.apply_reopens.beginning_of_day),
     )
     write_metric(
       :avg_time_to_complete_work_history_this_month,
@@ -131,7 +131,7 @@ private
     write_metric(
       :avg_sign_ins_before_submitting,
       magic_link_statistics.average_magic_link_requests_upto(
-        :created_at, EndOfCycleTimetable.apply_reopens.beginning_of_day
+        :created_at, CycleTimetableQuery.apply_reopens.beginning_of_day
       ),
     )
     write_metric(
@@ -152,7 +152,7 @@ private
     write_metric(
       :avg_sign_ins_before_offer,
       magic_link_statistics.average_magic_link_requests_upto(
-        :offered_at, EndOfCycleTimetable.apply_reopens.beginning_of_day
+        :offered_at, CycleTimetableQuery.apply_reopens.beginning_of_day
       ),
     )
     write_metric(
@@ -173,7 +173,7 @@ private
     write_metric(
       :avg_sign_ins_before_recruitment,
       magic_link_statistics.average_magic_link_requests_upto(
-        :recruited_at, EndOfCycleTimetable.apply_reopens.beginning_of_day
+        :recruited_at, CycleTimetableQuery.apply_reopens.beginning_of_day
       ),
     )
     write_metric(
@@ -194,7 +194,7 @@ private
     write_metric(
       :num_rejections_due_to_qualifications,
       reasons_for_rejection_statistics.rejections_due_to(
-        :qualifications_y_n, EndOfCycleTimetable.apply_reopens.beginning_of_day
+        :qualifications_y_n, CycleTimetableQuery.apply_reopens.beginning_of_day
       ),
     )
     write_metric(
@@ -215,7 +215,7 @@ private
     write_metric(
       :apply_again_success_rate,
       apply_again_statistics.formatted_success_rate(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetableQuery.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(
@@ -227,7 +227,7 @@ private
     write_metric(
       :apply_again_success_rate_upto_this_month,
       apply_again_statistics.formatted_success_rate(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetableQuery.apply_reopens.beginning_of_day,
         Time.zone.now.beginning_of_month,
       ),
     )
@@ -237,7 +237,7 @@ private
     write_metric(
       :apply_again_change_rate,
       apply_again_statistics.formatted_change_rate(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetableQuery.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(
@@ -259,7 +259,7 @@ private
     write_metric(
       :apply_again_application_rate,
       apply_again_statistics.formatted_application_rate(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetableQuery.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(
@@ -271,7 +271,7 @@ private
     write_metric(
       :apply_again_application_rate_upto_this_month,
       apply_again_statistics.formatted_application_rate(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetableQuery.apply_reopens.beginning_of_day,
         Time.zone.now.beginning_of_month,
       ),
     )
@@ -281,7 +281,7 @@ private
     write_metric(
       :carry_over_count,
       carry_over_statistics.carry_over_count(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetableQuery.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(
@@ -293,7 +293,7 @@ private
     write_metric(
       :carry_over_count_last_month,
       carry_over_statistics.carry_over_count(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetableQuery.apply_reopens.beginning_of_day,
         Time.zone.now.beginning_of_month,
       ),
     )
@@ -304,7 +304,7 @@ private
       :pct_applications_with_one_a_level,
       qualifications_statistics.formatted_a_level_percentage(
         1,
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetableQuery.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(
@@ -326,7 +326,7 @@ private
       :pct_applications_with_three_a_levels,
       qualifications_statistics.formatted_a_level_percentage(
         3,
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetableQuery.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(
@@ -350,7 +350,7 @@ private
     write_metric(
       :satisfaction_survey_response_rate,
       satisfaction_survey_statistics.formatted_response_rate(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetableQuery.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(
@@ -372,7 +372,7 @@ private
     write_metric(
       :equality_and_diversity_response_rate,
       equality_and_diversity_statistics.formatted_response_rate(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetableQuery.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -202,17 +202,10 @@ private
   end
 
   def date_range_query_for_recruitment_cycle_year(cycle_year)
-    start_date = CycleTimetableQuery::CYCLE_DATES[cycle_year][:apply_reopens]
+    start_date = RealCycleSchedule.new(cycle_year).cycle_dates[:apply_reopens]
+    end_date = RealCycleSchedule.new(cycle_year + 1).cycle_dates[:apply_reopens]
 
-    query = "created_at >= '#{start_date}'"
-
-    if CycleTimetableQuery::CYCLE_DATES[cycle_year + 1].present?
-      end_date = CycleTimetableQuery::CYCLE_DATES[cycle_year + 1][:apply_reopens]
-
-      query += " AND created_at <= '#{end_date}'"
-    end
-
-    query
+    "created_at >= '#{start_date}' AND created_at <= '#{end_date}'"
   end
 
   def application_form_status_total_counts(only: nil)

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -202,12 +202,12 @@ private
   end
 
   def date_range_query_for_recruitment_cycle_year(cycle_year)
-    start_date = EndOfCycleTimetable::CYCLE_DATES[cycle_year][:apply_reopens]
+    start_date = CycleTimetableQuery::CYCLE_DATES[cycle_year][:apply_reopens]
 
     query = "created_at >= '#{start_date}'"
 
-    if EndOfCycleTimetable::CYCLE_DATES[cycle_year + 1].present?
-      end_date = EndOfCycleTimetable::CYCLE_DATES[cycle_year + 1][:apply_reopens]
+    if CycleTimetableQuery::CYCLE_DATES[cycle_year + 1].present?
+      end_date = CycleTimetableQuery::CYCLE_DATES[cycle_year + 1][:apply_reopens]
 
       query += " AND created_at <= '#{end_date}'"
     end

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -5,7 +5,7 @@ module RecruitmentCycle
   }.freeze
 
   def self.current_year
-    if Time.zone.today < EndOfCycleTimetable.find_reopens
+    if Time.zone.today < CycleTimetableQuery.find_reopens
       2020
     else
       2021

--- a/app/services/candidate_interface/end_of_cycle_policy.rb
+++ b/app/services/candidate_interface/end_of_cycle_policy.rb
@@ -1,9 +1,9 @@
 module CandidateInterface
   class EndOfCyclePolicy
     def self.can_add_course_choice?(application_form)
-      return true if Time.zone.now.to_date >= EndOfCycleTimetable.find_reopens && !application_form.must_be_carried_over?
-      return true if Time.zone.now.to_date <= EndOfCycleTimetable.apply_1_deadline && application_form.apply_1?
-      return true if Time.zone.now.to_date <= EndOfCycleTimetable.apply_2_deadline && application_form.apply_2?
+      return true if Time.zone.now.to_date >= CycleTimetableQuery.find_reopens && !application_form.must_be_carried_over?
+      return true if Time.zone.now.to_date <= CycleTimetableQuery.apply_1_deadline && application_form.apply_1?
+      return true if Time.zone.now.to_date <= CycleTimetableQuery.apply_2_deadline && application_form.apply_2?
 
       false
     end
@@ -13,13 +13,13 @@ module CandidateInterface
     end
 
     def self.before_find_reopens?
-      return true if Time.zone.now.to_date <= EndOfCycleTimetable.find_reopens.beginning_of_day
+      return true if Time.zone.now.to_date <= CycleTimetableQuery.find_reopens.beginning_of_day
 
       false
     end
 
     def self.before_apply_reopens?
-      return true if Time.zone.now.to_date <= EndOfCycleTimetable.apply_reopens.beginning_of_day
+      return true if Time.zone.now.to_date <= CycleTimetableQuery.apply_reopens.beginning_of_day
 
       false
     end

--- a/app/services/candidate_interface/find_changed_apply_again_applications.rb
+++ b/app/services/candidate_interface/find_changed_apply_again_applications.rb
@@ -11,14 +11,14 @@ module CandidateInterface
     end
 
     def all_candidate_count(
-      start_time = EndOfCycleTimetable.apply_reopens.beginning_of_day,
+      start_time = CycleTimetableQuery.apply_reopens.beginning_of_day,
       end_time = Time.zone.now.end_of_day
     )
       all_forms(start_time, end_time).select(:candidate_id).distinct.count
     end
 
     def changed_candidate_count(
-      start_time = EndOfCycleTimetable.apply_reopens.beginning_of_day,
+      start_time = CycleTimetableQuery.apply_reopens.beginning_of_day,
       end_time = Time.zone.now.end_of_day
     )
       changed_forms(start_time, end_time).map(&:candidate_id).uniq.count

--- a/app/services/cycle_timetable_query.rb
+++ b/app/services/cycle_timetable_query.rb
@@ -1,5 +1,5 @@
 class CycleTimetableQuery
-  CURRENT_YEAR_FOR_SCHEDULE = 2021
+  RECRUITMENT_CYCLE_YEAR = 2021
 
   # These dates are configuration for when the previous cycle ends and the next cycle starts
   # The 2020 dates are made up so we can generate sensible test data

--- a/app/services/cycle_timetable_query.rb
+++ b/app/services/cycle_timetable_query.rb
@@ -1,27 +1,6 @@
 class CycleTimetableQuery
   RECRUITMENT_CYCLE_YEAR = 2021
 
-  # These dates are configuration for when the previous cycle ends and the next cycle starts
-  # The 2020 dates are made up so we can generate sensible test data
-  CYCLE_DATES = {
-    2020 => {
-      apply_1_deadline: Date.new(2019, 8, 24),
-      stop_applications_to_unavailable_course_options: Date.new(2019, 9, 7),
-      apply_2_deadline: Date.new(2019, 9, 18),
-      find_closes: Date.new(2019, 10, 3),
-      find_reopens: Date.new(2019, 10, 6),
-      apply_reopens: Date.new(2019, 10, 13),
-    },
-    2021 => {
-      apply_1_deadline: Date.new(2020, 8, 24),
-      stop_applications_to_unavailable_course_options: Date.new(2020, 9, 7),
-      apply_2_deadline: Date.new(2020, 9, 18),
-      find_closes: Date.new(2020, 10, 3),
-      find_reopens: Date.new(2020, 10, 6),
-      apply_reopens: Date.new(2020, 10, 13),
-    },
-  }.freeze
-
   def self.between_cycles?(phase)
     phase == 'apply_1' ? between_cycles_apply_1? : between_cycles_apply_2?
   end
@@ -95,7 +74,7 @@ class CycleTimetableQuery
 
   def self.schedules
     {
-      real: CYCLE_DATES,
+      real: RealCycleSchedule.new(RECRUITMENT_CYCLE_YEAR).cycle_dates,
 
       today_is_mid_cycle: {
         apply_1_deadline: 1.day.from_now.to_date,

--- a/app/services/cycle_timetable_query.rb
+++ b/app/services/cycle_timetable_query.rb
@@ -1,4 +1,4 @@
-class EndOfCycleTimetable
+class CycleTimetableQuery
   CURRENT_YEAR_FOR_SCHEDULE = 2021
 
   # These dates are configuration for when the previous cycle ends and the next cycle starts
@@ -95,7 +95,7 @@ class EndOfCycleTimetable
 
   def self.schedules
     {
-      real: CYCLE_DATES[CURRENT_YEAR_FOR_SCHEDULE],
+      real: CYCLE_DATES,
 
       today_is_mid_cycle: {
         apply_1_deadline: 1.day.from_now.to_date,

--- a/app/services/real_cycle_schedule.rb
+++ b/app/services/real_cycle_schedule.rb
@@ -1,0 +1,18 @@
+class RealCycleSchedule
+  attr_reader :year
+
+  def initialize(year)
+    @year = year
+  end
+
+  def cycle_dates
+    {
+      find_reopens: Date.new(year - 1, 10, 6),
+      apply_reopens: Date.new(year - 1, 10, 13),
+      apply_1_deadline: Date.new(year - 1, 8, 24),
+      stop_applications_to_unavailable_course_options: Date.new(year - 1, 9, 7),
+      apply_2_deadline: Date.new(year - 1, 9, 18),
+      find_closes: Date.new(year - 1, 10, 3),
+    }.freeze
+  end
+end

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -7,7 +7,7 @@
   <% if !@application_form.submitted? && !CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(@application_form) %>
     <p class="govuk-body">
       You’ll be able to find courses in <%= days_until_find_reopens %> <%= 'day'.pluralize(days_until_find_reopens) %>
-      (<%= EndOfCycleTimetable.find_reopens.to_s(:govuk_date) %>).
+      (<%= CycleTimetableQuery.find_reopens.to_s(:govuk_date) %>).
       You can keep making changes to the rest of your application until then.
     </p>
   <% else %>

--- a/app/views/candidate_interface/carry_over/start_between_cycles.html.erb
+++ b/app/views/candidate_interface/carry_over/start_between_cycles.html.erb
@@ -18,7 +18,7 @@
 
     <% if CandidateInterface::EndOfCyclePolicy.before_apply_reopens? %>
       <p class="govuk-body">
-        You can submit your application from <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date) %>.
+        You can submit your application from <%= CycleTimetableQuery.apply_reopens.to_s(:govuk_date) %>.
       </p>
     <% end %>
 

--- a/app/views/candidate_interface/carry_over/start_between_cycles_unsubmitted.html.erb
+++ b/app/views/candidate_interface/carry_over/start_between_cycles_unsubmitted.html.erb
@@ -12,7 +12,7 @@
 
     <% if CandidateInterface::EndOfCyclePolicy.before_apply_reopens? %>
       <p class="govuk-body">
-        You can submit your application from <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date) %>.
+        You can submit your application from <%= CycleTimetableQuery.apply_reopens.to_s(:govuk_date) %>.
       </p>
     <% end %>
 

--- a/app/views/candidate_interface/start_page/applications_closed.html.erb
+++ b/app/views/candidate_interface/start_page/applications_closed.html.erb
@@ -8,6 +8,6 @@
 
     <p class="govuk-body">Applications for courses starting this year have closed.</p>
 
-    <p class="govuk-body">You can create an account and submit an application from <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date).strip %>.</p>
+    <p class="govuk-body">You can create an account and submit an application from <%= CycleTimetableQuery.apply_reopens.to_s(:govuk_date).strip %>.</p>
   </div>
 </div>

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -34,6 +34,6 @@
 
 <%= render partial: 'candidate_interface/application_form/review', locals: { application_form: @application_form, editable: true } %>
 
-<% unless EndOfCycleTimetable.between_cycles?(@application_form.phase) %>
+<% unless CycleTimetableQuery.between_cycles?(@application_form.phase) %>
   <%= govuk_link_to t('continue'), candidate_interface_start_equality_and_diversity_path, button: true %>
 <% end %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -17,7 +17,7 @@
 
       <p class="govuk-body">
         You’ll be able to find courses in <%= days_until_find_reopens %> <%= 'day'.pluralize(days_until_find_reopens) %>
-        (<%= EndOfCycleTimetable.find_reopens.to_s(:govuk_date) %>). You can keep making changes to the rest of your application until then.
+        (<%= CycleTimetableQuery.find_reopens.to_s(:govuk_date) %>). You can keep making changes to the rest of your application until then.
       </p>
     </section>
     <% else %>
@@ -249,9 +249,9 @@
     </section>
 
     <section>
-      <% if EndOfCycleTimetable.between_cycles?(@application_form.phase) %>
+      <% if CycleTimetableQuery.between_cycles?(@application_form.phase) %>
         <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.review') %></h2>
-        <p class="govuk-body">You cannot submit your application until <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.</p>
+        <p class="govuk-body">You cannot submit your application until <%= CycleTimetableQuery.apply_reopens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.</p>
         <%= govuk_link_to 'Review your application', candidate_interface_application_review_path, button: true %>
       <% elsif CandidateInterface::EndOfCyclePolicy.can_submit?(@application_form) %>
         <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.check_and_submit') %></h2>

--- a/app/views/provider_interface/hesa_export/new.html.erb
+++ b/app/views/provider_interface/hesa_export/new.html.erb
@@ -12,7 +12,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <%= t('page_titles.provider.export_hesa_data', timeframe: "since #{EndOfCycleTimetable.apply_reopens.to_s(:govuk_date)}") %>
+      <%= t('page_titles.provider.export_hesa_data', timeframe: "since #{CycleTimetableQuery.apply_reopens.to_s(:govuk_date)}") %>
     </h1>
     <p class="govuk-body">
       The data will include all candidates who have accepted an offer from any of your organisations.

--- a/app/views/support_interface/settings/cycles.html.erb
+++ b/app/views/support_interface/settings/cycles.html.erb
@@ -9,7 +9,7 @@
 
       <%= f.govuk_radio_divider %>
 
-      <% (EndOfCycleTimetable.schedules.keys.map(&:to_s) - %w[real]).each_with_index do |option, i | %>
+      <% (CycleTimetableQuery.schedules.keys.map(&:to_s) - %w[real]).each_with_index do |option, i | %>
         <%= f.govuk_radio_button :cycle_schedule_name, option, label: { text: t("cycles.#{option}.name") }, hint: { text: t("cycles.#{option}.description") }, link_errors: i.zero? %>
       <% end %>
     <% end %>
@@ -25,7 +25,7 @@
 <%= render SummaryListComponent.new(rows: {
   'Previous cycle year' => RecruitmentCycle.previous_year,
   'Current cycle year' => RecruitmentCycle.current_year,
-  'Next cycle year' => EndOfCycleTimetable.next_cycle_year,
+  'Next cycle year' => CycleTimetableQuery.next_cycle_year,
   'Years visible to providers' => RecruitmentCycle.years_visible_to_providers.to_sentence,
 }) %>
 
@@ -34,21 +34,21 @@
 <p class="govuk-body">(Today is <%= Time.zone.today.to_s(:govuk_date) %>)</p>
 
 <%= render SummaryListComponent.new(rows: {
-  'Appy 1 deadline' => EndOfCycleTimetable.apply_1_deadline.to_s(:govuk_date),
-  'Stop applications to unavailable course options' => EndOfCycleTimetable.stop_applications_to_unavailable_course_options.to_s(:govuk_date),
-  'Apply 2 deadline' => EndOfCycleTimetable.apply_2_deadline.to_s(:govuk_date),
-  'Find closes on' => EndOfCycleTimetable.find_closes.to_s(:govuk_date),
-  'Find reopens on' => EndOfCycleTimetable.find_reopens.to_s(:govuk_date),
-  'Apply reopens on' => EndOfCycleTimetable.apply_reopens.to_s(:govuk_date),
+  'Appy 1 deadline' => CycleTimetableQuery.apply_1_deadline.to_s(:govuk_date),
+  'Stop applications to unavailable course options' => CycleTimetableQuery.stop_applications_to_unavailable_course_options.to_s(:govuk_date),
+  'Apply 2 deadline' => CycleTimetableQuery.apply_2_deadline.to_s(:govuk_date),
+  'Find closes on' => CycleTimetableQuery.find_closes.to_s(:govuk_date),
+  'Find reopens on' => CycleTimetableQuery.find_reopens.to_s(:govuk_date),
+  'Apply reopens on' => CycleTimetableQuery.apply_reopens.to_s(:govuk_date),
 }) %>
 
 <h2 class="govuk-heading-m">Flags</h2>
 
 <%= render SummaryListComponent.new(rows: {
-  'Show Apply 1 deadline banner?' => boolean_to_word(EndOfCycleTimetable.show_apply_1_deadline_banner?),
-  'Show Apply 2 deadline banner?' => boolean_to_word(EndOfCycleTimetable.show_apply_2_deadline_banner?),
-  'Are we between cycles for Apply 1?' => boolean_to_word(EndOfCycleTimetable.between_cycles_apply_1?),
-  'Are we between cycles for Apply 2?' => boolean_to_word(EndOfCycleTimetable.between_cycles_apply_2?),
-  'Stop applications to unavailable course options?' => boolean_to_word(EndOfCycleTimetable.stop_applications_to_unavailable_course_options?),
-  'Is find down?' => boolean_to_word(EndOfCycleTimetable.find_down?),
+  'Show Apply 1 deadline banner?' => boolean_to_word(CycleTimetableQuery.show_apply_1_deadline_banner?),
+  'Show Apply 2 deadline banner?' => boolean_to_word(CycleTimetableQuery.show_apply_2_deadline_banner?),
+  'Are we between cycles for Apply 1?' => boolean_to_word(CycleTimetableQuery.between_cycles_apply_1?),
+  'Are we between cycles for Apply 2?' => boolean_to_word(CycleTimetableQuery.between_cycles_apply_2?),
+  'Stop applications to unavailable course options?' => boolean_to_word(CycleTimetableQuery.stop_applications_to_unavailable_course_options?),
+  'Is find down?' => boolean_to_word(CycleTimetableQuery.find_down?),
 }) %>

--- a/app/views/support_interface/tasks/confirm_cancel_applications_at_end_of_cycle.html.erb
+++ b/app/views/support_interface/tasks/confirm_cancel_applications_at_end_of_cycle.html.erb
@@ -8,7 +8,7 @@
       <h1 class="govuk-heading-l">Are you sure you want to cancel all unsubmitted applications?</h1>
 
       <p class="govuk-body">This task finds any unsubmitted applications from the most recently closed recruitment cycle and moves them to the <code>application_not_sent</code> status.</p>
-      <p class="govuk-body">This should be run shortly after the Apply 2 deadline closes at midnight on <%= EndOfCycleTimetable.date(:apply_2_deadline).to_s(:govuk_date) %>.</p>
+      <p class="govuk-body">This should be run shortly after the Apply 2 deadline closes at midnight on <%= CycleTimetableQuery.date(:apply_2_deadline).to_s(:govuk_date) %>.</p>
 
       <%= f.govuk_submit 'Yes, I’m sure – cancel all unsubmitted applications', warning: true %>
 

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -43,7 +43,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">End-of-cycle: Cancel unsubmitted applications</h2>
       <p class="govuk-body">This task finds any unsubmitted applications from the most recently closed recruitment cycle and moves them to the <code>application_not_sent</code> status.</p>
-      <p class="govuk-body">It should be run shortly after the Apply 2 deadline closes at midnight on <%= EndOfCycleTimetable.date(:apply_2_deadline).to_s(:govuk_date) %>.</p>
+      <p class="govuk-body">It should be run shortly after the Apply 2 deadline closes at midnight on <%= CycleTimetableQuery.date(:apply_2_deadline).to_s(:govuk_date) %>.</p>
     </div>
     <div class="govuk-grid-column-one-third">
       <%= govuk_link_to 'Cancel applications', support_interface_confirm_cancel_applications_at_end_of_cycle_path, button: true, class: 'govuk-button--warning' %>

--- a/app/workers/cancel_unsubmitted_applications_worker.rb
+++ b/app/workers/cancel_unsubmitted_applications_worker.rb
@@ -10,7 +10,7 @@ class CancelUnsubmittedApplicationsWorker
 private
 
   def unsubmitted_applications_from_earlier_cycle
-    return [] unless EndOfCycleTimetable.between_cycles_apply_2?
+    return [] unless CycleTimetableQuery.between_cycles_apply_2?
 
     ApplicationForm
       .where(submitted_at: nil)

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
 
     context 'when Find is down' do
       it 'removes the link to Find' do
-        Timecop.travel(EndOfCycleTimetable.find_closes.end_of_day + 1.hour) do
+        Timecop.travel(CycleTimetableQuery.find_closes.end_of_day + 1.hour) do
           application_choice = application_form.application_choices.first
           result = render_inline(described_class.new(application_form: application_form))
 

--- a/spec/components/candidate_interface/deadline_banner_component_spec.rb
+++ b/spec/components/candidate_interface/deadline_banner_component_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
       application_form.phase = phase
       FeatureFlag.activate(:deadline_notices)
       allow(flash).to receive(:empty?).and_return true
-      allow(EndOfCycleTimetable).to receive(:show_apply_1_deadline_banner?).and_return(true)
-      allow(EndOfCycleTimetable).to receive(:show_apply_2_deadline_banner?).and_return(true)
+      allow(CycleTimetableQuery).to receive(:show_apply_1_deadline_banner?).and_return(true)
+      allow(CycleTimetableQuery).to receive(:show_apply_2_deadline_banner?).and_return(true)
     end
 
     it 'renders the Apply 1 banner when the right conditions are met' do
@@ -49,8 +49,8 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
 
     it 'renders nothing if it\'s not the right time to show the banner' do
       set_conditions_for_rendering_banner('apply_1')
-      allow(EndOfCycleTimetable).to receive(:show_apply_1_deadline_banner?).and_return(false)
-      allow(EndOfCycleTimetable).to receive(:show_apply_2_deadline_banner?).and_return(false)
+      allow(CycleTimetableQuery).to receive(:show_apply_1_deadline_banner?).and_return(false)
+      allow(CycleTimetableQuery).to receive(:show_apply_2_deadline_banner?).and_return(false)
 
       result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
 
@@ -59,7 +59,7 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
 
     it 'renders a banner if the timetable says only one of them should be shown' do
       set_conditions_for_rendering_banner('apply_2')
-      allow(EndOfCycleTimetable).to receive(:show_apply_1_deadline_banner?).and_return(false)
+      allow(CycleTimetableQuery).to receive(:show_apply_1_deadline_banner?).and_return(false)
 
       result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
 

--- a/spec/components/candidate_interface/grouped_provider_courses_component_spec.rb
+++ b/spec/components/candidate_interface/grouped_provider_courses_component_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CandidateInterface::GroupedProviderCoursesComponent do
 
   context 'when find is down' do
     it 'does not include a link to find' do
-      Timecop.travel(EndOfCycleTimetable.find_closes.end_of_day + 1.hour) do
+      Timecop.travel(CycleTimetableQuery.find_closes.end_of_day + 1.hour) do
         result = render_inline(
           described_class.new(courses_by_provider_and_region: @courses_by_provider_and_region),
         )

--- a/spec/components/candidate_interface/offer_review_component_spec.rb
+++ b/spec/components/candidate_interface/offer_review_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
            course_option: course_option,
            application_form: application_form)
   end
-  let(:find_closes) { EndOfCycleTimetable::CYCLE_DATES.dig(Time.zone.now.year, :find_closes) }
+  let(:find_closes) { CycleTimetableQuery::CYCLE_DATES.dig(Time.zone.now.year, :find_closes) }
 
   it 'renders component with correct values for the provider' do
     result = render_inline(described_class.new(course_choice: application_choice))

--- a/spec/components/candidate_interface/offer_review_component_spec.rb
+++ b/spec/components/candidate_interface/offer_review_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
            course_option: course_option,
            application_form: application_form)
   end
-  let(:find_closes) { CycleTimetableQuery::CYCLE_DATES.dig(Time.zone.now.year, :find_closes) }
+  let(:find_closes) { RealCycleSchedule.new(Time.zone.now.year).cycle_dates[:find_closes] }
 
   it 'renders component with correct values for the provider' do
     result = render_inline(described_class.new(course_choice: application_choice))

--- a/spec/components/candidate_interface/reopen_banner_component_spec.rb
+++ b/spec/components/candidate_interface/reopen_banner_component_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
       application_form.phase = phase
       FeatureFlag.activate(:deadline_notices)
       allow(flash).to receive(:empty?).and_return true
-      allow(EndOfCycleTimetable).to receive(:between_cycles_apply_1?).and_return(true)
-      allow(EndOfCycleTimetable).to receive(:between_cycles_apply_2?).and_return(true)
+      allow(CycleTimetableQuery).to receive(:between_cycles_apply_1?).and_return(true)
+      allow(CycleTimetableQuery).to receive(:between_cycles_apply_2?).and_return(true)
     end
 
     it 'renders the banner for an Apply 1 app' do
@@ -43,7 +43,7 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
 
     it 'does not render when we are not between cycles' do
       set_conditions_for_rendering_banner('apply_1')
-      allow(EndOfCycleTimetable).to receive(:between_cycles_apply_1?).and_return(false)
+      allow(CycleTimetableQuery).to receive(:between_cycles_apply_1?).and_return(false)
 
       result = render_inline(
         described_class.new(

--- a/spec/services/candidate_interface/end_of_cycle_policy_spec.rb
+++ b/spec/services/candidate_interface/end_of_cycle_policy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CandidateInterface::EndOfCyclePolicy do
 
       context 'when the date is after the apply1 submission deadline' do
         it 'returns false' do
-          Timecop.travel(EndOfCycleTimetable.apply_1_deadline + 1.day) do
+          Timecop.travel(CycleTimetableQuery.apply_1_deadline + 1.day) do
             expect(execute_service).to eq false
           end
         end
@@ -17,7 +17,7 @@ RSpec.describe CandidateInterface::EndOfCyclePolicy do
 
       context 'when the date is before the apply1 submission deadline' do
         it 'returns true' do
-          Timecop.travel(EndOfCycleTimetable.apply_1_deadline) do
+          Timecop.travel(CycleTimetableQuery.apply_1_deadline) do
             expect(execute_service).to eq true
           end
         end
@@ -25,7 +25,7 @@ RSpec.describe CandidateInterface::EndOfCyclePolicy do
 
       context 'when the date is post find reopening' do
         it 'returns true' do
-          Timecop.travel(EndOfCycleTimetable.find_reopens) do
+          Timecop.travel(CycleTimetableQuery.find_reopens) do
             expect(execute_service).to eq true
           end
         end
@@ -37,7 +37,7 @@ RSpec.describe CandidateInterface::EndOfCyclePolicy do
 
       context 'when the date is after the apply again submission deadline' do
         it 'returns false' do
-          Timecop.travel(EndOfCycleTimetable.apply_2_deadline + 1.day) do
+          Timecop.travel(CycleTimetableQuery.apply_2_deadline + 1.day) do
             expect(execute_service).to eq false
           end
         end
@@ -45,7 +45,7 @@ RSpec.describe CandidateInterface::EndOfCyclePolicy do
 
       context 'when the date is before the apply again submission deadline' do
         it 'returns true' do
-          Timecop.travel(EndOfCycleTimetable.apply_2_deadline) do
+          Timecop.travel(CycleTimetableQuery.apply_2_deadline) do
             expect(execute_service).to eq true
           end
         end
@@ -53,7 +53,7 @@ RSpec.describe CandidateInterface::EndOfCyclePolicy do
 
       context 'when the date is post find reopening' do
         it 'returns true' do
-          Timecop.travel(EndOfCycleTimetable.apply_reopens) do
+          Timecop.travel(CycleTimetableQuery.apply_reopens) do
             expect(execute_service).to eq true
           end
         end

--- a/spec/services/cycle_timetable_query_spec.rb
+++ b/spec/services/cycle_timetable_query_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe EndOfCycleTimetable do
+RSpec.describe CycleTimetableQuery do
   let(:one_hour_before_apply1_deadline) { Time.zone.local(2020, 8, 24, 23, 0, 0) }
   let(:one_hour_after_apply1_deadline) { Time.zone.local(2020, 8, 25, 1, 0, 0) }
   let(:one_hour_before_apply2_deadline) { Time.zone.local(2020, 9, 18, 23, 0, 0) }
@@ -10,13 +10,13 @@ RSpec.describe EndOfCycleTimetable do
   describe '.show_apply_1_deadline_banner?' do
     it 'returns true before the configured date' do
       Timecop.travel(one_hour_before_apply1_deadline) do
-        expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be true
+        expect(CycleTimetableQuery.show_apply_1_deadline_banner?).to be true
       end
     end
 
     it 'returns false after the configured date' do
       Timecop.travel(one_hour_after_apply1_deadline) do
-        expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be false
+        expect(CycleTimetableQuery.show_apply_1_deadline_banner?).to be false
       end
     end
   end
@@ -24,13 +24,13 @@ RSpec.describe EndOfCycleTimetable do
   describe '.show_apply_2_deadline_banner?' do
     it 'returns true before the configured date' do
       Timecop.travel(one_hour_before_apply2_deadline) do
-        expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be true
+        expect(CycleTimetableQuery.show_apply_2_deadline_banner?).to be true
       end
     end
 
     it 'returns false after the configured date' do
       Timecop.travel(one_hour_after_apply2_deadline) do
-        expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be false
+        expect(CycleTimetableQuery.show_apply_2_deadline_banner?).to be false
       end
     end
   end
@@ -38,19 +38,19 @@ RSpec.describe EndOfCycleTimetable do
   describe '.between_cycles_apply_1?' do
     it 'returns false before the configured date' do
       Timecop.travel(one_hour_before_apply1_deadline) do
-        expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
+        expect(CycleTimetableQuery.between_cycles_apply_1?).to be false
       end
     end
 
     it 'returns true after the configured date' do
       Timecop.travel(one_hour_after_apply1_deadline) do
-        expect(EndOfCycleTimetable.between_cycles_apply_1?).to be true
+        expect(CycleTimetableQuery.between_cycles_apply_1?).to be true
       end
     end
 
     it 'returns false after the new cycle opens' do
       Timecop.travel(one_hour_after_2021_cycle_opens) do
-        expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
+        expect(CycleTimetableQuery.between_cycles_apply_1?).to be false
       end
     end
   end
@@ -58,19 +58,19 @@ RSpec.describe EndOfCycleTimetable do
   describe '.between_cycles_apply_2?' do
     it 'returns false before the configured date' do
       Timecop.travel(one_hour_before_apply2_deadline) do
-        expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
+        expect(CycleTimetableQuery.between_cycles_apply_2?).to be false
       end
     end
 
     it 'returns true after the configured date' do
       Timecop.travel(one_hour_after_apply2_deadline) do
-        expect(EndOfCycleTimetable.between_cycles_apply_2?).to be true
+        expect(CycleTimetableQuery.between_cycles_apply_2?).to be true
       end
     end
 
     it 'returns false after the new cycle opens' do
       Timecop.travel(one_hour_after_2021_cycle_opens) do
-        expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
+        expect(CycleTimetableQuery.between_cycles_apply_2?).to be false
       end
     end
   end
@@ -78,27 +78,27 @@ RSpec.describe EndOfCycleTimetable do
   describe '.next_cycle_year' do
     it 'returns 2021 when in 2020 cycle' do
       Timecop.travel(Time.zone.local(2020, 8, 24, 23, 0, 0)) do
-        expect(EndOfCycleTimetable.next_cycle_year).to eq 2021
+        expect(CycleTimetableQuery.next_cycle_year).to eq 2021
       end
     end
   end
 
   describe '.find_down?' do
     it 'returns false before find closes' do
-      Timecop.travel(EndOfCycleTimetable.find_closes.beginning_of_day - 1.hour) do
-        expect(EndOfCycleTimetable.find_down?).to be false
+      Timecop.travel(CycleTimetableQuery.find_closes.beginning_of_day - 1.hour) do
+        expect(CycleTimetableQuery.find_down?).to be false
       end
     end
 
     it 'returns false after find_reopens' do
-      Timecop.travel(EndOfCycleTimetable.find_reopens.end_of_day + 1.hour) do
-        expect(EndOfCycleTimetable.find_down?).to be false
+      Timecop.travel(CycleTimetableQuery.find_reopens.end_of_day + 1.hour) do
+        expect(CycleTimetableQuery.find_down?).to be false
       end
     end
 
     it 'returns true between find_closes and find_reopens' do
-      Timecop.travel(EndOfCycleTimetable.find_closes.end_of_day + 1.hour) do
-        expect(EndOfCycleTimetable.find_down?).to be true
+      Timecop.travel(CycleTimetableQuery.find_closes.end_of_day + 1.hour) do
+        expect(CycleTimetableQuery.find_down?).to be true
       end
     end
   end
@@ -124,19 +124,19 @@ RSpec.describe EndOfCycleTimetable do
   describe 'stop_applications_to_unavailable_course_options?' do
     it 'is true when between "stop_applications_to_unavailable_course_options" and "apply_reopens"' do
       Timecop.travel(Time.zone.local(2020, 9, 7).end_of_day + 1.minute) do
-        expect(EndOfCycleTimetable.stop_applications_to_unavailable_course_options?).to be true
+        expect(CycleTimetableQuery.stop_applications_to_unavailable_course_options?).to be true
       end
     end
 
     it 'is false when before the window' do
       Timecop.travel(Time.zone.local(2020, 9, 7).end_of_day - 1.minute) do
-        expect(EndOfCycleTimetable.stop_applications_to_unavailable_course_options?).to be false
+        expect(CycleTimetableQuery.stop_applications_to_unavailable_course_options?).to be false
       end
     end
 
     it 'is false when after the window' do
       Timecop.travel(Time.zone.local(2020, 10, 13).beginning_of_day) do
-        expect(EndOfCycleTimetable.stop_applications_to_unavailable_course_options?).to be false
+        expect(CycleTimetableQuery.stop_applications_to_unavailable_course_options?).to be false
       end
     end
   end

--- a/spec/support/test_helpers/cycle_timetable_helper.rb
+++ b/spec/support/test_helpers/cycle_timetable_helper.rb
@@ -24,16 +24,16 @@ module CycleTimetableHelper
   end
 
   def after_apply_reopens
-    @_after_apply_reopens ||= rand((current_end_of_cycle_timetable[:apply_reopens])..Date.new(CycleTimetableQuery::CURRENT_YEAR_FOR_SCHEDULE, 12, 31)).midday
+    @_after_apply_reopens ||= rand((current_end_of_cycle_timetable[:apply_reopens])..Date.new(CycleTimetable::RECRUITMENT_CYCLE_YEAR, 12, 31)).midday
   end
 
 private
 
   def previous_end_of_cycle_timetable
-    CycleTimetableQuery::CYCLE_DATES[CycleTimetableQuery::CURRENT_YEAR_FOR_SCHEDULE - 1]
+    CycleTimetableQuery::CYCLE_DATES[CycleTimetableQuery::RECRUITMENT_CYCLE_YEAR - 1]
   end
 
   def current_end_of_cycle_timetable
-    CycleTimetableQuery::CYCLE_DATES[CycleTimetableQuery::CURRENT_YEAR_FOR_SCHEDULE]
+    CycleTimetableQuery::CYCLE_DATES[CycleTimetableQuery::RECRUITMENT_CYCLE_YEAR]
   end
 end

--- a/spec/support/test_helpers/cycle_timetable_helper.rb
+++ b/spec/support/test_helpers/cycle_timetable_helper.rb
@@ -24,16 +24,16 @@ module CycleTimetableHelper
   end
 
   def after_apply_reopens
-    @_after_apply_reopens ||= rand((current_end_of_cycle_timetable[:apply_reopens])..Date.new(EndOfCycleTimetable::CURRENT_YEAR_FOR_SCHEDULE, 12, 31)).midday
+    @_after_apply_reopens ||= rand((current_end_of_cycle_timetable[:apply_reopens])..Date.new(CycleTimetableQuery::CURRENT_YEAR_FOR_SCHEDULE, 12, 31)).midday
   end
 
 private
 
   def previous_end_of_cycle_timetable
-    EndOfCycleTimetable::CYCLE_DATES[EndOfCycleTimetable::CURRENT_YEAR_FOR_SCHEDULE - 1]
+    CycleTimetableQuery::CYCLE_DATES[CycleTimetableQuery::CURRENT_YEAR_FOR_SCHEDULE - 1]
   end
 
   def current_end_of_cycle_timetable
-    EndOfCycleTimetable::CYCLE_DATES[EndOfCycleTimetable::CURRENT_YEAR_FOR_SCHEDULE]
+    CycleTimetableQuery::CYCLE_DATES[CycleTimetableQuery::CURRENT_YEAR_FOR_SCHEDULE]
   end
 end

--- a/spec/support/test_helpers/cycle_timetable_helper.rb
+++ b/spec/support/test_helpers/cycle_timetable_helper.rb
@@ -24,16 +24,16 @@ module CycleTimetableHelper
   end
 
   def after_apply_reopens
-    @_after_apply_reopens ||= rand((current_end_of_cycle_timetable[:apply_reopens])..Date.new(CycleTimetable::RECRUITMENT_CYCLE_YEAR, 12, 31)).midday
+    @_after_apply_reopens ||= rand((current_end_of_cycle_timetable[:apply_reopens])..Date.new(CycleTimetableQuery::RECRUITMENT_CYCLE_YEAR, 12, 31)).midday
   end
 
 private
 
   def previous_end_of_cycle_timetable
-    CycleTimetableQuery::CYCLE_DATES[CycleTimetableQuery::RECRUITMENT_CYCLE_YEAR - 1]
+    RealCycleSchedule.new(CycleTimetableQuery::RECRUITMENT_CYCLE_YEAR - 1).cycle_dates
   end
 
   def current_end_of_cycle_timetable
-    CycleTimetableQuery::CYCLE_DATES[CycleTimetableQuery::RECRUITMENT_CYCLE_YEAR]
+    RealCycleSchedule.new(CycleTimetableQuery::RECRUITMENT_CYCLE_YEAR).cycle_dates
   end
 end

--- a/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_between_cycles_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
   end
 
   def then_i_can_see_that_i_need_to_select_courses_when_apply_reopens
-    expect(page).to have_content "You’ll be able to find courses in #{(EndOfCycleTimetable.find_reopens - Time.zone.today).to_i} days (#{EndOfCycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You’ll be able to find courses in #{(CycleTimetableQuery.find_reopens - Time.zone.today).to_i} days (#{CycleTimetableQuery.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
     expect(page).not_to have_link 'Choose your courses'
   end
 end

--- a/spec/system/candidate_interface/apply_again/carry_over_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/apply_again/carry_over_unsuccessful_application_between_cycles_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_click_on_start_now
-    expect(page).to have_content "You can submit your application from #{EndOfCycleTimetable.apply_reopens.to_s(:govuk_date)}."
+    expect(page).to have_content "You can submit your application from #{CycleTimetableQuery.apply_reopens.to_s(:govuk_date)}."
     expect(page).to have_content 'Your courses have been removed. You can add them again later.'
     click_button 'Apply again'
   end
@@ -72,7 +72,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_can_see_that_no_courses_are_selected_and_i_cannot_add_any_yet
-    expect(page).to have_content "You’ll be able to find courses in #{(EndOfCycleTimetable.find_reopens - Time.zone.today).to_i} days (#{EndOfCycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You’ll be able to find courses in #{(CycleTimetableQuery.find_reopens - Time.zone.today).to_i} days (#{CycleTimetableQuery.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
     expect(page).not_to have_link 'Course choice'
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Candidate vists their application form after the cycle has ended
   end
 
   def then_i_see_that_i_can_add_new_course_choices_in_october
-    expect(page).to have_content "You’ll be able to find courses in #{(EndOfCycleTimetable.find_reopens - Time.zone.today).to_i} days (#{EndOfCycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You’ll be able to find courses in #{(CycleTimetableQuery.find_reopens - Time.zone.today).to_i} days (#{CycleTimetableQuery.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
   end
 
   def and_there_is_not_a_link_to_the_course_choices_section

--- a/spec/system/candidate_interface/end_of_cycle/candidate_with_unsubmitted_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/end_of_cycle/candidate_with_unsubmitted_application_between_cycles_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Candidate attempts to submit the application after the end-of-cyc
 
   def then_i_can_only_review_my_application
     expect(page).not_to have_link 'Check and submit your application'
-    expect(page).to have_content "You cannot submit your application until #{EndOfCycleTimetable.apply_reopens.to_s(:govuk_date)}. You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You cannot submit your application until #{CycleTimetableQuery.apply_reopens.to_s(:govuk_date)}. You can keep making changes to the rest of your application until then."
     click_link 'Review your application'
   end
 

--- a/spec/system/support_interface/cycle_switching_spec.rb
+++ b/spec/system/support_interface/cycle_switching_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Cycle switching' do
 
   def then_i_see_the_cycle_information
     expect(page).to have_title 'Recruitment cycles'
-    expect(page).to have_content("Find closes on\n#{EndOfCycleTimetable.find_closes.to_s(:govuk_date)}")
+    expect(page).to have_content("Find closes on\n#{CycleTimetableQuery.find_closes.to_s(:govuk_date)}")
   end
 
   def when_i_click_to_choose_a_new_schedule
@@ -32,6 +32,6 @@ RSpec.feature 'Cycle switching' do
   end
 
   def then_the_schedule_is_updated
-    expect(page).to have_content("Appy 1 deadline\n#{EndOfCycleTimetable.apply_1_deadline.to_s(:govuk_date)}")
+    expect(page).to have_content("Appy 1 deadline\n#{CycleTimetableQuery.apply_1_deadline.to_s(:govuk_date)}")
   end
 end

--- a/spec/system/support_interface/feature_metrics_dashboard_spec.rb
+++ b/spec/system/support_interface/feature_metrics_dashboard_spec.rb
@@ -97,7 +97,7 @@ RSpec.feature 'Feature metrics dashboard' do
 
   def and_there_are_candidates_and_application_forms_in_the_system
     ApplicationForm.with_unsafe_application_choice_touches do
-      allow(EndOfCycleTimetable).to receive(:apply_reopens).and_return(60.days.ago)
+      allow(CycleTimetableQuery).to receive(:apply_reopens).and_return(60.days.ago)
       Timecop.freeze(@today - 65.days) do
         @previous_application_form = create_application_form_with_references(recruitment_cycle_year: 2020).first
       end

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Structured reasons for rejection dashboard' do
   end
 
   def and_there_are_candidates_and_application_forms_in_the_system
-    allow(EndOfCycleTimetable).to receive(:apply_reopens).and_return(60.days.ago)
+    allow(CycleTimetableQuery).to receive(:apply_reopens).and_return(60.days.ago)
     @application_choice1 = create(:application_choice, :awaiting_provider_decision)
     @application_choice2 = create(:application_choice, :awaiting_provider_decision)
     @application_choice3 = create(:application_choice, :awaiting_provider_decision)


### PR DESCRIPTION
## Context

At the moment, our EOC timetable is a bit funky in that the cycle starts with the apply1 deadline and ends with apply reopening. This doesn't really make sense. We should change it to reflect an actual recruitment cycle.


## Changes proposed in this pull request

Seeking feedback on what has been done so far:

- Extracting the 'live' schedule to it's own class. This allows us to dynamically generate timetables based on a year. 
- Renaming the 'EndOfCycle' class too 'CycleTimetableQuery' to more accurately reflect its role
- Issues and questions added also!

## Link to Trello card

https://trello.com/c/narHEhQx/3544-change-the-eoc-calendar-to-start-with-find-opening-and-end-with-find-closing

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
