### PR TITLE
Add RBD fields to SR4R export

### DIFF
--- a/app/exports/structured_reasons_for_rejection_export.yml
+++ b/app/exports/structured_reasons_for_rejection_export.yml
@@ -13,6 +13,22 @@ custom_columns:
     description: The date when the application choice was rejected
     example: 2020-11-01T00:00:00+00:00
 
+  rejected_by_default:
+    type: boolean
+    description: Was the application rejected by default?
+
+  reject_by_default_at:
+    type: string
+    format: date-time
+    description: The date when the application choice was rejected by default
+    example: 2020-11-01T00:00:00+00:00
+
+  reject_by_default_feedback_sent_at:
+    type: string
+    format: date-time
+    description: The date when feedback was sent about the application rejection
+    example: 2020-11-01T00:00:00+00:00
+
   something_you_did:
     type: boolean
     description: Was the reason for rejection related to candidate behaviour?

--- a/app/services/support_interface/structured_reasons_for_rejection_export.rb
+++ b/app/services/support_interface/structured_reasons_for_rejection_export.rb
@@ -9,7 +9,10 @@ module SupportInterface
           phase: application_choice.application_form.phase,
           provider_code: application_choice.provider.code,
           course_code: application_choice.course.code,
-          rejected_at: application_choice.rejected_at.strftime('%d/%m/%Y'),
+          rejected_at: application_choice.rejected_at.iso8601,
+          rejected_by_default: application_choice.rejected_by_default,
+          reject_by_default_at: application_choice.reject_by_default_at&.iso8601,
+          reject_by_default_feedback_sent_at: application_choice.reject_by_default_feedback_sent_at&.iso8601,
         }.merge!(FlatReasonsForRejectionPresenter.build_from_structured_rejection_reasons(ReasonsForRejection.new(application_choice.structured_rejection_reasons)))
       end
     end

--- a/spec/services/support_interface/structured_reasons_for_rejection_export_spec.rb
+++ b/spec/services/support_interface/structured_reasons_for_rejection_export_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe SupportInterface::StructuredReasonsForRejectionExport do
       application_choice_one = create(
         :application_choice,
         :with_structured_rejection_reasons,
+        rejected_by_default: false,
+        reject_by_default_at: nil,
+        reject_by_default_feedback_sent_at: nil,
         structured_rejection_reasons: {
           course_full_y_n: 'Yes',
           safeguarding_y_n: 'Yes',
@@ -54,6 +57,9 @@ RSpec.describe SupportInterface::StructuredReasonsForRejectionExport do
       application_choice_two = create(
         :application_choice,
         :with_structured_rejection_reasons,
+        rejected_by_default: true,
+        reject_by_default_at: Time.zone.local(2021, 7, 7),
+        reject_by_default_feedback_sent_at: Time.zone.local(2021, 6, 7),
         structured_rejection_reasons: {
           qualifications_y_n: 'Yes',
           qualifications_other_details: 'Not good',
@@ -69,7 +75,10 @@ RSpec.describe SupportInterface::StructuredReasonsForRejectionExport do
           phase: application_choice_one.application_form.phase,
           provider_code: application_choice_one.provider.code,
           course_code: application_choice_one.course.code,
-          rejected_at: application_choice_one.rejected_at.strftime('%d/%m/%Y'),
+          rejected_at: application_choice_one.rejected_at.iso8601,
+          rejected_by_default: false,
+          reject_by_default_at: nil,
+          reject_by_default_feedback_sent_at: nil,
           something_you_did: true,
           didn_t_reply_to_our_interview_offer: true,
           didn_t_attend_interview: true,
@@ -120,7 +129,10 @@ RSpec.describe SupportInterface::StructuredReasonsForRejectionExport do
            phase: application_choice_two.application_form.phase,
            provider_code: application_choice_two.provider.code,
            course_code: application_choice_two.course.code,
-           rejected_at: application_choice_two.rejected_at.strftime('%d/%m/%Y'),
+           rejected_at: application_choice_two.rejected_at.iso8601,
+           rejected_by_default: true,
+           reject_by_default_at: Time.zone.local(2021, 7, 7).iso8601,
+           reject_by_default_feedback_sent_at: Time.zone.local(2021, 6, 7).iso8601,
            something_you_did: false,
            didn_t_reply_to_our_interview_offer: false,
            didn_t_attend_interview: false,


### PR DESCRIPTION
## Context

We'd like to do further analysis of reasons given by providers for RBD.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds RBD fields to structured reasons for rejection export.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/JwfhVILB/3862-iterate-structured-reasons-for-rejection-export-available-through-support
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
