### PR TITLE
Upgrade govuk frontend and enable link styles

### DIFF
--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -19,6 +19,10 @@ $govuk-breakpoints: (
 
 $moj-images-path: "~@ministryofjustice/frontend/moj/assets/images/";
 
+// Enable new link styles (currently opt-in).
+// TODO: remove this when this becomes the default.
+$govuk-new-link-styles: true;
+
 // Shared (govuk-frontend)
 @import "~govuk-frontend/govuk/all";
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@ministryofjustice/frontend": "^0.2.4",
     "@rails/webpacker": "^5.4.0",
     "accessible-autocomplete": "^2.0.3",
-    "govuk-frontend": "^3.12.0",
+    "govuk-frontend": "^3.13.0",
     "jquery": "^3.6.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4543,10 +4543,10 @@ gonzales-pe@^4.3.0:
   dependencies:
     minimist "^1.2.5"
 
-govuk-frontend@^3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.12.0.tgz#55d7057ed8f480a3f83ffeae54b68e0fc81607a3"
-  integrity sha512-+mM8BqEUqsBVSV/ud0dEhE8OmMdhkK53eEUp5YyPN+y3mwcdRnwwP2A2B5qFdFi6E6j/2AYuCG8l5kXD+JXNxA==
+govuk-frontend@^3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.13.0.tgz#c52f3a3d54edccf58439db038dd75bbee5df0efa"
+  integrity sha512-JiPCeasuHZ+9m1VyqhsfE81PhWIW4Sweoe6Jvn6oMjQNr75ZpupiytN3DGwA+WKOoESHZibIG+heAzlkdZ/MhA==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.3"


### PR DESCRIPTION
The [new link styles](https://github.com/alphagov/govuk-frontend/releases/tag/v3.12.0) are currently opt-in. The main differences are:

> Links now have underlines that are consistently thinner and a bit further away from the link text.
>
> Links also have a clearer hover state, where the underline gets thicker to make the link stand out to users.

Version 3.13.0 of govuk-frontend [disables ink skipping of underlines in hover state](https://github.com/alphagov/govuk-frontend/pull/2251) to avoid large gaps appearing in the underline on hover in Safari and Firefox.