### PR TITLE
Remove cycle date 'stop_applications_to_unavailable_course_options'

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -6,7 +6,6 @@ class CycleTimetable
   CYCLE_DATES = {
     2020 => {
       apply_1_deadline: Date.new(2019, 8, 24),
-      stop_applications_to_unavailable_course_options: Date.new(2019, 9, 7),
       apply_2_deadline: Date.new(2019, 9, 18),
       find_closes: Date.new(2019, 10, 3),
       find_reopens: Date.new(2019, 10, 6),
@@ -14,7 +13,6 @@ class CycleTimetable
     },
     2021 => {
       apply_1_deadline: Date.new(2020, 8, 24),
-      stop_applications_to_unavailable_course_options: Date.new(2020, 9, 7),
       apply_2_deadline: Date.new(2020, 9, 18),
       find_closes: Date.new(2020, 10, 3),
       find_reopens: Date.new(2020, 10, 6),
@@ -51,17 +49,8 @@ class CycleTimetable
     Time.zone.now < date(:apply_2_deadline).end_of_day
   end
 
-  def self.stop_applications_to_unavailable_course_options?
-    Time.zone.now > date(:stop_applications_to_unavailable_course_options).end_of_day &&
-      Time.zone.now < date(:apply_reopens).beginning_of_day
-  end
-
   def self.apply_1_deadline
     date(:apply_1_deadline)
-  end
-
-  def self.stop_applications_to_unavailable_course_options
-    date(:stop_applications_to_unavailable_course_options)
   end
 
   def self.apply_2_deadline
@@ -112,7 +101,6 @@ class CycleTimetable
 
       today_is_mid_cycle: {
         apply_1_deadline: 1.day.from_now.to_date,
-        stop_applications_to_unavailable_course_options: 2.days.from_now.to_date,
         apply_2_deadline: 3.days.from_now.to_date,
         find_closes: 4.days.from_now.to_date,
         find_reopens: 5.days.from_now.to_date,
@@ -121,8 +109,6 @@ class CycleTimetable
 
       today_is_after_apply_1_deadline_passed: {
         apply_1_deadline: 1.day.ago.to_date,
-
-        stop_applications_to_unavailable_course_options: 1.day.from_now.to_date,
         apply_2_deadline: 2.days.from_now.to_date,
         find_closes: 3.days.from_now.to_date,
         find_reopens: 4.days.from_now.to_date,
@@ -131,8 +117,6 @@ class CycleTimetable
 
       today_is_after_full_course_deadline_passed: {
         apply_1_deadline: 2.days.ago.to_date,
-        stop_applications_to_unavailable_course_options: 1.day.ago.to_date,
-
         apply_2_deadline: 1.day.from_now.to_date,
         find_closes: 2.days.from_now.to_date,
         find_reopens: 3.days.from_now.to_date,
@@ -141,9 +125,7 @@ class CycleTimetable
 
       today_is_after_apply_2_deadline_passed: {
         apply_1_deadline: 3.days.ago.to_date,
-        stop_applications_to_unavailable_course_options: 2.days.ago.to_date,
         apply_2_deadline: 1.day.ago.to_date,
-
         find_closes: 1.day.from_now.to_date,
         find_reopens: 2.days.from_now.to_date,
         apply_reopens: 3.days.from_now.to_date,
@@ -151,27 +133,22 @@ class CycleTimetable
 
       today_is_after_find_closes: {
         apply_1_deadline: 4.days.ago.to_date,
-        stop_applications_to_unavailable_course_options: 3.days.ago.to_date,
         apply_2_deadline: 2.days.ago.to_date,
         find_closes: 1.day.ago.to_date,
-
         find_reopens: 1.day.from_now.to_date,
         apply_reopens: 2.days.from_now.to_date,
       },
 
       today_is_after_find_reopens: {
         apply_1_deadline: 5.days.ago.to_date,
-        stop_applications_to_unavailable_course_options: 4.days.ago.to_date,
         apply_2_deadline: 3.days.ago.to_date,
         find_closes: 2.days.ago.to_date,
         find_reopens: 1.day.ago.to_date,
-
         apply_reopens: 1.day.from_now.to_date,
       },
 
       today_is_after_apply_reopens: {
         apply_1_deadline: 6.days.ago.to_date,
-        stop_applications_to_unavailable_course_options: 5.days.ago.to_date,
         apply_2_deadline: 4.days.ago.to_date,
         find_closes: 3.days.ago.to_date,
         find_reopens: 2.days.ago.to_date,

--- a/app/views/support_interface/settings/cycles.html.erb
+++ b/app/views/support_interface/settings/cycles.html.erb
@@ -35,7 +35,6 @@
 
 <%= render SummaryListComponent.new(rows: {
   'Appy 1 deadline' => CycleTimetable.apply_1_deadline.to_s(:govuk_date),
-  'Stop applications to unavailable course options' => CycleTimetable.stop_applications_to_unavailable_course_options.to_s(:govuk_date),
   'Apply 2 deadline' => CycleTimetable.apply_2_deadline.to_s(:govuk_date),
   'Find closes on' => CycleTimetable.find_closes.to_s(:govuk_date),
   'Find reopens on' => CycleTimetable.find_reopens.to_s(:govuk_date),
@@ -49,6 +48,5 @@
   'Show Apply 2 deadline banner?' => boolean_to_word(CycleTimetable.show_apply_2_deadline_banner?),
   'Are we between cycles for Apply 1?' => boolean_to_word(CycleTimetable.between_cycles_apply_1?),
   'Are we between cycles for Apply 2?' => boolean_to_word(CycleTimetable.between_cycles_apply_2?),
-  'Stop applications to unavailable course options?' => boolean_to_word(CycleTimetable.stop_applications_to_unavailable_course_options?),
   'Is find down?' => boolean_to_word(CycleTimetable.find_down?),
 }) %>

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -127,26 +127,6 @@ RSpec.describe CycleTimetable do
     end
   end
 
-  describe 'stop_applications_to_unavailable_course_options?' do
-    it 'is true when between "stop_applications_to_unavailable_course_options" and "apply_reopens"' do
-      Timecop.travel(Time.zone.local(2020, 9, 7).end_of_day + 1.minute) do
-        expect(CycleTimetable.stop_applications_to_unavailable_course_options?).to be true
-      end
-    end
-
-    it 'is false when before the window' do
-      Timecop.travel(Time.zone.local(2020, 9, 7).end_of_day - 1.minute) do
-        expect(CycleTimetable.stop_applications_to_unavailable_course_options?).to be false
-      end
-    end
-
-    it 'is false when after the window' do
-      Timecop.travel(Time.zone.local(2020, 10, 13).beginning_of_day) do
-        expect(CycleTimetable.stop_applications_to_unavailable_course_options?).to be false
-      end
-    end
-  end
-
   describe 'can_add_course_choice?' do
     let(:execute_service) { described_class.can_add_course_choice?(application_form) }
 


### PR DESCRIPTION
## Context

Part of the end of cycle refactoring exercise. We don't require the `stop_applications_to_unavailable_course_options` cycle date anymore.

## Changes proposed in this pull request

- Remove cycle date `stop_applications_to_unavailable_course_options`

## Link to Trello card

https://trello.com/c/narHEhQx/3544-change-the-eoc-calendar-to-start-with-find-opening-and-end-with-find-closing

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
