### PR TITLE
Implement BigQuery events for Candidate sign-up

### DIFF
--- a/app/controllers/concerns/emit_request_events.rb
+++ b/app/controllers/concerns/emit_request_events.rb
@@ -14,7 +14,7 @@ module EmitRequestEvents
         .with_response_details(response)
         .with_user_and_namespace(current_user, current_namespace)
 
-      SendRequestEventsToBigquery.perform_async(request_event.as_json)
+      SendEventsToBigquery.perform_async(request_event.as_json)
     end
   end
 end

--- a/app/forms/candidate_interface/sign_up_form.rb
+++ b/app/forms/candidate_interface/sign_up_form.rb
@@ -24,6 +24,7 @@ module CandidateInterface
       return false if existing_candidate? || !valid?
 
       candidate.course_from_find_id = course_from_find_id
+      candidate.event_tags = ['candidate_sign_up']
       candidate.save
     end
 

--- a/app/lib/events/event.rb
+++ b/app/lib/events/event.rb
@@ -1,6 +1,6 @@
 module Events
   class Event
-    EVENT_TYPES = %w[web_request entity_created entity_updated].freeze
+    EVENT_TYPES = %w[web_request create_entity update_entity].freeze
 
     def initialize
       @event_hash = {

--- a/app/lib/events/event.rb
+++ b/app/lib/events/event.rb
@@ -54,6 +54,14 @@ module Events
       self
     end
 
+    def with_entity_table_name(table_name)
+      @event_hash.merge!(
+        entity_table_name: table_name,
+      )
+
+      self
+    end
+
     def with_data(hash)
       @event_hash.deep_merge!({
         data: hash_to_kv_pairs(hash),

--- a/app/lib/events/event.rb
+++ b/app/lib/events/event.rb
@@ -1,6 +1,6 @@
 module Events
   class Event
-    EVENT_TYPES = %w[web_request entity_created].freeze
+    EVENT_TYPES = %w[web_request entity_created entity_updated].freeze
 
     def initialize
       @event_hash = {

--- a/app/lib/events/event.rb
+++ b/app/lib/events/event.rb
@@ -1,6 +1,6 @@
 module Events
   class Event
-    EVENT_TYPES = %w[web_request].freeze
+    EVENT_TYPES = %w[web_request entity_created].freeze
 
     def initialize
       @event_hash = {
@@ -29,7 +29,7 @@ module Events
         request_user_agent: rack_request.user_agent,
         request_method: rack_request.method,
         request_path: rack_request.path,
-        request_query: query_to_kv_pairs(rack_request.query_string),
+        request_query: hash_to_kv_pairs(Rack::Utils.parse_query(rack_request.query_string)),
         request_referer: rack_request.referer,
       )
 
@@ -54,11 +54,24 @@ module Events
       self
     end
 
+    def with_data(hash)
+      @event_hash.deep_merge!({
+        data: hash_to_kv_pairs(hash),
+      })
+
+      self
+    end
+
+    def with_tags(tags)
+      @event_hash[:event_tags] = tags if tags
+
+      self
+    end
+
   private
 
-    def query_to_kv_pairs(query_string)
-      vars = Rack::Utils.parse_query(query_string)
-      vars.map do |(key, value)|
+    def hash_to_kv_pairs(hash)
+      hash.map do |(key, value)|
         { 'key' => key, 'value' => Array.wrap(value) }
       end
     end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
 class ApplicationRecord < ActiveRecord::Base
+  include EntityEvents
+
   self.abstract_class = true
 end

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -1,6 +1,7 @@
 class Candidate < ApplicationRecord
   include Chased
   include AuthenticatedUsingMagicLinks
+  include EntityEvents
 
   # Only Devise's :timeoutable module is enabled to handle session expiry
   devise :timeoutable

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -1,7 +1,6 @@
 class Candidate < ApplicationRecord
   include Chased
   include AuthenticatedUsingMagicLinks
-  include EntityEvents
 
   # Only Devise's :timeoutable module is enabled to handle session expiry
   devise :timeoutable

--- a/app/models/concerns/entity_events.rb
+++ b/app/models/concerns/entity_events.rb
@@ -10,7 +10,10 @@ module EntityEvents
     end
 
     after_update do
-      interesting_changes = entity_data(saved_changes)
+      # in this after_update hook we don’t have access to the new fields via
+      # #attributes — we need to dig them out of saved_changes which stores
+      # them in the format { attr: ['old', 'new'] }
+      interesting_changes = entity_data(saved_changes.transform_values(&:last))
 
       if interesting_changes.any?
         send_event('entity_updated', entity_data(attributes).merge(interesting_changes))

--- a/app/models/concerns/entity_events.rb
+++ b/app/models/concerns/entity_events.rb
@@ -1,0 +1,30 @@
+module EntityEvents
+  extend ActiveSupport::Concern
+
+  included do
+    attr_accessor :event_tags
+
+    after_create do
+      data = entity_data(attributes)
+      send_event('entity_created', data) if data.any?
+    end
+  end
+
+  def send_event(type, data)
+    event = Events::Event.new
+      .with_type(type)
+      .with_data(default_entity_data.merge(data))
+      .with_tags(event_tags)
+
+    SendEventsToBigquery.perform_async(event.as_json)
+  end
+
+  def entity_data(changeset)
+    exportable_attrs = Rails.configuration.analytics[self.class.table_name.to_sym]
+    changeset.slice(*exportable_attrs&.map(&:to_s))
+  end
+
+  def default_entity_data
+    { table_name: self.class.table_name }
+  end
+end

--- a/app/models/concerns/entity_events.rb
+++ b/app/models/concerns/entity_events.rb
@@ -24,7 +24,8 @@ module EntityEvents
   def send_event(type, data)
     event = Events::Event.new
       .with_type(type)
-      .with_data(default_entity_data.merge(data))
+      .with_entity_table_name(self.class.table_name)
+      .with_data(data)
       .with_tags(event_tags)
 
     SendEventsToBigquery.perform_async(event.as_json)
@@ -33,9 +34,5 @@ module EntityEvents
   def entity_data(changeset)
     exportable_attrs = Rails.configuration.analytics[self.class.table_name.to_sym]
     changeset.slice(*exportable_attrs&.map(&:to_s))
-  end
-
-  def default_entity_data
-    { table_name: self.class.table_name }
   end
 end

--- a/app/models/concerns/entity_events.rb
+++ b/app/models/concerns/entity_events.rb
@@ -10,8 +10,11 @@ module EntityEvents
     end
 
     after_update do
-      data = entity_data(saved_changes)
-      send_event('entity_updated', data) if data.any?
+      interesting_changes = entity_data(saved_changes)
+
+      if interesting_changes.any?
+        send_event('entity_updated', entity_data(attributes).merge(interesting_changes))
+      end
     end
   end
 

--- a/app/models/concerns/entity_events.rb
+++ b/app/models/concerns/entity_events.rb
@@ -8,6 +8,11 @@ module EntityEvents
       data = entity_data(attributes)
       send_event('entity_created', data) if data.any?
     end
+
+    after_update do
+      data = entity_data(saved_changes)
+      send_event('entity_updated', data) if data.any?
+    end
   end
 
   def send_event(type, data)

--- a/app/models/concerns/entity_events.rb
+++ b/app/models/concerns/entity_events.rb
@@ -6,7 +6,7 @@ module EntityEvents
 
     after_create do
       data = entity_data(attributes)
-      send_event('entity_created', data) if data.any?
+      send_event('create_entity', data) if data.any?
     end
 
     after_update do
@@ -16,7 +16,7 @@ module EntityEvents
       interesting_changes = entity_data(saved_changes.transform_values(&:last))
 
       if interesting_changes.any?
-        send_event('entity_updated', entity_data(attributes).merge(interesting_changes))
+        send_event('update_entity', entity_data(attributes).merge(interesting_changes))
       end
     end
   end

--- a/app/workers/send_events_to_bigquery.rb
+++ b/app/workers/send_events_to_bigquery.rb
@@ -1,4 +1,4 @@
-class SendRequestEventsToBigquery
+class SendEventsToBigquery
   include Sidekiq::Worker
 
   sidekiq_options retry: 3, queue: :low_priority

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,0 +1,3 @@
+shared:
+  candidates:
+    - created_at

--- a/config/application.rb
+++ b/config/application.rb
@@ -74,6 +74,8 @@ module ApplyForPostgraduateTeacherTraining
       app.routes.append { get '*path', to: 'errors#not_found' }
     end
 
+    config.analytics = config_for(:analytics)
+
     config.action_dispatch.default_headers = {
       'Feature-Policy' => "accelerometer 'none'; ambient-light-sensor: 'none', autoplay: 'none', battery: 'none', camera 'none'; display-capture: 'none', document-domain: 'none', fullscreen: 'none', geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; midi: 'none', payment 'none'; publickey-credentials-get: 'none', usb 'none', wake-lock: 'none', screen-wake-lock: 'none', web-share: 'none'",
     }

--- a/config/event-schema.json
+++ b/config/event-schema.json
@@ -11,7 +11,7 @@
     },
     "event_type": {
       "type": "string",
-      "enum": ["web_request", "entity_created"]
+      "enum": ["web_request", "entity_created", "entity_updated"]
     },
     "request_uuid": {
       "type": "string"

--- a/config/event-schema.json
+++ b/config/event-schema.json
@@ -11,7 +11,7 @@
     },
     "event_type": {
       "type": "string",
-      "enum": ["web_request"]
+      "enum": ["web_request", "entity_created"]
     },
     "request_uuid": {
       "type": "string"
@@ -49,8 +49,22 @@
     },
     "user_id": {
       "type": "integer"
+    },
+    "data": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "required": ["key", "value"]
+        }
+      ]
+    },
+    "event_tags": {
+      "type": "array",
+      "items" : [ { "type": "string" } ]
     }
   },
