### PR TITLE
Order offer conditions by created_at for UI consistency

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,6 +1,6 @@
 class Offer < ApplicationRecord
   belongs_to :application_choice
-  has_many :conditions, class_name: 'OfferCondition', dependent: :destroy
+  has_many :conditions, -> { order('created_at ASC') }, class_name: 'OfferCondition', dependent: :destroy
 
   has_one :course_option, through: :application_choice, source: :current_course_option
 

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe Offer do
   describe 'associations' do
-    it '#conditions returns the list of conditions' do
-      condition1 = create(:offer_condition, text: 'Provide evidence of degree qualification')
-      condition2 = create(:offer_condition, text: 'Do a backflip and send us a video')
+    it '#conditions returns the list of conditions ordered by created_at' do
+      condition1 = create(:offer_condition, text: 'Do a backflip and send us a video', created_at: 1.day.ago)
+      condition2 = create(:offer_condition, text: 'Provide evidence of degree qualification', created_at: 2.days.ago)
       offer = create(:offer, conditions: [condition1, condition2])
 
-      expect(offer.conditions.map(&:text)).to contain_exactly('Provide evidence of degree qualification', 'Do a backflip and send us a video')
+      expect(offer.conditions.reload.map(&:text)).to eq(['Provide evidence of degree qualification', 'Do a backflip and send us a video'])
     end
 
     describe '#course_option' do


### PR DESCRIPTION
## Context
When you update conditions, their order changes in the UI

## Changes proposed in this pull request
Set a default order on the offer conditions association so that the order is consistent

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
