### PR TITLE
Further content updates to the references section

### DIFF
--- a/app/components/candidate_interface/add_reference_component.html.erb
+++ b/app/components/candidate_interface/add_reference_component.html.erb
@@ -1,9 +1,9 @@
 <%= govuk_inset_text do %>
   <% if no_viable_references? %>
-    <p class="govuk-body">You need 2 references before you can submit your application.</p>
+    <p class="govuk-body">You need to get 2 references back before you can submit your application.</p>
     <%= govuk_link_to 'Add a referee', candidate_interface_references_start_path, button: true %>
   <% elsif one_viable_reference? %>
-    <p class="govuk-body">You need 2 references before you can submit your application.</p>
+    <p class="govuk-body">You need to get 2 references back before you can submit your application.</p>
     <%= govuk_link_to 'Add a second referee', candidate_interface_references_start_path, button: true %>
   <% else %>
     <% if FeatureFlag.active?(:reference_selection) && @application_form.minimum_references_available_for_selection? %>

--- a/app/views/candidate_interface/references/selection/new.html.erb
+++ b/app/views/candidate_interface/references/selection/new.html.erb
@@ -31,7 +31,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl"><%= t('page_titles.references_selection') %></h1>
 
-      <p class="govuk-body">Once you’ve received 2 or more references, you can select which ones to include in your application.</p>
+      <p class="govuk-body">Once you’ve received 2 or more references, you need to select 2 to include in your application.</p>
 
       <p class="govuk-body">You can <%= govuk_link_to 'request references and track their progress', candidate_interface_references_review_path %> in the references section.</p>
 

--- a/app/views/candidate_interface/references/start/show.html.erb
+++ b/app/views/candidate_interface/references/start/show.html.erb
@@ -19,13 +19,16 @@
 
     <p class="govuk-body">Training providers will only accept a character reference if there’s also an academic or professional reference.</p>
 
-    <p class="govuk-body">You can add as many referees as you like to increase the chances of getting 2 references quickly.</p>
-
     <h2 class="govuk-heading-m">Contact your referees</h2>
 
-    <p class="govuk-body">Contact your referees in advance to check that they can submit a reference quickly online.</p>
+    <p class="govuk-body">Your referees will receive a link to an online form to complete. References sent to providers by email will not be accepted.</p>
 
-    <p class="govuk-body">Check that they can give you a full reference and not just confirm the dates you worked there. Providers need to know if you're suitable to become a teacher.</p>
+    <p class="govuk-body">Contact your referees in advance to check that they can:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>type or paste their references into an online form (with a 500-word limit)</li>
+      <li>submit a reference quickly, so as not to delay your application</li>
+      <li>give you a full reference – providers need to know if you’re suitable to become a teacher</li>
+    </ul>
 
     <%= govuk_link_to t('continue'), candidate_interface_references_type_path, class: 'govuk-button' %>
   </div>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -40,11 +40,15 @@
       <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.references') %></h2>
 
       <% unless @application_form_presenter.references_completed? %>
-        <p class="govuk-body">Request your references as soon as possible. You need to get 2 references back before you can submit your application. It takes 8 days to get a reference on average.</p>
+        <% if @application_form.application_references.feedback_provided.count > 1 %>
+          <p class="govuk-body">You need to select 2 references to submit with your application.</p>
+        <% else %>
+          <%= govuk_inset_text(classes: 'govuk-!-margin-top-1 govuk-!-margin-bottom-1 govuk-!-margin-right-3') do %>
+            <p class="govuk-body">Request your references as soon as possible. You need to get 2 references back before you can submit your application. It takes 8 days to get a reference on average.</p>
 
-        <p class="govuk-body">You can add as many referees as you like to increase the chances of getting 2 references quickly.</p>
-
-        <p class="govuk-body">Once you’ve received your references, you can select which 2 to submit with your application.</p>
+            <p class="govuk-body">You can add as many referees as you like to increase the chances of getting 2 references quickly. Once you’ve received 2 or more references, you need to select 2 to include in your application.</p>
+          <% end %>
+        <% end %>
       <% end %>
 
       <% if FeatureFlag.active?(:reference_selection) %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -40,9 +40,11 @@
       <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.references') %></h2>
 
       <% unless @application_form_presenter.references_completed? %>
-        <p class="govuk-body">You have to get 2 references back before you can submit your application.</p>
+        <p class="govuk-body">Request your references as soon as possible. You need to get 2 references back before you can submit your application. It takes 8 days to get a reference on average.</p>
 
