### PR TITLE
Update apply again call to action content so it works year round

### DIFF
--- a/app/views/candidate_mailer/_still_interested_content.text.erb
+++ b/app/views/candidate_mailer/_still_interested_content.text.erb
@@ -1,6 +1,16 @@
-If now’s the right time for you, you can apply for teacher training again this year. 
+<% if EndOfCycleTimetable.between_cycles_apply_2? %>
+
+You can apply again for courses starting in the <%= "#{RecruitmentCycle.next_year} to #{RecruitmentCycle.next_year + 1}" %> academic year.
+
+Your last application has been saved. Make any changes and re-submit from <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date) %>.
+
+<% else %>
+
+If now’s the right time for you, you can still apply for teacher training again this year.
 
 Your last application has been saved. You can make changes and choose a different course before you submit a new application.
+
+<% end %>
 
 Sign in to apply again:
 

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -146,6 +146,29 @@ RSpec.describe CandidateMailer, type: :mailer do
           expect(email.body).not_to include('Future applications')
         end
       end
+
+      context 'when it is before the apply_2_deadline' do
+        before do
+          allow(EndOfCycleTimetable).to receive(:between_cycles_apply_2?).and_return(false)
+        end
+
+        it 'informs the candidate they can apply again this year' do
+          expect(email.body).to include('If now’s the right time for you, you can still apply for teacher training again this year.')
+        end
+      end
+
+      context 'when it is after the apply_2_deadline' do
+        before do
+          allow(EndOfCycleTimetable).to receive(:between_cycles_apply_2?).and_return(true)
+          allow(EndOfCycleTimetable).to receive(:apply_reopens).and_return(Date.new(2021, 10, 13))
+          allow(RecruitmentCycle).to receive(:next_year).and_return(2022)
+        end
+
+        it 'informs the candidate they can apply again next year' do
+          expect(email.body).to include('You can apply again for courses starting in the 2022 to 2023 academic year.')
+          expect(email.body).to include('Your last application has been saved. Make any changes and re-submit from 13 October 2021')
+        end
+      end
     end
 
     describe '.application_rejected_one_offer_one_awaiting_decision' do

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -175,7 +175,8 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.new_offer_decisions_pending(application_choice)
   end
 
-  def application_rejected_all_applications_rejected
+  def application_rejected_all_applications_rejected_mid_cycle
+    SiteSetting.set(name: 'cycle_schedule', value: 'today_is_mid_cycle')
     application_choice = FactoryBot.build_stubbed(
       :application_choice,
       application_form: application_form,
@@ -184,6 +185,22 @@ class CandidateMailerPreview < ActionMailer::Preview
       structured_rejection_reasons: reasons_for_rejection_with_qualifications,
     )
     CandidateMailer.application_rejected_all_applications_rejected(application_choice)
+  ensure
+    SiteSetting.set(name: 'real', value: 'real')
+  end
+
+  def application_rejected_all_applications_rejected_after_apply2_deadline
+    SiteSetting.set(name: 'cycle_schedule', value: 'today_is_after_apply_2_deadline_passed')
+    application_choice = FactoryBot.build_stubbed(
+      :application_choice,
+      application_form: application_form,
+      course_option: course_option,
+      status: :rejected,
+      structured_rejection_reasons: reasons_for_rejection_with_qualifications,
+    )
+    CandidateMailer.application_rejected_all_applications_rejected(application_choice)
+  ensure
+    SiteSetting.set(name: 'real', value: 'real')
   end
 
   def application_rejected_by_default_all_applications_rejected

--- a/spec/system/decline_by_default_spec.rb
+++ b/spec/system/decline_by_default_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Decline by default' do
 
     and_when_the_decline_by_default_limit_has_been_exceeded
     then_the_application_choice_is_declined
-    and_the_candidate_receives_a_decline_by_default_without_rejection_email
+    and_the_candidate_receives_a_decline_by_default_email
     and_the_provider_receives_an_email
 
     when_i_have_an_offer_waiting_for_my_decision
@@ -23,7 +23,7 @@ RSpec.feature 'Decline by default' do
 
     and_when_the_decline_by_default_limit_has_been_exceeded
     then_the_application_choice_is_declined
-    and_the_candidate_receives_a_decline_by_default_with_rejection_email
+    and_the_candidate_receives_a_decline_by_default_email
     and_the_provider_receives_an_email
   end
 
@@ -74,21 +74,14 @@ RSpec.feature 'Decline by default' do
     expect(current_email.subject).to include("Harry Potter’s (#{@application_form.support_reference}) application withdrawn automatically")
   end
 
-  def and_the_candidate_receives_a_decline_by_default_without_rejection_email
+  def and_the_candidate_receives_a_decline_by_default_email
     open_email(@application_form.candidate.email_address)
 
     expect(current_email.subject).to include('You did not respond to your offer: next steps')
-    expect(current_email.text).to include('If now’s the right time for you, you can apply for teacher training again this year.')
+    expect(current_email.text).to include('Your last application has been saved')
   end
 
   def and_i_have_a_rejection
     create(:application_choice, status: :rejected, application_form: @application_form)
-  end
-
-  def and_the_candidate_receives_a_decline_by_default_with_rejection_email
-    open_email(@application_form.candidate.email_address)
-
-    expect(current_email.subject).to include('You did not respond to your offer: next steps')
-    expect(current_email.text).to include('If now’s the right time for you, you can apply for teacher training again this year.')
   end
 end


### PR DESCRIPTION
## Context

This PR updates the apply again call to action so that candidates are correctly informed of when they can begin to apply again.

If it is before the apply again deadline they are informed they can apply again this academic year.

If it is after the apply again deadline they are informed they can apply again in the next cycle when apply reopens.

## Changes proposed in this pull request

- Email sent before the apply2 deadline 

![image](https://user-images.githubusercontent.com/42515961/123542893-e209b600-d743-11eb-9c32-c441b248a362.png)


- Email sent after the apply2 deadline

![image](https://user-images.githubusercontent.com/42515961/123542916-006fb180-d744-11eb-84ee-c9e9c9627ce1.png)

 
## Guidance to review

The dates are off in the emails as it is using the SiteSetting model to set the phase of cycle. This relies on the EOC timetable which sets the dates in a slightly different way to the prod cycle.

If you test it locally it would return for the 2022 cycle.

## Link to Trello card

https://trello.com/c/LoQgqf4T/3540-dev-eoc-add-conditional-logic-to-apply-2-calls-to-action-so-that-they-work-all-year-round

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
