### PR TITLE
Create custom methods from error field name

### DIFF
--- a/app/forms/provider_interface/provider_relationship_permissions_setup_wizard.rb
+++ b/app/forms/provider_interface/provider_relationship_permissions_setup_wizard.rb
@@ -150,7 +150,13 @@ module ProviderInterface
       return if current_permissions_form.valid?
 
       current_permissions_form.errors.map do |error|
-        errors.add("provider_relationship_permissions[#{current_provider_relationship_id}][#{error.attribute}]", error.message)
+        field_name = "provider_relationship_permissions[#{current_provider_relationship_id}][#{error.attribute}]"
+        # We record these validation errors and call the method named by the error key,
+        # see ApplicationController#track_validation_error
+        # in the case of indexed fields the method doesn't exist, so define this here.
+        self.class.send(:define_method, field_name) { error.message }
+
+        errors.add(field_name, error.message)
       end
     end
   end

--- a/spec/forms/provider_interface/provider_relationship_permissions_setup_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_relationship_permissions_setup_wizard_spec.rb
@@ -103,17 +103,24 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionsSetupWizard do
   end
 
   describe 'validations' do
-    context 'when no providers are selected for a permission' do
-      it 'is invalid' do
-        wizard = described_class.new(
-          state_store_for({}),
-          'current_provider_relationship_id' => '123',
-          'provider_relationship_permissions' => { '123' => { 'make_decisions' => [''], 'view_safeguarding_information' => %w[training], 'view_diversity_information' => %w[training] } },
-        )
+    let(:wizard) do
+      described_class.new(
+        state_store_for({}),
+        'current_provider_relationship_id' => '123',
+        'provider_relationship_permissions' => {
+          '123' => { 'make_decisions' => [''], 'view_safeguarding_information' => %w[training], 'view_diversity_information' => %w[training] },
+        },
+      )
+    end
 
-        expect(wizard.valid?(:permissions)).to be false
-        expect(wizard.errors.attribute_names).to eq([:'provider_relationship_permissions[123][make_decisions]'])
-      end
+    it 'is invalid when no providers are selected for a permission' do
+      expect(wizard.valid?(:permissions)).to be false
+      expect(wizard.errors.attribute_names).to eq([:'provider_relationship_permissions[123][make_decisions]'])
+    end
+
+    it 'creates custom methods with the field name that contain the error value' do
+      expect(wizard.valid?(:permissions)).to be false
+      expect(wizard.public_send('provider_relationship_permissions[123][make_decisions]')).to eq('Select which organisations can make decisions')
     end
   end
 


### PR DESCRIPTION
## Context

When tracking validation errors on indexed fields we attempt to retrieve the value via 'send' which won't work.
So define a custom method to satisfy the validation error tracking.

See https://github.com/DFE-Digital/apply-for-teacher-training/pull/4927 as example of how we've addressed this elsewhere.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Define a custom method to satisfy the validation error tracking.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ze3xIMoN/3886-validation-error-exception-from-permission-form
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
