### PR TITLE
Accessible Zendesk chat

### DIFF
--- a/app/frontend/packs/application-provider.js
+++ b/app/frontend/packs/application-provider.js
@@ -5,6 +5,7 @@ import filter from './components/paginated_filter'
 import checkboxSearchFilter from './components/checkbox_search_filter'
 import '../styles/application-provider.scss'
 import cookieBanners from './cookies/cookie-banners'
+import userSupportWebchat from './user-support-webchat'
 
 require.context('govuk-frontend/govuk/assets')
 
@@ -14,3 +15,4 @@ initAddFurtherConditions()
 checkboxSearchFilter('subject', 'Search for subject')
 filter()
 cookieBanners()
+userSupportWebchat()

--- a/app/frontend/packs/user-support-webchat.js
+++ b/app/frontend/packs/user-support-webchat.js
@@ -1,0 +1,71 @@
+function UserSupportWebchat () {
+  this.container = document.getElementById('app-web-chat')
+
+  this.configureWidget()
+  this.setupElements()
+  this.addButtonListener()
+  this.addStatusChangeListener()
+}
+
+UserSupportWebchat.prototype.configureWidget = function () {
+  window.zESettings = {
+    webWidget: {
+      chat: {
+        suppress: true
+      }
+    }
+  }
+}
+
+UserSupportWebchat.prototype.setupElements = function () {
+  this.enabledContainer = document.createElement('span')
+  this.enabledContainer.className = 'moj-hidden'
+
+  this.defaultContainer = document.querySelector('.app-web-chat__unavailable')
+
+  this.button = document.createElement('a')
+  this.button.href = '#'
+  this.button.className = 'govuk-link govuk-footer__link app-web-chat__button'
+  this.button.innerHTML = 'Speak to an advisor now (opens in new window)'
+  this.enabledContainer.append(this.button)
+
+  this.disabledContainer = document.createElement('span')
+  this.disabledContainer.className = 'app-web-chat__offline moj-hidden'
+  this.disabledContainer.innerHTML = 'Available Monday to Friday, 10am to midday (except public holidays).'
+
+  this.container.append(this.enabledContainer)
+  this.container.append(this.disabledContainer)
+}
+
+UserSupportWebchat.prototype.addButtonListener = function () {
+  this.button.addEventListener('click', function (e) {
+    e.preventDefault()
+
+    zE('webWidget', 'popout')
+  }, false)
+}
+
+UserSupportWebchat.prototype.addStatusChangeListener = function () {
+  zE('webWidget:on', 'chat:status', function (status) {
+    this.defaultContainer.classList.add('moj-hidden')
+
+    if (status === 'online') {
+      this.enableChat()
+    } else {
+      this.disableChat()
+    }
+  }.bind(this))
+}
+
+UserSupportWebchat.prototype.enableChat = function () {
+  this.disabledContainer.classList.add('moj-hidden')
+  this.enabledContainer.classList.remove('moj-hidden')
+}
+
+UserSupportWebchat.prototype.disableChat = function () {
+  this.disabledContainer.classList.remove('moj-hidden')
+  this.enabledContainer.classList.add('moj-hidden')
+}
+
+const userSupportWebchat = () => new UserSupportWebchat()
+export default userSupportWebchat

--- a/app/frontend/packs/zendesk-stub.js
+++ b/app/frontend/packs/zendesk-stub.js
@@ -1,0 +1,18 @@
+window.zendeskPopupOpen = false
+
+window.setZendeskStatus = function (status) {
+  const statusChangeEvent = new CustomEvent('setZendeskStubStatus', { detail: status })
+  document.body.dispatchEvent(statusChangeEvent)
+}
+
+window.zE = function (scope, command, callback = null) {
+  if (scope === 'webWidget' && command === 'popout') {
+    window.zendeskPopupOpen = true
+  } else if (scope === 'webWidget:on' && command === 'chat:status') {
+    document.body.addEventListener('setZendeskStubStatus', function (e) {
+      callback(e.detail)
+    })
+  } else {
+    throw Error('Unexpected Zendesk API function call')
+  }
+}

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -21,6 +21,7 @@ class FeatureFlag
     [:export_hesa_data, 'Providers can export applications including HESA data.', 'Apply team'],
     [:service_unavailable_page, 'Displays a maintenance page on the whole application', 'Apply team'],
     [:send_request_data_to_bigquery, 'Send request data to Google Bigquery via background worker', 'Apply team'],
