### PR TITLE
Update API documentation for identifiers

### DIFF
--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+## 2nd July
+
+Documentation:
+
+Add clarification in the identifier fields for `support_reference`, `application.id` and `candidate.id` in the documentation.
+
 ## 28th June
 
 Documentation:

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -380,7 +380,7 @@ components:
       properties:
         id:
           type: string
-          description: The unique ID of this application
+          description: The unique ID of this application. This identifies an application to a single course, also known as an application choice. Candidates can submit up to three application choices at a time.
           maxLength: 10
           example: 11fc0d3b2f
         type:
@@ -419,7 +419,7 @@ components:
       properties:
         support_reference:
           type: string
-          description: The candidate’s reference number for their application in the Apply system
+          description: The candidate’s reference number for their application form carrying this application choice in the Apply system. Candidates can have multiple application forms. For instance, when a candidate moves from Apply 1 to Apply again their candidate ID will stay the same, but that’s a new application form so the `support_reference` will be different.
           maxLength: 10
           example: AB1234
         status:
@@ -552,7 +552,7 @@ components:
       properties:
         id:
           type: string
-          description: The candidate’s ID in the Apply system
+          description: The candidate’s unique ID in the Apply system.
           maxLength: 10
           example: C5432
         first_name:


### PR DESCRIPTION
## Context

We have many identifiers in Manage which is causing confusion for providers, we should clarify further what those mean in the documentation 
## Changes proposed in this pull request

Add clarification for the support reference, application id and the candidate id in the API documentation.

## Guidance to review

I'm in two minds around mentioning the application form here, as that's not really a concept in the API. Thoughts?

## Link to Trello card

https://trello.com/c/Jvn10Qos/3957-update-identifier-content-in-api-reference

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
