### PR TITLE
Enable Style/Alias cop

### DIFF
--- a/app/components/candidate_interface/application_form_course_choice_component.rb
+++ b/app/components/candidate_interface/application_form_course_choice_component.rb
@@ -5,7 +5,7 @@ module CandidateInterface
     end
 
     attr_reader :completed
-    alias_method :completed?, :completed
+    alias completed? completed
 
     def view_courses_path
       if completed?

--- a/app/components/candidate_interface/application_form_course_choices_component.rb
+++ b/app/components/candidate_interface/application_form_course_choices_component.rb
@@ -6,8 +6,8 @@ module CandidateInterface
     end
 
     attr_reader :choices_are_present, :completed
-    alias_method :completed?, :completed
-    alias_method :choices_are_present?, :choices_are_present
+    alias completed? completed
+    alias choices_are_present? choices_are_present
 
     def view_courses_path
       if completed?

--- a/app/components/degree_qualification_cards_component.rb
+++ b/app/components/degree_qualification_cards_component.rb
@@ -5,7 +5,7 @@ class DegreeQualificationCardsComponent < ViewComponent::Base
 
   attr_reader :degrees, :application_choice_state, :show_hesa_codes
 
-  alias_method :show_hesa_codes?, :show_hesa_codes
+  alias show_hesa_codes? show_hesa_codes
 
   def initialize(degrees, application_choice_state: nil, show_hesa_codes: false)
     @degrees = degrees

--- a/app/components/qualifications_component.rb
+++ b/app/components/qualifications_component.rb
@@ -2,7 +2,7 @@
 class QualificationsComponent < ViewComponent::Base
   attr_reader :application_form, :application_choice_state, :show_hesa_codes
 
-  alias_method :show_hesa_codes?, :show_hesa_codes
+  alias show_hesa_codes? show_hesa_codes
 
   def initialize(application_form:, application_choice_state: nil, show_hesa_codes: false)
     @application_form = application_form

--- a/app/components/support_interface/data_export_history_component.rb
+++ b/app/components/support_interface/data_export_history_component.rb
@@ -3,7 +3,7 @@ module SupportInterface
     include ViewHelper
 
     attr_reader :data_exports, :show_name
-    alias_method :show_name?, :show_name
+    alias show_name? show_name
 
     def initialize(data_exports:, show_name:)
       @data_exports = data_exports

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -5,8 +5,8 @@ module CandidateInterface
     before_action :set_user_context
     before_action :check_cookie_preferences
     layout 'application'
-    alias_method :audit_user, :current_candidate
-    alias_method :current_user, :current_candidate
+    alias audit_user current_candidate
+    alias current_user current_candidate
 
     def set_user_context(candidate_id = current_candidate&.id)
       Raven.user_context(id: "candidate_#{candidate_id}")

--- a/app/controllers/dfe_sign_in_controller.rb
+++ b/app/controllers/dfe_sign_in_controller.rb
@@ -28,7 +28,7 @@ class DfESignInController < ActionController::Base
     end
   end
 
-  alias_method :bypass_callback, :callback
+  alias bypass_callback callback
 
   # This is called by a redirect from DfE Sign-in after visiting the signout
   # link on DSI. We tell DSI to redirect here using the

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -30,7 +30,7 @@ module ProviderInterface
       @current_provider_user ||= ProviderUser.load_from_session(session)
     end
 
-    alias_method :current_user, :current_provider_user
+    alias current_user current_provider_user
 
     def check_cookie_preferences
       if cookies['consented-to-manage-cookies'].eql?('yes')
@@ -40,7 +40,7 @@ module ProviderInterface
       end
     end
 
-    alias_method :audit_user, :current_provider_user
+    alias audit_user current_provider_user
 
   protected
 

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -14,8 +14,8 @@ module SupportInterface
       DfESignInUser.load_from_session(session)
     end
 
-    alias_method :audit_user, :current_support_user
-    alias_method :current_user, :current_support_user
+    alias audit_user current_support_user
+    alias current_user current_support_user
 
   private
 

--- a/app/controllers/support_interface/support_users_controller.rb
+++ b/app/controllers/support_interface/support_users_controller.rb
@@ -27,7 +27,7 @@ module SupportInterface
       @support_user = SupportUser.find(params[:id])
     end
 
-    alias_method :confirm_restore, :confirm_destroy
+    alias confirm_restore confirm_destroy
 
     def destroy
       SupportUser.find(params[:id]).discard

--- a/app/forms/candidate_interface/degree_enic_form.rb
+++ b/app/forms/candidate_interface/degree_enic_form.rb
@@ -6,7 +6,7 @@ module CandidateInterface
 
     delegate :international?, to: :degree, allow_nil: true
 
-    alias_method :have_enic_reference?, :have_enic_reference
+    alias have_enic_reference? have_enic_reference
 
     validates :have_enic_reference, presence: true
     validates :enic_reference, presence: true, if: -> { have_enic_reference == 'yes' }

