### PR TITLE
EOC carry over old work history

### DIFF
--- a/app/components/restructured_work_history/job_component.html.erb
+++ b/app/components/restructured_work_history/job_component.html.erb
@@ -19,7 +19,6 @@
         <%= govuk_link_to(
           'Select if this role used skills relevant to teaching',
           candidate_interface_edit_restructured_work_history_path(@work_experience.id),
-          class: 'govuk-!-margin-right-2',
         ) %>
       <% end %>
     <% end %>

--- a/app/components/restructured_work_history/job_component.html.erb
+++ b/app/components/restructured_work_history/job_component.html.erb
@@ -15,7 +15,7 @@
     <% if @work_experience.relevant_skills %>
       <p class="govuk-body-s govuk-!-margin-bottom-1">This role used skills relevant to teaching</p>
     <% elsif @work_experience.relevant_skills.nil? && @editable %>
-      <%= govuk_inset_text(classes: 'govuk-error-summary__list app-inset-text--error') do %>
+      <%= govuk_inset_text(classes: 'app-inset-text--error') do %>
         <%= govuk_link_to(
           'Select if this role used skills relevant to teaching',
           candidate_interface_edit_restructured_work_history_path(@work_experience.id),

--- a/app/components/restructured_work_history/job_component.html.erb
+++ b/app/components/restructured_work_history/job_component.html.erb
@@ -14,6 +14,14 @@
 
     <% if @work_experience.relevant_skills %>
       <p class="govuk-body-s govuk-!-margin-bottom-1">This role used skills relevant to teaching</p>
+    <% elsif @work_experience.relevant_skills.nil? && @editable %>
+      <%= govuk_inset_text(classes: 'govuk-error-summary__list app-inset-text--error') do %>
+        <%= govuk_link_to(
+          'Select if this role used skills relevant to teaching',
+          candidate_interface_edit_restructured_work_history_path(@work_experience.id),
+          class: 'govuk-!-margin-right-2',
+        ) %>
+      <% end %>
     <% end %>
   </div>
 

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -24,7 +24,7 @@ class DuplicateApplication
 
     original_application_form.application_work_experiences.each do |w|
       new_application_form.application_work_experiences.create!(
-        w.attributes.except(*ignored_work_experience_attributes).merge("currently_working" => infer_currently_working(w))
+        w.attributes.except(*ignored_work_experience_attributes).merge('currently_working' => infer_currently_working(w)),
       )
     end
     if original_application_form.feature_restructured_work_history == false &&
@@ -81,8 +81,8 @@ private
 
   def infer_currently_working(application_experience)
     return application_experience.currently_working unless application_experience.currently_working.nil?
-    
-    application_experience.start_date < Date.today &&
-      (application_experience.end_date.nil? || application_experience.end_date > Date.today)
+
+    application_experience.start_date < Time.zone.today &&
+      (application_experience.end_date.nil? || application_experience.end_date > Time.zone.today)
   end
 end

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -24,7 +24,7 @@ class DuplicateApplication
 
     original_application_form.application_work_experiences.each do |w|
       new_application_form.application_work_experiences.create!(
-        w.attributes.except(*ignored_work_experience_attributes),
+        w.attributes.except(*ignored_work_experience_attributes).merge("currently_working" => infer_currently_working(w))
       )
     end
     if original_application_form.feature_restructured_work_history == false &&
@@ -77,5 +77,12 @@ private
     else
       IGNORED_CHILD_ATTRIBUTES
     end
+  end
+
+  def infer_currently_working(application_experience)
+    return application_experience.currently_working unless application_experience.currently_working.nil?
+    
+    application_experience.start_date < Date.today &&
+      (application_experience.end_date.nil? || application_experience.end_date > Date.today)
   end
 end

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -27,8 +27,7 @@ class DuplicateApplication
         w.attributes.except(*ignored_work_experience_attributes).merge('currently_working' => infer_currently_working(w)),
       )
     end
