### PR TITLE
Use feature flag to identify what permission to check for interview m…

### DIFF
--- a/app/services/cancel_interview.rb
+++ b/app/services/cancel_interview.rb
@@ -14,10 +14,17 @@ class CancelInterview
   end
 
   def save!
-    auth.assert_can_set_up_interviews!(
-      application_choice: application_choice,
-      course_option: application_choice.current_course_option,
-    )
+    if FeatureFlag.active?(:interview_permissions)
+      auth.assert_can_set_up_interviews!(
+        application_choice: application_choice,
+        course_option: application_choice.current_course_option,
+      )
+    else
+      auth.assert_can_make_decisions!(
+        application_choice: application_choice,
+        course_option: application_choice.current_course_option,
+      )
+    end
 
     if ApplicationStateChange.new(application_choice).can_cancel_interview?
       ActiveRecord::Base.transaction do

--- a/app/services/create_interview.rb
+++ b/app/services/create_interview.rb
@@ -18,10 +18,17 @@ class CreateInterview
   end
 
   def save!
-    auth.assert_can_set_up_interviews!(
-      application_choice: application_choice,
-      course_option: application_choice.current_course_option,
-    )
+    if FeatureFlag.active?(:interview_permissions)
+      auth.assert_can_set_up_interviews!(
+        application_choice: application_choice,
+        course_option: application_choice.current_course_option,
+      )
+    else
+      auth.assert_can_make_decisions!(
+        application_choice: application_choice,
+        course_option: application_choice.current_course_option,
+      )
+    end
 
     ActiveRecord::Base.transaction do
       ApplicationStateChange.new(application_choice).interview!

--- a/app/services/update_interview.rb
+++ b/app/services/update_interview.rb
@@ -1,5 +1,5 @@
 class UpdateInterview
