### PR TITLE
Org permissions review card component

### DIFF
--- a/app/components/provider_interface/organisation_permissions_form_component.html.erb
+++ b/app/components/provider_interface/organisation_permissions_form_component.html.erb
@@ -15,7 +15,7 @@
   <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| %>
     <div class="govuk-form-group">
       <%= f.govuk_fieldset legend: { text: label_for(permission_name) } do %>
-        <% checkbox_details_for_providers.each_with_index do |checkbox_details, index| %>
+        <% presenter.checkbox_details_for_providers.each_with_index do |checkbox_details, index| %>
           <%= f.govuk_check_box(
             "#{checkbox_details[:type]}_provider_can_#{permission_name}",
             true,

--- a/app/components/provider_interface/organisation_permissions_form_component.rb
+++ b/app/components/provider_interface/organisation_permissions_form_component.rb
@@ -1,17 +1,17 @@
 module ProviderInterface
   class OrganisationPermissionsFormComponent < ViewComponent::Base
-    attr_reader :provider_user, :provider_relationship_permission, :mode, :form_url
+    attr_reader :presenter, :provider_relationship_permission, :mode, :form_url
 
     def initialize(provider_user:, provider_relationship_permission:, mode:, form_url:)
-      @provider_user = provider_user
       @provider_relationship_permission = provider_relationship_permission
+      @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(provider_relationship_permission, provider_user)
       @mode = mode
       @form_url = form_url
     end
 
     def page_caption
       if mode == :edit
-        provider_relationship_description
+        presenter.provider_relationship_description
       elsif mode == :setup
         t('.setup.caption')
       end
@@ -21,16 +21,7 @@ module ProviderInterface
       if mode == :edit
         t('.edit.heading')
       elsif mode == :setup
-        provider_relationship_description
-      end
-    end
-
-    def checkbox_details_for_providers
-      ordered_providers.map do |provider_type|
-        {
-          name: name_for_provider_of_type(provider_type),
-          type: provider_type,
-        }
+        presenter.provider_relationship_description
       end
     end
 
@@ -45,39 +36,6 @@ module ProviderInterface
       elsif mode == :setup
         :post
       end
-    end
-
-  private
-
-    def provider_relationship_description
-      provider_names = ordered_providers.map { |provider_type| name_for_provider_of_type(provider_type) }
-      provider_names.join(' and ')
-    end
-
-    def ordered_providers
-      providers = %w[training ratifying]
-
-      if provider_user_belongs_to_training_provider?
-        providers
-      else
-        providers.reverse
-      end
-    end
-
-    def provider_user_belongs_to_training_provider?
-      provider_user.providers.include? training_provider
-    end
-
-    def name_for_provider_of_type(provider_type)
-      send("#{provider_type}_provider").name
-    end
-
-    def training_provider
-      @training_provider ||= provider_relationship_permission.training_provider
-    end
-
-    def ratifying_provider
-      @ratifying_provider ||= provider_relationship_permission.ratifying_provider
     end
   end
 end

--- a/app/components/provider_interface/organisation_permissions_review_card_component.html.erb
+++ b/app/components/provider_interface/organisation_permissions_review_card_component.html.erb
@@ -1,0 +1,9 @@
+<%= render SummaryCardComponent.new(rows: permission_rows) do %>
+  <%= render SummaryCardHeaderComponent.new(title: presenter.provider_relationship_description, heading_level: 2) do %>
+    <% if change_path %>
+      <div class="app-summary-card__actions">
+        <%= govuk_link_to 'Change', change_path %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/provider_interface/organisation_permissions_review_card_component.rb
+++ b/app/components/provider_interface/organisation_permissions_review_card_component.rb
@@ -1,0 +1,38 @@
+module ProviderInterface
+  class OrganisationPermissionsReviewCardComponent < ViewComponent::Base
+    attr_reader :presenter, :provider_relationship_permission, :change_path
+
+    def initialize(provider_user:, provider_relationship_permission:, change_path: nil)
+      @provider_relationship_permission = provider_relationship_permission
+      @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(provider_relationship_permission, provider_user)
+      @change_path = change_path
+    end
+
+    def permission_rows
+      ProviderRelationshipPermissions::PERMISSIONS.map do |permission_name|
+        {
+          key: label_for(permission_name),
+          value: providers_to_render_for(permission_name),
+        }
+      end
+    end
+
+  private
+
+    def label_for(permission_name)
+      t("provider_relationship_permissions.#{permission_name}.description")
+    end
+
+    def providers_to_render_for(permission_name)
+      list_items = presenter.providers_with_permission(permission_name).map do |provider_name|
+        tag.li(provider_name)
+      end
+
+      provider_list = tag.ul(class: 'govuk-list') do
+        list_items.join.html_safe
+      end
+
+      provider_list.html_safe
+    end
+  end
+end

--- a/app/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter.rb
+++ b/app/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter.rb
@@ -1,0 +1,46 @@
+module ProviderInterface
+  class ProviderRelationshipPermissionAsProviderUserPresenter
+    def initialize(provider_relationship_permission, provider_user)
+      @provider_relationship_permission = provider_relationship_permission
+      @provider_user = provider_user
+    end
+
+    def provider_relationship_description
+      provider_names = ordered_provider_types.map { |provider_type| name_for_provider_of_type(provider_type) }
+      provider_names.join(' and ')
+    end
+
+    def checkbox_details_for_providers
+      ordered_provider_types.map do |provider_type|
+        {
+          name: name_for_provider_of_type(provider_type),
+          type: provider_type,
+        }
+      end
+    end
+
+  private
+
+    attr_reader :provider_relationship_permission, :provider_user
+
+    def ordered_provider_types
+      provider_types = %w[training ratifying]
+
+      if provider_user_belongs_to_training_provider?
+        provider_types
+      else
+        provider_types.reverse
+      end
+    end
+
+    def provider_user_belongs_to_training_provider?
+      provider_user.providers.include? training_provider
+    end
+
+    def name_for_provider_of_type(provider_type)
+      send("#{provider_type}_provider").name
+    end
+
+    delegate :training_provider, :ratifying_provider, to: :provider_relationship_permission
+  end
+end

--- a/app/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter.rb
+++ b/app/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter.rb
@@ -19,6 +19,14 @@ module ProviderInterface
       end
     end
 
+    def providers_with_permission(permission_name)
+      provider_types_with_permission = ordered_provider_types.select do |provider_type|
+        provider_relationship_permission.send("#{provider_type}_provider_can_#{permission_name}")
+      end
+
+      provider_types_with_permission.map { |provider_type| name_for_provider_of_type(provider_type) }
+    end
+
   private
 
     attr_reader :provider_relationship_permission, :provider_user

--- a/spec/components/previews/provider_interface/organisation_permissions_review_card_component_preview.rb
+++ b/spec/components/previews/provider_interface/organisation_permissions_review_card_component_preview.rb
@@ -1,0 +1,39 @@
+module ProviderInterface
+  class OrganisationPermissionsReviewCardComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
+    def with_change_path
+      render OrganisationPermissionsReviewCardComponent.new(
+        provider_user: example_provider_user,
+        provider_relationship_permission: example_provider_relationship,
+        change_path: '/change',
+      )
+    end
+
+    def without_change_path
+      render OrganisationPermissionsReviewCardComponent.new(
+        provider_user: example_provider_user,
+        provider_relationship_permission: example_provider_relationship,
+      )
+    end
+
+  private
+
+    def example_provider_relationship
+      @example_relationship ||= FactoryBot.build_stubbed(
+        :provider_relationship_permissions,
+        training_provider_can_make_decisions: [true, false].sample,
+        training_provider_can_view_safeguarding_information: [true, false].sample,
+        training_provider_can_view_diversity_information: [true, false].sample,
+        ratifying_provider_can_make_decisions: [true, false].sample,
+        ratifying_provider_can_view_safeguarding_information: [true, false].sample,
+        ratifying_provider_can_view_diversity_information: [true, false].sample,
+      )
+    end
+
+    def example_provider_user
+      provider = [example_provider_relationship.training_provider, example_provider_relationship.ratifying_provider].sample
+      FactoryBot.build_stubbed(:provider_user, providers: [provider])
+    end
+  end
+end

--- a/spec/components/provider_interface/organisation_permissions_review_card_component_spec.rb
+++ b/spec/components/provider_interface/organisation_permissions_review_card_component_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::OrganisationPermissionsReviewCardComponent do
+  let(:provider_relationship_permission) { build_stubbed(:provider_relationship_permissions) }
+  let(:training_provider) { provider_relationship_permission.training_provider }
+  let(:ratifying_provider) { provider_relationship_permission.ratifying_provider }
+  let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider]) }
+  let(:change_path) { nil }
+
+  let(:render) do
+    render_inline(
+      described_class.new(
+        provider_user: provider_user,
+        provider_relationship_permission: provider_relationship_permission,
+        change_path: change_path,
+      ),
+    )
+  end
+
+  describe 'change link' do
+    context 'when the change path is not provided' do
+      it 'does not render an action link' do
+        expect(render.css('a')).to be_empty
+      end
+    end
+
+    context 'when the change path is provided' do
+      let(:change_path) { '/path-to-change' }
+
+      it 'renders an action link' do
+        expect(render.css('a').text).to eq('Change')
+        expect(render.css('a').first.attributes['href'].value).to eq(change_path)
+      end
+    end
+  end
+
+  describe 'permissions display' do
+    let(:provider_relationship_permission) do
+      build_stubbed(
+        :provider_relationship_permissions,
+        training_provider_can_make_decisions: true,
+        training_provider_can_view_safeguarding_information: false,
+        training_provider_can_view_diversity_information: false,
+        ratifying_provider_can_make_decisions: true,
+        ratifying_provider_can_view_safeguarding_information: true,
+        ratifying_provider_can_view_diversity_information: true,
+      )
+    end
+
+    it 'renders the names of the providers that have the make_decision permission' do
+      make_decision_row = row_with_key('Make offers and reject applications')
+      expect(entries_in_row(make_decision_row)).to contain_exactly(training_provider.name, ratifying_provider.name)
+    end
+
+    it 'renders the names of the providers that have the safeguarding permission' do
+      safeguarding_row = row_with_key('View criminal convictions and professional misconduct')
+      expect(entries_in_row(safeguarding_row)).to contain_exactly(ratifying_provider.name)
+    end
+
+    it 'renders the names of the providers that have the diversity permission' do
+      diversity_row = row_with_key('View sex, disability and ethnicity information')
+      expect(entries_in_row(diversity_row)).to contain_exactly(ratifying_provider.name)
+    end
+
+    context 'when the provider user belongs to the training provider' do
+      it 'renders the training provider name first' do
+        make_decision_row = row_with_key('Make offers and reject applications')
+        expect(entries_in_row(make_decision_row)).to eq([training_provider.name, ratifying_provider.name])
+      end
+    end
+
+    context 'when the provider user belongs to the ratifying provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [ratifying_provider]) }
+
+      it 'renders the ratifying provider name first' do
+        make_decision_row = row_with_key('Make offers and reject applications')
+        expect(entries_in_row(make_decision_row)).to eq([ratifying_provider.name, training_provider.name])
+      end
+    end
+
+    context 'when the provider user belongs to both providers' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider, ratifying_provider]) }
+
+      it 'renders the training provider name first' do
+        make_decision_row = row_with_key('Make offers and reject applications')
+        expect(entries_in_row(make_decision_row)).to eq([training_provider.name, ratifying_provider.name])
+      end
+    end
+
+    def row_with_key(key)
+      rows = render.css('.govuk-summary-list__row')
+      rows.find { |row| row.css('.govuk-summary-list__key').text.squish == key }
+    end
+
+    def entries_in_row(row)
+      row.css('.govuk-summary-list__value > ul > li').map(&:text)
+    end
+  end
+end

