### PR TITLE
Show site codes alongside vacancies in Support

### DIFF
--- a/app/components/support_interface/course_choices_table_component.html.erb
+++ b/app/components/support_interface/course_choices_table_component.html.erb
@@ -16,7 +16,7 @@
             <%= govuk_tag(text: 'Course no longer offered at this site', colour: 'red') %>
           <% end %>
 
-          <%= govuk_link_to(course_option.course.name_and_code, support_interface_course_path(course_option.course)) %> - <%= course_option.study_mode.humanize %> at <%= course_option.site.name %>
+          <%= govuk_link_to(course_option.course.name_and_code, support_interface_course_path(course_option.course)) %> - <%= course_option.study_mode.humanize %> at <%= course_option.site.name_and_code %>
         </td>
         <td class='govuk-table__cell'>
           <% if course_option.vacancies? %>

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -245,7 +245,7 @@ RSpec.feature 'Providers and courses' do
 
   def then_i_see_courses_with_vacancies
     expect(page).to have_title 'Primary (ABC1)'
-    expect(page).to have_content 'Primary (ABC1) - Full time at Main site Vacancies'
+    expect(page).to have_content 'Primary (ABC1) - Full time at Main site (X) Vacancies'
   end
 
   def when_i_visit_course


### PR DESCRIPTION
From support: candidates sometimes refer to sites by code in support requests.