### PR TITLE
Add satisfaction survey performance metrics to dashboard

### DIFF
--- a/app/models/feature_metrics_dashboard.rb
+++ b/app/models/feature_metrics_dashboard.rb
@@ -23,6 +23,7 @@ class FeatureMetricsDashboard < ApplicationRecord
     load_carry_over_counts
     load_qualifications
     load_satisfaction_survey_response_rate
+    load_satisfaction_survey_positive_feedback_rate
     load_equality_and_diversity_response_rate
   end
 
@@ -362,6 +363,28 @@ private
     write_metric(
       :satisfaction_survey_response_rate_last_month,
       satisfaction_survey_statistics.formatted_response_rate(
+        Time.zone.now.beginning_of_month - 1.month,
+        Time.zone.now.beginning_of_month,
+      ),
+    )
+  end
+
+  def load_satisfaction_survey_positive_feedback_rate
+    write_metric(
+      :satisfaction_survey_positive_feedback_rate,
+      satisfaction_survey_statistics.formatted_positive_feedback_rate(
+        CycleTimetable.apply_reopens.beginning_of_day,
+      ),
+    )
+    write_metric(
+      :satisfaction_survey_positive_feedback_rate_this_month,
+      satisfaction_survey_statistics.formatted_positive_feedback_rate(
+        Time.zone.now.beginning_of_month,
+      ),
+    )
+    write_metric(
+      :satisfaction_survey_positive_feedback_rate_last_month,
+      satisfaction_survey_statistics.formatted_positive_feedback_rate(
         Time.zone.now.beginning_of_month - 1.month,
         Time.zone.now.beginning_of_month,
       ),

--- a/app/models/satisfaction_survey_feature_metrics.rb
+++ b/app/models/satisfaction_survey_feature_metrics.rb
@@ -12,11 +12,29 @@ class SatisfactionSurveyFeatureMetrics
     success_count / (fail_count + success_count)
   end
 
+  def positive_feedback_rate(
+    start_time,
+    end_time = Time.zone.now.end_of_day
+  )
+    feedback_count = application_forms_with_feedback(start_time, end_time).count.to_f
+    positive_feedback_count = application_forms_with_positive_feedback(start_time, end_time).count.to_f
+    return nil if feedback_count.zero?
+
+    positive_feedback_count / feedback_count
+  end
+
   def formatted_response_rate(
     start_time,
     end_time = Time.zone.now.end_of_day
   )
     format_as_percentage(response_rate(start_time, end_time))
+  end
+
+  def formatted_positive_feedback_rate(
+    start_time,
+    end_time = Time.zone.now.end_of_day
+  )
+    format_as_percentage(positive_feedback_rate(start_time, end_time))
   end
 
 private
@@ -39,6 +57,16 @@ private
       )
       .where('application_forms.submitted_at BETWEEN ? AND ?', start_time, end_time)
       .where.not(feedback_satisfaction_level: '')
+      .where(recruitment_cycle_year: RecruitmentCycle.current_year)
+  end
+
+  def application_forms_with_positive_feedback(start_time, end_time)
+    ApplicationForm
+      .where(
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+      )
+      .where('application_forms.submitted_at BETWEEN ? AND ?', start_time, end_time)
+      .where(feedback_satisfaction_level: 'very_satisfied').or(ApplicationForm.where(feedback_satisfaction_level: 'satisfied'))
       .where(recruitment_cycle_year: RecruitmentCycle.current_year)
   end
 

--- a/app/models/satisfaction_survey_feature_metrics.rb
+++ b/app/models/satisfaction_survey_feature_metrics.rb
@@ -17,8 +17,9 @@ class SatisfactionSurveyFeatureMetrics
     end_time = Time.zone.now.end_of_day
   )
     feedback_count = application_forms_with_feedback(start_time, end_time).count.to_f
-    positive_feedback_count = application_forms_with_positive_feedback(start_time, end_time).count.to_f
     return nil if feedback_count.zero?
+
+    positive_feedback_count = application_forms_with_positive_feedback(start_time, end_time).count.to_f
 
     positive_feedback_count / feedback_count
   end
@@ -52,31 +53,28 @@ private
 
   def application_forms_with_feedback(start_time, end_time)
     ApplicationForm
