### PR TITLE
Add request_status to BigQuery events, update BigQuery schema

### DIFF
--- a/app/controllers/concerns/emit_request_events.rb
+++ b/app/controllers/concerns/emit_request_events.rb
@@ -11,6 +11,7 @@ module EmitRequestEvents
       request_event = Events::Event.new
         .with_type('web_request')
         .with_request_details(request)
+        .with_response_details(response)
         .with_user_and_namespace(current_user, current_namespace)
 
       SendRequestEventsToBigquery.perform_async(request_event.as_json)

--- a/app/controllers/concerns/emit_request_events.rb
+++ b/app/controllers/concerns/emit_request_events.rb
@@ -9,6 +9,7 @@ module EmitRequestEvents
   def trigger_request_event
     if FeatureFlag.active?(:send_request_data_to_bigquery)
       request_event = Events::Event.new
+        .with_type('web_request')
         .with_request_details(request)
         .with_user_and_namespace(current_user, current_namespace)
 

--- a/app/lib/events/event.rb
+++ b/app/lib/events/event.rb
@@ -29,7 +29,7 @@ module Events
         request_user_agent: rack_request.user_agent,
         request_method: rack_request.method,
         request_path: rack_request.path,
-        request_query: rack_request.query_string.presence,
+        request_query: query_to_kv_pairs(rack_request.query_string),
         request_referer: rack_request.referer,
       )
 
@@ -52,6 +52,15 @@ module Events
       )
 
       self
+    end
+
+  private
+
+    def query_to_kv_pairs(query_string)
+      vars = Rack::Utils.parse_query(query_string)
+      vars.map do |(key, value)|
+        { 'key' => key, 'value' => Array.wrap(value) }
+      end
     end
   end
 end

--- a/app/lib/events/event.rb
+++ b/app/lib/events/event.rb
@@ -5,7 +5,7 @@ module Events
     def initialize
       @event_hash = {
         environment: HostingEnvironment.environment_name,
-        timestamp: Time.zone.now.iso8601,
+        occurred_at: Time.zone.now.iso8601,
       }
     end
 
@@ -26,8 +26,20 @@ module Events
     def with_request_details(rack_request)
       @event_hash.merge!(
         request_uuid: rack_request.uuid,
-        request_path: rack_request.path,
+        request_user_agent: rack_request.user_agent,
         request_method: rack_request.method,
+        request_path: rack_request.path,
+        request_query: rack_request.query_string.presence,
+        request_referer: rack_request.referer,
+      )
+
+      self
+    end
+
+    def with_response_details(rack_response)
+      @event_hash.merge!(
+        response_content_type: rack_response.content_type,
+        response_status: rack_response.status,
       )
 
       self

--- a/app/lib/events/event.rb
+++ b/app/lib/events/event.rb
@@ -1,5 +1,7 @@
 module Events
   class Event
+    EVENT_TYPES = %w[web_request].freeze
+
     def initialize
       @event_hash = {
         environment: HostingEnvironment.environment_name,
@@ -9,6 +11,16 @@ module Events
 
     def as_json
       @event_hash.as_json
+    end
+
+    def with_type(type)
+      raise 'Invalid analytics event type' unless EVENT_TYPES.include?(type.to_s)
+
+      @event_hash.merge!(
+        type: type,
+      )
+
+      self
     end
 
     def with_request_details(rack_request)

--- a/app/lib/events/event.rb
+++ b/app/lib/events/event.rb
@@ -17,7 +17,7 @@ module Events
       raise 'Invalid analytics event type' unless EVENT_TYPES.include?(type.to_s)
 
       @event_hash.merge!(
-        type: type,
+        event_type: type,
       )
 
       self

--- a/app/workers/send_request_events_to_bigquery.rb
+++ b/app/workers/send_request_events_to_bigquery.rb
@@ -3,12 +3,11 @@ class SendRequestEventsToBigquery
 
   sidekiq_options retry: 3, queue: :low_priority
 
-  TABLE_NAME = 'events'.freeze
-
   def perform(request_event_json)
+    table_name = ENV.fetch('BIG_QUERY_TABLE_NAME', 'events')
     bq = Google::Cloud::Bigquery.new(project: ENV.fetch('BIG_QUERY_PROJECT_ID'))
     dataset = bq.dataset(ENV.fetch('BIG_QUERY_DATASET'), skip_lookup: true)
-    bq_table = dataset.table(TABLE_NAME, skip_lookup: true)
+    bq_table = dataset.table(table_name, skip_lookup: true)
     bq_table.insert([request_event_json])
   end
 end

--- a/config/event-schema.json
+++ b/config/event-schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "environment": {
+      "type": "string"
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["web_request"]
+    },
+    "request_uuid": {
+      "type": "string"
+    },
+    "request_user_agent": {
+      "type": "string"
+    },
+    "request_method": {
+      "type": "string"
+    },
+    "request_path": {
+      "type": "string"
+    },
+    "request_query": {
+      "anyOf": [
+        {"type": "string"},
+        {"type": "null"}
+      ]
+    },
+    "request_referer": {
+      "anyOf": [
+        {"type": "string"},
+        {"type": "null"}
+      ]
+    },
+    "response_content_type": {
+      "type": "string"
+    },
+    "response_status": {
+      "type": "integer"
+    },
+    "namespace": {
+      "type": "string"
+    },
+    "user_id": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "environment",
+    "occurred_at",
+    "type"
+  ]
+}

