### PR TITLE
Reject blank conditions when initializing save conditions service

### DIFF
--- a/app/services/save_offer_conditions_from_text.rb
+++ b/app/services/save_offer_conditions_from_text.rb
@@ -3,7 +3,7 @@ class SaveOfferConditionsFromText
 
   def initialize(application_choice:, conditions:)
     @offer = application_choice.offer || application_choice.build_offer
-    @conditions = conditions
+    @conditions = conditions.reject(&:blank?)
   end
 
   def save

--- a/spec/services/save_offer_conditions_from_text_spec.rb
+++ b/spec/services/save_offer_conditions_from_text_spec.rb
@@ -3,6 +3,14 @@ RSpec.describe SaveOfferConditionsFromText do
   let(:conditions) { ['Test', 'Test but longer'] }
   let(:application_choice) { create(:application_choice) }
 
+  describe 'initialize' do
+    it 'discards blank conditions' do
+      instance = described_class.new(application_choice: build(:application_choice), conditions: ['Dance', ''])
+
+      expect(instance.conditions).to eq(['Dance'])
+    end
+  end
+
   describe '#save' do
     context 'when the application choice does not have an offer and there are empty conditions' do
       let(:conditions) { [] }


### PR DESCRIPTION
## Context

Tribal have reported making unconditional offers with empty strings in the conditions array and this resulting in a conditional offer with blank conditions. While this doesn't conform to API docs about how to make unconditional offers we should clean up empty conditions params to ensure this doesn't happen in future.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Reject blank conditions from conditions passed to the persistence service.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/S4S2ASsj/3876-persisting-empty-conditions-from-offers-made-via-the-api
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
