### PR TITLE
New org permissions setup start page

### DIFF
--- a/app/components/provider_interface/dsa_success_page_component.html.erb
+++ b/app/components/provider_interface/dsa_success_page_component.html.erb
@@ -11,7 +11,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= govuk_link_to t('continue'), provider_interface_provider_relationship_permissions_organisations_path, button: true %>
+      <%= govuk_link_to t('continue'), provider_interface_organisation_permissions_setup_index_path, button: true %>
     </p>
   <% else %>
     <h2 class="govuk-heading-m">

--- a/app/components/provider_interface/organisation_permissions_setup_list_component.html.erb
+++ b/app/components/provider_interface/organisation_permissions_setup_list_component.html.erb
@@ -1,0 +1,41 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= t('provider_interface.organisation_permissions_setup.index.title') %>
+    </h1>
+
+    <% if multiple_providers_to_set_up? %>
+      <p class="govuk-body">
+        <%= t('.multiple.introduction') %>
+      </p>
+      <p class="govuk-body">
+        <%= t('.multiple.cannot_manage_rules') %>
+      </p>
+    <% else %>
+      <p class="govuk-body">
+        <%= t('.single.introduction', provider_name: grouped_provider_names.keys.first) %>
+      </p>
+    <% end %>
+
+    <% grouped_provider_names.each do |main_provider_name, other_provider_list| %>
+      <% if multiple_providers_to_set_up? %>
+        <p class="govuk-body">
+          <%= t('.multiple.provider_list_heading', provider_name: main_provider_name) %>
+        </p>
+      <% end %>
+      <ul class="govuk-list govuk-list--bullet">
+        <% other_provider_list.each do |other_provider_name| %>
+          <li><%= other_provider_name %></li>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <% unless multiple_providers_to_set_up? %>
+      <p class="govuk-body">
+        <%= t('.single.cannot_manage_rules') %>
+      </p>
+    <% end %>
+
+    <%= govuk_button_to t('.continue_button'), continue_button_path %>
+  </div>
+</div>

--- a/app/components/provider_interface/organisation_permissions_setup_list_component.rb
+++ b/app/components/provider_interface/organisation_permissions_setup_list_component.rb
@@ -1,0 +1,14 @@
+module ProviderInterface
+  class OrganisationPermissionsSetupListComponent < ViewComponent::Base
+    attr_reader :grouped_provider_names, :continue_button_path
+
+    def initialize(grouped_provider_names:, continue_button_path:)
+      @grouped_provider_names = grouped_provider_names
+      @continue_button_path = continue_button_path
+    end
+
+    def multiple_providers_to_set_up?
+      @multiple_providers_to_set_up ||= grouped_provider_names.length > 1
+    end
+  end
+end

--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -1,0 +1,36 @@
+module ProviderInterface
+  class OrganisationPermissionsSetupController < ProviderInterfaceController
+    before_action :require_manage_organisations_permission!
+    before_action :redirect_unless_permissions_to_setup
+
+    def index
+      permission_setup_presenter = ProviderRelationshipPermissionSetupPresenter.new(
+        provider_relationship_permissions_needing_setup,
+        current_provider_user,
+      )
+      @sorted_and_grouped_provider_names = permission_setup_presenter.grouped_provider_names
+      @sorted_permission_ids = permission_setup_presenter.sorted_provider_permission_ids
+    end
+
+  private
+
+    def require_access_to_manage_provider_relationship_permissions!
+      provider_relationship_permissions = ProviderRelationshipPermissions.find(params[:id])
+      permitted_relationship_permissions = current_provider_user.authorisation.training_provider_relationships_that_actor_can_manage_organisations_for
+
+      render_403 unless permitted_relationship_permissions.include?(provider_relationship_permissions)
+    end
+
+    def redirect_unless_permissions_to_setup
+      redirect_to provider_interface_applications_path if provider_relationship_permissions_needing_setup.blank?
+    end
+
+    def provider_relationship_permissions_needing_setup
+      ProviderSetup.new(provider_user: current_provider_user).relationships_pending
+    end
+
+    def require_manage_organisations_permission!
+      render_404 unless current_provider_user.authorisation.can_manage_organisations_for_at_least_one_provider?
+    end
+  end
+end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -97,7 +97,7 @@ module ProviderInterface
       if @provider_setup.next_agreement_pending
         redirect_to provider_interface_new_data_sharing_agreement_path
       elsif @provider_setup.next_relationship_pending