+      .where.not(feedback_satisfaction_level: '')
       .where(
         recruitment_cycle_year: RecruitmentCycle.current_year,
+        application_forms: { submitted_at: start_time..end_time },
       )
-      .where('application_forms.submitted_at BETWEEN ? AND ?', start_time, end_time)
-      .where.not(feedback_satisfaction_level: '')
-      .where(recruitment_cycle_year: RecruitmentCycle.current_year)
   end
 
   def application_forms_with_positive_feedback(start_time, end_time)
     ApplicationForm
       .where(
+        feedback_satisfaction_level: %w[very_satisfied satisfied],
         recruitment_cycle_year: RecruitmentCycle.current_year,
+        application_forms: { submitted_at: start_time..end_time },
       )
-      .where('application_forms.submitted_at BETWEEN ? AND ?', start_time, end_time)
-      .where(feedback_satisfaction_level: 'very_satisfied').or(ApplicationForm.where(feedback_satisfaction_level: 'satisfied'))
-      .where(recruitment_cycle_year: RecruitmentCycle.current_year)
   end
 
   def application_forms_with_no_feedback(start_time, end_time)
     ApplicationForm
       .where(
+        feedback_satisfaction_level: [nil, ''],
         recruitment_cycle_year: RecruitmentCycle.current_year,
+        application_forms: { submitted_at: start_time..end_time },
       )
-      .where('application_forms.submitted_at BETWEEN ? AND ?', start_time, end_time)
-      .where(feedback_satisfaction_level: nil).or(ApplicationForm.where(feedback_satisfaction_level: ''))
-      .where(recruitment_cycle_year: RecruitmentCycle.current_year)
   end
 end

--- a/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
+++ b/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
@@ -383,7 +383,7 @@
       <div class="govuk-grid-column-one-half">
         <%= render SupportInterface::TileComponent.new(
           count: @dashboard.read_metric(:satisfaction_survey_response_rate),
-          label: 'survey response rate',
+          label: 'response rate',
           colour: :blue,
           size: :reduced,
         ) %>
@@ -404,43 +404,41 @@
           </div>
         </div>
       </div>
-    </div>
-
-    <div class="govuk-grid-column-one-half">
-      <div class="govuk-!-margin-bottom-4">
+      <div class="govuk-grid-column-one-half">
         <%= render SupportInterface::TileComponent.new(
           count: @dashboard.read_metric(:satisfaction_survey_positive_feedback_rate),
-          label: 'Satisfaction Survey Positive Feedback',
+          label: 'satisfied or very satisfied',
           colour: :blue,
           size: :reduced,
         ) %>
-      </div>
-      <div class="govuk-grid-row govuk-!-margin-bottom-4">
-        <div class="govuk-grid-column-one-half">
-          <%= render SupportInterface::TileComponent.new(
-            count: @dashboard.read_metric(:satisfaction_survey_positive_feedback_rate_this_month),
-            label: 'this month',
-            size: :reduced,
-          ) %>
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <%= render SupportInterface::TileComponent.new(
-            count: @dashboard.read_metric(:satisfaction_survey_positive_feedback_rate_last_month),
-            label: 'last month',
-            size: :reduced,
-          ) %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-one-half">
+            <%= render SupportInterface::TileComponent.new(
+              count: @dashboard.read_metric(:satisfaction_survey_positive_feedback_rate_this_month),
+              label: 'this month',
+              size: :reduced,
+            ) %>
+          </div>
+          <div class="govuk-grid-column-one-half">
+            <%= render SupportInterface::TileComponent.new(
+              count: @dashboard.read_metric(:satisfaction_survey_positive_feedback_rate_last_month),
+              label: 'last month',
+              size: :reduced,
+            ) %>
+          </div>
         </div>
       </div>
     </div>
   </section>
 
-<section class="app-section">
-  <h2 id="equality-and-diversity" class="govuk-heading-m govuk-!-font-size-27">Equality and diversity</h2>
+  <section class="app-section">
+    <h2 id="equality-and-diversity" class="govuk-heading-m govuk-!-font-size-27">Equality and diversity</h2>
+
     <div class="govuk-grid-row" data-qa="section-equality-and-diversity">
       <div class="govuk-grid-column-one-half">
         <%= render SupportInterface::TileComponent.new(
           count: @dashboard.read_metric(:equality_and_diversity_response_rate),
-          label: 'survey response rate',
+          label: 'response rate',
           colour: :blue,
           size: :reduced,
         ) %>