+    [:enable_chat_support, 'Enable Zendesk chat support', 'Apply team'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [

--- a/app/views/layouts/_footer_meta_provider.html.erb
+++ b/app/views/layouts/_footer_meta_provider.html.erb
@@ -2,18 +2,21 @@
 
 <div class="govuk-footer__meta-custom">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
-      <div class="govuk-!-padding-right-1">
-        <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
-          Online chat
-        </h3>
+    <% if FeatureFlag.active?(:enable_chat_support) %>
+      <div class="govuk-grid-column-one-half">
+        <div class="govuk-!-padding-right-1">
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+            Online chat
+          </h3>
 
-        <p class="govuk-!-margin-top-0 govuk-!-font-size-16"><span id="app-web-chat">
-          <span class="app-web-chat__unavailable">
-            You cannot use online chat because there’s a problem. Send an email if you keep seeing this message.</span>
-        </span></p>
+          <p class="govuk-!-margin-top-0 govuk-!-font-size-16"><span id="app-web-chat">
+            <span class="app-web-chat__unavailable">
+              You cannot use online chat because there’s a problem. Send an email if you keep seeing this message.</span>
+          </span></p>
+        </div>
       </div>
-    </div>
+    <% end %>
+
     <div class="govuk-grid-column-one-half">
       <div class="govuk-!-padding-left-1">
         <h3 class="govuk-heading-s govuk-!-margin-bottom-1">

--- a/app/views/layouts/_footer_meta_provider.html.erb
+++ b/app/views/layouts/_footer_meta_provider.html.erb
@@ -1,14 +1,36 @@
 <h2 class="govuk-heading-m"><%= t('layout.support.title') %></h2>
-<ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-  <li>Email: <%= bat_contact_mail_to(html_options: { class: 'govuk-footer__link' }) %></li>
-  <li><%= t('layout.support.response_time') %></li>
-  <li>Alternatively, <%= link_to 'give feedback through our survey', ProviderInterface::FEEDBACK_LINK, class: 'govuk-footer__link' %></li>
-</ul>
-<p class="govuk-body govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
-  <%= link_to t('layout.support.provider_service_guidance'), provider_interface_service_guidance_path, class: 'govuk-footer__link' %>
-</p>
+
+<div class="govuk-footer__meta-custom">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <div class="govuk-!-padding-right-1">
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+          Online chat
+        </h3>
+
+        <p class="govuk-!-margin-top-0 govuk-!-font-size-16"><span id="app-web-chat">
+          <span class="app-web-chat__unavailable">
+            You cannot use online chat because there’s a problem. Send an email if you keep seeing this message.</span>
+        </span></p>
+      </div>
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <div class="govuk-!-padding-left-1">
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+          Email
+        </h3>
+        <p class="govuk-!-margin-top-0 govuk-!-font-size-16 govuk-!-margin-bottom-1"><%= bat_contact_mail_to(html_options: { class: 'govuk-footer__link' }) %></p>
+        <p class="govuk-!-font-size-16"><%= t('layout.support.response_time') %></p>
+      </div>
+    </div>
+  </div>
+</div>
+
 <h2 class="govuk-visually-hidden"><%= t('layout.support_links.title') %></h2>
-<ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
+<ul class="govuk-footer__inline-list">
+  <li class="govuk-footer__inline-list-item">
+    <%= link_to t('layout.support.provider_service_guidance'), provider_interface_service_guidance_path, class: 'govuk-footer__link' %>
+  </li>
   <li class="govuk-footer__inline-list-item">
     <%= link_to t('layout.support_links.accessibility'), provider_interface_accessibility_path, class: 'govuk-footer__link' %>
   </li>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -66,8 +66,8 @@
     <% when 'support_interface' %>
       <%= javascript_pack_tag 'application-support' %>
     <% when 'provider_interface' %>
-      <%= javascript_pack_tag 'application-provider' %>
       <%= render 'shared/zendesk_snippet' if HostingEnvironment.test_environment? %>
+      <%= javascript_pack_tag 'application-provider' %>
     <% when /api_docs/ %>
       <%= javascript_pack_tag 'application-api-docs' %>
     <% else %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -65,7 +65,7 @@
     <% when 'support_interface' %>
       <%= javascript_pack_tag 'application-support' %>
     <% when 'provider_interface' %>
-      <%= render 'shared/zendesk_snippet' if HostingEnvironment.test_environment? %>
+      <%= render 'shared/zendesk_snippet' if FeatureFlag.active?(:enable_chat_support) %>
       <%= javascript_pack_tag 'application-provider' %>
     <% when /api_docs/ %>
       <%= javascript_pack_tag 'application-api-docs' %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -62,7 +62,6 @@
     <% case try(:current_namespace) %>
     <% when 'candidate_interface' %>
       <%= javascript_pack_tag 'application-candidate' %>
-      <%= render 'shared/zendesk_snippet' if HostingEnvironment.test_environment? %>
     <% when 'support_interface' %>
       <%= javascript_pack_tag 'application-support' %>
     <% when 'provider_interface' %>

--- a/app/views/shared/_zendesk_snippet.html.erb
+++ b/app/views/shared/_zendesk_snippet.html.erb
@@ -1,5 +1,9 @@
-<script
-  id="ze-snippet"
-  nonce="<%= request.content_security_policy_nonce %>"
-  src=https://static.zdassets.com/ekr/snippet.js?key=904d04ae-8027-4ebb-ad39-d0e9f68d6ab1>
-</script>
+<% if Rails.env.test? %>
+  <%= javascript_pack_tag('zendesk-stub') %>
+<% else %>
+  <script
+    id="ze-snippet"
+    nonce="<%= request.content_security_policy_nonce %>"
+    src=https://static.zdassets.com/ekr/snippet.js?key=904d04ae-8027-4ebb-ad39-d0e9f68d6ab1>
+  </script>
+<% end %>

--- a/babel.config.js
+++ b/babel.config.js
@@ -66,6 +66,12 @@ module.exports = function(api) {
         {
           async: false
         }
+      ],
+      [
+        '@babel/plugin-proposal-private-methods',
+        {
+          loose: true
+        }
       ]
     ].filter(Boolean)
   }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -246,12 +246,12 @@ en:
     check_and_submit: Check and submit your application
   layout:
     support:
