### PR TITLE
EoC refactor - Rename EndOfCycleTimetable to CycleTimetable

### DIFF
--- a/app/components/candidate_interface/apply_again_call_to_action_component.rb
+++ b/app/components/candidate_interface/apply_again_call_to_action_component.rb
@@ -18,7 +18,7 @@ module CandidateInterface
     end
 
     def render?
-      !EndOfCycleTimetable.between_cycles_apply_2? &&
+      !CycleTimetable.between_cycles_apply_2? &&
         application_form.recruitment_cycle_year == RecruitmentCycle.current_year
     end
 

--- a/app/components/candidate_interface/carry_over_banner_component.rb
+++ b/app/components/candidate_interface/carry_over_banner_component.rb
@@ -15,7 +15,7 @@ module CandidateInterface
     end
 
     def between_cycles?
-      EndOfCycleTimetable.between_cycles_apply_2?
+      CycleTimetable.between_cycles_apply_2?
     end
 
     def start_path

--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -1,6 +1,6 @@
 <% application_choices.each do |application_choice| %>
   <div class="<%= container_class(application_choice) %>" id="course-choice-<%= application_choice.id %>" data-qa="application-choice-<%= application_choice.id %>">
-  <% if EndOfCycleTimetable.can_add_course_choice?(application_choice.application_form) && @editable %>
+  <% if CycleTimetable.can_add_course_choice?(application_choice.application_form) && @editable %>
     <% if application_choice.course_not_available? %>
       <p class="app-inset-text__title"><%= application_choice.course_not_available_error %>.</p>
       <p class="govuk-body"><%= application_choice.provider.name %> have decided not to run this course.</p>

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -111,7 +111,7 @@ module CandidateInterface
     end
 
     def course_row_value(application_choice)
-      if EndOfCycleTimetable.find_down?
+      if CycleTimetable.find_down?
         "#{application_choice.current_course.name} (#{application_choice.current_course.code})"
       else
         govuk_link_to("#{application_choice.current_course.name} (#{application_choice.current_course.code})", application_choice.current_course.find_url, target: '_blank', rel: 'noopener')

--- a/app/components/candidate_interface/deadline_banner_component.rb
+++ b/app/components/candidate_interface/deadline_banner_component.rb
@@ -19,13 +19,13 @@ private
 
   def show_apply_1_deadline_banner?
     apply_1? &&
-      EndOfCycleTimetable.show_apply_1_deadline_banner? &&
+      CycleTimetable.show_apply_1_deadline_banner? &&
       FeatureFlag.active?(:deadline_notices)
   end
 
   def show_apply_2_deadline_banner?
     apply_2? &&
-      EndOfCycleTimetable.show_apply_2_deadline_banner? &&
+      CycleTimetable.show_apply_2_deadline_banner? &&
       FeatureFlag.active?(:deadline_notices)
   end
 
@@ -38,10 +38,10 @@ private
   end
 
   def apply_1_deadline
-    EndOfCycleTimetable.date(:apply_1_deadline).strftime('%d %B')
+    CycleTimetable.date(:apply_1_deadline).strftime('%d %B')
   end
 
   def apply_2_deadline
-    EndOfCycleTimetable.date(:apply_2_deadline).strftime('%d %B')
+    CycleTimetable.date(:apply_2_deadline).strftime('%d %B')
   end
 end

--- a/app/components/candidate_interface/grouped_provider_courses_component.html.erb
+++ b/app/components/candidate_interface/grouped_provider_courses_component.html.erb
@@ -1,4 +1,4 @@
-<% find_down = EndOfCycleTimetable.find_down? %>
+<% find_down = CycleTimetable.find_down? %>
 
 <% courses_by_provider_and_region.each do |region_code, courses_by_provider| %>
   <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-8"><%= label_for(region_code) %></h2>

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -47,7 +47,7 @@ module CandidateInterface
     end
 
     def course_row_value
-      if EndOfCycleTimetable.find_down?
+      if CycleTimetable.find_down?
         tag.p(@course_choice.current_course.name_and_code, class: 'govuk-!-margin-bottom-0') +
           tag.p(@course_choice.current_course.description, class: 'govuk-body')
       else

--- a/app/components/candidate_interface/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons_component.rb
@@ -28,7 +28,7 @@ module CandidateInterface
     end
 
     def course_details_row_value(application_choice)
