### PR TITLE
Add 2022 cycle dates and refactor RecruitmentCycle class

### DIFF
--- a/app/components/candidate_interface/carry_over_banner_component.html.erb
+++ b/app/components/candidate_interface/carry_over_banner_component.html.erb
@@ -7,7 +7,7 @@
     <p class="govuk-body">Your application did not lead to a place, but you can <%= govuk_link_to 'apply again', start_path, class: 'govuk-notification-banner__link' %></p>
   <% else %>
     <%= notification_banner.slot(:heading, text: 'Do you want to continue applying?') %>
-    <p class="govuk-body">Applications are open for courses starting academic year 2021 to 2022.</p>
+    <p class="govuk-body">Applications are open for courses starting academic year <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %>.</p>
     <p class="govuk-body"><%= govuk_link_to 'Continue your application', start_path, class: 'govuk-notification-banner__link' %></p>
   <% end %>
 <% end %>

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -5,11 +5,7 @@ module RecruitmentCycle
   }.freeze
 
   def self.current_year
-    now = Time.zone.today
-
-    EndOfCycleTimetable::CYCLE_DATES.keys.detect do |year|
-      now.between?(EndOfCycleTimetable::CYCLE_DATES[year][:find_reopens], EndOfCycleTimetable::CYCLE_DATES[year + 1][:find_reopens])
-    end
+    EndOfCycleTimetable.current_year
   end
 
   def self.next_year

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -12,12 +12,12 @@ module RecruitmentCycle
     end
   end
 
-  def self.previous_year
-    current_year - 1
-  end
-
   def self.next_year
     current_year + 1
+  end
+
+  def self.previous_year
+    current_year - 1
   end
 
   def self.years_visible_to_providers

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -5,10 +5,10 @@ module RecruitmentCycle
   }.freeze
 
   def self.current_year
-    if Time.zone.today < EndOfCycleTimetable.find_reopens
-      2020
-    else
-      2021
+    now = Time.zone.today
+
+    EndOfCycleTimetable::CYCLE_DATES.keys.detect do |year|
+      now.between?(EndOfCycleTimetable::CYCLE_DATES[year][:find_reopens], EndOfCycleTimetable::CYCLE_DATES[year + 1][:find_reopens])
     end
   end
 

--- a/app/queries/get_application_choices_for_providers.rb
+++ b/app/queries/get_application_choices_for_providers.rb
@@ -11,9 +11,7 @@ class GetApplicationChoicesForProviders
     },
   ].freeze
 
-  DEFAULT_RECRUITMENT_CYCLE_YEAR = RecruitmentCycle.years_visible_to_providers
-
-  def self.call(providers:, vendor_api: false, includes: DEFAULT_INCLUDES, recruitment_cycle_year: DEFAULT_RECRUITMENT_CYCLE_YEAR)
+  def self.call(providers:, vendor_api: false, includes: DEFAULT_INCLUDES, recruitment_cycle_year: RecruitmentCycle.years_visible_to_providers)
     providers = Array.wrap(providers).select(&:present?)
 
     raise MissingProvider if providers.none?

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -20,6 +20,13 @@ class EndOfCycleTimetable
       find_reopens: Date.new(2020, 10, 6),
       apply_reopens: Date.new(2020, 10, 13),
     },
+    2022 => {
+      apply_1_deadline: Date.new(2021, 9, 6),
+      apply_2_deadline: Date.new(2021, 9, 20),
+      find_closes: Date.new(2021, 10, 3),
+      find_reopens: Date.new(2021, 9, 5),
+      apply_reopens: Date.new(2021, 10, 12),
+    }
   }.freeze
 
   def self.between_cycles?(phase)

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -193,7 +193,7 @@ class EndOfCycleTimetable
   end
 
   def self.can_submit?(application_form)
-    current_year == application_form.recruitment_cycle_year
+    current_cycle?(application_form)
   end
 
   def self.before_find_reopens?

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -29,6 +29,16 @@ class EndOfCycleTimetable
     }
   }.freeze
 
+  def self.current_year
+    now = Time.zone.today
+
+    CYCLE_DATES.keys.detect do |year|
+      return year if year == CYCLE_DATES.keys.last
+
+      now.between?(CYCLE_DATES[year][:find_reopens], CYCLE_DATES[year + 1][:find_reopens])
+    end
+  end
+
   def self.between_cycles?(phase)
     phase == 'apply_1' ? between_cycles_apply_1? : between_cycles_apply_2?
   end

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -26,7 +26,7 @@ class EndOfCycleTimetable
       find_closes: Date.new(2021, 10, 3),
       find_reopens: Date.new(2021, 9, 5),
       apply_reopens: Date.new(2021, 10, 12),