-  attr_reader :auth, :interview, :provider, :date_and_time, :location, :additional_details
+  attr_reader :auth, :interview, :provider, :date_and_time, :location, :additional_details, :application_choice
 
   def initialize(
     actor:,
@@ -15,13 +15,21 @@ class UpdateInterview
     @date_and_time = date_and_time
     @location = location
     @additional_details = additional_details
+    @application_choice = interview.application_choice
   end
 
   def save!
-    auth.assert_can_set_up_interviews!(
-      application_choice: interview.application_choice,
-      course_option: interview.application_choice.current_course_option,
-    )
+    if FeatureFlag.active?(:interview_permissions)
+      auth.assert_can_set_up_interviews!(
+        application_choice: application_choice,
+        course_option: application_choice.current_course_option,
+      )
+    else
+      auth.assert_can_make_decisions!(
+        application_choice: application_choice,
+        course_option: application_choice.current_course_option,
+      )
+    end
 
     interview.provider = provider
     interview.date_and_time = date_and_time

--- a/spec/queries/get_activity_log_events_spec.rb
+++ b/spec/queries/get_activity_log_events_spec.rb
@@ -211,6 +211,7 @@ RSpec.describe GetActivityLogEvents, with_audited: true do
     let(:auth) { instance_double(ProviderAuthorisation, assert_can_set_up_interviews!: true) }
 
     before do
+      FeatureFlag.activate(:interview_permissions)
       allow(ProviderAuthorisation).to receive(:new).and_return(auth)
       CancelInterview.new(
         actor: provider_user,

--- a/spec/services/update_interview_spec.rb
+++ b/spec/services/update_interview_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe UpdateInterview do
   let(:interview) { application_choice.interviews.first }
   let(:course_option) { course_option_for_provider(provider: provider) }
   let(:provider) { create(:provider) }
-  let(:provider_user) { create(:provider_user, :with_set_up_interviews, providers: [provider]) }
   let(:amended_date_and_time) { 1.day.since(interview.date_and_time) }
   let(:service_params) do
     {
@@ -20,50 +19,113 @@ RSpec.describe UpdateInterview do
     }
   end
 
-  describe '#save!' do
-    it 'updates the existing interview with provided params' do
-      described_class.new(service_params).save!
-
-      expect(interview.provider).to eq(provider)
-      expect(interview.date_and_time).to eq(amended_date_and_time)
-      expect(interview.location).to eq('Zoom call')
-      expect(interview.additional_details).to eq('Business casual')
+  context 'when the interview_permissions feature_flag is active' do
+    before do
+      FeatureFlag.activate(:interview_permissions)
     end
 
-    context 'if the interview is not changed' do
-      let(:service_params) do
-        {
-          actor: provider_user,
-          provider: interview.provider,
-          interview: interview,
-          date_and_time: interview.date_and_time,
-          location: interview.location,
-          additional_details: interview.additional_details,
-        }
-      end
+    let(:provider_user) { create(:provider_user, :with_set_up_interviews, providers: [provider]) }
 
-      it 'an email is not sent', sidekiq: true do
+    describe '#save!' do
+      it 'updates the existing interview with provided params' do
         described_class.new(service_params).save!
 
-        expect(ActionMailer::Base.deliveries.map { |d| d['rails-mail-template'].value }).not_to include('interview_updated')
+        expect(interview.provider).to eq(provider)
+        expect(interview.date_and_time).to eq(amended_date_and_time)
+        expect(interview.location).to eq('Zoom call')
+        expect(interview.additional_details).to eq('Business casual')
+      end
+
+      context 'if the interview is not changed' do
+        let(:service_params) do
+          {
+            actor: provider_user,
+            provider: interview.provider,
+            interview: interview,
+            date_and_time: interview.date_and_time,
+            location: interview.location,
+            additional_details: interview.additional_details,
+          }
+        end
+
+        it 'an email is not sent', sidekiq: true do
+          described_class.new(service_params).save!
+
+          expect(ActionMailer::Base.deliveries.map { |d| d['rails-mail-template'].value }).not_to include('interview_updated')
+        end
+      end
+
+      it 'creates an audit entry and sends an email', with_audited: true, sidekiq: true do
+        described_class.new(service_params).save!
+
+        associated_audit = application_choice.associated_audits.last
+        expect(associated_audit.auditable).to eq(application_choice.interviews.first)
+        expect(associated_audit.audited_changes.keys).to contain_exactly(
+          'location',
+          'date_and_time',
+          'additional_details',
+        )
+
+        expect(associated_audit.audited_changes['location'].last).to eq('Zoom call')
+        expect(associated_audit.audited_changes['additional_details'].last).to eq('Business casual')
+
+        expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('interview_updated')
       end
     end
+  end
 
-    it 'creates an audit entry and sends an email', with_audited: true, sidekiq: true do
-      described_class.new(service_params).save!
+  context 'when the interview_permissions feature_flag is inactive' do
+    before do
+      FeatureFlag.deactivate(:interview_permissions)
+    end
 
-      associated_audit = application_choice.associated_audits.last
-      expect(associated_audit.auditable).to eq(application_choice.interviews.first)
-      expect(associated_audit.audited_changes.keys).to contain_exactly(
-        'location',
-        'date_and_time',
-        'additional_details',
-      )
+    let(:provider_user) { create(:provider_user, :with_make_decisions, providers: [provider]) }
 
-      expect(associated_audit.audited_changes['location'].last).to eq('Zoom call')
-      expect(associated_audit.audited_changes['additional_details'].last).to eq('Business casual')
+    describe '#save!' do
+      it 'updates the existing interview with provided params' do
+        described_class.new(service_params).save!
 
-      expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('interview_updated')
+        expect(interview.provider).to eq(provider)
+        expect(interview.date_and_time).to eq(amended_date_and_time)
+        expect(interview.location).to eq('Zoom call')
+        expect(interview.additional_details).to eq('Business casual')
+      end
+
+      context 'if the interview is not changed' do
+        let(:service_params) do
+          {
+            actor: provider_user,
+            provider: interview.provider,
+            interview: interview,
+            date_and_time: interview.date_and_time,
+            location: interview.location,
+            additional_details: interview.additional_details,
+          }
+        end
+
+        it 'an email is not sent', sidekiq: true do
+          described_class.new(service_params).save!
+
+          expect(ActionMailer::Base.deliveries.map { |d| d['rails-mail-template'].value }).not_to include('interview_updated')
+        end
+      end
+
+      it 'creates an audit entry and sends an email', with_audited: true, sidekiq: true do
+        described_class.new(service_params).save!
+
+        associated_audit = application_choice.associated_audits.last
+        expect(associated_audit.auditable).to eq(application_choice.interviews.first)
+        expect(associated_audit.audited_changes.keys).to contain_exactly(
+          'location',
+          'date_and_time',
+          'additional_details',
+        )
+
+        expect(associated_audit.audited_changes['location'].last).to eq('Zoom call')
+        expect(associated_audit.audited_changes['additional_details'].last).to eq('Business casual')
+
+        expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('interview_updated')
+      end
     end
   end
 end


### PR DESCRIPTION
…anagement

`set_up_interview` permissions should only be checked if the `interview_permissions` feature flag has been activated, alternatively `make_decisions` should be used to identify if the user is able to manage interviews.