### PR TITLE
Update apply1 deadline date

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -19,7 +19,7 @@ class CycleTimetable
     2021 => {
       find_opens: Date.new(2020, 10, 6),
       apply_opens: Date.new(2020, 10, 13),
-      apply_1_deadline: Date.new(2021, 9, 6),
+      apply_1_deadline: Date.new(2021, 9, 7),
       apply_2_deadline: Date.new(2021, 9, 20),
       find_closes: Date.new(2021, 10, 3),
     },


### PR DESCRIPTION
## Context

The apply 1 deadline date is currently 6th of September – this should actually be the 7th. 

## Changes proposed in this pull request

`apply_1_deadline: Date.new(2021, 9, 6)` to `apply_1_deadline: Date.new(2021, 9, 7)` 

## Guidance to review

Refer to [EoC doc](https://docs.google.com/document/d/1_9cdLUtgrR36iuvkdQkNy_7Kv1qTV1ZFCaNR6UHb8b4/edit?usp=sharing)

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
