### PR TITLE
Fix site sync concurrency issue

### DIFF
--- a/app/services/teacher_training_public_api/sync_sites.rb
+++ b/app/services/teacher_training_public_api/sync_sites.rb
@@ -18,6 +18,9 @@ module TeacherTrainingPublicAPI
 
       sites.each do |site_from_api|
         site = provider.sites.create_or_find_by(code: site_from_api.code) do |s|
+          # We need to set the name here so that the record is valid when created.
+          # If it is not valid, it just gets initialised (and is not persisted to the db). When calling save! below, it
+          # is possible for a duplicate record to have already been created by another sidekiq worker.
           s.name = site_from_api.name
         end
 

--- a/app/services/teacher_training_public_api/sync_sites.rb
+++ b/app/services/teacher_training_public_api/sync_sites.rb
@@ -17,17 +17,11 @@ module TeacherTrainingPublicAPI
       ).includes(:location_status).paginate(per_page: 500)
 
       sites.each do |site_from_api|
-        site = provider.sites.find_or_create_by(code: site_from_api.code)
+        site = provider.sites.create_or_find_by(code: site_from_api.code) do |s|
+          s.name = site_from_api.name
+        end
 
-        site.name = site_from_api.name
-        site.address_line1 = site_from_api.street_address_1&.strip
-        site.address_line2 = site_from_api.street_address_2&.strip
-        site.address_line3 = site_from_api.city&.strip
-        site.address_line4 = site_from_api.county&.strip
-        site.postcode = site_from_api.postcode&.strip
-        site.region = site_from_api.region_code&.strip
-        site.latitude = site_from_api.latitude
-        site.longitude = site_from_api.longitude
+        assign_site_attributes(site, site_from_api)
         site.save!
 
         site_status = site_from_api.location_status
@@ -43,6 +37,18 @@ module TeacherTrainingPublicAPI
     end
 
   private
+
+    def assign_site_attributes(site, site_from_api)
+      site.name = site_from_api.name
+      site.address_line1 = site_from_api.street_address_1&.strip
+      site.address_line2 = site_from_api.street_address_2&.strip
+      site.address_line3 = site_from_api.city&.strip
+      site.address_line4 = site_from_api.county&.strip
+      site.postcode = site_from_api.postcode&.strip
+      site.region = site_from_api.region_code&.strip
+      site.latitude = site_from_api.latitude
+      site.longitude = site_from_api.longitude
+    end
 
     def study_modes(course)
       both_modes = %w[full_time part_time]


### PR DESCRIPTION
## Context
Since the same site can be specified by multiple courses in the TTAPI, we sometimes try to sync the same site at the same time. If the site is new, then in rare cases the find_or_create_by tries to insert the same site twice which raises an error.

## Changes proposed in this pull request
Use `create_or_find_by` which catches any error raised by postgres on the create, and finds instead.
We have to specify the name in the create so that validations pass and the site is actually inserted into the DB

## Guidance to review
It would be nice to have a test for this, but it requires two sidekiq jobs to run at the exact same time to reproduce. I managed this locally in the rails console

## Sentry
https://sentry.io/organizations/dfe-bat/issues/2267092709/events/e0d7364a0a4840a08ab709e51f048825/?project=1765973

