### PR TITLE
DSA signed confirmation page new design

### DIFF
--- a/app/components/provider_interface/dsa_success_page_component.html.erb
+++ b/app/components/provider_interface/dsa_success_page_component.html.erb
@@ -3,7 +3,7 @@
 
   <% if provider_permission_setup_pending %>
     <h2 class="govuk-heading-m">
-      Next steps
+      <%= t('.next_steps') %>
     </h2>
 
     <p class="govuk-body">
@@ -14,27 +14,27 @@
       <%= govuk_link_to t('continue'), provider_interface_provider_relationship_permissions_organisations_path, button: true %>
     </p>
   <% else %>
-    <% if provider_user.authorisation.can_manage_users_for_at_least_one_provider? %>
-      <h2 class="govuk-heading-m">
-        Inviting users
-      </h2>
-
-      <p class="govuk-body govuk-!-margin-bottom-4">
-        Select <%= govuk_link_to 'Users', provider_interface_provider_users_path %> (at the top of every page) to add users and manage their permissions.
-      </p>
-    <% end %>
-
     <h2 class="govuk-heading-m">
-      Manage your applications
+      <%= t('.next_steps') %>
     </h2>
 
     <p class="govuk-body">
-      Continue to your applications.
+      <%= t('.options_list_description') %>
     </p>
 
-    <p class="govuk-body">
-      <%= govuk_link_to t('continue'), provider_interface_applications_path, button: true %>
-    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        <%= govuk_link_to t('.view_applications'), provider_interface_applications_path %>
+      </li>
+      <% if user_can_manage_users? %>
+        <li>
+          <%= govuk_link_to t('.invite_or_manage_users'), provider_interface_provider_users_path %>
+        </li>
+      <% end %>
+      <li>
+        <%= govuk_link_to t('.manage_email_notifications'), provider_interface_notifications_path %>
+      </li>
+    </ul>
   <% end %>
 <% else %>
   <%= govuk_panel(title: t('.old.success_message'), body: nil) %>
@@ -52,7 +52,7 @@
       <%= govuk_link_to t('.old.setup_permissions_action'), provider_interface_provider_relationship_permissions_organisations_path, button: true %>
     </p>
   <% else %>
-    <% if provider_user.authorisation.can_manage_users_for_at_least_one_provider? %>
+    <% if user_can_manage_users? %>
       <h2 class="govuk-heading-m">
         Inviting users
       </h2>

--- a/app/components/provider_interface/dsa_success_page_component.html.erb
+++ b/app/components/provider_interface/dsa_success_page_component.html.erb
@@ -1,37 +1,77 @@
-<%= govuk_panel(title: 'You’ve successfully signed the data sharing agreement', body: nil) %>
+<% if FeatureFlag.active?(:accredited_provider_setting_permissions) %>
+  <%= govuk_panel(title: t('.success_message'), body: nil) %>
 
-<% if provider_permission_setup_pending %>
-  <h2 class="govuk-heading-m">
-    Next steps
-  </h2>
-
-  <p class="govuk-body">
-    You need to set up permissions for your organisation before you do anything else. We’ll guide you through this process.
-  </p>
-
-  <p class="govuk-body">
-    <%= govuk_link_to 'Set up permissions', provider_interface_provider_relationship_permissions_organisations_path, button: true %>
-  </p>
-<% else %>
-  <% if provider_user.authorisation.can_manage_users_for_at_least_one_provider? %>
+  <% if provider_permission_setup_pending %>
     <h2 class="govuk-heading-m">
-      Inviting users
+      Next steps
     </h2>
 
-    <p class="govuk-body govuk-!-margin-bottom-4">
-      Select <%= govuk_link_to 'Users', provider_interface_provider_users_path %> (at the top of every page) to add users and manage their permissions.
+    <p class="govuk-body">
+      <%= t('.setup_permissions_message') %>
+    </p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t('continue'), provider_interface_provider_relationship_permissions_organisations_path, button: true %>
+    </p>
+  <% else %>
+    <% if provider_user.authorisation.can_manage_users_for_at_least_one_provider? %>
+      <h2 class="govuk-heading-m">
+        Inviting users
+      </h2>
+
+      <p class="govuk-body govuk-!-margin-bottom-4">
+        Select <%= govuk_link_to 'Users', provider_interface_provider_users_path %> (at the top of every page) to add users and manage their permissions.
+      </p>
+    <% end %>
+
+    <h2 class="govuk-heading-m">
+      Manage your applications
+    </h2>
+
+    <p class="govuk-body">
+      Continue to your applications.
+    </p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t('continue'), provider_interface_applications_path, button: true %>
     </p>
   <% end %>
