### PR TITLE
Set up interview permissions when inviting a user

### DIFF
--- a/app/components/provider_interface/provider_user_invitation_permissions_component.rb
+++ b/app/components/provider_interface/provider_user_invitation_permissions_component.rb
@@ -6,6 +6,7 @@ module ProviderInterface
       'view_safeguarding_information' => 'Access safeguarding information',
       'manage_organisations' => 'Manage organisational permissions',
       'manage_users' => 'Manage users',
+      'set_up_interviews' => 'Set up interviews',
       'make_decisions' => 'Make decisions',
       'view_diversity_information' => 'Access diversity information',
     }.freeze
@@ -15,7 +16,15 @@ module ProviderInterface
     end
 
     def permissions
-      @permissions.map { |p| HUMAN_READABLE_PERMISSIONS.fetch(p.to_s) }
+      @permissions.map { |p| readable_permissions.fetch(p.to_s, nil) }.compact
+    end
+
+    def readable_permissions
+      if FeatureFlag.active?(:interview_permissions)
+        HUMAN_READABLE_PERMISSIONS
+      else
+        HUMAN_READABLE_PERMISSIONS.except('set_up_interviews')
+      end
     end
   end
 end

--- a/app/models/provider_permissions.rb
+++ b/app/models/provider_permissions.rb
@@ -3,6 +3,7 @@ class ProviderPermissions < ApplicationRecord
     manage_users
     manage_organisations
     view_safeguarding_information
+    set_up_interviews
     make_decisions
     view_diversity_information
   ].freeze

--- a/app/views/provider_interface/_fields_for_permissions.html.erb
+++ b/app/views/provider_interface/_fields_for_permissions.html.erb
@@ -38,6 +38,14 @@
           hint: { text: 'Invite or delete users and set their permissions' },
         ) %>
 
+        <% if FeatureFlag.active?(:interview_permissions) %>
+          <%= pf.govuk_check_box(
+            :permissions,
+            'set_up_interviews',
+            label: { text: 'Set up interviews' },
+          ) %>
+        <% end %>
+
         <%= pf.govuk_check_box(
           :permissions,
           'make_decisions',

--- a/spec/components/provider_interface/provider_user_invitation_details_component_spec.rb
+++ b/spec/components/provider_interface/provider_user_invitation_details_component_spec.rb
@@ -58,18 +58,34 @@ RSpec.describe ProviderInterface::ProviderUserInvitationDetailsComponent do
         email_address: 'ed@example.com',
         providers: [provider.id.to_s],
         provider_permissions: {
-          provider.id.to_s => { 'provider_id' => provider.id, 'permissions' => %w[manage_users] },
+          provider.id.to_s => { 'provider_id' => provider.id, 'permissions' => %w[manage_users set_up_interviews] },
         },
         single_provider: 'true',
       )
     end
 
-    it 'conditionally hides provider information' do
-      result = render_inline(described_class.new(wizard: wizard))
+    context 'conditionally hides provider information' do
+      it 'when the interview_permissions feature flag is on' do
+        FeatureFlag.activate(:interview_permissions)
 
-      expect(result.css('.govuk-summary-list__key')[3].text).to include('Permissions')
-      expect(result.css('.govuk-summary-list__key')[3].text).not_to include("Permissions: #{provider.name}")
-      expect(result.css('.govuk-summary-list__value')[3].text).to include('Manage users')
+        result = render_inline(described_class.new(wizard: wizard))
+
+        expect(result.css('.govuk-summary-list__key')[3].text).to include('Permissions')
+        expect(result.css('.govuk-summary-list__key')[3].text).not_to include("Permissions: #{provider.name}")
+        expect(result.css('.govuk-summary-list__value')[3].text).to include('Manage users')
+        expect(result.css('.govuk-summary-list__value')[3].text).to include('Set up interviews')
+      end
+
+      it 'when the interview_permissions feature flag is off' do
+        FeatureFlag.deactivate(:interview_permissions)
+
+        result = render_inline(described_class.new(wizard: wizard))
+
+        expect(result.css('.govuk-summary-list__key')[3].text).to include('Permissions')
+        expect(result.css('.govuk-summary-list__key')[3].text).not_to include("Permissions: #{provider.name}")
+        expect(result.css('.govuk-summary-list__value')[3].text).to include('Manage users')
+        expect(result.css('.govuk-summary-list__value')[3].text).not_to include('Set up interviews')
+      end
     end
   end
 

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -4,6 +4,10 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
   include DfESignInHelpers
   include DsiAPIHelper
 
+  before do
+    FeatureFlag.activate(:interview_permissions)
+  end
+
   scenario 'Provider sends invite to user' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_manage_applications_for_two_providers
@@ -154,6 +158,7 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
   end
 
   def when_i_select_make_decisions_permission
+    check 'Set up interviews'
     check 'Make decisions'
   end
 
@@ -164,6 +169,7 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
     expect(page).to have_content 'ed@example.com'
     expect(page).not_to have_content 'Example Provider'
     expect(page).to have_content 'Another Provider'
+    expect(page).to have_content 'Set up interviews'
     expect(page).to have_content 'Make decisions'
     expect(page).not_to have_content 'Manage users'
     expect(page).not_to have_content 'Access diversity information'
@@ -205,6 +211,7 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
 
   def then_i_see_the_confirm_page_with_the_new_permissions
     expect(page).to have_content 'Another Provider'
+    expect(page).to have_content 'Set up interviews'
     expect(page).to have_content 'Make decisions'
     expect(page).to have_content 'Manage users'
   end


### PR DESCRIPTION
Includes commits from #5088 

## Context

Update the Invite provider user flow’s change permissions step to enable configuring the `set_up_interview` permission.


## Guidance to review

Activate `interview_permissions` feature flag
Invite a new user and configure `Set up interviews`

## Link to Trello card

https://trello.com/c/n975UKe6/3914-set-up-interview-permissions-when-inviting-a-user

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
