### PR TITLE
Squash provider user flow bugs

### DIFF
--- a/app/components/support_interface/provider_users_table_component.rb
+++ b/app/components/support_interface/provider_users_table_component.rb
@@ -7,7 +7,7 @@ module SupportInterface
     end
 
     def table_rows
-      provider_users.map do |provider_user|
+      provider_users.sort_by(&:last_name).map do |provider_user|
         {
           provider_user: provider_user,
           created_at: provider_user.created_at,

--- a/app/controllers/support_interface/bulk_upload/permissions_controller.rb
+++ b/app/controllers/support_interface/bulk_upload/permissions_controller.rb
@@ -72,7 +72,9 @@ module SupportInterface
       end
 
       def backlink_path
-        if index.zero?
+        if params[:change]
+          support_interface_bulk_upload_checks_path
+        elsif index.zero?
           new_support_interface_bulk_upload_provider_users_details_path
         else
           edit_support_interface_bulk_upload_permissions_path(position: index)

--- a/app/controllers/support_interface/bulk_upload/permissions_controller.rb
+++ b/app/controllers/support_interface/bulk_upload/permissions_controller.rb
@@ -30,10 +30,10 @@ module SupportInterface
         if @form.valid?
           multiple_provider_users_wizard.save_user_to_state_store!(@form)
 
-          if multiple_provider_users_wizard.more_users_to_process?
-            redirect_to edit_support_interface_bulk_upload_permissions_path(position: multiple_provider_users_wizard.next_position)
-          else
+          if multiple_provider_users_wizard.no_more_users_to_process?
             redirect_to support_interface_bulk_upload_checks_path
+          else
+            redirect_to edit_support_interface_bulk_upload_permissions_path(position: multiple_provider_users_wizard.next_position)
           end
         else
           render :edit

--- a/app/forms/support_interface/multiple_provider_users_wizard.rb
+++ b/app/forms/support_interface/multiple_provider_users_wizard.rb
@@ -82,8 +82,8 @@ module SupportInterface
       index + 2
     end
 
-    def more_users_to_process?
-      read_state['provider_users'].select { |pu| pu['complete'] == false }.present?
+    def no_more_users_to_process?
+      read_state['provider_users'].count == index + 1
     end
 
     def single_provider_user_form(index)
@@ -121,7 +121,6 @@ module SupportInterface
           first_name: provider_user[0],
           last_name: provider_user[1],
           email_address: provider_user[2],
-          complete: false,
         }
       end
 
@@ -137,7 +136,6 @@ module SupportInterface
         last_name: form.last_name,
         email_address: form.email_address,
         permissions: form.permission_form.provider_permission,
-        complete: true,
       }
 
       state['provider_users'][form.index] = updated_user_details

--- a/app/views/support_interface/bulk_upload/checks/show.html.erb
+++ b/app/views/support_interface/bulk_upload/checks/show.html.erb
@@ -29,7 +29,7 @@
         ].compact) do %>
           <%= render SummaryCardHeaderComponent.new(title: "User #{index + 1}", heading_level: 2) do %>
             <div class="app-summary-card__actions">
-              <%= govuk_link_to 'Change', edit_support_interface_bulk_upload_permissions_path(position: index + 1) %>
+              <%= govuk_link_to 'Change', edit_support_interface_bulk_upload_permissions_path(position: index + 1, change: true) %>
             </div>
           <% end %>
         <% end %>

--- a/app/views/support_interface/single_provider_users/new.html.erb
+++ b/app/views/support_interface/single_provider_users/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix('Add provider user', @form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(support_interface_provider_users_path) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_provider_user_list_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/forms/support_interface/multiple_provider_users_wizard_spec.rb
+++ b/spec/forms/support_interface/multiple_provider_users_wizard_spec.rb
@@ -20,13 +20,11 @@ RSpec.describe SupportInterface::MultipleProviderUsersWizard do
             'first_name' => 'Bob',
             'last_name' => 'Smith',
             'email_address' => 'bob@foo.com',
-            'complete' => false,
           },
           {
             'first_name' => 'Fred',
             'last_name' => 'Jones',
             'email_address' => 'fred@bar.com',
-            'complete' => false,
           },
         ],
       }
@@ -53,7 +51,6 @@ RSpec.describe SupportInterface::MultipleProviderUsersWizard do
             first_name: 'Bob',
             last_name: 'Smith',
             email_address: 'bob@foo.com',
-            complete: false,
             permissions: { manage_users: 'true' },
           },
         ],
@@ -90,7 +87,6 @@ RSpec.describe SupportInterface::MultipleProviderUsersWizard do
             first_name: 'Bob',
             last_name: 'Smith',
             email_address: 'bob@foo.com',
