### PR TITLE
Restrict visibility of withdraw on candidate's request link

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -55,6 +55,11 @@ module ProviderInterface
       end
     end
 
+    def application_withdrawable?
+      provider_can_respond && !ApplicationStateChange::UNSUCCESSFUL_END_STATES.include?(@application_choice.status.to_sym)
+    end
+    helper_method :application_withdrawable?
+
   private
 
     def available_providers

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -4,26 +4,28 @@
 
 <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice, options: @status_box_options) unless @offer_present || @application_choice.rejected? %>
 
-<section class="app-section">
+<h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Application</h2>
+
+<p class="govuk-body govuk-!-display-none-print">
+  <% if FeatureFlag.active?(:withdraw_at_candidates_request) && application_withdrawable? %>
+    <%= govuk_link_to(
+      "Withdraw at candidate's request",
+      provider_interface_decline_or_withdraw_edit_path(@application_choice),
+      class: 'govuk-!-margin-right-2',
+    ) %>
+  <% end %>
+  <%= govuk_link_to(
+    'Download application (PDF)',
+    provider_interface_application_choice_path(@application_choice.id, format: :pdf),
+    download: @application_choice.application_form.support_reference,
+  ) %>
+</p>
+
+<section class="app-section govuk-!-margin-top-7">
   <h2 class="govuk-heading-m govuk-!-font-size-27">Application details</h2>
 
   <div class="govuk-!-width-two-thirds">
     <%= render ProviderInterface::ApplicationSummaryComponent.new(application_form: @application_choice.application_form) %>
-
-    <p class="govuk-body govuk-!-display-none-print">
-      <% if FeatureFlag.active?(:withdraw_at_candidates_request) && @provider_can_respond %>
-        <%= govuk_link_to(
-          "Withdraw at candidate's request",
-          provider_interface_decline_or_withdraw_edit_path(@application_choice),
-          class: 'govuk-!-margin-right-2',
-        ) %>
-      <% end %>
-      <%= govuk_link_to(
-        'Download application (PDF)',
-        provider_interface_application_choice_path(@application_choice.id, format: :pdf),
-        download: @application_choice.application_form.support_reference,
-      ) %>
-    </p>
   </div>
 </section>
 

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -9,7 +9,7 @@
 <p class="govuk-body govuk-!-display-none-print">
   <% if FeatureFlag.active?(:withdraw_at_candidates_request) && application_withdrawable? %>
     <%= govuk_link_to(
-      "Withdraw at candidate's request",
+      'Withdraw at candidate’s request',
       provider_interface_decline_or_withdraw_edit_path(@application_choice),
       class: 'govuk-!-margin-right-2',
     ) %>

--- a/spec/system/provider_interface/withdraw_an_application_at_candidates_request_spec.rb
+++ b/spec/system/provider_interface/withdraw_an_application_at_candidates_request_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "withdrawing an application at the candidate's request", type: :f
     and_i_click_a_link_to_withdraw_at_candidates_request
     and_i_confirm_the_withdrawal
     then_i_see_a_message_confirming_that_the_application_has_been_withdrawn
+    and_i_can_no_longer_see_the_withdraw_at_candidates_request_link
     and_the_candidate_receives_an_email_about_the_withdrawal
   end
 
@@ -56,6 +57,10 @@ RSpec.describe "withdrawing an application at the candidate's request", type: :f
   def then_i_see_a_message_confirming_that_the_application_has_been_withdrawn
     expect(page).to have_current_path(provider_interface_application_choice_path(@application_choice))
     expect(page).to have_content('Application withdrawn')
+  end
+
+  def and_i_can_no_longer_see_the_withdraw_at_candidates_request_link
+    expect(page).not_to have_link "Withdraw at candidate's request"
   end
 
   def and_the_candidate_receives_an_email_about_the_withdrawal

--- a/spec/system/provider_interface/withdraw_an_application_at_candidates_request_spec.rb
+++ b/spec/system/provider_interface/withdraw_an_application_at_candidates_request_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "withdrawing an application at the candidate's request", type: :f
   end
 
   def and_i_click_a_link_to_withdraw_at_candidates_request
-    click_on "Withdraw at candidate's request"
+    click_on 'Withdraw at candidate’s request'
   end
 
   def and_i_confirm_the_withdrawal
@@ -60,7 +60,7 @@ RSpec.describe "withdrawing an application at the candidate's request", type: :f
   end
 
   def and_i_can_no_longer_see_the_withdraw_at_candidates_request_link
-    expect(page).not_to have_link "Withdraw at candidate's request"
+    expect(page).not_to have_link 'Withdraw at candidate’s request'
   end
 
   def and_the_candidate_receives_an_email_about_the_withdrawal


### PR DESCRIPTION
## Context

Spotted in dev/design review:
When an application is already in an unsuccessful end state we should not be able to see the link to withdraw it at the candidate's request.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Moves the link along with the PDF link above the _Application details_ h2 to be consistent with design prototype.
- Only renders the withdrawal link for applications which can be withdrawn/declined at the candidate's request.

### Link rendered on withdrawable application...

![image](https://user-images.githubusercontent.com/93511/123946731-71f36e00-d997-11eb-980d-12547613cacf.png)

### After withdrawing...

![image](https://user-images.githubusercontent.com/93511/123946811-8afc1f00-d997-11eb-8fdf-93947d5b0841.png)


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Vuz0WbZa/3894-withdraw-on-candidates-request-dev-design-amends
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
