### PR TITLE
Remove `interview_permissions` feature flag

### DIFF
--- a/app/components/permissions_list_component.html.erb
+++ b/app/components/permissions_list_component.html.erb
@@ -7,7 +7,7 @@
     <li><%= render IconComponent.new(type: 'check') %> <span class="govuk-!-font-weight-bold">Manage users</span></li>
   <% end %>
 
-  <% if FeatureFlag.active?(:interview_permissions) && permission_model.set_up_interviews? %>
+  <% if permission_model.set_up_interviews? %>
     <li>
       <%= render IconComponent.new(type: 'check') %><span class="govuk-!-font-weight-bold">Set up interviews</span>
     </li>

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -60,9 +60,7 @@ module ProviderInterface
     end
 
     def set_up_interview?
-      application_choice.decision_pending? &&
-        (FeatureFlag.active?(:interview_permissions) && provider_can_set_up_interviews ||
-         !FeatureFlag.active?(:interview_permissions) && provider_can_respond)
+      application_choice.decision_pending? && provider_can_set_up_interviews
     end
 
     def inset_text_title

--- a/app/components/provider_interface/provider_user_invitation_permissions_component.rb
+++ b/app/components/provider_interface/provider_user_invitation_permissions_component.rb
@@ -16,15 +16,7 @@ module ProviderInterface
     end
 
     def permissions
-      @permissions.map { |p| readable_permissions.fetch(p.to_s, nil) }.compact
-    end
-
-    def readable_permissions
-      if FeatureFlag.active?(:interview_permissions)
-        HUMAN_READABLE_PERMISSIONS
-      else
-        HUMAN_READABLE_PERMISSIONS.except('set_up_interviews')
-      end
+      @permissions.map { |p| HUMAN_READABLE_PERMISSIONS.fetch(p.to_s, nil) }.compact
     end
   end
 end

--- a/app/components/support_interface/permissions_list_component.html.erb
+++ b/app/components/support_interface/permissions_list_component.html.erb
@@ -14,12 +14,10 @@
       <li><%= render IconComponent.new(type: 'cross') %> Manage users – No</li>
     <% end %>
 
-    <% if FeatureFlag.active?(:interview_permissions) %>
-      <% if permission_model.set_up_interviews? %>
-        <li><%= render IconComponent.new(type: 'check') %> Set up interviews – Yes</li>
-      <% else %>
-        <li><%= render IconComponent.new(type: 'cross') %> Set up interviews – No</li>
-      <% end %>
+    <% if permission_model.set_up_interviews? %>
+      <li><%= render IconComponent.new(type: 'check') %> Set up interviews – Yes</li>
+    <% else %>
+      <li><%= render IconComponent.new(type: 'cross') %> Set up interviews – No</li>
     <% end %>
 
     <% if permission_model.make_decisions? %>

--- a/app/components/support_interface/permissions_list_review_component.html.erb
+++ b/app/components/support_interface/permissions_list_review_component.html.erb
@@ -11,12 +11,10 @@
     <li><%= render IconComponent.new(type: 'cross') %> Manage users</li>
   <% end %>
 
-  <% if FeatureFlag.active?(:interview_permissions) %>
-    <% if permissions['set_up_interviews'] %>
-      <li><%= render IconComponent.new(type: 'check') %> Set up interviews</li>
-    <% else %>
-      <li><%= render IconComponent.new(type: 'cross') %> Set up interviews</li>
-    <% end %>
+  <% if permissions['set_up_interviews'] %>
+    <li><%= render IconComponent.new(type: 'check') %> Set up interviews</li>
+  <% else %>
+    <li><%= render IconComponent.new(type: 'cross') %> Set up interviews</li>
   <% end %>
 
   <% if permissions['make_decisions'] %>

--- a/app/services/cancel_interview.rb
+++ b/app/services/cancel_interview.rb
@@ -14,17 +14,8 @@ class CancelInterview
   end
 
   def save!
