### PR TITLE
Differentiate error message for line 2 of the address

### DIFF
--- a/config/locales/candidate_interface/contact_details.yml
+++ b/config/locales/candidate_interface/contact_details.yml
@@ -55,9 +55,9 @@ en:
               too_long: Phone number must be %{count} characters or fewer
             address_line1:
               blank: Enter your building and street
-              too_long: Building and street must be %{count} characters or fewer
+              too_long: Building and street line 1 must be %{count} characters or fewer
             address_line2:
-              too_long: Building and street must be %{count} characters or fewer
+              too_long: Building and street line 2 must be %{count} characters or fewer
             address_line3:
               blank: Enter your town or city
               too_long: Town or city must be %{count} characters or fewer

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -149,9 +149,9 @@ en:
           attributes:
             address_line1:
               blank: Enter your building and street
-              too_long: Building and street must be %{count} characters or fewer
+              too_long: Building and street line 1 must be %{count} characters or fewer
             address_line2:
-              too_long: Building and street must be %{count} characters or fewer
+              too_long: Building and street line 2 must be %{count} characters or fewer
             address_line3:
               blank: Enter your town or city
               too_long: Town or city must be %{count} characters or fewer


### PR DESCRIPTION
## Context

If a user enters too many characters for the second line, the error message should be something like

> Building and street line 2 must be 50 characters or fewer

...to differentiate it from the first line.

## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/47917431/125799246-0882a23f-a4a5-406c-923c-31e891078764.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Tewe2DVX/3574-uk-address-form-should-differentiate-error-messages-for-line-2-of-the-address

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