+<% else %>
+  <%= govuk_panel(title: t('.old.success_message'), body: nil) %>
 
-  <h2 class="govuk-heading-m">
-    Manage your applications
-  </h2>
+  <% if provider_permission_setup_pending %>
+    <h2 class="govuk-heading-m">
+      Next steps
+    </h2>
 
-  <p class="govuk-body">
-    Continue to your applications.
-  </p>
+    <p class="govuk-body">
+      <%= t('.old.setup_permissions_message') %>
+    </p>
 
-  <p class="govuk-body">
-    <%= govuk_link_to t('continue'), provider_interface_applications_path, button: true %>
-  </p>
+    <p class="govuk-body">
+      <%= govuk_link_to t('.old.setup_permissions_action'), provider_interface_provider_relationship_permissions_organisations_path, button: true %>
+    </p>
+  <% else %>
+    <% if provider_user.authorisation.can_manage_users_for_at_least_one_provider? %>
+      <h2 class="govuk-heading-m">
+        Inviting users
+      </h2>
+
+      <p class="govuk-body govuk-!-margin-bottom-4">
+        Select <%= govuk_link_to 'Users', provider_interface_provider_users_path %> (at the top of every page) to add users and manage their permissions.
+      </p>
+    <% end %>
+
+    <h2 class="govuk-heading-m">
+      Manage your applications
+    </h2>
+
+    <p class="govuk-body">
+      Continue to your applications.
+    </p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t('continue'), provider_interface_applications_path, button: true %>
+    </p>
+  <% end %>
 <% end %>

--- a/app/components/provider_interface/dsa_success_page_component.html.erb
+++ b/app/components/provider_interface/dsa_success_page_component.html.erb
@@ -1,0 +1,37 @@
+<%= govuk_panel(title: 'You’ve successfully signed the data sharing agreement', body: nil) %>
+
+<% if provider_permission_setup_pending %>
+  <h2 class="govuk-heading-m">
+    Next steps
+  </h2>
+
+  <p class="govuk-body">
+    You need to set up permissions for your organisation before you do anything else. We’ll guide you through this process.
+  </p>
+
+  <p class="govuk-body">
+    <%= govuk_link_to 'Set up permissions', provider_interface_provider_relationship_permissions_organisations_path, button: true %>
+  </p>
+<% else %>
+  <% if provider_user.authorisation.can_manage_users_for_at_least_one_provider? %>
+    <h2 class="govuk-heading-m">
+      Inviting users
+    </h2>
+
+    <p class="govuk-body govuk-!-margin-bottom-4">
+      Select <%= govuk_link_to 'Users', provider_interface_provider_users_path %> (at the top of every page) to add users and manage their permissions.
+    </p>
+  <% end %>
+
+  <h2 class="govuk-heading-m">
+    Manage your applications
+  </h2>
+
+  <p class="govuk-body">
+    Continue to your applications.
+  </p>
+
+  <p class="govuk-body">
+    <%= govuk_link_to t('continue'), provider_interface_applications_path, button: true %>
+  </p>
+<% end %>

--- a/app/components/provider_interface/dsa_success_page_component.rb
+++ b/app/components/provider_interface/dsa_success_page_component.rb
@@ -1,0 +1,10 @@
+module ProviderInterface
+  class DsaSuccessPageComponent < ViewComponent::Base
+    attr_reader :provider_user, :provider_permission_setup_pending
+
+    def initialize(provider_user:, provider_permission_setup_pending:)
+      @provider_user = provider_user
+      @provider_permission_setup_pending = provider_permission_setup_pending
+    end
+  end
+end

