### PR TITLE
Fix params bug on UCAS interstitial

### DIFF
--- a/app/controllers/candidate_interface/apply_from_find_controller.rb
+++ b/app/controllers/candidate_interface/apply_from_find_controller.rb
@@ -8,8 +8,8 @@ module CandidateInterface
 
     def show
       apply_from_find = ApplyFromFindPage.new(
-        provider_code: params[:providerCode],
-        course_code: params[:courseCode],
+        provider_code: params.fetch(:providerCode),
+        course_code: params.fetch(:courseCode),
         current_candidate: current_candidate,
       )
 
@@ -59,8 +59,8 @@ module CandidateInterface
         end
       else
         @course = ApplyFromFindPage.new(
-          provider_code: apply_on_ucas_or_apply_params[:provider_code],
-          course_code: apply_on_ucas_or_apply_params[:course_code],
+          provider_code: apply_on_ucas_or_apply_params.fetch(:provider_code),
+          course_code: apply_on_ucas_or_apply_params.fetch(:course_code),
           current_candidate: current_candidate,
         ).course
 

--- a/app/controllers/candidate_interface/apply_from_find_controller.rb
+++ b/app/controllers/candidate_interface/apply_from_find_controller.rb
@@ -70,8 +70,8 @@ module CandidateInterface
 
     def ucas_interstitial
       @course = ApplyFromFindPage.new(
-        provider_code: ucas_interstitial_params[:provider_code],
-        course_code: ucas_interstitial_params[:course_code],
+        provider_code: ucas_interstitial_params.fetch(:provider_code),
+        course_code: ucas_interstitial_params.fetch(:course_code),
         current_candidate: current_candidate,
       ).course
     end


### PR DESCRIPTION
## Context
Navgiating to `candidate/apply/ucas` without params causes a 500. 
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Fetch
params in the controller so that an ActionController::ParameterMissing
exception is raised.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/LvoNyZWB
## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
