### PR TITLE
Suppress Google::Cloud::Errors in Sentry

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -15,6 +15,7 @@ OkComputer.mount_at = 'integrations/monitoring'
 
 OkComputer::Registry.register 'postgres', OkComputer::ActiveRecordCheck.new
 OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ENV['REDIS_URL'])
+OkComputer::Registry.register 'sidekiq_low_priority_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'low_priority', threshold: 100) # threshold in seconds
 OkComputer::Registry.register 'sidekiq_default_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'default', threshold: 100) # threshold in seconds
 OkComputer::Registry.register 'sidekiq_mailers_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'mailers', threshold: 100) # threshold in seconds
 OkComputer::Registry.register 'simulated_failure', SimulatedFailureCheck.new

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -30,5 +30,12 @@ Raven.configure do |config|
     # in Sentry.
     'Redis::TimeoutError',
     'Redis::CannotConnectError',
+
+    # Google cloud (ie Bigquery) errors are usually caused by transient network
+    # issues. If there's a genuine problem the queues will stack up and the Sidekiq
+    # latency check will alert. That takes at most 100 seconds to happen, so if
+    # something is actually wrong it's not meaningfully less useful than hearing about
+    # it via Sentry.
+    'Google::Cloud::Error',
   ]
 end


### PR DESCRIPTION
## Context

We can't do anything about these 99% of the time. For the other 1%, we'll be alerted by OkComputer anyway.
