### PR TITLE
Add JMeter app config and Manage/Vendor API test plans

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,7 @@ AllCops:
     - 'config/initializers/nationalities.rb'
     - 'features/support/env.rb'
     - 'vendor/**/*'
+    - 'jmeter/**/*'
 
 Bundler/OrderedGems:
   Enabled: false

--- a/jmeter/.dockerignore
+++ b/jmeter/.dockerignore
@@ -1,0 +1,6 @@
+.terraform
+*.tf
+*.tfvars
+*.tfstate
+*.env
+*token*

--- a/jmeter/.gitignore
+++ b/jmeter/.gitignore
@@ -1,0 +1,5 @@
+.terraform
+*.tfvars
+*token*
+!qa.tfvars
+!prod.tfvars

--- a/jmeter/Dockerfile
+++ b/jmeter/Dockerfile
@@ -1,0 +1,42 @@
+FROM ruby:2.7.4-alpine3.12
+ARG BUILD_DEPS="git gcc libc-dev make build-base libxml2-dev libxslt-dev"
+
+WORKDIR /app
+
+RUN apk -U upgrade && \
+    apk add --update --no-cache $BUILD_DEPS tzdata libxml2 libxslt curl unzip && \
+    echo "Europe/London" > /etc/timezone && \
+    cp /usr/share/zoneinfo/Europe/London /etc/localtime
+
+RUN apk update && apk add openjdk11-jre-headless
+
+ENV JMETER_VERSION="5.4.1"
+ENV JMETER_MIRROR https://downloads.apache.org/jmeter/binaries
+ENV JMETER_PATH /opt/apache-jmeter-${JMETER_VERSION}
+RUN cd /opt && \
+    curl -o apache-jmeter-${JMETER_VERSION}.tgz ${JMETER_MIRROR}/apache-jmeter-${JMETER_VERSION}.tgz && \
+    curl -o apache-jmeter-${JMETER_VERSION}.tgz.sha512 ${JMETER_MIRROR}/apache-jmeter-${JMETER_VERSION}.tgz.sha512 && \
+    sha512sum -c apache-jmeter-${JMETER_VERSION}.tgz.sha512 && \
+    tar xzf apache-jmeter-${JMETER_VERSION}.tgz && \
+    ln -s ${JMETER_PATH}/bin/jmeter /usr/local/bin
+
+RUN cd ${JMETER_PATH} && \
+    curl -o jmeter-prometheus.zip https://jmeter-plugins.org/files/packages/jmeter-prometheus-0.6.0.zip && \
+    unzip jmeter-prometheus.zip
+
+RUN cd ${JMETER_PATH} && \
+    curl -o jmeter-json.zip https://jmeter-plugins.org/files/packages/jpgc-json-2.7.zip && \
+    unzip -o jmeter-json.zip
+
+EXPOSE 8080
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+RUN mkdir plans
+COPY plans/ plans/
+
+ENV JMETER_TARGET_BASEURL=
+ENV JMETER_TARGET_PLAN=
+COPY add_prometheus_xml.rb ./
+COPY run.sh ./
+
+CMD ash ./run.sh

--- a/jmeter/Gemfile
+++ b/jmeter/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+ruby '2.7.4'
+
+gem 'ruby-jmeter'

