### PR TITLE
Update Cycle Calendar (CYCLE_DATES)

### DIFF
--- a/app/components/candidate_interface/deadline_banner_component.rb
+++ b/app/components/candidate_interface/deadline_banner_component.rb
@@ -38,10 +38,10 @@ private
   end
 
   def apply_1_deadline
-    CycleTimetable.date(:apply_1_deadline).strftime('%d %B')
+    CycleTimetable.date(:apply_1_deadline).to_s(:day_and_month)
   end
 
   def apply_2_deadline
-    CycleTimetable.date(:apply_2_deadline).strftime('%d %B')
+    CycleTimetable.date(:apply_2_deadline).to_s(:day_and_month)
   end
 end

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -32,6 +32,6 @@ private
   end
 
   def reopen_date
-    CycleTimetable.date(:apply_reopens).to_s(:govuk_date)
+    CycleTimetable.date(:apply_opens).to_s(:govuk_date)
   end
 end

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -537,7 +537,7 @@ private
       earliest_date = 20.days.ago.to_date
       latest_date = Time.zone.now.to_date
     else
-      earliest_date = CycleTimetable::CYCLE_DATES[recruitment_cycle_year][:apply_reopens]
+      earliest_date = CycleTimetable::CYCLE_DATES[recruitment_cycle_year][:apply_opens]
       latest_date = CycleTimetable::CYCLE_DATES[recruitment_cycle_year + 1][:apply_1_deadline]
     end
 

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -537,8 +537,8 @@ private
       earliest_date = 20.days.ago.to_date
       latest_date = Time.zone.now.to_date
     else
-      earliest_date = CycleTimetable::CYCLE_DATES[recruitment_cycle_year][:apply_opens]
-      latest_date = CycleTimetable::CYCLE_DATES[recruitment_cycle_year + 1][:apply_1_deadline]
+      earliest_date = CycleTimetable.apply_opens(recruitment_cycle_year)
+      latest_date = CycleTimetable.apply_1_deadline(recruitment_cycle_year + 1)
     end
 
     @time = rand(earliest_date..latest_date)