-      if EndOfCycleTimetable.find_down?
+      if CycleTimetable.find_down?
         tag.p(application_choice.current_course.name_and_code, class: 'govuk-!-margin-bottom-0') + tag.p(application_choice.course.description, class: 'govuk-body')
       else
         govuk_link_to(application_choice.current_course.name_and_code,

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -15,12 +15,12 @@ private
 
   def show_apply_1_reopen_banner?
     apply_1? &&
-      EndOfCycleTimetable.between_cycles_apply_1?
+      CycleTimetable.between_cycles_apply_1?
   end
 
   def show_apply_2_reopen_banner?
     apply_2? &&
-      EndOfCycleTimetable.between_cycles_apply_2?
+      CycleTimetable.between_cycles_apply_2?
   end
 
   def apply_1?
@@ -32,6 +32,6 @@ private
   end
 
   def reopen_date
-    EndOfCycleTimetable.date(:apply_reopens).to_s(:govuk_date)
+    CycleTimetable.date(:apply_reopens).to_s(:govuk_date)
   end
 end

--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_submitted
 
     def index
-      redirect_to candidate_interface_application_form_path and return unless EndOfCycleTimetable.can_add_course_choice?(current_application)
+      redirect_to candidate_interface_application_form_path and return unless CycleTimetable.can_add_course_choice?(current_application)
 
       @application_choices = current_candidate.current_application.application_choices
 

--- a/app/controllers/candidate_interface/carry_over_controller.rb
+++ b/app/controllers/candidate_interface/carry_over_controller.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     before_action :redirect_if_already_carried_over
 
     def start
-      if EndOfCycleTimetable.between_cycles_apply_2?
+      if CycleTimetable.between_cycles_apply_2?
         render current_application.submitted? ? :start_between_cycles : :start_between_cycles_unsubmitted
       else
         render :start

--- a/app/controllers/candidate_interface/course_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/base_controller.rb
@@ -7,7 +7,7 @@ module CandidateInterface
     private
 
       def redirect_to_dashboard_if_cycle_is_over
-        redirect_to candidate_interface_application_complete_path and return unless EndOfCycleTimetable.can_add_course_choice?(current_application)
+        redirect_to candidate_interface_application_complete_path and return unless CycleTimetable.can_add_course_choice?(current_application)
       end
     end
   end

--- a/app/controllers/candidate_interface/find_course_selections_controller.rb
+++ b/app/controllers/candidate_interface/find_course_selections_controller.rb
@@ -4,7 +4,7 @@ module CandidateInterface
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
     def confirm_selection
-      redirect_to candidate_interface_application_form_path and return unless EndOfCycleTimetable.can_add_course_choice?(current_application)
+      redirect_to candidate_interface_application_form_path and return unless CycleTimetable.can_add_course_choice?(current_application)
 
       course = Course.find(params[:course_id])
       @course_selection_form = CourseSelectionForm.new(course)

--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -5,13 +5,13 @@ module CandidateInterface
     before_action :show_pilot_holding_page_if_not_open
 
     def new
-      redirect_to candidate_interface_applications_closed_path and return if EndOfCycleTimetable.between_cycles_apply_1?
+      redirect_to candidate_interface_applications_closed_path and return if CycleTimetable.between_cycles_apply_1?
 
       @sign_up_form = CandidateInterface::SignUpForm.new
     end
 
     def create
-      redirect_to candidate_interface_applications_closed_path and return if EndOfCycleTimetable.between_cycles_apply_1?
+      redirect_to candidate_interface_applications_closed_path and return if CycleTimetable.between_cycles_apply_1?
 
       @sign_up_form = CandidateInterface::SignUpForm.new(candidate_sign_up_form_params)
 

--- a/app/controllers/candidate_interface/submitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/submitted_application_form_controller.rb
@@ -19,7 +19,7 @@ module CandidateInterface
     end
 
     def start_carry_over
-      render EndOfCycleTimetable.between_cycles_apply_2? ? :start_carry_over_between_cycles : :start_carry_over
+      render CycleTimetable.between_cycles_apply_2? ? :start_carry_over_between_cycles : :start_carry_over
     end
 
     def carry_over

--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -54,7 +54,7 @@ module CandidateInterface
     end
 
     def redirect_to_application_if_between_cycles
-      if EndOfCycleTimetable.between_cycles?(current_application.phase)
+      if CycleTimetable.between_cycles?(current_application.phase)
         redirect_to candidate_interface_application_form_path and return false
       end
 

--- a/app/forms/support_interface/change_cycle_form.rb
+++ b/app/forms/support_interface/change_cycle_form.rb
@@ -3,7 +3,7 @@ module SupportInterface
     include ActiveModel::Model
 
     def cycle_schedule_name
-      EndOfCycleTimetable.current_cycle_schedule
+      CycleTimetable.current_cycle_schedule
     end
   end
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -113,7 +113,7 @@ module ViewHelper
   end
 
   def days_until_find_reopens
-    (EndOfCycleTimetable.find_reopens - Time.zone.today).to_i
+    (CycleTimetable.find_reopens - Time.zone.today).to_i
   end
 
   def percent_of(numerator, denominator)

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -537,8 +537,8 @@ private
       earliest_date = 20.days.ago.to_date
       latest_date = Time.zone.now.to_date
     else
-      earliest_date = EndOfCycleTimetable::CYCLE_DATES[recruitment_cycle_year][:apply_reopens]
-      latest_date = EndOfCycleTimetable::CYCLE_DATES[recruitment_cycle_year + 1][:apply_1_deadline]
+      earliest_date = CycleTimetable::CYCLE_DATES[recruitment_cycle_year][:apply_reopens]
+      latest_date = CycleTimetable::CYCLE_DATES[recruitment_cycle_year + 1][:apply_1_deadline]
     end
 
     @time = rand(earliest_date..latest_date)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -209,9 +209,9 @@ class ApplicationForm < ApplicationRecord
 
   def must_be_carried_over?
     if ended_without_success?
-      recruitment_cycle_year < RecruitmentCycle.current_year || EndOfCycleTimetable.between_cycles_apply_2?
+      recruitment_cycle_year < RecruitmentCycle.current_year || CycleTimetable.between_cycles_apply_2?
     elsif !submitted?
-      recruitment_cycle_year < RecruitmentCycle.current_year && !EndOfCycleTimetable.between_cycles_apply_1?
+      recruitment_cycle_year < RecruitmentCycle.current_year && !CycleTimetable.between_cycles_apply_1?
     end
   end
 

--- a/app/models/feature_metrics_dashboard.rb
+++ b/app/models/feature_metrics_dashboard.rb
@@ -75,7 +75,7 @@ private
   def load_avg_time_to_get_references
     write_metric(
       :avg_time_to_get_references,
-      reference_statistics.average_time_to_get_references(EndOfCycleTimetable.apply_reopens.beginning_of_day),
+      reference_statistics.average_time_to_get_references(CycleTimetable.apply_reopens.beginning_of_day),
     )
     write_metric(
       :avg_time_to_get_references_this_month,
@@ -93,7 +93,7 @@ private
     write_metric(
       :pct_references_completed_within_30_days,
       reference_statistics.percentage_references_within(
-        30, EndOfCycleTimetable.apply_reopens.beginning_of_day
+        30, CycleTimetable.apply_reopens.beginning_of_day
       ),
     )
     write_metric(
@@ -113,7 +113,7 @@ private
   def load_avg_time_to_complete_work_history
     write_metric(
       :avg_time_to_complete_work_history,
-      work_history_statistics.average_time_to_complete(EndOfCycleTimetable.apply_reopens.beginning_of_day),
+      work_history_statistics.average_time_to_complete(CycleTimetable.apply_reopens.beginning_of_day),
     )
     write_metric(
       :avg_time_to_complete_work_history_this_month,
@@ -131,7 +131,7 @@ private
     write_metric(
       :avg_sign_ins_before_submitting,
       magic_link_statistics.average_magic_link_requests_upto(
-        :created_at, EndOfCycleTimetable.apply_reopens.beginning_of_day
+        :created_at, CycleTimetable.apply_reopens.beginning_of_day
       ),
     )
     write_metric(
@@ -152,7 +152,7 @@ private
     write_metric(
       :avg_sign_ins_before_offer,
       magic_link_statistics.average_magic_link_requests_upto(
-        :offered_at, EndOfCycleTimetable.apply_reopens.beginning_of_day
+        :offered_at, CycleTimetable.apply_reopens.beginning_of_day
       ),
     )
     write_metric(
@@ -173,7 +173,7 @@ private
     write_metric(
       :avg_sign_ins_before_recruitment,
       magic_link_statistics.average_magic_link_requests_upto(
-        :recruited_at, EndOfCycleTimetable.apply_reopens.beginning_of_day
+        :recruited_at, CycleTimetable.apply_reopens.beginning_of_day
       ),
     )
     write_metric(
@@ -194,7 +194,7 @@ private
     write_metric(
       :num_rejections_due_to_qualifications,
       reasons_for_rejection_statistics.rejections_due_to(
-        :qualifications_y_n, EndOfCycleTimetable.apply_reopens.beginning_of_day
+        :qualifications_y_n, CycleTimetable.apply_reopens.beginning_of_day
       ),
     )
     write_metric(
@@ -215,7 +215,7 @@ private
     write_metric(
       :apply_again_success_rate,
       apply_again_statistics.formatted_success_rate(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(
@@ -227,7 +227,7 @@ private
     write_metric(
       :apply_again_success_rate_upto_this_month,
       apply_again_statistics.formatted_success_rate(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_reopens.beginning_of_day,
         Time.zone.now.beginning_of_month,
       ),
     )
@@ -237,7 +237,7 @@ private
     write_metric(
       :apply_again_change_rate,
       apply_again_statistics.formatted_change_rate(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(
@@ -259,7 +259,7 @@ private
     write_metric(
       :apply_again_application_rate,
       apply_again_statistics.formatted_application_rate(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(
@@ -271,7 +271,7 @@ private
     write_metric(
       :apply_again_application_rate_upto_this_month,
       apply_again_statistics.formatted_application_rate(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_reopens.beginning_of_day,
         Time.zone.now.beginning_of_month,
       ),
     )
@@ -281,7 +281,7 @@ private
     write_metric(
       :carry_over_count,
       carry_over_statistics.carry_over_count(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(
@@ -293,7 +293,7 @@ private
     write_metric(
       :carry_over_count_last_month,
       carry_over_statistics.carry_over_count(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_reopens.beginning_of_day,
         Time.zone.now.beginning_of_month,
       ),
     )
@@ -304,7 +304,7 @@ private
       :pct_applications_with_one_a_level,
       qualifications_statistics.formatted_a_level_percentage(
         1,
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(
@@ -326,7 +326,7 @@ private
       :pct_applications_with_three_a_levels,
       qualifications_statistics.formatted_a_level_percentage(
         3,
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(
@@ -350,7 +350,7 @@ private
     write_metric(
       :satisfaction_survey_response_rate,
       satisfaction_survey_statistics.formatted_response_rate(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(
@@ -372,7 +372,7 @@ private
     write_metric(
       :equality_and_diversity_response_rate,
       equality_and_diversity_statistics.formatted_response_rate(
-        EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_reopens.beginning_of_day,
       ),
     )
     write_metric(

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -202,12 +202,12 @@ private
   end
 
   def date_range_query_for_recruitment_cycle_year(cycle_year)
-    start_date = EndOfCycleTimetable::CYCLE_DATES[cycle_year][:apply_reopens]
+    start_date = CycleTimetable::CYCLE_DATES[cycle_year][:apply_reopens]
 
     query = "created_at >= '#{start_date}'"
 
-    if EndOfCycleTimetable::CYCLE_DATES[cycle_year + 1].present?
-      end_date = EndOfCycleTimetable::CYCLE_DATES[cycle_year + 1][:apply_reopens]
+    if CycleTimetable::CYCLE_DATES[cycle_year + 1].present?
+      end_date = CycleTimetable::CYCLE_DATES[cycle_year + 1][:apply_reopens]
 
       query += " AND created_at <= '#{end_date}'"
     end

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -5,7 +5,7 @@ module RecruitmentCycle
   }.freeze
 
   def self.current_year
-    EndOfCycleTimetable.current_year
+    CycleTimetable.current_year
   end
 
   def self.next_year

--- a/app/services/candidate_interface/find_changed_apply_again_applications.rb
+++ b/app/services/candidate_interface/find_changed_apply_again_applications.rb
@@ -11,14 +11,14 @@ module CandidateInterface
     end
 
     def all_candidate_count(
-      start_time = EndOfCycleTimetable.apply_reopens.beginning_of_day,
+      start_time = CycleTimetable.apply_reopens.beginning_of_day,
       end_time = Time.zone.now.end_of_day
     )
       all_forms(start_time, end_time).select(:candidate_id).distinct.count
     end
 
     def changed_candidate_count(
-      start_time = EndOfCycleTimetable.apply_reopens.beginning_of_day,
+      start_time = CycleTimetable.apply_reopens.beginning_of_day,
       end_time = Time.zone.now.end_of_day
     )
       changed_forms(start_time, end_time).map(&:candidate_id).uniq.count

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -1,4 +1,4 @@
-class EndOfCycleTimetable
+class CycleTimetable
   CURRENT_YEAR_FOR_SCHEDULE = 2021
 
   # These dates are configuration for when the previous cycle ends and the next cycle starts

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -4,10 +4,10 @@
 
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.courses') %></h2>
-  <% if !@application_form.submitted? && !EndOfCycleTimetable.can_add_course_choice?(@application_form) %>
+  <% if !@application_form.submitted? && !CycleTimetable.can_add_course_choice?(@application_form) %>
     <p class="govuk-body">
       You’ll be able to find courses in <%= days_until_find_reopens %> <%= 'day'.pluralize(days_until_find_reopens) %>
-      (<%= EndOfCycleTimetable.find_reopens.to_s(:govuk_date) %>).
+      (<%= CycleTimetable.find_reopens.to_s(:govuk_date) %>).
       You can keep making changes to the rest of your application until then.
     </p>
   <% else %>

--- a/app/views/candidate_interface/carry_over/start_between_cycles.html.erb
+++ b/app/views/candidate_interface/carry_over/start_between_cycles.html.erb
@@ -6,7 +6,7 @@
 
     <h1 class="govuk-heading-xl"><%= t('page_titles.start_carry_over_between_cycles') %></h1>
 
-    <% if EndOfCycleTimetable.before_find_reopens? %>
+    <% if CycleTimetable.before_find_reopens? %>
       <p class="govuk-body">
         Applications for courses starting in the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.current_year) %> academic year are closed.
       </p>
@@ -16,15 +16,15 @@
       Carry on with your application for courses starting in the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> academic year.
     </p>
 
-    <% if EndOfCycleTimetable.before_apply_reopens? %>
+    <% if CycleTimetable.before_apply_reopens? %>
       <p class="govuk-body">
-        You can submit your application from <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date) %>.
+        You can submit your application from <%= CycleTimetable.apply_reopens.to_s(:govuk_date) %>.
       </p>
     <% end %>
 
     <p class="govuk-body">
       Your courses have been removed.
-      <% if EndOfCycleTimetable.before_find_reopens? %>
+      <% if CycleTimetable.before_find_reopens? %>
         You can add them again later.
       <% else %>
         You can add them again now.

--- a/app/views/candidate_interface/carry_over/start_between_cycles_unsubmitted.html.erb
+++ b/app/views/candidate_interface/carry_over/start_between_cycles_unsubmitted.html.erb
@@ -10,15 +10,15 @@
 
     <p class="govuk-body">But you can carry on with your application for courses starting in the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> academic year.</p>
 
-    <% if EndOfCycleTimetable.before_apply_reopens? %>
+    <% if CycleTimetable.before_apply_reopens? %>
       <p class="govuk-body">
-        You can submit your application from <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date) %>.
+        You can submit your application from <%= CycleTimetable.apply_reopens.to_s(:govuk_date) %>.
       </p>
     <% end %>
 
     <p class="govuk-body">
       Your courses have been removed.
-      <% if EndOfCycleTimetable.before_find_reopens? %>
+      <% if CycleTimetable.before_find_reopens? %>
         You can add them again later.
       <% else %>
         You can add them again now.

--- a/app/views/candidate_interface/start_page/applications_closed.html.erb
+++ b/app/views/candidate_interface/start_page/applications_closed.html.erb
@@ -8,6 +8,6 @@
 
     <p class="govuk-body">Applications for courses starting this year have closed.</p>
 
-    <p class="govuk-body">You can create an account and submit an application from <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date).strip %>.</p>
+    <p class="govuk-body">You can create an account and submit an application from <%= CycleTimetable.apply_reopens.to_s(:govuk_date).strip %>.</p>
   </div>
 </div>

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -34,6 +34,6 @@
 
 <%= render partial: 'candidate_interface/application_form/review', locals: { application_form: @application_form, editable: true } %>
 
-<% unless EndOfCycleTimetable.between_cycles?(@application_form.phase) %>
+<% unless CycleTimetable.between_cycles?(@application_form.phase) %>
   <%= govuk_link_to t('continue'), candidate_interface_start_equality_and_diversity_path, button: true %>
 <% end %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -11,13 +11,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if !EndOfCycleTimetable.can_add_course_choice?(@application_form) %>
+    <% if !CycleTimetable.can_add_course_choice?(@application_form) %>
     <section class="govuk-!-margin-bottom-8">
       <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.courses') %></h2>
 
       <p class="govuk-body">
         You’ll be able to find courses in <%= days_until_find_reopens %> <%= 'day'.pluralize(days_until_find_reopens) %>
-        (<%= EndOfCycleTimetable.find_reopens.to_s(:govuk_date) %>). You can keep making changes to the rest of your application until then.
+        (<%= CycleTimetable.find_reopens.to_s(:govuk_date) %>). You can keep making changes to the rest of your application until then.
       </p>
     </section>
     <% else %>
@@ -249,11 +249,11 @@
     </section>
 
     <section>
-      <% if EndOfCycleTimetable.between_cycles?(@application_form.phase) %>
+      <% if CycleTimetable.between_cycles?(@application_form.phase) %>
         <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.review') %></h2>
-        <p class="govuk-body">You cannot submit your application until <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.</p>
+        <p class="govuk-body">You cannot submit your application until <%= CycleTimetable.apply_reopens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.</p>
         <%= govuk_link_to 'Review your application', candidate_interface_application_review_path, button: true %>
-      <% elsif EndOfCycleTimetable.can_submit?(@application_form) %>
+      <% elsif CycleTimetable.can_submit?(@application_form) %>
         <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.check_and_submit') %></h2>
         <%= govuk_link_to t('section_items.check_and_submit'), candidate_interface_application_review_path, button: true %>
       <% end %>

--- a/app/views/candidate_mailer/_still_interested_content.text.erb
+++ b/app/views/candidate_mailer/_still_interested_content.text.erb
@@ -1,8 +1,8 @@
-<% if EndOfCycleTimetable.between_cycles_apply_2? %>
+<% if CycleTimetable.between_cycles_apply_2? %>
 
 You can apply again for courses starting in the <%= "#{RecruitmentCycle.next_year} to #{RecruitmentCycle.next_year + 1}" %> academic year.
 
-Your last application has been saved. Make any changes and re-submit from <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date) %>.
+Your last application has been saved. Make any changes and re-submit from <%= CycleTimetable.apply_reopens.to_s(:govuk_date) %>.
 
 <% else %>
 

--- a/app/views/provider_interface/hesa_export/new.html.erb
+++ b/app/views/provider_interface/hesa_export/new.html.erb
@@ -12,7 +12,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <%= t('page_titles.provider.export_hesa_data', timeframe: "since #{EndOfCycleTimetable.apply_reopens.to_s(:govuk_date)}") %>
+      <%= t('page_titles.provider.export_hesa_data', timeframe: "since #{CycleTimetable.apply_reopens.to_s(:govuk_date)}") %>
     </h1>
     <p class="govuk-body">
       The data will include all candidates who have accepted an offer from any of your organisations.

--- a/app/views/support_interface/settings/cycles.html.erb
+++ b/app/views/support_interface/settings/cycles.html.erb
@@ -9,7 +9,7 @@
 
       <%= f.govuk_radio_divider %>
 
-      <% (EndOfCycleTimetable.schedules.keys.map(&:to_s) - %w[real]).each_with_index do |option, i | %>
+      <% (CycleTimetable.schedules.keys.map(&:to_s) - %w[real]).each_with_index do |option, i | %>
         <%= f.govuk_radio_button :cycle_schedule_name, option, label: { text: t("cycles.#{option}.name") }, hint: { text: t("cycles.#{option}.description") }, link_errors: i.zero? %>
       <% end %>
     <% end %>
@@ -34,21 +34,21 @@
 <p class="govuk-body">(Today is <%= Time.zone.today.to_s(:govuk_date) %>)</p>
 
 <%= render SummaryListComponent.new(rows: {
-  'Appy 1 deadline' => EndOfCycleTimetable.apply_1_deadline.to_s(:govuk_date),
-  'Stop applications to unavailable course options' => EndOfCycleTimetable.stop_applications_to_unavailable_course_options.to_s(:govuk_date),
-  'Apply 2 deadline' => EndOfCycleTimetable.apply_2_deadline.to_s(:govuk_date),
-  'Find closes on' => EndOfCycleTimetable.find_closes.to_s(:govuk_date),
-  'Find reopens on' => EndOfCycleTimetable.find_reopens.to_s(:govuk_date),
-  'Apply reopens on' => EndOfCycleTimetable.apply_reopens.to_s(:govuk_date),
+  'Appy 1 deadline' => CycleTimetable.apply_1_deadline.to_s(:govuk_date),
+  'Stop applications to unavailable course options' => CycleTimetable.stop_applications_to_unavailable_course_options.to_s(:govuk_date),
+  'Apply 2 deadline' => CycleTimetable.apply_2_deadline.to_s(:govuk_date),
+  'Find closes on' => CycleTimetable.find_closes.to_s(:govuk_date),
+  'Find reopens on' => CycleTimetable.find_reopens.to_s(:govuk_date),
+  'Apply reopens on' => CycleTimetable.apply_reopens.to_s(:govuk_date),
 }) %>
 
 <h2 class="govuk-heading-m">Flags</h2>
 
 <%= render SummaryListComponent.new(rows: {
-  'Show Apply 1 deadline banner?' => boolean_to_word(EndOfCycleTimetable.show_apply_1_deadline_banner?),
-  'Show Apply 2 deadline banner?' => boolean_to_word(EndOfCycleTimetable.show_apply_2_deadline_banner?),
-  'Are we between cycles for Apply 1?' => boolean_to_word(EndOfCycleTimetable.between_cycles_apply_1?),
-  'Are we between cycles for Apply 2?' => boolean_to_word(EndOfCycleTimetable.between_cycles_apply_2?),
-  'Stop applications to unavailable course options?' => boolean_to_word(EndOfCycleTimetable.stop_applications_to_unavailable_course_options?),
-  'Is find down?' => boolean_to_word(EndOfCycleTimetable.find_down?),
+  'Show Apply 1 deadline banner?' => boolean_to_word(CycleTimetable.show_apply_1_deadline_banner?),
+  'Show Apply 2 deadline banner?' => boolean_to_word(CycleTimetable.show_apply_2_deadline_banner?),
+  'Are we between cycles for Apply 1?' => boolean_to_word(CycleTimetable.between_cycles_apply_1?),
+  'Are we between cycles for Apply 2?' => boolean_to_word(CycleTimetable.between_cycles_apply_2?),
+  'Stop applications to unavailable course options?' => boolean_to_word(CycleTimetable.stop_applications_to_unavailable_course_options?),
+  'Is find down?' => boolean_to_word(CycleTimetable.find_down?),
 }) %>

--- a/app/views/support_interface/tasks/confirm_cancel_applications_at_end_of_cycle.html.erb
+++ b/app/views/support_interface/tasks/confirm_cancel_applications_at_end_of_cycle.html.erb
@@ -8,7 +8,7 @@
       <h1 class="govuk-heading-l">Are you sure you want to cancel all unsubmitted applications?</h1>
 
       <p class="govuk-body">This task finds any unsubmitted applications from the most recently closed recruitment cycle and moves them to the <code>application_not_sent</code> status.</p>
-      <p class="govuk-body">This should be run shortly after the Apply 2 deadline closes at midnight on <%= EndOfCycleTimetable.date(:apply_2_deadline).to_s(:govuk_date) %>.</p>
+      <p class="govuk-body">This should be run shortly after the Apply 2 deadline closes at midnight on <%= CycleTimetable.date(:apply_2_deadline).to_s(:govuk_date) %>.</p>
 
       <%= f.govuk_submit 'Yes, I’m sure – cancel all unsubmitted applications', warning: true %>
 

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -43,7 +43,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">End-of-cycle: Cancel unsubmitted applications</h2>
       <p class="govuk-body">This task finds any unsubmitted applications from the most recently closed recruitment cycle and moves them to the <code>application_not_sent</code> status.</p>
-      <p class="govuk-body">It should be run shortly after the Apply 2 deadline closes at midnight on <%= EndOfCycleTimetable.date(:apply_2_deadline).to_s(:govuk_date) %>.</p>
+      <p class="govuk-body">It should be run shortly after the Apply 2 deadline closes at midnight on <%= CycleTimetable.date(:apply_2_deadline).to_s(:govuk_date) %>.</p>
     </div>
     <div class="govuk-grid-column-one-third">
       <%= govuk_link_to 'Cancel applications', support_interface_confirm_cancel_applications_at_end_of_cycle_path, button: true, class: 'govuk-button--warning' %>

--- a/app/workers/cancel_unsubmitted_applications_worker.rb
+++ b/app/workers/cancel_unsubmitted_applications_worker.rb
@@ -10,7 +10,7 @@ class CancelUnsubmittedApplicationsWorker
 private
 
   def unsubmitted_applications_from_earlier_cycle
-    return [] unless EndOfCycleTimetable.between_cycles_apply_2?
+    return [] unless CycleTimetable.between_cycles_apply_2?
 
     ApplicationForm
       .where(submitted_at: nil)

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
 
     context 'when Find is down' do
       it 'removes the link to Find' do
-        Timecop.travel(EndOfCycleTimetable.find_closes.end_of_day + 1.hour) do
+        Timecop.travel(CycleTimetable.find_closes.end_of_day + 1.hour) do
           application_choice = application_form.application_choices.first
           result = render_inline(described_class.new(application_form: application_form))
 

--- a/spec/components/candidate_interface/deadline_banner_component_spec.rb
+++ b/spec/components/candidate_interface/deadline_banner_component_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
       application_form.phase = phase
       FeatureFlag.activate(:deadline_notices)
       allow(flash).to receive(:empty?).and_return true
-      allow(EndOfCycleTimetable).to receive(:show_apply_1_deadline_banner?).and_return(true)
-      allow(EndOfCycleTimetable).to receive(:show_apply_2_deadline_banner?).and_return(true)
+      allow(CycleTimetable).to receive(:show_apply_1_deadline_banner?).and_return(true)
+      allow(CycleTimetable).to receive(:show_apply_2_deadline_banner?).and_return(true)
     end
 
     it 'renders the Apply 1 banner when the right conditions are met' do
@@ -49,8 +49,8 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
 
     it 'renders nothing if it\'s not the right time to show the banner' do
       configure_conditions_for_rendering_banner('apply_1')
-      allow(EndOfCycleTimetable).to receive(:show_apply_1_deadline_banner?).and_return(false)
-      allow(EndOfCycleTimetable).to receive(:show_apply_2_deadline_banner?).and_return(false)
+      allow(CycleTimetable).to receive(:show_apply_1_deadline_banner?).and_return(false)
+      allow(CycleTimetable).to receive(:show_apply_2_deadline_banner?).and_return(false)
 
       result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
 
@@ -59,7 +59,7 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
 
     it 'renders a banner if the timetable says only one of them should be shown' do
       configure_conditions_for_rendering_banner('apply_2')
-      allow(EndOfCycleTimetable).to receive(:show_apply_1_deadline_banner?).and_return(false)
+      allow(CycleTimetable).to receive(:show_apply_1_deadline_banner?).and_return(false)
 
       result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
 

--- a/spec/components/candidate_interface/grouped_provider_courses_component_spec.rb
+++ b/spec/components/candidate_interface/grouped_provider_courses_component_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CandidateInterface::GroupedProviderCoursesComponent do
 
   context 'when find is down' do
     it 'does not include a link to find' do
-      Timecop.travel(EndOfCycleTimetable.find_closes.end_of_day + 1.hour) do
+      Timecop.travel(CycleTimetable.find_closes.end_of_day + 1.hour) do
         result = render_inline(
           described_class.new(courses_by_provider_and_region: @courses_by_provider_and_region),
         )

--- a/spec/components/candidate_interface/offer_review_component_spec.rb
+++ b/spec/components/candidate_interface/offer_review_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
            course_option: course_option,
            application_form: application_form)
   end
-  let(:find_closes) { EndOfCycleTimetable::CYCLE_DATES.dig(Time.zone.now.year, :find_closes) }
+  let(:find_closes) { CycleTimetable::CYCLE_DATES.dig(Time.zone.now.year, :find_closes) }
 
   it 'renders component with correct values for the provider' do
     result = render_inline(described_class.new(course_choice: application_choice))

--- a/spec/components/candidate_interface/reopen_banner_component_spec.rb
+++ b/spec/components/candidate_interface/reopen_banner_component_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
       application_form.phase = phase
       FeatureFlag.activate(:deadline_notices)
       allow(flash).to receive(:empty?).and_return true
-      allow(EndOfCycleTimetable).to receive(:between_cycles_apply_1?).and_return(true)
-      allow(EndOfCycleTimetable).to receive(:between_cycles_apply_2?).and_return(true)
+      allow(CycleTimetable).to receive(:between_cycles_apply_1?).and_return(true)
+      allow(CycleTimetable).to receive(:between_cycles_apply_2?).and_return(true)
     end
 
     it 'renders the banner for an Apply 1 app' do
@@ -43,7 +43,7 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
 
     it 'does not render when we are not between cycles' do
       configure_conditions_for_rendering_banner('apply_1')
-      allow(EndOfCycleTimetable).to receive(:between_cycles_apply_1?).and_return(false)
+      allow(CycleTimetable).to receive(:between_cycles_apply_1?).and_return(false)
 
       result = render_inline(
         described_class.new(

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       context 'when it is before the apply_2_deadline' do
         before do
-          allow(EndOfCycleTimetable).to receive(:between_cycles_apply_2?).and_return(false)
+          allow(CycleTimetable).to receive(:between_cycles_apply_2?).and_return(false)
         end
 
         it 'informs the candidate they can apply again this year' do
@@ -159,8 +159,8 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       context 'when it is after the apply_2_deadline' do
         before do
-          allow(EndOfCycleTimetable).to receive(:between_cycles_apply_2?).and_return(true)
-          allow(EndOfCycleTimetable).to receive(:apply_reopens).and_return(Date.new(2021, 10, 13))
+          allow(CycleTimetable).to receive(:between_cycles_apply_2?).and_return(true)
+          allow(CycleTimetable).to receive(:apply_reopens).and_return(Date.new(2021, 10, 13))
           allow(RecruitmentCycle).to receive(:next_year).and_return(2022)
         end
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       context 'when it is before the apply_2_deadline' do
         before do
-          allow(EndOfCycleTimetable).to receive(:between_cycles_apply_2?).and_return(false)
+          allow(CycleTimetable).to receive(:between_cycles_apply_2?).and_return(false)
         end
 
         it_behaves_like(
@@ -138,8 +138,8 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       context 'when it is after the apply_2_deadline' do
         before do
-          allow(EndOfCycleTimetable).to receive(:between_cycles_apply_2?).and_return(true)
-          allow(EndOfCycleTimetable).to receive(:apply_reopens).and_return(Date.new(2021, 10, 13))
+          allow(CycleTimetable).to receive(:between_cycles_apply_2?).and_return(true)
+          allow(CycleTimetable).to receive(:apply_reopens).and_return(Date.new(2021, 10, 13))
           allow(RecruitmentCycle).to receive(:next_year).and_return(2022)
         end
 

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -2,18 +2,18 @@ require 'rails_helper'
 
 RSpec.describe RecruitmentCycle do
   describe '.current_year' do
-    it 'delegates to EndOfCycleTimetable' do
-      allow(EndOfCycleTimetable).to receive(:current_year)
+    it 'delegates to ECycleTimetable' do
+      allow(CycleTimetable).to receive(:current_year)
 
       RecruitmentCycle.current_year
 
-      expect(EndOfCycleTimetable).to have_received(:current_year)
+      expect(CycleTimetable).to have_received(:current_year)
     end
   end
 
   describe '.next_year' do
     it 'is 2021 if the current year is 2020' do
-      allow(EndOfCycleTimetable).to receive(:current_year).and_return(2020)
+      allow(CycleTimetable).to receive(:current_year).and_return(2020)
 
       expect(RecruitmentCycle.next_year).to eq(2021)
     end
@@ -21,7 +21,7 @@ RSpec.describe RecruitmentCycle do
 
   describe '.previous_year' do
     it 'is 2019 if the current year is 2020' do
-      allow(EndOfCycleTimetable).to receive(:current_year).and_return(2020)
+      allow(CycleTimetable).to receive(:current_year).and_return(2020)
 
       expect(RecruitmentCycle.previous_year).to eq(2019)
     end
@@ -29,7 +29,7 @@ RSpec.describe RecruitmentCycle do
 
   describe '.cycle_name' do
     it 'defaults from current year to the following year' do
-      allow(EndOfCycleTimetable).to receive(:current_year).and_return(2020)
+      allow(CycleTimetable).to receive(:current_year).and_return(2020)
 
       expect(RecruitmentCycle.cycle_name).to eq('2019 to 2020')
     end

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe EndOfCycleTimetable do
+RSpec.describe CycleTimetable do
   let(:one_hour_before_apply1_deadline) { Time.zone.local(2020, 8, 24, 23, 0, 0) }
   let(:one_hour_after_apply1_deadline) { Time.zone.local(2020, 8, 25, 1, 0, 0) }
   let(:one_hour_before_apply2_deadline) { Time.zone.local(2020, 9, 18, 23, 0, 0) }
@@ -10,13 +10,13 @@ RSpec.describe EndOfCycleTimetable do
   describe '.current_year' do
     it 'is 2020 if we are in the middle of the 2020 cycle' do
       Timecop.travel(Time.zone.local(2020, 1, 1, 12, 0, 0)) do
-        expect(EndOfCycleTimetable.current_year).to eq(2020)
+        expect(CycleTimetable.current_year).to eq(2020)
       end
     end
 
     it 'is 2021 if we are in the middle of the 2021 cycle' do
       Timecop.travel(Time.zone.local(2020, 11, 1, 12, 0, 0)) do
-        expect(EndOfCycleTimetable.current_year).to eq(2021)
+        expect(CycleTimetable.current_year).to eq(2021)
       end
     end
   end
@@ -24,13 +24,13 @@ RSpec.describe EndOfCycleTimetable do
   describe '.show_apply_1_deadline_banner?' do
     it 'returns true before the configured date' do
       Timecop.travel(one_hour_before_apply1_deadline) do
-        expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be true
+        expect(CycleTimetable.show_apply_1_deadline_banner?).to be true
       end
     end
 
     it 'returns false after the configured date' do
       Timecop.travel(one_hour_after_apply1_deadline) do
-        expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be false
+        expect(CycleTimetable.show_apply_1_deadline_banner?).to be false
       end
     end
   end
@@ -38,13 +38,13 @@ RSpec.describe EndOfCycleTimetable do
   describe '.show_apply_2_deadline_banner?' do
     it 'returns true before the configured date' do
       Timecop.travel(one_hour_before_apply2_deadline) do
-        expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be true
+        expect(CycleTimetable.show_apply_2_deadline_banner?).to be true
       end
     end
 
     it 'returns false after the configured date' do
       Timecop.travel(one_hour_after_apply2_deadline) do
-        expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be false
+        expect(CycleTimetable.show_apply_2_deadline_banner?).to be false
       end
     end
   end
@@ -52,19 +52,19 @@ RSpec.describe EndOfCycleTimetable do
   describe '.between_cycles_apply_1?' do
     it 'returns false before the configured date' do
       Timecop.travel(one_hour_before_apply1_deadline) do
-        expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
+        expect(CycleTimetable.between_cycles_apply_1?).to be false
       end
     end
 
     it 'returns true after the configured date' do
       Timecop.travel(one_hour_after_apply1_deadline) do
-        expect(EndOfCycleTimetable.between_cycles_apply_1?).to be true
+        expect(CycleTimetable.between_cycles_apply_1?).to be true
       end
     end
 
     it 'returns false after the new cycle opens' do
       Timecop.travel(one_hour_after_2021_cycle_opens) do
-        expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
+        expect(CycleTimetable.between_cycles_apply_1?).to be false
       end
     end
   end
@@ -72,39 +72,39 @@ RSpec.describe EndOfCycleTimetable do
   describe '.between_cycles_apply_2?' do
     it 'returns false before the configured date' do
       Timecop.travel(one_hour_before_apply2_deadline) do
-        expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
+        expect(CycleTimetable.between_cycles_apply_2?).to be false
       end
     end
 
     it 'returns true after the configured date' do
       Timecop.travel(one_hour_after_apply2_deadline) do
-        expect(EndOfCycleTimetable.between_cycles_apply_2?).to be true
+        expect(CycleTimetable.between_cycles_apply_2?).to be true
       end
     end
 
     it 'returns false after the new cycle opens' do
       Timecop.travel(one_hour_after_2021_cycle_opens) do
-        expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
+        expect(CycleTimetable.between_cycles_apply_2?).to be false
       end
     end
   end
 
   describe '.find_down?' do
     it 'returns false before find closes' do
-      Timecop.travel(EndOfCycleTimetable.find_closes.beginning_of_day - 1.hour) do
-        expect(EndOfCycleTimetable.find_down?).to be false
+      Timecop.travel(CycleTimetable.find_closes.beginning_of_day - 1.hour) do
+        expect(CycleTimetable.find_down?).to be false
       end
     end
 
     it 'returns false after find_reopens' do
-      Timecop.travel(EndOfCycleTimetable.find_reopens.end_of_day + 1.hour) do
-        expect(EndOfCycleTimetable.find_down?).to be false
+      Timecop.travel(CycleTimetable.find_reopens.end_of_day + 1.hour) do
+        expect(CycleTimetable.find_down?).to be false
       end
     end
 
     it 'returns true between find_closes and find_reopens' do
-      Timecop.travel(EndOfCycleTimetable.find_closes.end_of_day + 1.hour) do
-        expect(EndOfCycleTimetable.find_down?).to be true
+      Timecop.travel(CycleTimetable.find_closes.end_of_day + 1.hour) do
+        expect(CycleTimetable.find_down?).to be true
       end
     end
   end
@@ -130,19 +130,19 @@ RSpec.describe EndOfCycleTimetable do
   describe 'stop_applications_to_unavailable_course_options?' do
     it 'is true when between "stop_applications_to_unavailable_course_options" and "apply_reopens"' do
       Timecop.travel(Time.zone.local(2020, 9, 7).end_of_day + 1.minute) do
-        expect(EndOfCycleTimetable.stop_applications_to_unavailable_course_options?).to be true
+        expect(CycleTimetable.stop_applications_to_unavailable_course_options?).to be true
       end
     end
 
     it 'is false when before the window' do
       Timecop.travel(Time.zone.local(2020, 9, 7).end_of_day - 1.minute) do
-        expect(EndOfCycleTimetable.stop_applications_to_unavailable_course_options?).to be false
+        expect(CycleTimetable.stop_applications_to_unavailable_course_options?).to be false
       end
     end
 
     it 'is false when after the window' do
       Timecop.travel(Time.zone.local(2020, 10, 13).beginning_of_day) do
-        expect(EndOfCycleTimetable.stop_applications_to_unavailable_course_options?).to be false
+        expect(CycleTimetable.stop_applications_to_unavailable_course_options?).to be false
       end
     end
   end
@@ -155,7 +155,7 @@ RSpec.describe EndOfCycleTimetable do
 
       context 'when the date is after the apply1 submission deadline' do
         it 'returns false' do
-          Timecop.travel(EndOfCycleTimetable.apply_1_deadline + 1.day) do
+          Timecop.travel(CycleTimetable.apply_1_deadline + 1.day) do
             expect(execute_service).to eq false
           end
         end
@@ -163,7 +163,7 @@ RSpec.describe EndOfCycleTimetable do
 
       context 'when the date is before the apply1 submission deadline' do
         it 'returns true' do
-          Timecop.travel(EndOfCycleTimetable.apply_1_deadline) do
+          Timecop.travel(CycleTimetable.apply_1_deadline) do
             expect(execute_service).to eq true
           end
         end
@@ -171,7 +171,7 @@ RSpec.describe EndOfCycleTimetable do
 
       context 'when the date is post find reopening' do
         it 'returns true' do
-          Timecop.travel(EndOfCycleTimetable.find_reopens) do
+          Timecop.travel(CycleTimetable.find_reopens) do
             expect(execute_service).to eq true
           end
         end
@@ -183,7 +183,7 @@ RSpec.describe EndOfCycleTimetable do
 
       context 'when the date is after the apply again submission deadline' do
         it 'returns false' do
-          Timecop.travel(EndOfCycleTimetable.apply_2_deadline + 1.day) do
+          Timecop.travel(CycleTimetable.apply_2_deadline + 1.day) do
             expect(execute_service).to eq false
           end
         end
@@ -191,7 +191,7 @@ RSpec.describe EndOfCycleTimetable do
 
       context 'when the date is before the apply again submission deadline' do
         it 'returns true' do
-          Timecop.travel(EndOfCycleTimetable.apply_2_deadline) do
+          Timecop.travel(CycleTimetable.apply_2_deadline) do
             expect(execute_service).to eq true
           end
         end
@@ -199,7 +199,7 @@ RSpec.describe EndOfCycleTimetable do
 
       context 'when the date is post find reopening' do
         it 'returns true' do
-          Timecop.travel(EndOfCycleTimetable.apply_reopens) do
+          Timecop.travel(CycleTimetable.apply_reopens) do
             expect(execute_service).to eq true
           end
         end

--- a/spec/support/test_helpers/cycle_timetable_helper.rb
+++ b/spec/support/test_helpers/cycle_timetable_helper.rb
@@ -30,10 +30,10 @@ module CycleTimetableHelper
 private
 
   def previous_end_of_cycle_timetable
-    EndOfCycleTimetable::CYCLE_DATES[EndOfCycleTimetable::CURRENT_YEAR_FOR_SCHEDULE - 1]
+    CycleTimetable::CYCLE_DATES[CycleTimetable::CURRENT_YEAR_FOR_SCHEDULE - 1]
   end
 
   def current_end_of_cycle_timetable
-    EndOfCycleTimetable::CYCLE_DATES[EndOfCycleTimetable::CURRENT_YEAR_FOR_SCHEDULE]
+    CycleTimetable::CYCLE_DATES[CycleTimetable::CURRENT_YEAR_FOR_SCHEDULE]
   end
 end

--- a/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_between_cycles_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
   end
 
   def then_i_can_see_that_i_need_to_select_courses_when_apply_reopens
-    expect(page).to have_content "You’ll be able to find courses in #{(EndOfCycleTimetable.find_reopens - Time.zone.today).to_i} days (#{EndOfCycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You’ll be able to find courses in #{(CycleTimetable.find_reopens - Time.zone.today).to_i} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
     expect(page).not_to have_link 'Choose your courses'
   end
 end

--- a/spec/system/candidate_interface/apply_again/carry_over_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/apply_again/carry_over_unsuccessful_application_between_cycles_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_click_on_start_now
-    expect(page).to have_content "You can submit your application from #{EndOfCycleTimetable.apply_reopens.to_s(:govuk_date)}."
+    expect(page).to have_content "You can submit your application from #{CycleTimetable.apply_reopens.to_s(:govuk_date)}."
     expect(page).to have_content 'Your courses have been removed. You can add them again later.'
     click_button 'Apply again'
   end
@@ -72,7 +72,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_can_see_that_no_courses_are_selected_and_i_cannot_add_any_yet
-    expect(page).to have_content "You’ll be able to find courses in #{(EndOfCycleTimetable.find_reopens - Time.zone.today).to_i} days (#{EndOfCycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You’ll be able to find courses in #{(CycleTimetable.find_reopens - Time.zone.today).to_i} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
     expect(page).not_to have_link 'Course choice'
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Candidate vists their application form after the cycle has ended
   end
 
   def then_i_see_that_i_can_add_new_course_choices_in_october
-    expect(page).to have_content "You’ll be able to find courses in #{(EndOfCycleTimetable.find_reopens - Time.zone.today).to_i} days (#{EndOfCycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You’ll be able to find courses in #{(CycleTimetable.find_reopens - Time.zone.today).to_i} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
   end
 
   def and_there_is_not_a_link_to_the_course_choices_section

--- a/spec/system/candidate_interface/end_of_cycle/candidate_with_unsubmitted_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/end_of_cycle/candidate_with_unsubmitted_application_between_cycles_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Candidate attempts to submit the application after the end-of-cyc
 
   def then_i_can_only_review_my_application
     expect(page).not_to have_link 'Check and submit your application'
-    expect(page).to have_content "You cannot submit your application until #{EndOfCycleTimetable.apply_reopens.to_s(:govuk_date)}. You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You cannot submit your application until #{CycleTimetable.apply_reopens.to_s(:govuk_date)}. You can keep making changes to the rest of your application until then."
     click_link 'Review your application'
   end
 

--- a/spec/system/support_interface/cycle_switching_spec.rb
+++ b/spec/system/support_interface/cycle_switching_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Cycle switching' do
 
   def then_i_see_the_cycle_information
     expect(page).to have_title 'Recruitment cycles'
-    expect(page).to have_content("Find closes on\n#{EndOfCycleTimetable.find_closes.to_s(:govuk_date)}")
+    expect(page).to have_content("Find closes on\n#{CycleTimetable.find_closes.to_s(:govuk_date)}")
   end
 
   def when_i_click_to_choose_a_new_schedule
@@ -32,6 +32,6 @@ RSpec.feature 'Cycle switching' do
   end
 
   def then_the_schedule_is_updated
-    expect(page).to have_content("Appy 1 deadline\n#{EndOfCycleTimetable.apply_1_deadline.to_s(:govuk_date)}")
+    expect(page).to have_content("Appy 1 deadline\n#{CycleTimetable.apply_1_deadline.to_s(:govuk_date)}")
   end
 end

--- a/spec/system/support_interface/feature_metrics_dashboard_spec.rb
+++ b/spec/system/support_interface/feature_metrics_dashboard_spec.rb
@@ -97,7 +97,7 @@ RSpec.feature 'Feature metrics dashboard' do
 
   def and_there_are_candidates_and_application_forms_in_the_system
     ApplicationForm.with_unsafe_application_choice_touches do
-      allow(EndOfCycleTimetable).to receive(:apply_reopens).and_return(60.days.ago)
+      allow(CycleTimetable).to receive(:apply_reopens).and_return(60.days.ago)
       Timecop.freeze(@today - 65.days) do
         @previous_application_form = create_application_form_with_references(recruitment_cycle_year: 2020).first
       end

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Structured reasons for rejection dashboard' do
   end
 
   def and_there_are_candidates_and_application_forms_in_the_system
-    allow(EndOfCycleTimetable).to receive(:apply_reopens).and_return(60.days.ago)
+    allow(CycleTimetable).to receive(:apply_reopens).and_return(60.days.ago)
     @application_choice1 = create(:application_choice, :awaiting_provider_decision)
     @application_choice2 = create(:application_choice, :awaiting_provider_decision)
     @application_choice3 = create(:application_choice, :awaiting_provider_decision)


### PR DESCRIPTION
## Context

Part of the EoC refactor – this is just to rename the class.

## Changes proposed in this pull request

A lot of changes but this is just a rename of `EndOfCycleTimetable` to `CycleTimetable`.

## Guidance to review

[Discussion per slack](https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1625044581486100)

## Link to Trello card

https://trello.com/c/bbSxTl1H

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