--- a/jmeter/Gemfile.lock
+++ b/jmeter/Gemfile.lock
@@ -1,0 +1,40 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.4)
+      domain_name (~> 0.5)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0225)
+    mini_portile2 (2.5.3)
+    netrc (0.11.0)
+    nokogiri (1.11.7)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    racc (1.5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    ruby-jmeter (3.1.08)
+      nokogiri
+      rest-client
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ruby-jmeter
+
+RUBY VERSION
+   ruby 2.7.4p191
+
+BUNDLED WITH
+   2.1.4

--- a/jmeter/README.md
+++ b/jmeter/README.md
@@ -1,0 +1,40 @@
+## Deploying the app
+
+Make sure you are logged into the GitHub container register, this is required to publish the latest image to GHCR.
+
+```
+docker login -u github -p <GITHUB_TOKEN> ghcr.io
+```
+
+Build and publish the latest docker image by running `./build.sh` from your local terminal. This will build the docker image `[ghcr.io/dfe-digital/apply-jmeter-runner:latest]` and push it to GHCR.
+
+<br/><br/>
+
+Download and install [Terraform 0.14.9](https://releases.hashicorp.com/terraform/0.14.9)
+
+Create a `terraform.tfvars` file with the below content
+```
+cf_user         = "<paas user id>" # set to null if cf_sso_passcode is not null
+cf_password     = "<password>"     # set to null if cf_sso_passcode is not null
+cf_space        = "bat-qa" # or "bat-prod"
+cf_sso_passcode = null # or value obtained from https://login.london.cloud.service.gov.uk/passcode
+prometheus_app  = "prometheus-bat-qa" # "prometheus-bat" when space is bat-prod
+```
+
+if `cf_sso_passcode` is supplied make sure `cf_user` and `cf_password` are set to null.
+
+Then run the below commands from inside the `/jmeter` folder.
+
+```
+terraform init # Should be required only once.
+terraform apply -var-file qa.tfvars #or -var-file prod.tfvars
+```
+
+The app will be created in a stopped state, you have to manually start and stop the app for testing.
+
+```
+cf start apply-jmeter # to start the app
+cf stop apply-jmeter  # to stop the app
+```
+
+Run `terraform destroy` to delete the app once your testing is complete, you can run `terraform apply` again to recreate/update the app.

--- a/jmeter/add_prometheus_xml.rb
+++ b/jmeter/add_prometheus_xml.rb
@@ -1,0 +1,173 @@
+# See: # https://raw.githubusercontent.com/johrstrom/jmeter-prometheus-plugin/master/docs/examples/simple_prometheus_example.jmx
+
+prometheus_xml = <<PROMETHEUS_LISTENER_CONFIG
+      <com.github.johrstrom.listener.PrometheusListener guiclass="com.github.johrstrom.listener.gui.PrometheusListenerGui" testclass="com.github.johrstrom.listener.PrometheusListener" testname="Prometheus listener" enabled="true">
+        <collectionProp name="prometheus.collector_definitions">
+          <elementProp name="" elementType="com.github.johrstrom.listener.ListenerCollectorConfig">
+            <stringProp name="collector.help">the response time for a jsr223 sampler</stringProp>
+            <stringProp name="collector.metric_name">jmeter_response_times_as_hist</stringProp>
+            <stringProp name="collector.type">HISTOGRAM</stringProp>
+            <collectionProp name="collector.labels">
+              <stringProp name="102727412">label</stringProp>
+              <stringProp name="96801">app</stringProp>
+              <stringProp name="96802">guid</stringProp>
+              <stringProp name="96803">exported_instance</stringProp>
+              <stringProp name="96804">organisation</stringProp>
+              <stringProp name="96805">space</stringProp>
+            </collectionProp>
+            <stringProp name="collector.quantiles_or_buckets">100,500,1000,3000</stringProp>
+            <stringProp name="listener.collector.listen_to">samples</stringProp>
+            <stringProp name="listener.collector.measuring">ResponseTime</stringProp>
+          </elementProp>
+          <elementProp name="" elementType="com.github.johrstrom.listener.ListenerCollectorConfig">
+            <stringProp name="collector.help">the response time for a jsr223 sampler</stringProp>
+            <stringProp name="collector.metric_name">jmeter_response_times_as_summary</stringProp>
+            <stringProp name="collector.type">SUMMARY</stringProp>
+            <collectionProp name="collector.labels">
+              <stringProp name="102727412">label</stringProp>
+              <stringProp name="3059181">code</stringProp>
+              <stringProp name="102727412">label</stringProp>
+              <stringProp name="96801">app</stringProp>
+              <stringProp name="96802">guid</stringProp>
+              <stringProp name="96803">exported_instance</stringProp>
+              <stringProp name="96804">organisation</stringProp>
+              <stringProp name="96805">space</stringProp>
+            </collectionProp>
+            <stringProp name="collector.quantiles_or_buckets">0.75,0.5|0.95,0.1|0.99,0.01</stringProp>
+            <stringProp name="listener.collector.measuring">ResponseTime</stringProp>
+          </elementProp>
+          <elementProp name="" elementType="com.github.johrstrom.listener.ListenerCollectorConfig">
+            <stringProp name="collector.help">the total number of samplers</stringProp>
+            <stringProp name="collector.metric_name">jmeter_total_count</stringProp>
+            <stringProp name="collector.type">COUNTER</stringProp>
+            <collectionProp name="collector.labels">
+              <stringProp name="102727412">label</stringProp>
+              <stringProp name="96801">app</stringProp>
+              <stringProp name="96802">guid</stringProp>
+              <stringProp name="96803">exported_instance</stringProp>
+              <stringProp name="96804">organisation</stringProp>
+              <stringProp name="96805">space</stringProp>
+            </collectionProp>
+            <stringProp name="collector.quantiles_or_buckets"></stringProp>
+            <stringProp name="listener.collector.measuring">CountTotal</stringProp>
+          </elementProp>
+          <elementProp name="" elementType="com.github.johrstrom.listener.ListenerCollectorConfig">
+            <stringProp name="collector.help">the total number of successful samplers</stringProp>
+            <stringProp name="collector.metric_name">jmeter_total_success</stringProp>
+            <stringProp name="collector.type">COUNTER</stringProp>
+            <collectionProp name="collector.labels">
+              <stringProp name="102727412">label</stringProp>
+              <stringProp name="96801">app</stringProp>
+              <stringProp name="96802">guid</stringProp>
+              <stringProp name="96803">exported_instance</stringProp>
+              <stringProp name="96804">organisation</stringProp>
+              <stringProp name="96805">space</stringProp>
+            </collectionProp>
+            <stringProp name="collector.quantiles_or_buckets"></stringProp>
+            <stringProp name="listener.collector.measuring">SuccessTotal</stringProp>
+          </elementProp>
+          <elementProp name="" elementType="com.github.johrstrom.listener.ListenerCollectorConfig">
+            <stringProp name="collector.help">the response size for a jsr223 sampler</stringProp>
+            <stringProp name="collector.metric_name">jmeter_response_size_as_hist</stringProp>
+            <stringProp name="collector.type">HISTOGRAM</stringProp>
+            <collectionProp name="collector.labels">
+              <stringProp name="96801">app</stringProp>
+              <stringProp name="96802">guid</stringProp>
+              <stringProp name="96803">exported_instance</stringProp>
+              <stringProp name="96804">organisation</stringProp>
+              <stringProp name="96805">space</stringProp>
+            </collectionProp>
+            <stringProp name="collector.quantiles_or_buckets">100,500,1000,3000</stringProp>
+            <stringProp name="listener.collector.measuring">ResponseSize</stringProp>
+          </elementProp>
+          <elementProp name="" elementType="com.github.johrstrom.listener.ListenerCollectorConfig">
+            <stringProp name="collector.help">success ratio of the can_fail_sampler</stringProp>
+            <stringProp name="collector.metric_name">jmeter_success_ratio</stringProp>
+            <stringProp name="collector.type">SUCCESS_RATIO</stringProp>
+            <collectionProp name="collector.labels">
+              <stringProp name="96801">app</stringProp>
+              <stringProp name="96802">guid</stringProp>
+              <stringProp name="96803">exported_instance</stringProp>
+              <stringProp name="96804">organisation</stringProp>
+              <stringProp name="96805">space</stringProp>
+            </collectionProp>
+            <stringProp name="collector.quantiles_or_buckets"></stringProp>
+            <stringProp name="listener.collector.measuring">SuccessRatio</stringProp>
+          </elementProp>
+          <elementProp name="" elementType="com.github.johrstrom.listener.ListenerCollectorConfig">
+            <stringProp name="collector.help">the latency (ttfb) for a jsr223 sampler</stringProp>
+            <stringProp name="collector.metric_name">jmeter_latency_as_hist</stringProp>
+            <stringProp name="collector.type">HISTOGRAM</stringProp>
+            <collectionProp name="collector.labels">
+              <stringProp name="102727412">label</stringProp>
+              <stringProp name="96801">app</stringProp>
+              <stringProp name="96802">guid</stringProp>
+              <stringProp name="96803">exported_instance</stringProp>
+              <stringProp name="96804">organisation</stringProp>
+              <stringProp name="96805">space</stringProp>
+            </collectionProp>
+            <stringProp name="collector.quantiles_or_buckets">100,500,1000,3000</stringProp>
+            <stringProp name="listener.collector.measuring">Latency</stringProp>
+          </elementProp>
+          <elementProp name="" elementType="com.github.johrstrom.listener.ListenerCollectorConfig">
+            <stringProp name="collector.help">the idle time for a jsr223 sampler</stringProp>
+            <stringProp name="collector.metric_name">jmeter_idle_time</stringProp>
+            <stringProp name="collector.type">SUMMARY</stringProp>
+            <collectionProp name="collector.labels">
+              <stringProp name="96801">app</stringProp>
+              <stringProp name="96802">guid</stringProp>
+              <stringProp name="96803">exported_instance</stringProp>
+              <stringProp name="96804">organisation</stringProp>
+              <stringProp name="96805">space</stringProp>
+            </collectionProp>
+            <stringProp name="collector.quantiles_or_buckets">0.75,0.5|0.95,0.1|0.99,0.01</stringProp>
+            <stringProp name="listener.collector.measuring">IdleTime</stringProp>
+          </elementProp>
+        </collectionProp>
+        <stringProp name="TestPlan.comments">This listener &quot;measures&quot; everything, sometimes in summaries, sometimes in histograms.</stringProp>
+      </com.github.johrstrom.listener.PrometheusListener>
+      <hashTree/>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Define
+d Variables" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="app" elementType="Argument">
+            <stringProp name="Argument.name">app</stringProp>
+            <stringProp name="Argument.value">${__P(app,)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="guid" elementType="Argument">
+            <stringProp name="Argument.name">guid</stringProp>
+            <stringProp name="Argument.value">${__P(guid,)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="exported_instance" elementType="Argument">
+            <stringProp name="Argument.name">exported_instance</stringProp>
+            <stringProp name="Argument.value">${__P(exported_instance,)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="organisation" elementType="Argument">
+            <stringProp name="Argument.name">organisation</stringProp>
+            <stringProp name="Argument.value">${__P(organisation,)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="space" elementType="Argument">
+            <stringProp name="Argument.name">space</stringProp>
+            <stringProp name="Argument.value">${__P(space,)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+PROMETHEUS_LISTENER_CONFIG
+
+output = File.open('testplan.jmx', 'w')
+
+File.foreach('ruby-jmeter.jmx') do |line|
+  if line =~ /^    <\/hashTree>$/
+    output.puts(prometheus_xml)
+  end
+
+  output.puts line
+end
+
+output.close

--- a/jmeter/build.sh
+++ b/jmeter/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+IMAGE=ghcr.io/dfe-digital/apply-jmeter-runner:latest
+
+docker build -t $IMAGE .
+docker push $IMAGE

--- a/jmeter/plans/manage.rb
+++ b/jmeter/plans/manage.rb
@@ -1,0 +1,112 @@
+require 'ruby-jmeter'
+
+BASEURL = ENV.fetch('JMETER_TARGET_BASEURL')
+
+def log_in(user_id)
+  visit name: 'Provider user signs in', url: BASEURL + '/provider' do
+    extract name: 'csrf-token', regex: 'name="csrf-token" content="(.+?)"'
+  end
+  visit name: 'Go to sign in', url: BASEURL + '/provider/sign-in'
+  submit name: 'Authenticate', url: BASEURL + '/auth/developer/callback',
+    fill_in: { 'uid' => user_id }
+end
+
+test do
+  cookies clear_each_iteration: true
+
+  # Expected Oct usage per hour: 50 users, 12 sessions/user, 5 minutes per session
+  # Providers on average have 2-3 users
+  # Section below must have 25 uids, each belonging to a different provider
+  %w[
+    dev-support
+  ].each do |uid|
+
+    # Each thread below must take 5 minutes
+    # The total number of sessions for each uid (below) should be 12
+
+    # See interviewing application and interview information
+    threads count: 2, continue_forever: true, duration: 3600 do
+      log_in uid
+      think_time 3000
+      visit name: 'Filter by interviewing', url: BASEURL + '/provider/applications?commit=Apply+filters&status%5B%5D=interviewing' do
+        extract name: 'application_id', regex: 'href="/provider/applications/(\d+)"', match_number: 0
+      end
+      think_time 2000
+      visit name: 'Load interviewing application', url: BASEURL + '/provider/applications/${application_id}'
+      think_time 1000
+      visit name: 'See application interviews', url: BASEURL + '/provider/applications/${application_id}/interviews'
+      think_time 295000
+    end
+
+    # Start making an offer
+    threads count: 2, continue_forever: true, duration: 3600 do
+      log_in uid
+      think_time 1000
+      visit name: 'Filter by awaiting_provider_decision', url: BASEURL + '/provider/applications?commit=Apply+filters&status%5B%5D=awaiting_provider_decision' do
+        extract name: 'application_id', regex: 'href="/provider/applications/(\d+)"', match_number: 0
+      end
+      think_time 1000
+      visit name: 'Load received application', url: BASEURL + '/provider/applications/${application_id}'
+      think_time 1000
+      visit name: 'Load make decision page', url: BASEURL + '/provider/applications/${application_id}/decision/new' do
+        extract name: 'authenticity_token', regex: 'name="authenticity_token" value="(.+?)"'
+      end
+      think_time 1000
+      submit name: 'Start make offer flow', url: BASEURL + '/provider/applications/${application_id}/decision',
+        'DO_MULTIPART_POST': 'true',
+        fill_in: {
+          'provider_interface_offer_wizard[decision]' => 'make_offer',
+          'authenticity_token' => '${authenticity_token}',
+          commit: 'Continue'
+        }
+      think_time 295000
+    end
+
+    # See rejected application
+    threads count: 2, continue_forever: true, duration: 3600 do
+      log_in uid
+      think_time 2000
+      visit name: 'Filter by rejected', url: BASEURL + '/provider/applications?commit=Apply+filters&status%5B%5D=rejected' do
+        extract name: 'application_id', regex: 'href="/provider/applications/(\d+)"', match_number: 0
+      end
+      think_time 1000
+
+      visit name: 'Load rejected application', url: BASEURL + '/provider/applications/${application_id}'
+      think_time 1000
+      visit name: 'View application timeline', url: BASEURL + '/provider/applications/${application_id}/timeline'
+      think_time 1000
+      visit name: 'View application notes', url: BASEURL + '/provider/applications/${application_id}/notes'
+      think_time 295000
+    end
+
+    # See provider interview schedule
+    threads count: 2, continue_forever: true, duration: 3600 do
+      log_in uid
+      think_time 3000
+      visit name: 'See interview schedule', url: BASEURL + '/provider/interview-schedule'
+      think_time 3000
+      visit name: 'See past interview schedule', url: BASEURL + '/provider/interview-schedule/past'
+      think_time 295000
+    end
+
+    # See provider activity log
+    threads count: 2, continue_forever: true, duration: 3600 do
+      log_in uid
+      think_time 10000
+      visit name: 'Load activity log', url: BASEURL + '/provider/activity'
+      think_time 290000
+    end
+
+    # Data export
+     threads count: 2, continue_forever: true, duration: 3600 do
+      log_in uid
+      think_time 3000
+      visit name: 'Load provider data export form', url: BASEURL + '/provider/applications/data-export/new' do
+        extract name: 'provider_id', regex: 'value="(\d+)" name="provider_interface_application_data_export_form\[provider_ids\]', match_number: 0
+      end
+      think_time 2000
+      visit name: 'Download data export', url: BASEURL + '/provider/applications/data-export?provider_interface_application_data_export_form[recruitment_cycle_years][]=&provider_interface_application_data_export_form[recruitment_cycle_years][]=2021&provider_interface_application_data_export_form[recruitment_cycle_years][]=2020&provider_interface_application_data_export_form[application_status_choice]=all&provider_interface_application_data_export_form[statuses][]=&provider_interface_application_data_export_form[provider_ids][]=&provider_interface_application_data_export_form[provider_ids][]=${provider_id}&commit=Export+data+(CSV)'
+      think_time 295000
+    end
+  end
+end.jmx

--- a/jmeter/plans/test.rb
+++ b/jmeter/plans/test.rb
@@ -1,0 +1,16 @@
+require 'ruby-jmeter'
+
+BASEURL = ENV.fetch('JMETER_TARGET_BASEURL')
+
+test do
+  threads count: 1, continue_forever: true, duration: 300 do
+    visit name: 'Go to Manage', url: BASEURL + '/provider?jmeter=true'
+    think_time 1000, 1
+  end
+
+  threads count: 1, continue_forever: true, duration: 300 do
+    think_time 500, 1
+    visit name: 'Go to Apply', url: BASEURL + '/candidate/account?jmeter=true'
+    think_time 500, 1
+  end
+end.jmx

--- a/jmeter/plans/vendor.rb
+++ b/jmeter/plans/vendor.rb
@@ -1,0 +1,72 @@
+require 'ruby-jmeter'
+
+BASEURL = ENV.fetch('JMETER_TARGET_BASEURL')
+
+def set_headers(api_key)
+  header [
+    { name: 'Content-Type', value: 'application/json' },
+    { name: 'Authorization', value: "Bearer #{api_key}" },
+  ]
+end
+
+# Expected Oct usage per hour:
+#   71 SRS systems polling every hour for 90 days of data
+test do
+  # Section below must have 71 api keys, each belonging to a different provider
+  %w[
+    Xp9jU2_2BeDqsRP8Yy8C
+  ].each do |api_key|
+
+    # Sync applications (last 90 days) once every hour
+    threads count: 1, continue_forever: true, duration: 3600 do
+      set_headers api_key
+
+      params = { since: (Time.now - 7776000).strftime('%Y-%m-%dT%H:%M:%S.%L%z') }
+      visit name: 'API Sync applications',
+        url: BASEURL + '/api/v1/applications',
+        raw_body: params.to_json do
+          with_xhr
+        end
+
+      think_time 1800000
+    end
+
+    # Make offer
+    threads count: 1, continue_forever: true, duration: 3600 do
+      set_headers api_key
+
+      params = { since: (Time.now - 7776000).strftime('%Y-%m-%dT%H:%M:%S.%L%z') }
+      visit name: 'API Sync applications',
+        url: BASEURL + '/api/v1/applications',
+        raw_body: params.to_json do
+          extract name: 'last_application_id', json: '$.data[-1].id'
+          with_xhr
+        end
+
+      offer_payload = {
+        data: {
+          conditions: [
+            'Completion of subject knowledge enhancement',
+            'Completion of professional skills test'
+          ]
+        },
+        meta: {
+          attribution: {
+            full_name: 'Jane Smith',
+            email: 'jane.smith@example.com',
+            user_id: '12345'
+          },
+          timestamp: (Time.now - 7776000).strftime('%Y-%m-%dT%H:%M:%S.%L%z')
+        }
+      }
+
+      submit name: 'API Make offer',
+        url: BASEURL + '/api/v1/applications/${last_application_id}/offer',
+        raw_body: offer_payload.to_json do
+          with_xhr
+        end
+
+      think_time 30000
+    end
+  end
+end.jmx

--- a/jmeter/prod.tfvars
+++ b/jmeter/prod.tfvars
@@ -1,0 +1,6 @@
+app_env_variables = {
+  JMETER_TARGET_PLAN      = "manage"
+  JMETER_TARGET_BASEURL   = "https://apply-load-test.london.cloudapps.digital"
+  JMETER_TARGET_APP       = "apply-load-test"
+  JMETER_TARGET_APP_SPACE = "bat-prod"
+}

--- a/jmeter/qa.tfvars
+++ b/jmeter/qa.tfvars
@@ -1,0 +1,6 @@
+app_env_variables = {
+  JMETER_TARGET_PLAN      = "test"
+  JMETER_TARGET_BASEURL   = "https://qa.apply-for-teacher-training.service.gov.uk"
+  JMETER_TARGET_APP       = "apply-qa"
+  JMETER_TARGET_APP_SPACE = "bat-qa"
+}

--- a/jmeter/run.sh
+++ b/jmeter/run.sh
@@ -1,0 +1,8 @@
+if [ -z "$JMETER_TARGET_PLAN" ]; then exit 1; fi
+
+bundle exec ruby plans/$JMETER_TARGET_PLAN.rb && \
+  bundle exec ruby add_prometheus_xml.rb && \
+    jmeter -Japp=$JMETER_TARGET_APP -Jguid=$CF_INSTANCE_GUID -Jorganisation=dfe \
+    -Jspace=$JMETER_TARGET_APP_SPACE -Jinstance=$CF_INSTANCE_INTERNAL_IP:8080 -Jexported_instance=$CF_INSTANCE_INDEX \
+    -Jprometheus.ip=0.0.0.0 -Jprometheus.save.jvm=false \
+    -Jprometheus.port=8080 -Jprometheus.delay=120 -n -t testplan.jmx

--- a/jmeter/terraform.tf
+++ b/jmeter/terraform.tf
@@ -1,0 +1,88 @@
+terraform {
+  required_version = "~> 0.14.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "2.53.0"
+    }
+    cloudfoundry = {
+      source  = "cloudfoundry-community/cloudfoundry"
+      version = "0.13.0"
+    }
+  }
+}
+
+provider "cloudfoundry" {
+  api_url           = "https://api.london.cloud.service.gov.uk"
+  user              = var.cf_sso_passcode == null ? var.cf_user : null
+  password          = var.cf_sso_passcode == null ? var.cf_password : null
+  sso_passcode      = var.cf_sso_passcode != null ? var.cf_sso_passcode : null
+  store_tokens_path = var.cf_sso_passcode != null ? ".cftoken" : null
+}
+
+resource "cloudfoundry_app" "jmeter_app" {
+  name                 = local.app_name
+  docker_image         = local.docker_image
+  health_check_type    = "process"
+  health_check_timeout = 180
+  stopped              = true
+  instances            = 1
+  memory               = 1024
+  space                = data.cloudfoundry_space.space.id
+  environment          = local.app_env_variables
+  routes {
+    route = cloudfoundry_route.jmeter_app_internal_route.id
+  }
+  routes {
+    route = cloudfoundry_route.jmeter_cloudpps_route.id
+  }
+}
+
+data "cloudfoundry_app" "jmeter_app" {
+  depends_on = [cloudfoundry_app.jmeter_app]
+  name_or_id = cloudfoundry_app.jmeter_app.name
+  space      = data.cloudfoundry_space.space.id
+}
+
+data "cloudfoundry_app" "prometheus_app" {
+  name_or_id = var.prometheus_app
+  space      = data.cloudfoundry_space.space.id
+}
+
+resource "cloudfoundry_network_policy" "prometheus_policy" {
+  depends_on = [data.cloudfoundry_app.jmeter_app]
+  policy {
+    source_app      = data.cloudfoundry_app.prometheus_app.id
+    destination_app = data.cloudfoundry_app.jmeter_app.id
+    port            = "8080"
+  }
+}
+
+resource "cloudfoundry_route" "jmeter_app_internal_route" {
+  domain   = data.cloudfoundry_domain.internal.id
+  space    = data.cloudfoundry_space.space.id
+  hostname = local.app_name
+}
+
+resource "cloudfoundry_route" "jmeter_cloudpps_route" {
+  domain   = data.cloudfoundry_domain.london_cloudapps_digital.id
+  space    = data.cloudfoundry_space.space.id
+  hostname = local.app_name
+}
+
+data "cloudfoundry_org" "org" {
+  name = "dfe"
+}
+
+data "cloudfoundry_space" "space" {
+  name = var.cf_space
+  org  = data.cloudfoundry_org.org.id
+}
+
+data "cloudfoundry_domain" "internal" {
+  name = "apps.internal"
+}
+
+data "cloudfoundry_domain" "london_cloudapps_digital" {
+  name = "london.cloudapps.digital"
+}

--- a/jmeter/variables.tf
+++ b/jmeter/variables.tf
@@ -1,0 +1,17 @@
+variable "cf_user" { default = null }
+
+variable "cf_password" { default = null }
+
+variable "cf_sso_passcode" { default = null }
+
+variable "cf_space" { default = "bat-qa" }
+
+variable "prometheus_app" { default = null }
+
+variable "app_env_variables" {}
+
+locals {
+  app_name          = "apply-jmeter"
+  docker_image      = "ghcr.io/dfe-digital/apply-jmeter-runner:latest"
+  app_env_variables = var.app_env_variables
+}


### PR DESCRIPTION
## Context

We need a way to create realistic load tests and run them in preparation for the new cycle. This PR introduces a Dockerfile for a custom JMeter image, which includes a couple of plugins, namely a prometheus plugin for JMeter metrics and a json plugin for extracting information from JSON responses.

## Changes proposed in this pull request

Add a `jmeter/` folder with the relevant Dockerfile and terraform configuration. Add a `plans/` folder within with `ruby-jmeter` scenaria the jmeter containers may run. We have used `ruby-jmeter` before as part of https://github.com/DFE-Digital/apply-for-teacher-training/pull/2960.

## Guidance to review

To test against a local environment:

```bash
cd jmeter
docker build . -t jmeter
docker run --rm -ti --net=host -e JMETER_TARGET_BASEURL=http://localhost:3000 -e JMETER_TARGET_PLAN=test jmeter
```

While the test is running, visit `http://localhost:8080` in your browser to see prometheus metrics accumulating.

You can stop the load test with Ctrl-C. Alternatively, the docker container will terminate once the jmeter test completes.

## Link to Trello card

https://trello.com/c/lqchzM6g

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
