### PR TITLE
Update user profile views to render set up interviews permission

### DIFF
--- a/app/components/permissions_list_component.html.erb
+++ b/app/components/permissions_list_component.html.erb
@@ -7,6 +7,12 @@
     <li><%= render IconComponent.new(type: 'check') %> <span class="govuk-!-font-weight-bold">Manage users</span></li>
   <% end %>
 
+  <% if FeatureFlag.active?(:interview_permissions) && permission_model.set_up_interviews? %>
+    <li>
+      <%= render IconComponent.new(type: 'check') %><span class="govuk-!-font-weight-bold">Set up interviews</span>
+    </li>
+  <% end %>
+
   <% if permission_model.make_decisions? %>
     <li>
       <%= render IconComponent.new(type: 'check') %><span class="govuk-!-font-weight-bold">Make decisions</span>

--- a/app/components/support_interface/permissions_list_component.html.erb
+++ b/app/components/support_interface/permissions_list_component.html.erb
@@ -14,6 +14,14 @@
       <li><%= render IconComponent.new(type: 'cross') %> Manage users – No</li>
     <% end %>
 
+    <% if FeatureFlag.active?(:interview_permissions) %>
+      <% if permission_model.set_up_interviews? %>
+        <li><%= render IconComponent.new(type: 'check') %> Set up interviews – Yes</li>
+      <% else %>
+        <li><%= render IconComponent.new(type: 'cross') %> Set up interviews – No</li>
+      <% end %>
+    <% end %>
+
     <% if permission_model.make_decisions? %>
       <li>
         <%= render IconComponent.new(type: 'check') %>

--- a/spec/components/permissions_list_component_spec.rb
+++ b/spec/components/permissions_list_component_spec.rb
@@ -12,10 +12,12 @@ RSpec.describe PermissionsListComponent do
   end
 
   it 'renders permissions' do
-    permission_model = create(:provider_permissions, manage_organisations: true)
+    FeatureFlag.activate(:interview_permissions)
+    permission_model = create(:provider_permissions, manage_organisations: true, set_up_interviews: true)
     result = render_inline(described_class.new(permission_model, user_is_viewing_their_own_permissions: false))
 
     expect(result.css('li').text).to include('Manage organisational permissions')
+    expect(result.css('li').text).to include('Set up interviews')
     expect(result.css('li').text).not_to include('The user can only view applications')
   end
 

--- a/spec/components/support_interface/permissions_list_component_spec.rb
+++ b/spec/components/support_interface/permissions_list_component_spec.rb
@@ -12,67 +12,115 @@ RSpec.describe SupportInterface::PermissionsListComponent do
   end
   let(:tick_svg_path_shape) { 'M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z' }
   let(:cross_svg_path_shape) { 'M100 0a100 100 0 110 200 100 100 0 010-200zm30 50l-30 30-30-30-20 20 30 30-30 30 20 20 30-30 30 30 20-20-30-30 30-30-20-20z' }
+  let(:permission_model) do
+    create(:provider_permissions,
+           set_up_interviews: set_up_interviews,
+           make_decisions: make_decisions,
+           manage_users: manage_users,
+           manage_organisations: manage_organisations,
+           view_safeguarding_information: view_safeguarding_information,
+           view_diversity_information: view_diversity_information)
+  end
+  let(:manage_organisations) { true }
+  let(:manage_users) { true }
+  let(:set_up_interviews) { true }
+  let(:make_decisions) { true }
+  let(:view_safeguarding_information) { true }
+  let(:view_diversity_information) { true }
+
+  before do
+    FeatureFlag.activate(:interview_permissions)
+  end
 
   describe 'rendering permissions' do
-    it 'displays all permissions has been assigned' do
-      permission_model = create_permission_model
-      result = render_inline(described_class.new(permission_model))
+    context 'when all permissions have been assigned' do
+      it 'displays Yes on all' do
+        result = render_inline(described_class.new(permission_model))
 
-      expect(result.css('li').text).to include('Manage organisational permissions – Yes')
-      expect(result.css('path')[0].attribute('d').value).to eq(tick_svg_path_shape)
-      expect(result.css('li').text).to include('Manage users – Yes')
-      expect(result.css('path')[1].attribute('d').value).to eq(tick_svg_path_shape)
-      expect(result.css('li').text).to include('Make decisions – Yes')
-      expect(result.css('path')[2].attribute('d').value).to eq(tick_svg_path_shape)
-      expect(result.css('li').text).to include('Access safeguarding information – Yes')
-      expect(result.css('path')[3].attribute('d').value).to eq(tick_svg_path_shape)
-      expect(result.css('li').text).to include('Access diversity information – Yes')
-      expect(result.css('path')[4].attribute('d').value).to eq(tick_svg_path_shape)
+        expect(result.css('li').text).to include('Manage organisational permissions – Yes')
+        expect(result.css('path')[0].attribute('d').value).to eq(tick_svg_path_shape)
+        expect(result.css('li').text).to include('Manage users – Yes')
+        expect(result.css('path')[1].attribute('d').value).to eq(tick_svg_path_shape)
+        expect(result.css('li').text).to include('Set up interviews – Yes')
+        expect(result.css('path')[2].attribute('d').value).to eq(tick_svg_path_shape)
+        expect(result.css('li').text).to include('Make decisions – Yes')
+        expect(result.css('path')[3].attribute('d').value).to eq(tick_svg_path_shape)
+        expect(result.css('li').text).to include('Access safeguarding information – Yes')
+        expect(result.css('path')[4].attribute('d').value).to eq(tick_svg_path_shape)
+        expect(result.css('li').text).to include('Access diversity information – Yes')
+        expect(result.css('path')[5].attribute('d').value).to eq(tick_svg_path_shape)
+      end
     end
 