-    }
+    },
   }.freeze
 
   def self.current_year
@@ -181,7 +181,7 @@ class EndOfCycleTimetable
   end
 
   def self.current_cycle?(application_form)
-    application_form.recruitment_cycle_year == RecruitmentCycle.current_year
+    application_form.recruitment_cycle_year == current_year
   end
 
   def self.can_add_course_choice?(application_form)
@@ -193,7 +193,7 @@ class EndOfCycleTimetable
   end
 
   def self.can_submit?(application_form)
-    RecruitmentCycle.current_year == application_form.recruitment_cycle_year
+    current_year == application_form.recruitment_cycle_year
   end
 
   def self.before_find_reopens?

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -96,10 +96,6 @@ class EndOfCycleTimetable
     SiteSetting.cycle_schedule
   end
 
-  def self.next_cycle_year
-    RecruitmentCycle.current_year + 1
-  end
-
   def self.schedules
     {
       real: CYCLE_DATES[CURRENT_YEAR_FOR_SCHEDULE],

--- a/app/views/candidate_interface/carry_over/start.html.erb
+++ b/app/views/candidate_interface/carry_over/start.html.erb
@@ -7,7 +7,7 @@
     <h1 class="govuk-heading-xl"><%= t('page_titles.start_carry_over') %></h1>
 
     <p class="govuk-body">
-      Carry on with your application for courses starting in the 2021 to 2022 academic year.
+      Carry on with your application for courses starting in the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> academic year.
     </p>
 
     <p class="govuk-body">

--- a/app/views/candidate_interface/carry_over/start_between_cycles.html.erb
+++ b/app/views/candidate_interface/carry_over/start_between_cycles.html.erb
@@ -8,12 +8,12 @@
 
     <% if EndOfCycleTimetable.before_find_reopens? %>
       <p class="govuk-body">
-        Applications for courses starting in the 2020 to 2021 academic year are closed.
+        Applications for courses starting in the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.current_year) %> academic year are closed.
       </p>
     <% end %>
 
     <p class="govuk-body">
-      Carry on with your application for courses starting in the 2021 to 2022 academic year.
+      Carry on with your application for courses starting in the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> academic year.
     </p>
 
     <% if EndOfCycleTimetable.before_apply_reopens? %>

--- a/app/views/candidate_interface/carry_over/start_between_cycles_unsubmitted.html.erb
+++ b/app/views/candidate_interface/carry_over/start_between_cycles_unsubmitted.html.erb
@@ -4,11 +4,11 @@
 
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl"><%= t('page_titles.start_carry_over_between_cycles_unsubmitted') %></h1>
+    <h1 class="gov uk-heading-xl"><%= t('page_titles.start_carry_over_between_cycles_unsubmitted') %></h1>
 
-    <p class="govuk-body">You did not submit your application in time to start a course in the 2020 to 2021 academic year.</p>
+    <p class="govuk-body">You did not submit your application in time to start a course in the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.current_year) %> academic year.</p>
 
-    <p class="govuk-body">But you can carry on with your application for courses starting in the 2021 to 2022 academic year.</p>
+    <p class="govuk-body">But you can carry on with your application for courses starting in the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> academic year.</p>
 
     <% if EndOfCycleTimetable.before_apply_reopens? %>
       <p class="govuk-body">

--- a/app/views/support_interface/settings/cycles.html.erb
+++ b/app/views/support_interface/settings/cycles.html.erb
@@ -25,7 +25,7 @@
 <%= render SummaryListComponent.new(rows: {
   'Previous cycle year' => RecruitmentCycle.previous_year,
   'Current cycle year' => RecruitmentCycle.current_year,
-  'Next cycle year' => EndOfCycleTimetable.next_cycle_year,
+  'Next cycle year' => RecruitmentCycle.next_year,
   'Years visible to providers' => RecruitmentCycle.years_visible_to_providers.to_sentence,
 }) %>
 

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe RecruitmentCycle do
     end
   end
 
+  describe '.next_year' do
+    it 'is 2021' do
+      Timecop.travel(Time.zone.local(2020, 1, 1, 12, 0, 0)) do
+        expect(RecruitmentCycle.next_year).to eq(2021)
+      end
+    end
+  end
+
   describe '.cycle_name' do
     it 'defaults to current year to the following year' do
       Timecop.travel(Time.zone.local(2020, 1, 1, 1, 0, 0)) do

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -12,29 +12,29 @@ RSpec.describe RecruitmentCycle do
   end
 
   describe '.next_year' do
