### PR TITLE
Summer recruitment banner

### DIFF
--- a/app/components/provider_interface/summer_recruitment_banner.html.erb
+++ b/app/components/provider_interface/summer_recruitment_banner.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= govuk_notification_banner(title: t('summer_recruitment_banner.title')) do |notification_banner| %>
+      <%= notification_banner.slot(:heading, text: t('summer_recruitment_banner.header')) %>
+      <p class="govuk-body"><%= t('summer_recruitment_banner.body') %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/components/provider_interface/summer_recruitment_banner.rb
+++ b/app/components/provider_interface/summer_recruitment_banner.rb
@@ -1,0 +1,7 @@
+module ProviderInterface
+  class SummerRecruitmentBanner < ViewComponent::Base
+    def render?
+      FeatureFlag.active?('summer_recruitment_banner')
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -36,6 +36,7 @@ class FeatureFlag
     [:new_provider_user_flow, 'New flow for creating or updating a single ProviderUser and adding Provider users in bulk', 'Toby Retallick'],
     [:individual_offer_conditions, 'Enables individual offer condition management', 'Despo Pentara'],
     [:withdraw_at_candidates_request, "Allows providers to withdraw an application at the candidate's request", 'Steve Laing'],
+    [:summer_recruitment_banner, 'Show a banner to indicate a shorter recruitment timeframe during summer', 'Richard Pattinson'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -1,6 +1,7 @@
 <% content_for :browser_title, "Applications (#{@application_choices.total_count})" %>
 
 <%= render ServiceInformationBanner.new(namespace: :provider) %>
+<%= render ProviderInterface::SummerRecruitmentBanner.new %>
 
 <h1 class="govuk-heading-xl">Applications (<%= @application_choices.total_count %>)</h1>
 

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -9,10 +9,10 @@
           <p class="govuk-body-l">Try our new service to see how easy it is to use. It’s free for providers and candidates.</p>
         </div>
         <%= govuk_start_now_button(
-          text: 'Get started',
-          href: @pilot_enrolment_form_url,
-          classes: 'govuk-!-margin-bottom-0 app-button--inverted',
-        ) %>
+              text: 'Get started',
+              href: @pilot_enrolment_form_url,
+              classes: 'govuk-!-margin-bottom-0 app-button--inverted',
+            ) %>
         <span class="app-masthead__alternative-action">or <%= govuk_link_to 'sign in', provider_interface_sign_in_path %> if you’ve used it before</span>
       </div>
       <div class="govuk-grid-column-one-third">
@@ -27,6 +27,7 @@
 <div class="govuk-width-container">
   <section class="app-section">
     <%= render ServiceInformationBanner.new(namespace: :provider) %>
+    <%= render ProviderInterface::SummerRecruitmentBanner.new %>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">

--- a/config/locales/summer_recruitment_banner.yml
+++ b/config/locales/summer_recruitment_banner.yml
@@ -1,0 +1,5 @@
+en:
+  summer_recruitment_banner:
+    title: Important
+    header: Applications will be automatically rejected if you do not make a decision within 20 working days
+    body: This reduced time to make a decision will last until the recruitment cycle ends on 4 October.

--- a/spec/components/provider_interface/summer_recruitment_banner_spec.rb
+++ b/spec/components/provider_interface/summer_recruitment_banner_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::SummerRecruitmentBanner do
+  before { FeatureFlag.activate('summer_recruitment_banner') }
+
+  subject(:result) { render_inline(ProviderInterface::SummerRecruitmentBanner.new) }
+
+  context 'when the provider information banner feature flag is on' do
+    it 'renders the banner title' do
+      expect(result.text).to include('Important')
+    end
+
+    it 'renders the banner header' do
+      expect(result.text).to include('Applications will be automatically rejected if you do not make a decision within 20 working days')
+    end
+
+    it 'renders the banner content' do
+      expect(result.text).to include('This reduced time to make a decision will last until the recruitment cycle ends on 4 October.')
+    end
+  end
+
+  context 'when the provider information banner feature flag is off' do
+    it 'does not render the banner' do
+      FeatureFlag.deactivate('summer_recruitment_banner')
+
+      expect(result.text).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Context

From the first of July, the amount of time providers have to respond to applications before the reject by default reduces to 20 working days.

Applications will be automatically rejected on 4 October 2021 if Providers have not responded to them. This aligns with UCAS.

We want to notify Providers in-service, so they are reminded that they have less time to respond to applications

## Changes proposed in this pull request

Add a summer recruitment banner component and hide it behind a feature flag, this will manually have to be enabled/ disabled for the time period.

## Link to Trello card

https://trello.com/c/abYnOUBy/3858-summer-recruitment-banner-for-1st-july