+  "additionalProperties": false,
   "required": [
     "environment",
     "occurred_at",

--- a/config/event-schema.json
+++ b/config/event-schema.json
@@ -13,6 +13,9 @@
       "type": "string",
       "enum": ["web_request", "entity_created", "entity_updated"]
     },
+    "entity_table_name": {
+      "type": "string"
+    },
     "request_uuid": {
       "type": "string"
     },

--- a/config/event-schema.json
+++ b/config/event-schema.json
@@ -11,7 +11,7 @@
     },
     "event_type": {
       "type": "string",
-      "enum": ["web_request", "entity_created", "entity_updated"]
+      "enum": ["web_request", "create_entity", "update_entity"]
     },
     "entity_table_name": {
       "type": "string"

--- a/spec/forms/candidate_interface/sign_up_form_spec.rb
+++ b/spec/forms/candidate_interface/sign_up_form_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::SignUpForm, type: :model do
-  let(:valid_email) { Faker::Internet.email }
-  let(:new_email) { valid_email }
+  let(:new_email) { Faker::Internet.email }
   let(:existing_candidate) { create(:candidate) }
   let(:existing_email) { existing_candidate.email_address }
 
@@ -57,6 +56,15 @@ RSpec.describe CandidateInterface::SignUpForm, type: :model do
       form = new_form(email: new_email, accept_ts_and_cs: true, course_id: 12)
       expect(form.save).to eq(true)
       expect(form.course_from_find_id).to eq(12)
+    end
+
+    it 'includes an event tag for BigQuery' do
+      form = new_form(email: new_email, accept_ts_and_cs: true)
+
+      form.save
+
+      expect(SendEventsToBigquery).to have_received(:perform_async)
+        .with(a_hash_including({ 'event_tags' => ['candidate_sign_up'] }))
     end
   end
 

--- a/spec/models/concerns/entity_events_spec.rb
+++ b/spec/models/concerns/entity_events_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+# This spec is coupled to the Candidate model. I thought
+# this was preferable to making an elaborate mock which
+# didn't depend on the db
+RSpec.describe EntityEvents do
+  let(:interesting_fields) { [] }
+
+  before do
+    allow(Rails.configuration).to receive(:analytics).and_return({
+      candidates: interesting_fields,
+    })
+  end
+
+  describe 'entity_created events' do
+    context 'when fields are specified in the analytics file' do
+      let(:interesting_fields) { [:id] }
+
+      it 'includes attributes specified in the settings file' do
+        candidate = create(:candidate)
+
+        expect(SendEventsToBigquery).to have_received(:perform_async)
+          .with a_hash_including({
+            'event_type' => 'entity_created',
+            'data' => [
+              { 'key' => 'table_name', 'value' => ['candidates'] },
+              { 'key' => 'id', 'value' => [candidate.id] },
+            ],
+          })
+      end
+
+      it 'does not include attributes not specified in the settings file' do
+        candidate = create(:candidate, course_from_find_id: 123)
+
+        expect(SendEventsToBigquery).to have_received(:perform_async)
+          .with a_hash_including({
+            'event_type' => 'entity_created',
+            'data' => [
+              { 'key' => 'table_name', 'value' => ['candidates'] },
+              { 'key' => 'id', 'value' => [candidate.id] },
+              # ie the same payload as above
+            ],
+          })
+      end
+
+      it 'sends events that are valid according to the schema' do
+        create(:candidate)
+
+        expect(SendEventsToBigquery).to have_received(:perform_async) do |payload|
+          schema = File.read('config/event-schema.json')
+          schema_validator = JSONSchemaValidator.new(schema, payload)
+
+          expect(schema_validator).to be_valid, schema_validator.failure_message
+        end
+      end
+    end
+
+    context 'when no fields are specified in the analytics file' do
+      let(:interesting_fields) { [] }
+
+      it 'does not send entity_created events at all' do
+        create(:candidate)
+        create(:email) # some other model, for example
+
+        expect(SendEventsToBigquery).not_to have_received(:perform_async)
+          .with(a_hash_including({ 'event_type' => 'entity_created' }))
+      end
+    end
+  end
+end

--- a/spec/models/concerns/entity_events_spec.rb
+++ b/spec/models/concerns/entity_events_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe EntityEvents do
     })
   end
 
