### PR TITLE
Update the r4r export to pass the correct ids for candidate_id

### DIFF
--- a/app/services/support_interface/structured_reasons_for_rejection_export.rb
+++ b/app/services/support_interface/structured_reasons_for_rejection_export.rb
@@ -3,7 +3,7 @@ module SupportInterface
     def data_for_export
       application_choices.order(:id).find_each(batch_size: 100).map do |application_choice|
         {
-          candidate_id: application_choice.application_form_id,
+          candidate_id: application_choice.candidate.id,
           application_choice_id: application_choice.id,
           recruitment_cycle_year: application_choice.course.recruitment_cycle_year,
           phase: application_choice.application_form.phase,

--- a/spec/services/support_interface/structured_reasons_for_rejection_export_spec.rb
+++ b/spec/services/support_interface/structured_reasons_for_rejection_export_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe SupportInterface::StructuredReasonsForRejectionExport do
 
       expect(described_class.new.data_for_export).to eq(
         [{
-          candidate_id: application_choice_one.application_form_id,
+          candidate_id: application_choice_one.application_form.candidate.id,
           application_choice_id: application_choice_one.id,
           recruitment_cycle_year: application_choice_one.course.recruitment_cycle_year,
           phase: application_choice_one.application_form.phase,
@@ -114,7 +114,7 @@ RSpec.describe SupportInterface::StructuredReasonsForRejectionExport do
           why_are_you_rejecting_this_application_details: nil,
         },
          {
-           candidate_id: application_choice_two.application_form_id,
+           candidate_id: application_choice_two.application_form.candidate.id,
            application_choice_id: application_choice_two.id,
            recruitment_cycle_year: application_choice_two.course.recruitment_cycle_year,
            phase: application_choice_two.application_form.phase,


### PR DESCRIPTION
## Context

We're passing application_form_id instead of candidate_id in the candidate column

## Changes proposed in this pull request

- Pass the candidate id to the candidate_id column