### PR TITLE
Don't trigger builds from master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,9 @@ name: Build
 on:
   push:
     branches:
-      - master
       - main
   pull_request:
     branches:
-      - master
       - main
 
 jobs:
@@ -148,7 +146,7 @@ jobs:
     name: Trigger Deployment
     needs: [build, test]
     runs-on: ubuntu-latest
-    if: ${{ success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') }}
+    if: ${{ success() && github.ref == 'refs/heads/main' }}
     steps:
       - name: Trigger Deployment to QA and Staging
         uses: benc-uk/workflow-dispatch@v1.1

--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -2,7 +2,7 @@ name: Pull request checks
 
 on:
   pull_request:
-    branches: [ master, main ]
+    branches: [ main ]
     paths:
     - 'app/models/**'
 


### PR DESCRIPTION
## Context

`main` is now the default branch

## Changes proposed in this pull request

Remove references for `refs/heads/master` to trigger builds/deployments

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