-    it 'is 2021' do
-      Timecop.travel(Time.zone.local(2020, 1, 1, 12, 0, 0)) do
-        expect(RecruitmentCycle.next_year).to eq(2021)
-      end
+    it 'is 2021 if the current year is 2020' do
+      allow(EndOfCycleTimetable).to receive(:current_year).and_return(2020)
+
+      expect(RecruitmentCycle.next_year).to eq(2021)
     end
   end
 
   describe '.previous_year' do
-    it 'is 2019' do
-      Timecop.travel(Time.zone.local(2020, 1, 1, 12, 0, 0)) do
-        expect(RecruitmentCycle.previous_year).to eq(2019)
-      end
+    it 'is 2019 if the current year is 2020' do
+      allow(EndOfCycleTimetable).to receive(:current_year).and_return(2020)
+
+      expect(RecruitmentCycle.previous_year).to eq(2019)
     end
   end
 
   describe '.cycle_name' do
-    it 'defaults to current year to the following year' do
-      Timecop.travel(Time.zone.local(2020, 1, 1, 1, 0, 0)) do
-        expect(RecruitmentCycle.cycle_name).to eq('2019 to 2020')
-      end
+    it 'defaults from current year to the following year' do
+      allow(EndOfCycleTimetable).to receive(:current_year).and_return(2020)
+
+      expect(RecruitmentCycle.cycle_name).to eq('2019 to 2020')
     end
 
-    it 'is the argument year to the following year' do
+    it 'is from argument(year) to the following year' do
       expect(RecruitmentCycle.cycle_name(2021)).to eq('2020 to 2021')
     end
   end

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -2,16 +2,12 @@ require 'rails_helper'
 
 RSpec.describe RecruitmentCycle do
   describe '.current_year' do
-    it 'is 2020 before the end of cycle' do
-      Timecop.travel(Time.zone.local(2020, 1, 1, 12, 0, 0)) do
-        expect(RecruitmentCycle.current_year).to eq(2020)
-      end
-    end
+    it 'delegates to EndOfCycleTimetable' do
+      allow(EndOfCycleTimetable).to receive(:current_year)
 
-    it 'is 2021 in the new cycle' do
-      Timecop.travel(Time.zone.local(2020, 11, 1, 12, 0, 0)) do
-        expect(RecruitmentCycle.current_year).to eq(2021)
-      end
+      RecruitmentCycle.current_year
+
+      expect(EndOfCycleTimetable).to have_received(:current_year)
     end
   end
 
@@ -19,6 +15,14 @@ RSpec.describe RecruitmentCycle do
     it 'is 2021' do
       Timecop.travel(Time.zone.local(2020, 1, 1, 12, 0, 0)) do
         expect(RecruitmentCycle.next_year).to eq(2021)
+      end
+    end
+  end
+
+  describe '.previous_year' do
+    it 'is 2019' do
+      Timecop.travel(Time.zone.local(2020, 1, 1, 12, 0, 0)) do
+        expect(RecruitmentCycle.previous_year).to eq(2019)
       end
     end
   end

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -7,6 +7,28 @@ RSpec.describe EndOfCycleTimetable do
   let(:one_hour_after_apply2_deadline) { Time.zone.local(2020, 9, 19, 1, 0, 0) }
   let(:one_hour_after_2021_cycle_opens) { Time.zone.local(2020, 10, 13, 1, 0, 0) }
 
+  describe '.current_year' do
+    it 'is 2020 before the end of cycle' do
+      Timecop.travel(Time.zone.local(2020, 1, 1, 12, 0, 0)) do
+        expect(EndOfCycleTimetable.current_year).to eq(2020)
+      end
+    end
+
+    it 'is 2021 in the new cycle' do
+      Timecop.travel(Time.zone.local(2020, 11, 1, 12, 0, 0)) do
+        expect(EndOfCycleTimetable.current_year).to eq(2021)
+      end
+    end
+  end
+
+  describe '.next_year' do
+    it 'is 2021' do
+      Timecop.travel(Time.zone.local(2020, 1, 1, 12, 0, 0)) do
+        expect(RecruitmentCycle.next_year).to eq(2021)
+      end
+    end
+  end
+
   describe '.show_apply_1_deadline_banner?' do
     it 'returns true before the configured date' do
       Timecop.travel(one_hour_before_apply1_deadline) do

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -8,23 +8,15 @@ RSpec.describe EndOfCycleTimetable do
   let(:one_hour_after_2021_cycle_opens) { Time.zone.local(2020, 10, 13, 1, 0, 0) }
 
   describe '.current_year' do
