### PR TITLE
Handle large date input numbers when validating dates

### DIFF
--- a/app/helpers/date_validation_helper.rb
+++ b/app/helpers/date_validation_helper.rb
@@ -1,11 +1,11 @@
 module DateValidationHelper
   def valid_or_invalid_date(year, month)
+    raise ArgumentError if year.blank?
+
     date_args = [year, month, 1].map(&:to_i)
-    if year.present? && Date.valid_date?(*date_args)
-      Date.new(*date_args)
-    else
-      Struct.new(:day, :month, :year).new(1, month, year)
-    end
+    Date.new(*date_args)
+  rescue ArgumentError, RangeError
+    Struct.new(:day, :month, :year).new(1, month, year)
   end
 
   def month_and_year_blank?(date)

--- a/spec/helpers/date_validation_helper_spec.rb
+++ b/spec/helpers/date_validation_helper_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe DateValidationHelper, type: :helper do
+  shared_examples_for 'a date that is invalid' do
+    it 'returns a struct' do
+      expect(subject).not_to be_a(Date)
+      expect(subject).to have_attributes(year: year, month: expected_month, day: 1)
+    end
+  end
+
+  shared_examples_for 'a date that is valid' do
+    it 'returns a valid date' do
+      expect(subject).to be_a(Date)
+      expect(subject).to have_attributes(year: year.to_i, month: expected_month.to_i, day: 1)
+    end
+  end
+
+  describe '#valid_or_invalid_date' do
+    let(:year) { '2018' }
+    let(:month) { '12' }
+    let(:expected_month) { month }
+
+    subject { valid_or_invalid_date(year, month) }
+
+    it_behaves_like 'a date that is valid'
+
+    context 'when the month is blank' do
+      let(:month) { '' }
+
+      it_behaves_like 'a date that is invalid'
+    end
+
+    context 'when the month is a large number' do
+      let(:month) { '123456789123456789123456789' }
+
+      it_behaves_like 'a date that is invalid'
+    end
+
+    context 'when the month is a negative number' do
+      let(:month) { '-5' }
+      let(:expected_month) { '8' }
+
+      it_behaves_like 'a date that is valid'
+    end
+
+    context 'when the month is a large negative number' do
+      let(:month) { '-123456789123456789123456789' }
+
+      it_behaves_like 'a date that is invalid'
+    end
+
+    context 'when the month includes non-numerics' do
+      let(:month) { 'december' }
+
+      it_behaves_like 'a date that is invalid'
+    end
+
+    context 'when the year is blank' do
+      let(:year) { '' }
+
+      it_behaves_like 'a date that is invalid'
+    end
+
+    context 'when the year is a negative number' do
+      let(:year) { '-2018' }
+
+      it_behaves_like 'a date that is valid'
+    end
+
+    context 'when the year is a large number' do
+      let(:year) { '123456789123456789123456789' }
+
+      it_behaves_like 'a date that is valid'
+    end
+
+    context 'when the year includes non-numerics' do
+      let(:month) { 'last year' }
+
+      it_behaves_like 'a date that is invalid'
+    end
+  end
+end


### PR DESCRIPTION
## Context
If you enter a really large value for the month in the job form, then you get an error.

## Changes proposed in this pull request
Handle the big numbers

## Sentry error
https://sentry.io/organizations/dfe-bat/issues/2473964480/events/d280c541dbae4f65a75e2c64cf72663e/?project=1765973