-            complete: false,
             permissions: { manage_users: true },
           },
         ],
@@ -110,13 +106,11 @@ RSpec.describe SupportInterface::MultipleProviderUsersWizard do
             first_name: 'Bob',
             last_name: 'Smith',
             email_address: 'bob@foo.com',
-            complete: false,
           },
           {
             first_name: 'Fred',
             last_name: 'Jones',
             email_address: 'fred@bar.com',
-            complete: false,
           },
         ],
       }
@@ -140,7 +134,6 @@ RSpec.describe SupportInterface::MultipleProviderUsersWizard do
             first_name: 'Bob',
             last_name: 'Smith',
             email_address: 'bob@foo.com',
-            complete: false,
           },
         ],
       }
@@ -151,8 +144,8 @@ RSpec.describe SupportInterface::MultipleProviderUsersWizard do
     end
   end
 
-  describe '#more_users_to_process?' do
-    context 'there are more users to process' do
+  describe '#no_more_users_to_process?' do
+    context 'there are no more users to process' do
       it 'returns true' do
         stored_users = {
           provider_users: [
@@ -160,7 +153,6 @@ RSpec.describe SupportInterface::MultipleProviderUsersWizard do
               first_name: 'Bob',
               last_name: 'Smith',
               email_address: 'bob@foo.com',
-              complete: false,
             },
           ],
         }
@@ -168,13 +160,13 @@ RSpec.describe SupportInterface::MultipleProviderUsersWizard do
         allow(store).to receive(:read).and_return(stored_users.to_json)
 
         expect(
-          described_class.new(state_store: store).more_users_to_process?,
+          described_class.new(state_store: store, index: 0).no_more_users_to_process?,
         )
         .to eq(true)
       end
     end
 
-    context 'there are no more users to process' do
+    context 'there are more users to process' do
       it 'returns false' do
         stored_users = {
           provider_users: [
@@ -182,7 +174,11 @@ RSpec.describe SupportInterface::MultipleProviderUsersWizard do
               first_name: 'Bob',
               last_name: 'Smith',
               email_address: 'bob@foo.com',
-              complete: true,
+            },
+            {
+              first_name: 'Melanie',
+              last_name: 'Jones',
+              email_address: 'melanie@jones.com',
             },
           ],
         }
@@ -190,7 +186,7 @@ RSpec.describe SupportInterface::MultipleProviderUsersWizard do
         allow(store).to receive(:read).and_return(stored_users.to_json)
 
         expect(
-          described_class.new(state_store: store).more_users_to_process?,
+          described_class.new(state_store: store, index: 0).no_more_users_to_process?,
         ).to eq(false)
       end
     end
@@ -208,7 +204,6 @@ RSpec.describe SupportInterface::MultipleProviderUsersWizard do
             first_name: first_name,
             last_name: last_name,
             email_address: email_address,
-            complete: false,
           },
         ],
       }

--- a/spec/system/support_interface/managing_users_v2/bulk_upload_multiple_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_users_v2/bulk_upload_multiple_provider_users_spec.rb
@@ -53,7 +53,11 @@ RSpec.feature 'bulk upload provider users' do
     then_i_should_see_the_edit_permissions_form_for_the_second_user
     and_the_permissions_i_selected_are_checked
 
-    when_i_edit_permissions_for_the_second_user
+    when_i_click_back
+    then_i_can_see_the_check_users_page
+
+    when_i_click_change_within_the_second_user_summary
+    and_i_edit_permissions_for_the_second_user
     and_i_click_continue
     then_i_can_see_the_check_users_page
 
@@ -147,6 +151,10 @@ RSpec.feature 'bulk upload provider users' do
   def when_i_edit_permissions_for_the_second_user
     check 'Manage users'
     check 'Manage organisational permissions'
+  end
+
+  def and_i_edit_permissions_for_the_second_user
+    when_i_edit_permissions_for_the_second_user
   end
 
   def when_i_click_back


### PR DESCRIPTION
## Context

Some bugs were identified after the new single provider flow and bulk provider user flows were deployed to prod. 

_Note not all bugs have been addressed_. Please see comments on Trello ticket.

## Changes proposed in this pull request

#### Squashed bugs
- Provider users page - Users should be listed alphabetically by name
- Add single provider user flow - The back button doesn't take you back to the providers/{{providerId}}/users but rather users/provider
- Add bulk users flow - If clicking change on check answers and going to the user details page, if I click the back link it should take me to the check answers page, not the previous form page.
- Add bulk users flow - If clicking change on check answers and going to the user details page, make a change to something and it errors, if I click the back link, I get a page not found error. The user should be taken back to the check answers page

## Link to Trello card

https://trello.com/c/XfUnWnPz/3562-new-provider-user-flow-bugs

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

