### PR TITLE
Don't rely on the ordering of providers from NotificationsList#for

### DIFF
--- a/spec/services/accept_unconditional_offer_spec.rb
+++ b/spec/services/accept_unconditional_offer_spec.rb
@@ -48,8 +48,10 @@ RSpec.describe AcceptUnconditionalOffer do
 
       expect { described_class.new(application_choice: application_choice).save! }.to change { ActionMailer::Base.deliveries.count }.by(3)
       expect(ActionMailer::Base.deliveries.first.subject).to match(/has accepted your offer/)
-      expect(ActionMailer::Base.deliveries.first.to).to eq [training_provider_user.email_address]
-      expect(ActionMailer::Base.deliveries.second.to).to eq [ratifying_provider_user.email_address]
+
+      mailer_recipients = ActionMailer::Base.deliveries.map(&:to).flatten
+      expect(mailer_recipients).to include(training_provider_user.email_address)
+      expect(mailer_recipients).to include(ratifying_provider_user.email_address)
     end
 
     it 'sends a confirmation email to the candidate' do


### PR DESCRIPTION


## Context

This spec recently failed on an unrelated PR merge.

Instead of testing the first and second recipients of emails sent by the service we should just verify that both the training provider and ratifying provider have received an email.
`NotificationsList#for` does not contain an ordering clause so we can't be sure which provider user will be returned first.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Test for email addresses of both provider users without expecting an explicit order.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