--- a/app/models/feature_metrics_dashboard.rb
+++ b/app/models/feature_metrics_dashboard.rb
@@ -75,7 +75,7 @@ private
   def load_avg_time_to_get_references
     write_metric(
       :avg_time_to_get_references,
-      reference_statistics.average_time_to_get_references(CycleTimetable.apply_reopens.beginning_of_day),
+      reference_statistics.average_time_to_get_references(CycleTimetable.apply_opens.beginning_of_day),
     )
     write_metric(
       :avg_time_to_get_references_this_month,
@@ -93,7 +93,7 @@ private
     write_metric(
       :pct_references_completed_within_30_days,
       reference_statistics.percentage_references_within(
-        30, CycleTimetable.apply_reopens.beginning_of_day
+        30, CycleTimetable.apply_opens.beginning_of_day
       ),
     )
     write_metric(
@@ -113,7 +113,7 @@ private
   def load_avg_time_to_complete_work_history
     write_metric(
       :avg_time_to_complete_work_history,
-      work_history_statistics.average_time_to_complete(CycleTimetable.apply_reopens.beginning_of_day),
+      work_history_statistics.average_time_to_complete(CycleTimetable.apply_opens.beginning_of_day),
     )
     write_metric(
       :avg_time_to_complete_work_history_this_month,
@@ -131,7 +131,7 @@ private
     write_metric(
       :avg_sign_ins_before_submitting,
       magic_link_statistics.average_magic_link_requests_upto(
-        :created_at, CycleTimetable.apply_reopens.beginning_of_day
+        :created_at, CycleTimetable.apply_opens.beginning_of_day
       ),
     )
     write_metric(
@@ -152,7 +152,7 @@ private
     write_metric(
       :avg_sign_ins_before_offer,
       magic_link_statistics.average_magic_link_requests_upto(
-        :offered_at, CycleTimetable.apply_reopens.beginning_of_day
+        :offered_at, CycleTimetable.apply_opens.beginning_of_day
       ),
     )
     write_metric(
@@ -173,7 +173,7 @@ private
     write_metric(
       :avg_sign_ins_before_recruitment,
       magic_link_statistics.average_magic_link_requests_upto(
-        :recruited_at, CycleTimetable.apply_reopens.beginning_of_day
+        :recruited_at, CycleTimetable.apply_opens.beginning_of_day
       ),
     )
     write_metric(
@@ -194,7 +194,7 @@ private
     write_metric(
       :num_rejections_due_to_qualifications,
       reasons_for_rejection_statistics.rejections_due_to(
-        :qualifications_y_n, CycleTimetable.apply_reopens.beginning_of_day
+        :qualifications_y_n, CycleTimetable.apply_opens.beginning_of_day
       ),
     )
     write_metric(
@@ -215,7 +215,7 @@ private
     write_metric(
       :apply_again_success_rate,
       apply_again_statistics.formatted_success_rate(
-        CycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_opens.beginning_of_day,
       ),
     )
     write_metric(
@@ -227,7 +227,7 @@ private
     write_metric(
       :apply_again_success_rate_upto_this_month,
       apply_again_statistics.formatted_success_rate(
-        CycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_opens.beginning_of_day,
         Time.zone.now.beginning_of_month,
       ),
     )
@@ -237,7 +237,7 @@ private
     write_metric(
       :apply_again_change_rate,
       apply_again_statistics.formatted_change_rate(
-        CycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_opens.beginning_of_day,
       ),
     )
     write_metric(
@@ -259,7 +259,7 @@ private
     write_metric(
       :apply_again_application_rate,
       apply_again_statistics.formatted_application_rate(
-        CycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_opens.beginning_of_day,
       ),
     )
     write_metric(
@@ -271,7 +271,7 @@ private
     write_metric(
       :apply_again_application_rate_upto_this_month,
       apply_again_statistics.formatted_application_rate(
-        CycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_opens.beginning_of_day,
         Time.zone.now.beginning_of_month,
       ),
     )
@@ -281,7 +281,7 @@ private
     write_metric(
       :carry_over_count,
       carry_over_statistics.carry_over_count(
-        CycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_opens.beginning_of_day,
       ),
     )
     write_metric(
@@ -293,7 +293,7 @@ private
     write_metric(
       :carry_over_count_last_month,
       carry_over_statistics.carry_over_count(
-        CycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_opens.beginning_of_day,
         Time.zone.now.beginning_of_month,
       ),
     )
@@ -304,7 +304,7 @@ private
       :pct_applications_with_one_a_level,
       qualifications_statistics.formatted_a_level_percentage(
         1,
-        CycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_opens.beginning_of_day,
       ),
     )
     write_metric(
@@ -326,7 +326,7 @@ private
       :pct_applications_with_three_a_levels,
       qualifications_statistics.formatted_a_level_percentage(
         3,
-        CycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_opens.beginning_of_day,
       ),
     )
     write_metric(
@@ -350,7 +350,7 @@ private
     write_metric(
       :satisfaction_survey_response_rate,
       satisfaction_survey_statistics.formatted_response_rate(
-        CycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_opens.beginning_of_day,
       ),
     )
     write_metric(
@@ -372,7 +372,7 @@ private
     write_metric(
       :equality_and_diversity_response_rate,
       equality_and_diversity_statistics.formatted_response_rate(
-        CycleTimetable.apply_reopens.beginning_of_day,
+        CycleTimetable.apply_opens.beginning_of_day,
       ),
     )
     write_metric(

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -202,12 +202,12 @@ private
   end
 
   def date_range_query_for_recruitment_cycle_year(cycle_year)
-    start_date = CycleTimetable::CYCLE_DATES[cycle_year][:apply_opens]
+    start_date = CycleTimetable.apply_opens(cycle_year)
 
     query = "created_at >= '#{start_date}'"
 
     if CycleTimetable::CYCLE_DATES[cycle_year + 1].present?
-      end_date = CycleTimetable::CYCLE_DATES[cycle_year + 1][:apply_opens]
+      end_date = CycleTimetable.apply_opens(cycle_year + 1)
 
       query += " AND created_at <= '#{end_date}'"
     end

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -202,12 +202,12 @@ private
   end
 
   def date_range_query_for_recruitment_cycle_year(cycle_year)
-    start_date = CycleTimetable::CYCLE_DATES[cycle_year][:apply_reopens]
+    start_date = CycleTimetable::CYCLE_DATES[cycle_year][:apply_opens]
 
     query = "created_at >= '#{start_date}'"
 
     if CycleTimetable::CYCLE_DATES[cycle_year + 1].present?
-      end_date = CycleTimetable::CYCLE_DATES[cycle_year + 1][:apply_reopens]
+      end_date = CycleTimetable::CYCLE_DATES[cycle_year + 1][:apply_opens]
 
       query += " AND created_at <= '#{end_date}'"
     end

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -9,7 +9,7 @@ module RecruitmentCycle
   end
 
   def self.next_year
-    current_year + 1
+    CycleTimetable.next_year
   end
 
   def self.previous_year

--- a/app/services/candidate_interface/find_changed_apply_again_applications.rb
+++ b/app/services/candidate_interface/find_changed_apply_again_applications.rb
@@ -11,14 +11,14 @@ module CandidateInterface
     end
 
     def all_candidate_count(
-      start_time = CycleTimetable.apply_reopens.beginning_of_day,
+      start_time = CycleTimetable.apply_opens.beginning_of_day,
       end_time = Time.zone.now.end_of_day
     )
       all_forms(start_time, end_time).select(:candidate_id).distinct.count
     end
 
     def changed_candidate_count(
-      start_time = CycleTimetable.apply_reopens.beginning_of_day,
+      start_time = CycleTimetable.apply_opens.beginning_of_day,
       end_time = Time.zone.now.end_of_day
     )
       changed_forms(start_time, end_time).map(&:candidate_id).uniq.count

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -79,14 +79,18 @@ class CycleTimetable
     date(:apply_opens)
   end
 
+  def self.apply_reopens
+    date(:apply_opens, next_year)
+  end
+
   def self.between_cycles_apply_1?
-    Time.zone.now > date(:apply_1_deadline).end_of_day &&
-      Time.zone.now < date(:apply_opens, next_year).beginning_of_day
+    Time.zone.now > apply_1_deadline.end_of_day &&
+      Time.zone.now < apply_reopens.beginning_of_day
   end
 
   def self.between_cycles_apply_2?
-    Time.zone.now > date(:apply_2_deadline).end_of_day &&
-      Time.zone.now < date(:apply_opens, next_year).beginning_of_day
+    Time.zone.now > apply_2_deadline.end_of_day &&
+      Time.zone.now < apply_reopens.beginning_of_day
   end
 
   def self.date(name, year = current_year)
@@ -187,9 +191,7 @@ class CycleTimetable
   end
 
   def self.before_apply_reopens?
-    return true if Time.zone.now.to_date <= CYCLE_DATES[next_year][:apply_opens].beginning_of_day
-
-    false
+    Time.zone.now.to_date <= apply_reopens
   end
 
   def self.last_recruitment_cycle_year?(year)

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -35,7 +35,7 @@ class CycleTimetable
     CYCLE_DATES.keys.detect do |year|
       return year if last_recruitment_cycle_year?(year)
 
-      now.between?(CYCLE_DATES[year][:find_opens], CYCLE_DATES[year + 1][:find_opens])
+      now.between?(date(:find_opens, year), date(:find_opens, year + 1))
     end
   end
 

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -39,6 +39,10 @@ class CycleTimetable
     end
   end
 
+  def self.next_year
+    current_year + 1
+  end
+
   def self.between_cycles?(phase)
     phase == 'apply_1' ? between_cycles_apply_1? : between_cycles_apply_2?
   end
@@ -64,7 +68,7 @@ class CycleTimetable
   end
 
   def self.find_reopens
-    date(:find_opens, current_year + 1)
+    date(:find_opens, next_year)
   end
 
   def self.find_down?
@@ -77,12 +81,12 @@ class CycleTimetable
 
   def self.between_cycles_apply_1?
     Time.zone.now > date(:apply_1_deadline).end_of_day &&
-      Time.zone.now < date(:apply_opens, current_year + 1).beginning_of_day
+      Time.zone.now < date(:apply_opens, next_year).beginning_of_day
   end
 
   def self.between_cycles_apply_2?
     Time.zone.now > date(:apply_2_deadline).end_of_day &&
-      Time.zone.now < date(:apply_opens, current_year + 1).beginning_of_day
+      Time.zone.now < date(:apply_opens, next_year).beginning_of_day
   end
 
   def self.date(name, year = current_year)
@@ -182,7 +186,7 @@ class CycleTimetable
   end
 
   def self.before_apply_reopens?
-    return true if Time.zone.now.to_date <= CYCLE_DATES[current_year + 1][:apply_opens].beginning_of_day
+    return true if Time.zone.now.to_date <= CYCLE_DATES[next_year][:apply_opens].beginning_of_day
 
     false
   end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -168,7 +168,8 @@ class CycleTimetable
   end
 
   def self.can_add_course_choice?(application_form)
-    return true if Time.zone.now.to_date >= find_reopens && !application_form.must_be_carried_over?
+    return false if application_form.must_be_carried_over?
+    return true if Time.zone.now.to_date >= find_reopens
     return true if Time.zone.now.to_date <= apply_1_deadline && application_form.apply_1?
     return true if Time.zone.now.to_date <= apply_2_deadline && application_form.apply_2?
 

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -182,7 +182,7 @@ class CycleTimetable
   end
 
   def self.before_apply_reopens?
-    return true if Time.zone.now.to_date <= apply_reopens.beginning_of_day
+    return true if Time.zone.now.to_date <= CYCLE_DATES[current_year + 1][:apply_reopens].beginning_of_day
 
     false
   end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -153,7 +153,7 @@ class CycleTimetable
         apply_opens: 2.days.from_now.to_date,
       },
 
-      today_is_after_find_reopens: {
+      today_is_after_find_opens: {
         apply_1_deadline: 5.days.ago.to_date,
         apply_2_deadline: 3.days.ago.to_date,
         find_closes: 2.days.ago.to_date,
@@ -161,7 +161,7 @@ class CycleTimetable
         apply_opens: 1.day.from_now.to_date,
       },
 
-      today_is_after_apply_reopens: {
+      today_is_after_apply_opens: {
         apply_1_deadline: 6.days.ago.to_date,
         apply_2_deadline: 4.days.ago.to_date,
         find_closes: 3.days.ago.to_date,

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -4,28 +4,28 @@ class CycleTimetable
   CYCLE_DATES = {
     2019 => {
       find_opens: Date.new(2018, 10, 6),
-      apply_reopens: Date.new(2018, 10, 13),
+      apply_opens: Date.new(2018, 10, 13),
       apply_1_deadline: Date.new(2019, 8, 24),
       apply_2_deadline: Date.new(2019, 9, 18),
       find_closes: Date.new(2019, 10, 3),
     },
     2020 => {
       find_opens: Date.new(2019, 10, 6),
-      apply_reopens: Date.new(2019, 10, 13),
+      apply_opens: Date.new(2019, 10, 13),
       apply_1_deadline: Date.new(2020, 8, 24),
       apply_2_deadline: Date.new(2020, 9, 18),
       find_closes: Date.new(2020, 10, 3),
     },
     2021 => {
       find_opens: Date.new(2020, 10, 6),
-      apply_reopens: Date.new(2020, 10, 13),
+      apply_opens: Date.new(2020, 10, 13),
       apply_1_deadline: Date.new(2021, 9, 6),
       apply_2_deadline: Date.new(2021, 9, 20),
       find_closes: Date.new(2021, 10, 3),
     },
     2022 => {
       find_opens: Date.new(2021, 10, 5),
-      apply_reopens: Date.new(2021, 10, 12),
+      apply_opens: Date.new(2021, 10, 12),
     },
   }.freeze
 
@@ -71,18 +71,18 @@ class CycleTimetable
     Time.zone.now.between?(find_closes.end_of_day, find_reopens.beginning_of_day)
   end
 
-  def self.apply_reopens
-    date(:apply_reopens)
+  def self.apply_opens
+    date(:apply_opens)
   end
 
   def self.between_cycles_apply_1?
     Time.zone.now > date(:apply_1_deadline).end_of_day &&
-      Time.zone.now < date(:apply_reopens, current_year + 1).beginning_of_day
+      Time.zone.now < date(:apply_opens, current_year + 1).beginning_of_day
   end
 
   def self.between_cycles_apply_2?
     Time.zone.now > date(:apply_2_deadline).end_of_day &&
-      Time.zone.now < date(:apply_reopens, current_year + 1).beginning_of_day
+      Time.zone.now < date(:apply_opens, current_year + 1).beginning_of_day
   end
 
   def self.date(name, year = current_year)
@@ -106,7 +106,7 @@ class CycleTimetable
         apply_2_deadline: 3.days.from_now.to_date,
         find_closes: 4.days.from_now.to_date,
         find_opens: 5.days.from_now.to_date,
-        apply_reopens: 6.days.from_now.to_date,
+        apply_opens: 6.days.from_now.to_date,
       },
 
       today_is_after_apply_1_deadline_passed: {
@@ -114,7 +114,7 @@ class CycleTimetable
         apply_2_deadline: 2.days.from_now.to_date,
         find_closes: 3.days.from_now.to_date,
         find_opens: 4.days.from_now.to_date,
-        apply_reopens: 5.days.from_now.to_date,
+        apply_opens: 5.days.from_now.to_date,
       },
 
       today_is_after_full_course_deadline_passed: {
@@ -122,7 +122,7 @@ class CycleTimetable
         apply_2_deadline: 1.day.from_now.to_date,
         find_closes: 2.days.from_now.to_date,
         find_opens: 3.days.from_now.to_date,
-        apply_reopens: 4.days.from_now.to_date,
+        apply_opens: 4.days.from_now.to_date,
       },
 
       today_is_after_apply_2_deadline_passed: {
@@ -130,7 +130,7 @@ class CycleTimetable
         apply_2_deadline: 1.day.ago.to_date,
         find_closes: 1.day.from_now.to_date,
         find_opens: 2.days.from_now.to_date,
-        apply_reopens: 3.days.from_now.to_date,
+        apply_opens: 3.days.from_now.to_date,
       },
 
       today_is_after_find_closes: {
@@ -138,7 +138,7 @@ class CycleTimetable
         apply_2_deadline: 2.days.ago.to_date,
         find_closes: 1.day.ago.to_date,
         find_opens: 1.day.from_now.to_date,
-        apply_reopens: 2.days.from_now.to_date,
+        apply_opens: 2.days.from_now.to_date,
       },
 
       today_is_after_find_reopens: {
@@ -146,7 +146,7 @@ class CycleTimetable
         apply_2_deadline: 3.days.ago.to_date,
         find_closes: 2.days.ago.to_date,
         find_opens: 1.day.ago.to_date,
-        apply_reopens: 1.day.from_now.to_date,
+        apply_opens: 1.day.from_now.to_date,
       },
 
       today_is_after_apply_reopens: {
@@ -154,7 +154,7 @@ class CycleTimetable
         apply_2_deadline: 4.days.ago.to_date,
         find_closes: 3.days.ago.to_date,
         find_opens: 2.days.ago.to_date,
-        apply_reopens: 1.day.ago.to_date,
+        apply_opens: 1.day.ago.to_date,
       },
     }
   end
@@ -182,7 +182,7 @@ class CycleTimetable
   end
 
   def self.before_apply_reopens?
-    return true if Time.zone.now.to_date <= CYCLE_DATES[current_year + 1][:apply_reopens].beginning_of_day
+    return true if Time.zone.now.to_date <= CYCLE_DATES[current_year + 1][:apply_opens].beginning_of_day
 
     false
   end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -3,28 +3,28 @@ class CycleTimetable
   # The 2019 dates are made up so we can generate sensible test data
   CYCLE_DATES = {
     2019 => {
-      find_reopens: Date.new(2018, 10, 6),
+      find_opens: Date.new(2018, 10, 6),
       apply_reopens: Date.new(2018, 10, 13),
       apply_1_deadline: Date.new(2019, 8, 24),
       apply_2_deadline: Date.new(2019, 9, 18),
       find_closes: Date.new(2019, 10, 3),
     },
     2020 => {
-      find_reopens: Date.new(2019, 10, 6),
+      find_opens: Date.new(2019, 10, 6),
       apply_reopens: Date.new(2019, 10, 13),
       apply_1_deadline: Date.new(2020, 8, 24),
       apply_2_deadline: Date.new(2020, 9, 18),
       find_closes: Date.new(2020, 10, 3),
     },
     2021 => {
-      find_reopens: Date.new(2020, 10, 6),
+      find_opens: Date.new(2020, 10, 6),
       apply_reopens: Date.new(2020, 10, 13),
       apply_1_deadline: Date.new(2021, 9, 6),
       apply_2_deadline: Date.new(2021, 9, 20),
       find_closes: Date.new(2021, 10, 3),
     },
     2022 => {
-      find_reopens: Date.new(2021, 10, 5),
+      find_opens: Date.new(2021, 10, 5),
       apply_reopens: Date.new(2021, 10, 12),
     },
   }.freeze
@@ -35,7 +35,7 @@ class CycleTimetable
     CYCLE_DATES.keys.detect do |year|
       return year if year == CYCLE_DATES.keys.last
 
-      now.between?(CYCLE_DATES[year][:find_reopens], CYCLE_DATES[year + 1][:find_reopens])
+      now.between?(CYCLE_DATES[year][:find_opens], CYCLE_DATES[year + 1][:find_opens])
     end
   end
 
@@ -64,7 +64,7 @@ class CycleTimetable
   end
 
   def self.find_reopens
-    date(:find_reopens, current_year + 1)
+    date(:find_opens, current_year + 1)
   end
 
   def self.find_down?
@@ -105,7 +105,7 @@ class CycleTimetable
         apply_1_deadline: 1.day.from_now.to_date,
         apply_2_deadline: 3.days.from_now.to_date,
         find_closes: 4.days.from_now.to_date,
-        find_reopens: 5.days.from_now.to_date,
+        find_opens: 5.days.from_now.to_date,
         apply_reopens: 6.days.from_now.to_date,
       },
 
@@ -113,7 +113,7 @@ class CycleTimetable
         apply_1_deadline: 1.day.ago.to_date,
         apply_2_deadline: 2.days.from_now.to_date,
         find_closes: 3.days.from_now.to_date,
-        find_reopens: 4.days.from_now.to_date,
+        find_opens: 4.days.from_now.to_date,
         apply_reopens: 5.days.from_now.to_date,
       },
 
@@ -121,7 +121,7 @@ class CycleTimetable
         apply_1_deadline: 2.days.ago.to_date,
         apply_2_deadline: 1.day.from_now.to_date,
         find_closes: 2.days.from_now.to_date,
-        find_reopens: 3.days.from_now.to_date,
+        find_opens: 3.days.from_now.to_date,
         apply_reopens: 4.days.from_now.to_date,
       },
 
@@ -129,7 +129,7 @@ class CycleTimetable
         apply_1_deadline: 3.days.ago.to_date,
         apply_2_deadline: 1.day.ago.to_date,
         find_closes: 1.day.from_now.to_date,
-        find_reopens: 2.days.from_now.to_date,
+        find_opens: 2.days.from_now.to_date,
         apply_reopens: 3.days.from_now.to_date,
       },
 
@@ -137,7 +137,7 @@ class CycleTimetable
         apply_1_deadline: 4.days.ago.to_date,
         apply_2_deadline: 2.days.ago.to_date,
         find_closes: 1.day.ago.to_date,
-        find_reopens: 1.day.from_now.to_date,
+        find_opens: 1.day.from_now.to_date,
         apply_reopens: 2.days.from_now.to_date,
       },
 
@@ -145,7 +145,7 @@ class CycleTimetable
         apply_1_deadline: 5.days.ago.to_date,
         apply_2_deadline: 3.days.ago.to_date,
         find_closes: 2.days.ago.to_date,
-        find_reopens: 1.day.ago.to_date,
+        find_opens: 1.day.ago.to_date,
         apply_reopens: 1.day.from_now.to_date,
       },
 
@@ -153,7 +153,7 @@ class CycleTimetable
         apply_1_deadline: 6.days.ago.to_date,
         apply_2_deadline: 4.days.ago.to_date,
         find_closes: 3.days.ago.to_date,
-        find_reopens: 2.days.ago.to_date,
+        find_opens: 2.days.ago.to_date,
         apply_reopens: 1.day.ago.to_date,
       },
     }

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -176,12 +176,7 @@ class CycleTimetable
   end
 
   def self.can_add_course_choice?(application_form)
-    return false if application_form.must_be_carried_over?
-    return true if Time.zone.now.to_date >= find_reopens
-    return true if Time.zone.now.to_date <= apply_1_deadline && application_form.apply_1?
-    return true if Time.zone.now.to_date <= apply_2_deadline && application_form.apply_2?
-
-    false
+    currently_mid_cycle?(application_form) && current_cycle?(application_form)
   end
 
   def self.can_submit?(application_form)
@@ -202,5 +197,13 @@ class CycleTimetable
     year == CYCLE_DATES.keys.last
   end
 
-  private_class_method :last_recruitment_cycle_year?
+  def self.currently_mid_cycle?(application_form)
+    if application_form.apply_1?
+      Time.zone.now.between?(find_opens, apply_1_deadline)
+    else
+      Time.zone.now.between?(find_opens, apply_2_deadline)
+    end
+  end
+
+  private_class_method :last_recruitment_cycle_year?, :currently_mid_cycle?
 end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -1,28 +1,30 @@
 class CycleTimetable
-  CURRENT_YEAR_FOR_SCHEDULE = 2021
-
   # These dates are configuration for when the previous cycle ends and the next cycle starts
-  # The 2020 dates are made up so we can generate sensible test data
+  # The 2019 dates are made up so we can generate sensible test data
   CYCLE_DATES = {
-    2020 => {
+    2019 => {
+      find_reopens: Date.new(2018, 10, 6),
+      apply_reopens: Date.new(2018, 10, 13),
       apply_1_deadline: Date.new(2019, 8, 24),
       apply_2_deadline: Date.new(2019, 9, 18),
       find_closes: Date.new(2019, 10, 3),
+    },
+    2020 => {
       find_reopens: Date.new(2019, 10, 6),
       apply_reopens: Date.new(2019, 10, 13),
-    },
-    2021 => {
       apply_1_deadline: Date.new(2020, 8, 24),
       apply_2_deadline: Date.new(2020, 9, 18),
       find_closes: Date.new(2020, 10, 3),
+    },
+    2021 => {
       find_reopens: Date.new(2020, 10, 6),
       apply_reopens: Date.new(2020, 10, 13),
-    },
-    2022 => {
       apply_1_deadline: Date.new(2021, 9, 6),
       apply_2_deadline: Date.new(2021, 9, 20),
       find_closes: Date.new(2021, 10, 3),
-      find_reopens: Date.new(2021, 9, 5),
+    },
+    2022 => {
+      find_reopens: Date.new(2021, 10, 5),
       apply_reopens: Date.new(2021, 10, 12),
     },
   }.freeze
@@ -62,7 +64,7 @@ class CycleTimetable
   end
 
   def self.find_reopens
-    date(:find_reopens)
+    date(:find_reopens, current_year + 1)
   end
 
   def self.find_down?
@@ -75,16 +77,16 @@ class CycleTimetable
 
   def self.between_cycles_apply_1?
     Time.zone.now > date(:apply_1_deadline).end_of_day &&
-      Time.zone.now < date(:apply_reopens).beginning_of_day
+      Time.zone.now < date(:apply_reopens, current_year + 1).beginning_of_day
   end
 
   def self.between_cycles_apply_2?
     Time.zone.now > date(:apply_2_deadline).end_of_day &&
-      Time.zone.now < date(:apply_reopens).beginning_of_day
+      Time.zone.now < date(:apply_reopens, current_year + 1).beginning_of_day
   end
 
-  def self.date(name)
-    schedule = schedules.fetch(current_cycle_schedule)
+  def self.date(name, year = current_year)
+    schedule = schedules(year).fetch(current_cycle_schedule)
     schedule.fetch(name)
   end
 
@@ -95,9 +97,9 @@ class CycleTimetable
     SiteSetting.cycle_schedule
   end
 
-  def self.schedules
+  def self.schedules(year = current_year)
     {
-      real: CYCLE_DATES[CURRENT_YEAR_FOR_SCHEDULE],
+      real: CYCLE_DATES[year],
 
       today_is_mid_cycle: {
         apply_1_deadline: 1.day.from_now.to_date,

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -33,7 +33,7 @@ class CycleTimetable
     now = Time.zone.today
 
     CYCLE_DATES.keys.detect do |year|
-      return year if year == CYCLE_DATES.keys.last
+      return year if last_recruitment_cycle_year?(year)
 
       now.between?(CYCLE_DATES[year][:find_opens], CYCLE_DATES[year + 1][:find_opens])
     end
@@ -191,4 +191,10 @@ class CycleTimetable
 
     false
   end
+
+  def self.last_recruitment_cycle_year?(year)
+    year == CYCLE_DATES.keys.last
+  end
+
+  private_class_method :last_recruitment_cycle_year?
 end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -35,7 +35,7 @@ class CycleTimetable
     CYCLE_DATES.keys.detect do |year|
       return year if last_recruitment_cycle_year?(year)
 
-      now.between?(date(:find_opens, year), date(:find_opens, year + 1))
+      now.between?(find_opens(year), find_opens(year + 1))
     end
   end
 
@@ -55,32 +55,36 @@ class CycleTimetable
     Time.zone.now < date(:apply_2_deadline).end_of_day
   end
 
-  def self.apply_1_deadline
-    date(:apply_1_deadline)
+  def self.apply_1_deadline(year = current_year)
+    date(:apply_1_deadline, year)
   end
 
-  def self.apply_2_deadline
-    date(:apply_2_deadline)
+  def self.apply_2_deadline(year = current_year)
+    date(:apply_2_deadline, year)
   end
 
-  def self.find_closes
-    date(:find_closes)
+  def self.find_closes(year = current_year)
+    date(:find_closes, year)
   end
 
-  def self.find_reopens
-    date(:find_opens, next_year)
+  def self.find_opens(year = current_year)
+    date(:find_opens, year)
+  end
+
+  def self.find_reopens(year = next_year)
+    date(:find_opens, year)
   end
 
   def self.find_down?
     Time.zone.now.between?(find_closes.end_of_day, find_reopens.beginning_of_day)
   end
 
-  def self.apply_opens
-    date(:apply_opens)
+  def self.apply_opens(year = current_year)
+    date(:apply_opens, year)
   end
 
-  def self.apply_reopens
-    date(:apply_opens, next_year)
+  def self.apply_reopens(year = next_year)
+    date(:apply_opens, year)
   end
 
   def self.between_cycles_apply_1?

--- a/app/views/candidate_interface/carry_over/start_between_cycles.html.erb
+++ b/app/views/candidate_interface/carry_over/start_between_cycles.html.erb
@@ -18,7 +18,7 @@
 
     <% if CycleTimetable.before_apply_reopens? %>
       <p class="govuk-body">
-        You can submit your application from <%= CycleTimetable.apply_reopens.to_s(:govuk_date) %>.
+        You can submit your application from <%= CycleTimetable.apply_opens.to_s(:govuk_date) %>.
       </p>
     <% end %>
 

--- a/app/views/candidate_interface/carry_over/start_between_cycles_unsubmitted.html.erb
+++ b/app/views/candidate_interface/carry_over/start_between_cycles_unsubmitted.html.erb
@@ -12,7 +12,7 @@
 
     <% if CycleTimetable.before_apply_reopens? %>
       <p class="govuk-body">
-        You can submit your application from <%= CycleTimetable.apply_reopens.to_s(:govuk_date) %>.
+        You can submit your application from <%= CycleTimetable.apply_opens.to_s(:govuk_date) %>.
       </p>
     <% end %>
 

--- a/app/views/candidate_interface/start_page/applications_closed.html.erb
+++ b/app/views/candidate_interface/start_page/applications_closed.html.erb
@@ -8,6 +8,6 @@
 
     <p class="govuk-body">Applications for courses starting this year have closed.</p>
 
-    <p class="govuk-body">You can create an account and submit an application from <%= CycleTimetable.apply_reopens.to_s(:govuk_date).strip %>.</p>
+    <p class="govuk-body">You can create an account and submit an application from <%= CycleTimetable.apply_opens.to_s(:govuk_date).strip %>.</p>
   </div>
 </div>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -251,7 +251,7 @@
     <section>
       <% if CycleTimetable.between_cycles?(@application_form.phase) %>
         <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.review') %></h2>
-        <p class="govuk-body">You cannot submit your application until <%= CycleTimetable.apply_reopens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.</p>
+        <p class="govuk-body">You cannot submit your application until <%= CycleTimetable.apply_opens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.</p>
         <%= govuk_link_to 'Review your application', candidate_interface_application_review_path, button: true %>
       <% elsif CycleTimetable.can_submit?(@application_form) %>
         <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.check_and_submit') %></h2>

--- a/app/views/candidate_mailer/_still_interested_content.text.erb
+++ b/app/views/candidate_mailer/_still_interested_content.text.erb
@@ -2,7 +2,7 @@
 
 You can apply again for courses starting in the <%= "#{RecruitmentCycle.next_year} to #{RecruitmentCycle.next_year + 1}" %> academic year.
 
-Your last application has been saved. Make any changes and re-submit from <%= CycleTimetable.apply_reopens.to_s(:govuk_date) %>.
+Your last application has been saved. Make any changes and re-submit from <%= CycleTimetable.apply_opens.to_s(:govuk_date) %>.
 
 <% else %>
 

--- a/app/views/provider_interface/hesa_export/new.html.erb
+++ b/app/views/provider_interface/hesa_export/new.html.erb
@@ -12,7 +12,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <%= t('page_titles.provider.export_hesa_data', timeframe: "since #{CycleTimetable.apply_reopens.to_s(:govuk_date)}") %>
+      <%= t('page_titles.provider.export_hesa_data', timeframe: "since #{CycleTimetable.apply_opens.to_s(:govuk_date)}") %>
     </h1>
     <p class="govuk-body">
       The data will include all candidates who have accepted an offer from any of your organisations.

--- a/app/views/support_interface/settings/cycles.html.erb
+++ b/app/views/support_interface/settings/cycles.html.erb
@@ -38,7 +38,7 @@
   'Apply 2 deadline' => CycleTimetable.apply_2_deadline.to_s(:govuk_date),
   'Find closes on' => CycleTimetable.find_closes.to_s(:govuk_date),
   'Find reopens on' => CycleTimetable.find_reopens.to_s(:govuk_date),
-  'Apply reopens on' => CycleTimetable.apply_opens.to_s(:govuk_date),
+  'Apply reopens on' => CycleTimetable.apply_reopens.to_s(:govuk_date),
 }) %>
 
 <h2 class="govuk-heading-m">Flags</h2>

--- a/app/views/support_interface/settings/cycles.html.erb
+++ b/app/views/support_interface/settings/cycles.html.erb
@@ -38,7 +38,7 @@
   'Apply 2 deadline' => CycleTimetable.apply_2_deadline.to_s(:govuk_date),
   'Find closes on' => CycleTimetable.find_closes.to_s(:govuk_date),
   'Find reopens on' => CycleTimetable.find_reopens.to_s(:govuk_date),
-  'Apply reopens on' => CycleTimetable.apply_reopens.to_s(:govuk_date),
+  'Apply reopens on' => CycleTimetable.apply_opens.to_s(:govuk_date),
 }) %>
 
 <h2 class="govuk-heading-m">Flags</h2>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -8,6 +8,9 @@ Date::DATE_FORMATS[:month_and_year] = '%B %Y'
 Time::DATE_FORMATS[:short_month_and_year] = '%b %Y'
 Date::DATE_FORMATS[:short_month_and_year] = '%b %Y'
 
+Time::DATE_FORMATS[:day_and_month] = '%d %B'
+Date::DATE_FORMATS[:day_and_month] = '%d %B'
+
 Time::DATE_FORMATS[:govuk_date_and_time] = lambda do |time|
   format = if time >= time.midday && time <= time.midday.end_of_minute
              '%e %B %Y at %l%P (midday)'

--- a/config/locales/support_interface/cycles.yml
+++ b/config/locales/support_interface/cycles.yml
@@ -18,9 +18,9 @@ en:
     today_is_after_find_closes:
       name: Find has closed
       description: Candidates can no longer browse courses on Find
-    today_is_after_find_reopens:
+    today_is_after_find_opens:
       name: Find has reopened
       description: Candidates can browse courses on Find
-    today_is_after_apply_reopens:
+    today_is_after_apply_opens:
       name: Apply has reopened
       description: Candidates can apply for courses

--- a/spec/components/candidate_interface/deadline_banner_component_spec.rb
+++ b/spec/components/candidate_interface/deadline_banner_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
 
       result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
 
-      expect(result.text).to include('The deadline for applying to courses starting this academic year is 24 August')
+      expect(result.text).to include("The deadline for applying to courses starting this academic year is #{CycleTimetable.apply_1_deadline.strftime('%d %B')}")
     end
 
     it 'renders the Apply 2 banner when the right conditions are met' do
@@ -26,7 +26,7 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
 
       result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
 
-      expect(result.text).to include('The deadline for applying to courses starting this academic year is 18 September')
+      expect(result.text).to include("The deadline for applying to courses starting this academic year is #{CycleTimetable.apply_2_deadline.strftime('%d %B')}")
     end
 
     it 'renders nothing if feature flag is inactive' do
@@ -63,7 +63,7 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
 
       result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
 
-      expect(result.text).to include('The deadline for applying to courses starting this academic year is 18 September')
+      expect(result.text).to include("The deadline for applying to courses starting this academic year is #{CycleTimetable.apply_2_deadline.strftime('%d %B')}")
     end
   end
 end

--- a/spec/components/candidate_interface/deadline_banner_component_spec.rb
+++ b/spec/components/candidate_interface/deadline_banner_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
 
       result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
 
-      expect(result.text).to include("The deadline for applying to courses starting this academic year is #{CycleTimetable.apply_1_deadline.strftime('%d %B')}")
+      expect(result.text).to include("The deadline for applying to courses starting this academic year is #{CycleTimetable.apply_1_deadline.to_s(:day_and_month)}")
     end
 
     it 'renders the Apply 2 banner when the right conditions are met' do
@@ -26,7 +26,7 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
 
       result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
 
-      expect(result.text).to include("The deadline for applying to courses starting this academic year is #{CycleTimetable.apply_2_deadline.strftime('%d %B')}")
+      expect(result.text).to include("The deadline for applying to courses starting this academic year is #{CycleTimetable.apply_2_deadline.to_s(:day_and_month)}")
     end
 
     it 'renders nothing if feature flag is inactive' do
@@ -63,7 +63,7 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
 
       result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
 
-      expect(result.text).to include("The deadline for applying to courses starting this academic year is #{CycleTimetable.apply_2_deadline.strftime('%d %B')}")
+      expect(result.text).to include("The deadline for applying to courses starting this academic year is #{CycleTimetable.apply_2_deadline.to_s(:day_and_month)}")
     end
   end
 end

--- a/spec/components/candidate_interface/offer_review_component_spec.rb
+++ b/spec/components/candidate_interface/offer_review_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
            course_option: course_option,
            application_form: application_form)
   end
-  let(:find_closes) { CycleTimetable::CYCLE_DATES.dig(RecruitmentCycle.previous_year, :find_closes) }
+  let(:find_closes) { CycleTimetable.find_closes(RecruitmentCycle.previous_year) }
 
   it 'renders component with correct values for the provider' do
     result = render_inline(described_class.new(course_choice: application_choice))

--- a/spec/components/candidate_interface/offer_review_component_spec.rb
+++ b/spec/components/candidate_interface/offer_review_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
            course_option: course_option,
            application_form: application_form)
   end
-  let(:find_closes) { CycleTimetable::CYCLE_DATES.dig(Time.zone.now.year, :find_closes) }
+  let(:find_closes) { CycleTimetable::CYCLE_DATES.dig(RecruitmentCycle.previous_year, :find_closes) }
 
   it 'renders component with correct values for the provider' do
     result = render_inline(described_class.new(course_choice: application_choice))

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       context 'when it is after the apply_2_deadline' do
         before do
           allow(CycleTimetable).to receive(:between_cycles_apply_2?).and_return(true)
-          allow(CycleTimetable).to receive(:apply_reopens).and_return(Date.new(2021, 10, 13))
+          allow(CycleTimetable).to receive(:apply_opens).and_return(Date.new(2021, 10, 13))
           allow(RecruitmentCycle).to receive(:next_year).and_return(2022)
         end
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       context 'when it is after the apply_2_deadline' do
         before do
           allow(CycleTimetable).to receive(:between_cycles_apply_2?).and_return(true)
-          allow(CycleTimetable).to receive(:apply_reopens).and_return(Date.new(2021, 10, 13))
+          allow(CycleTimetable).to receive(:apply_opens).and_return(Date.new(2021, 10, 13))
           allow(RecruitmentCycle).to receive(:next_year).and_return(2022)
         end
 

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe RecruitmentCycle do
   describe '.current_year' do
-    it 'delegates to ECycleTimetable' do
+    it 'delegates to CycleTimetable' do
       allow(CycleTimetable).to receive(:current_year)
 
       RecruitmentCycle.current_year
@@ -12,10 +12,12 @@ RSpec.describe RecruitmentCycle do
   end
 
   describe '.next_year' do
-    it 'is 2021 if the current year is 2020' do
-      allow(CycleTimetable).to receive(:current_year).and_return(2020)
+    it 'delegates to CycleTimetable' do
+      allow(CycleTimetable).to receive(:next_year).and_return(2020)
 
-      expect(RecruitmentCycle.next_year).to eq(2021)
+      RecruitmentCycle.next_year
+
+      expect(CycleTimetable).to have_received(:next_year)
     end
   end
 

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -202,8 +202,8 @@ RSpec.describe CycleTimetable do
 
     context 'application form is from a previous recruitment cycle' do
       let(:application_form) { build_stubbed(:application_form, recruitment_cycle_year: 2020) }
-      # Currently failing. Check business rules
-      xit 'returns false' do
+
+      it 'returns false' do
         Timecop.travel('2021-02-03') do
           expect(execute_service).to eq false
         end

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe CycleTimetable do
 
   describe '.current_year' do
     it 'is 2020 if we are in the middle of the 2020 cycle' do
-      Timecop.travel(Time.zone.local(2020, 1, 1, 12, 0, 0)) do
+      Timecop.travel(CycleTimetable.apply_opens(2020) + 1.day) do
         expect(CycleTimetable.current_year).to eq(2020)
       end
     end
 
     it 'is 2021 if we are in the middle of the 2021 cycle' do
-      Timecop.travel(Time.zone.local(2020, 11, 1, 12, 0, 0)) do
+      Timecop.travel(CycleTimetable.apply_opens(2021) + 1.day) do
         expect(CycleTimetable.current_year).to eq(2021)
       end
     end
@@ -23,13 +23,13 @@ RSpec.describe CycleTimetable do
 
   describe '.next_year' do
     it 'is 2020 if we are in the middle of the 2020 cycle' do
-      Timecop.travel(Time.zone.local(2020, 1, 1, 12, 0, 0)) do
+      Timecop.travel(CycleTimetable.apply_opens(2020) + 1.day) do
         expect(CycleTimetable.next_year).to eq(2021)
       end
     end
 
     it 'is 2021 if we are in the middle of the 2021 cycle' do
-      Timecop.travel(Time.zone.local(2020, 11, 1, 12, 0, 0)) do
+      Timecop.travel(CycleTimetable.apply_opens(2021) + 1.day) do
         expect(CycleTimetable.next_year).to eq(2022)
       end
     end
@@ -105,19 +105,19 @@ RSpec.describe CycleTimetable do
 
   describe '.find_down?' do
     it 'returns false before find closes' do
-      Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:find_closes].beginning_of_day - 1.hour) do
+      Timecop.travel(CycleTimetable.find_closes(2020).beginning_of_day - 1.hour) do
         expect(CycleTimetable.find_down?).to be false
       end
     end
 
     it 'returns false after find_reopens' do
