### PR TITLE
When auto-selecting single site pick from available sites

### DIFF
--- a/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
@@ -46,7 +46,7 @@ module CandidateInterface
             course_choice_id: params[:course_choice_id],
           )
         elsif @pick_course.single_site?
-          course_option = CourseOption.where(course_id: @pick_course.course.id).first
+          course_option = @pick_course.available_course_options.first
           AddOrUpdateCourseChoice.new(
             course_option_id: course_option.id,
             application_form: current_application,

--- a/app/forms/candidate_interface/pick_course_form.rb
+++ b/app/forms/candidate_interface/pick_course_form.rb
@@ -28,7 +28,11 @@ module CandidateInterface
     end
 
     def single_site?
-      Course.find(course_id).course_options.available.one?
+      available_course_options.one?
+    end
+
+    def available_course_options
+      Course.find(course_id).course_options.available
     end
 
     def courses_for_current_cycle

--- a/spec/forms/candidate_interface/pick_course_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_course_form_spec.rb
@@ -178,6 +178,36 @@ RSpec.describe CandidateInterface::PickCourseForm do
     end
   end
 
+  describe '#available_courses' do
+    let(:provider) { create(:provider, name: 'Royal Academy of Dance', code: 'R55') }
+    let(:course) { create(:course, :open_on_apply, provider: provider) }
+    let(:pick_course_form) { described_class.new(provider_id: provider.id, course_id: course.id) }
+
+    context 'when there are two sites' do
+      let(:site1) { build(:site, provider: provider) }
+      let(:site2) { build(:site, provider: provider) }
+      let(:course_option1) { create(:course_option, site: site1, course: course) }
+      let(:course_option2) { create(:course_option, site: site2, course: course) }
+
+      before do
+        course_option1
+        course_option2
+      end
+
+      it 'returns both sites' do
+        expect(pick_course_form.available_course_options).to eq([course_option1, course_option2])
+      end
+
+      context 'when one site is not longer valid' do
+        let(:course_option2) { create(:course_option, site: site2, course: course, site_still_valid: false) }
+
+        it 'returns only the valid site' do
+          expect(pick_course_form.available_course_options).to eq([course_option1])
+        end
+      end
+    end
+  end
+
   describe '#single_site?' do
     let(:provider) { create(:provider, name: 'Royal Academy of Dance', code: 'R55') }
     let(:course) { create(:course, :open_on_apply, provider: provider) }

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_when_only_one_site_available_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_when_only_one_site_available_spec.rb
@@ -1,0 +1,139 @@
+require 'rails_helper'
+
+RSpec.feature 'Selecting a course when only a single site is available' do
+  include CandidateHelper
+
+  scenario 'Candidate selects a course choice' do
+    given_i_am_signed_in
+    and_there_are_course_options
+
+    when_i_visit_the_site
+    and_i_click_on_course_choices
+    and_i_click_on_add_course
+    and_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_a_provider
+    then_i_should_see_a_course_and_its_description
+
+    and_i_choose_a_course
+    and_i_choose_not_to_add_another_course
+    then_i_am_on_the_course_choices_page
+    and_i_see_my_completed_course_choice
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_there_are_course_options
+    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
+    first_site = create(
+      :site,
+      name: 'Main site',
+      code: '-',
+      provider: @provider,
+      address_line1: 'Gorse SCITT',
+      address_line2: 'C/O The Bruntcliffe Academy',
+      address_line3: 'Bruntcliffe Lane',
+      address_line4: 'MORLEY, lEEDS',
+      postcode: 'LS27 0LZ',
+    )
+    second_site = create(
+      :site,
+      name: 'Harehills Primary School',
+      code: '1',
+      provider: @provider,
+      address_line1: 'Darfield Road',
+      address_line2: '',
+      address_line3: 'Leeds',
+      address_line4: 'West Yorkshire',
+      postcode: 'LS8 5DQ',
+    )
+    third_site = create(
+      :site,
+      name: 'Rabbitvale Primary School',
+      code: '2',
+      provider: @provider,
+      address_line1: 'Garfield Road',
+      address_line2: '',
+      address_line3: 'Leeds',
+      address_line4: 'West Yorkshire',
+      postcode: 'LS8 5DP',
+    )
+    @course = create(
+      :course,
+      name: 'Primary',
+      code: '2XT2',
+      provider: @provider,
+      exposed_in_find: true,
+      open_on_apply: true,
+    )
+    create(
+      :course_option,
+      site: first_site,
+      course: @course,
+      vacancy_status: :no_vacancies,
+      site_still_valid: true,
+    )
+    create(
+      :course_option,
+      site: second_site,
+      course: @course,
+      vacancy_status: :vacancies,
+      site_still_valid: true,
+    )
+    create(
+      :course_option,
+      site: third_site,
+      course: @course,
+      vacancy_status: :vacancies,
+      site_still_valid: false,
+    )
+  end
+
+  def when_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def and_i_click_on_course_choices
+    click_link 'Choose your courses'
+  end
+
+  def and_i_click_on_add_course
+    click_link t('continue')
+  end
+
+  def and_i_choose_that_i_know_where_i_want_to_apply
+    choose 'Yes, I know where I want to apply'
+    click_button t('continue')
+  end
+
+  def and_i_choose_a_provider
+    select 'Gorse SCITT (1N1)'
+    click_button t('continue')
+  end
+
+  def then_i_should_see_a_course_and_its_description
+    expect(page).to have_content(@course.name_and_code)
+    expect(page).to have_content(@course.description)
+  end
+
+  def and_i_choose_a_course
+    choose 'Primary (2XT2)'
+    click_button t('continue')
+  end
+
+  def and_i_choose_not_to_add_another_course
+    choose 'No, not at the moment'
+    click_button t('continue')
+  end
+
+  def then_i_am_on_the_course_choices_page
+    expect(page).to have_current_path(candidate_interface_course_choices_review_path)
+  end
+
+  def and_i_see_my_completed_course_choice
+    expect(page).to have_content('Gorse SCITT')
+    expect(page).to have_content('Primary (2XT2)')
+    expect(page).to have_content('Harehills Primary School')
+  end
+end


### PR DESCRIPTION
## Context

This PR is an attempt to fix an issue that has come up twice in support this week. In both cases a course had multiple sites but only one was available. In such cases we automatically pick the first choice, but we don't take into account availability so a candidate often ends up with the wrong course option and that course option is unavailable.

## Changes proposed in this pull request

- Move the query that fetches the single course option to auto-select
inside PickCourseForm and fix it - it should only return sites that are
available, otherwise we may auto-select a course option that has no
vacancies or is withdrawn.
- New system spec to exercise this feature better.

## Guidance to review

I reproduced this locally by syncing courses for Tes Institute (H40) and applying to Art and design (R222). YMMV because the order may be random. Alternatively you can find a course with a few sites and set all but one to `no_vacancies`, then, as a candidate, apply to it and see which site you end up with.

## Link to Trello card

https://trello.com/c/TF617Hxf/3582-when-course-is-multi-site-but-only-one-is-available-we-auto-select-wrong-site

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
