### PR TITLE
Add before_action redirect to references controllers

### DIFF
--- a/app/controllers/candidate_interface/references/base_controller.rb
+++ b/app/controllers/candidate_interface/references/base_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   module References
     class BaseController < CandidateInterfaceController
       before_action :render_application_feedback_component, :set_reference
+      before_action :redirect_to_dashboard_if_submitted
 
     private
 


### PR DESCRIPTION
For all actions in all reference-related controllers in the
CandidateInterface, redirect to the dashboard if the application is
already submitted. This matches behaviour in other sections, and ensures
we don't permit any state changes from stale forms.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
na
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
