### PR TITLE
Email to warn candidates about EoC deadlines

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -465,6 +465,13 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def eoc_deadline_reminder(application_form)
+    email_for_candidate(
+      application_form,
+      subject: I18n.t!('candidate_mailer.approaching_eoc_deadline.subject'),
+    )
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/models/chaser_sent.rb
+++ b/app/models/chaser_sent.rb
@@ -9,5 +9,6 @@ class ChaserSent < ApplicationRecord
     candidate_decision_request: 'candidate_decision_request',
     course_unavailable_notification: 'course_unavailable_notification',
     course_unavailable_slack_notification: 'course_unavailable_slack_notification',
+    eoc_deadline_reminder: 'eoc_deadline_reminder',
   }
 end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -87,6 +87,22 @@ class CycleTimetable
     date(:apply_opens, year)
   end
 
+  def self.apply_1_deadline_first_reminder
+    (apply_1_deadline - 2.months).beginning_of_week + 1.week
+  end
+
+  def self.apply_1_deadline_second_reminder
+    (apply_1_deadline - 1.month).beginning_of_week + 1.week
+  end
+
+  def self.apply_2_deadline_first_reminder
+    (apply_2_deadline - 2.months).beginning_of_week + 1.week
+  end
+
+  def self.apply_2_deadline_second_reminder
+    (apply_2_deadline - 1.month).beginning_of_week + 1.week
+  end
+
   def self.between_cycles_apply_1?
     Time.zone.now > apply_1_deadline.end_of_day &&
       Time.zone.now < apply_reopens.beginning_of_day
@@ -206,4 +222,9 @@ class CycleTimetable
   end
 
   private_class_method :last_recruitment_cycle_year?, :currently_mid_cycle?
+
+  def self.need_to_send_deadline_reminder?
+    return :apply_1 if Time.zone.now.to_date == apply_1_deadline_first_reminder || Time.zone.now.to_date == apply_1_deadline_second_reminder
+    return :apply_2 if Time.zone.now.to_date == apply_2_deadline_first_reminder || Time.zone.now.to_date == apply_2_deadline_second_reminder
+  end
 end

--- a/app/services/send_eoc_deadline_reminder_email_to_candidate.rb
+++ b/app/services/send_eoc_deadline_reminder_email_to_candidate.rb
@@ -1,0 +1,6 @@
+class SendEocDeadlineReminderEmailToCandidate
+  def self.call(application_form:)
+    CandidateMailer.eoc_deadline_reminder(application_form)
+    ChaserSent.create!(chased: application_form, chaser_type: :eoc_deadline_reminder)
+  end
+end

--- a/app/views/candidate_mailer/eoc_deadline_reminder.erb
+++ b/app/views/candidate_mailer/eoc_deadline_reminder.erb
@@ -1,0 +1,18 @@
+Dear <%= @application_form.first_name %>,
+
+# Complete your teacher training application – courses fill up quickly at this time of year
+
+Submit your application as soon as you can to get on a course starting in the <%= RecruitmentCycle.current_year %> to <%= RecruitmentCycle.next_year %> academic year:
+
+<%= candidate_magic_link(@application_form.candidate) %>
+
+<% apply_1_copy =  "The deadline to submit your application is 6pm on #{CycleTimetable.apply_1_deadline.to_s(:govuk_date)} but courses may fill up before then." %>
+<% apply_2_copy =  "The deadline to submit your application is 6pm on #{CycleTimetable.apply_2_deadline.to_s(:govuk_date)} but courses may fill up before then." %>
+
+<%= apply_1_copy if @application_form.phase == 'apply_1' %>
+<%= apply_2_copy if @application_form.phase == 'apply_2' %>
+
+# Get help to complete your application
+
+Talk to a teacher training adviser to get help writing a strong application:
+https://adviser-getintoteaching.education.gov.uk/

--- a/app/workers/send_eoc_deadline_reminder_email_to_candidates_worker.rb
+++ b/app/workers/send_eoc_deadline_reminder_email_to_candidates_worker.rb
@@ -1,0 +1,25 @@
+class SendEocDeadlineReminderEmailToCandidatesWorker
+  include Sidekiq::Worker
+
+  def perform
+    applications_to_send_reminders_to.each do |application|
+      SendEocDeadlineReminderEmailToCandidate.call(application_form: application)
+    end
+  end
+
+  def applications_to_send_reminders_to
+    return [] unless CycleTimetable.need_to_send_deadline_reminder?
+
+    if CycleTimetable.need_to_send_deadline_reminder? == :apply_1
+      ApplicationForm
+        .current_cycle
+        .where(submitted_at: nil)
+        .where(phase: 'apply_1')
+    elsif CycleTimetable.need_to_send_deadline_reminder? == :apply_2
+      ApplicationForm
+      .current_cycle
+      .where(submitted_at: nil)
+      .where(phase: 'apply_2')
+    end
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -47,5 +47,7 @@ class Clock
 
   every(1.day, 'Generate export for TAD', at: '23:59') { DataAPI::TADExport.run_daily }
 