-        <p class="govuk-body">It takes 8 days to get a reference on average.</p>
+        <p class="govuk-body">You can add as many referees as you like to increase the chances of getting 2 references quickly.</p>
+
+        <p class="govuk-body">Once you’ve received your references, you can select which 2 to submit with your application.</p>
       <% end %>
 
       <% if FeatureFlag.active?(:reference_selection) %>

--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -1,19 +1,17 @@
 # You have a reference from <%= @reference.name %>
 
 <% if FeatureFlag.active?(:reference_selection) && @selected_references.count >= ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
-You have enough references to send your application to training providers.
-
 You’ve selected 2 references to submit with your application already, but you can change your selection if you want.
 
 Sign in to complete your application:
 <% elsif FeatureFlag.active?(:reference_selection) && @provided_references.count > ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
 You have more than enough references to send your application to training providers.
 
-Sign in to complete your application:
+Sign in and select 2 references to submit with your application:
 <% elsif FeatureFlag.active?(:reference_selection) && @provided_references.count == ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
 You have enough references to send your application to training providers.
 
-Sign in to complete your application:
+Sign in and select 2 references to submit with your application:
 <% elsif @application_form.enough_references_have_been_provided? %>
 You’ve got 2 references back now.
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,7 +161,7 @@ en:
     references_select: Which 2 references do you want to include in your application?
     references_request: Add your references
     references_review: Review your references
-    references_selection: Select your references
+    references_selection: Select 2 references
     application_feedback: How can we improve %{section} section?
     application_feedback_thank_you: Thank you for your feedback
     find_feedback: Help us improve this service

--- a/spec/components/candidate_interface/add_reference_component_spec.rb
+++ b/spec/components/candidate_interface/add_reference_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CandidateInterface::AddReferenceComponent do
 
       expect(link_text(result)).to eq 'Add a referee'
       expect(href(result)).to eq '/candidate/application/references/start'
-      expect(body_text(result)).to eq 'You need 2 references before you can submit your application.'
+      expect(body_text(result)).to eq 'You need to get 2 references back before you can submit your application.'
     end
   end
 
@@ -24,7 +24,7 @@ RSpec.describe CandidateInterface::AddReferenceComponent do
 
       expect(link_text(result)).to eq 'Add a second referee'
       expect(href(result)).to eq '/candidate/application/references/start'
-      expect(body_text(result)).to eq 'You need 2 references before you can submit your application.'
+      expect(body_text(result)).to eq 'You need to get 2 references back before you can submit your application.'
     end
   end
 

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -131,7 +131,7 @@ module CandidateHelper
 
   def select_references_and_complete_section
     visit candidate_interface_application_form_path
-    click_link 'Select your references'
+    click_link 'Select 2 references'
     application_form = ApplicationForm.last
     first_reference = application_form.application_references.feedback_provided.first
     second_reference = application_form.application_references.feedback_provided.second

--- a/spec/system/candidate_interface/apply_again/candidate_reviews_rejection_reasons_from_previous_applications_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_reviews_rejection_reasons_from_previous_applications_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature 'Candidate with unsuccessful application can review rejection reas
     candidate_fills_in_apply_again_course_choice
 
     if FeatureFlag.active?(:reference_selection)
-      click_link 'Select your references'
+      click_link 'Select 2 references'
       choose 'Yes, I have completed this section'
       click_button t('save_and_continue')
     end

--- a/spec/system/candidate_interface/references/reference_selection/candidate_deletes_a_selected_reference_spec.rb
+++ b/spec/system/candidate_interface/references/reference_selection/candidate_deletes_a_selected_reference_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature 'References' do
 
   def and_the_section_is_not_marked_as_completed
     visit candidate_interface_application_form_path
-    expect(page).to have_css('#select-your-references-badge-id', text: 'Incomplete')
+    expect(page).to have_css('#select-2-references-badge-id', text: 'Incomplete')
   end
 
   def and_i_am_no_longer_told_i_can_still_change_my_choice
@@ -84,7 +84,7 @@ RSpec.feature 'References' do
   end
 
   def then_the_section_is_marked_as_completed
-    expect(page).to have_css('#select-your-references-badge-id', text: 'Completed')
+    expect(page).to have_css('#select-2-references-badge-id', text: 'Completed')
   end
 
   def when_i_visit_the_select_references_page
@@ -93,6 +93,6 @@ RSpec.feature 'References' do
 
   def then_i_am_presented_with_the_guidance
     expect(page).to have_current_path candidate_interface_select_references_path
-    expect(page).to have_content 'Once you’ve received 2 or more references, you can select which ones to include in your application.'
+    expect(page).to have_content 'Once you’ve received 2 or more references, you need to select 2 to include in your application.'
   end
 end