-    it 'is 2020 before the end of cycle' do
+    it 'is 2020 if we are in the middle of the 2020 cycle' do
       Timecop.travel(Time.zone.local(2020, 1, 1, 12, 0, 0)) do
         expect(EndOfCycleTimetable.current_year).to eq(2020)
       end
     end
 
-    it 'is 2021 in the new cycle' do
+    it 'is 2021 if we are in the middle of the 2021 cycle' do
       Timecop.travel(Time.zone.local(2020, 11, 1, 12, 0, 0)) do
         expect(EndOfCycleTimetable.current_year).to eq(2021)
-      end
-    end
-  end
-
-  describe '.next_year' do
-    it 'is 2021' do
-      Timecop.travel(Time.zone.local(2020, 1, 1, 12, 0, 0)) do
-        expect(RecruitmentCycle.next_year).to eq(2021)
       end
     end
   end

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -75,14 +75,6 @@ RSpec.describe EndOfCycleTimetable do
     end
   end
 
-  describe '.next_cycle_year' do
-    it 'returns 2021 when in 2020 cycle' do
-      Timecop.travel(Time.zone.local(2020, 8, 24, 23, 0, 0)) do
-        expect(EndOfCycleTimetable.next_cycle_year).to eq 2021
-      end
-    end
-  end
-
   describe '.find_down?' do
     it 'returns false before find closes' do
       Timecop.travel(EndOfCycleTimetable.find_closes.beginning_of_day - 1.hour) do

--- a/spec/support/test_helpers/cycle_timetable_helper.rb
+++ b/spec/support/test_helpers/cycle_timetable_helper.rb
@@ -1,30 +1,30 @@
 module CycleTimetableHelper
   def mid_cycle
-    @_mid_cycle ||= rand(previous_end_of_cycle_timetable[:apply_reopens]..current_end_of_cycle_timetable[:apply_1_deadline]).midday
+    previous_end_of_cycle_timetable[:apply_reopens] + 1.day
   end
 
   def after_apply_1_deadline
-    @_after_apply_1_deadline ||= rand((current_end_of_cycle_timetable[:apply_1_deadline] + 1.day)..current_end_of_cycle_timetable[:stop_applications_to_unavailable_course_options]).midday
+    current_end_of_cycle_timetable[:apply_1_deadline] + 1.day
   end
 
   def after_full_course_deadline
-    @_after_full_course_deadline ||= rand((current_end_of_cycle_timetable[:stop_applications_to_unavailable_course_options] + 1.day)..current_end_of_cycle_timetable[:apply_2_deadline]).midday
+    current_end_of_cycle_timetable[:stop_applications_to_unavailable_course_options] + 1.day
   end
 
   def after_apply_2_deadline
-    @_after_apply_2_deadline ||= rand((current_end_of_cycle_timetable[:apply_2_deadline] + 1.day)..current_end_of_cycle_timetable[:find_closes]).midday
+    current_end_of_cycle_timetable[:apply_2_deadline] + 1.day
   end
 
   def after_find_closes
-    @_after_find_closes ||= rand((current_end_of_cycle_timetable[:find_closes])..current_end_of_cycle_timetable[:find_reopens]).midday
+    current_end_of_cycle_timetable[:find_closes] + 1.day
   end
 
   def after_find_reopens
-    @_after_find_reopens ||= rand((current_end_of_cycle_timetable[:find_reopens])..current_end_of_cycle_timetable[:apply_reopens]).midday
+    current_end_of_cycle_timetable[:find_reopens] + 1.day
   end
 
   def after_apply_reopens
-    @_after_apply_reopens ||= rand((current_end_of_cycle_timetable[:apply_reopens])..Date.new(EndOfCycleTimetable::CURRENT_YEAR_FOR_SCHEDULE, 12, 31)).midday
+    current_end_of_cycle_timetable[:apply_reopens] + 1.day
   end
 
 private


### PR DESCRIPTION
## Context

This PR is part of the 'end of cycle' refactoring exercise.

## Changes proposed in this pull request

- Add the 2022 cycle dates to the EndOfCycleTimetable class
- Refactor the RecruitmentCycle class. We now no longer hard code the current recruitment cycle year.

## Guidance to review

See Slack discussion - https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1625044581486100

## Link to Trello card

https://trello.com/c/bbSxTl1H/3575-eoc-refactor

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
