### PR TITLE
Revert "Allow monitoring the staging app"

### DIFF
--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -12,9 +12,6 @@ key_vault_name              = "s121t01-shared-kv-01"
 key_vault_app_secret_name   = "APPLY-APP-SECRETS-STAGING"
 key_vault_infra_secret_name = "BAT-INFRA-SECRETS-STAGING"
 
-# Network Policy
-prometheus_app = "prometheus-bat"
-
 # StatusCake
 statuscake_alerts = {
   apply-staging = {


### PR DESCRIPTION
## Context

Failed deployment when trying to monitor staging rails from production.

## Changes proposed in this pull request

Reverting https://github.com/DFE-Digital/apply-for-teacher-training/pull/5070

This is because the network policy is created by the staging paas user but it needs access to the production space as prometheus is in production. We can't let this happen to keep environments segregated.

## Guidance to review

## Link to Trello card

https://trello.com/c/tGZf1JTK/475-enable-monitoring-on-staging-and-sandbox

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
