### PR TITLE
Update ActiveProviderUserPermissions export

### DIFF
--- a/app/exports/active_provider_user_permissions_export.yml
+++ b/app/exports/active_provider_user_permissions_export.yml
@@ -27,3 +27,6 @@ custom_columns:
 
   has_manage_organisations:
     type: boolean
+
+  has_set_up_interviews:
+    type: boolean

--- a/app/models/provider_permissions.rb
+++ b/app/models/provider_permissions.rb
@@ -20,6 +20,7 @@ class ProviderPermissions < ApplicationRecord
   scope :make_decisions, -> { where(make_decisions: true) }
   scope :view_safeguarding_information, -> { where(view_safeguarding_information: true) }
   scope :view_diversity_information, -> { where(view_diversity_information: true) }
+  scope :set_up_interviews, -> { where(set_up_interviews: true) }
 
   def self.possible_permissions(current_provider_user:, provider_user:)
     providers = current_provider_user.authorisation.providers_that_actor_can_manage_users_for.order(:name)

--- a/app/services/support_interface/active_provider_user_permissions_export.rb
+++ b/app/services/support_interface/active_provider_user_permissions_export.rb
@@ -11,17 +11,24 @@ module SupportInterface
     def data_for_user(provider_user)
       provider_user.providers.map do |provider|
         permissions = provider_user.provider_permissions
-        {
-          name: provider_user.full_name,
-          email_address: provider_user.email_address,
-          provider: provider.name,
-          last_signed_in_at: provider_user.last_signed_in_at,
-          has_make_decisions: permissions.make_decisions.exists?(provider: provider),
-          has_view_safeguarding: permissions.view_safeguarding_information.exists?(provider: provider),
-          has_view_diversity: permissions.view_diversity_information.exists?(provider: provider),
-          has_manage_users: permissions.manage_users.exists?(provider: provider),
-          has_manage_organisations: permissions.manage_organisations.exists?(provider: provider),
-        }
+        user_data =
+          {
+            name: provider_user.full_name,
+            email_address: provider_user.email_address,
+            provider: provider.name,
+            last_signed_in_at: provider_user.last_signed_in_at,
+            has_make_decisions: permissions.make_decisions.exists?(provider: provider),
+            has_view_safeguarding: permissions.view_safeguarding_information.exists?(provider: provider),
+            has_view_diversity: permissions.view_diversity_information.exists?(provider: provider),
+            has_manage_users: permissions.manage_users.exists?(provider: provider),
+            has_manage_organisations: permissions.manage_organisations.exists?(provider: provider),
+          }
+
+        if FeatureFlag.active?(:interview_permissions)
+          user_data.merge!(has_set_up_interviews: permissions.set_up_interviews.exists?(provider: provider))
+        end
+
+        user_data
       end
     end
   end

--- a/spec/models/provider_permissions_spec.rb
+++ b/spec/models/provider_permissions_spec.rb
@@ -1,6 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe ProviderPermissions do
+  context 'scopes' do
+    describe 'set_up_interviews' do
+      it 'returns all permissions where `set_up_interviews` is set' do
+        create_list(:provider_permissions, 3, set_up_interviews: false)
+        interview_permissions = create_list(:provider_permissions, 2, set_up_interviews: true)
+
+        expect(described_class.set_up_interviews).to eq(interview_permissions)
+      end
+    end
+  end
+
   describe '.possible_permissions' do
     let(:current_provider_user) { create(:provider_user, providers: providers) }
     let(:provider_user) { create(:provider_user, providers: providers << non_visible_provider) }

--- a/spec/services/support_interface/active_provider_user_permissions_export_spec.rb
+++ b/spec/services/support_interface/active_provider_user_permissions_export_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe SupportInterface::ActiveProviderUserPermissionsExport do
   end
 
   before do
+    FeatureFlag.activate(:interview_permissions)
+
     @provider1 = create(:provider)
     @provider2 = create(:provider)
     @provider_user_with_permissions = create(
@@ -40,6 +42,7 @@ RSpec.describe SupportInterface::ActiveProviderUserPermissionsExport do
           has_view_diversity: true,
           has_manage_users: true,
           has_manage_organisations: true,
+          has_set_up_interviews: false,
         },
         {
           name: @provider_user2.full_name,
@@ -51,6 +54,7 @@ RSpec.describe SupportInterface::ActiveProviderUserPermissionsExport do
           has_view_diversity: false,
           has_manage_users: false,
           has_manage_organisations: false,
+          has_set_up_interviews: false,
         },
         {
           name: @provider_user3.full_name,
@@ -62,6 +66,7 @@ RSpec.describe SupportInterface::ActiveProviderUserPermissionsExport do
           has_view_diversity: false,
           has_manage_users: false,
           has_manage_organisations: false,
+          has_set_up_interviews: false,
         },
         {
           name: @provider_user3.full_name,
@@ -73,6 +78,7 @@ RSpec.describe SupportInterface::ActiveProviderUserPermissionsExport do
           has_view_diversity: false,
           has_manage_users: false,
           has_manage_organisations: false,
+          has_set_up_interviews: false,
         },
       ]
 


### PR DESCRIPTION
## Context

In order for support users to be able to get detailed information on provider user permissions, ActiveProviderUserPermissionsExport should display the number of users that have set_up_interviews.

## Link to Trello card

https://trello.com/c/yt0rRG1j/3921-update-activeprovideruserpermissionsexport-to-display-number-of-users-with-setupinterviews

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
