### PR TITLE
Support user can set up interview permissions when creating a new pro…

### DIFF
--- a/app/components/support_interface/permissions_list_review_component.html.erb
+++ b/app/components/support_interface/permissions_list_review_component.html.erb
@@ -11,6 +11,14 @@
     <li><%= render IconComponent.new(type: 'cross') %> Manage users</li>
   <% end %>
 
+  <% if FeatureFlag.active?(:interview_permissions) %>
+    <% if permissions['set_up_interviews'] %>
+      <li><%= render IconComponent.new(type: 'check') %> Set up interviews</li>
+    <% else %>
+      <li><%= render IconComponent.new(type: 'cross') %> Set up interviews</li>
+    <% end %>
+  <% end %>
+
   <% if permissions['make_decisions'] %>
     <li><%= render IconComponent.new(type: 'check') %> Make decisions</li>
   <% else %>

--- a/app/views/support_interface/bulk_upload/permissions/_provider_permissions.html.erb
+++ b/app/views/support_interface/bulk_upload/permissions/_provider_permissions.html.erb
@@ -24,6 +24,14 @@
             multiple: false,
             label: { text: 'Make decisions' },
           ) %>
+      <% if FeatureFlag.active?(:interview_permissions) %>
+        <%= ppf.govuk_check_box(
+              :set_up_interviews,
+              true,
+              multiple: false,
+              label: { text: 'Set up interviews' },
+            ) %>
+      <% end %>
       <%= ppf.govuk_check_box(
             :view_safeguarding_information,
             true,

--- a/app/views/support_interface/provider_users/_provider_options.html.erb
+++ b/app/views/support_interface/provider_users/_provider_options.html.erb
@@ -25,6 +25,14 @@
                 multiple: false,
                 label: { text: 'Manage organisational permissions' },
               ) %>
+              <% if FeatureFlag.active?(:interview_permissions) %>
+                <%= ppf.govuk_check_box(
+                  :set_up_interviews,
+                  true,
+                  multiple: false,
+                  label: { text: 'Set up interviews' },
+                ) %>
+              <% end %>
               <%= ppf.govuk_check_box(
                 :make_decisions,
                 true,

--- a/app/views/support_interface/single_provider_users/_edit_provider_permissions.html.erb
+++ b/app/views/support_interface/single_provider_users/_edit_provider_permissions.html.erb
@@ -18,6 +18,14 @@
               multiple: false,
               label: { text: 'Manage organisational permissions' },
             ) %>
+        <% if FeatureFlag.active?(:interview_permissions) %>
+          <%= ppf.govuk_check_box(
+                :set_up_interviews,
+                true,
+                multiple: false,
+                label: { text: 'Set up interviews' },
+              ) %>
+        <% end %>
         <%= ppf.govuk_check_box(
               :make_decisions,
               true,

--- a/app/views/support_interface/single_provider_users/_provider_permissions.html.erb
+++ b/app/views/support_interface/single_provider_users/_provider_permissions.html.erb
@@ -18,6 +18,14 @@
             multiple: false,
             label: { text: 'Manage organisational permissions' },
           ) %>
