### PR TITLE
Update Vendor API documentation

### DIFF
--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+## 15th July
+
+Documentation:
+
+- Add maximum lengths for the following fields: `other_ethnicity_details` and `other_disability_details`.
+
 ## 2nd July
 
 Documentation:

--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -3,6 +3,7 @@
 Documentation:
 
 - Add maximum lengths for the following fields: `other_ethnicity_details` and `other_disability_details`.
+- Add clarification on where changed course details can be found when changing on offer.
 
 ## 2nd July
 

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -1181,11 +1181,13 @@ components:
           type: string
           nullable: true
           description: The candidate’s description of their disability, if they selected “Other” and entered a value. This corresponds to HESA disability code `96`.
+          maxLength: 10240
           example: "My disability is..."
         other_ethnicity_details:
           type: string
           nullable: true
           description: The candidate’s description of their ethnicity, if they selected “Other” and entered a value.
+          maxLength: 10240
           example: "My ethnicity is..."
     Attribution:
       type: object

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -81,6 +81,8 @@ paths:
         If the application has already received an offer, POSTing a second offer will change that offer.
 
         The replacement offer must be for a different course to that originally offered.
+
+        After changing an offer, the updated course details are included in the Offer object. The Application Course object will always return the original course the candidate applied to.
       parameters:
       - "$ref": "#/components/parameters/application_id"
       requestBody:


### PR DESCRIPTION
## Context

We've had a few queries around field limits and where changed offer course details should be. Update the docs to include this info.

## Changes proposed in this pull request

- Add limits to the fields `other_ethnicity_details` and `other_disability_details`
- Add clarification on where original course details and changed course details are in an application after an offer is changed.

## Guidance to review

We currently don't limit the `other_ethnicity_details` and `other_disability_details` fields, so we left those out intentionally. Due to the vendor question I added them back in as that was what they were using. I'm still not sure as this value seems quite odd. Maybe we should just not add a limit after all?


## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
