### PR TITLE
Don’t zero-pad day in the "short month and year" format

### DIFF
--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -8,8 +8,8 @@ Date::DATE_FORMATS[:month_and_year] = '%B %Y'
 Time::DATE_FORMATS[:short_month_and_year] = '%b %Y'
 Date::DATE_FORMATS[:short_month_and_year] = '%b %Y'
 
-Time::DATE_FORMATS[:day_and_month] = '%d %B'
-Date::DATE_FORMATS[:day_and_month] = '%d %B'
+Time::DATE_FORMATS[:day_and_month] = '%-d %B'
+Date::DATE_FORMATS[:day_and_month] = '%-d %B'
 
 Time::DATE_FORMATS[:govuk_date_and_time] = lambda do |time|
   format = if time >= time.midday && time <= time.midday.end_of_minute


### PR DESCRIPTION
We should avoid zero-padding the day in the "short month and year" format, to avoid this:

<img width="986" alt="Screenshot 2021-07-14 at 16 29 48" src="https://user-images.githubusercontent.com/30665/125649811-60052267-e0a0-4123-a972-afde18c26639.png">

(The other date formats already do this)