### PR TITLE
Add provider permissions edit form

### DIFF
--- a/app/components/provider_interface/organisation_permissions_form_component.html.erb
+++ b/app/components/provider_interface/organisation_permissions_form_component.html.erb
@@ -1,0 +1,31 @@
+<%= form_with(
+  model: provider_relationship_permission,
+  url: form_url,
+  method: form_method,
+) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l"><%= page_caption %></span>
+  <h1 class="govuk-heading-l">
+    <%= page_heading %>
+  </h1>
+
+  <p class="govuk-body"><%= t('.explanation') %></p>
+
+  <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| %>
+    <div class="govuk-form-group">
+      <%= f.govuk_fieldset legend: { text: label_for(permission_name) } do %>
+        <% checkbox_details_for_providers.each_with_index do |checkbox_details, index| %>
+          <%= f.govuk_check_box(
+            "#{checkbox_details[:type]}_provider_can_#{permission_name}",
+            true,
+            label: { text: checkbox_details[:name] },
+            link_errors: index.zero?,
+          ) %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= f.govuk_submit t(".#{mode}.submit_button") %>
+<% end %>

--- a/app/components/provider_interface/organisation_permissions_form_component.rb
+++ b/app/components/provider_interface/organisation_permissions_form_component.rb
@@ -1,0 +1,82 @@
+module ProviderInterface
+  class OrganisationPermissionsFormComponent < ViewComponent::Base
+    attr_reader :provider_user, :provider_relationship_permission, :mode, :form_url
+
+    def initialize(provider_user:, provider_relationship_permission:, mode:, form_url:)
+      @provider_user = provider_user
+      @provider_relationship_permission = provider_relationship_permission
+      @mode = mode
+      @form_url = form_url
+    end
+
+    def page_caption
+      if mode == :edit
+        provider_relationship_description
+      elsif mode == :setup
+        t('.setup.caption')
+      end
+    end
+
+    def page_heading
+      if mode == :edit
+        t('.edit.heading')
+      elsif mode == :setup
+        provider_relationship_description
+      end
+    end
+
+    def checkbox_details_for_providers
+      ordered_providers.map do |provider_type|
+        {
+          name: name_for_provider_of_type(provider_type),
+          type: provider_type,
+        }
+      end
+    end
+
+    def label_for(permission_name)
+      "Who can #{t("provider_relationship_permissions.#{permission_name}.description").downcase}?"
+    end
+
+    def form_method
+      if mode == :edit
+        :patch
+      elsif mode == :setup
+        :post
+      end
+    end
+
+  private
+
+    def provider_relationship_description
+      provider_names = ordered_providers.map { |provider_type| name_for_provider_of_type(provider_type) }
+      provider_names.join(' and ')
+    end
+
+    def ordered_providers
+      providers = %w[training ratifying]
+
+      if provider_user_belongs_to_training_provider?
+        providers
+      else
+        providers.reverse
+      end
+    end
+
+    def provider_user_belongs_to_training_provider?
+      provider_user.providers.include? training_provider
+    end
+
+    def name_for_provider_of_type(provider_type)
+      send("#{provider_type}_provider").name
+    end
+
+    def training_provider
+      @training_provider ||= provider_relationship_permission.training_provider
+    end
+
+    def ratifying_provider
+      @ratifying_provider ||= provider_relationship_permission.ratifying_provider
+    end
+  end
+end

--- a/app/components/provider_interface/organisation_permissions_form_component.rb
+++ b/app/components/provider_interface/organisation_permissions_form_component.rb
@@ -35,7 +35,8 @@ module ProviderInterface
     end
 
     def label_for(permission_name)
-      "Who can #{t("provider_relationship_permissions.#{permission_name}.description").downcase}?"
+      permission_description = t("provider_relationship_permissions.#{permission_name}.description")
+      t('provider_relationship_permissions.question', permission_description: permission_description.downcase)
     end
 
     def form_method

--- a/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
@@ -24,7 +24,7 @@
         <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| %>
           <div class="govuk-form-group <%= permission_name.to_s.dasherize %>" id="<%= permission_name %>">
             <%= pf.govuk_check_boxes_fieldset permission_name, legend: { text: "Who can #{permission_name.to_s.humanize.downcase}?" } do %>
-              <div id="makedecisions-hint" class="govuk-hint"><%= t("provider_relationship_permissions.#{permission_name}") %></div>
+              <div id="makedecisions-hint" class="govuk-hint"><%= t("provider_relationship_permissions.#{permission_name}.hint") %></div>
               <%= hidden_field_tag "#{pf.object_name}[#{permission_name}][]", '' %>
               <%= pf.govuk_check_box permission_name, 'training',
                                      label: { text: @permissions_model.training_provider.name },