-    if FeatureFlag.active?(:interview_permissions)
-      auth.assert_can_set_up_interviews!(
-        application_choice: application_choice,
-        course_option: application_choice.current_course_option,
-      )
-    else
-      auth.assert_can_make_decisions!(
-        application_choice: application_choice,
-        course_option: application_choice.current_course_option,
-      )
-    end
+    auth.assert_can_set_up_interviews!(application_choice: application_choice,
+                                       course_option: application_choice.current_course_option)
 
     if ApplicationStateChange.new(application_choice).can_cancel_interview?
       ActiveRecord::Base.transaction do

--- a/app/services/create_interview.rb
+++ b/app/services/create_interview.rb
@@ -18,17 +18,8 @@ class CreateInterview
   end
 
   def save!
-    if FeatureFlag.active?(:interview_permissions)
-      auth.assert_can_set_up_interviews!(
-        application_choice: application_choice,
-        course_option: application_choice.current_course_option,
-      )
-    else
-      auth.assert_can_make_decisions!(
-        application_choice: application_choice,
-        course_option: application_choice.current_course_option,
-      )
-    end
+    auth.assert_can_set_up_interviews!(application_choice: application_choice,
+                                       course_option: application_choice.current_course_option)
 
     ActiveRecord::Base.transaction do
       ApplicationStateChange.new(application_choice).interview!

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -39,7 +39,6 @@ class FeatureFlag
     [:withdraw_at_candidates_request, "Allows providers to withdraw an application at the candidate's request", 'Steve Laing'],
     [:summer_recruitment_banner, 'Show a banner to indicate a shorter recruitment timeframe during summer', 'Richard Pattinson'],
     [:accredited_provider_setting_permissions, 'Allow accredited providers to set org permissions', 'Michael Nacos'],
-    [:interview_permissions, 'Enables a user-level permission for managing interviews', 'Steve Laing'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map do |name, description, owner|

--- a/app/services/support_interface/active_provider_user_permissions_export.rb
+++ b/app/services/support_interface/active_provider_user_permissions_export.rb
@@ -22,11 +22,8 @@ module SupportInterface
             has_view_diversity: permissions.view_diversity_information.exists?(provider: provider),
             has_manage_users: permissions.manage_users.exists?(provider: provider),
             has_manage_organisations: permissions.manage_organisations.exists?(provider: provider),
+            has_set_up_interviews: permissions.set_up_interviews.exists?(provider: provider),
           }
-
-        if FeatureFlag.active?(:interview_permissions)
-          user_data.merge!(has_set_up_interviews: permissions.set_up_interviews.exists?(provider: provider))
-        end
 
         user_data
       end

--- a/app/services/update_interview.rb
+++ b/app/services/update_interview.rb
@@ -19,17 +19,8 @@ class UpdateInterview
   end
 
   def save!
-    if FeatureFlag.active?(:interview_permissions)
-      auth.assert_can_set_up_interviews!(
-        application_choice: application_choice,
-        course_option: application_choice.current_course_option,
-      )
-    else
-      auth.assert_can_make_decisions!(
-        application_choice: application_choice,
-        course_option: application_choice.current_course_option,
-      )
-    end
+    auth.assert_can_set_up_interviews!(application_choice: application_choice,
+                                       course_option: application_choice.current_course_option)
 
     interview.provider = provider
     interview.date_and_time = date_and_time

--- a/app/views/provider_interface/_fields_for_permissions.html.erb
+++ b/app/views/provider_interface/_fields_for_permissions.html.erb
@@ -38,13 +38,11 @@
           hint: { text: 'Invite or delete users and set their permissions' },
         ) %>
 
-        <% if FeatureFlag.active?(:interview_permissions) %>
-          <%= pf.govuk_check_box(
-            :permissions,
-            'set_up_interviews',
-            label: { text: 'Set up interviews' },
-          ) %>
-        <% end %>
+        <%= pf.govuk_check_box(
+          :permissions,
+          'set_up_interviews',
+          label: { text: 'Set up interviews' },
+        ) %>
 
         <%= pf.govuk_check_box(
           :permissions,

--- a/app/views/support_interface/bulk_upload/permissions/_provider_permissions.html.erb
+++ b/app/views/support_interface/bulk_upload/permissions/_provider_permissions.html.erb
@@ -24,14 +24,12 @@
             multiple: false,
             label: { text: 'Make decisions' },
           ) %>
