### PR TITLE
The format method is overloaded and clashes with view component

### DIFF
--- a/app/helpers/geocode_helper.rb
+++ b/app/helpers/geocode_helper.rb
@@ -23,7 +23,7 @@ private
     return 'n/a' if number.blank? && with_units
     return '' if number.blank?
 
-    rounded = format('%.1f', number)
+    rounded = sprintf('%.1f', number) # rubocop:disable Style/FormatString
     with_units ? "#{rounded} miles" : rounded
   end
 end


### PR DESCRIPTION
## Context

`format` is an alias for `sprintf`. This was fixed to enable a rubocop cop https://github.com/DFE-Digital/apply-for-teacher-training/pull/5012/commits/01a831fecaf178a7e4977c54164326e161d94b42. However this clashes with the `view_component` method of the same name causing an error https://github.com/github/view_component/blob/v2.34.0/lib/view_component/base.rb#L181. Keep old method and disable rubocop only for that.

Sentry error: https://sentry.io/organizations/dfe-bat/issues/2472630910/?project=1765973&referrer=slack

## Changes proposed in this pull request

Bring back `sprintf` and disable rubocop for that

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
