### PR TITLE
add backfill for setup_interviews permission

### DIFF
--- a/app/services/data_migrations/backfill_setup_interviews_permission.rb
+++ b/app/services/data_migrations/backfill_setup_interviews_permission.rb
@@ -1,0 +1,12 @@
+module DataMigrations
+  class BackfillSetupInterviewsPermission
+    TIMESTAMP = 20210701153532
+    MANUAL_RUN = true
+
+    def change
+      ActiveRecord::Base.no_touching do
+        ProviderPermissions.where(make_decisions: true).update_all(set_up_interviews: true)
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillSetupInterviewsPermission',
   'DataMigrations::FixEmptyOfferConditions',
   'DataMigrations::RemoveSurplusReferenceSelections',
   'DataMigrations::BackfillCandidateAPIUpdatedAt',

--- a/spec/services/data_migrations/backfill_setup_interviews_permission_spec.rb
+++ b/spec/services/data_migrations/backfill_setup_interviews_permission_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillSetupInterviewsPermission do
+  let!(:provider_permissions) { create(:provider_permissions, make_decisions: true, set_up_interviews: false) }
+
+  it 'sets the setup_interviews permission to true' do
+    described_class.new.change
+    expect(provider_permissions.reload.set_up_interviews).to be(true)
+  end
+
+  it 'does not update the application_choice timestamps' do
+    provider_permissions_created_at = provider_permissions.created_at
+    provider_permissions_updated_at = provider_permissions.updated_at
+
+    described_class.new.change
+
+    expect(provider_permissions.created_at).to eq(provider_permissions_created_at)
+    expect(provider_permissions.updated_at).to eq(provider_permissions_updated_at)
+  end
+
+  it 'does not update the audit log', with_audited: true do
+    provider_permissions_created_at = provider_permissions.created_at
+    provider_permissions_updated_at = provider_permissions.updated_at
+
+    expect { described_class.new.change }.not_to(change { Audited::Audit.count })
+
+    expect(provider_permissions.created_at).to eq(provider_permissions_created_at)
+    expect(provider_permissions.updated_at).to eq(provider_permissions_updated_at)
+  end
+end


### PR DESCRIPTION
## Context

Adding the setup_interviews permission to all permissions sets with make_decisions permission. This will enable us to read from it later.

## Link to Trello card

https://trello.com/c/YZFD0yQA/3903-datamigration-to-grant-setupinterview-permissions
## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
