### PR TITLE
Update interview actions to only be visible to users with correct permissions

### DIFF
--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -2,6 +2,7 @@ module ProviderInterface
   class InterviewsController < ProviderInterfaceController
     before_action :set_application_choice
     before_action :requires_make_decisions_permission, except: %i[index]
+    before_action :requires_set_up_interviews_permission, except: %i[index], if: :interviews_permission_feature_flag
     before_action :confirm_application_is_in_decision_pending_state, except: %i[index]
     before_action :redirect_to_index_if_store_cleared, only: %i[check commit]
 
@@ -169,6 +170,10 @@ module ProviderInterface
 
     def redirect_to_index_if_store_cleared
       redirect_to provider_interface_application_choice_interviews_path(@application_choice) if interview_store.read.blank?
+    end
+
+    def interviews_permission_feature_flag
+      FeatureFlag.active?(:interview_permissions)
     end
   end
 end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -122,6 +122,20 @@ module ProviderInterface
       end
     end
 
+    def requires_set_up_interviews_permission
+      if !current_provider_user.authorisation.can_set_up_interviews?(
+        application_choice: @application_choice,
+        course_option: @application_choice.current_course_option,
+      )
+        raise ProviderInterface::AccessDenied.new({
+          permission: 'set_up_interviews',
+          training_provider: @application_choice.current_course.provider,
+          ratifying_provider: @application_choice.current_course.accredited_provider,
+          provider_user: current_provider_user,
+        }), 'set_up_interviews required'
+      end
+    end
+
     def render_404
       render 'errors/not_found', status: :not_found
     end

--- a/spec/factories/provider_user.rb
+++ b/spec/factories/provider_user.rb
@@ -47,6 +47,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_set_up_interviews do
+      after(:create) do |user, _evaluator|
+        user.provider_permissions.update_all(set_up_interviews: true)
+      end
+    end
+
     trait :with_make_decisions do
       after(:create) do |user, _evaluator|
         user.provider_permissions.update_all(make_decisions: true)

--- a/spec/requests/provider_interface/interviews_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ProviderInterface::InterviewsController, type: :request do
   include DfESignInHelpers
 
-  let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions) }
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions, :with_set_up_interviews) }
   let(:provider) { provider_user.providers.first }
   let(:application_form) { build(:application_form, :minimum_info) }
   let(:course) { build(:course, :open_on_apply, provider: provider) }
@@ -11,6 +11,7 @@ RSpec.describe ProviderInterface::InterviewsController, type: :request do
   let(:interview) { create(:interview, application_choice: application_choice) }
 
   before do
+    FeatureFlag.activate(:interview_permissions)
     allow(DfESignInUser).to receive(:load_from_session).and_return(provider_user)
 
     user_exists_in_dfe_sign_in(email_address: provider_user.email_address)

--- a/spec/support/test_helpers/provider_user_permissions_helper.rb
+++ b/spec/support/test_helpers/provider_user_permissions_helper.rb
@@ -20,4 +20,15 @@ module ProviderUserPermissionsHelper
 
     permissions.update_all(make_decisions: false)
   end
+
+  def permit_set_up_interviews!(dfe_sign_in_uid: 'DFE_SIGN_IN_UID', provider: nil)
+    provider_user = ProviderUser.find_by_dfe_sign_in_uid dfe_sign_in_uid
+    permissions = if provider
+                    provider_user.provider_permissions.where(provider: provider)
+                  else
+                    provider_user.provider_permissions
+                  end
+
+    permissions.update_all(set_up_interviews: true)
+  end
 end

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -14,10 +14,15 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     end
   end
 
+  before do
+    FeatureFlag.activate(:interview_permissions)
+  end
+
   scenario 'can view, create and cancel interviews' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
-    and_i_am_permitted_to_make_decisions_for_my_provider
+    and_i_can_see_the_application_actions
+    and_i_am_permitted_to_set_up_interviews_for_my_provider
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_that_application_in_the_provider_interface
@@ -92,8 +97,12 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     provider_user_exists_in_apply_database
   end
 
-  def and_i_am_permitted_to_make_decisions_for_my_provider
+  def and_i_can_see_the_application_actions
     permit_make_decisions!
+  end
+
+  def and_i_am_permitted_to_set_up_interviews_for_my_provider
+    permit_set_up_interviews!
   end
 
   def when_i_visit_that_application_in_the_provider_interface

--- a/spec/system/support_interface/validation_errors_provider_spec.rb
+++ b/spec/system/support_interface/validation_errors_provider_spec.rb
@@ -14,6 +14,10 @@ RSpec.feature 'Validation errors Provider' do
     end
   end
 
+  before do
+    FeatureFlag.activate(:interview_permissions)
+  end
+
   scenario 'Review validation errors' do
     given_i_signed_in_as_a_provider_user
     and_i_enter_an_invalid_interview_time
@@ -34,6 +38,7 @@ RSpec.feature 'Validation errors Provider' do
     provider_exists_in_dfe_sign_in
     provider_user_exists_in_apply_database
     permit_make_decisions!
+    permit_set_up_interviews!
     provider_signs_in_using_dfe_sign_in
     visit provider_interface_application_choice_path(application_choice)
   end

--- a/spec/system/support_interface/validation_errors_provider_summary_spec.rb
+++ b/spec/system/support_interface/validation_errors_provider_summary_spec.rb
@@ -8,6 +8,10 @@ RSpec.feature 'Validation errors provider summary' do
   let(:application_choice) { create(:application_choice, :awaiting_provider_decision, course_option: course_option) }
   let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
 
+  before do
+    FeatureFlag.activate(:interview_permissions)
+  end
+
   scenario 'Review validation error summary' do
     given_i_signed_in_as_a_provider_user
     and_i_enter_an_invalid_interview_time
@@ -25,6 +29,7 @@ RSpec.feature 'Validation errors provider summary' do
     provider_exists_in_dfe_sign_in
     provider_user_exists_in_apply_database
     permit_make_decisions!
+    permit_set_up_interviews!
     provider_signs_in_using_dfe_sign_in
     visit provider_interface_application_choice_path(application_choice)
   end


### PR DESCRIPTION
## Context

Only users with Set up interview permissions should be able to access the Create, Cancel and Edit buttons on the interviews page

## Changes proposed in this pull request

Amendments to the authorisation service to take into account both the training and accredited provider user permissions, as well as the application visiblity,

## Guidance to review

- Enable the interview feature flag
- Assign Make decisions permissions only to your user
- Create a new interview (the actions on the application choice page will be amended as part of a different PR)
- You should not be able to perform any further actions on the /interviews page
- Grant your user Set up interview permissions
- You should not be able to Create, Cancel and Edit interviews.

## Link to Trello card

https://trello.com/c/2KjUSGHv/3919-update-interview-actions-to-only-be-visible-to-users-with-correct-permissions

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