--- a/config/event-schema.json
+++ b/config/event-schema.json
@@ -9,7 +9,7 @@
       "type": "string",
       "format": "date-time"
     },
-    "type": {
+    "event_type": {
       "type": "string",
       "enum": ["web_request"]
     },
@@ -54,6 +54,6 @@
   "required": [
     "environment",
     "occurred_at",
-    "type"
+    "event_type"
   ]
 }

--- a/config/event-schema.json
+++ b/config/event-schema.json
@@ -26,10 +26,11 @@
       "type": "string"
     },
     "request_query": {
-      "anyOf": [
-        {"type": "string"},
-        {"type": "null"}
-      ]
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["key", "value"]
+      }
     },
     "request_referer": {
       "anyOf": [

--- a/spec/requests/emit_request_events_spec.rb
+++ b/spec/requests/emit_request_events_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe EmitRequestEvents, type: :request, with_bigquery: true do
       expect(payload['request_method']).to eq('GET')
       expect(payload['request_user_agent']).to eq('Test agent')
       expect(payload['environment']).to eq('test')
-      expect(payload['type']).to eq('web_request')
+      expect(payload['event_type']).to eq('web_request')
       expect(payload['namespace']).to eq('provider_interface')
       expect(payload['response_status']).to eq(200)
       expect(payload['request_query']).to eq([

--- a/spec/requests/emit_request_events_spec.rb
+++ b/spec/requests/emit_request_events_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe EmitRequestEvents, type: :request, with_bigquery: true do
       expect(payload['environment']).to eq('test')
       expect(payload['type']).to eq('web_request')
       expect(payload['namespace']).to eq('provider_interface')
+      expect(payload['response_status']).to eq(200)
+
+      schema = File.read('config/event-schema.json')
+      schema_validator = JSONSchemaValidator.new(schema, payload)
+
+      expect(schema_validator).to be_valid, schema_validator.failure_message
     end
   end
 end

--- a/spec/workers/send_request_events_to_bigquery_spec.rb
+++ b/spec/workers/send_request_events_to_bigquery_spec.rb
@@ -21,14 +21,14 @@ RSpec.describe SendRequestEventsToBigquery do
     before do
       allow(Google::Cloud::Bigquery).to receive(:new).and_return(project)
       allow(table).to receive(:insert)
-      allow(ENV).to receive(:fetch).with('BIG_QUERY_PROJECT_ID').and_return('bat-apply-test')
-      allow(ENV).to receive(:fetch).with('BIG_QUERY_DATASET').and_return('bat-apply-test-events')
     end
 
     it 'sends request event JSON to Bigquery' do
-      described_class.new.perform(request_event.as_json)
+      ClimateControl.modify(BIG_QUERY_PROJECT_ID: 'bat-apply-test', BIG_QUERY_DATASET: 'bat-apply-test-events') do
+        described_class.new.perform(request_event.as_json)
 
-      expect(table).to have_received(:insert).with([request_event.as_json])
+        expect(table).to have_received(:insert).with([request_event.as_json])
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

We're standardising the BigQuery `Event` schema across Find and Apply.

## Changes proposed in this pull request

- create a JSON schema file, usable in tests, to act as a reference point — we can copy this into Find. The field names etc (eg `occurred_at`) are now also aligned with TVS
- add the request_status field to bring us into line with the schema

## Link to Trello card

https://trello.com/c/nKBZ0XEX/3541-add-requeststatus-to-bigquery-events
