### PR TITLE
Enable editing provider notification prefs via support

### DIFF
--- a/app/components/support_interface/provider_user_summary_component.rb
+++ b/app/components/support_interface/provider_user_summary_component.rb
@@ -29,7 +29,7 @@ module SupportInterface
 
     def change_path
       if FeatureFlag.active?(:new_provider_user_flow)
-        support_interface_edit_permissions_path(provider_user)
+        support_interface_edit_provider_notifications_path(provider_user)
       else
         edit_support_interface_provider_user_path(provider_user, anchor: 'update-email-notifications')
       end

--- a/app/controllers/support_interface/single_provider_user_notifications_controller.rb
+++ b/app/controllers/support_interface/single_provider_user_notifications_controller.rb
@@ -1,0 +1,28 @@
+module SupportInterface
+  class SingleProviderUserNotificationsController < ApplicationController
+    def edit
+      @form = SaveProviderUserNotificationPreferences.new(provider_user: provider_user_being_edited)
+    end
+
+    def update
+      SaveProviderUserNotificationPreferences.new(provider_user: provider_user_being_edited)
+        .update_all_notification_preferences!(notification_preferences_params: notification_preferences_params)
+
+      flash[:success] = 'Provider user notifications updated'
+      redirect_to support_interface_provider_user_path(provider_user_being_edited)
+    end
+
+  private
+
+    def provider_user_being_edited
+      @_provider_user_being_edited ||= ProviderUser.find(params[:provider_user_id])
+    end
+
+    def notification_preferences_params
+      return ActionController::Parameters.new unless params.key?(:provider_user_notification_preferences)
+
+      params.require(:provider_user_notification_preferences)
+        .permit(ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
+    end
+  end
+end

--- a/app/views/support_interface/single_provider_user_notifications/edit.html.erb
+++ b/app/views/support_interface/single_provider_user_notifications/edit.html.erb
@@ -1,0 +1,14 @@
+<% content_for :browser_title, "Edit #{@form.provider_user.display_name}’s email notifications" %>
+<% content_for :before_content, govuk_back_link_to(support_interface_provider_user_path(@form.provider_user)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">Edit <%= @form.provider_user.display_name %>’s email notifications</h1>
+
+    <%= render ProviderUserNotificationPreferencesComponent.new(
+      @form.provider_user.notification_preferences,
+      form_path: support_interface_update_provider_notifications_path(provider_user_id: @form.provider_user.id),
+    ) %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -913,6 +913,8 @@ Rails.application.routes.draw do
     scope path: '/providers/users/:provider_user_id' do
       get '/permissions/edit' => 'single_provider_users#edit', as: :edit_permissions
       patch '/permissions' => 'single_provider_users#update', as: :update_permissions
+      get '/notifications/edit' => 'single_provider_user_notifications#edit', as: :edit_provider_notifications
+      put '/notifications' => 'single_provider_user_notifications#update', as: :update_provider_notifications
     end
 
     scope path: '/providers/:provider_id' do

--- a/spec/system/support_interface/managing_users_v2/managing_provider_user_notification_preferences_spec.rb
+++ b/spec/system/support_interface/managing_users_v2/managing_provider_user_notification_preferences_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing provider user notification preferences' do
+  include DfESignInHelpers
+  include DsiAPIHelper
+
+  scenario 'editing the settings' do
+    FeatureFlag.activate(:new_provider_user_flow)
+
+    given_dfe_signin_is_configured
+    and_i_am_a_support_user
+    and_a_provider_user_exist
+
+    when_i_visit_the_support_console
+    and_i_navigate_to_provider_users_page
+    and_i_click_on_the_user
+    and_i_click_the_change_link
+
+    then_i_can_see_all_notifications_are_on_by_default
+
+    when_i_update_all_notifications_to_be_off
+    then_the_notification_preferences_are_updated
+  end
+
+  def given_dfe_signin_is_configured
+    dsi_api_response(success: true)
+  end
+
+  def and_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_a_provider_user_exist
+    @provider_user = create(:provider_user, :with_notifications_enabled)
+  end
+
+  def when_i_visit_the_support_console
+    visit support_interface_path
+  end
+
+  def and_i_navigate_to_provider_users_page
+    click_link 'Providers'
+    click_link 'Provider users'
+  end
+
+  def and_i_click_on_the_user
+    click_link @provider_user.full_name
+  end
+
+  def and_i_click_the_change_link
+    click_on 'Change notifications'
+  end
+
+  def then_i_can_see_all_notifications_are_on_by_default
+    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
+      expect(find(:css, "#provider-user-notification-preferences-#{type.to_s.dasherize}-true-field")).to be_checked
+    end
+  end
+
+  def when_i_update_all_notifications_to_be_off
+    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
+      choose "provider-user-notification-preferences-#{type.to_s.dasherize}-false-field"
+    end
+    click_on 'Save settings'
+  end
+
+  def then_the_notification_preferences_are_updated
+    expect(page).to have_content 'Provider user notifications updated'
+    expect(page).to have_content 'Application received – No'
+    expect(page).to have_content 'Application withdrawn by candidate – No'
+    expect(page).to have_content 'Application automatically rejected – No'
+    expect(page).to have_content 'Offer accepted – No'
+    expect(page).to have_content 'Offer declined – No'
+  end
+end


### PR DESCRIPTION
## Context

We accidentally disabled editing notification prefs via support when we shipped the new invite/edit provider user flow. Copy the logic from the notification-editing flow into a new controller and clone the old spec, turning on the feature flag at the top.

## Changes proposed in this pull request

<img width="1106" alt="Screenshot 2021-06-28 at 21 19 47" src="https://user-images.githubusercontent.com/642279/123698982-a4498200-d856-11eb-99bc-5493af8eff2e.png">

<img width="790" alt="Screenshot 2021-06-28 at 21 17 35" src="https://user-images.githubusercontent.com/642279/123698996-a7dd0900-d856-11eb-8253-b5a45b157361.png">


## Guidance to review

There's no validation on the form. This is the same as in the provider interface — it's left out because the radios are always populated whenever the form is viewed, so it's impossible to make an invalid form without hacking the HTML. This is even less of a worry in Support, so don't take on the extra complexity.

## Link to Trello card

https://trello.com/c/tSjJUyyD/3565-implement-managing-email-notifications-for-provider-users-via-support

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
