### PR TITLE
Deprecate master and transition to main branch

### DIFF
--- a/.github/scripts/enums_in_models.rb
+++ b/.github/scripts/enums_in_models.rb
@@ -9,7 +9,7 @@ if filename
   end
   model_names.compact.uniq.map(&:constantize) rescue nil
 else
-  diff_tree_output = `git diff-tree -r --name-only --no-commit-id --no-renames --diff-filter=d origin/master HEAD app/models`
+  diff_tree_output = `git diff-tree -r --name-only --no-commit-id --no-renames --diff-filter=d origin/main HEAD app/models`
   diff_tree_output.split(/\n/).map do |model_path|
     require "./#{model_path}"
   end

--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -60,11 +60,11 @@ jobs:
       - name: Preserve the detection script
         run: cp .github/scripts/enums_in_models.rb /tmp/enums_in_models.rb
 
-      # Check-out master
-      - name: Checkout master branch
-        run: git checkout master
+      # Check-out main
+      - name: Checkout main branch
+        run: git checkout main
 
-      # Get all previous enum definitions for changed models from master
+      # Get all previous enum definitions for changed models from main
       - name: Get previous enum definitions
         run: |
           bundle install

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A service for candidates to [apply for teacher training](https://www.apply-for-t
 | Production | [www](https://www.apply-for-teacher-training.service.gov.uk)         | Public site                                                             | `bat-prod`    | `apply-prod`     |
 | Sandbox    | [sandbox](https://sandbox.apply-for-teacher-training.service.gov.uk) | Demo environment for software vendors who integrate with our API        | `bat-prod`    | `apply-sandbox`  |
 | Staging    | [staging](https://staging.apply-for-teacher-training.service.gov.uk) | For internal use by DfE to test deploys                                 | `bat-staging` | `apply-staging`  |
-| QA         | [qa](https://qa.apply-for-teacher-training.service.gov.uk)           | For internal use by DfE for testing. Automatically deployed from master | `bat-qa`      | `apply-qa`       |
+| QA         | [qa](https://qa.apply-for-teacher-training.service.gov.uk)           | For internal use by DfE for testing. Automatically deployed from main   | `bat-qa`      | `apply-qa`       |
 
 ## Table of Contents
 

--- a/docs/bigquery.md
+++ b/docs/bigquery.md
@@ -5,7 +5,7 @@ This document explains the necessary steps to configure the app to use Google Bi
 ## What do we use BigQuery for?
 
 We've added BigQuery as an external store for event data. At the time of writing we will be pushing a common set of request data events from Apply to BigQuery.
-[The data is sent asynchronously using Sidekiq](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/workers/send_request_events_to_bigquery.rb).
+[The data is sent asynchronously using Sidekiq](https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/app/workers/send_request_events_to_bigquery.rb).
 
 
 ## Credentials

--- a/docs/code-review-guidelines.md
+++ b/docs/code-review-guidelines.md
@@ -4,7 +4,7 @@
 
 We use pull requests (PRs) for all code changes. All PRs have to be
 reviewed and approved by at least one other developer before being merged into
-`master`.
+`main`.
 
 The main objective of code reviews is to improve the quality of code that
 reaches production, so that our codebase is maintainable and correct. We want
@@ -31,7 +31,7 @@ benefits like knowledge sharing.
   it as requiring two approvals rather than the normal one.
 - Follow general best practice for raising PR e.g. [How to raise a good pull request](https://www.annashipman.co.uk/jfdi/good-pull-requests.html).
   - Aim for each commit to be atomic, introducing a non-breaking change with all tests and linter passing. Consider arranging your commits into appropriate logical chunks with [git's history rewriting features](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History). This can make the PR easier to review and revert.
-  - Try to avoid merge commits and use `git rebase master` instead.
+  - Try to avoid merge commits and use `git rebase main` instead.
 
 ### Reviewing PRs
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,7 @@
 
 The apply build and release process is split into two separate Azure DevOps pipelines.
 
-- [apply-for-teacher-training](https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=49&_a=summary): This is the main development CI pipeline which will automatically trigger a build from a commit to any branch within the Apply GitHub code repository. When commits are made to the master branch, this pipeline will also deploy the application to the QA infrastructure environment in Azure automatically.
+- [apply-for-teacher-training](https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=49&_a=summary): This is the main development CI pipeline which will automatically trigger a build from a commit to any branch within the Apply GitHub code repository. When commits are made to the main branch, this pipeline will also deploy the application to the QA infrastructure environment in Azure automatically.
 
 - [apply-for-teacher-training-releases](https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=325&_a=summary): This is the main release pipeline that is used to deploy to all other Azure environments except QA. Releases are triggered manually and the target environments can be chosen prior to deployment.
 
@@ -38,7 +38,7 @@ Once the deployment begins, this will automatically post the list of PRs being d
 Summarise what you're deploying and tell the team in Slack on the `#twd_apply` channel. Use `:ship_it_parrot:` as required.
 1. Load the [apply-for-teacher-training-releases](https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=325&_a=summary) page in Azure DevOps.
 1. Click the blue "Run pipeline" button (sometimes it says "Queue") at the top right of the page which will open the run pipeline menu.
-1. Ensure the branch is set to "master".
+1. Ensure the branch is set to "main".
 1. Specify the commit
 1. Under the Variables section, make sure only `deploy_staging` is set to true (this should be the default)
 1. Click the Run button to start the deployment.
@@ -56,7 +56,7 @@ Click on the `Deploy` button next to the commit SHA under the Production section
 ### Manually
 1. Load the [apply-for-teacher-training-releases](https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=325&_a=summary) page in Azure DevOps.
 1. Click the blue "Run pipeline" button (sometimes it says "Queue") at the top right of the page which will open the run pipeline menu.
-1. Ensure the branch is set to "master".
+1. Ensure the branch is set to "main".
 1. Specify the commit again - **do not forget this**
 1. Under the Variables section set `deploy_staging` to `false` and `deploy_production` and `deploy_sandbox` to `true`.
 1. Click the Run button to start the deployment

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,6 +1,6 @@
 # Frontend development
 
-Our services use the [GOV.UK Design System](https://design-system.service.gov.uk). We implement this by using [GOV.UK Components](https://github.com/dfE-Digital/govuk-components), [GOV.UK Form Builder](https://govuk-form-builder.netlify.app) alongside several [view helpers](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/helpers/view_helper.rb). CSS and JavaScript is provided by [govuk-frontend](https://github.com/alphagov/govuk-frontend).
+Our services use the [GOV.UK Design System](https://design-system.service.gov.uk). We implement this by using [GOV.UK Components](https://github.com/dfE-Digital/govuk-components), [GOV.UK Form Builder](https://govuk-form-builder.netlify.app) alongside several [view helpers](https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/app/helpers/view_helper.rb). CSS and JavaScript is provided by [govuk-frontend](https://github.com/alphagov/govuk-frontend).
 
 Using these components and helpers means that there shouldn’t be a need to write any HTML, CSS or JavaScript. For example, using `f.govuk_submit` for submit buttons (or `govuk_link_to` for links) means these elements use the correct attributes, are styled correctly – and require less code.
 

--- a/docs/hotfix-deployment.md
+++ b/docs/hotfix-deployment.md
@@ -8,12 +8,12 @@ This document describes the process of manually deploying a hotfix.
 
 Normally deployments to the `staging`, `sandbox` and `production` environments
 happen on a daily (or more frequent) basis and include all changes that
-have been merged into master. A hotfix is a more urgent deployment
+have been merged into main. A hotfix is a more urgent deployment
 containing typically just one pull request. A hotfix should be performed
 when:
 
 1. The fix is urgent.
-2. There are other changes already merged into master since the last
+2. There are other changes already merged into main since the last
    deployment that we do not want to deploy yet perhaps because they are
    not fully tested.
 
@@ -22,7 +22,7 @@ when:
 We assume that we begin in a situation like this:
 
 ```
-master        ---D--------x-----x--------------x--->
+main          ---D--------x-----x--------------x--->
                   \      /     / \            /
 feature1           -x-x-x     /   \          /
                    \         /     \        /
@@ -32,14 +32,14 @@ feature3                              -x-x
 ```
 
 Since last deployed at `D` we've merged two additional features into
-`master`. We urgently need to create a fix that does not include
+`main`. We urgently need to create a fix that does not include
 features 1, 2 and 3, we just want everything up to `D`.
 
 ### Instructions
 
 1. Inform the team that a hotfix is being prepared by posting a new
    thread in Slack to #twd_apply.
-2. Fetch `master` to your local machine and create a branch called
+2. Fetch `main` to your local machine and create a branch called
    `hotfix` from the last deployed commit (not `HEAD` as we normally
    would). You can specify the last deployed commit using its SHA and
    find out which SHA to use on the
@@ -47,7 +47,7 @@ features 1, 2 and 3, we just want everything up to `D`.
    look for the current production version. Push the new branch to Github.
 
   ```
-  $ git fetch origin master
+  $ git fetch origin main
   $ git checkout -b hotfix <sha-from-ops-dashboard>
   $ git push origin hotfix
   ```
@@ -55,22 +55,22 @@ features 1, 2 and 3, we just want everything up to `D`.
 3. Implement the fix locally, raise a PR and get it approved in the
    normal way. Test it locally or using the Heroku review app that is
    automatically created.
-4. After the PR is approved DO NOT MERGE IT to `master` straight away.
+4. After the PR is approved DO NOT MERGE IT to `main` straight away.
    First deploy the `hotfix` branch using the [normal deployment
    procedure](deployment.md) (except picking `HEAD` of the
-   `hotfix` branch rather than a specific SHA on `master` as we normally
+   `hotfix` branch rather than a specific SHA on `main` as we normally
    do).
-5. Merge the `hotfix` branch back to `master`. At this point the `hotfix`
+5. Merge the `hotfix` branch back to `main`. At this point the `hotfix`
    branch should be automatically deleted.
 
 Here is an example of the process where the last 'normal' deployment was
 at `D` and the hotfix was deployed at `H`. After the `hotfix` branch is
-merged back into `master` it's back to business as usual.
+merged back into `main` it's back to business as usual.
 
 ```
 hotfix             ------------------------------x-x-x-H
                   /                                     \
-master        ---D--------x-----x--------------x----------->
+main          ---D--------x-----x--------------x----------->
                   \      /     / \            /
 feature1           -x-x-x     /   \          /
                    \         /     \        /
@@ -84,7 +84,7 @@ feature3                              -x-x
   ever have one hotfix branch at a time.
 - When starting a hotfix it's important that the rest of the team knows
   about it so that nobody else starts any other kind of deploy until
-  the hotfix is complete and merged back into `master`.
+  the hotfix is complete and merged back into `main`.
 - Pushing the new `hotfix` branch to Github at the start of the
   process (before any fix commits are made) acts as a signal to other
   developers/systems that a hotfix is in progress.

--- a/docs/new-environment.md
+++ b/docs/new-environment.md
@@ -21,7 +21,7 @@ To create a new environment, clone an existing environment specific variable gro
 
 ## Create a new stage in the deployment pipeline for the new environment
 
-There are two deployment stages defined in `build.yml`, `deploy_qa` and `deploy_devops` to deploy to QA and DevOps environment respectively. `deploy_qa` stage is run only if the build is triggered for the `master` branch and `deploy_devops` stage only if the build is triggered from a branch name defined in `devDeployBranchNameOverride` variable inside the `APPLY - ENV - DevOps` variable group.
+There are two deployment stages defined in `build.yml`, `deploy_qa` and `deploy_devops` to deploy to QA and DevOps environment respectively. `deploy_qa` stage is run only if the build is triggered for the `main` branch and `deploy_devops` stage only if the build is triggered from a branch name defined in `devDeployBranchNameOverride` variable inside the `APPLY - ENV - DevOps` variable group.
 
 To create or deploy to a new environment, create a new stage in the pipeline by cloning an existing stage and modifying the run conditions and variables.
 


### PR DESCRIPTION
## Context
Update repo to support use `main` as primary branch

## Changes proposed in this pull request

- Update enum and pull request checks to checkout out and check `main` branch for changes
- Update docs to refer to `main`

## Link to Trello card
https://trello.com/c/S8y0LmKy/3870-deprecate-master-and-transition-to-main-branch

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
