### PR TITLE
Add query returning provider relationships that the user can manage

### DIFF
--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -565,4 +565,44 @@ RSpec.describe ProviderAuthorisation do
       end
     end
   end
+
+  describe '#provider_relationships_that_actor_can_manage_organisations_for' do
+    let(:training_provider) { create(:provider) }
+    let(:ratifying_provider) { create(:provider) }
+
+    let!(:provider_relationship) do
+      create(
+        :provider_relationship_permissions,
+        training_provider: training_provider,
+        ratifying_provider: ratifying_provider,
+      )
+    end
+
+    it 'returns training provider relationships the user has manage orgs for' do
+      provider_user = create(:provider_user, providers: [training_provider])
+
+      ProviderPermissions.find_by(
+        provider_user: provider_user,
+        provider: training_provider,
+      ).update!(manage_organisations: true)
+
+      expect(ProviderAuthorisation.new(actor: provider_user).provider_relationships_that_actor_can_manage_organisations_for).to eq([provider_relationship])
+    end
+
+    it 'returns ratifying provider relationships the user has manage orgs for' do
+      provider_user = create(:provider_user, providers: [ratifying_provider])
+
+      ProviderPermissions.find_by(
+        provider_user: provider_user,
+        provider: ratifying_provider,
+      ).update!(manage_organisations: true)
+
+      expect(ProviderAuthorisation.new(actor: provider_user).provider_relationships_that_actor_can_manage_organisations_for).to eq([provider_relationship])
+    end
+
+    it 'does not return any relationships if user lacks manage orgs' do
+      provider_user = create(:provider_user, providers: [training_provider, ratifying_provider])
+      expect(ProviderAuthorisation.new(actor: provider_user).provider_relationships_that_actor_can_manage_organisations_for).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
## Context

We are starting a permissions-related epic which will allow users of ratifying providers to define org-level permissions for each provider relationship. Up to now, this has been restricted to training provider users.

The app has been using `#training_provider_relationships_that_actor_can_manage_organisations_for` to decide whether to prompt users to set up permissions or display navigation elements for editing these relationships. We'll need a similar query which extends the result set to include provider relationships referencing ratifying providers the user belongs to.

We already have `#providers_that_actor_can_manage_organisations_for` which returns providers, but we need a similar method which returns provider relationships instead.

## Changes proposed in this pull request

Extract the first part of `#providers_that_actor_can_manage_organisations_for` into a new method (`#provider_relationships_for_actor`) and reuse this in other methods. Combine queries to include checks for user-level `manage_organisations` permission.

Add a new method called `#provider_relationships_that_actor_can_manage_organisations_for`.

## Guidance to review

I have opted to use Arel within `#provider_relationships_for_actor` simply because standard Rails `.or` generates SQL sub-queries, which add complexity when multiple queries are chained together. Using Arel generates a more compact WHERE clause, which takes us from

```sql
WITH "provider_ids" AS (
  SELECT 
    "provider_users_providers"."provider_id" 
  FROM
    "provider_users_providers"
  WHERE
    "provider_users_providers"."provider_user_id" = 11
    AND "provider_users_providers"."manage_organisations" = TRUE
)
SELECT
  "provider_relationship_permissions".*
FROM
  "provider_relationship_permissions"
  INNER JOIN provider_ids ON training_provider_id = provider_id
  OR ratifying_provider_id = provider_id
WHERE
  (
    "provider_relationship_permissions"."training_provider_id" IN (
      SELECT
        "providers"."id"
      FROM
        "providers"
        INNER JOIN "provider_users_providers" ON "providers"."id" = "provider_users_providers"."provider_id"
      WHERE
        "provider_users_providers"."provider_user_id" = 11
    )
    OR "provider_relationship_permissions"."ratifying_provider_id" IN (
      SELECT
        "providers"."id"
      FROM
        "providers"
        INNER JOIN "provider_users_providers" ON "providers"."id" = "provider_users_providers"."provider_id"
      WHERE
        "provider_users_providers"."provider_user_id" = 11
    )
  )
```

to

```sql
WITH "provider_ids" AS (
  SELECT
    "provider_users_providers"."provider_id"
  FROM
    "provider_users_providers"
  WHERE
    "provider_users_providers"."provider_user_id" = 30
    AND "provider_users_providers"."manage_organisations" = TRUE
)
SELECT
  "provider_relationship_permissions".*
FROM
  "provider_relationship_permissions"
  INNER JOIN provider_ids ON (
    training_provider_id = provider_id
    OR ratifying_provider_id = provider_id
  )
WHERE
  (
    "provider_relationship_permissions"."training_provider_id" IN (59, 60)
    OR "provider_relationship_permissions"."ratifying_provider_id" IN (59, 60)
  )
```

I have also employed `.with` to make the inner joins for `#provider_relationships_that_actor_can_manage_organisations_for` more readable as Rails code.

## Link to Trello card

https://trello.com/c/sZknXc3L

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