--- a/app/components/provider_interface/dsa_success_page_component.rb
+++ b/app/components/provider_interface/dsa_success_page_component.rb
@@ -6,5 +6,9 @@ module ProviderInterface
       @provider_user = provider_user
       @provider_permission_setup_pending = provider_permission_setup_pending
     end
+
+    def user_can_manage_users?
+      provider_user.authorisation.can_manage_users_for_at_least_one_provider?
+    end
   end
 end

--- a/app/views/provider_interface/provider_agreements/success.html.erb
+++ b/app/views/provider_interface/provider_agreements/success.html.erb
@@ -1,41 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_panel(title: 'You’ve successfully signed the data sharing agreement', body: nil) %>
-
-    <% if @provider_relationship_pending %>
-      <h2 class="govuk-heading-m">
-        Next steps
-      </h2>
-
-      <p class="govuk-body">
-        You need to set up permissions for your organisation before you do anything else. We’ll guide you through this process.
-      </p>
-
-      <p class="govuk-body">
-        <%= govuk_link_to 'Set up permissions', provider_interface_provider_relationship_permissions_organisations_path, button: true %>
-      </p>
-    <% else %>
-      <% if current_provider_user.authorisation.can_manage_users_for_at_least_one_provider? %>
-        <h2 class="govuk-heading-m">
-          Inviting users
-        </h2>
-
-        <p class="govuk-body govuk-!-margin-bottom-4">
-          Select <%= govuk_link_to 'Users', provider_interface_provider_users_path %> (at the top of every page) to add users and manage their permissions.
-        </p>
-      <% end %>
-
-      <h2 class="govuk-heading-m">
-        Manage your applications
-      </h2>
-
-      <p class="govuk-body">
-        Continue to your applications.
-      </p>
-
-      <p class="govuk-body">
-        <%= govuk_link_to t('continue'), provider_interface_applications_path, button: true %>
-      </p>
-    <% end %>
+    <%= render ProviderInterface::DsaSuccessPageComponent.new(
+      provider_user: current_provider_user,
+      provider_permission_setup_pending: @provider_relationship_pending,
+    ) %>
   </div>
 </div>

--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -19,3 +19,12 @@ en:
       edit:
         heading: Organisation permissions
         submit_button: Save organisation permissions
+    dsa_success_page_component:
+      success_message: Data sharing agreement signed
+      setup_permissions_message: Either you or your partner organisations must set up organisation permissions before you can manage teacher training applications.
+      old:
+        success_message: You’ve successfully signed the data sharing agreement
+        setup_permissions_message: You need to set up permissions for your organisation before you do anything else. We’ll guide you through this process.
+        setup_permissions_action: Set up permissions
+
+

--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -22,6 +22,11 @@ en:
     dsa_success_page_component:
       success_message: Data sharing agreement signed
       setup_permissions_message: Either you or your partner organisations must set up organisation permissions before you can manage teacher training applications.
+      next_steps: Next steps
+      options_list_description: 'You can now:'
+      view_applications: view applications
+      invite_or_manage_users: invite or manage users
+      manage_email_notifications: manage your email notifications
       old:
         success_message: You’ve successfully signed the data sharing agreement
         setup_permissions_message: You need to set up permissions for your organisation before you do anything else. We’ll guide you through this process.

--- a/spec/components/previews/provider_interface/dsa_success_page_component_preview.rb
+++ b/spec/components/previews/provider_interface/dsa_success_page_component_preview.rb
@@ -1,0 +1,27 @@
+module ProviderInterface
+  class DsaSuccessPageComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
+    def permission_setup_required
+      render DsaSuccessPageComponent.new(
+        provider_user: example_provider_user,
+        provider_permission_setup_pending: true,
+      )
+    end
+
+    def permission_setup_not_required
+      render DsaSuccessPageComponent.new(
+        provider_user: example_provider_user,
+        provider_permission_setup_pending: false,
+      )
+    end
+
+  private
+
+    def example_provider_user
+      traits = %i[with_provider]
+      traits << :with_manage_users if rand < 0.5
+      FactoryBot.create(:provider_user, *traits)
+    end
+  end
+end