-      <% if FeatureFlag.active?(:interview_permissions) %>
-        <%= ppf.govuk_check_box(
-              :set_up_interviews,
-              true,
-              multiple: false,
-              label: { text: 'Set up interviews' },
-            ) %>
-      <% end %>
+      <%= ppf.govuk_check_box(
+            :set_up_interviews,
+            true,
+            multiple: false,
+            label: { text: 'Set up interviews' },
+          ) %>
       <%= ppf.govuk_check_box(
             :view_safeguarding_information,
             true,

--- a/app/views/support_interface/single_provider_users/_edit_provider_permissions.html.erb
+++ b/app/views/support_interface/single_provider_users/_edit_provider_permissions.html.erb
@@ -18,14 +18,12 @@
               multiple: false,
               label: { text: 'Manage organisational permissions' },
             ) %>
-        <% if FeatureFlag.active?(:interview_permissions) %>
-          <%= ppf.govuk_check_box(
-                :set_up_interviews,
-                true,
-                multiple: false,
-                label: { text: 'Set up interviews' },
-              ) %>
-        <% end %>
+        <%= ppf.govuk_check_box(
+              :set_up_interviews,
+              true,
+              multiple: false,
+              label: { text: 'Set up interviews' },
+            ) %>
         <%= ppf.govuk_check_box(
               :make_decisions,
               true,

--- a/app/views/support_interface/single_provider_users/_provider_permissions.html.erb
+++ b/app/views/support_interface/single_provider_users/_provider_permissions.html.erb
@@ -18,14 +18,12 @@
             multiple: false,
             label: { text: 'Manage organisational permissions' },
           ) %>
-      <% if FeatureFlag.active?(:interview_permissions) %>
-        <%= ppf.govuk_check_box(
-              :set_up_interviews,
-              true,
-              multiple: false,
-              label: { text: 'Set up interviews' },
-            ) %>
-      <% end %>
+      <%= ppf.govuk_check_box(
+            :set_up_interviews,
+            true,
+            multiple: false,
+            label: { text: 'Set up interviews' },
+          ) %>
       <%= ppf.govuk_check_box(
             :make_decisions,
             true,

--- a/spec/components/permissions_list_component_spec.rb
+++ b/spec/components/permissions_list_component_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe PermissionsListComponent do
   end
 
   it 'renders permissions' do
-    FeatureFlag.activate(:interview_permissions)
     permission_model = create(:provider_permissions, manage_organisations: true, set_up_interviews: true)
     result = render_inline(described_class.new(permission_model, user_is_viewing_their_own_permissions: false))
 

--- a/spec/components/provider_interface/application_choice_header_component_spec.rb
+++ b/spec/components/provider_interface/application_choice_header_component_spec.rb
@@ -18,37 +18,16 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
       )
     end
 
-    context 'when interview permissions feature is not active' do
-      before { FeatureFlag.deactivate(:interview_permissions) }
-
-      context 'when the application is awaiting provider decision and the user can make decisions' do
-        let(:reject_by_default_at) { 1.day.from_now }
-
-        it 'the Make decision and Set up interview buttons are available and RDB info is presented ' do
-          expect(result.css('h2.govuk-heading-m').first.text.strip).to eq('Set up an interview or make a decision')
-          expect(result.css('.govuk-button').first.text).to eq('Set up interview')
-          expect(result.css('.govuk-button').last.text).to eq('Make decision')
-          expect(result.css('.govuk-inset-text').text).to include(
-            "This application will be automatically rejected if a decision has not been made by the end of tomorrow (#{reject_by_default_at.to_s(:govuk_date_and_time)}).",
-          )
-        end
-      end
-    end
-
-    context 'when interview permissions feature is active' do
+    context 'when the application is awaiting provider decision and the user can make decisions and set up interviews' do
       let(:reject_by_default_at) { 1.day.from_now }
 
