### PR TITLE
Enable provider users to be removed via Support

### DIFF
--- a/app/components/summary_list_component.html.erb
+++ b/app/components/summary_list_component.html.erb
@@ -5,6 +5,7 @@
       key: row[:key],
       value: value(row),
       action: action(row),
+      html_attributes: html_attributes(row),
     ) %>
   <% end %>
 <% end %>

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -23,6 +23,13 @@ class SummaryListComponent < ViewComponent::Base
       end
     elsif row[:action_path]
       govuk_link_to(row[:action], row[:action_path], class: 'govuk-!-display-none-print')
+    elsif row[:actions]
+      links = row[:actions].map do |action|
+        govuk_link_to(action[:path], class: 'govuk-!-display-none-print') do
+          "#{action[:verb]}<span class=\"govuk-visually-hidden\"> #{action[:object]}</span>".html_safe
+        end
+      end
+      links.join('<br>').html_safe
     elsif any_row_has_action_span?
       tag.dd(class: 'govuk-summary-list__actions')
     end

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -28,6 +28,14 @@ class SummaryListComponent < ViewComponent::Base
     end
   end
 
+  def html_attributes(row)
+    if row[:data_qa]
+      { 'data-qa' => row[:data_qa] }
+    else
+      {}
+    end
+  end
+
 private
 
   attr_reader :rows

--- a/app/components/support_interface/provider_user_permissions_summary_component.rb
+++ b/app/components/support_interface/provider_user_permissions_summary_component.rb
@@ -18,6 +18,7 @@ module SupportInterface
           value: render(SupportInterface::PermissionsListComponent.new(permission)),
           action: 'permissions',
           change_path: change_path,
+          data_qa: "provider-id-#{permission.provider.id}",
         }
       end
     end

--- a/app/components/support_interface/provider_user_permissions_summary_component.rb
+++ b/app/components/support_interface/provider_user_permissions_summary_component.rb
@@ -12,7 +12,14 @@ module SupportInterface
       permissions = provider_user
         .provider_permissions
         .includes(provider: %i[ratifying_provider_permissions training_provider_permissions])
-      if FeatureFlag.active?(:new_provider_user_flow)
+
+      if permissions.empty?
+        [
+          {
+            key: 'This user does not have access to any providers',
+          },
+        ]
+      elsif FeatureFlag.active?(:new_provider_user_flow)
         permissions.map do |permission|
           {
             key: permission.provider.name_and_code,
@@ -27,7 +34,6 @@ module SupportInterface
             data_qa: "provider-id-#{permission.provider.id}",
           }
         end
