### PR TITLE
Redirect away from change offer flow unless application is in offer state

### DIFF
--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -2,7 +2,8 @@ module ProviderInterface
   class OffersController < ProviderInterfaceController
     before_action :set_application_choice
     before_action :confirm_application_is_in_decision_pending_state, except: %i[edit update show]
-    before_action :confirm_application_is_in_offered_state, only: %i[edit update show]
+    before_action :confirm_application_is_in_offered_state, only: %i[show]
+    before_action :confirm_application_can_have_offer_changed, only: %i[edit update]
     before_action :requires_make_decisions_permission, except: %i[show]
 
     def new
@@ -87,6 +88,12 @@ module ProviderInterface
 
     def confirm_application_is_in_offered_state
       return if ApplicationStateChange::OFFERED_STATES.include?(@application_choice.status.to_sym)
+
+      redirect_to(provider_interface_application_choice_path(@application_choice))
+    end
+
+    def confirm_application_can_have_offer_changed
+      return if @application_choice.offer?
 
       redirect_to(provider_interface_application_choice_path(@application_choice))
     end

--- a/spec/requests/provider_interface/offers_controller_spec.rb
+++ b/spec/requests/provider_interface/offers_controller_spec.rb
@@ -6,6 +6,18 @@ RSpec.shared_examples 'an action which tracks validation errors' do |action|
   end
 end
 
+RSpec.shared_examples 'an action that can only happen to applications in the offer state' do
+  context 'when the application is not in the offered state' do
+    let(:trait) { :with_accepted_offer }
+
+    it 'redirects to the application choice path' do
+      subject
+      expect(response.status).to eq(302)
+      expect(response.redirect_url).to eq(provider_interface_application_choice_url(application_choice))
+    end
+  end
+end
+
 RSpec.describe ProviderInterface::OffersController, type: :request do
   include DfESignInHelpers
   include ModelWithErrorsStubHelper
@@ -103,6 +115,7 @@ RSpec.describe ProviderInterface::OffersController, type: :request do
       subject { put provider_interface_application_choice_offer_path(application_choice) }
 
       it_behaves_like 'an action which tracks validation errors', 'PUT to update'
+      it_behaves_like 'an action that can only happen to applications in the offer state'
     end
 
     context 'POST to (providers) create' do
@@ -126,6 +139,7 @@ RSpec.describe ProviderInterface::OffersController, type: :request do
       end
 
       it_behaves_like 'an action which tracks validation errors', 'PUT to (providers) update'
+      it_behaves_like 'an action that can only happen to applications in the offer state'
     end
 
     context 'POST to (conditions) create' do
@@ -149,6 +163,7 @@ RSpec.describe ProviderInterface::OffersController, type: :request do
       end
 
       it_behaves_like 'an action which tracks validation errors', 'PATCH to (conditions) update'
+      it_behaves_like 'an action that can only happen to applications in the offer state'
     end
 
     context 'POST to (courses) create' do
@@ -172,6 +187,7 @@ RSpec.describe ProviderInterface::OffersController, type: :request do
       end
 
       it_behaves_like 'an action which tracks validation errors', 'PATCH to (courses) update'
+      it_behaves_like 'an action that can only happen to applications in the offer state'
     end
 
     context 'POST to (locations) create' do
@@ -195,6 +211,7 @@ RSpec.describe ProviderInterface::OffersController, type: :request do
       end
 
       it_behaves_like 'an action which tracks validation errors', 'PATCH to (locations) update'
+      it_behaves_like 'an action that can only happen to applications in the offer state'
     end
 
     context 'POST to (study_modes) create' do
@@ -218,6 +235,7 @@ RSpec.describe ProviderInterface::OffersController, type: :request do
       end
 
       it_behaves_like 'an action which tracks validation errors', 'PATCH to (study_modes) update'
+      it_behaves_like 'an action that can only happen to applications in the offer state'
     end
   end
 end


### PR DESCRIPTION
## Context
ChangeOffer does not work if the application is not in the right state, so only allow it to happen if the application is in the offered state

## Changes proposed in this pull request
Any of the edit and update actions in the offer flow now redirect away unless the application is in the offer state

## Guidance to review
Are there any edge cases I've not thought of here?

My assumption is that if we are in an edit or an update action, then we are in the change offer flow
