### PR TITLE
Support: show date a course was opened on Apply

### DIFF
--- a/app/components/support_interface/course_details_component.rb
+++ b/app/components/support_interface/course_details_component.rb
@@ -9,7 +9,7 @@ module SupportInterface
     end
 
     def rows
-      [
+      rows = [
         {
           key: 'Recruitment cycle year',
           value: course.recruitment_cycle_year,
@@ -83,6 +83,15 @@ module SupportInterface
           action_path: candidate_interface_apply_from_find_path(providerCode: course.provider.code, courseCode: course.code),
         },
       ]
+
+      if course.open_on_apply?
+        rows.push({
+          key: 'Opened on Apply at',
+          value: course.opened_on_apply_at.to_s(:govuk_date_and_time),
+        })
+      end
+
+      rows
     end
   end
 end

--- a/spec/components/support_interface/course_details_component_spec.rb
+++ b/spec/components/support_interface/course_details_component_spec.rb
@@ -27,4 +27,24 @@ RSpec.describe SupportInterface::CourseDetailsComponent do
       )
     }.not_to raise_error
   end
+
+  describe 'showing Opened on Apply at' do
+    it 'shows the date when the course is open' do
+      course = create(:course, :open_on_apply)
+
+      result = render_inline(
+        described_class.new(course: course),
+      )
+      expect(result.text).to include('Opened on Apply at')
+    end
+
+    it 'does not show the date when the course is not open' do
+      course = create(:course, :ucas_only)
+
+      result = render_inline(
+        described_class.new(course: course),
+      )
+      expect(result.text).not_to include('Opened on Apply at')
+    end
+  end
 end


### PR DESCRIPTION
## Context

We backfilled this when we removed courses from the audit log, but didn't include it in the course details in Support.

## Changes proposed in this pull request

<img width="1211" alt="Screenshot 2021-06-29 at 14 21 26" src="https://user-images.githubusercontent.com/642279/123804704-59c31680-d8e5-11eb-9c8a-4120ad9a2201.png">