+  every(1.day, 'SendEocDeadlineReminderEmailToCandidatesWorker', at: '12:00') { SendEocDeadlineReminderEmailToCandidatesWorker.new.perform }
+
   every(3.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: '00:59') { TeacherTrainingPublicAPI::FullSyncAllProvidersAndCoursesWorker.perform_async }
 end

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -117,3 +117,5 @@ en:
       subject: Interview details updated - %{provider_name}
     interview_cancelled:
       subject: Interview cancelled - %{provider_name}
+    approaching_eoc_deadline:
+      subject: Submit your application before courses fill up

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -381,4 +381,34 @@ RSpec.describe CandidateMailer, type: :mailer do
       )
     end
   end
+
+  describe '.deadline_reminder' do
+    context 'when a candidate is in Apply 1' do
+      let(:email) { mailer.eoc_deadline_reminder(application_form) }
+
+      let(:application_form) { build_stubbed(:application_form, phase: 'apply_1') }
+      let(:application_choice) { build_stubbed(:application_choice, application_form: application_form) }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Submit your application before courses fill up',
+        'cycle_details' => "Submit your application as soon as you can to get on a course starting in the #{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year} academic year:",
+        'details' => "The deadline to submit your application is 6pm on #{CycleTimetable.apply_1_deadline.to_s(:govuk_date)}",
+      )
+    end
+
+    context 'when a candidate is in Apply 2' do
+      let(:email) { mailer.eoc_deadline_reminder(application_form) }
+
+      let(:application_form) { build_stubbed(:application_form, phase: 'apply_2') }
+      let(:application_choice) { build_stubbed(:application_choice, application_form: application_form) }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Submit your application before courses fill up',
+        'cycle_details' => "Submit your application as soon as you can to get on a course starting in the #{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year} academic year:",
+        'details' => "The deadline to submit your application is 6pm on #{CycleTimetable.apply_2_deadline.to_s(:govuk_date)}",
+      )
+    end
+  end
 end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -716,6 +716,15 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.deferred_offer_reminder(application_choice)
   end
 
