### PR TITLE
Paginate the courses without vacancies dashboard

### DIFF
--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -5,7 +5,11 @@ module SupportInterface
     def index; end
 
     def course_options
-      @course_options = CourseOption.where('vacancy_status != ?', 'vacancies').includes(:course, :site)
+      @course_options = CourseOption
+        .where('vacancy_status != ?', 'vacancies')
+        .includes(:course, :site)
+        .page(params[:page] || 1)
+        .per(30)
     end
 
     def courses_dashboard; end

--- a/app/views/support_interface/performance/course_options.html.erb
+++ b/app/views/support_interface/performance/course_options.html.erb
@@ -8,3 +8,5 @@
 <% end %>
 
 <%= render(SupportInterface::CourseChoicesTableComponent.new(course_options: @course_options)) %>
+
+<%= render(PaginatorComponent.new(scope: @course_options)) %>


### PR DESCRIPTION
## Context

Three of the performance dashboards in the support interface are not working now that the data set has grown significantly. This PR fixes the second one that shows courses that no longer have vacancies.

## Changes proposed in this pull request

Paginate results.

## Guidance to review

- Is there more we need to do here? Filter by recruitment cycle? Make the list searchable?

## Link to Trello card

https://trello.com/c/n15tykVN/3513-performance-dashboards-not-loading

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
