### PR TITLE
add touch true to relations in models

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,5 +1,5 @@
 class Offer < ApplicationRecord
-  belongs_to :application_choice
+  belongs_to :application_choice, touch: true
   has_many :conditions, -> { order('created_at ASC') }, class_name: 'OfferCondition', dependent: :destroy
 
   has_one :course_option, through: :application_choice, source: :current_course_option

--- a/app/models/offer_condition.rb
+++ b/app/models/offer_condition.rb
@@ -1,7 +1,7 @@
 class OfferCondition < ApplicationRecord
   STANDARD_CONDITIONS = ['Fitness to train to teach check', 'Disclosure and Barring Service (DBS) check'].freeze
 
-  belongs_to :offer
+  belongs_to :offer, touch: true
   has_one :application_choice, through: :offer
 
   audited associated_with: :application_choice

--- a/spec/models/offer_condition_spec.rb
+++ b/spec/models/offer_condition_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe OfferCondition do
     end
   end
 
+  describe 'touching' do
+    it 'changes the updated at timestamp on the offer' do
+      offer_condition = create(:offer_condition, text: 'Provide evidence of degree qualification')
+      expect { offer_condition.update(text: 'different time') }
+        .to(change { offer_condition.offer.application_choice.updated_at })
+    end
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:status) }
   end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe Offer do
     end
   end
 
+  describe 'touching' do
+    it 'changes the updated at timestamp on the application choice' do
+      offer = create(:offer, conditions: [])
+      expect { offer.update(conditions: [build(:offer_condition), build(:offer_condition)]) }
+        .to(change { offer.application_choice.reload.updated_at })
+    end
+  end
+
   describe '#unconditional' do
     it 'returns true when there are no conditions' do
       offer = create(:unconditional_offer)

--- a/spec/queries/get_recruited_application_choices_spec.rb
+++ b/spec/queries/get_recruited_application_choices_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe GetRecruitedApplicationChoices do
         :application_choice,
         :with_deferred_offer_previously_recruited,
         application_form: build(:application_form, recruitment_cycle_year: '2021'),
-        updated_at: Time.zone.now + 1.day,
       )
+      deferred_application.update(updated_at: Time.zone.now + 1.day)
 
       application_choices = described_class.call(recruitment_cycle_year: '2021', changed_since: Time.zone.now)
       expect(application_choices).to contain_exactly(deferred_application)


### PR DESCRIPTION
## Context

The updated_at timestamp on application choices is used in the API to display recently changed application choices so that API requests can send the minimal amount of data to clients interested in changes only.

We moved the offer data off the ApplicationChoice model, so we lost the automatic updating of the updated_at timestamp. 

This should be readded with touch: true.

## Link to Trello card

https://trello.com/c/3Gy5nZY1/3900-offer-and-conditions-should-touch-relevant-application-choice-updatedat
## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
