### PR TITLE
Enable syncing of rolled over courses using a feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -22,6 +22,7 @@ class FeatureFlag
     [:service_unavailable_page, 'Displays a maintenance page on the whole application', 'Apply team'],
     [:send_request_data_to_bigquery, 'Send request data to Google Bigquery via background worker', 'Apply team'],
     [:enable_chat_support, 'Enable Zendesk chat support', 'Apply team'],
+    [:sync_next_cycle, 'Sync courses for the next recruitment cycle. Turn on after rollover', 'Apply team'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [

--- a/app/workers/teacher_training_public_api/full_sync_all_providers_and_courses_worker.rb
+++ b/app/workers/teacher_training_public_api/full_sync_all_providers_and_courses_worker.rb
@@ -6,6 +6,10 @@ module TeacherTrainingPublicAPI
     def perform
       SyncSubjects.new.perform
       SyncAllProvidersAndCourses.call(incremental_sync: false)
+
+      if FeatureFlag.active?(:sync_next_cycle)
+        SyncAllProvidersAndCourses.call(recruitment_cycle_year: RecruitmentCycle.next_year, incremental_sync: false)
+      end
     end
   end
 end

--- a/app/workers/teacher_training_public_api/incremental_sync_all_providers_and_courses_worker.rb
+++ b/app/workers/teacher_training_public_api/incremental_sync_all_providers_and_courses_worker.rb
@@ -6,6 +6,10 @@ module TeacherTrainingPublicAPI
     def perform
       SyncSubjects.new.perform
       SyncAllProvidersAndCourses.call
+
+      if FeatureFlag.active?(:sync_next_cycle)
+        SyncAllProvidersAndCourses.call(recruitment_cycle_year: RecruitmentCycle.next_year)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

We need to start syncing courses for 2022.

## Changes proposed in this pull request

Add a feature flag to the sync jobs to also kick off syncs for next cycle.

This is only to be turned on and tested in the rollover environment. We can toggle the flag as desired in advance of the big sync.

## Link to Trello card

https://trello.com/c/2bFnG9pR/3542-start-syncing-2022-courses

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