-      Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:find_opens].end_of_day + 1.hour) do
+      Timecop.travel(CycleTimetable.find_opens(2020).end_of_day + 1.hour) do
         expect(CycleTimetable.find_down?).to be false
       end
     end
 
     it 'returns true between find_closes and find_reopens' do
-      Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:find_closes].end_of_day + 1.hour) do
+      Timecop.travel(CycleTimetable.find_closes(2020).end_of_day + 1.hour) do
         expect(CycleTimetable.find_down?).to be true
       end
     end
@@ -149,7 +149,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is after the apply1 submission deadline' do
         it 'returns false' do
-          Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:apply_1_deadline] + 1.day) do
+          Timecop.travel(CycleTimetable.apply_1_deadline(2020) + 1.day) do
             expect(execute_service).to eq false
           end
         end
@@ -157,7 +157,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is before the apply1 submission deadline' do
         it 'returns true' do
-          Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:apply_1_deadline] - 1.day) do
+          Timecop.travel(CycleTimetable.apply_1_deadline(2020) - 1.day) do
             expect(execute_service).to eq true
           end
         end
@@ -165,7 +165,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is post find reopening' do
         it 'returns true' do
-          Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:find_opens] + 1.day) do
+          Timecop.travel(CycleTimetable.find_reopens(2021) + 1.day) do
             expect(execute_service).to eq true
           end
         end
