### PR TITLE
Update permission services to check for setupinterviews

### DIFF
--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -1,7 +1,7 @@
 module ProviderInterface
   class InterviewsController < ProviderInterfaceController
     before_action :set_application_choice
-    before_action :requires_make_decisions_permission, except: %i[index]
+    before_action :requires_make_decisions_permission, except: %i[index], unless: :interviews_permission_feature_flag
     before_action :requires_set_up_interviews_permission, except: %i[index], if: :interviews_permission_feature_flag
     before_action :confirm_application_is_in_decision_pending_state, except: %i[index]
     before_action :redirect_to_index_if_store_cleared, only: %i[check commit]

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -54,7 +54,7 @@ class ProviderUser < ApplicationRecord
   end
 
   def authorisation
-    @authorisation ||= ProviderAuthorisation.new(actor: self)
+    @authorisation = ProviderAuthorisation.new(actor: self)
   end
 
   def can_manage_organisations?

--- a/app/services/cancel_interview.rb
+++ b/app/services/cancel_interview.rb
@@ -14,9 +14,9 @@ class CancelInterview
   end
 
   def save!
-    auth.assert_can_make_decisions!(
+    auth.assert_can_set_up_interviews!(
       application_choice: application_choice,
-      course_option_id: application_choice.current_course_option.id,
+      course_option: application_choice.current_course_option,
     )
 
     if ApplicationStateChange.new(application_choice).can_cancel_interview?

--- a/app/services/create_interview.rb
+++ b/app/services/create_interview.rb
@@ -18,9 +18,9 @@ class CreateInterview
   end
 
   def save!
-    auth.assert_can_make_decisions!(
+    auth.assert_can_set_up_interviews!(
       application_choice: application_choice,
-      course_option_id: application_choice.current_course_option.id,
+      course_option: application_choice.current_course_option,
     )
 
     ActiveRecord::Base.transaction do

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -132,6 +132,15 @@ class ProviderAuthorisation
     errors.blank?
   end
 
+  def assert_can_set_up_interviews!(application_choice:, course_option: nil)
+    if course_option.blank?
+      raise ValidationException, ['Please provide a course_option']
+    end
+    return if can_set_up_interviews?(application_choice: application_choice, course_option: course_option)
+
+    raise NotAuthorisedError, full_error_messages.join(' ')
+  end
+
   def assert_can_make_decisions!(application_choice:, course_option_id: nil, course_option: nil)
     if course_option_id.blank? && course_option.blank?
       raise ValidationException, ['Please provide a course_option or course_option_id']

--- a/app/services/update_interview.rb
+++ b/app/services/update_interview.rb
@@ -18,9 +18,9 @@ class UpdateInterview
   end
 
   def save!
-    auth.assert_can_make_decisions!(
+    auth.assert_can_set_up_interviews!(
       application_choice: interview.application_choice,
-      course_option_id: interview.application_choice.current_course_option.id,
+      course_option: interview.application_choice.current_course_option,
     )
 
     interview.provider = provider

--- a/config/locales/provider_authorisation.yml
+++ b/config/locales/provider_authorisation.yml
@@ -8,6 +8,10 @@ en:
         requires_ratifying_provider_permission: You do not have the required organisation level permissions as a ratifying provider to make decisions on applications.
         requires_application_choice_visibility: You are not permitted to view this application.
         requires_user_course_association: The specified course is not associated with any of your organisations.
+      set_up_interviews:
+        requires_provider_user_permission: You do not have the required user level permissions to set up interviews on applications for this provider.
+        requires_application_choice_visibility: You are not permitted to view this application.
+        requires_user_course_association: The specified course is not associated with any of your organisations.
       view_diversity_information:
         requires_provider_user_permission: You do not have the required user level permissions to view diversity information for this provider.
         requires_training_or_ratifying_provider_permission: You do not have the required organisation level permissions as a training or ratifying provider to view diversity information.

--- a/spec/queries/get_activity_log_events_spec.rb
+++ b/spec/queries/get_activity_log_events_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe GetActivityLogEvents, with_audited: true do
 
   context 'with a cancelled interview' do
     let(:application_choice) { create(:application_choice, :with_scheduled_interview) }
-    let(:auth) { instance_double(ProviderAuthorisation, assert_can_make_decisions!: true) }
+    let(:auth) { instance_double(ProviderAuthorisation, assert_can_set_up_interviews!: true) }
 
     before do
       allow(ProviderAuthorisation).to receive(:new).and_return(auth)

--- a/spec/services/cancel_interview_spec.rb
+++ b/spec/services/cancel_interview_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CancelInterview do
   let(:interview) { create(:interview, application_choice: application_choice) }
   let(:course_option) { course_option_for_provider(provider: provider) }
   let(:provider) { create(:provider) }
-  let(:provider_user) { create(:provider_user, :with_make_decisions, providers: [provider]) }
+  let(:provider_user) { create(:provider_user, :with_set_up_interviews, providers: [provider]) }
   let(:service_params) do
     {
       actor: provider_user,

--- a/spec/services/create_interview_spec.rb
+++ b/spec/services/create_interview_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CreateInterview do
   let(:application_choice) { create(:application_choice, :awaiting_provider_decision, course_option: course_option) }
   let(:course_option) { course_option_for_provider(provider: provider) }
   let(:provider) { create(:provider) }
-  let(:provider_user) { create(:provider_user, :with_make_decisions, providers: [provider]) }
+  let(:provider_user) { create(:provider_user, :with_set_up_interviews, providers: [provider]) }
   let(:service_params) do
     {
       actor: provider_user,

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -3,6 +3,20 @@ require 'rails_helper'
 RSpec.describe ProviderAuthorisation do
   include CourseOptionHelpers
 
+  describe '#assert_can_set_up_interviews!' do
+    let(:auth_context) { ProviderAuthorisation.new(actor: nil) }
+
+    it 'raises a ValidationException if a course_option is not provided' do
+      expect { auth_context.assert_can_set_up_interviews!(application_choice: nil) }.to raise_error(ValidationException, 'Please provide a course_option')
+    end
+
+    it 'raises an error if the actor cannot set up interviews' do
+      allow(auth_context).to receive(:can_set_up_interviews?).and_return(false)
+
+      expect { auth_context.assert_can_set_up_interviews!(application_choice: nil, course_option: build_stubbed(:course_option)) }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
+    end
+  end
+
   describe '#assert_can_make_decisions!' do
     let(:auth_context) { ProviderAuthorisation.new(actor: nil) }
 

--- a/spec/services/update_interview_spec.rb
+++ b/spec/services/update_interview_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe UpdateInterview do
   let(:interview) { application_choice.interviews.first }
   let(:course_option) { course_option_for_provider(provider: provider) }
   let(:provider) { create(:provider) }
-  let(:provider_user) { create(:provider_user, :with_make_decisions, providers: [provider]) }
+  let(:provider_user) { create(:provider_user, :with_set_up_interviews, providers: [provider]) }
   let(:amended_date_and_time) { 1.day.since(interview.date_and_time) }
   let(:service_params) do
     {

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   scenario 'can view, create and cancel interviews' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
-    and_i_can_see_the_application_actions
     and_i_am_permitted_to_set_up_interviews_for_my_provider
     and_i_sign_in_to_the_provider_interface
 
@@ -57,6 +56,8 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     when_i_set_up_another_interview(days_in_future: 4)
     then_another_interview_has_been_created(4.days.from_now.to_s(:govuk_date))
 
+    when_i_can_make_decisions_for_my_provider
+    and_i_visit_that_application_in_the_provider_interface
     when_i_click_make_decision
     and_i_make_an_offer
     then_i_should_see_the_interview_on_the_interview_tab(4.days.from_now.to_s(:govuk_date))
@@ -97,7 +98,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     provider_user_exists_in_apply_database
   end
 
-  def and_i_can_see_the_application_actions
+  def when_i_can_make_decisions_for_my_provider
     permit_make_decisions!
   end
 
@@ -108,6 +109,8 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   def when_i_visit_that_application_in_the_provider_interface
     visit provider_interface_application_choice_path(application_choice)
   end
+
+  alias_method :and_i_visit_that_application_in_the_provider_interface, :when_i_visit_that_application_in_the_provider_interface
 
   def and_i_click_set_up_an_interview
     click_on 'Set up interview'


### PR DESCRIPTION
## Context

Currently the interview related services rely on the make decision permission being configured for the provider user. These should be amended to check for set_up_interviews.

Changes should also be made to the interviews controller and system spec to reflect this change.

## Link to Trello card
https://trello.com/c/ZwRjBh5r/3966-update-permission-services-to-check-for-setupinterviews

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