-      before { FeatureFlag.activate(:interview_permissions) }
-
-      context 'when the application is awaiting provider decision and the user can make decisions and set up interviews' do
-        it 'the Make decision and Set up interview buttons are available and RDB info is presented ' do
-          expect(result.css('h2.govuk-heading-m').first.text.strip).to eq('Set up an interview or make a decision')
-          expect(result.css('.govuk-button').first.text).to eq('Set up interview')
-          expect(result.css('.govuk-button').last.text).to eq('Make decision')
-          expect(result.css('.govuk-inset-text').text).to include(
-            "This application will be automatically rejected if a decision has not been made by the end of tomorrow (#{reject_by_default_at.to_s(:govuk_date_and_time)}).",
-          )
-        end
+      it 'the Make decision and Set up interview buttons are available and RDB info is presented ' do
+        expect(result.css('h2.govuk-heading-m').first.text.strip).to eq('Set up an interview or make a decision')
+        expect(result.css('.govuk-button').first.text).to eq('Set up interview')
+        expect(result.css('.govuk-button').last.text).to eq('Make decision')
+        expect(result.css('.govuk-inset-text').text).to include(
+          "This application will be automatically rejected if a decision has not been made by the end of tomorrow (#{reject_by_default_at.to_s(:govuk_date_and_time)}).",
+        )
       end
 
       context 'when the application is awaiting provider decision and the user can only set up interviews' do

--- a/spec/components/provider_interface/provider_user_invitation_details_component_spec.rb
+++ b/spec/components/provider_interface/provider_user_invitation_details_component_spec.rb
@@ -64,28 +64,13 @@ RSpec.describe ProviderInterface::ProviderUserInvitationDetailsComponent do
       )
     end
 
-    context 'conditionally hides provider information' do
-      it 'when the interview_permissions feature flag is on' do
-        FeatureFlag.activate(:interview_permissions)
+    it 'conditionally hides provider information' do
+      result = render_inline(described_class.new(wizard: wizard))
 
-        result = render_inline(described_class.new(wizard: wizard))
-
-        expect(result.css('.govuk-summary-list__key')[3].text).to include('Permissions')
-        expect(result.css('.govuk-summary-list__key')[3].text).not_to include("Permissions: #{provider.name}")
-        expect(result.css('.govuk-summary-list__value')[3].text).to include('Manage users')
-        expect(result.css('.govuk-summary-list__value')[3].text).to include('Set up interviews')
-      end
-
-      it 'when the interview_permissions feature flag is off' do
-        FeatureFlag.deactivate(:interview_permissions)
-
-        result = render_inline(described_class.new(wizard: wizard))
-
-        expect(result.css('.govuk-summary-list__key')[3].text).to include('Permissions')
-        expect(result.css('.govuk-summary-list__key')[3].text).not_to include("Permissions: #{provider.name}")
-        expect(result.css('.govuk-summary-list__value')[3].text).to include('Manage users')
-        expect(result.css('.govuk-summary-list__value')[3].text).not_to include('Set up interviews')
-      end
+      expect(result.css('.govuk-summary-list__key')[3].text).to include('Permissions')
+      expect(result.css('.govuk-summary-list__key')[3].text).not_to include("Permissions: #{provider.name}")
+      expect(result.css('.govuk-summary-list__value')[3].text).to include('Manage users')
+      expect(result.css('.govuk-summary-list__value')[3].text).to include('Set up interviews')
     end
   end
 

--- a/spec/components/support_interface/permissions_list_component_spec.rb
+++ b/spec/components/support_interface/permissions_list_component_spec.rb
@@ -28,10 +28,6 @@ RSpec.describe SupportInterface::PermissionsListComponent do
   let(:view_safeguarding_information) { true }
   let(:view_diversity_information) { true }
 
-  before do
-    FeatureFlag.activate(:interview_permissions)
-  end
-
   describe 'rendering permissions' do
     context 'when all permissions have been assigned' do
       it 'displays Yes on all' do

