### PR TITLE
Withdraw associated applications when accepting unconditional offers

### DIFF
--- a/app/services/accept_unconditional_offer.rb
+++ b/app/services/accept_unconditional_offer.rb
@@ -1,12 +1,10 @@
-class AcceptUnconditionalOffer
-  def initialize(application_choice:)
-    @application_choice = application_choice
-  end
-
+class AcceptUnconditionalOffer < AcceptOffer
   def save!
     ActiveRecord::Base.transaction do
       ApplicationStateChange.new(@application_choice).accept_unconditional_offer!
       @application_choice.update!(accepted_at: Time.zone.now, recruited_at: Time.zone.now)
+
+      withdraw_and_decline_associated_application_choices!
     end
 
     NotificationsList.for(@application_choice, event: :unconditional_offer_accepted, include_ratifying_provider: true).each do |provider_user|

--- a/spec/services/accept_unconditional_offer_spec.rb
+++ b/spec/services/accept_unconditional_offer_spec.rb
@@ -33,6 +33,30 @@ RSpec.describe AcceptUnconditionalOffer do
     expect(state_change_double).to have_received(:accept_unconditional_offer!)
   end
 
+  describe 'other choices in the application' do
+    it 'declines offered applications' do
+      application_choice = create(:application_choice, :with_offer)
+      application_form = application_choice.application_form
+      other_choice_with_offer = create(:application_choice, :with_offer, application_form: application_form)
+
+      described_class.new(application_choice: application_choice).save!
+
+      expect(other_choice_with_offer.reload.status).to eq('declined')
+    end
+
+    it 'withdraws applications pending provider decisions' do
+      application_choice = create(:application_choice, :with_offer)
+      application_form = application_choice.application_form
+      other_choice_awaiting_decision = create(:application_choice, :awaiting_provider_decision, application_form: application_form)
+      other_choice_interviewing = create(:application_choice, :with_scheduled_interview, application_form: application_form)
+
+      described_class.new(application_choice: application_choice).save!
+
+      expect(other_choice_awaiting_decision.reload.status).to eq('withdrawn')
+      expect(other_choice_interviewing.reload.status).to eq('withdrawn')
+    end
+  end
+
   describe 'emails' do
     around { |example| perform_enqueued_jobs(&example) }
 


### PR DESCRIPTION
## Context

When a candidate accepts an unconditional offer their other application choices should be withdrawn/declined appropriate to their current state.
A vendor has raised the issue that associated applications are not being withdrawn or declined when accepting unconditional offers.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Calls state change services on associated applications when accepting an unconditional offer.


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

I'm not sure inheritance is the right approach here, though it is convenient. The services are very closely related in terms of intention and need to share a few methods. Perhaps that's best achieved in a module or even by merging the services?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/qWLkIzyz/3922-when-a-candidate-accepts-an-offer-their-other-application-choices-arent-automatically-withdrawn
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
