### PR TITLE
Add an authentication shortcut for load testing accounts

### DIFF
--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -16,15 +16,15 @@ module CandidateInterface
       @sign_up_form = CandidateInterface::SignUpForm.new(candidate_sign_up_form_params)
 
       if @sign_up_form.existing_candidate?
-        CandidateInterface::RequestMagicLink.for_sign_in(candidate: @sign_up_form.candidate)
+        magic_link_token = CandidateInterface::RequestMagicLink.for_sign_in(candidate: @sign_up_form.candidate)
         set_user_context @sign_up_form.candidate.id
         candidate = Candidate.find(@sign_up_form.candidate.id)
         candidate.update!(course_from_find_id: @sign_up_form.course_from_find_id)
-        redirect_to candidate_interface_check_email_sign_up_path
+        redirect_after_signup(candidate, magic_link_token)
       elsif @sign_up_form.save
-        CandidateInterface::RequestMagicLink.for_sign_up(candidate: @sign_up_form.candidate)
+        magic_link_token = CandidateInterface::RequestMagicLink.for_sign_up(candidate: @sign_up_form.candidate)
         set_user_context @sign_up_form.candidate.id
-        redirect_to candidate_interface_check_email_sign_up_path
+        redirect_after_signup(@sign_up_form.candidate, magic_link_token)
       else
         track_validation_error(@sign_up_form)
         redirect_to candidate_interface_external_sign_up_forbidden_path and return if external_sign_up_forbidden?
@@ -38,6 +38,14 @@ module CandidateInterface
     def external_sign_up_forbidden; end
 
   private
+
+    def redirect_after_signup(candidate, magic_link_token)
+      if candidate.load_tester?
+        redirect_to candidate_interface_authenticate_url(token: magic_link_token)
+      else
+        redirect_to candidate_interface_check_email_sign_up_path
+      end
+    end
 
     def external_sign_up_forbidden?
       @sign_up_form.errors.details[:email_address].include?(error: :dfe_signup_only)

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -44,6 +44,10 @@ class Candidate < ApplicationRecord
     "C#{id}"
   end
 
+  def load_tester?
+    email_address.include?('@loadtest.example.com') && !HostingEnvironment.production?
+  end
+
 private
 
   def downcase_email

--- a/app/services/candidate_interface/request_magic_link.rb
+++ b/app/services/candidate_interface/request_magic_link.rb
@@ -3,12 +3,14 @@ module CandidateInterface
     def self.for_sign_in(candidate:, path: nil)
       magic_link_token = candidate.create_magic_link_token!(path: path)
       AuthenticationMailer.sign_in_email(candidate: candidate, token: magic_link_token).deliver_later
+      magic_link_token
     end
 
     def self.for_sign_up(candidate:)
       magic_link_token = candidate.create_magic_link_token!
       AuthenticationMailer.sign_up_email(candidate: candidate, token: magic_link_token).deliver_later
       StateChangeNotifier.sign_up(candidate)
+      magic_link_token
     end
   end
 end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -81,4 +81,31 @@ RSpec.describe Candidate, type: :model do
       expect(candidate.encrypted_id).to eq 'encrypted id value'
     end
   end
+
+  describe '#load_tester?' do
+    context 'environment is production' do
+      before { allow(HostingEnvironment).to receive(:production?).and_return true }
+
+      it 'returns false regardless of the email address pattern' do
+        candidate = build(:candidate, email_address: 'someone@loadtest.example.com')
+        expect(candidate).not_to be_load_tester
+        candidate.email_address = 'someone@example.com'
+        expect(candidate).not_to be_load_tester
+      end
+    end
+
+    context 'environment is not production' do
+      before { allow(HostingEnvironment).to receive(:production?).and_return false }
+
+      it 'returns true if email address is for load testing' do
+        candidate = build(:candidate, email_address: 'someone@loadtest.example.com')
+        expect(candidate).to be_load_tester
+      end
+
+      it 'returns false if email is not for load testing' do
+        candidate = build(:candidate, email_address: 'someone@example.com')
+        expect(candidate).not_to be_load_tester
+      end
+    end
+  end
 end


### PR DESCRIPTION


## Context
When load testing Apply, test users driven by JMeter will create
accounts. We need some way to sign in these users via the magic link
that gets emailed out.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Introduce logic to the SignUpController that checks for a load testing
email address, and if found redirects the candidate to the magic link.

I originally assumed this would be merged into master, hence the presence of a feature flag check. Spoke with @mnacos , however, and it looks like we'll probably have a separate branch that contains various changes just for the load testing environment (eg - disabling certain side effects, 3rd party services, etc). @vigneshmsft do we have this branch created yet?

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/h9GePh0M
## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