--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -1,5 +1,6 @@
 en:
   provider_relationship_permissions:
+    question: Who can %{permission_description}?
     make_decisions:
       description: Make offers and reject applications
       hint: This includes making offers, amending offers and rejecting applications

--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -1,8 +1,11 @@
 en:
   provider_relationship_permissions:
     make_decisions:
+      description: Make offers and reject applications
       hint: This includes making offers, amending offers and rejecting applications
     view_safeguarding_information:
+      description: View criminal convictions and professional misconduct
       hint: This information is in the ‘criminal convictions and professional misconduct’ section of the application
     view_diversity_information:
+      description: View sex, disability and ethnicity information
       hint: This information is in the ‘equality and diversity’ section of the application – it includes sex, ethnicity and disability status

--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -9,3 +9,12 @@ en:
     view_diversity_information:
       description: View sex, disability and ethnicity information
       hint: This information is in the ‘equality and diversity’ section of the application – it includes sex, ethnicity and disability status
+  provider_interface:
+    organisation_permissions_form_component:
+      explanation: All users can view applications.
+      setup:
+        caption: Set up organisation permissions
+        submit_button: Continue
+      edit:
+        heading: Organisation permissions
+        submit_button: Save organisation permissions

--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -1,5 +1,8 @@
 en:
   provider_relationship_permissions:
-    make_decisions: This includes making offers, amending offers and rejecting applications
-    view_safeguarding_information: This information is in the ‘criminal convictions and professional misconduct’ section of the application
-    view_diversity_information: This information is in the ‘equality and diversity’ section of the application – it includes sex, ethnicity and disability status
+    make_decisions:
+      hint: This includes making offers, amending offers and rejecting applications
+    view_safeguarding_information:
+      hint: This information is in the ‘criminal convictions and professional misconduct’ section of the application
+    view_diversity_information:
+      hint: This information is in the ‘equality and diversity’ section of the application – it includes sex, ethnicity and disability status

--- a/spec/components/previews/provider_interface/organisation_permissions_form_component_preview.rb
+++ b/spec/components/previews/provider_interface/organisation_permissions_form_component_preview.rb
@@ -1,0 +1,42 @@
+module ProviderInterface
+  class OrganisationPermissionsFormComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
+    def setup_permissions
+      render OrganisationPermissionsFormComponent.new(
+        provider_user: example_provider_user,
+        provider_relationship_permission: example_provider_relationship,
+        mode: :setup,
+        form_url: '/setup',
+      )
+    end
+
+    def edit_permissions
+      render OrganisationPermissionsFormComponent.new(
+        provider_user: example_provider_user,
+        provider_relationship_permission: example_provider_relationship,
+        mode: :edit,
+        form_url: '/edit',
+      )
+    end
+
+  private
+
+    def example_provider_relationship
+      @example_relationship ||= FactoryBot.build_stubbed(
+        :provider_relationship_permissions,
+        training_provider_can_make_decisions: [true, false].sample,
+        training_provider_can_view_safeguarding_information: [true, false].sample,
+        training_provider_can_view_diversity_information: [true, false].sample,
+        ratifying_provider_can_make_decisions: [true, false].sample,
+        ratifying_provider_can_view_safeguarding_information: [true, false].sample,
+        ratifying_provider_can_view_diversity_information: [true, false].sample,
+      )
+    end
+
+    def example_provider_user
+      provider = [example_provider_relationship.training_provider, example_provider_relationship.ratifying_provider].sample
+      FactoryBot.build_stubbed(:provider_user, providers: [provider])
+    end
+  end
+end

