### PR TITLE
Do not truncate condition text in the conditions flow

### DIFF
--- a/app/components/provider_interface/individual_condition_status_form_component.html.erb
+++ b/app/components/provider_interface/individual_condition_status_form_component.html.erb
@@ -14,7 +14,7 @@
 
   <% form_object.conditions.each do |condition| %>
     <%= f.fields_for 'statuses[]', condition do |sf| %>
-      <%= sf.govuk_radio_buttons_fieldset :status, legend: { text: "Status of ‘#{condition.text.truncate_words(6)}’", size: 'm' } do %>
+      <%= sf.govuk_radio_buttons_fieldset :status, legend: { text: "Status of ‘#{condition.text}’", size: 'm' } do %>
         <%= sf.govuk_radio_button :status, 'pending', label: { text: 'Pending' }, link_errors: true %>
         <%= sf.govuk_radio_button :status, 'unmet', label: { text: 'Not met' } %>
         <%= sf.govuk_radio_button :status, 'met', label: { text: 'Met' } %>


### PR DESCRIPTION
## Context

Spotted in design review, it's not really necessary to truncate the condition text here

## Link to Trello card
https://trello.com/c/qypK2xh6/3909-do-not-truncate-condition-text-in-conditions-flow