--- a/app/forms/provider_interface/fields_for_provider_user_permissions_form.rb
+++ b/app/forms/provider_interface/fields_for_provider_user_permissions_form.rb
@@ -5,7 +5,7 @@ module ProviderInterface
     attr_accessor :view_applications_only, :provider_id
     attr_writer :permissions
 
-    alias_method :id, :provider_id
+    alias id provider_id
 
     validates :view_applications_only, presence: { message: 'Choose whether this user has extra permissions' }
     validate :at_least_one_extra_permission_is_set, if: -> { view_applications_only == 'false' }

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -2,7 +2,7 @@ class Interview < ApplicationRecord
   include Discard::Model
 
   self.discard_column = :cancelled_at
-  alias_method :cancelled?, :discarded?
+  alias cancelled? discarded?
 
   audited associated_with: :application_choice
 

--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -32,7 +32,7 @@ module SupportInterface
       results
     end
 
-    alias_method :data_for_export, :application_choices
+    alias data_for_export application_choices
 
   private
 

--- a/app/services/support_interface/applications_export.rb
+++ b/app/services/support_interface/applications_export.rb
@@ -74,6 +74,6 @@ module SupportInterface
       results
     end
 
-    alias_method :data_for_export, :applications
+    alias data_for_export applications
   end
 end

--- a/app/services/support_interface/candidate_journey_tracking_export.rb
+++ b/app/services/support_interface/candidate_journey_tracking_export.rb
@@ -13,7 +13,7 @@ module SupportInterface
       end
     end
 
-    alias_method :data_for_export, :application_choices
+    alias data_for_export application_choices
 
   private
 

--- a/app/services/support_interface/offer_conditions_export.rb
+++ b/app/services/support_interface/offer_conditions_export.rb
@@ -31,7 +31,7 @@ module SupportInterface
       end
     end
 
-    alias_method :data_for_export, :offers
+    alias data_for_export offers
 
   private
 

--- a/app/services/support_interface/providers_export.rb
+++ b/app/services/support_interface/providers_export.rb
@@ -13,7 +13,7 @@ module SupportInterface
       end
     end
 
-    alias_method :data_for_export, :providers
+    alias data_for_export providers
 
   private
 

--- a/app/services/support_interface/referee_survey_export.rb
+++ b/app/services/support_interface/referee_survey_export.rb
@@ -30,7 +30,7 @@ module SupportInterface
       output
     end
 
-    alias_method :data_for_export, :call
+    alias data_for_export call
 
   private
 

--- a/app/services/support_interface/sites_export.rb
+++ b/app/services/support_interface/sites_export.rb
@@ -13,7 +13,7 @@ module SupportInterface
       end
     end
 
-    alias_method :data_for_export, :sites
+    alias data_for_export sites
 
   private
 

--- a/app/services/support_interface/tad_provider_stats_export.rb
+++ b/app/services/support_interface/tad_provider_stats_export.rb
@@ -22,7 +22,7 @@ module SupportInterface
       data_for_export.sort_by { |row| row[:provider_code] }
     end
 
-    alias_method :data_for_export, :call
+    alias data_for_export call
 
   private
 

--- a/config/rubocop/config/style.yml
+++ b/config/rubocop/config/style.yml
@@ -62,7 +62,7 @@ Style/FormatStringToken:
   EnforcedStyle: template
 
 Style/Alias:
-  Enabled: false
+  Enabled: true
 
 Style/RegexpLiteral:
   Enabled: false

--- a/spec/support/active_record_relation_stub.rb
+++ b/spec/support/active_record_relation_stub.rb
@@ -1,6 +1,6 @@
 class ActiveRecordRelationStub
   attr_reader :records
-  alias_method :to_a, :records
+  alias to_a records
 
   # @param model_klass [ActiveRecord::Base] the stubbing association's class
   # @param records [Array] list of records the association holds

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -10,7 +10,7 @@ module DfESignInHelpers
     )
   end
 
-  alias_method :provider_exists_in_dfe_sign_in, :user_exists_in_dfe_sign_in
+  alias provider_exists_in_dfe_sign_in user_exists_in_dfe_sign_in
 
   def provider_signs_in_using_dfe_sign_in
     visit provider_interface_path
@@ -18,7 +18,7 @@ module DfESignInHelpers
     click_button 'Sign in using DfE Sign-in'
   end
 
-  alias_method :and_i_sign_in_to_the_provider_interface, :provider_signs_in_using_dfe_sign_in
+  alias and_i_sign_in_to_the_provider_interface provider_signs_in_using_dfe_sign_in
 
   def support_user_signs_in_using_dfe_sign_in
     visit support_interface_sign_in_path


### PR DESCRIPTION
From the rubocop docs:

> Prefer alias when aliasing methods in lexical class scope as the resolution of self in this context is also lexical, and it communicates clearly to the user that the indirection of your alias will not be altered at runtime or by any subclass unless made explicit.

## Link to Trello card
https://trello.com/c/I6JiD7cR/3856-rubocop-cleanup

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