--- a/spec/components/support_interface/permissions_list_review_component_spec.rb
+++ b/spec/components/support_interface/permissions_list_review_component_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe SupportInterface::PermissionsListReviewComponent do
   let(:tick_svg_path_shape) { 'M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z' }
   let(:cross_svg_path_shape) { 'M100 0a100 100 0 110 200 100 100 0 010-200zm30 50l-30 30-30-30-20 20 30 30-30 30 20 20 30-30 30 30 20-20-30-30 30-30-20-20z' }
 
-  before do
-    FeatureFlag.activate(:interview_permissions)
-  end
-
   context 'Manage organisational permissions' do
     it 'displays permission has been assigned' do
       permissions = { 'manage_organisations' => true, 'set_up_interviews' => true }

--- a/spec/queries/get_activity_log_events_spec.rb
+++ b/spec/queries/get_activity_log_events_spec.rb
@@ -211,7 +211,6 @@ RSpec.describe GetActivityLogEvents, with_audited: true do
     let(:auth) { instance_double(ProviderAuthorisation, assert_can_set_up_interviews!: true) }
 
     before do
-      FeatureFlag.activate(:interview_permissions)
       allow(ProviderAuthorisation).to receive(:new).and_return(auth)
       CancelInterview.new(
         actor: provider_user,

--- a/spec/requests/provider_interface/interviews_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews_controller_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe ProviderInterface::InterviewsController, type: :request do
   let(:interview) { create(:interview, application_choice: application_choice) }
 
   before do
-    FeatureFlag.activate(:interview_permissions)
     allow(DfESignInUser).to receive(:load_from_session).and_return(provider_user)
 
     user_exists_in_dfe_sign_in(email_address: provider_user.email_address)

--- a/spec/services/cancel_interview_spec.rb
+++ b/spec/services/cancel_interview_spec.rb
@@ -16,79 +16,35 @@ RSpec.describe CancelInterview do
     }
   end
 
-  context 'when the interview_permissions feature_flag is active' do
-    before do
-      FeatureFlag.activate(:interview_permissions)
-    end
+  let(:provider_user) { create(:provider_user, :with_set_up_interviews, providers: [provider]) }
 
-    let(:provider_user) { create(:provider_user, :with_set_up_interviews, providers: [provider]) }
+  describe '#save!' do
+    describe 'when there are no other interviews' do
+      it 'transitions the application_choice state to `awaiting_provider_decision` if successful' do
+        service = CancelInterview.new(service_params)
 
-    describe '#save!' do
-      describe 'when there are no other interviews' do
-        it 'transitions the application_choice state to `awaiting_provider_decision` if successful' do
-          service = CancelInterview.new(service_params)
-
-          expect { service.save! }.to change { application_choice.status }.to('awaiting_provider_decision')
-        end
-      end
-
-      describe 'when there are other interviews' do
-        it 'does not change the application_choice state' do
-          create(:interview, application_choice: application_choice)
-          service = CancelInterview.new(service_params)
-
-          expect { service.save! }.not_to(change { application_choice.status })
-        end
-      end
-
-      it 'creates an audit entry and sends an email', with_audited: true, sidekiq: true do
-        CancelInterview.new(service_params).save!
-
-        associated_audit = application_choice.associated_audits.last
-        expect(associated_audit.auditable).to eq(application_choice.interviews.first)
-        expect(associated_audit.audited_changes.keys).to eq(%w[cancelled_at cancellation_reason])
-        expect(associated_audit.audited_changes['cancellation_reason']).to eq([nil, 'There is a global pandemic going on'])
-
-        expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('interview_cancelled')
+        expect { service.save! }.to change { application_choice.status }.to('awaiting_provider_decision')
       end
     end
-  end
 
-  context 'when the interview_permissions feature_flag is inactive' do
-    before do
-      FeatureFlag.deactivate(:interview_permissions)
+    describe 'when there are other interviews' do
+      it 'does not change the application_choice state' do
+        create(:interview, application_choice: application_choice)
+        service = CancelInterview.new(service_params)
+
+        expect { service.save! }.not_to(change { application_choice.status })
+      end
     end
 