@@ -177,7 +177,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is after the apply again submission deadline' do
         it 'returns false' do
-          Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:apply_2_deadline] + 1.day) do
+          Timecop.travel(CycleTimetable.apply_2_deadline(2020) + 1.day) do
             expect(execute_service).to eq false
           end
         end
@@ -185,7 +185,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is before the apply again submission deadline' do
         it 'returns true' do
-          Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:apply_2_deadline] - 1.day) do
+          Timecop.travel(CycleTimetable.apply_2_deadline(2020) - 1.day) do
             expect(execute_service).to eq true
           end
         end
@@ -193,7 +193,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is post find reopening' do
         it 'returns true' do
-          Timecop.travel(CycleTimetable.apply_opens) do
+          Timecop.travel(CycleTimetable.find_reopens(2021) + 1.day) do
             expect(execute_service).to eq true
           end
         end

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -21,6 +21,20 @@ RSpec.describe CycleTimetable do
     end
   end
 
+  describe '.next_year' do
+    it 'is 2020 if we are in the middle of the 2020 cycle' do
+      Timecop.travel(Time.zone.local(2020, 1, 1, 12, 0, 0)) do
+        expect(CycleTimetable.next_year).to eq(2021)
+      end
+    end
+
+    it 'is 2021 if we are in the middle of the 2021 cycle' do
+      Timecop.travel(Time.zone.local(2020, 11, 1, 12, 0, 0)) do
+        expect(CycleTimetable.next_year).to eq(2022)
+      end
+    end
+  end
+
   describe '.show_apply_1_deadline_banner?' do
     it 'returns true before the configured date' do
       Timecop.travel(one_hour_before_apply1_deadline) do

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -91,19 +91,19 @@ RSpec.describe CycleTimetable do
 
   describe '.find_down?' do
     it 'returns false before find closes' do
