### PR TITLE
Update validation for selected references on application submit

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -374,8 +374,8 @@ class ApplicationForm < ApplicationRecord
     selected_references.count >= MINIMUM_COMPLETE_REFERENCES
   end
 
-  def selected_too_many_references?
-    selected_references.count > MINIMUM_COMPLETE_REFERENCES
+  def selected_incorrect_number_of_references?
+    selected_references.count != MINIMUM_COMPLETE_REFERENCES
   end
 
   def selected_references

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -112,8 +112,9 @@ module CandidateInterface
     def reference_section_errors
       [].tap do |errors|
         if FeatureFlag.active?(:reference_selection)
-          if @application_form.selected_too_many_references?
-            errors << OpenStruct.new(message: I18n.t('application_form.references.review.more_than_two_selected'), anchor: '#references')
+          # A defensive check, in case the candidate somehow ends up in this state
+          if @application_form.references_completed? && @application_form.selected_incorrect_number_of_references?
+            errors << OpenStruct.new(message: I18n.t('application_form.references.review.incorrect_number_selected'), anchor: '#references')
           end
         elsif @application_form.too_many_complete_references?
           errors << OpenStruct.new(message: I18n.t('application_form.references.review.more_than_two'), anchor: '#references')

--- a/config/locales/candidate_interface/references.yml
+++ b/config/locales/candidate_interface/references.yml
@@ -88,7 +88,7 @@ en:
       review:
         more_than_two: More than 2 references have been given
         need_two: You need to have received at least 2 references before marking this section complete
-        more_than_two_selected: More than 2 references have been selected
+        incorrect_number_selected: You need to have exactly 2 references selected before submitting your application
 
   activemodel:
     errors:

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -309,6 +309,32 @@ RSpec.describe ApplicationForm do
     end
   end
 
+  describe '#selected_incorrect_number_of_references?' do
+    it 'is true when < 2 selections' do
+      application_form = create(:application_form)
+      create(:selected_reference, application_form: application_form)
+
+      expect(application_form.selected_incorrect_number_of_references?).to eq true
+    end
+
+    it 'is true when > 2 selections' do
+      application_form = create(:application_form)
+      create(:selected_reference, application_form: application_form)
+      create(:selected_reference, application_form: application_form)
+      create(:selected_reference, application_form: application_form)
+
+      expect(application_form.selected_incorrect_number_of_references?).to eq true
+    end
+
+    it 'is false when 2 selections' do
+      application_form = create(:application_form)
+      create(:selected_reference, application_form: application_form)
+      create(:selected_reference, application_form: application_form)
+
+      expect(application_form.selected_incorrect_number_of_references?).to eq false
+    end
+  end
+
   describe '#equality_and_diversity_answers_provided?' do
     context 'when minimal expected attributes are present' do
       it 'is true' do

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -648,17 +648,32 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     context 'with reference_selection feature on' do
       before { FeatureFlag.activate(:reference_selection) }
 
-      it 'returns an error if the application form has too many selected references' do
-        application_form = instance_double(ApplicationForm, selected_too_many_references?: true)
+      it 'returns an error if a references_completed application form has an invalid number of selected references' do
+        application_form = instance_double(
+          ApplicationForm,
+          references_completed?: true,
+          selected_incorrect_number_of_references?: true,
+        )
         presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
         expect(presenter.reference_section_errors).to eq(
-          [OpenStruct.new(message: 'More than 2 references have been selected', anchor: '#references')],
+          [OpenStruct.new(message: 'You need to have exactly 2 references selected before submitting your application', anchor: '#references')],
         )
       end
 
-      it 'returns an empty array if the application form does not have too many selected references' do
-        application_form = instance_double(ApplicationForm, selected_too_many_references?: false)
+      it 'returns an empty array if a references_completed application form has the required number of reference selections' do
+        application_form = instance_double(
+          ApplicationForm,
+          references_completed?: true,
+          selected_incorrect_number_of_references?: false,
+        )
+        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+        expect(presenter.reference_section_errors).to eq []
+      end
+
+      it 'returns an empty array if the application form is not references_completed' do
+        application_form = instance_double(ApplicationForm, references_completed?: false)
         presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
         expect(presenter.reference_section_errors).to eq []

--- a/spec/system/candidate_interface/apply_again/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -43,11 +43,11 @@ RSpec.feature 'Candidate with unsuccessful application' do
     @application_form = create(
       :completed_application_form,
       :with_gcses,
-      :with_completed_references,
-      references_count: 2,
       candidate: @candidate,
       safeguarding_issues_status: :no_safeguarding_issues_to_declare,
+      references_completed: true,
     )
+    create_list(:selected_reference, 2, application_form: @application_form)
     create(:application_choice, status: :rejected, application_form: @application_form)
   end
 

--- a/spec/system/candidate_interface/entering_details/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_equality_and_diversity_information_spec.rb
@@ -105,7 +105,6 @@ RSpec.feature 'Entering their equality and diversity information' do
   end
 
   def and_i_submit_my_application
-    receive_references
     click_link 'Check and submit your application'
     click_link t('continue')
   end

--- a/spec/system/candidate_interface/references/reference_selection/candidate_has_too_many_selected_references_spec.rb
+++ b/spec/system/candidate_interface/references/reference_selection/candidate_has_too_many_selected_references_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Handle applications with too many selected references' do
 
   def and_i_have_a_completed_application_with_more_than_two_selected_references
     create_and_sign_in_candidate
-    candidate_completes_application_form
+    candidate_completes_application_form # Including two reference selections
     create(:reference, :feedback_provided, selected: true, application_form: @application)
     visit candidate_interface_application_form_path
   end
@@ -34,7 +34,7 @@ RSpec.feature 'Handle applications with too many selected references' do
 
   def then_i_see_an_error_message
     within('.govuk-error-summary') do
-      expect(page).to have_content 'More than 2 references have been selected'
+      expect(page).to have_content 'You need to have exactly 2 references selected before submitting your application'
     end
   end
 


### PR DESCRIPTION

## Context
Aside from the standard set of section completeness checks, the
ApplicationFormPresenter contains some additional validation logic which
checks that candidates don't have more than two selected references.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
This commit updates the validation logic so that it simply checks for
exactly 2 reference selections. Furthermore, it only makes this check if
the application form has `references_completed` marked as true (ie -
if other parts of the system have failed to enforce the 'two reference
selections' constraint, trigger this error message as a backstop).

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Probably easier to test locally, as forcing a state where >2 references are selected (or <2 and `references_completed: true`) will require a console.


<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/itsTTjwH
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