-        redirect_to provider_interface_provider_relationship_permissions_organisations_path
+        redirect_to setup_organisation_permissions_path
       end
     end
 
@@ -105,7 +105,16 @@ module ProviderInterface
       [
         ProviderInterface::ProviderAgreementsController,
         ProviderInterface::ProviderRelationshipPermissionsSetupController,
+        ProviderInterface::OrganisationPermissionsSetupController,
       ].include?(request.controller_class)
+    end
+
+    def setup_organisation_permissions_path
+      if FeatureFlag.active?(:accredited_provider_setting_permissions)
+        provider_interface_organisation_permissions_setup_index_path
+      else
+        provider_interface_provider_relationship_permissions_organisations_path
+      end
     end
 
     def requires_make_decisions_permission

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -102,11 +102,15 @@ module ProviderInterface
     end
 
     def performing_provider_organisation_setup?
-      [
-        ProviderInterface::ProviderAgreementsController,
-        ProviderInterface::ProviderRelationshipPermissionsSetupController,
-        ProviderInterface::OrganisationPermissionsSetupController,
-      ].include?(request.controller_class)
+      setup_controllers = [ProviderInterface::ProviderAgreementsController]
+
+      setup_controllers << if FeatureFlag.active?(:accredited_provider_setting_permissions)
+                             ProviderInterface::OrganisationPermissionsSetupController
+                           else
+                             ProviderInterface::ProviderRelationshipPermissionsSetupController
+                           end
+
+      setup_controllers.include?(request.controller_class)
     end
 
     def setup_organisation_permissions_path

--- a/app/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter.rb
+++ b/app/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter.rb
@@ -5,6 +5,10 @@ module ProviderInterface
       @provider_user = provider_user
     end
 
+    def ordered_providers
+      ordered_provider_types.map { |provider_type| send("#{provider_type}_provider") }
+    end
+
     def provider_relationship_description
       provider_names = ordered_provider_types.map { |provider_type| name_for_provider_of_type(provider_type) }
       provider_names.join(' and ')

--- a/app/presenters/provider_interface/provider_relationship_permission_setup_presenter.rb
+++ b/app/presenters/provider_interface/provider_relationship_permission_setup_presenter.rb
@@ -1,0 +1,43 @@
+module ProviderInterface
+  class ProviderRelationshipPermissionSetupPresenter
+    def initialize(provider_relationship_permissions_list, provider_user)
+      @provider_relationship_permissions_list = provider_relationship_permissions_list
+      @provider_user = provider_user
+    end
+
+    def grouped_provider_names
+      sorted_and_grouped_provider_names_with_relationships.transform_values do |array|
+        array.map { |permission| permission[:other_provider_name] }
+      end
+    end
+
+    def sorted_provider_permission_ids
+      sorted_and_grouped_provider_names_with_relationships.values.flat_map do |array|
+        array.map { |permission| permission[:organisation_permission_id] }
+      end
+    end
+
+  private
+
+    attr_reader :provider_relationship_permissions_list, :provider_user
+
+    def sorted_and_grouped_provider_names_with_relationships
+      @sorted_and_grouped_provider_names_with_relationships ||= grouped_provider_names_with_relationships
+        .sort_by { |main_provider_name, _| main_provider_name }
+        .to_h
+        .transform_values do |provider_permission|
+          provider_permission.sort_by { |hash| hash[:other_provider_name] }
+        end
+    end
+
+    def grouped_provider_names_with_relationships
+      provider_relationship_permissions_list.each_with_object({}) do |prp, h|
+        presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(prp, provider_user)
+        main_provider = presenter.ordered_providers.first
+        other_provider = presenter.ordered_providers.second
+        h[main_provider.name] ||= []
+        h[main_provider.name] << { other_provider_name: other_provider.name, organisation_permission_id: prp.id }
+      end
+    end
+  end
+end

