### PR TITLE
Prefer sprintf over format in rubocop rule

### DIFF
--- a/app/helpers/geocode_helper.rb
+++ b/app/helpers/geocode_helper.rb
@@ -23,7 +23,7 @@ private
     return 'n/a' if number.blank? && with_units
     return '' if number.blank?
 
-    rounded = sprintf('%.1f', number) # rubocop:disable Style/FormatString
+    rounded = sprintf('%.1f', number)
     with_units ? "#{rounded} miles" : rounded
   end
 end

--- a/config/rubocop/config/style.yml
+++ b/config/rubocop/config/style.yml
@@ -80,6 +80,7 @@ Style/ClassAndModuleChildren:
 
 Style/FormatString:
   Enabled: true
+  EnforcedStyle: sprintf
 
 Style/AccessorGrouping:
   Enabled: false


### PR DESCRIPTION
## Context

We had issues with the format clashing with the method of the same name in view_component. This resulted in crashes whenever format was used from inside a component
