### PR TITLE
Spike JMeter test plan for Apply

### DIFF
--- a/jmeter/plans/apply.rb
+++ b/jmeter/plans/apply.rb
@@ -6,87 +6,108 @@ def url(path)
   BASEURL + path
 end
 
-# 975 concurrent users, ~7 minutes per session
+def think(milliseconds = 500)
+  think_time milliseconds
+end
+
+# 975 concurrent users, 15 minute run time
 test do
   cookies clear_each_iteration: true
+  view_results_tree
   thread_count = 975
 
-  threads count: thread_count, continue_forever: true, duration: 420 do
+  threads count: thread_count, continue_forever: true, duration: 900 do
     #-> Sign up
     visit name: 'Account page', url: url('/candidate/account') do
       extract name: 'authenticity_token', regex: 'name="authenticity_token" value="(.+?)"'
     end
-    think_time 2000
+
+    think
+
     submit(
-      name: 'Account page - create an account', url: url('/candidate/account'),
+      'DO_MULTIPART_POST': 'true',
+      name: 'Account page - choose no existing account', url: url('/candidate/account'),
       fill_in: {
         'candidate_interface_create_account_or_sign_in_form[existing_account]' => 'false',
         'authenticity_token' => '${authenticity_token}',
       }
     )
-    think_time 1000
+
+    think
+
     visit name: 'Sign up page', url: url('/candidate/sign-up') do
       extract name: 'authenticity_token', regex: 'name="authenticity_token" value="(.+?)"'
     end
-    think_time 2000
+
+    think
+
     submit(
-      name: 'Sign up page - submit email', url: url('/candidate/account'),
+      'DO_MULTIPART_POST': 'true',
+      name: 'Sign up page - submit email', url: url('/candidate/sign-up'),
       fill_in: {
-        'authenticity_token': '${authenticity_token}',
         'candidate_interface_sign_up_form[email_address]': '${__threadNum}' + '@loadtest.example.com',
         'candidate_interface_sign_up_form[accept_ts_and_cs][]': '',
         'candidate_interface_sign_up_form[accept_ts_and_cs]': 'true',
+        'authenticity_token': '${authenticity_token}',
+        'commit': 'Continue',
+      }
+    ) do
+      # Assume that an authentication bypass is present which redirects to the magic link page at this point
+      extract name: 'sign_in_token', xpath: '//input[@type="hidden" and @name="token"]/@value', tolerant: true
+      extract name: 'authenticity_token', regex: 'name="authenticity_token" value="(.+?)"'
+    end
+
+    think
+
+    #-> Sign in
+    submit(
+      'DO_MULTIPART_POST': 'true',
+      name: 'Confirm authentication - continue', url: url('/candidate/sign-in/confirm'),
+      fill_in: {
+        'authenticity_token': '${authenticity_token}',
+        'token': '${sign_in_token}',
         'commit': 'Continue',
       }
     )
-    think_time 1000
 
-    #-> Sign in
-    visit name: 'Account page', url: url('/candidate/account') do
-      extract name: 'authenticity_token', regex: 'name="authenticity_token" value="(.+?)"'
-    end
-    think_time 2000
-    submit(
-      name: 'Account page - sign in', url: url('/candidate/account'),
-      fill_in: {
-        'candidate-interface-create-account-or-sign-in-form-email-field' => '${__threadNum}' + '@loadtest.example.com',
-        'authenticity_token' => '${authenticity_token}',
-      }
-    )
-    think_time 1000
-    # TODO: add a bypass to our auth logic that immediately signs in @loadtest.example.com email addresses
+    think
 
     #-> Partially navigate through course choice flow
     visit name: 'Do you know which course?', url: url('/candidate/application/courses/choose') do
       extract name: 'authenticity_token', regex: 'name="authenticity_token" value="(.+?)"'
     end
-    think_time 2000
+
+    think
+
     submit(
-      name: 'Do you know which course? - say yes', url: url('/candidate/account'),
+      'DO_MULTIPART_POST': 'true',
+      name: 'Do you know which course? - say yes', url: url('/candidate/application/courses/choose'),
       fill_in: {
         'candidate_interface_course_chosen_form[choice]' => 'yes',
         'authenticity_token' => '${authenticity_token}',
         'commit' => 'Continue',
       }
     )
-    think_time 1000
+
+    think
+
     visit name: 'Which training provider?', url: url('/candidate/application/courses/provider')
-    think_time 2000
+
+    think
 
     #-> View several other sections of the form
     visit name: 'References', url: url('/candidate/application/references/start')
-    think_time 2000
+    think
     visit name: 'Back to application', url: url('/candidate/application')
-    think_time 2000
+    think
     visit name: 'GCSE English', url: url('/candidate/application/gcse/english')
-    think_time 2000
+    think
     visit name: 'Back to application', url: url('/candidate/application')
-    think_time 2000
+    think
     visit name: 'Work history', url: url('/candidate/application/restructured-work-history')