--- a/spec/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter_spec.rb
+++ b/spec/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter_spec.rb
@@ -1,7 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::ProviderRelationshipPermissionAsProviderUserPresenter do
-  let(:provider_relationship_permission) { build_stubbed(:provider_relationship_permissions) }
+  let(:provider_relationship_permission) do
+    build_stubbed(
+      :provider_relationship_permissions,
+      training_provider_can_make_decisions: true,
+      training_provider_can_view_safeguarding_information: false,
+      training_provider_can_view_diversity_information: false,
+      ratifying_provider_can_make_decisions: true,
+      ratifying_provider_can_view_safeguarding_information: true,
+      ratifying_provider_can_view_diversity_information: true,
+    )
+  end
   let(:training_provider) { provider_relationship_permission.training_provider }
   let(:ratifying_provider) { provider_relationship_permission.ratifying_provider }
 
@@ -58,6 +68,34 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionAsProviderUserPr
 
       it 'returns the training provider checkbox first' do
         expect(presenter.checkbox_details_for_providers.first[:type]).to eq('training')
+      end
+    end
+  end
+
+  describe '#providers_with_permission' do
+    context 'when the provider user is part of the training provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider]) }
+
+      it 'returns the names providers that have the specified permission with the training provider first' do
+        expect(presenter.providers_with_permission(:make_decisions)).to eq([training_provider.name, ratifying_provider.name])
+        expect(presenter.providers_with_permission(:view_safeguarding_information)).to contain_exactly(ratifying_provider.name)
+        expect(presenter.providers_with_permission(:view_diversity_information)).to contain_exactly(ratifying_provider.name)
+      end
+    end
+
+    context 'when the provider user is part of the ratifying provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [ratifying_provider]) }
+
+      it 'returns the names providers that have the specified permission with the ratifying provider firs' do
+        expect(presenter.providers_with_permission(:make_decisions)).to eq([ratifying_provider.name, training_provider.name])
+      end
+    end
+
+    context 'when the provider user is part of both of the providers' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider, ratifying_provider]) }
+
+      it 'returns the names providers that have the specified permission with the ratifying provider firs' do
+        expect(presenter.providers_with_permission(:make_decisions)).to eq([training_provider.name, ratifying_provider.name])
       end
     end
   end