-      Timecop.travel(CycleTimetable.find_closes.beginning_of_day - 1.hour) do
+      Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:find_closes].beginning_of_day - 1.hour) do
         expect(CycleTimetable.find_down?).to be false
       end
     end
 
     it 'returns false after find_reopens' do
-      Timecop.travel(CycleTimetable.find_reopens.end_of_day + 1.hour) do
+      Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:find_reopens].end_of_day + 1.hour) do
         expect(CycleTimetable.find_down?).to be false
       end
     end
 
     it 'returns true between find_closes and find_reopens' do
-      Timecop.travel(CycleTimetable.find_closes.end_of_day + 1.hour) do
+      Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:find_closes].end_of_day + 1.hour) do
         expect(CycleTimetable.find_down?).to be true
       end
     end
@@ -135,7 +135,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is after the apply1 submission deadline' do
         it 'returns false' do
-          Timecop.travel(CycleTimetable.apply_1_deadline + 1.day) do
+          Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:apply_1_deadline] + 1.day) do
             expect(execute_service).to eq false
           end
         end
@@ -143,7 +143,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is before the apply1 submission deadline' do
         it 'returns true' do
-          Timecop.travel(CycleTimetable.apply_1_deadline) do
+          Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:apply_1_deadline] - 1.day) do
             expect(execute_service).to eq true
           end
         end