-
       else
         permissions.map do |permission|
           {

--- a/app/components/support_interface/provider_user_permissions_summary_component.rb
+++ b/app/components/support_interface/provider_user_permissions_summary_component.rb
@@ -9,17 +9,35 @@ module SupportInterface
     end
 
     def rows
-      provider_user
+      permissions = provider_user
         .provider_permissions
         .includes(provider: %i[ratifying_provider_permissions training_provider_permissions])
-        .map do |permission|
-        {
-          key: permission.provider.name_and_code,
-          value: render(SupportInterface::PermissionsListComponent.new(permission)),
-          action: 'permissions',
-          change_path: change_path,
-          data_qa: "provider-id-#{permission.provider.id}",
-        }
+      if FeatureFlag.active?(:new_provider_user_flow)
+        permissions.map do |permission|
+          {
+            key: permission.provider.name_and_code,
+            value: render(SupportInterface::PermissionsListComponent.new(permission)),
+            actions: [
+              { verb: 'Change', object: "permissions for #{permission.provider.name_and_code}", path: change_path },
+              { verb: 'Remove access', object: "to #{permission.provider.name_and_code}", path: support_interface_provider_user_removals_path(
+                provider_user_id: permission.provider_user.id,
+                provider_permissions_id: permission.id,
+              ) },
+            ],
+            data_qa: "provider-id-#{permission.provider.id}",
+          }
+        end
+
+      else
+        permissions.map do |permission|
+          {
+            key: permission.provider.name_and_code,
+            value: render(SupportInterface::PermissionsListComponent.new(permission)),
+            action: 'permissions',
+            change_path: change_path,
+            data_qa: "provider-id-#{permission.provider.id}",
+          }
+        end
       end
     end
 

--- a/app/components/support_interface/provider_users_table_component.html.erb
+++ b/app/components/support_interface/provider_users_table_component.html.erb
@@ -27,8 +27,10 @@
         </td>
         <td class="govuk-table__cell">
           <% if FeatureFlag.active?(:new_provider_user_flow) %>
-            <%= govuk_link_to(support_interface_edit_permissions_path(row[:provider_user])) do %>
-              Update permissions<span class="govuk-visually-hidden"> for <%= row[:provider_user].display_name %></span>
+            <% if row[:provider_user].provider_permissions.any? %>
+              <%= govuk_link_to(support_interface_edit_permissions_path(row[:provider_user])) do %>
+                Update permissions<span class="govuk-visually-hidden"> for <%= row[:provider_user].display_name %></span>
+              <% end %>
             <% end %>
           <% else %>
             <%= govuk_link_to(edit_support_interface_provider_user_path(row[:provider_user])) do %>

--- a/app/controllers/support_interface/single_provider_user_removals_controller.rb
+++ b/app/controllers/support_interface/single_provider_user_removals_controller.rb
@@ -1,0 +1,24 @@
+module SupportInterface
+  class SingleProviderUserRemovalsController < ApplicationController
+    def new
+      @permissions = permissions_to_remove
+      @provider = permissions_to_remove.provider
+      @user = permissions_to_remove.provider_user
+    end
+
+    def create
+      flash[:success] = "User no longer has access to #{permissions_to_remove.provider.name}"
+      user = permissions_to_remove.provider_user
+
+      permissions_to_remove.destroy
+
+      redirect_to support_interface_provider_user_path(user)
+    end
+
+  private
+
+    def permissions_to_remove
+      @_permissions_to_remove = ProviderPermissions.find(params[:provider_permissions_id])
+    end
+  end
+end

--- a/app/views/support_interface/single_provider_user_removals/new.html.erb
+++ b/app/views/support_interface/single_provider_user_removals/new.html.erb
@@ -1,0 +1,16 @@
+<% content_for :before_content, govuk_back_link_to(support_interface_provider_user_path(@user)) %>
+
+<span class="govuk-caption-xl"><%= @user.display_name %></span>
+<h1 class="govuk-heading-xl">Are you sure you want to remove this user’s access to <%= @provider.name %>?</h1>
+
+<%= govuk_button_to(
+  'Yes I’m sure - remove access',
+  support_interface_remove_provider_user_path(
+    provider_user_id: @user.id,
+    provider_permissions_id: @permissions.id,
+  ),
+  class: 'govuk-button--warning',
+  method: :delete,
+) %>
+
+<%= govuk_link_to 'Cancel', support_interface_provider_user_path(@user) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -919,6 +919,8 @@ Rails.application.routes.draw do
       patch '/permissions' => 'single_provider_users#update', as: :update_permissions
       get '/notifications/edit' => 'single_provider_user_notifications#edit', as: :edit_provider_notifications
       put '/notifications' => 'single_provider_user_notifications#update', as: :update_provider_notifications
+      get '/permissions/:provider_permissions_id/remove' => 'single_provider_user_removals#new', as: :provider_user_removals
+      delete '/permissions/:provider_permissions_id/remove' => 'single_provider_user_removals#create', as: :remove_provider_user
     end
 
     scope path: '/providers/:provider_id' do

--- a/spec/components/summary_list_component_spec.rb
+++ b/spec/components/summary_list_component_spec.rb
@@ -103,4 +103,25 @@ RSpec.describe SummaryListComponent do
 
     expect(result.to_html).to include('<dd class="govuk-summary-list__actions"></dd>')
   end
+
+  it 'handles rows with multiple actions' do
+    rows = [
+      { key: 'Role',
+        value: 'Chef de partie',
+        actions: [
+          { verb: 'Change', object: 'role', path: '#change-role' },
+          { verb: 'Remove', object: 'this chef', path: '#remove' },
+        ] },
+    ]
+
+    result = render_inline(SummaryListComponent.new(rows: rows))
+
+    links = result.css('.govuk-summary-list__actions a')
+
+    expect(links[0].text).to eq 'Change role'
+    expect(links[0].attr('href')).to eq '#change-role'
+
+    expect(links[1].text).to eq 'Remove this chef'
+    expect(links[1].attr('href')).to eq '#remove'
+  end
 end

--- a/spec/components/summary_list_component_spec.rb
+++ b/spec/components/summary_list_component_spec.rb
@@ -63,6 +63,16 @@ RSpec.describe SummaryListComponent do
     expect(result.css('.govuk-summary-list__value p').to_html).to eq('<p class="govuk-body">Unsafe</p>')
   end
 
+  it 'supports adding data_qa to rows' do
+    rows = [{ key: 'Job',
+              value: 'Ice cream man',
+              data_qa: 'ice-cream-man' }]
+
+    result = render_inline(SummaryListComponent.new(rows: rows))
+
+    expect(result.css('[data-qa="ice-cream-man"]')).to be_present
+  end
+
   it 'does not render an extra dd if no row has an action' do
     rows = [{ key: 'Job',
               value: ['Teacher', 'Clearcourt High'] },

--- a/spec/components/support_interface/provider_user_permissions_summary_component_spec.rb
+++ b/spec/components/support_interface/provider_user_permissions_summary_component_spec.rb
@@ -12,4 +12,12 @@ RSpec.describe SupportInterface::ProviderUserPermissionsSummaryComponent do
     expect(rendered_component_text).to include('Manage users')
     expect(rendered_component_text).to include('Change')
   end
+
+  it 'renders an empty state when there are no permissions' do
+    provider_user = create(:provider_user)
+
+    rendered_component_text = render_inline(described_class.new(provider_user)).text
+
+    expect(rendered_component_text).to include('This user does not have access to any providers')
+  end
 end

--- a/spec/components/support_interface/provider_users_table_component_spec.rb
+++ b/spec/components/support_interface/provider_users_table_component_spec.rb
@@ -28,4 +28,34 @@ RSpec.describe SupportInterface::ProviderUsersTableComponent do
 
     it { is_expected.to be_blank }
   end
+
+  describe 'permissions link' do
+    before do
+      FeatureFlag.activate(:new_provider_user_flow)
+    end
+
+    context 'when the provider user has permissions' do
+      let(:provider_users) do
+        [
+          create(:provider_user, :with_provider),
+        ]
+      end
+
+      it 'renders a link to edit permissions' do
+        expect(rendered_component).to include('Update permissions')
+      end
+    end
+
+    context 'when the provider user lacks permissions' do
+      let(:provider_users) do
+        [
+          create(:provider_user),
+        ]
+      end
+
+      it 'renders no link to edit permissions' do
+        expect(rendered_component).not_to include('Update permissions')
+      end
+    end
+  end
 end

--- a/spec/system/support_interface/managing_users_v2/removing_a_provider_user_spec.rb
+++ b/spec/system/support_interface/managing_users_v2/removing_a_provider_user_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing provider users v2' do
+  include DfESignInHelpers
+  include DsiAPIHelper
+
+  scenario 'removing a user from a provider' do
+    FeatureFlag.activate(:new_provider_user_flow)
+
+    given_dfe_signin_is_configured
+    and_i_am_a_support_user
+    and_synced_providers_exist
+    and_a_provider_user_exists_for_both_providers
+
+    when_i_visit_the_support_page_for_that_user
+    and_i_click_remove_on_the_first_provider
+    then_i_should_see_a_confirmation_page
+
+    when_i_click_yes_i_am_sure
+    then_i_should_see_a_flash_message
+    and_i_should_see_that_the_user_is_no_longer_associated_with_that_provider
+  end
+
+  def given_dfe_signin_is_configured
+    dsi_api_response(success: true)
+  end
+
+  def and_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_synced_providers_exist
+    @provider_one = create(:provider, name: 'Example provider one', code: 'ABC', sync_courses: true)
+    @provider_two = create(:provider, name: 'Example provider two', code: 'DEF', sync_courses: true)
+
+    create(:course, :open_on_apply, provider: @provider_one)
+    create(:course, :open_on_apply, provider: @provider_two)
+  end
+
+  def and_a_provider_user_exists_for_both_providers
+    @provider_user = create(:provider_user, providers: [@provider_one, @provider_two])
+  end
+
+  def when_i_visit_the_support_page_for_that_user
+    visit "/support/users/provider/#{@provider_user.id}"
+  end
+
+  def and_i_click_remove_on_the_first_provider
+    within("[data-qa=\"provider-id-#{@provider_one.id}\"]") do
+      click_link 'Remove access'
+    end
+  end
+
+  def then_i_should_see_a_confirmation_page
+    expect(page).to have_content('Are you sure you want to remove this user’s access to Example provider one')
+  end
+
+  def when_i_click_yes_i_am_sure
+    click_button 'Yes I’m sure - remove access'
+  end
+
+  def then_i_should_see_a_flash_message
+    expect(page).to have_content 'User no longer has access to Example provider one'
+  end
+
+  def and_i_should_see_that_the_user_is_no_longer_associated_with_that_provider
+    expect(page).not_to have_selector("[data-qa=\"provider-id-#{@provider_one.id}\"]")
+  end
+end


### PR DESCRIPTION
## Context

When we moved to the new provider user flow we lost the ability to revoke Providers' access via Support

## Changes proposed in this pull request

_First soup up the SummaryListComponent_

- support multiple actions
- enable us to add a `data-qa` field by specifying it on the row, to simplify testing

_Then add new flow_

### "Remove access" link

<img width="983" alt="Screenshot 2021-07-06 at 17 45 11" src="https://user-images.githubusercontent.com/642279/124637803-1c7cfc80-de82-11eb-9da6-e46f42cb49b6.png">


### Confirmation page

<img width="853" alt="Screenshot 2021-07-06 at 17 45 17" src="https://user-images.githubusercontent.com/642279/124637814-20108380-de82-11eb-9fc7-d6341cd75337.png">


### Flash message

<img width="1000" alt="Screenshot 2021-07-06 at 17 45 22" src="https://user-images.githubusercontent.com/642279/124637831-230b7400-de82-11eb-84eb-9786d810520a.png">


### Empty state

<img width="993" alt="Screenshot 2021-07-06 at 17 45 32" src="https://user-images.githubusercontent.com/642279/124637844-256dce00-de82-11eb-8df8-fe22259fd99d.png">

## Link to Trello card

https://trello.com/c/wjbc7uEt/3952-add-remove-links-to-new-provider-user-flow-in-support

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