-    if original_application_form.feature_restructured_work_history == false &&
-        FeatureFlag.active?(:restructured_work_history)
+    if original_application_form.feature_restructured_work_history == false && FeatureFlag.active?(:restructured_work_history)
       new_application_form.update(
         feature_restructured_work_history: true,
         work_history_completed: false,
@@ -71,8 +70,7 @@ class DuplicateApplication
 private
 
   def ignored_work_experience_attributes
-    if original_application_form.feature_restructured_work_history == false &&
-        FeatureFlag.active?(:restructured_work_history)
+    if original_application_form.feature_restructured_work_history == false && FeatureFlag.active?(:restructured_work_history)
       IGNORED_CHILD_ATTRIBUTES + IGNORED_LEGACY_WORK_HISTORY_ATTRIBUTES
     else
       IGNORED_CHILD_ATTRIBUTES

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -80,7 +80,7 @@ private
   def infer_currently_working(application_experience)
     return application_experience.currently_working unless application_experience.currently_working.nil?
 
-    application_experience.start_date < Time.zone.today &&
-      (application_experience.end_date.nil? || application_experience.end_date > Time.zone.today)
+    application_experience.start_date <= Time.zone.today &&
+      (application_experience.end_date.nil? || application_experience.end_date >= Time.zone.today)
   end
 end

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -9,6 +9,7 @@ class DuplicateApplication
 
   IGNORED_ATTRIBUTES = %w[id created_at updated_at submitted_at course_choices_completed phase support_reference].freeze
   IGNORED_CHILD_ATTRIBUTES = %w[id created_at updated_at application_form_id public_id].freeze
+  IGNORED_LEGACY_WORK_HISTORY_ATTRIBUTES = %w[working_with_children working_pattern].freeze
 
   def duplicate
     attrs = original_application_form.attributes.except(
@@ -23,7 +24,7 @@ class DuplicateApplication
 
     original_application_form.application_work_experiences.each do |w|
       new_application_form.application_work_experiences.create!(
-        w.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
+        w.attributes.except(*ignored_work_experience_attributes),
       )
     end
     if original_application_form.feature_restructured_work_history == false &&
@@ -65,5 +66,16 @@ class DuplicateApplication
     end
 
     new_application_form
+  end
+
+private
+
+  def ignored_work_experience_attributes
+    if original_application_form.feature_restructured_work_history == false &&
+        FeatureFlag.active?(:restructured_work_history)
+      IGNORED_CHILD_ATTRIBUTES + IGNORED_LEGACY_WORK_HISTORY_ATTRIBUTES
+    else
+      IGNORED_CHILD_ATTRIBUTES
+    end
   end
 end

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -26,6 +26,13 @@ class DuplicateApplication
         w.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
       )
     end
+    if original_application_form.feature_restructured_work_history == false &&
+        FeatureFlag.active?(:restructured_work_history)
+      new_application_form.update(
+        feature_restructured_work_history: true,
+        work_history_completed: false,
+      )
+    end
 
     original_application_form.application_volunteering_experiences.each do |w|
       new_application_form.application_volunteering_experiences.create!(

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -121,8 +121,9 @@ RSpec.describe CarryOverApplication do
 
       described_class.new(original_application_form.reload).call
 
-      expect(first_job.reload.currently_working?).to be(false)
-      expect(second_job.reload.currently_working?).to be(false)
+      carried_over_application_form = ApplicationForm.last
+      expect(carried_over_application_form.application_work_experiences.first.currently_working?).to be(false)
+      expect(carried_over_application_form.application_work_experiences.last.currently_working?).to be(false)
     end
 
     it 'infers that `currently_working` is true if there is an ongoing work history item' do
@@ -134,8 +135,9 @@ RSpec.describe CarryOverApplication do
 
       described_class.new(original_application_form.reload).call
 
-      expect(first_job.reload.currently_working?).to be(false)
-      expect(second_job.reload.currently_working?).to be(true)
+      carried_over_application_form = ApplicationForm.last
+      expect(carried_over_application_form.application_work_experiences.first.currently_working?).to be(false)
+      expect(carried_over_application_form.application_work_experiences.last.currently_working?).to be(true)
     end
   end
 end

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -122,8 +122,8 @@ RSpec.describe CarryOverApplication do
       described_class.new(original_application_form.reload).call
 
       carried_over_application_form = ApplicationForm.last
-      expect(carried_over_application_form.application_work_experiences.find_by(organisation: first_job.organisation).currently_working?).to be(false)
-      expect(carried_over_application_form.application_work_experiences.find_by(organisation: second_job.organisation).currently_working?).to be(false)
+      expect(carried_over_application_form.application_work_experiences.find_by(start_date: first_job.start_date).currently_working?).to be(false)
+      expect(carried_over_application_form.application_work_experiences.find_by(start_date: second_job.start_date).currently_working?).to be(false)
     end
 
     it 'infers that `currently_working` is true if there is an ongoing work history item' do
@@ -136,8 +136,8 @@ RSpec.describe CarryOverApplication do
       described_class.new(original_application_form.reload).call
 
       carried_over_application_form = ApplicationForm.last
-      expect(carried_over_application_form.application_work_experiences.find_by(organisation: first_job.organisation).currently_working?).to be(false)
-      expect(carried_over_application_form.application_work_experiences.find_by(organisation: second_job.organisation).currently_working?).to be(true)
+      expect(carried_over_application_form.application_work_experiences.find_by(start_date: first_job.start_date).currently_working?).to be(false)
+      expect(carried_over_application_form.application_work_experiences.find_by(start_date: second_job.start_date).currently_working?).to be(true)
     end
   end
 end

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -99,6 +99,17 @@ RSpec.describe CarryOverApplication do
     end
 
     it 'only carries over required attributes' do
+      described_class.new(original_application_form).call
+
+      carried_over_application_form = ApplicationForm.last
+
+      carried_over_application_form.application_work_experiences.each do |experience|
+        expect(experience.working_pattern).to be_nil
+        expect(experience.working_with_children).to be_nil
+        expect(experience.role).to be_present
+        expect(experience.organisation).to be_present
+        expect(experience.details).to be_present
+      end
     end
   end
 end

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -113,35 +113,29 @@ RSpec.describe CarryOverApplication do
     end
 
     it 'infers that `currently_working` is false if there is no ongoing work history item' do
-      original_application_form.application_work_experiences.first.update(
-        start_date: 4.years.ago,
-        end_date: 3.years.ago,
-      )
-      original_application_form.application_work_experiences.last.update(
-        start_date: 2.years.ago,
-        end_date: 1.years.ago,
-      )
-      described_class.new(original_application_form.reload).call
-      carried_over_application_form = ApplicationForm.last
+      first_job = original_application_form.application_work_experiences.first
+      first_job.update(start_date: 4.years.ago, end_date: 3.years.ago)
 
-      expect(carried_over_application_form.reload.application_work_experiences.first.currently_working?).to be(false)
-      expect(carried_over_application_form.application_work_experiences.last.currently_working?).to be(false)
+      second_job = original_application_form.application_work_experiences.last
+      second_job.update(start_date: 2.years.ago, end_date: 1.year.ago)
+
+      described_class.new(original_application_form.reload).call
+
+      expect(first_job.reload.currently_working?).to be(false)
+      expect(second_job.reload.currently_working?).to be(false)
     end
 
     it 'infers that `currently_working` is true if there is an ongoing work history item' do
-      original_application_form.application_work_experiences.first.update(
-        start_date: 3.years.ago,
-        end_date: 2.years.ago,
-      )
-      original_application_form.application_work_experiences.last.update(
-        start_date: 1.years.ago,
-        end_date: nil,
-      )
-      described_class.new(original_application_form.reload).call
-      carried_over_application_form = ApplicationForm.last
+      first_job = original_application_form.application_work_experiences.first
+      first_job.update(start_date: 3.years.ago, end_date: 2.years.ago)
 
-      expect(carried_over_application_form.reload.application_work_experiences.first.currently_working?).to be(false)
-      expect(carried_over_application_form.application_work_experiences.last.currently_working?).to be(true)
+      second_job = original_application_form.application_work_experiences.last
+      second_job.update(start_date: 1.year.ago, end_date: nil)
+
+      described_class.new(original_application_form.reload).call
+
+      expect(first_job.reload.currently_working?).to be(false)
+      expect(second_job.reload.currently_working?).to be(true)
     end
   end
 end

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -111,5 +111,37 @@ RSpec.describe CarryOverApplication do
         expect(experience.details).to be_present
       end
     end
+
+    it 'infers that `currently_working` is false if there is no ongoing work history item' do
+      original_application_form.application_work_experiences.first.update(
+        start_date: 4.years.ago,
+        end_date: 3.years.ago,
+      )
+      original_application_form.application_work_experiences.last.update(
+        start_date: 2.years.ago,
+        end_date: 1.years.ago,
+      )
+      described_class.new(original_application_form.reload).call
+      carried_over_application_form = ApplicationForm.last
+
+      expect(carried_over_application_form.reload.application_work_experiences.first.currently_working?).to be(false)
+      expect(carried_over_application_form.application_work_experiences.last.currently_working?).to be(false)
+    end
+
+    it 'infers that `currently_working` is true if there is an ongoing work history item' do
+      original_application_form.application_work_experiences.first.update(
+        start_date: 3.years.ago,
+        end_date: 2.years.ago,
+      )
+      original_application_form.application_work_experiences.last.update(
+        start_date: 1.years.ago,
+        end_date: nil,
+      )
+      described_class.new(original_application_form.reload).call
+      carried_over_application_form = ApplicationForm.last
+
+      expect(carried_over_application_form.reload.application_work_experiences.first.currently_working?).to be(false)
+      expect(carried_over_application_form.application_work_experiences.last.currently_working?).to be(true)
+    end
   end
 end

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe CarryOverApplication do
         :completed_application_form,
         :with_gcses,
         application_choices_count: 1,
-        work_experiences_count: 1,
         volunteering_experiences_count: 1,
         full_work_history: true,
       )
@@ -75,6 +74,31 @@ RSpec.describe CarryOverApplication do
 
       expect(ApplicationForm.last.application_references.count).to eq 2
       expect(ApplicationForm.last.application_references.map(&:name)).to eq ['Carrie Over', 'Nixt Cycle']
+    end
+  end
+
+  context 'when application form has unstructured work history' do
+    before do
+      original_application_form.update(feature_restructured_work_history: false)
+      FeatureFlag.activate(:restructured_work_history)
+    end
+
+    it 'carries over history and sets feature_structured_work_history to true' do
+      described_class.new(original_application_form).call
+      carried_over_application_form = ApplicationForm.last
+
+      expect(carried_over_application_form.application_work_experiences.count).to eq(2)
+      expect(carried_over_application_form.feature_restructured_work_history).to be(true)
+    end
+
+    it 'sets the work history section to incomplete' do
+      described_class.new(original_application_form).call
+      carried_over_application_form = ApplicationForm.last
+
+      expect(carried_over_application_form.work_history_completed).to be(false)
+    end
+
+    it 'only carries over required attributes' do
     end
   end
 end

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -122,8 +122,8 @@ RSpec.describe CarryOverApplication do
       described_class.new(original_application_form.reload).call
 
       carried_over_application_form = ApplicationForm.last
-      expect(carried_over_application_form.application_work_experiences.first.currently_working?).to be(false)
-      expect(carried_over_application_form.application_work_experiences.last.currently_working?).to be(false)
+      expect(carried_over_application_form.application_work_experiences.find_by(organisation: first_job.organisation).currently_working?).to be(false)
+      expect(carried_over_application_form.application_work_experiences.find_by(organisation: second_job.organisation).currently_working?).to be(false)
     end
 
     it 'infers that `currently_working` is true if there is an ongoing work history item' do
@@ -136,8 +136,8 @@ RSpec.describe CarryOverApplication do
       described_class.new(original_application_form.reload).call
 
       carried_over_application_form = ApplicationForm.last
-      expect(carried_over_application_form.application_work_experiences.first.currently_working?).to be(false)
-      expect(carried_over_application_form.application_work_experiences.last.currently_working?).to be(true)
+      expect(carried_over_application_form.application_work_experiences.find_by(organisation: first_job.organisation).currently_working?).to be(false)
+      expect(carried_over_application_form.application_work_experiences.find_by(organisation: second_job.organisation).currently_working?).to be(true)
     end
   end
 end


### PR DESCRIPTION
## Context

We have recently restructured the model and UI for work history. `ApplicationForm#feature_restructured_work_history` indicates whether an application has the old or restructured work history model.

We want to be able to copy over old work histories into the new model when carrying over applications at EOC. Once copied we need to give the candidate appropriate prompts to enter any data that is present in the restructured model that was not there in the past.

## Changes proposed in this pull request

When we carry over an application that has pre-restructured work history we do the following:

- [x] Set the `feature_restructured_work_history` attribute to `true`
- [x] We only copy over the required attributes over
- [x] We set the `ApplicationForm#work_history_complete` attribute to `false`
- [x] Add link to review component to highlight the need to fill in the `relevant_skills` attribute on carried over applications.

<img width="991" alt="image" src="https://user-images.githubusercontent.com/450843/124729781-a7a0d580-df08-11eb-8b60-c5371559bd99.png">


Not covered in this PR:

- Changes to the UI to use inline change links to prompt the candidate for missing info
- The only attributes from the 'legacy' model that appear to be no longer required are `working_with_children` and `working_pattern` - is this correct?

## Guidance to review

- Per commit, though there are only 2

## Link to Trello card

https://trello.com/c/14r9GTKO/3382-eoc-carrying-over-applications-with-the-old-work-history-section

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
