### PR TITLE
Make notify callbacks asynchronous 

### DIFF
--- a/app/controllers/integrations/notify_controller.rb
+++ b/app/controllers/integrations/notify_controller.rb
@@ -13,7 +13,7 @@ module Integrations
 
       process_notify_callback = ProcessNotifyCallback.new(notify_reference: params.fetch(:reference), status: params.fetch(:status))
 
-      process_notify_callback.call
+      ProcessNotifyCallbackWorker.perform_async(reference_status_parameters)
 
       if process_notify_callback.not_found?
         render_not_found

--- a/app/controllers/integrations/notify_controller.rb
+++ b/app/controllers/integrations/notify_controller.rb
@@ -11,15 +11,9 @@ module Integrations
       return render_unprocessable_entity if params.fetch(:status).nil?
       return render json: nil, status: :ok if params.fetch(:reference).nil?
 
-      process_notify_callback = ProcessNotifyCallback.new(notify_reference: params.fetch(:reference), status: params.fetch(:status))
-
       ProcessNotifyCallbackWorker.perform_async(reference_status_parameters)
 
-      if process_notify_callback.not_found?
-        render_not_found
-      else
-        render json: nil, status: :ok
-      end
+      render json: nil, status: :ok
     end
 
   private

--- a/app/controllers/integrations/notify_controller.rb
+++ b/app/controllers/integrations/notify_controller.rb
@@ -8,8 +8,8 @@ module Integrations
 
     def callback
       return render_unauthorized unless authorized?
-      return render_unprocessable_entity if params.fetch(:status).nil?
-      return render json: nil, status: :ok if params.fetch(:reference).nil?
+      return render_unprocessable_entity if params['status'].nil?
+      return render json: nil, status: :ok if params['reference'].nil?
 
       ProcessNotifyCallbackWorker.perform_async(reference_status_parameters)
 

--- a/app/workers/process_notify_callback_worker.rb
+++ b/app/workers/process_notify_callback_worker.rb
@@ -1,0 +1,10 @@
+class ProcessNotifyCallbackWorker
+  include Sidekiq::Worker
+
+  def perform(params)
+    ProcessNotifyCallback.new(
+      notify_reference: params.fetch('reference'),
+      status: params.fetch('status'),
+    ).call
+  end
+end

--- a/app/workers/process_notify_callback_worker.rb
+++ b/app/workers/process_notify_callback_worker.rb
@@ -1,6 +1,8 @@
 class ProcessNotifyCallbackWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: :low_priority
+
   def perform(params)
     ProcessNotifyCallback.new(
       notify_reference: params.fetch('reference'),

--- a/db/migrate/20210714120419_add_index_to_emails_notify_reference.rb
+++ b/db/migrate/20210714120419_add_index_to_emails_notify_reference.rb
@@ -1,0 +1,7 @@
+class AddIndexToEmailsNotifyReference < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :emails, :notify_reference, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_01_173512) do
+ActiveRecord::Schema.define(version: 2021_07_14_120419) do
 
   create_sequence "application_choices_id_seq"
   create_sequence "application_choices_id_seq1"
@@ -499,6 +499,7 @@ ActiveRecord::Schema.define(version: 2021_07_01_173512) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "delivery_status", default: "unknown", null: false
     t.index ["application_form_id"], name: "index_emails_on_application_form_id"
+    t.index ["notify_reference"], name: "index_emails_on_notify_reference", unique: true
   end
 
   create_table "english_proficiencies", force: :cascade do |t|

--- a/spec/requests/integrations/post_notify_callback_spec.rb
+++ b/spec/requests/integrations/post_notify_callback_spec.rb
@@ -39,14 +39,14 @@ RSpec.describe 'Notify Callback - POST /integrations/notify/callback', type: :re
     expect(response).to have_http_status(:unauthorized)
   end
 
-  it 'returns unprocessable entity if Notify reference is not provided' do
+  it 'returns success if Notify reference is not provided' do
     request_body = {
       status: 'permanent-failure',
     }.to_json
 
     post '/integrations/notify/callback', headers: headers, params: request_body
 
-    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response).to have_http_status(:success)
   end
 
   it 'returns unprocessable entity if Notify status is not provided' do

--- a/spec/requests/integrations/post_notify_callback_spec.rb
+++ b/spec/requests/integrations/post_notify_callback_spec.rb
@@ -81,22 +81,6 @@ RSpec.describe 'Notify Callback - POST /integrations/notify/callback', type: :re
     expect(response).to have_http_status(:unprocessable_entity)
   end
 
-  it 'returns not found if Notify reference includes unknown reference id' do
-    process_notify_callback = instance_double('ProcessNotifyCallback')
-    allow(ProcessNotifyCallback).to receive(:new).and_return(process_notify_callback)
-    allow(process_notify_callback).to receive(:call)
-    allow(process_notify_callback).to receive(:not_found?).and_return(true)
-
-    request_body = {
-      reference: "test-reference_request-#{reference.id}",
-      status: 'permanent-failure',
-    }.to_json
-
-    post '/integrations/notify/callback', headers: headers, params: request_body
-
-    expect(response).to have_http_status(:not_found)
-  end
-
   it 'updates the referee status if expected Notify reference and status' do
     request_body = {
       reference: "test-reference_request-#{reference.id}",

--- a/spec/workers/process_notify_callback_worker_spec.rb
+++ b/spec/workers/process_notify_callback_worker_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe ProcessNotifyCallbackWorker do
+  describe '#perform' do
+    it 'calls the process_notify_callback service' do
+      instantiated_service = instance_double(ProcessNotifyCallback)
+      allow(ProcessNotifyCallback).to receive(:new).and_return instantiated_service
+      allow(instantiated_service).to receive(:call)
+
+      described_class.new.perform({ 'reference' => 'foo', 'status' => 'bar' })
+
+      expect(ProcessNotifyCallback).to have_received(:new).with({ notify_reference: 'foo', status: 'bar' })
+      expect(instantiated_service).to have_received(:call)
+    end
+  end
+end


### PR DESCRIPTION
## Context

We recently caused a P1 incident by sending out 13,000 emails in a short space of time. This caused notify to ping us for each one to confirm they had been delivered.

One way that we could have avoided the requests overwhelming the service is to ensure that we enqueue our response to their callback in a job. 

## Changes proposed in this pull request

- have a worker handle the notify callback asynchronously  
- Index the notify_reference column in the emails table

## Guidance to review

Does this seem like the right approach? Unfortunately you still have to generate the service in the controller to generate the appropriate response

## Link to Trello card

https://trello.com/c/qSkBnTEx/3644-ensure-that-the-notify-callback-is-dealt-with-asynchronously

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