--- a/spec/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter_spec.rb
+++ b/spec/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ProviderRelationshipPermissionAsProviderUserPresenter do
+  let(:provider_relationship_permission) { build_stubbed(:provider_relationship_permissions) }
+  let(:training_provider) { provider_relationship_permission.training_provider }
+  let(:ratifying_provider) { provider_relationship_permission.ratifying_provider }
+
+  let(:presenter) { described_class.new(provider_relationship_permission, provider_user) }
+
+  describe '#provider_relationship_description_for' do
+    context 'when the provider user is part of the training provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider]) }
+
+      it 'returns the training provider name first' do
+        expected_string = "#{training_provider.name} and #{ratifying_provider.name}"
+        expect(presenter.provider_relationship_description).to eq(expected_string)
+      end
+    end
+
+    context 'when the provider user is part of the ratifying provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [ratifying_provider]) }
+
+      it 'returns the ratifying provider name first' do
+        expected_string = "#{ratifying_provider.name} and #{training_provider.name}"
+        expect(presenter.provider_relationship_description).to eq(expected_string)
+      end
+    end
+
+    context 'when the provider user is part of both of the providers' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider, ratifying_provider]) }
+
+      it 'returns the training provider name first' do
+        expected_string = "#{training_provider.name} and #{ratifying_provider.name}"
+        expect(presenter.provider_relationship_description).to eq(expected_string)
+      end
+    end
+  end
+
+  describe '#checkbox_details_for_providers' do
+    context 'when the provider user is part of the training provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider]) }
+
+      it 'returns the training provider checkbox first' do
+        expect(presenter.checkbox_details_for_providers.first[:type]).to eq('training')
+      end
+    end
+
+    context 'when the provider user is part of the ratifying provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [ratifying_provider]) }
+
+      it 'returns the ratifying provider checkbox first' do
+        expect(presenter.checkbox_details_for_providers.first[:type]).to eq('ratifying')
+      end
+    end
+
+    context 'when the provider user is part of both of the providers' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider, ratifying_provider]) }
+
+      it 'returns the training provider checkbox first' do
+        expect(presenter.checkbox_details_for_providers.first[:type]).to eq('training')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
We are modifying the permissions setup flow, and with it the designs for components.

## Changes proposed in this pull request
Refactor some common logic into a presenter
Add the new review card component for a single provider relationship permission 

## Guidance to review
Any opinions on the refactor?

Test out the component in the previews in the review app: https://apply-for-te-3891-org-p-vunomz.herokuapp.com/rails/view_components/provider_interface/organisation_permissions_review_card_component

## Link to Trello card

https://trello.com/c/mVwP7rVr/3891-add-a-component-for-the-permission-review-card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