--- a/app/views/provider_interface/organisation_permissions_setup/index.html.erb
+++ b/app/views/provider_interface/organisation_permissions_setup/index.html.erb
@@ -1,0 +1,6 @@
+<% content_for :browser_title, t('.title') %>
+
+<%= render ProviderInterface::OrganisationPermissionsSetupListComponent.new(
+  grouped_provider_names: @sorted_and_grouped_provider_names,
+  continue_button_path: edit_provider_interface_organisation_permissions_setup_path(@sorted_permission_ids.first),
+) %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -27,7 +27,7 @@
       "check_name": "UnscopedFind",
       "message": "Unscoped call to `ProviderRelationshipPermissions#find`",
       "file": "app/controllers/provider_interface/provider_relationship_permissions_controller.rb",
-      "line": 32,
+      "line": 33,
       "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
       "code": "ProviderRelationshipPermissions.find(params[:id])",
       "render_path": null,
@@ -147,7 +147,7 @@
       "check_name": "UnscopedFind",
       "message": "Unscoped call to `ProviderRelationshipPermissions#find`",
       "file": "app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb",
-      "line": 113,
+      "line": 114,
       "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
       "code": "ProviderRelationshipPermissions.find(params[:id])",
       "render_path": null,
@@ -259,8 +259,28 @@
       "user_input": "audits_sql",
       "confidence": "Medium",
       "note": ""
+    },
+    {
+      "warning_type": "Unscoped Find",
+      "warning_code": 82,
+      "fingerprint": "edddf2b86e36c4cb5be692df0f01d5d6bcba4956421b752f096e902e092c1f26",
+      "check_name": "UnscopedFind",
+      "message": "Unscoped call to `ProviderRelationshipPermissions#find`",
+      "file": "app/controllers/provider_interface/organisation_permissions_setup_controller.rb",
+      "line": 18,
+      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
+      "code": "ProviderRelationshipPermissions.find(params[:id])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ProviderInterface::OrganisationPermissionsSetupController",
+        "method": "require_access_to_manage_provider_relationship_permissions!"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "note": ""
     }
   ],
-  "updated": "2021-06-17 17:15:11 +0100",
+  "updated": "2021-07-12 19:18:00 +0100",
   "brakeman_version": "5.0.4"
 }

--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -19,6 +19,18 @@ en:
       edit:
         heading: Organisation permissions
         submit_button: Save organisation permissions
+    organisation_permissions_setup:
+      index:
+        title: Set up organisation permissions
+    organisation_permissions_setup_list_component:
+      single:
+        introduction: 'Candidates can now apply through GOV.UK for courses %{provider_name} works on with:'
+        cannot_manage_rules: You cannot manage applications to these courses until you set up organisation permissions.
+      multiple:
+        introduction: Candidates can now apply through GOV.UK for courses you work on with partner organisations.
+        cannot_manage_rules: You cannot manage applications to these courses until either you or your partner organisations have set up organisation permissions.
+        provider_list_heading: 'For %{provider_name}, you need to set up permissions for courses you work on with:'
+      continue_button: Set up organisation permissions
     dsa_success_page_component:
       success_message: Data sharing agreement signed
       setup_permissions_message: Either you or your partner organisations must set up organisation permissions before you can manage teacher training applications.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -770,6 +770,14 @@ Rails.application.routes.draw do
 
     resources :organisation_settings, path: '/organisation-settings', only: :index
 
+    resources :organisation_permissions_setup, only: %i[index edit update], path: 'organisation-permissions/setup' do
+      collection do
+        get :check
+        post :commit
+        get :success
+      end
+    end
+
     scope path: '/provider-relationship-permissions' do
       get '/organisations-to-setup' => 'provider_relationship_permissions_setup#organisations',
           as: :provider_relationship_permissions_organisations

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -770,11 +770,13 @@ Rails.application.routes.draw do
 
     resources :organisation_settings, path: '/organisation-settings', only: :index
 