-    think_time 2000
+    think
     visit name: 'Back to application', url: url('/candidate/application')
-    think_time 2000
+    think
     visit name: 'Personal statement', url: url('/candidate/application/personal-statement')
-    think_time 2000
   end
-end
+end.jmx

--- a/jmeter/plans/apply.rb
+++ b/jmeter/plans/apply.rb
@@ -1,0 +1,92 @@
+require 'ruby-jmeter'
+
+BASEURL = ENV.fetch('JMETER_TARGET_BASEURL')
+
+def url(path)
+  BASEURL + path
+end
+
+# 975 concurrent users, ~7 minutes per session
+test do
+  cookies clear_each_iteration: true
+  thread_count = 975
+
+  threads count: thread_count, continue_forever: true, duration: 420 do
+    #-> Sign up
+    visit name: 'Account page', url: url('/candidate/account') do
+      extract name: 'authenticity_token', regex: 'name="authenticity_token" value="(.+?)"'
+    end
+    think_time 2000
+    submit(
+      name: 'Account page - create an account', url: url('/candidate/account'),
+      fill_in: {
+        'candidate_interface_create_account_or_sign_in_form[existing_account]' => 'false',
+        'authenticity_token' => '${authenticity_token}',
+      }
+    )
+    think_time 1000
+    visit name: 'Sign up page', url: url('/candidate/sign-up') do
+      extract name: 'authenticity_token', regex: 'name="authenticity_token" value="(.+?)"'
+    end
+    think_time 2000
+    submit(
+      name: 'Sign up page - submit email', url: url('/candidate/account'),
+      fill_in: {
+        'authenticity_token': '${authenticity_token}',
+        'candidate_interface_sign_up_form[email_address]': '${__threadNum}' + '@loadtest.example.com',
+        'candidate_interface_sign_up_form[accept_ts_and_cs][]': '',
+        'candidate_interface_sign_up_form[accept_ts_and_cs]': 'true',
+        'commit': 'Continue',
+      }
+    )
+    think_time 1000
+
+    #-> Sign in
+    visit name: 'Account page', url: url('/candidate/account') do
+      extract name: 'authenticity_token', regex: 'name="authenticity_token" value="(.+?)"'
+    end
+    think_time 2000
+    submit(
+      name: 'Account page - sign in', url: url('/candidate/account'),
+      fill_in: {
+        'candidate-interface-create-account-or-sign-in-form-email-field' => '${__threadNum}' + '@loadtest.example.com',
+        'authenticity_token' => '${authenticity_token}',
+      }
+    )
+    think_time 1000
+    # TODO: add a bypass to our auth logic that immediately signs in @loadtest.example.com email addresses
+
+    #-> Partially navigate through course choice flow
+    visit name: 'Do you know which course?', url: url('/candidate/application/courses/choose') do
+      extract name: 'authenticity_token', regex: 'name="authenticity_token" value="(.+?)"'
+    end
+    think_time 2000
+    submit(
+      name: 'Do you know which course? - say yes', url: url('/candidate/account'),
+      fill_in: {
+        'candidate_interface_course_chosen_form[choice]' => 'yes',
+        'authenticity_token' => '${authenticity_token}',
+        'commit' => 'Continue',
+      }
+    )
+    think_time 1000
+    visit name: 'Which training provider?', url: url('/candidate/application/courses/provider')
+    think_time 2000
+
+    #-> View several other sections of the form
+    visit name: 'References', url: url('/candidate/application/references/start')
+    think_time 2000
+    visit name: 'Back to application', url: url('/candidate/application')
+    think_time 2000
+    visit name: 'GCSE English', url: url('/candidate/application/gcse/english')
+    think_time 2000
+    visit name: 'Back to application', url: url('/candidate/application')
+    think_time 2000
+    visit name: 'Work history', url: url('/candidate/application/restructured-work-history')
+    think_time 2000
+    visit name: 'Back to application', url: url('/candidate/application')
+    think_time 2000
+    visit name: 'Personal statement', url: url('/candidate/application/personal-statement')
+    think_time 2000
+  end
+end


### PR DESCRIPTION
## Context
We've completed some [initial analysis](https://docs.google.com/document/d/1Vzq9hquJ5LIbzu9FEYeySrwhnj4pDezJNZj0GMpe5C8/edit?usp=sharing) on expected load levels on Apply for the new cycle. Using this as a starting point, spike out what the JMeter test plan should look like.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This hasn't been tested yet, raising the PR for early visibility and feedback on the approach.

The plan outlines a set of steps to load test Apply. This covers:

- Signing up
- Signing in
- Starting (but not completing) the course choice flow
- Viewing several other sections of the form.

The plan uses as many threads as the projected concurrent user count,
and repeats on a loop for ~7 minutes, the average length of an Apply
session.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Steps are comprised of one of the following actions:
    - `visit`
    - `submit` (do a POST of some description)
    - `think_time n` (pause for *n*  milliseconds to simulate pauses by the user)
 - Github comments left inline with open questions.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/h9GePh0M
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