-    let(:provider_user) { create(:provider_user, :with_make_decisions, providers: [provider]) }
+    it 'creates an audit entry and sends an email', with_audited: true, sidekiq: true do
+      CancelInterview.new(service_params).save!
 
-    describe '#save!' do
-      describe 'when there are no other interviews' do
-        it 'transitions the application_choice state to `awaiting_provider_decision` if successful' do
-          service = CancelInterview.new(service_params)
+      associated_audit = application_choice.associated_audits.last
+      expect(associated_audit.auditable).to eq(application_choice.interviews.first)
+      expect(associated_audit.audited_changes.keys).to eq(%w[cancelled_at cancellation_reason])
+      expect(associated_audit.audited_changes['cancellation_reason']).to eq([nil, 'There is a global pandemic going on'])
 
-          expect { service.save! }.to change { application_choice.status }.to('awaiting_provider_decision')
-        end
-      end
-
-      describe 'when there are other interviews' do
-        it 'does not change the application_choice state' do
-          create(:interview, application_choice: application_choice)
-          service = CancelInterview.new(service_params)
-
-          expect { service.save! }.not_to(change { application_choice.status })
-        end
-      end
-
-      it 'creates an audit entry and sends an email', with_audited: true, sidekiq: true do
-        CancelInterview.new(service_params).save!
-
-        associated_audit = application_choice.associated_audits.last
-        expect(associated_audit.auditable).to eq(application_choice.interviews.first)
-        expect(associated_audit.audited_changes.keys).to eq(%w[cancelled_at cancellation_reason])
-        expect(associated_audit.audited_changes['cancellation_reason']).to eq([nil, 'There is a global pandemic going on'])
-
-        expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('interview_cancelled')
-      end
+      expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('interview_cancelled')
     end
   end
 end

--- a/spec/services/support_interface/active_provider_user_permissions_export_spec.rb
+++ b/spec/services/support_interface/active_provider_user_permissions_export_spec.rb
@@ -8,8 +8,6 @@ RSpec.describe SupportInterface::ActiveProviderUserPermissionsExport do
   end
 
   before do
-    FeatureFlag.activate(:interview_permissions)
-
     @provider1 = create(:provider)
     @provider2 = create(:provider)
     @provider_user_with_permissions = create(

--- a/spec/services/update_interview_spec.rb
+++ b/spec/services/update_interview_spec.rb
@@ -19,113 +19,52 @@ RSpec.describe UpdateInterview do
     }
   end
 
-  context 'when the interview_permissions feature_flag is active' do
-    before do
-      FeatureFlag.activate(:interview_permissions)
+  let(:provider_user) { create(:provider_user, :with_set_up_interviews, providers: [provider]) }
+
+  describe '#save!' do
+    it 'updates the existing interview with provided params' do
+      described_class.new(service_params).save!
+
+      expect(interview.provider).to eq(provider)
+      expect(interview.date_and_time).to eq(amended_date_and_time)
+      expect(interview.location).to eq('Zoom call')
+      expect(interview.additional_details).to eq('Business casual')
     end
 
-    let(:provider_user) { create(:provider_user, :with_set_up_interviews, providers: [provider]) }
-
-    describe '#save!' do
-      it 'updates the existing interview with provided params' do
-        described_class.new(service_params).save!
-
-        expect(interview.provider).to eq(provider)
-        expect(interview.date_and_time).to eq(amended_date_and_time)
-        expect(interview.location).to eq('Zoom call')
-        expect(interview.additional_details).to eq('Business casual')
+    context 'if the interview is not changed' do
+      let(:service_params) do
+        {
+          actor: provider_user,
+          provider: interview.provider,
+          interview: interview,
+          date_and_time: interview.date_and_time,
+          location: interview.location,
+          additional_details: interview.additional_details,
+        }
       end
 
