### PR TITLE
Cleanse EOC chaser sent data

### DIFF
--- a/app/services/data_migrations/cleanse_eoc_chasers_sent_data.rb
+++ b/app/services/data_migrations/cleanse_eoc_chasers_sent_data.rb
@@ -1,0 +1,12 @@
+module DataMigrations
+  class CleanseEocChasersSentData
+    TIMESTAMP = 20210713100502
+    MANUAL_RUN = false
+
+    def change
+      ChaserSent
+      .where('chaser_type = ? AND chasers_sent.created_at < ?', 'eoc_deadline_reminder', Time.zone.local(2021, 7, 12, 14, 55))
+      .find_each(&:destroy!)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::CleanseEocChasersSentData',
   'DataMigrations::BackfillSetupInterviewsPermission',
   'DataMigrations::FixEmptyOfferConditions',
   'DataMigrations::RemoveSurplusReferenceSelections',

--- a/spec/services/data_migrations/cleanse_eoc_chasers_sent_data_spec.rb
+++ b/spec/services/data_migrations/cleanse_eoc_chasers_sent_data_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::CleanseEocChasersSentData do
+  it 'destoys any `eoc_deadline_reminder` chasers sent before 14.55 on the 12/7/2021' do
+    application_form = create(:application_form)
+    create(:chaser_sent, chaser_type: 'reference_request', chased: application_form, created_at: Time.zone.local(2021, 7, 12, 14, 54))
+    create(:chaser_sent, chaser_type: 'eoc_deadline_reminder', chased: application_form)
+    create(:chaser_sent, chaser_type: 'eoc_deadline_reminder', chased: application_form, created_at: Time.zone.local(2021, 7, 12, 14, 54))
+
+    described_class.new.change
+
+    expect(ChaserSent.count).to eq 2
+  end
+end


### PR DESCRIPTION
## Context

On 12/7 at 12pm the SendEocDeadlineReminderEmailToCandidatesWorker ran. However the deilver now method was not called on the mailer. This meant that no email was sent, but the line of code below ran which created ~20,000 ChaserSent's

Any created past 14:55 on the 12/7 were sent.

## Changes proposed in this pull request

- Destroy any `eoc_deadline_reminder` chasers created before 14:55 on 12/7 ( we ran the worker manually at 14.59

## Link to Trello card

https://trello.com/c/KmGE8xiA/3641-follow-up-work-for-the-end-of-cycle-deadlines-email

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