--- a/spec/components/provider_interface/dsa_success_page_component_spec.rb
+++ b/spec/components/provider_interface/dsa_success_page_component_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::DsaSuccessPageComponent do
+  let(:feature_flag_state) { :on }
+  let(:provider_user) { create(:provider_user) }
+  let(:render) { render_inline(described_class.new(provider_user: provider_user, provider_permission_setup_pending: permissions_require_setup)) }
+
+  before do
+    if feature_flag_state == :on
+      FeatureFlag.activate(:accredited_provider_setting_permissions)
+    else
+      FeatureFlag.deactivate(:accredited_provider_setting_permissions)
+    end
+  end
+
+  context 'when there are permissions to set up' do
+    let(:permissions_require_setup) { true }
+
+    it 'shows a continue button' do
+      expect(render.css('a').text).to eq('Continue')
+    end
+
+    it 'renders the correct text' do
+      expect(render.css('p').first.text.squish).to eq('Either you or your partner organisations must set up organisation permissions before you can manage teacher training applications.')
+    end
+  end
+
+  context 'when permissions have been set up' do
+    let(:permissions_require_setup) { false }
+
+    it 'shows a link to the applications page' do
+      expect(render.css('a')[0].text).to eq('view applications')
+      expect(render.css('a')[0].attributes['href'].value).to eq('/provider/applications')
+    end
+
+    context 'when the provider can manage users' do
+      let(:provider_user) { create(:provider_user, :with_provider, :with_manage_users) }
+
+      it 'shows a link to the users page' do
+        expect(render.css('a')[1].text).to eq('invite or manage users')
+        expect(render.css('a')[1].attributes['href'].value).to eq('/provider/account/users')
+      end
+    end
+
+    context 'when the provider can not manage users' do
+      it 'does not show a link to the users page' do
+        expect(render.css('a').text).not_to include('invite or manage users')
+      end
+    end
+
+    it 'shows a link to the notifications page' do
+      expect(render.css('a').last.text).to eq('manage your email notifications')
+      expect(render.css('a').last.attributes['href'].value).to eq('/provider/account/notification-settings')
+    end
+  end
+
+  context 'when the feature flag is off' do
+    let(:feature_flag_state) { :off }
+
+    context 'when there are permissions to set up' do
+      let(:permissions_require_setup) { true }
+
+      it 'shows a set up permissions button' do
+        expect(render.css('a').text).to eq('Set up permissions')
+      end
+
+      it 'renders the correct text' do
+        expect(render.css('p').first.text.squish).to eq('You need to set up permissions for your organisation before you do anything else. We’ll guide you through this process.')
+      end
+    end
+
+    context 'when permissions have been set up' do
+      let(:permissions_require_setup) { false }
+
+      it 'shows a link to the applications page' do
+        expect(render.css('a').last.text).to eq('Continue')
+        expect(render.css('a').last.attributes['href'].value).to eq('/provider/applications')
+      end
+
+      context 'when the provider can manage users' do
+        let(:provider_user) { create(:provider_user, :with_provider, :with_manage_users) }
+
+        it 'shows a link to the users page' do
+          expect(render.css('a').first.text).to eq('Users')
+          expect(render.css('a').first.attributes['href'].value).to eq('/provider/account/users')
+        end
+      end
+
+      context 'when the provider can not manage users' do
+        it 'does not show a link to the users page' do
+          expect(render.css('a').text).not_to include('Users')
+        end
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_accepts_data_sharing_agreement_spec.rb
+++ b/spec/system/provider_interface/provider_accepts_data_sharing_agreement_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Accept data sharing agreement' do
   include DfESignInHelpers
 
+  before { FeatureFlag.deactivate(:accredited_provider_setting_permissions) }
+
   scenario 'Provider user cannot access provider_interface without a data sharing agreement in place' do
     given_i_am_an_authorised_provider_user
     and_no_data_sharing_agreement_for_my_provider_has_been_accepted


### PR DESCRIPTION
## Context
As part of the new permissions work, we are updating the design and logic behind the DSA signed confirmation page.

## Changes proposed in this pull request
Add a new component to wrap up the DSA signed page.

Still to do:
Change the query behind `@provider_relationship_pending` to use the new query service


## Link to Trello card
https://trello.com/c/RrmQivR8/3906-amend-dsa-agreement-permissions-setup-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
