### PR TITLE
Add `can_set_up_interviews?` authorisation method

### DIFF
--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -74,6 +74,16 @@ class ProviderAuthorisation
     @actor.provider_permissions.exists?(provider: provider, manage_organisations: true)
   end
 
+  def can_set_up_interviews?(provider:)
+    return true if @actor.is_a?(SupportUser)
+
+    ProviderPermissions.exists?(
+      provider: provider,
+      provider_user: @actor,
+      set_up_interviews: true,
+    )
+  end
+
   def can_manage_organisations_for_at_least_one_provider?
     providers_that_actor_can_manage_organisations_for.any?
   end

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -448,6 +448,44 @@ RSpec.describe ProviderAuthorisation do
     end
   end
 
+  describe '#can_set_up_interviews?' do
+    context 'for a support user' do
+      let(:support_user) { create(:support_user) }
+
+      subject(:auth_context) { ProviderAuthorisation.new(actor: support_user) }
+
+      it 'is true' do
+        expect(auth_context.can_set_up_interviews?(provider: create(:provider))).to be true
+      end
+    end
+
+    context 'for a provider user with permission to set up interviews' do
+      let(:provider_user) { create(:provider_user, :with_provider) }
+
+      subject(:auth_context) { ProviderAuthorisation.new(actor: provider_user) }
+
+      it 'is true' do
+        provider = provider_user.providers.first
+        provider_user.provider_permissions.find_by(provider: provider).update(set_up_interviews: true)
+
+        expect(auth_context.can_set_up_interviews?(provider: provider)).to be true
+      end
+    end
+
+    context 'for a provider user without permission to set up interviews' do
+      let(:provider_user) { create(:provider_user, :with_provider) }
+
+      subject(:auth_context) { ProviderAuthorisation.new(actor: provider_user) }
+
+      it 'is false' do
+        provider = provider_user.providers.first
+        provider_user.provider_permissions.find_by(provider: provider).update(set_up_interviews: true)
+
+        expect(auth_context.can_manage_organisation?(provider: create(:provider))).to be false
+      end
+    end
+  end
+
   describe 'can_manage_organisation?' do
     context 'for a support user' do
       let(:support_user) { create(:support_user) }


### PR DESCRIPTION
## Context

We need a consistent way to check for permission to set up interviews.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds `can_set_up_interviews?` method to `ProviderAuthorisation`.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/YJRz2no1/3904-update-providerauthorisation-service
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
