### PR TITLE
Redirect away from reference cancel if reference deleted

### DIFF
--- a/app/controllers/candidate_interface/references/review_controller.rb
+++ b/app/controllers/candidate_interface/references/review_controller.rb
@@ -67,7 +67,7 @@ module CandidateInterface
       end
 
       def confirm_cancel
-        if @reference.feedback_requested?
+        if @reference&.feedback_requested?
           @application_form = current_application
         else
           redirect_to_review_page
@@ -75,7 +75,7 @@ module CandidateInterface
       end
 
       def cancel
-        if @reference.feedback_requested?
+        if @reference&.feedback_requested?
           CancelReferee.new.call(reference: @reference)
 
           redirect_to_review_page


### PR DESCRIPTION
## Context
Navigating to the cancel reference confirmation page after the reference has been destroyed causes an error https://sentry.io/organizations/dfe-bat/issues/2488264210/?project=1765973&referrer=slack
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Redirect to the review page if the reference can't be found.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/h4F6Jk67
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
