### PR TITLE
Remove unique constraint from `notify_reference` index

### DIFF
--- a/db/migrate/20210714120419_add_index_to_emails_notify_reference.rb
+++ b/db/migrate/20210714120419_add_index_to_emails_notify_reference.rb
@@ -2,6 +2,6 @@ class AddIndexToEmailsNotifyReference < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 
   def change
-    add_index :emails, :notify_reference, unique: true, algorithm: :concurrently
+    add_index :emails, :notify_reference, algorithm: :concurrently
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -450,7 +450,7 @@ ActiveRecord::Schema.define(version: 2021_07_14_120419) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "delivery_status", default: "unknown", null: false
     t.index ["application_form_id"], name: "index_emails_on_application_form_id"
-    t.index ["notify_reference"], name: "index_emails_on_notify_reference", unique: true
+    t.index ["notify_reference"], name: "index_emails_on_notify_reference"
   end
 
   create_table "english_proficiencies", force: :cascade do |t|


### PR DESCRIPTION
## Context

There are already non-unique indexes for this so it won't build 

## Changes proposed in this pull request

- Remove the constraint

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