+  def eoc_deadline_reminder
+    application_form = FactoryBot.build(
+      :application_form,
+      first_name: 'Tester',
+    )
+
+    CandidateMailer.eoc_deadline_reminder(application_form)
+  end
+
   def reinstated_offer_with_conditions
     application_choice = FactoryBot.build(
       :application_choice,

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -208,4 +208,36 @@ RSpec.describe CycleTimetable do
       expect(described_class.can_submit?(application_form)).to be false
     end
   end
+
+  describe '.need_to_send_deadline_reminder?' do
+    it 'does not return for a non deadline date' do
+      Timecop.travel(CycleTimetable.apply_1_deadline_first_reminder - 1.day) do
+        expect(described_class.need_to_send_deadline_reminder?).to be nil
+      end
+    end
+
+    it 'returns apply_1 when it is the first apply 1 deadline' do
+      Timecop.travel(CycleTimetable.apply_1_deadline_first_reminder) do
+        expect(described_class.need_to_send_deadline_reminder?).to be :apply_1
+      end
+    end
+
+    it 'returns apply_1 when it is the second apply 1 deadline' do
+      Timecop.travel(CycleTimetable.apply_1_deadline_second_reminder) do
+        expect(described_class.need_to_send_deadline_reminder?).to be :apply_1
+      end
+    end
+
+    it 'returns apply_2 when it is the first apply 2 deadline' do
+      Timecop.travel(CycleTimetable.apply_2_deadline_first_reminder) do
+        expect(described_class.need_to_send_deadline_reminder?).to be :apply_2
+      end
+    end
+
+    it 'returns apply_2 when it is the second apply 2 deadline' do
+      Timecop.travel(CycleTimetable.apply_2_deadline_second_reminder) do
+        expect(described_class.need_to_send_deadline_reminder?).to be :apply_2
+      end
+    end
+  end
 end

--- a/spec/services/send_eoc_deadline_reminder_email_to_candidate_spec.rb
+++ b/spec/services/send_eoc_deadline_reminder_email_to_candidate_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe SendEocDeadlineReminderEmailToCandidate do
+  describe '#call' do
+    context 'when the candidate is in Apply 1' do
+      let(:application_form) { create(:application_form, phase: 'apply_1') }
+
+      it 'sends a reminder email to the candidate' do
+        described_class.call(application_form: application_form)
+        expect(application_form.chasers_sent.eoc_deadline_reminder.count).to eq(1)
+      end
+    end
+
+    context 'when the candidate is in Apply 2' do
+      let(:application_form) { create(:application_form, phase: 'apply_2') }
+
+      it 'sends a reminder email to the candidate' do
+        described_class.call(application_form: application_form)
+        expect(application_form.chasers_sent.eoc_deadline_reminder.count).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -40,6 +40,7 @@ RSpec.feature 'Docs' do
       provider_mailer-ucas_match_initial_email_duplicate_applications
       candidate_mailer-apply_again_call_to_action
       candidate_mailer-course_unavailable_notification
+      candidate_mailer-eoc_deadline_reminder
       candidate_mailer-ucas_match_initial_email_duplicate_applications
       candidate_mailer-ucas_match_initial_email_multiple_acceptances
       candidate_mailer-ucas_match_reminder_email_duplicate_applications

--- a/spec/workers/send_eoc_deadline_reminder_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_eoc_deadline_reminder_email_to_candidates_worker_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, sidekiq: true do
+  let(:application_choice) { build(:application_choice) }
+  let(:application_choices) { [application_choice] }
+  let(:send_reminder) { described_class.new.applications_to_send_reminders_to }
+
+  describe '#perform' do
+    context 'when the candidate is in Apply 1' do
+      it 'returns an application when the deadline is 2 months away' do
+        Timecop.travel(CycleTimetable.apply_1_deadline_first_reminder) do
+          application_form = create(:application_form, application_choices: application_choices, phase: 'apply_1')
+
+          expect(send_reminder).to include application_form
+        end
+      end
+
+      it 'returns an application when the deadline is 1 month away' do
+        Timecop.travel(CycleTimetable.apply_1_deadline_second_reminder) do
+          application_form = create(:application_form, application_choices: application_choices, phase: 'apply_1')
+
+          expect(send_reminder).to include application_form
+        end
+      end
+
+      it 'does not return an application when the deadline is 3 months away' do
+        Timecop.travel(CycleTimetable.apply_1_deadline_first_reminder - 1.month) do
+          create(:application_form, application_choices: application_choices, phase: 'apply_1')
+
+          expect(send_reminder).to be_empty
+        end
+      end
+
+      it 'does not return an application when the deadline has passed' do
+        Timecop.travel(CycleTimetable.apply_1_deadline + 1.day) do
+          create(:application_form, application_choices: application_choices, phase: 'apply_1')
+
+          expect(send_reminder).to be_empty
+        end
+      end
+    end
+
+    context 'when the candidate is in Apply 2' do
+      it 'returns an application when the deadline is 2 months away' do
+        Timecop.travel(CycleTimetable.apply_2_deadline_first_reminder) do
+          application_form = create(:application_form, application_choices: application_choices, phase: 'apply_2')
+
+          expect(send_reminder).to include application_form
+        end
+      end
+
+      it 'returns an application when the deadline is 1 month away' do
+        Timecop.travel(CycleTimetable.apply_2_deadline_second_reminder) do
+          application_form = create(:application_form, application_choices: application_choices, phase: 'apply_2')
+
+          expect(send_reminder).to include application_form
+        end
+      end
+
+      it 'does not return an application when the deadline is 3 months away' do
+        Timecop.travel(CycleTimetable.apply_2_deadline_first_reminder - 1.month) do
+          create(:application_form, application_choices: application_choices, phase: 'apply_2')
+
+          expect(send_reminder).to be_empty
+        end
+      end
+
+      it 'does not return an application when the deadline has passed' do
+        Timecop.travel(CycleTimetable.apply_2_deadline + 1.day) do
+          create(:application_form, application_choices: application_choices, phase: 'apply_2')
+
+          expect(send_reminder).to be_empty
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We need to warn candidates who've started an application about their upcoming deadlines. 

This will send an email 2 months and 1 month before the deadline relevant to those candidates.

## Changes proposed in this pull request

- Queries to get all unsubmitted applications at the date of the the two deadlines
- New worker to send the reminder email
- New email copy:
![image](https://user-images.githubusercontent.com/47917431/123822451-36ec2e80-d8f4-11eb-9d3a-f2b16582f17b.png)


## Guidance to review

[Email preview](https://apply-for-te-3538-eoc-d-dbnez3.herokuapp.com/rails/mailers/candidate_mailer/eoc_deadline_reminder)

## Link to Trello card

https://trello.com/c/QjNQUe5G

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