-    it 'displays that manage permission has not been assigned' do
-      permission_model = create_permission_model(manage_organisations: false)
-      result = render_inline(described_class.new(permission_model))
+    context 'when Manage Organisations has not been assigned' do
+      let(:manage_organisations) { false }
 
-      expect(result.css('li').text).to include('Manage organisational permissions – No')
-      expect(result.css('path')[0].attribute('d').value).to eq(cross_svg_path_shape)
+      it 'reflects that the permission has not been assigned' do
+        result = render_inline(described_class.new(permission_model))
+
+        expect(result.css('li').text).to include('Manage organisational permissions – No')
+        expect(result.css('path')[0].attribute('d').value).to eq(cross_svg_path_shape)
+      end
     end
 
-    it 'displays that manage users permission has not been assigned' do
-      permission_model = create_permission_model(manage_users: false)
-      result = render_inline(described_class.new(permission_model))
+    context 'when Manage Users has not been assigned' do
+      let(:manage_users) { false }
 
-      expect(result.css('li').text).to include('Manage users – No')
-      expect(result.css('path')[1].attribute('d').value).to eq(cross_svg_path_shape)
+      it 'reflects that the permission has not been assigned' do
+        result = render_inline(described_class.new(permission_model))
+
+        expect(result.css('li').text).to include('Manage users – No')
+        expect(result.css('path')[1].attribute('d').value).to eq(cross_svg_path_shape)
+      end
     end
 
-    it 'displays that make decisions permission has not been assigned' do
-      permission_model = create_permission_model(make_decisions: false)
-      result = render_inline(described_class.new(permission_model))
+    context 'when Set up interviews has not been assigned' do
+      let(:set_up_interviews) { false }
 
-      expect(result.css('li').text).to include('Make decisions – No')
-      expect(result.css('path')[2].attribute('d').value).to eq(cross_svg_path_shape)
+      it 'reflects that the permission has not been assigned' do
+        result = render_inline(described_class.new(permission_model))
+
+        expect(result.css('li').text).to include('Set up interviews – No')
+        expect(result.css('path')[2].attribute('d').value).to eq(cross_svg_path_shape)
+      end
     end
 
-    it 'displays that access safeguarding permission has not been assigned' do
-      permission_model = create_permission_model(view_safeguarding_information: false)
-      result = render_inline(described_class.new(permission_model))
+    context 'when Make Decisions has not been assigned' do
+      let(:make_decisions) { false }
 
-      expect(result.css('li').text).to include('Access safeguarding information – No')
-      expect(result.css('path')[3].attribute('d').value).to eq(cross_svg_path_shape)
+      it 'reflects that the permission has not been assigned' do
+        result = render_inline(described_class.new(permission_model))
+
+        expect(result.css('li').text).to include('Make decisions – No')
+        expect(result.css('path')[3].attribute('d').value).to eq(cross_svg_path_shape)
+      end
     end
 
-    it 'displays that permission has not been assigned' do
-      permission_model = create_permission_model(view_diversity_information: false)
-      result = render_inline(described_class.new(permission_model))
+    context 'when View Safeguarding Information has not been assigned' do
+      let(:view_safeguarding_information) { false }
 
-      expect(result.css('li').text).to include('Access diversity information – No')
-      expect(result.css('path')[4].attribute('d').value).to eq(cross_svg_path_shape)
+      it 'reflects that the permission has not been assigned' do
+        result = render_inline(described_class.new(permission_model))
+
+        expect(result.css('li').text).to include('Access safeguarding information – No')
+        expect(result.css('path')[4].attribute('d').value).to eq(cross_svg_path_shape)
+      end
+    end
+
+    context 'when View Diversity Information has not been assigned' do
+      let(:view_diversity_information) { false }
+
+      it 'displays that permission has not been assigned' do
+        result = render_inline(described_class.new(permission_model))
+
+        expect(result.css('li').text).to include('Access diversity information – No')
+        expect(result.css('path')[5].attribute('d').value).to eq(cross_svg_path_shape)
+      end
     end
   end
 
-  describe 'rendering View applications only' do
-    it 'shows an appropriate message when the user is viewing another user’s permissions' do
+  describe 'when the user has no permissions set' do
+    it 'they cannot see user permissions' do
       permission_model = create(:provider_permissions)
       result = render_inline(described_class.new(permission_model))
 
@@ -103,20 +151,5 @@ RSpec.describe SupportInterface::PermissionsListComponent do
 
     expect(result.text).to include('Applies to courses run by:')
     expect(result.css('li').text).to include(training_provider.name.to_s)
-  end
-
-  def create_permission_model(
-    manage_organisations: true,
-    manage_users: true,
-    make_decisions: true,
-    view_safeguarding_information: true,
-    view_diversity_information: true
-  )
-    create(:provider_permissions,
-           make_decisions: make_decisions,
-           manage_users: manage_users,
-           manage_organisations: manage_organisations,
-           view_safeguarding_information: view_safeguarding_information,
-           view_diversity_information: view_diversity_information)
   end
 end


### PR DESCRIPTION
## Context

In order to be able to see if a provider user has set_up_interviews permissions, the new permission should be visible on the user profile when configured.

## Guidance to review

Enable `interview_permissions` feature flag

- You should be able to see the new permission rendered on the Support user profile

To see the permission on the Provider profile or Provider organisation user list, you need to set `set_up_interviews` to true on the `provider_permissions` association of the specific provider user directly on the database.


## Link to Trello card
https://trello.com/c/dmlSre3D/3913-update-user-profile-views-to-render-set-up-interviews-permission

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
