### PR TITLE
Send anonymised_user_agent_and_ip to BigQuery

### DIFF
--- a/app/lib/events/event.rb
+++ b/app/lib/events/event.rb
@@ -31,6 +31,7 @@ module Events
         request_path: rack_request.path,
         request_query: hash_to_kv_pairs(Rack::Utils.parse_query(rack_request.query_string)),
         request_referer: rack_request.referer,
+        anonymised_user_agent_and_ip: anonymised_user_agent_and_ip(rack_request),
       )
 
       self
@@ -82,6 +83,16 @@ module Events
       hash.map do |(key, value)|
         { 'key' => key, 'value' => Array.wrap(value) }
       end
+    end
+
+    def anonymised_user_agent_and_ip(rack_request)
+      if rack_request.remote_ip.present?
+        anonymise(rack_request.user_agent.to_s + rack_request.remote_ip.to_s)
+      end
+    end
+
+    def anonymise(text)
+      Digest::SHA2.hexdigest(text)
     end
   end
 end

--- a/config/event-schema.json
+++ b/config/event-schema.json
@@ -41,6 +41,9 @@
         {"type": "null"}
       ]
     },
+    "anonymised_user_agent_and_ip": {
+      "type": "string"
+    },
     "response_content_type": {
       "type": "string"
     },

--- a/spec/lib/events/event_spec.rb
+++ b/spec/lib/events/event_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe Events::Event do
+  it 'can append request details' do
+    event = Events::Event.new
+    output = event.with_request_details(fake_request).as_json
+
+    expect(output).to match a_hash_including({
+      'request_uuid' => '123',
+      'request_user_agent' => 'SomeClient',
+      'request_method' => 'GET',
+      'request_path' => '/',
+      'request_query' => [],
+      'request_referer' => nil,
+    })
+  end
+
+  describe 'anonymised_user_agent_and_ip' do
+    subject(:field) do
+      request = fake_request(
+        remote_ip: remote_ip,
+        user_agent: user_agent,
+      )
+
+      event = Events::Event.new
+      event.with_request_details(request).as_json['anonymised_user_agent_and_ip']
+    end
+
+    context 'user agent and IP are both present' do
+      let(:user_agent) { 'SomeClient' }
+      let(:remote_ip) { '1.2.3.4' }
+
+      it { is_expected.to eq '90d5c396fe8da875d25688dfec3f2881c52e81507614ba1958262c8443db29c5' }
+    end
+
+    context 'user agent is present but IP is not' do
+      let(:user_agent) { 'SomeClient' }
+      let(:remote_ip) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'IP is present but user agent is not' do
+      let(:user_agent) { nil }
+      let(:remote_ip) { '1.2.3.4' }
+
+      it { is_expected.to eq '6694f83c9f476da31f5df6bcc520034e7e57d421d247b9d34f49edbfc84a764c' }
+    end
+
+    context 'neither IP not user agent is present' do
+      let(:user_agent) { nil }
+      let(:remote_ip) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  def fake_request(overrides = {})
+    attrs = {
+      uuid: '123',
+      method: 'GET',
+      path: '/',
+      query_string: '',
+      referer: nil,
+      user_agent: 'SomeClient',
+      remote_ip: '1.2.3.4',
+    }.merge(overrides)
+
+    instance_double(ActionDispatch::Request, attrs)
+  end
+end


### PR DESCRIPTION
As on Find, we only send a value if we have a remote_ip for the user

## Context

We want to be able to group events by user, but we don't want PII (which includes IPs) in BigQuery. Copy the TVS approach [already implemented in Find](https://github.com/DFE-Digital/find-teacher-training/pull/833).

## Changes proposed in this pull request

Add `anonymised_user_agent_and_ip` field to the request details we send to BQ.

## Link to Trello card

https://trello.com/c/hBfnkeMI/3626-add-user-anonymous-identifier-field-to-event-being-sent-to-bq-apply

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