-      title: Get support
+      title: Get help
       telephone: Telephone
       online_chat: Online chat
       talk_to_advisor: Talk to an adviser online
-      response_time: We respond within 5 working days, or one working day for more urgent queries
-      provider_service_guidance: How to use Manage teacher training applications
+      response_time: "- response times are usually under one working day"
+      provider_service_guidance: How to use this service
     support_links:
       title: Support links
       accessibility: Accessibility

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -250,7 +250,7 @@ en:
       telephone: Telephone
       online_chat: Online chat
       talk_to_advisor: Talk to an adviser online
-      response_time: "- response times are usually under one working day"
+      response_time: You’ll get a response within 5 working days, or one working day for urgent requests.
       provider_service_guidance: How to use this service
     support_links:
       title: Support links

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     ],
     "globals": [
       "$",
-      "history"
+      "history",
+      "zE",
+      "CustomEvent"
     ]
   },
   "stylelint": {

--- a/spec/system/provider_interface/provider_uses_webchat_spec.rb
+++ b/spec/system/provider_interface/provider_uses_webchat_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Provider uses webchat' do
 
   scenario 'controlling the widget via a link in the footer', js: true do
     given_i_am_a_provider_user
+    and_chat_support_is_enabled
     and_i_sign_in_to_the_provider_interface
     when_i_visit_the_provider_interface
     and_there_is_no_support_agent_online
@@ -22,6 +23,10 @@ RSpec.feature 'Provider uses webchat' do
   def given_i_am_a_provider_user
     provider_user = create(:provider_user)
     user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+  end
+
+  def and_chat_support_is_enabled
+    FeatureFlag.activate(:enable_chat_support)
   end
 
   def and_i_sign_in_to_the_provider_interface

--- a/spec/system/provider_interface/provider_uses_webchat_spec.rb
+++ b/spec/system/provider_interface/provider_uses_webchat_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider uses webchat' do
+  include DfESignInHelpers
+
+  scenario 'controlling the widget via a link in the footer', js: true do
+    given_i_am_a_provider_user
+    and_i_sign_in_to_the_provider_interface
+    when_i_visit_the_provider_interface
+    and_there_is_no_support_agent_online
+
+    then_i_should_see_a_placeholder_in_the_footer
+
+    when_a_support_agent_comes_online
+    then_i_should_see_a_link_in_the_footer
+    and_when_i_click_the_link_i_see_a_popup
+
+    when_the_support_agent_goes_offline
+    then_i_should_be_informed_chat_is_unavailable
+  end
+
+  def given_i_am_a_provider_user
+    provider_user = create(:provider_user)
+    user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+  end
+
+  def and_i_sign_in_to_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def when_i_visit_the_provider_interface
+    visit provider_interface_applications_path
+  end
+
+  def and_there_is_no_support_agent_online; end
+
+  def then_i_should_see_a_placeholder_in_the_footer
+    expect(page).to have_content('You cannot use online chat')
+  end
+
+  def when_a_support_agent_comes_online
+    page.evaluate_script('setZendeskStatus("online")')
+  end
+
+  def then_i_should_see_a_link_in_the_footer
+    expect(page).to have_content('Speak to an advisor now')
+  end
+
+  def and_when_i_click_the_link_i_see_a_popup
+    click_link 'Speak to an advisor now'
+
+    expect(page.evaluate_script('window.zendeskPopupOpen')).to eq true
+  end
+
+  def when_the_support_agent_goes_offline
+    page.evaluate_script('setZendeskStatus("offline")')
+  end
+
+  def then_i_should_be_informed_chat_is_unavailable
+    expect(page).to have_content('Available Monday to Friday')
+  end
+end


### PR DESCRIPTION
## Context

Zendesk chat is usually triggered by a floating button, which isn't accessible. We would prefer to trigger from an ordinary link in the footer.

## Changes proposed in this pull request

- add JS and markup to show or hide the chat link depending on whether support agents are online. Provide a default message for when JS is disabled or the Zendesk API is not working.
- include a stub version of the Zendesk chat JS snippet for testing

## Link to Trello card

https://trello.com/c/nTSDfNj7/3896-design-chat-widget

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
