### PR TITLE
Ensure applications are ordered by updated_at timestamp

### DIFF
--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -35,6 +35,7 @@ module VendorAPI
     def get_application_choices_for_provider_since(since:)
       application_choices_visible_to_provider
         .where('application_choices.updated_at > ?', since)
+        .order('application_choices.updated_at DESC')
     end
 
     def since_param


### PR DESCRIPTION
## Context

We say Applications are returned with the most recently updated ones first but the order of applications stays the same after making an offer.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Chains an explicit order clause to `application_choices_visible_to_provider` so that applications are returned in `updated_at DESC` order.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Not sure about the system spec as it feels like a clumsy way to test this.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Ry71jCoi/3880-order-of-applications-in-api-response-is-not-based-on-most-recent-updates

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