-      context 'if the interview is not changed' do
-        let(:service_params) do
-          {
-            actor: provider_user,
-            provider: interview.provider,
-            interview: interview,
-            date_and_time: interview.date_and_time,
-            location: interview.location,
-            additional_details: interview.additional_details,
-          }
-        end
-
-        it 'an email is not sent', sidekiq: true do
-          described_class.new(service_params).save!
-
-          expect(ActionMailer::Base.deliveries.map { |d| d['rails-mail-template'].value }).not_to include('interview_updated')
-        end
-      end
-
-      it 'creates an audit entry and sends an email', with_audited: true, sidekiq: true do
+      it 'an email is not sent', sidekiq: true do
         described_class.new(service_params).save!
 
-        associated_audit = application_choice.associated_audits.last
-        expect(associated_audit.auditable).to eq(application_choice.interviews.first)
-        expect(associated_audit.audited_changes.keys).to contain_exactly(
-          'location',
-          'date_and_time',
-          'additional_details',
-        )
-
-        expect(associated_audit.audited_changes['location'].last).to eq('Zoom call')
-        expect(associated_audit.audited_changes['additional_details'].last).to eq('Business casual')
-
-        expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('interview_updated')
+        expect(ActionMailer::Base.deliveries.map { |d| d['rails-mail-template'].value }).not_to include('interview_updated')
       end
     end
-  end
 
-  context 'when the interview_permissions feature_flag is inactive' do
-    before do
-      FeatureFlag.deactivate(:interview_permissions)
-    end
+    it 'creates an audit entry and sends an email', with_audited: true, sidekiq: true do
+      described_class.new(service_params).save!
 
-    let(:provider_user) { create(:provider_user, :with_make_decisions, providers: [provider]) }
+      associated_audit = application_choice.associated_audits.last
+      expect(associated_audit.auditable).to eq(application_choice.interviews.first)
+      expect(associated_audit.audited_changes.keys).to contain_exactly(
+        'location',
+        'date_and_time',
+        'additional_details',
+      )
 
-    describe '#save!' do
-      it 'updates the existing interview with provided params' do
-        described_class.new(service_params).save!
+      expect(associated_audit.audited_changes['location'].last).to eq('Zoom call')
+      expect(associated_audit.audited_changes['additional_details'].last).to eq('Business casual')
 
-        expect(interview.provider).to eq(provider)
-        expect(interview.date_and_time).to eq(amended_date_and_time)
-        expect(interview.location).to eq('Zoom call')
-        expect(interview.additional_details).to eq('Business casual')
-      end
-
-      context 'if the interview is not changed' do
-        let(:service_params) do
-          {
-            actor: provider_user,
-            provider: interview.provider,
-            interview: interview,
-            date_and_time: interview.date_and_time,
-            location: interview.location,
-            additional_details: interview.additional_details,
-          }
-        end
-
-        it 'an email is not sent', sidekiq: true do
-          described_class.new(service_params).save!
-
-          expect(ActionMailer::Base.deliveries.map { |d| d['rails-mail-template'].value }).not_to include('interview_updated')
-        end
-      end
-
-      it 'creates an audit entry and sends an email', with_audited: true, sidekiq: true do
-        described_class.new(service_params).save!
-
-        associated_audit = application_choice.associated_audits.last
-        expect(associated_audit.auditable).to eq(application_choice.interviews.first)
-        expect(associated_audit.audited_changes.keys).to contain_exactly(
-          'location',
-          'date_and_time',
-          'additional_details',
-        )
-
-        expect(associated_audit.audited_changes['location'].last).to eq('Zoom call')
-        expect(associated_audit.audited_changes['additional_details'].last).to eq('Business casual')
-
-        expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('interview_updated')
-      end
+      expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('interview_updated')
     end
   end
 end

--- a/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 RSpec.feature 'Managing provider user permissions' do
   include DfESignInHelpers
 
-  before do
-    FeatureFlag.activate(:interview_permissions)
-  end
-
   scenario 'Provider manages permissions for users' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_the_accredited_provider_setting_permissions_flag_is_inactive

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -4,10 +4,6 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
   include DfESignInHelpers
   include DsiAPIHelper
 
