### PR TITLE
Remove 'add provider user' button if 'new provider user flow' is turned on

### DIFF
--- a/app/views/support_interface/provider_users/index.html.erb
+++ b/app/views/support_interface/provider_users/index.html.erb
@@ -1,7 +1,9 @@
 <%= render 'support_interface/providers/providers_navigation', title: 'Provider users' %>
 
 <div class="govuk-button-group">
-  <%= govuk_link_to 'Add provider user', new_support_interface_provider_user_path, button: true %>
+  <% unless FeatureFlag.active?(:new_provider_user_flow) %>
+    <%= govuk_link_to 'Add provider user', new_support_interface_provider_user_path, button: true %>
+  <% end %>
   <%= govuk_link_to 'Download active provider users (CSV)', "#{new_support_interface_data_export_path}#providers_export", button: true, class: 'govuk-button--secondary' %>
 </div>
 


### PR DESCRIPTION
## Context

Under the new provider user on the the ProviderUsers index page, we do not want to have the option to add a provider user as we do not know the provider id (adding provider users under the new flow is scoped to a single provider, not multiple)

## Changes proposed in this pull request

- Only display 'add provider user' button if 'new provider user flow' is turned off and vice-versa

## Link to Trello card

https://trello.com/c/ow63AQnC/3389-%E2%9B%B5%EF%B8%8F-epic-add-provider-user

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