-  describe 'entity_created events' do
+  describe 'create_entity events' do
     context 'when fields are specified in the analytics file' do
       let(:interesting_fields) { [:id] }
 
@@ -22,7 +22,7 @@ RSpec.describe EntityEvents do
         expect(SendEventsToBigquery).to have_received(:perform_async)
           .with a_hash_including({
             'entity_table_name' => 'candidates',
-            'event_type' => 'entity_created',
+            'event_type' => 'create_entity',
             'data' => [
               { 'key' => 'id', 'value' => [candidate.id] },
             ],
@@ -35,7 +35,7 @@ RSpec.describe EntityEvents do
         expect(SendEventsToBigquery).to have_received(:perform_async)
           .with a_hash_including({
             'entity_table_name' => 'candidates',
-            'event_type' => 'entity_created',
+            'event_type' => 'create_entity',
             'data' => [
               { 'key' => 'id', 'value' => [candidate.id] },
               # ie the same payload as above
@@ -58,17 +58,17 @@ RSpec.describe EntityEvents do
     context 'when no fields are specified in the analytics file' do
       let(:interesting_fields) { [] }
 
-      it 'does not send entity_created events at all' do
+      it 'does not send create_entity events at all' do
         create(:candidate)
         create(:email) # some other model, for example
 
         expect(SendEventsToBigquery).not_to have_received(:perform_async)
-          .with(a_hash_including({ 'event_type' => 'entity_created' }))
+          .with(a_hash_including({ 'event_type' => 'create_entity' }))
       end
     end
   end
 
-  describe 'entity_updated events' do
+  describe 'update_entity events' do
     context 'when fields are specified in the analytics file' do
       let(:interesting_fields) { %i[email_address hide_in_reporting] }
 
@@ -79,7 +79,7 @@ RSpec.describe EntityEvents do
         expect(SendEventsToBigquery).to have_received(:perform_async)
           .with a_hash_including({
             'entity_table_name' => 'candidates',
-            'event_type' => 'entity_updated',
+            'event_type' => 'update_entity',
             'data' => [
               { 'key' => 'email_address', 'value' => ['bar@baz.com'] },
               { 'key' => 'hide_in_reporting', 'value' => [false] },
@@ -93,7 +93,7 @@ RSpec.describe EntityEvents do
 
         expect(SendEventsToBigquery).not_to have_received(:perform_async)
           .with a_hash_including({
-            'event_type' => 'entity_updated',
+            'event_type' => 'update_entity',
           })
       end
 
@@ -119,7 +119,7 @@ RSpec.describe EntityEvents do
 
         expect(SendEventsToBigquery).not_to have_received(:perform_async)
           .with a_hash_including({
-            'event_type' => 'entity_updated',
+            'event_type' => 'update_entity',
           })
       end
     end

--- a/spec/models/concerns/entity_events_spec.rb
+++ b/spec/models/concerns/entity_events_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe EntityEvents do
 
         expect(SendEventsToBigquery).to have_received(:perform_async)
           .with a_hash_including({
+            'entity_table_name' => 'candidates',
             'event_type' => 'entity_created',
             'data' => [
-              { 'key' => 'table_name', 'value' => ['candidates'] },
               { 'key' => 'id', 'value' => [candidate.id] },
             ],
           })
@@ -34,9 +34,9 @@ RSpec.describe EntityEvents do
 
         expect(SendEventsToBigquery).to have_received(:perform_async)
           .with a_hash_including({
+            'entity_table_name' => 'candidates',
             'event_type' => 'entity_created',
             'data' => [
-              { 'key' => 'table_name', 'value' => ['candidates'] },
               { 'key' => 'id', 'value' => [candidate.id] },
               # ie the same payload as above
             ],
@@ -78,9 +78,9 @@ RSpec.describe EntityEvents do
 
         expect(SendEventsToBigquery).to have_received(:perform_async)
           .with a_hash_including({
+            'entity_table_name' => 'candidates',
             'event_type' => 'entity_updated',
             'data' => [
-              { 'key' => 'table_name', 'value' => ['candidates'] },
               { 'key' => 'email_address', 'value' => ['bar@baz.com'] },
               { 'key' => 'hide_in_reporting', 'value' => [false] },
             ],

--- a/spec/models/concerns/entity_events_spec.rb
+++ b/spec/models/concerns/entity_events_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe EntityEvents do
             'event_type' => 'entity_updated',
             'data' => [
               { 'key' => 'table_name', 'value' => ['candidates'] },
-              { 'key' => 'email_address', 'value' => ['foo@bar.com', 'bar@baz.com'] },
+              { 'key' => 'email_address', 'value' => ['bar@baz.com'] },
               { 'key' => 'hide_in_reporting', 'value' => [false] },
             ],
           })

--- a/spec/models/concerns/entity_events_spec.rb
+++ b/spec/models/concerns/entity_events_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe EntityEvents do
 
   describe 'entity_updated events' do
     context 'when fields are specified in the analytics file' do
-      let(:interesting_fields) { [:email_address] }
+      let(:interesting_fields) { %i[email_address hide_in_reporting] }
 
       it 'sends update events for fields we care about' do
         candidate = create(:candidate, email_address: 'foo@bar.com')
@@ -82,13 +82,14 @@ RSpec.describe EntityEvents do
             'data' => [
               { 'key' => 'table_name', 'value' => ['candidates'] },
               { 'key' => 'email_address', 'value' => ['foo@bar.com', 'bar@baz.com'] },
+              { 'key' => 'hide_in_reporting', 'value' => [false] },
             ],
           })
       end
 
       it 'does not send update events for fields we don’t care about' do
         candidate = create(:candidate)
-        candidate.update(hide_in_reporting: true)
+        candidate.update(course_from_find_id: 1)
 
         expect(SendEventsToBigquery).not_to have_received(:perform_async)
           .with a_hash_including({

--- a/spec/requests/emit_request_events_spec.rb
+++ b/spec/requests/emit_request_events_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe EmitRequestEvents, type: :request, with_bigquery: true do
         get(provider_interface_applications_path,
             params: { page: '1', per_page: '25', array_param: %w[1 2] },
             headers: { 'HTTP_USER_AGENT' => 'Test agent' })
-      }.to change(SendRequestEventsToBigquery.jobs, :size).by(1)
+      }.to change(SendEventsToBigquery.jobs, :size).by(1)
 
-      payload = SendRequestEventsToBigquery.jobs.first['args'].first
+      payload = SendEventsToBigquery.jobs.first['args'].first
 
       expect(payload['request_method']).to eq('GET')
       expect(payload['request_user_agent']).to eq('Test agent')

--- a/spec/support/bigquery.rb
+++ b/spec/support/bigquery.rb
@@ -1,5 +1,5 @@
 RSpec.configure do |config|
   config.before do |example|
-    allow(SendRequestEventsToBigquery).to receive(:perform_async) if example.metadata[:with_bigquery].blank?
+    allow(SendEventsToBigquery).to receive(:perform_async) if example.metadata[:with_bigquery].blank?
   end
 end

--- a/spec/workers/send_events_to_bigquery_spec.rb
+++ b/spec/workers/send_events_to_bigquery_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SendRequestEventsToBigquery do
+RSpec.describe SendEventsToBigquery do
   describe '#perform' do
     let(:request_event) do
       {


### PR DESCRIPTION
## Context

We need to recreate the Apply weekly stats report (https://ukgovernmentdfe.slack.com/archives/CAHBLU6ET/p1625494623108500) in BigQuery

This requires us to send all the information required for generating that report from Apply to BigQuery.

We would like to copy the TVS approach of maintaining a whitelist (`analytics.yml`) of models and fields to pay attention to when sending updates to BigQuery.

We would also like to add arbitrary _tags_ to events we send to BigQuery, so that analysts can more easily deal with domain events (eg `user_sign_up`) rather than more granular data details (`candidate.created_at`).

## Changes proposed in this pull request

Add callbacks to the `ApplicationRecord` which check, on _any_ (!) model update or create, whether that model is in the `analytics.yml` whitelist and if so, pluck the fields we are interested in and send their state and/or changes to BQ.

This PR requires a change to the BQ schema to add `event_tags` so it should not be merged until that is updated.

It does not implement the `analytics-pii.yml` feature from TVS, where sensitive attrs are hashed before sending to BQ. We will add this when we need it.

## Link to Trello card

https://trello.com/c/vUirUN9U/3538-implement-bigquery-event-for-candidate-signup

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