@@ -151,7 +151,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is post find reopening' do
         it 'returns true' do
-          Timecop.travel(CycleTimetable.find_reopens) do
+          Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:find_reopens] + 1.day) do
             expect(execute_service).to eq true
           end
         end
@@ -163,7 +163,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is after the apply again submission deadline' do
         it 'returns false' do
-          Timecop.travel(CycleTimetable.apply_2_deadline + 1.day) do
+          Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:apply_2_deadline] + 1.day) do
             expect(execute_service).to eq false
           end
         end
@@ -171,7 +171,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is before the apply again submission deadline' do
         it 'returns true' do
-          Timecop.travel(CycleTimetable.apply_2_deadline) do
+          Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:apply_2_deadline] - 1.day) do
             expect(execute_service).to eq true
           end
         end
@@ -188,8 +188,8 @@ RSpec.describe CycleTimetable do
 
     context 'application form is from a previous recruitment cycle' do
       let(:application_form) { build_stubbed(:application_form, recruitment_cycle_year: 2020) }
-
-      it 'returns false' do
+      # Currently failing. Check business rules
+      xit 'returns false' do
         Timecop.travel('2021-02-03') do
           expect(execute_service).to eq false
         end

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe CycleTimetable do
     end
 
     it 'returns false after find_reopens' do
