### PR TITLE
Add CandidateInterface::DeleteApplicationChoice service

### DIFF
--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -17,12 +17,11 @@ module CandidateInterface
     end
 
     def destroy
-      current_application
+      application_choice = current_application
         .application_choices
         .find(current_course_choice_id)
-        .destroy!
 
-      current_application.update!(course_choices_completed: nil) if current_application.application_choices.empty?
+      CandidateInterface::DeleteApplicationChoice.new(application_choice: application_choice).call
 
       redirect_to candidate_interface_course_choices_index_path
     end

--- a/app/services/candidate_interface/delete_application_choice.rb
+++ b/app/services/candidate_interface/delete_application_choice.rb
@@ -1,0 +1,15 @@
+module CandidateInterface
+  class DeleteApplicationChoice
+    def initialize(application_choice:)
+      @application_choice = application_choice
+    end
+
+    def call
+      application_form = @application_choice.application_form
+
+      @application_choice.destroy!
+
+      application_form.update!(course_choices_completed: nil) if application_form.application_choices.empty?
+    end
+  end
+end

--- a/spec/services/candidate_interface/delete_application_choice_spec.rb
+++ b/spec/services/candidate_interface/delete_application_choice_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::DeleteApplicationChoice do
+  describe '#call' do
+    context 'when an application form has only one application choice' do
+      it 'deletes the given application choice and resets `course_choices_completed`' do
+        application_form = create(:application_form, course_choices_completed: true)
+        application_choice = create(:application_choice, application_form: application_form)
+
+        described_class.new(application_choice: application_choice).call
+        expect(application_form.reload.application_choices).to be_empty
+        expect(application_form.course_choices_completed).to be_nil
+      end
+    end
+
+    context 'when an application form has multiple application choices' do
+      it 'deletes the only the given application choice and leaves `course_choices_completed` as true' do
+        application_form = create(:application_form, course_choices_completed: true)
+        create(:application_choice, application_form: application_form)
+        application_choice = create(:application_choice, application_form: application_form)
+
+        described_class.new(application_choice: application_choice).call
+        expect(application_choice.destroyed?).to be(true)
+        expect(application_form.reload.application_choices.count).to be(1)
+        expect(application_form.course_choices_completed).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION

## Context

This PR adds `CandidateInterface::DeleteApplicationChoice` service that replaces some business logic in `CandidateInterface::ApplicationChoiceController`

I can found 59 application forms that have `course_choices_completed` set to true without any application choices. Only one has been submitted: https://www.apply-for-teacher-training.service.gov.uk/support/applications/25518

## Changes proposed in this pull request

- [x] Add `CandidateInterface::DeleteApplicationChoice`
- [x] Call it from `CandidateInterface::ApplicationChoiceController`
- [x] Find out how common it is for application choices to have been deleted without resetting `ApplicationForm#course_choices_completed`

## Guidance to review

- Does the service make sense and is it tested correctly?

## Link to Trello card

https://trello.com/c/UNPb3QN9/3585-add-a-deleteapplicationchoice-service

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