-    resources :organisation_permissions_setup, only: %i[index edit update], path: 'organisation-permissions/setup' do
-      collection do
-        get :check
-        post :commit
-        get :success
+    scope path: 'setup' do
+      resources :organisation_permissions_setup, only: %i[index edit update], path: 'organisation-permissions' do
+        collection do
+          get :check
+          post :commit
+          get :success
+        end
       end
     end
 

--- a/spec/components/previews/provider_interface/organisation_permissions_setup_list_component_preview.rb
+++ b/spec/components/previews/provider_interface/organisation_permissions_setup_list_component_preview.rb
@@ -1,0 +1,35 @@
+module ProviderInterface
+  class OrganisationPermissionsSetupListComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
+    def single
+      render OrganisationPermissionsSetupListComponent.new(
+        grouped_provider_names: {
+          'A university' => [
+            'One Uni',
+            'Two Uni',
+            'Three Uni',
+          ],
+        },
+        continue_button_path: '',
+      )
+    end
+
+    def multiple
+      render OrganisationPermissionsSetupListComponent.new(
+        grouped_provider_names: {
+          'My university' => [
+            'One School',
+            'Two School',
+            'Three School',
+          ],
+          'Local SD' => [
+            'University of school',
+            'Another uni',
+          ],
+        },
+        continue_button_path: '',
+      )
+    end
+  end
+end

--- a/spec/components/provider_interface/organisation_permissions_setup_list_component_spec.rb
+++ b/spec/components/provider_interface/organisation_permissions_setup_list_component_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::OrganisationPermissionsSetupListComponent do
+  let(:grouped_provider_names) do
+    {
+      'Main provider' => ['A Provider', 'B Provider'],
+    }
+  end
+  let(:path) { '/path' }
+  let(:render) do
+    render_inline(
+      described_class.new(
+        grouped_provider_names: grouped_provider_names,
+        continue_button_path: path,
+      ),
+    )
+  end
+
+  it 'renders the correct page title' do
+    expect(render.css('h1').first.text.squish).to eq('Set up organisation permissions')
+  end
+
+  it 'renders a button with the correct path' do
+    form = render.css('form').first
+    expect(form.attributes['action'].value).to eq(path)
+    expect(form.css('input').first.attributes['value'].value).to eq('Set up organisation permissions')
+  end
+
+  context 'when there is a single main provider' do
+    it 'renders the correct intro text' do
+      expect(render.css('p').first.text.squish).to eq('Candidates can now apply through GOV.UK for courses Main provider works on with:')
+    end
+
+    it 'renders the providers in order' do
+      expect(render.css('li').map(&:text)).to eq(grouped_provider_names['Main provider'])
+    end
+
+    it 'renders the text about managing applications' do
+      expect(render.css('p').last.text.squish).to eq('You cannot manage applications to these courses until you set up organisation permissions.')
+    end
+  end
+
+  context 'when there are multiple main providers' do
+    let(:grouped_provider_names) do
+      {
+        'First main provider' => ['A Provider', 'B Provider'],
+        'Second main provider' => ['Other Provider', 'Another Provider'],
+      }
+    end
+
+    it 'renders the correct intro text' do
+      expect(render.css('p')[0].text.squish).to eq('Candidates can now apply through GOV.UK for courses you work on with partner organisations.')
+    end
+
+    it 'renders the text about managing applications' do
+      expect(render.css('p')[1].text.squish).to eq('You cannot manage applications to these courses until either you or your partner organisations have set up organisation permissions.')
+    end
+
+    it 'does not renders the main provider name for each list' do
+      expect(render.css('p')[2].text.squish).to eq('For First main provider, you need to set up permissions for courses you work on with:')
+      expect(render.css('p')[3].text.squish).to eq('For Second main provider, you need to set up permissions for courses you work on with:')
+    end
+
+    it 'renders the providers in order' do
+      expected_provider_names = grouped_provider_names.values.flatten
+      expect(render.css('li').map(&:text)).to eq(expected_provider_names)
+    end
+  end
+end