--- a/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
+++ b/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
@@ -405,11 +405,37 @@
         </div>
       </div>
     </div>
+
+    <div class="govuk-grid-column-one-half">
+      <div class="govuk-!-margin-bottom-4">
+        <%= render SupportInterface::TileComponent.new(
+          count: @dashboard.read_metric(:satisfaction_survey_positive_feedback_rate),
+          label: 'Satisfaction Survey Positive Feedback',
+          colour: :blue,
+          size: :reduced,
+        ) %>
+      </div>
+      <div class="govuk-grid-row govuk-!-margin-bottom-4">
+        <div class="govuk-grid-column-one-half">
+          <%= render SupportInterface::TileComponent.new(
+            count: @dashboard.read_metric(:satisfaction_survey_positive_feedback_rate_this_month),
+            label: 'this month',
+            size: :reduced,
+          ) %>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= render SupportInterface::TileComponent.new(
+            count: @dashboard.read_metric(:satisfaction_survey_positive_feedback_rate_last_month),
+            label: 'last month',
+            size: :reduced,
+          ) %>
+        </div>
+      </div>
+    </div>
   </section>
 
-  <section class="app-section">
-    <h2 id="equality-and-diversity" class="govuk-heading-m govuk-!-font-size-27">Equality and diversity</h2>
-
+<section class="app-section">
+  <h2 id="equality-and-diversity" class="govuk-heading-m govuk-!-font-size-27">Equality and diversity</h2>
     <div class="govuk-grid-row" data-qa="section-equality-and-diversity">
       <div class="govuk-grid-column-one-half">
         <%= render SupportInterface::TileComponent.new(

--- a/spec/models/feature_metrics_dashboard_spec.rb
+++ b/spec/models/feature_metrics_dashboard_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe FeatureMetricsDashboard do
       allow(carry_over_metrics_double).to receive(:carry_over_count).and_return(20)
       allow(qualifications_metrics_double).to receive(:formatted_a_level_percentage).and_return('30%')
       allow(satisfaction_survey_metrics_double).to receive(:formatted_response_rate).and_return('15.4%')
+      allow(satisfaction_survey_metrics_double).to receive(:formatted_positive_feedback_rate).and_return('95.8%')
       allow(equality_and_diversity_metrics_double).to receive(:formatted_response_rate).and_return('50.7%')
 
       dashboard = described_class.new
@@ -126,6 +127,9 @@ RSpec.describe FeatureMetricsDashboard do
         'satisfaction_survey_response_rate' => '15.4%',
         'satisfaction_survey_response_rate_this_month' => '15.4%',
         'satisfaction_survey_response_rate_last_month' => '15.4%',
+        'satisfaction_survey_positive_feedback_rate' => '95.8%',
+        'satisfaction_survey_positive_feedback_rate_this_month' => '95.8%',
+        'satisfaction_survey_positive_feedback_rate_last_month' => '95.8%',
         'equality_and_diversity_response_rate' => '50.7%',
         'equality_and_diversity_response_rate_this_month' => '50.7%',
         'equality_and_diversity_response_rate_last_month' => '50.7%',

--- a/spec/models/satisfaction_survey_feature_metrics_spec.rb
+++ b/spec/models/satisfaction_survey_feature_metrics_spec.rb
@@ -7,8 +7,12 @@ RSpec.describe SatisfactionSurveyFeatureMetrics, with_audited: true do
     create(:completed_application_form, submitted_at: Time.zone.now)
   end
 
-  def create_application_with_feedback
+  def create_application_with_positive_feedback
     create(:completed_application_form, feedback_satisfaction_level: 'very_satisfied', submitted_at: Time.zone.now)
+  end
+
+  def create_application_with_negative_feedback
+    create(:completed_application_form, feedback_satisfaction_level: 'very_dissatisfied', submitted_at: Time.zone.now)
   end
 
   describe '#formatted_response_rate' do
@@ -26,25 +30,65 @@ RSpec.describe SatisfactionSurveyFeatureMetrics, with_audited: true do
 
       it 'returns the right percentages when submitted applications with feedback exist' do
         create_application
-        2.times { create_application_with_feedback }
+        2.times { create_application_with_positive_feedback }
         expect(feature_metrics.formatted_response_rate(1.month.ago)).to eq('66.7%')
       end
 
       it 'returns the right percentages over a range of dates' do
         @today = Time.zone.local(2021, 3, 10, 12)
         Timecop.freeze(@today - 40.days) do
-          2.times { create_application_with_feedback }
+          2.times { create_application_with_positive_feedback }
         end
         Timecop.freeze(@today - 20.days) do
           create_application
         end
         Timecop.freeze(@today - 5.days) do
-          create_application_with_feedback
+          create_application_with_positive_feedback
         end
         Timecop.freeze(@today) do
           expect(feature_metrics.formatted_response_rate(25.days.ago)).to eq('50%')
           expect(feature_metrics.formatted_response_rate(25.days.ago, 10.days.ago)).to eq('0%')
           expect(feature_metrics.formatted_response_rate(45.days.ago)).to eq('75%')
+        end
+      end
+    end
+  end
+
+  describe '#formatted_positive_feedback_rate' do
+    context 'without any data' do
+      it 'returns n/a' do
+        create_application
+        expect(feature_metrics.formatted_positive_feedback_rate(1.month.ago)).to eq('n/a')
+      end
+    end
+
+    context 'with applications with feedback' do
+      it 'returns 0 when there are no submitted applications with positive feedback' do
+        create_application_with_negative_feedback
+        expect(feature_metrics.formatted_positive_feedback_rate(1.month.ago)).to eq('0%')
+      end
+
+      it 'returns the right percentages when submitted applications with feedback exist' do
+        create_application_with_positive_feedback
+        create_application_with_negative_feedback
+        expect(feature_metrics.formatted_positive_feedback_rate(1.month.ago)).to eq('50%')
+      end
+
+      it 'returns the right percentages over a range of dates' do
+        @today = Time.zone.local(2021, 3, 10, 12)
+        Timecop.freeze(@today - 40.days) do
+          2.times { create_application_with_positive_feedback }
+        end
+        Timecop.freeze(@today - 20.days) do
+          create_application_with_negative_feedback
+        end
+        Timecop.freeze(@today - 5.days) do
+          create_application_with_positive_feedback
+        end
+        Timecop.freeze(@today) do
+          expect(feature_metrics.formatted_positive_feedback_rate(25.days.ago)).to eq('50%')
+          expect(feature_metrics.formatted_positive_feedback_rate(25.days.ago, 10.days.ago)).to eq('0%')
+          expect(feature_metrics.formatted_positive_feedback_rate(45.days.ago)).to eq('75%')
         end
       end
     end

--- a/spec/system/support_interface/feature_metrics_dashboard_spec.rb
+++ b/spec/system/support_interface/feature_metrics_dashboard_spec.rb
@@ -202,15 +202,16 @@ RSpec.feature 'Feature metrics dashboard' do
 
   def and_i_should_see_satisfaction_survey_metrics
     within('[data-qa="section-satisfaction-survey"]') do
-      expect(page).to have_content('n/a survey response rate')
+      expect(page).to have_content('n/a response rate')
       expect(page).to have_content('n/a last month')
       expect(page).to have_content('n/a this month')
+      expect(page).to have_content('n/a satisfied or very satisfied')
     end
   end
 
   def and_i_should_see_equality_and_diversity_metrics
     within('[data-qa="section-equality-and-diversity"]') do
-      expect(page).to have_content('n/a survey response rate')
+      expect(page).to have_content('n/a response rate')
       expect(page).to have_content('n/a last month')
       expect(page).to have_content('n/a this month')
     end


### PR DESCRIPTION
## Context

In order to make our positive survey result more accessible they should be added to the feature metric dashboard.

## Changes proposed in this pull request

<img width="1232" alt="image" src="https://user-images.githubusercontent.com/62567622/124810869-bbc0f300-df59-11eb-83d2-fffba803489d.png">

## Guidance to review

Test in support App and QA to check values are representative. Any thoughts RE the naming on the dashboard front end?

## Link to Trello card

https://trello.com/c/XdeMPLhi/3520-display-csat-with-performance-metrics

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
