### PR TITLE
Add sync logic to reinstate previously withdrawn course options

### DIFF
--- a/app/services/teacher_training_public_api/sync_sites.rb
+++ b/app/services/teacher_training_public_api/sync_sites.rb
@@ -34,6 +34,7 @@ module TeacherTrainingPublicAPI
         end
 
         handle_course_options_with_invalid_sites(sites)
+        handle_course_options_with_reinstated_sites(sites)
       end
     rescue JsonApiClient::Errors::ApiError
       raise TeacherTrainingPublicAPI::SyncError
@@ -111,6 +112,17 @@ module TeacherTrainingPublicAPI
 
         course_option.update!(site_still_valid: false)
       end
+    end
+
+    def handle_course_options_with_reinstated_sites(sites)
+      withdrawn_course_options = @course.course_options.joins(:site).where(site_still_valid: false)
+      site_codes = sites.map(&:code)
+
+      course_options_to_reinstate = withdrawn_course_options.select do |course_option|
+        site_codes.include?(course_option.site.code)
+      end
+
+      course_options_to_reinstate.update_all(site_still_valid: true)
     end
   end
 end

--- a/app/services/teacher_training_public_api/sync_sites.rb
+++ b/app/services/teacher_training_public_api/sync_sites.rb
@@ -32,10 +32,10 @@ module TeacherTrainingPublicAPI
         study_modes.each do |study_mode|
           create_course_options(site, study_mode, site_status)
         end
-
-        handle_course_options_with_invalid_sites(sites)
-        handle_course_options_with_reinstated_sites(sites)
       end
+
+      handle_course_options_with_invalid_sites(sites)
+      handle_course_options_with_reinstated_sites(sites)
     rescue JsonApiClient::Errors::ApiError
       raise TeacherTrainingPublicAPI::SyncError
     end
@@ -118,11 +118,13 @@ module TeacherTrainingPublicAPI
       withdrawn_course_options = @course.course_options.joins(:site).where(site_still_valid: false)
       site_codes = sites.map(&:code)
 
-      course_options_to_reinstate = withdrawn_course_options.select do |course_option|
-        site_codes.include?(course_option.site.code)
-      end
+      course_options_to_reinstate = withdrawn_course_options.where(
+        sites: { code: site_codes },
+      )
 
-      course_options_to_reinstate.update_all(site_still_valid: true)
+      course_options_to_reinstate.each do |course_option|
+        course_option.update!(site_still_valid: true)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

In our code to sync data from the TTAPI, we have logic to set `site_still_valid` to `false` if a CourseOption's site is no longer returned by TTAPI. This allows us to invalidate course options (preventing candidates submitting applications to them) without break referential integrity with applications that may have been associated with them in the past. However if the site is reinstated there is no corresponding logic to set `site_still_valid` back to `true`.

Relates to support issue https://trello.com/c/IHnjU5VX/618-error-cant-change-course-make-offer

## Changes proposed in this pull request

- Add a new `TeacherTrainingPublicAPI::SyncSites#handle_course_options_with_reinstated_sites` method to re-check any CourseOptions that were previously invalid.

## Guidance to review

You can test this locally or on a review app by manually setting a `CourseOption#site_still_valid` to `false` on a previously synced option and then re-running `TeacherTrainingPublicAPI::SyncCourses.new.perform(<provider-id>, 2021, run_in_background: false)` in a Rails console. This should reset `site_still_valid` to `true` on this branch, it won't work on `master`.

## Link to Trello card

https://trello.com/c/y2UAgsN2/3584-synching-course-options-from-ttapi-does-not-reset-sitestillvalid

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
