### PR TITLE
Ensure the test data generator chooses a valid course to offer

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -390,9 +390,15 @@ private
   def change_offer(choice, conditions: ['Complete DBS'])
     as_provider_user(choice) do
       fast_forward
-      year = choice.current_course.recruitment_cycle_year
-      new_course = choice.current_course.provider.courses
-                         .in_cycle(year).with_course_options.sample
+      current_course = choice.current_course
+      year = current_course.recruitment_cycle_year
+      other_available_courses = current_course.provider.courses
+                                              .in_cycle(year)
+                                              .with_course_options
+                                              .where(accredited_provider: current_course.accredited_provider)
+
+      new_course = (other_available_courses - [current_course]).sample || current_course
+
       update_conditions_service = SaveOfferConditionsFromText.new(application_choice: choice, conditions: conditions)
       ChangeOffer.new(
         actor: actor,

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -37,6 +37,19 @@ RSpec.describe TestApplications do
     expect(application_choice.sent_to_provider_at <= application_choice.offered_at).to be true
   end
 
+  it 'changes the course to a valid one if the offer is changed' do
+    provider = create(:provider)
+    ratifying_provider = create(:provider)
+
+    course_to_make_original_offer_for = create(:course_option, course: create(:course, :open_on_apply, provider: provider, accredited_provider: ratifying_provider)).course
+    create(:course_option, course: create(:course, :open_on_apply, provider: provider, accredited_provider: ratifying_provider)).course
+    create(:course_option, course: create(:course, :open_on_apply, provider: provider))
+
+    application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2020, states: %i[offer_changed], courses_to_apply_to: [course_to_make_original_offer_for]).first
+
+    expect(application_choice.current_course.ratifying_provider).to eq(ratifying_provider)
+  end
+
   it 'attributes actions to candidates', with_audited: true do
     courses_we_want = create_list(:course_option, 1, course: create(:course, :open_on_apply)).map(&:course)
 


### PR DESCRIPTION

## Context

ChangeOffer has a validation that the ratifying body does not change. Make sure the automatic generation doesn't break that

## Sentry error

https://sentry.io/organizations/dfe-bat/issues/2472050719/?project=1765973
