### PR TITLE
Selected references: suppress "section not complete" warning

### DIFF
--- a/app/components/selected_references_component.rb
+++ b/app/components/selected_references_component.rb
@@ -12,7 +12,7 @@ class SelectedReferencesComponent < ViewComponent::Base
   end
 
   def show_incomplete_banner?
-    !application_form.references_completed? && show_incomplete
+    !application_form.references_completed? && show_incomplete && editable
   end
 
   def rows

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -28,7 +28,7 @@
 <section class="govuk-!-margin-bottom-8" id="references">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.references') %></h2>
   <% if FeatureFlag.active?(:reference_selection) %>
-    <%= render(SelectedReferencesComponent.new(application_form, show_incomplete: true, is_errored: missing_error)) %>
+    <%= render(SelectedReferencesComponent.new(application_form, editable: editable, show_incomplete: true, is_errored: missing_error)) %>
   <% else %>
     <% if !application_form.enough_references_have_been_provided? && editable %>
       <%= render(

--- a/spec/components/selected_references_component_spec.rb
+++ b/spec/components/selected_references_component_spec.rb
@@ -20,17 +20,17 @@ RSpec.describe SelectedReferencesComponent, type: :component do
   context 'when references section is not completed' do
     let(:application) { create(:application_form, references_completed: false) }
 
-    context 'and `show_incomplete` is false' do
+    context 'and `editable` and `show_incomplete` are false' do
       it 'simply renders the summary table' do
-        render_inline(described_class.new(application, show_incomplete: false))
+        render_inline(described_class.new(application, editable: false, show_incomplete: false))
 
         expect(page).to have_css '.app-summary-card'
         expect(page).to have_content 'Selected references'
       end
     end
 
-    context 'and `show_incomplete` is true' do
-      let(:render) { render_inline(described_class.new(application, show_incomplete: true)) }
+    context 'and `editable` and `show_incomplete` are true' do
+      let(:render) { render_inline(described_class.new(application, editable: true, show_incomplete: true)) }
 
       context 'and no references exist on the application' do
         it 'warns that not enough references received and links to the appropriate page' do


### PR DESCRIPTION
This was showing in error on the application review page post submission, because candidates had not had the chance to check the "section complete" box for references. We will backfill the data in due course.

## Context

https://ukgovernmentdfe.slack.com/archives/CP18YJXPY/p1625841594161600
