### PR TITLE
Remove `Dear` heading from the EOC deadline email if the candidate has not provided a first name

### DIFF
--- a/app/views/candidate_mailer/eoc_deadline_reminder.erb
+++ b/app/views/candidate_mailer/eoc_deadline_reminder.erb
@@ -1,4 +1,6 @@
+<% if @application_form.first_name.present? %>
 Dear <%= @application_form.first_name %>,
+<% end %>
 
 # Complete your teacher training application – courses fill up quickly at this time of year
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -385,13 +385,12 @@ RSpec.describe CandidateMailer, type: :mailer do
   describe '.deadline_reminder' do
     context 'when a candidate is in Apply 1' do
       let(:email) { mailer.eoc_deadline_reminder(application_form) }
-
-      let(:application_form) { build_stubbed(:application_form, phase: 'apply_1') }
-      let(:application_choice) { build_stubbed(:application_choice, application_form: application_form) }
+      let(:application_form) { build_stubbed(:application_form, phase: 'apply_1', first_name: 'Fred') }
 
       it_behaves_like(
         'a mail with subject and content',
         'Submit your application before courses fill up',
+        'heading' => 'Dear Fred',
         'cycle_details' => "Submit your application as soon as you can to get on a course starting in the #{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year} academic year:",
         'details' => "The deadline to submit your application is 6pm on #{CycleTimetable.apply_1_deadline.to_s(:govuk_date)}",
       )
@@ -399,16 +398,24 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     context 'when a candidate is in Apply 2' do
       let(:email) { mailer.eoc_deadline_reminder(application_form) }
-
-      let(:application_form) { build_stubbed(:application_form, phase: 'apply_2') }
-      let(:application_choice) { build_stubbed(:application_choice, application_form: application_form) }
+      let(:application_form) { build_stubbed(:application_form, phase: 'apply_2', first_name: 'Fred') }
 
       it_behaves_like(
         'a mail with subject and content',
         'Submit your application before courses fill up',
+        'heading' => 'Dear Fred',
         'cycle_details' => "Submit your application as soon as you can to get on a course starting in the #{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year} academic year:",
         'details' => "The deadline to submit your application is 6pm on #{CycleTimetable.apply_2_deadline.to_s(:govuk_date)}",
       )
+    end
+
+    context 'when a candidate has not provided a first name' do
+      let(:email) { mailer.eoc_deadline_reminder(application_form) }
+      let(:application_form) { build_stubbed(:application_form, first_name: nil) }
+
+      it 'does not include a `Dear` heading' do
+        expect(email.body).not_to include('Dear')
+      end
     end
   end
 end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -725,6 +725,15 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.eoc_deadline_reminder(application_form)
   end
 
+  def eoc_deadline_reminder_with_no_first_name
+    application_form = FactoryBot.build(
+      :application_form,
+      first_name: nil,
+    )
+
+    CandidateMailer.eoc_deadline_reminder(application_form)
+  end
+
   def reinstated_offer_with_conditions
     application_choice = FactoryBot.build(
       :application_choice,


### PR DESCRIPTION
## Context

Yesterday we sent out a bunch of deadline reminder emails. Quite a large proportion have not provided a first name so the header just says 

```
Dear,
```

If a candidate has not provided a first name we should just skip the header.

## Changes proposed in this pull request

- Remove the `Dear` header from the EOC deadline reminder in no email address is present
with 

![image](https://user-images.githubusercontent.com/42515961/125437948-afbf59c4-2217-4904-95f7-fb2e3b3418af.png)



without

 
![image](https://user-images.githubusercontent.com/42515961/125436847-ee794772-a380-464d-8601-a0eec67ba910.png)

## Link to Trello card

https://trello.com/c/ZSxDbWTq/3640-dev-end-of-cycle-email-remove-dear-candidate-name-when-candidate-hasnt-filled-out-their-name-yet

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