--- a/spec/components/provider_interface/organisation_permissions_form_component_spec.rb
+++ b/spec/components/provider_interface/organisation_permissions_form_component_spec.rb
@@ -1,0 +1,146 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::OrganisationPermissionsFormComponent do
+  let(:provider_relationship_permission) { build_stubbed(:provider_relationship_permissions) }
+  let(:training_provider) { provider_relationship_permission.training_provider }
+  let(:ratifying_provider) { provider_relationship_permission.ratifying_provider }
+  let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider]) }
+  let(:mode) { :setup }
+
+  let(:render) do
+    render_inline(
+      described_class.new(
+        provider_user: provider_user,
+        provider_relationship_permission: provider_relationship_permission,
+        mode: mode,
+        form_url: '',
+      ),
+    )
+  end
+
+  context 'when mode is setup' do
+    it 'renders the correct button text' do
+      expect(render.css('button').text).to eq('Continue')
+    end
+
+    it 'renders the correct caption' do
+      expect(render.css('.govuk-caption-l').text.squish).to eq('Set up organisation permissions')
+    end
+
+    context 'when the provider user is part of the training provider' do
+      it 'renders the heading with the training provider first' do
+        expected_heading = "#{training_provider.name} and #{ratifying_provider.name}"
+        expect(render.css('h1').text.squish).to eq(expected_heading)
+      end
+    end
+
+    context 'when the provider user is part of the ratifying provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [ratifying_provider]) }
+
+      it 'renders the heading with the ratifying provider first' do
+        expected_heading = "#{ratifying_provider.name} and #{training_provider.name}"
+        expect(render.css('h1').text.squish).to eq(expected_heading)
+      end
+    end
+
+    context 'when the provider user is part of both of the providers' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider, ratifying_provider]) }
+
+      it 'renders the heading with the training provider first' do
+        expected_heading = "#{training_provider.name} and #{ratifying_provider.name}"
+        expect(render.css('h1').text.squish).to eq(expected_heading)
+      end
+    end
+  end
+
+  context 'when mode is edit' do
+    let(:mode) { :edit }
+
+    it 'renders the correct button text' do
+      expect(render.css('button').text).to eq('Save organisation permissions')
+    end
+
+    it 'renders the correct heading' do
+      expect(render.css('h1').text.squish).to eq('Organisation permissions')
+    end
+
+    context 'when the provider user is part of the training provider' do
+      it 'renders the heading with the training provider first' do
+        expected_heading = "#{training_provider.name} and #{ratifying_provider.name}"
+        expect(render.css('.govuk-caption-l').text.squish).to eq(expected_heading)
+      end
+    end
+
+    context 'when the provider user is part of the ratifying provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [ratifying_provider]) }
+
+      it 'renders the heading with the ratifying provider first' do
+        expected_heading = "#{ratifying_provider.name} and #{training_provider.name}"
+        expect(render.css('.govuk-caption-l').text.squish).to eq(expected_heading)
+      end
+    end
+
+    context 'when the provider user is part of both of the providers' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider, ratifying_provider]) }
+
+      it 'renders the heading with the training provider first' do
+        expected_heading = "#{training_provider.name} and #{ratifying_provider.name}"
+        expect(render.css('.govuk-caption-l').text.squish).to eq(expected_heading)
+      end
+    end
+  end
+
+  it 'renders the explanation about view applications permissions' do
+    expect(render.css('p').text.squish).to eq('All users can view applications.')
+  end
+
+  describe 'form group legends' do
+    it 'renders the correct legend for make decisions' do
+      expect(render.css('legend')[0].text).to eq('Who can make offers and reject applications?')
+    end
+
+    it 'renders the correct legend for view safeguarding' do
+      expect(render.css('legend')[1].text).to eq('Who can view criminal convictions and professional misconduct?')
+    end
+
+    it 'renders the correct legend for view diversity' do
+      expect(render.css('legend')[2].text).to eq('Who can view sex, disability and ethnicity information?')
+    end
+  end
+
+  describe 'order of checkboxes for providers' do
+    context 'when the provider user is part of the training provider' do
+      it 'renders the checkbox for the training provider first' do
+        fieldsets = render.css('fieldset')
+        fieldsets.each do |fieldset|
+          expect(fieldset.css('label').first.text).to eq(training_provider.name)
+          expect(fieldset.css('label').last.text).to eq(ratifying_provider.name)
+        end
+      end
+    end
+
+    context 'when the provider user is part of the ratifying provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [ratifying_provider]) }
+
+      it 'renders the checkbox for the ratifying provider first' do
+        fieldsets = render.css('fieldset')
+        fieldsets.each do |fieldset|
+          expect(fieldset.css('label').first.text).to eq(ratifying_provider.name)
+          expect(fieldset.css('label').last.text).to eq(training_provider.name)
+        end
+      end
+    end
+
+    context 'when the provider user is part of both of the providers' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider, ratifying_provider]) }
+
+      it 'renders the checkbox for the training provider first' do
+        fieldsets = render.css('fieldset')
+        fieldsets.each do |fieldset|
+          expect(fieldset.css('label').first.text).to eq(training_provider.name)
+          expect(fieldset.css('label').last.text).to eq(ratifying_provider.name)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
We are making content and flow changes for provider permissions. Adding a new component helps to commonise the logic around editing permissions

## Changes proposed in this pull request
Add a component, preview and specs

## Guidance to review
Test out the preview: http://apply-for-te-3889-permi-uxdbvt.herokuapp.com/rails/view_components/provider_interface/organisation_permissions_form_component

## Link to Trello card
https://trello.com/c/J1ztSOwX/3889-add-a-component-for-the-permission-form-checkboxes

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