-      Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:find_reopens].end_of_day + 1.hour) do
+      Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:find_opens].end_of_day + 1.hour) do
         expect(CycleTimetable.find_down?).to be false
       end
     end
@@ -151,7 +151,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is post find reopening' do
         it 'returns true' do
-          Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:find_reopens] + 1.day) do
+          Timecop.travel(CycleTimetable::CYCLE_DATES[2020][:find_opens] + 1.day) do
             expect(execute_service).to eq true
           end
         end

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -162,14 +162,6 @@ RSpec.describe CycleTimetable do
           end
         end
       end
-
-      context 'when the date is post find reopening' do
-        it 'returns true' do
-          Timecop.travel(CycleTimetable.find_reopens(2021) + 1.day) do
-            expect(execute_service).to eq true
-          end
-        end
-      end
     end
 
     context 'application form is in the apply again state' do
@@ -186,14 +178,6 @@ RSpec.describe CycleTimetable do
       context 'when the date is before the apply again submission deadline' do
         it 'returns true' do
           Timecop.travel(CycleTimetable.apply_2_deadline(2020) - 1.day) do
-            expect(execute_service).to eq true
-          end
-        end
-      end
-
-      context 'when the date is post find reopening' do
-        it 'returns true' do
-          Timecop.travel(CycleTimetable.find_reopens(2021) + 1.day) do
             expect(execute_service).to eq true
           end
         end

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is post find reopening' do
         it 'returns true' do
-          Timecop.travel(CycleTimetable.apply_reopens) do
+          Timecop.travel(CycleTimetable.apply_opens) do
             expect(execute_service).to eq true
           end
         end

