### PR TITLE
Remove 5-day edit window from Sandbox landing page

### DIFF
--- a/app/views/content/sandbox.html.erb
+++ b/app/views/content/sandbox.html.erb
@@ -44,12 +44,6 @@
 
     <p class="govuk-body">In sandbox, enter these email addresses to generate 2 references for your test application.</p>
 
-    <h3 class="govuk-heading-m">A note on editing after submission</h3>
-
-    <p class="govuk-body">In the live service, applications are sent to the provider 5 working days after submission. This gives candidates a window to edit their application.</p>
-
-    <p class="govuk-body">In the Apply sandbox, applications are sent immediately, if the references are complete.</p>
-
     <%= govuk_start_now_button(
       text: 'Continue as a candidate',
       href: candidate_interface_account_path,


### PR DESCRIPTION
This is no longer true and hasn't been for a while.
