### PR TITLE
Update application inset prompt according to interview permissions

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -7,37 +7,26 @@
   <div class="govuk-grid-row govuk-!-display-none-print">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= govuk_inset_text(classes: 'govuk-!-margin-top-0') do %>
-        <% if respond_to_application? -%>
+        <% if set_up_interview? || respond_to_application? || waiting_for_interview? -%>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-            Set up an interview or make a decision
+            <%= inset_text_title %>
           </h2>
           <p class="govuk-body">
             <% if time_is_today_or_tomorrow?(application_choice.reject_by_default_at) -%>
-              This application will be automatically rejected at the end of <%= date_and_time_today_or_tomorrow(application_choice.reject_by_default_at) %> if you do not make a decision.
+              This application will be automatically rejected if a decision has not been made by the end of <%= date_and_time_today_or_tomorrow(application_choice.reject_by_default_at) %>.
             <% else -%>
-              This application will be automatically rejected in <%= days_until(application_choice.reject_by_default_at.to_date) %> (<%= application_choice.reject_by_default_at.to_s(:govuk_date_and_time) %>) if you do not make a decision.
+              This application will be automatically rejected if a decision has not been made within <%= days_until(application_choice.reject_by_default_at.to_date) %> (<%= application_choice.reject_by_default_at.to_s(:govuk_date_and_time) %>).
             <% end -%>
           </p>
 
           <div class="govuk-button-group">
-            <%= govuk_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice), button: true, class: 'govuk-!-margin-bottom-0 govuk-!-margin-right-2' %>
-            <%= govuk_link_to 'Make decision', new_provider_interface_application_choice_decision_path(application_choice), button: true, class: 'govuk-button--secondary govuk-!-margin-bottom-0 govuk-!-margin-right-2' %>
+            <% if set_up_interview? %>
+              <%= govuk_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice), button: true, class: 'govuk-!-margin-bottom-0 govuk-!-margin-right-2' %>
+            <% end %>
+            <% if respond_to_application? %>
+              <%= govuk_link_to 'Make decision', new_provider_interface_application_choice_decision_path(application_choice), button: true, class: "#{secondary_button_css}govuk-!-margin-bottom-0 govuk-!-margin-right-2" %>
+            <% end %>
           </div>
-
-        <% elsif waiting_for_interview? %>
-          <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-            Make a decision
-          </h2>
-          <p class="govuk-body">
-            <% if time_is_today_or_tomorrow?(application_choice.reject_by_default_at) -%>
-              This application will be automatically rejected at the end of <%= date_and_time_today_or_tomorrow(application_choice.reject_by_default_at) %> if you do not make a decision.
-            <% else -%>
-              This application will be automatically rejected in <%= days_until(application_choice.reject_by_default_at.to_date) %> (<%= application_choice.reject_by_default_at.to_s(:govuk_date_and_time) %>) if you do not make a decision.
-            <% end -%>
-          </p>
-
-          <%= govuk_link_to 'Make decision', new_provider_interface_application_choice_decision_path(application_choice), button: true %>
-
         <% elsif awaiting_decision_but_cannot_respond? -%>
           <p class="govuk-body">
             <% if time_is_today_or_tomorrow?(application_choice.reject_by_default_at) -%>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -1,6 +1,10 @@
 <% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code}" %>
 
-<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: @provider_can_respond) %>
+<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(
+  application_choice: @application_choice,
+  provider_can_respond: @provider_can_respond,
+  provider_can_set_up_interviews: @provider_can_set_up_interviews,
+) %>
 
 <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice, options: @status_box_options) unless @offer_present || @application_choice.rejected? %>
 


### PR DESCRIPTION
## Context

The presence of interview permissions should control whether a provider user sees the 'Set up interview' controls and headings.
This also needs to be controlled by a feature flag and legacy 'make decisions' behaviours supported.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Updates the inset text heading according to permissions:
- If the feature is disabled _Set up interview or make a decision_ if the user has make decisions permissions
- _Set up interview or make a decision_ if the user has both `set_up_interviews` and `make_decisions` permissions
- _Set up interview_ if the user only has `set_up_interviews` permissions
- _Make a decision_ if the user only has `make_decisions` permissions

Otherwise no heading is shown.

_Set up interview_ and _Make decision_ Buttons are similarly controlled by the absence/presence of permissions and also the feature flag.

### Both permissions

![image](https://user-images.githubusercontent.com/93511/124892356-b4d5c700-dfd1-11eb-830b-99431f3ff47f.png)

### Make decisions only

![image](https://user-images.githubusercontent.com/93511/124892606-ea7ab000-dfd1-11eb-80d4-d86482d2c913.png)

### Set up interviews only
 
![image](https://user-images.githubusercontent.com/93511/124905710-37fd1a00-dfde-11eb-86bd-541dab41372a.png)


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/F7Wi7lJT/3920-updates-to-application-page-prompt
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
