### PR TITLE
Ensure we only retrieve courses with course options for TestProvider

### DIFF
--- a/app/services/test_provider.rb
+++ b/app/services/test_provider.rb
@@ -8,7 +8,7 @@ class TestProvider
   def self.training_courses
     test_provider = find_or_create
 
-    existing_courses = test_provider.courses.where(
+    existing_courses = test_provider.courses.joins(:course_options).where(
       open_on_apply: true,
       recruitment_cycle_year: RecruitmentCycle.current_year,
     )

--- a/spec/services/test_provider_spec.rb
+++ b/spec/services/test_provider_spec.rb
@@ -25,9 +25,12 @@ RSpec.describe TestProvider do
   describe '.training_courses' do
     let!(:test_provider) { create(:provider, code: 'TEST') }
 
-    context 'when there are 3 or more existing open courses' do
+    context 'when there are 3 or more existing open courses with course options' do
       let!(:test_provider_courses) do
-        create_list(:course, 3, :open_on_apply, provider: test_provider)
+        create_list(:course_option, 3, course: create(:course, :open_on_apply, provider: test_provider)).map(&:course)
+      end
+      let!(:test_provider_courses_without_options) do
+        create(:course, :open_on_apply, provider: test_provider)
       end
 
       it 'returns the list of courses run by the training provider' do


### PR DESCRIPTION
## Context

`TestProvider.training_courses` should only return courses with course options.
Currently if a course without a course option is returned, an error is raised when we attempt to make applications to the course.

See https://sentry.io/organizations/dfe-bat/issues/2391273181/?project=1765973&referrer=slack

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Perform an `INNER JOIN` on `course_options` when finding test provider courses.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

The other course retrieval methods already perform this join, this is the only place I could find where a course might be returned without a course option.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/XuXJ4SGT/3541-missing-course-options-when-generating-test-data-through-the-api
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