--- a/spec/system/candidate_interface/references/reference_selection/candidate_reviews_references_spec.rb
+++ b/spec/system/candidate_interface/references/reference_selection/candidate_reviews_references_spec.rb
@@ -46,14 +46,14 @@ RSpec.feature 'Review references' do
 
   def then_the_references_section_is_incomplete
     when_i_view_my_application
-    within '#select-your-references-badge-id' do
+    within '#select-2-references-badge-id' do
       expect(page).to have_content 'Incomplete'
     end
   end
 
   def then_the_references_section_is_still_incomplete
     when_i_view_my_application
-    within '#select-your-references-badge-id' do
+    within '#select-2-references-badge-id' do
       expect(page).to have_content 'Incomplete'
     end
   end
@@ -75,14 +75,14 @@ RSpec.feature 'Review references' do
 
   def and_i_mark_the_section_complete
     when_i_view_my_application
-    click_link 'Select your references'
+    click_link 'Select 2 references'
     choose 'Yes'
     click_button t('save_and_continue')
   end
 
   def then_the_references_section_is_complete
     when_i_view_my_application
-    within '#select-your-references-badge-id' do
+    within '#select-2-references-badge-id' do
       expect(page).to have_content 'Complete'
     end
   end

--- a/spec/system/candidate_interface/references/reference_selection/candidate_selects_two_references_spec.rb
+++ b/spec/system/candidate_interface/references/reference_selection/candidate_selects_two_references_spec.rb
@@ -83,7 +83,7 @@ RSpec.feature 'Candidate selects two references of many feedback_provided refere
   alias_method :and_i_visit_the_select_references_page, :when_i_visit_the_select_references_page
 
   def then_i_am_told_i_need_to_receive_references
-    expect(page).to have_content 'Once you’ve received 2 or more references, you can select which ones to include in your application.'
+    expect(page).to have_content 'Once you’ve received 2 or more references, you need to select 2 to include in your application.'
   end
 
   def and_i_see_the_select_references_page
@@ -149,7 +149,7 @@ RSpec.feature 'Candidate selects two references of many feedback_provided refere
   end
 
   def when_i_revisit_the_select_references_page
-    click_link 'Select your references'
+    click_link 'Select 2 references'
   end
 
   def and_i_mark_the_section_as_completed
@@ -157,7 +157,7 @@ RSpec.feature 'Candidate selects two references of many feedback_provided refere
   end
 
   def then_i_see_the_section_is_incomplete
-    expect(page).to have_css('#select-your-references-badge-id', text: 'Incomplete')
+    expect(page).to have_css('#select-2-references-badge-id', text: 'Incomplete')
   end
 
   def and_that_i_can_still_change_my_choice
@@ -165,6 +165,6 @@ RSpec.feature 'Candidate selects two references of many feedback_provided refere
   end
 
   def then_i_see_the_references_section_is_complete
-    expect(page).to have_css('#select-your-references-badge-id', text: 'Completed')
+    expect(page).to have_css('#select-2-references-badge-id', text: 'Completed')
   end
 end

--- a/spec/system/candidate_interface/references/reference_selection/candidate_submits_an_application_spec.rb
+++ b/spec/system/candidate_interface/references/reference_selection/candidate_submits_an_application_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature 'Submitting an application' do
     then_i_get_an_error_about_not_having_enough_references
 
     when_most_of_my_references_have_been_provided
+    then_the_copy_is_updated
     and_i_submit_the_application
     then_i_get_an_error_about_not_selecting_enough_references
 
@@ -128,6 +129,11 @@ RSpec.feature 'Submitting an application' do
   def when_most_of_my_references_have_been_provided
     receive_references
     SubmitReference.new(reference: @reference3).save!
+  end
+
+  def then_the_copy_is_updated
+    visit candidate_interface_application_form_path
+    expect(page).to have_content('You need to select 2 references to submit with your application.')
   end
 
   def when_i_select_my_references

--- a/spec/system/candidate_interface/references/reference_selection/candidate_submits_an_application_spec.rb
+++ b/spec/system/candidate_interface/references/reference_selection/candidate_submits_an_application_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature 'Submitting an application' do
 
   def then_i_can_see_references_are_in_progress
     visit candidate_interface_application_form_path
-    expect(page).to have_content('You have to get 2 references back before you can submit your application.')
+    expect(page).to have_content('Request your references as soon as possible. You need to get 2 references back before you can submit your application.')
     within(all('.app-task-list')[1]) do
       expect(page).to have_content("#{@reference1.name}: Awaiting response")
       expect(page).to have_content("#{@reference2.name}: Awaiting response")