--- a/spec/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter_spec.rb
+++ b/spec/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter_spec.rb
@@ -17,6 +17,24 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionAsProviderUserPr
 
   let(:presenter) { described_class.new(provider_relationship_permission, provider_user) }
 
+  describe '#ordered_providers' do
+    context 'when the user belongs to the training provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider]) }
+
+      it 'returns the training provider followed by the ratifying provider' do
+        expect(presenter.ordered_providers).to eq([training_provider, ratifying_provider])
+      end
+    end
+
+    context 'when the user belongs to the ratifying provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [ratifying_provider]) }
+
+      it 'returns the ratifying provider followed by the training provider' do
+        expect(presenter.ordered_providers).to eq([ratifying_provider, training_provider])
+      end
+    end
+  end
+
   describe '#provider_relationship_description_for' do
     context 'when the provider user is part of the training provider' do
       let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider]) }

--- a/spec/presenters/provider_interface/provider_relationship_permission_setup_presenter_spec.rb
+++ b/spec/presenters/provider_interface/provider_relationship_permission_setup_presenter_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ProviderRelationshipPermissionSetupPresenter do
+  let(:provider_1) { create(:provider, name: 'First provider') }
+  let(:provider_2) { create(:provider, name: 'Second provider') }
+  let(:provider_user) { create(:provider_user, providers: [provider_1, provider_2]) }
+  let(:org_permissions_list) do
+    other_provider_1 = create(:provider, name: 'B provider')
+    other_provider_2 = create(:provider, name: 'A provider')
+    other_provider_3 = create(:provider, name: 'School provider')
+    [
+      create(:provider_relationship_permissions, training_provider: provider_1, ratifying_provider: other_provider_1),
+      create(:provider_relationship_permissions, training_provider: provider_1, ratifying_provider: other_provider_2),
+      create(:provider_relationship_permissions, ratifying_provider: provider_2, training_provider: other_provider_3),
+    ]
+  end
+  let(:presenter) { described_class.new(org_permissions_list, provider_user) }
+
+  describe '#grouped_provider_names' do
+    it 'returns a hash with the main provider names as keys sorted alphabetically' do
+      sorted_names = [provider_1.name, provider_2.name].sort
+      expect(presenter.grouped_provider_names.keys).to eq(sorted_names)
+    end
+
+    it 'returns a hash with values sorted alphabetically' do
+      grouped_provider_names = presenter.grouped_provider_names
+      expect(grouped_provider_names[provider_1.name]).to eq(['A provider', 'B provider'])
+      expect(grouped_provider_names[provider_2.name]).to contain_exactly('School provider')
+    end
+  end
+
+  describe '#sorted_provider_permission_ids' do
+    it 'returns the ids of the permissions objects sorted by main provider name and then by other provider name' do
+      expect(presenter.sorted_provider_permission_ids).to eq([
+        org_permissions_list.second.id,
+        org_permissions_list.first.id,
+        org_permissions_list.last.id,
+      ])
+    end
+  end
+end