--- a/spec/services/set_reject_by_default_spec.rb
+++ b/spec/services/set_reject_by_default_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe SetRejectByDefault do
 
   describe 'RBD calculation' do
     submitted_vs_rbd_dates = [
-      ['2 Sept 2019 9:00:00 AM BST', '29 Oct 2019 0:00:00 AM GMT', 'near the BST/GMT boundary'],
-      ['1 Jul 2019 9:00:00 AM BST',  '28 Aug 2019 0:00:00 AM BST', 'safely within BST'],
+      ['2 Sept 2019 9:00:00 AM BST', '01 Oct 2019 0:00:00 AM BST', 'near the BST/GMT boundary'],
+      ['1 Jul 2019 9:00:00 AM BST',  '30 Jul 2019 0:00:00 AM BST', 'safely within BST'],
       ['4 Jan 2019 11:00:00 PM GMT', '2 Mar 2019 0:00:00 AM GMT',  'safely within GMT'],
       ['1 Jul 2020 11:00:00 PM BST', '30 Jul 2020 0:00:00 AM BST', 'during the 20-day summer period'],
       ['21 Nov 2020 12:00:00 PM GMT', '2 Feb 2021 0:00:00 AM GMT', 'near the UCAS winter break'],

--- a/spec/support/test_helpers/cycle_timetable_helper.rb
+++ b/spec/support/test_helpers/cycle_timetable_helper.rb
@@ -1,17 +1,17 @@
 module CycleTimetableHelper
   def mid_cycle
-    CycleTimetable::CYCLE_DATES.dig(2020, :apply_opens) + 1.day
+    CycleTimetable.apply_opens(2020) + 1.day
   end
 
   def after_apply_1_deadline
-    CycleTimetable::CYCLE_DATES.dig(2020, :apply_1_deadline) + 1.day
+    CycleTimetable.apply_1_deadline(2020) + 1.day
   end
 
   def after_apply_2_deadline
-    CycleTimetable::CYCLE_DATES.dig(2020, :apply_2_deadline) + 1.day
+    CycleTimetable.apply_2_deadline(2020) + 1.day
   end
 
   def after_apply_reopens
-    CycleTimetable::CYCLE_DATES.dig(2021, :apply_opens) + 1.day
+    CycleTimetable.apply_reopens(2021) + 1.day
   end
 end

--- a/spec/support/test_helpers/cycle_timetable_helper.rb
+++ b/spec/support/test_helpers/cycle_timetable_helper.rb
@@ -1,6 +1,6 @@
 module CycleTimetableHelper
   def mid_cycle
-    CycleTimetable::CYCLE_DATES.dig(2020, :apply_reopens) + 1.day
+    CycleTimetable::CYCLE_DATES.dig(2020, :apply_opens) + 1.day
   end
 
   def after_apply_1_deadline
@@ -12,6 +12,6 @@ module CycleTimetableHelper
   end
 
   def after_apply_reopens
-    CycleTimetable::CYCLE_DATES.dig(2021, :apply_reopens) + 1.day
+    CycleTimetable::CYCLE_DATES.dig(2021, :apply_opens) + 1.day
   end
 end

--- a/spec/support/test_helpers/cycle_timetable_helper.rb
+++ b/spec/support/test_helpers/cycle_timetable_helper.rb
@@ -1,39 +1,17 @@
 module CycleTimetableHelper
   def mid_cycle
-    previous_end_of_cycle_timetable[:apply_reopens] + 1.day
+    CycleTimetable::CYCLE_DATES.dig(2020, :apply_reopens) + 1.day
   end
 
   def after_apply_1_deadline
-    current_end_of_cycle_timetable[:apply_1_deadline] + 1.day
-  end
-
-  def after_full_course_deadline
-    current_end_of_cycle_timetable[:stop_applications_to_unavailable_course_options] + 1.day
+    CycleTimetable::CYCLE_DATES.dig(2020, :apply_1_deadline) + 1.day
   end
 
   def after_apply_2_deadline
-    current_end_of_cycle_timetable[:apply_2_deadline] + 1.day
-  end
-
-  def after_find_closes
-    current_end_of_cycle_timetable[:find_closes] + 1.day
-  end
-
-  def after_find_reopens
-    current_end_of_cycle_timetable[:find_reopens] + 1.day
+    CycleTimetable::CYCLE_DATES.dig(2020, :apply_2_deadline) + 1.day
   end
 
   def after_apply_reopens
-    current_end_of_cycle_timetable[:apply_reopens] + 1.day
-  end
-
-private
-
-  def previous_end_of_cycle_timetable
-    CycleTimetable::CYCLE_DATES[CycleTimetable::CURRENT_YEAR_FOR_SCHEDULE - 1]
-  end
-
-  def current_end_of_cycle_timetable
-    CycleTimetable::CYCLE_DATES[CycleTimetable::CURRENT_YEAR_FOR_SCHEDULE]
+    CycleTimetable::CYCLE_DATES.dig(2021, :apply_reopens) + 1.day
   end
 end

--- a/spec/system/candidate_interface/apply_again/carry_over_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/apply_again/carry_over_unsuccessful_application_between_cycles_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_click_on_start_now
-    expect(page).to have_content "You can submit your application from #{CycleTimetable.apply_reopens.to_s(:govuk_date)}."
+    expect(page).to have_content "You can submit your application from #{CycleTimetable.apply_opens.to_s(:govuk_date)}."
     expect(page).to have_content 'Your courses have been removed. You can add them again later.'
     click_button 'Apply again'
   end

--- a/spec/system/candidate_interface/end_of_cycle/candidate_with_unsubmitted_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/end_of_cycle/candidate_with_unsubmitted_application_between_cycles_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Candidate attempts to submit the application after the end-of-cyc
 
   def then_i_can_only_review_my_application
     expect(page).not_to have_link 'Check and submit your application'
-    expect(page).to have_content "You cannot submit your application until #{CycleTimetable.apply_reopens.to_s(:govuk_date)}. You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You cannot submit your application until #{CycleTimetable.apply_opens.to_s(:govuk_date)}. You can keep making changes to the rest of your application until then."
     click_link 'Review your application'
   end
 

--- a/spec/system/support_interface/feature_metrics_dashboard_spec.rb
+++ b/spec/system/support_interface/feature_metrics_dashboard_spec.rb
@@ -97,7 +97,7 @@ RSpec.feature 'Feature metrics dashboard' do
 
   def and_there_are_candidates_and_application_forms_in_the_system
     ApplicationForm.with_unsafe_application_choice_touches do
-      allow(CycleTimetable).to receive(:apply_reopens).and_return(60.days.ago)
+      allow(CycleTimetable).to receive(:apply_opens).and_return(60.days.ago)
       Timecop.freeze(@today - 65.days) do
         @previous_application_form = create_application_form_with_references(recruitment_cycle_year: 2020).first
       end

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Structured reasons for rejection dashboard' do
   end
 
   def and_there_are_candidates_and_application_forms_in_the_system
-    allow(CycleTimetable).to receive(:apply_reopens).and_return(60.days.ago)
+    allow(CycleTimetable).to receive(:apply_opens).and_return(60.days.ago)
     @application_choice1 = create(:application_choice, :awaiting_provider_decision)
     @application_choice2 = create(:application_choice, :awaiting_provider_decision)
     @application_choice3 = create(:application_choice, :awaiting_provider_decision)


### PR DESCRIPTION
## Context

A cycle should start with Find opening and end with Find closing

## Changes proposed in this pull request

- Update `CYCLE_DATES` with Find opening and end with Find closing
- Add 2022 cycle dates
- Updated the CycleTimetableHelper to play nicely with specs as  a result of calendar changes (returns static dates)
- Fix all the broken things

## Guidance to review

Recommend review by commit as these are quite fundamental changes. 

## Link to Trello card

https://trello.com/c/narHEhQx/3544-%F0%9F%94%81-eoc-change-calendar-to-start-with-find-opening-and-end-with-find-closing

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
