### PR TITLE
Add deliver_later to EoC deadline mailer

### DIFF
--- a/app/services/send_eoc_deadline_reminder_email_to_candidate.rb
+++ b/app/services/send_eoc_deadline_reminder_email_to_candidate.rb
@@ -1,6 +1,6 @@
 class SendEocDeadlineReminderEmailToCandidate
   def self.call(application_form:)
-    CandidateMailer.eoc_deadline_reminder(application_form)
+    CandidateMailer.eoc_deadline_reminder(application_form).deliver_later
     ChaserSent.create!(chased: application_form, chaser_type: :eoc_deadline_reminder)
   end
 end


### PR DESCRIPTION
## Context

`deliver_later` was missed from when CandidateMailer is called in the EoC mailer – original PR: [#5039](https://github.com/DFE-Digital/apply-for-teacher-training/pull/5039)

## Changes proposed in this pull request

Add `deliver_later`
```
class SendEocDeadlineReminderEmailToCandidate
  def self.call(application_form:)
    CandidateMailer.eoc_deadline_reminder(application_form).deliver_later
    ChaserSent.create!(chased: application_form, chaser_type: :eoc_deadline_reminder)
  end
end
```

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
