### PR TITLE
Clarify that the possible values for `uk_residency_status_code` do no…

### DIFF
--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+## 28th June
+
+Documentation:
+
+- Add clarification in the description of `uk_residency_status_code` field in the documentation.
+
 ## 15th June
 
 Documentation has been amended to mark the following endpoint as deprecated: `/test-data/regenerate`.

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -598,6 +598,8 @@ components:
             - B - Irish Citizen
             - C - Candidate needs to apply for permission to work and study in the UK
             - D - Candidate's free text response
+
+            These values do not correspond to the UCAS residency statuses.
           example: 'B'
           enum:
             - 'A'


### PR DESCRIPTION
…rrespond to the expected values for the UCAS residency status

## Context

Add a line to API docs explaining that residency status codes are not equivalent to UCAS's

## Link to Trello card

https://trello.com/c/iZA6FvV9/3859-add-a-line-to-api-docs-explaining-that-residency-status-codes-are-not-equivalent-to-ucass

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