+      <% if FeatureFlag.active?(:interview_permissions) %>
+        <%= ppf.govuk_check_box(
+              :set_up_interviews,
+              true,
+              multiple: false,
+              label: { text: 'Set up interviews' },
+            ) %>
+      <% end %>
       <%= ppf.govuk_check_box(
             :make_decisions,
             true,

--- a/spec/components/support_interface/permissions_list_review_component_spec.rb
+++ b/spec/components/support_interface/permissions_list_review_component_spec.rb
@@ -4,13 +4,18 @@ RSpec.describe SupportInterface::PermissionsListReviewComponent do
   let(:tick_svg_path_shape) { 'M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z' }
   let(:cross_svg_path_shape) { 'M100 0a100 100 0 110 200 100 100 0 010-200zm30 50l-30 30-30-30-20 20 30 30-30 30 20 20 30-30 30 30 20-20-30-30 30-30-20-20z' }
 
+  before do
+    FeatureFlag.activate(:interview_permissions)
+  end
+
   context 'Manage organisational permissions' do
     it 'displays permission has been assigned' do
-      permissions = { 'manage_organisations' => true }
+      permissions = { 'manage_organisations' => true, 'set_up_interviews' => true }
 
       result = render_inline(described_class.new(permissions))
 
       expect(result.css('li').text).to include('Manage organisational permissions')
+      expect(result.css('li').text).to include('Set up interviews')
       expect(result.css('path')[0].attribute('d').value).to eq(tick_svg_path_shape)
     end
 
@@ -44,13 +49,13 @@ RSpec.describe SupportInterface::PermissionsListReviewComponent do
     end
   end
 
-  context 'Make decisions' do
+  context 'Set up interviews' do
     it 'displays permission has been assigned' do
-      permissions = { 'make_decisions' => true }
+      permissions = { 'set_up_interviews' => true }
 
       result = render_inline(described_class.new(permissions))
 
-      expect(result.css('li').text).to include('Make decisions')
+      expect(result.css('li').text).to include('Set up interviews')
       expect(result.css('path')[2].attribute('d').value).to eq(tick_svg_path_shape)
     end
 
@@ -59,8 +64,28 @@ RSpec.describe SupportInterface::PermissionsListReviewComponent do
 
       result = render_inline(described_class.new(permissions))
 
-      expect(result.css('li').text).to include('Make decisions')
+      expect(result.css('li').text).to include('Set up interviews')
       expect(result.css('path')[2].attribute('d').value).to eq(cross_svg_path_shape)
+    end
+  end
+
+  context 'Make decisions' do
+    it 'displays permission has been assigned' do
+      permissions = { 'make_decisions' => true }
+
+      result = render_inline(described_class.new(permissions))
+
+      expect(result.css('li').text).to include('Make decisions')
+      expect(result.css('path')[3].attribute('d').value).to eq(tick_svg_path_shape)
+    end
+
+    it 'does not display that permission has been assigned' do
+      permissions = {}
+
+      result = render_inline(described_class.new(permissions))
+
+      expect(result.css('li').text).to include('Make decisions')
+      expect(result.css('path')[3].attribute('d').value).to eq(cross_svg_path_shape)
     end
   end
 
@@ -71,7 +96,7 @@ RSpec.describe SupportInterface::PermissionsListReviewComponent do
       result = render_inline(described_class.new(permissions))
 
       expect(result.css('li').text).to include('Access safeguarding information')
-      expect(result.css('path')[3].attribute('d').value).to eq(tick_svg_path_shape)
+      expect(result.css('path')[4].attribute('d').value).to eq(tick_svg_path_shape)
     end
 
     it 'does not display that permission has been assigned' do
@@ -80,7 +105,7 @@ RSpec.describe SupportInterface::PermissionsListReviewComponent do
       result = render_inline(described_class.new(permissions))
 
       expect(result.css('li').text).to include('Access safeguarding information')
-      expect(result.css('path')[3].attribute('d').value).to eq(cross_svg_path_shape)
+      expect(result.css('path')[4].attribute('d').value).to eq(cross_svg_path_shape)
     end
   end
 
@@ -91,7 +116,7 @@ RSpec.describe SupportInterface::PermissionsListReviewComponent do
       result = render_inline(described_class.new(permissions))
 
       expect(result.css('li').text).to include('Access diversity information')
-      expect(result.css('path')[4].attribute('d').value).to eq(tick_svg_path_shape)
+      expect(result.css('path')[5].attribute('d').value).to eq(tick_svg_path_shape)
     end
 
     it 'does not display that permission has been assigned' do
@@ -100,7 +125,7 @@ RSpec.describe SupportInterface::PermissionsListReviewComponent do
       result = render_inline(described_class.new(permissions))
 
       expect(result.css('li').text).to include('Access diversity information')
-      expect(result.css('path')[4].attribute('d').value).to eq(cross_svg_path_shape)
+      expect(result.css('path')[5].attribute('d').value).to eq(cross_svg_path_shape)
     end
   end
 end

--- a/spec/system/support_interface/managing_users_v2/adding_a_new_provider_user_spec.rb
+++ b/spec/system/support_interface/managing_users_v2/adding_a_new_provider_user_spec.rb
@@ -4,9 +4,12 @@ RSpec.feature 'Managing provider users v2' do
   include DfESignInHelpers
   include DsiAPIHelper
 
-  scenario 'adding a new provider user', with_audited: true do
+  before do
+    FeatureFlag.activate(:interview_permissions)
     FeatureFlag.activate(:new_provider_user_flow)
+  end
 
+  scenario 'adding a new provider user', with_audited: true do
     given_dfe_signin_is_configured
     and_i_am_a_support_user
     and_providers_exist
@@ -26,6 +29,7 @@ RSpec.feature 'Managing provider users v2' do
 
     when_i_enter_the_users_email_and_name
     and_i_check_permission_to_manage_users
+    and_i_check_permission_to_set_up_interviews
     and_i_check_permission_to_manage_organisations
     and_i_check_permission_to_view_safeguarding_information
     and_i_check_permission_to_make_decisions
@@ -87,6 +91,10 @@ RSpec.feature 'Managing provider users v2' do
 
   def and_i_check_permission_to_manage_users
     check 'Manage users'
+  end
+
+  def and_i_check_permission_to_set_up_interviews
+    check 'Set up interviews'
   end
 
   def and_i_check_permission_to_manage_organisations

--- a/spec/system/support_interface/managing_users_v2/adding_provider_to_existing_provider_user_spec.rb
+++ b/spec/system/support_interface/managing_users_v2/adding_provider_to_existing_provider_user_spec.rb
@@ -4,9 +4,12 @@ RSpec.feature 'Managing provider users v2' do
   include DfESignInHelpers
   include DsiAPIHelper
 
-  scenario 'adding provider to an existing provider user', with_audited: true do
+  before do
+    FeatureFlag.activate(:interview_permissions)
     FeatureFlag.activate(:new_provider_user_flow)
+  end
 
+  scenario 'adding provider to an existing provider user', with_audited: true do
     given_dfe_signin_is_configured
     and_i_am_a_support_user
     and_synced_providers_exist
@@ -69,6 +72,7 @@ RSpec.feature 'Managing provider users v2' do
   def and_i_check_permissions
     check 'Manage users'
     check 'Manage organisational permissions'
+    check 'Set up interviews'
   end
 
   def and_i_submit_the_form

--- a/spec/system/support_interface/managing_users_v2/bulk_upload_a_single_provider_user_spec.rb
+++ b/spec/system/support_interface/managing_users_v2/bulk_upload_a_single_provider_user_spec.rb
@@ -4,9 +4,12 @@ RSpec.feature 'bulk upload provider users' do
   include DfESignInHelpers
   include DsiAPIHelper
 
-  scenario 'bulk upload a single provider user', with_audited: true do
+  before do
     FeatureFlag.activate(:new_provider_user_flow)
+    FeatureFlag.activate(:interview_permissions)
+  end
 
+  scenario 'bulk upload a single provider user', with_audited: true do
     given_dfe_signin_is_configured
     and_i_am_a_support_user
     and_a_provider_exists
@@ -123,6 +126,7 @@ RSpec.feature 'bulk upload provider users' do
     check 'Manage organisational permissions'
     check 'Access safeguarding information'
     check 'Make decisions'
+    check 'Set up interviews'
     check 'Access diversity information'
   end
 
@@ -158,6 +162,7 @@ RSpec.feature 'bulk upload provider users' do
     expect(find_field('Manage organisational permissions')).to be_checked
     expect(find_field('Access safeguarding information')).to be_checked
     expect(find_field('Make decisions')).to be_checked
+    expect(find_field('Set up interviews')).to be_checked
     expect(find_field('Access diversity information')).to be_checked
   end
 

--- a/spec/system/support_interface/managing_users_v2/bulk_upload_multiple_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_users_v2/bulk_upload_multiple_provider_users_spec.rb
@@ -4,9 +4,12 @@ RSpec.feature 'bulk upload provider users' do
   include DfESignInHelpers
   include DsiAPIHelper
 
-  scenario 'bulk upload multiple provider users', with_audited: true do
+  before do
     FeatureFlag.activate(:new_provider_user_flow)
+    FeatureFlag.activate(:interview_permissions)
+  end
 
+  scenario 'bulk upload multiple provider users', with_audited: true do
     given_dfe_signin_is_configured
     and_i_am_a_support_user
     and_a_provider_exists
@@ -117,6 +120,7 @@ RSpec.feature 'bulk upload provider users' do
     check 'Manage organisational permissions'
     check 'Access safeguarding information'
     check 'Make decisions'
+    check 'Set up interviews'
     check 'Access diversity information'
   end
 
@@ -168,6 +172,7 @@ RSpec.feature 'bulk upload provider users' do
     expect(find_field('Manage organisational permissions')).to be_checked
     expect(find_field('Access safeguarding information')).to be_checked
     expect(find_field('Make decisions')).to be_checked
+    expect(find_field('Set up interviews')).to be_checked
     expect(find_field('Access diversity information')).to be_checked
   end
 


### PR DESCRIPTION
…vider user or updating an existing user’s details

## Context
Enable support users to configure new `set up interviews` permission when inviting a new provider user or updating an existing provider user's details.

## Guidance to review
- Enable `interview_permissions` and `new_provider_user_flow` feature flags
- Create a new provider user and bulk create provider users for a provider
- Disable new_provider_user_flow feature flag
- Craete a new provider user

## Link to Trello card

https://trello.com/c/PrB6tNKE/3916-set-up-interviews-permissions-when-a-support-user-creates-a-new-or-multiple-provider-user
https://trello.com/c/UujXrlir/3917-set-up-interviews-permissions-when-a-support-user-edits-a-provider-users-permissions

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
