### PR TITLE
Sort organisation permissions consistently

### DIFF
--- a/app/components/provider_interface/organisation_list_component.rb
+++ b/app/components/provider_interface/organisation_list_component.rb
@@ -8,9 +8,11 @@ module ProviderInterface
         .or(ProviderRelationshipPermissions.where(training_provider: all_manageable_providers, ratifying_provider: provider))
         .where.not(setup_at: nil)
         .includes(:training_provider)
+        .sort_by { |permissions| permissions.ratifying_provider.name }
       @ratifying_permissions = ProviderRelationshipPermissions.where(ratifying_provider: provider)
         .where.not(training_provider: all_manageable_providers)
         .includes(:training_provider, :ratifying_provider)
+        .sort_by { |permissions| permissions.training_provider.name }
     end
 
   private

--- a/spec/components/provider_interface/organisation_list_component_spec.rb
+++ b/spec/components/provider_interface/organisation_list_component_spec.rb
@@ -107,5 +107,18 @@ RSpec.describe ProviderInterface::OrganisationListComponent do
         expect(render.text).not_to include("#{permission.training_provider.name} have not set up permissions yet")
       end
     end
+
+    context 'with multiple relationships' do
+      let(:ratifying_provider1) { create(:provider, name: 'XYZ academy') }
+      let(:ratifying_provider2) { create(:provider, name: 'ABC academy') }
+      let(:permissions1) { create(:provider_relationship_permissions, training_provider: provider, ratifying_provider: ratifying_provider1) }
+      let(:permissions2) { create(:provider_relationship_permissions, training_provider: provider, ratifying_provider: ratifying_provider2) }
+      let!(:permissions) { [permissions1, permissions2] }
+
+      it 'orders relationships consistently' do
+        instance = described_class.new(provider: provider, current_provider_user: provider_user)
+        expect(instance.training_permissions).to eq(permissions.reverse)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

The order in which training and ratifying permissions are returned is not consistent. 
The queries include the training and ratifying providers so sort on the provider name on the 'other' side of the organisation in question ie. for training provider permissions, sort on ratifying provider name and for ratifying provider permissions sort on the training provider name. This ensures the relationships maintain a predictable order when updating multiple relationships.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds a bubble sort to the queried results, this is preferable to a SQL order clause because:
- We'd need to rewrite the queries so that the multiple joins to the provider table were aliasable
- The training/ratifying providers are included in the queries to avoid lazy loading so we have the sort fields already.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/YyY6YlXr/3874-organisational-permissions-in-manage-appear-in-a-different-order-after-editing
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
