### PR TITLE
Fix interview system spec filling in dates

### DIFF
--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -157,7 +157,10 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     expect(page).to have_field('Additional details (optional)', with: '')
 
     fill_in 'Day', with: 2.days.from_now.day
+    fill_in 'Month', with: 2.days.from_now.month
+    fill_in 'Year', with: 2.days.from_now.year
     fill_in 'Time', with: '10am'
+
     fill_in 'Address or online meeting details', with: 'Zoom meeting'
     fill_in 'Additional details (optional)', with: 'Business casual'
 


### PR DESCRIPTION
## Context

When changing dates in the interview test, we are setting the day forward but not the month. If this happens to be at the end of the month, this will cause the test to fail as we are changing the date for instance from the 30th of June to the 1st of June without changing the month.

## Changes proposed in this pull request

Make sure to change all the values for the day, month, year when setting the new date.

## Guidance to review

The interview spec needs a bit of a refactor, but pushing a quick fix to unblock master

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