--- a/spec/requests/provider_interface/organisation_permissions_setup_controller_spec.rb
+++ b/spec/requests/provider_interface/organisation_permissions_setup_controller_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::OrganisationPermissionsSetupController do
+  let(:provider) { create(:provider, :with_signed_agreement) }
+  let(:provider_user) { create(:provider_user, :with_manage_organisations, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
+
+  before do
+    allow(DfESignInUser).to receive(:load_from_session)
+    .and_return(
+      DfESignInUser.new(
+        email_address: provider_user.email_address,
+        dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+        first_name: provider_user.first_name,
+        last_name: provider_user.last_name,
+      ),
+    )
+  end
+
+  context 'when there are permissions requiring setup' do
+    let(:ratifying_provider) { create(:provider) }
+    let!(:course) { create(:course, :open_on_apply, accredited_provider: ratifying_provider, provider: provider) }
+    let!(:permissions) do
+      create(
+        :provider_relationship_permissions,
+        ratifying_provider: ratifying_provider,
+        training_provider: provider,
+        setup_at: nil,
+      )
+    end
+
+    context 'when the accredited_provider_setting_permissions flag is on' do
+      before { FeatureFlag.activate(:accredited_provider_setting_permissions) }
+
+      it 'returns a 200 on the setup index page' do
+        get provider_interface_organisation_permissions_setup_index_path
+
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context 'when the accredited_provider_setting_permissions flag is off' do
+      before { FeatureFlag.deactivate(:accredited_provider_setting_permissions) }
+
+      it 'redirects to the old setup start page' do
+        get provider_interface_organisation_permissions_setup_index_path
+
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(provider_interface_provider_relationship_permissions_organisations_url)
+      end
+    end
+  end
+end

--- a/spec/requests/provider_interface/provider_interface_controller_spec.rb
+++ b/spec/requests/provider_interface/provider_interface_controller_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ProviderInterfaceController do
+  let(:provider) { create(:provider, :with_signed_agreement) }
+  let(:provider_user) { create(:provider_user, :with_manage_organisations, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
+
+  before do
+    allow(DfESignInUser).to receive(:load_from_session)
+    .and_return(
+      DfESignInUser.new(
+        email_address: provider_user.email_address,
+        dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+        first_name: provider_user.first_name,
+        last_name: provider_user.last_name,
+      ),
+    )
+  end
+
+  context 'when there are permissions requiring setup' do
+    let(:ratifying_provider) { create(:provider) }
+    let!(:course) { create(:course, :open_on_apply, accredited_provider: ratifying_provider, provider: provider) }
+    let!(:permissions) do
+      create(
+        :provider_relationship_permissions,
+        ratifying_provider: ratifying_provider,
+        training_provider: provider,
+        setup_at: nil,
+      )
+    end
+
+    context 'when the accredited_provider_setting_permissions flag is on' do
+      before { FeatureFlag.activate(:accredited_provider_setting_permissions) }
+
+      it 'redirects provider interface requests to the organisation permissions setup controller' do
+        get provider_interface_applications_path
+
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(provider_interface_organisation_permissions_setup_index_url)
+      end
+    end
+
+    context 'when the accredited_provider_setting_permissions flag is off' do
+      before { FeatureFlag.deactivate(:accredited_provider_setting_permissions) }
+
+      it 'redirects provider interface requests to the provider relationship permissions setup controller' do
+        get provider_interface_applications_path
+
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(provider_interface_provider_relationship_permissions_organisations_url)
+      end
+    end
+  end
+end

--- a/spec/requests/provider_interface/provider_relationship_permissions_request_spec.rb
+++ b/spec/requests/provider_interface/provider_relationship_permissions_request_spec.rb
@@ -81,6 +81,8 @@ RSpec.describe 'ProviderRelationshipPermissions', type: :request do
     end
     let!(:course) { create(:course, :open_on_apply, provider: provider, accredited_provider: ratifying_provider) }
 
+    before { FeatureFlag.deactivate(:accredited_provider_setting_permissions) }
+
     it 'tracks validation errors on save_permissions' do
       stub_model_instance_with_errors(
         ProviderInterface::ProviderRelationshipPermissionsSetupWizard,

--- a/spec/requests/provider_interface/setup_provider_relationship_permissions_request_spec.rb
+++ b/spec/requests/provider_interface/setup_provider_relationship_permissions_request_spec.rb
@@ -16,6 +16,42 @@ RSpec.describe 'Set up ProviderRelationshipPermissions', type: :request do
       )
   end
 
+  describe 'when there are permissions to set up' do
+    let(:provider_user) { create(:provider_user, :with_manage_organisations, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
+
+    before do
+      ratifying_provider = create(:provider)
+      create(
+        :provider_relationship_permissions,
+        ratifying_provider: ratifying_provider,
+        training_provider: provider,
+        setup_at: nil,
+      )
+      create(:course, :open_on_apply, accredited_provider: ratifying_provider, provider: provider)
+    end
+
+    context 'when the accredited_provider_setting_permissions flag is on' do
+      before { FeatureFlag.activate(:accredited_provider_setting_permissions) }
+
+      it 'redirects to the new setup start page' do
+        get provider_interface_provider_relationship_permissions_organisations_path
+
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(provider_interface_organisation_permissions_setup_index_url)
+      end
+    end
+
+    context 'when the accredited_provider_setting_permissions flag is off' do
+      before { FeatureFlag.deactivate(:accredited_provider_setting_permissions) }
+
+      it 'returns a 200 on the setup start page' do
+        get provider_interface_provider_relationship_permissions_organisations_path
+
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+
   describe 'invalid provider relationship params' do
     context 'GET edit' do
       it 'responds with 404' do

--- a/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.feature 'Setting up organisation permissions' do
+  include DfESignInHelpers
+
+  before { FeatureFlag.activate(:accredited_provider_setting_permissions) }
+
+  scenario 'Provider user sets up organisation permissions' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_can_manage_organisations
+    and_my_organisations_have_not_had_permissions_setup
+
+    when_i_sign_in_to_the_provider_interface
+    then_i_can_see_the_organisations_needing_permissions_setup
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_user_exists_in_apply_database
+  end
+
+  def and_i_can_manage_organisations
+    @provider_user = ProviderUser.last
+    @training_provider = Provider.find_by(code: 'ABC')
+    @ratifying_provider = Provider.find_by(code: 'DEF')
+
+    @another_ratifying_provider = create(:provider, :with_signed_agreement)
+    @another_training_provider = create(:provider, :with_signed_agreement)
+    @provider_user.provider_permissions.update_all(manage_organisations: true)
+  end
+
+  def and_my_organisations_have_not_had_permissions_setup
+    create(
+      :provider_relationship_permissions,
+      ratifying_provider: @another_ratifying_provider,
+      training_provider: @training_provider,
+      training_provider_can_make_decisions: false,
+      training_provider_can_view_safeguarding_information: false,
+      training_provider_can_view_diversity_information: false,
+      setup_at: nil,
+    )
+    create(:course, :open_on_apply, provider: @training_provider, accredited_provider: @another_ratifying_provider)
+
+    create(
+      :provider_relationship_permissions,
+      ratifying_provider: @ratifying_provider,
+      training_provider: @another_training_provider,
+      training_provider_can_make_decisions: false,
+      training_provider_can_view_safeguarding_information: false,
+      training_provider_can_view_diversity_information: false,
+      setup_at: nil,
+    )
+    create(:course, :open_on_apply, provider: @another_training_provider, accredited_provider: @ratifying_provider)
+  end
+
+  alias_method :when_i_sign_in_to_the_provider_interface, :and_i_sign_in_to_the_provider_interface
+
+  def then_i_can_see_the_organisations_needing_permissions_setup
+    expect(page).to have_content('Set up organisation permissions')
+    expect(page).to have_content('Candidates can now apply through GOV.UK for courses you work on with partner organisations')
+    expect(page).to have_content("For #{@training_provider.name}, you need to set up permissions for courses you work on with:")
+    expect(page).to have_content(@another_ratifying_provider.name)
+    expect(page).to have_content("For #{@ratifying_provider.name}, you need to set up permissions for courses you work on with:")
+    expect(page).to have_content(@another_training_provider.name)
+  end
+end


### PR DESCRIPTION
## Context
We are updating the organisation permissions set up flow to be more user friendly

## Changes proposed in this pull request
Add a new component and view to display sorted and grouped organisation permissions before the flow begins
Set up the controller so that the flow can easily be powered by the same permissions list (this keeps the order consistent)

## Guidance to review
Test in the review app

Have a play with the component preview - although it doesn't do much: the sorting and grouping is done in the controller

## Link to Trello card
https://trello.com/c/5xdYki9b/3907-add-new-permissions-setup-start-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