-  before do
-    FeatureFlag.activate(:interview_permissions)
-  end
-
   scenario 'Provider sends invite to user' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_the_accredited_provider_setting_permissions_flag_is_inactive

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -14,10 +14,6 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     end
   end
 
-  before do
-    FeatureFlag.activate(:interview_permissions)
-  end
-
   scenario 'can view, create and cancel interviews' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider

--- a/spec/system/support_interface/adding_a_new_provider_user_spec.rb
+++ b/spec/system/support_interface/adding_a_new_provider_user_spec.rb
@@ -4,10 +4,6 @@ RSpec.feature 'Managing provider users v2' do
   include DfESignInHelpers
   include DsiAPIHelper
 
-  before do
-    FeatureFlag.activate(:interview_permissions)
-  end
-
   scenario 'adding a new provider user', with_audited: true do
     given_dfe_signin_is_configured
     and_i_am_a_support_user

--- a/spec/system/support_interface/adding_provider_to_existing_provider_user_spec.rb
+++ b/spec/system/support_interface/adding_provider_to_existing_provider_user_spec.rb
@@ -4,10 +4,6 @@ RSpec.feature 'Managing provider users v2' do
   include DfESignInHelpers
   include DsiAPIHelper
 
-  before do
-    FeatureFlag.activate(:interview_permissions)
-  end
-
   scenario 'adding provider to an existing provider user', with_audited: true do
     given_dfe_signin_is_configured
     and_i_am_a_support_user

--- a/spec/system/support_interface/bulk_upload_a_single_provider_user_spec.rb
+++ b/spec/system/support_interface/bulk_upload_a_single_provider_user_spec.rb
@@ -4,10 +4,6 @@ RSpec.feature 'bulk upload provider users' do
   include DfESignInHelpers
   include DsiAPIHelper
 
-  before do
-    FeatureFlag.activate(:interview_permissions)
-  end
-
   scenario 'bulk upload a single provider user', with_audited: true do
     given_dfe_signin_is_configured
     and_i_am_a_support_user

--- a/spec/system/support_interface/bulk_upload_multiple_provider_users_spec.rb
+++ b/spec/system/support_interface/bulk_upload_multiple_provider_users_spec.rb
@@ -4,10 +4,6 @@ RSpec.feature 'bulk upload provider users' do
   include DfESignInHelpers
   include DsiAPIHelper
 
-  before do
-    FeatureFlag.activate(:interview_permissions)
-  end
-
   scenario 'bulk upload multiple provider users', with_audited: true do
     given_dfe_signin_is_configured
     and_i_am_a_support_user

--- a/spec/system/support_interface/validation_errors_provider_spec.rb
+++ b/spec/system/support_interface/validation_errors_provider_spec.rb
@@ -14,10 +14,6 @@ RSpec.feature 'Validation errors Provider' do
     end
   end
 
-  before do
-    FeatureFlag.activate(:interview_permissions)
-  end
-
   scenario 'Review validation errors' do
     given_i_signed_in_as_a_provider_user
     and_i_enter_an_invalid_interview_time

--- a/spec/system/support_interface/validation_errors_provider_summary_spec.rb
+++ b/spec/system/support_interface/validation_errors_provider_summary_spec.rb
@@ -8,10 +8,6 @@ RSpec.feature 'Validation errors provider summary' do
   let(:application_choice) { create(:application_choice, :awaiting_provider_decision, course_option: course_option) }
   let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
 
-  before do
-    FeatureFlag.activate(:interview_permissions)
-  end
-
   scenario 'Review validation error summary' do
     given_i_signed_in_as_a_provider_user
     and_i_enter_an_invalid_interview_time


### PR DESCRIPTION
Dependgs on #5124 being merged 

Removes `interview_permissions` feature flag.


## Trello card
https://trello.com/c/H0UkrlVb/3946-remove-interviewpermissions-feature-flag

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