@@ -61,7 +61,7 @@ RSpec.feature 'Submitting an application' do
   end
 
   def then_i_can_see_references_are_incomplete
-    expect(page).to have_content('You have to get 2 references back before you can submit your application.')
+    expect(page).to have_content('Request your references as soon as possible. You need to get 2 references back before you can submit your application.')
     within(all('.app-task-list')[1]) do
       expect(page).to have_content('Incomplete')
     end
@@ -69,7 +69,7 @@ RSpec.feature 'Submitting an application' do
 
   def then_i_can_see_the_references_section_is_complete
     visit candidate_interface_application_form_path
-    expect(page).not_to have_content('You have to get 2 references back before you can submit your application.')
+    expect(page).not_to have_content('Request your references as soon as possible. You need to get 2 references back before you can submit your application.')
     within(all('.app-task-list')[1]) do
       expect(page).to have_content('Complete')
       expect(page).to have_content("#{@reference1.name}: Reference received")

--- a/spec/system/candidate_interface/references/submitting_an_application_spec.rb
+++ b/spec/system/candidate_interface/references/submitting_an_application_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Submitting an application' do
   end
 
   def then_i_can_see_references_are_incomplete
-    expect(page).to have_content('You have to get 2 references back before you can submit your application.')
+    expect(page).to have_content('Request your references as soon as possible. You need to get 2 references back before you can submit your application.')
     within(all('.app-task-list')[1]) do
       expect(page).to have_content('Incomplete')
       expect(page).to have_link('Add your references')
@@ -39,7 +39,7 @@ RSpec.feature 'Submitting an application' do
 
   def then_i_can_see_references_are_in_progress
     visit candidate_interface_application_form_path
-    expect(page).to have_content('You have to get 2 references back before you can submit your application.')
+    expect(page).to have_content('Request your references as soon as possible. You need to get 2 references back before you can submit your application.')
     within(all('.app-task-list')[1]) do
       expect(page).to have_content('In progress')
       expect(page).to have_link('Manage your references')
@@ -50,7 +50,7 @@ RSpec.feature 'Submitting an application' do
 
   def then_i_can_see_references_are_complete
     visit candidate_interface_application_form_path
-    expect(page).not_to have_content('You have to get 2 references back before you can submit your application.')
+    expect(page).not_to have_content('Request your references as soon as possible. You need to get 2 references back before you can submit your application.')
     within(all('.app-task-list')[1]) do
       expect(page).to have_content('Complete')
       expect(page).to have_link('Review your references')


### PR DESCRIPTION
## Context

These are further changes to the new references section, following UR sessions.

## Changes proposed in this pull request

Copy update for when the candidate has not yet received a reference (the link text has also been updated):
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/47917431/124430183-c1a2b280-dd66-11eb-8c3d-a853f47f2b10.png)|![image](https://user-images.githubusercontent.com/47917431/124637087-31a55b80-de81-11eb-9fb1-591b2dae81a1.png)|

Conditionally change the section advice:
|No references received|Two (or more) references received|Section completed|
|---|---|---|
|![image](https://user-images.githubusercontent.com/47917431/124637087-31a55b80-de81-11eb-9fb1-591b2dae81a1.png)|![image](https://user-images.githubusercontent.com/47917431/124445570-95dbf880-dd77-11eb-888f-bca5c1622de3.png)|![image](https://user-images.githubusercontent.com/47917431/124445744-b906a800-dd77-11eb-8aef-2d56f5ca9379.png)|

Updated email copy:
|Received 2 references|Received 3 or more references|Already selected 2 and another comes in|
|---|---|---|
|![image](https://user-images.githubusercontent.com/47917431/124600756-f72ac700-de5e-11eb-9e42-e82ef84d8e75.png)|![image](https://user-images.githubusercontent.com/47917431/124470545-a00bf000-dd93-11eb-974a-653fab520be4.png)|![image](https://user-images.githubusercontent.com/47917431/124470491-91bdd400-dd93-11eb-89ac-f062651b4ead.png)|

Copy change for 'Choose your referees' guidance:
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/47917431/124475280-6fc75000-dd99-11eb-903a-e8164ef21ac5.png)|![image](https://user-images.githubusercontent.com/47917431/124475215-5d4d1680-dd99-11eb-9af0-3fff01614a5e.png)|

Copy change for guidance:
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/47917431/124475772-0136c200-dd9a-11eb-9477-956982fba226.png)|![image](https://user-images.githubusercontent.com/47917431/124475719-f1b77900-dd99-11eb-939e-237ebbde782a.png)|

## Guidance to review

Refer to the Google Doc attached to the Trello ticket for the requested changes

## Link to Trello card

https://trello.com/c/yLQLuKz1

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
