### PR TITLE
Migrate to sentry-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,8 @@ gem 'active_hash'
 # in active record queries; may eventually be merged into Rails
 gem 'activerecord-cte'
 
-gem 'sentry-raven'
+gem 'sentry-rails'
+gem 'sentry-sidekiq'
 
 gem 'factory_bot_rails'
 gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -528,8 +528,14 @@ GEM
     semantic_logger (4.8.0)
       concurrent-ruby (~> 1.0)
     semantic_range (3.0.0)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
+    sentry-rails (4.6.1)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.6.0)
+    sentry-ruby-core (4.6.1)
+      concurrent-ruby
+      faraday
+    sentry-sidekiq (4.6.1)
+      sentry-ruby-core (~> 4.6.0)
     set (1.0.1)
     shellany (0.0.1)
     shoulda-matchers (5.0.0)
@@ -730,7 +736,8 @@ DEPENDENCIES
   ruby-graphviz
   ruby-jmeter
   selenium-webdriver
-  sentry-raven
+  sentry-rails
+  sentry-sidekiq
   shoulda-matchers (~> 5.0)
   sidekiq
   simplecov

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,7 @@ class ApplicationController < ActionController::Base
     )
   rescue StandardError => e
     # Never crash validation error tracking
-    Raven.capture_exception(e)
+    Sentry.capture_exception(e)
   end
 
   def render_404

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -13,7 +13,7 @@ module CandidateInterface
 
       return unless current_candidate
 
-      Raven.tags_context(application_support_url: support_interface_application_form_url(current_application))
+      Sentry.set_tags(application_support_url: support_interface_application_form_url(current_application))
     end
 
     def check_cookie_preferences

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -9,7 +9,7 @@ module CandidateInterface
     alias current_user current_candidate
 
     def set_user_context(candidate_id = current_candidate&.id)
-      Raven.user_context(id: "candidate_#{candidate_id}")
+      Sentry.set_user(id: "candidate_#{candidate_id}")
 
       return unless current_candidate
 

--- a/app/controllers/integrations/notify_controller.rb
+++ b/app/controllers/integrations/notify_controller.rb
@@ -49,7 +49,7 @@ module Integrations
     end
 
     def set_context
-      Raven.extra_context(reference_status_parameters)
+      Sentry.set_extras(reference_status_parameters)
     end
 
     def reference_status_parameters

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -45,7 +45,7 @@ module ProviderInterface
   protected
 
     def permission_error(e)
-      Raven.capture_exception(e)
+      Sentry.capture_exception(e)
       @error = e
       render template: 'provider_interface/permission_error', status: :forbidden
     end
@@ -65,7 +65,7 @@ module ProviderInterface
       return unless current_provider_user
 
       Sentry.set_user(id: "provider_#{current_provider_user.id}")
-      Raven.extra_context(current_user_details)
+      Sentry.set_extras(current_user_details)
     end
 
     def append_info_to_payload(payload)
@@ -82,7 +82,7 @@ module ProviderInterface
         providers: current_provider_user.providers,
       ).find(params[:application_choice_id])
 
-      Raven.extra_context(application_support_url)
+      Sentry.set_extras(application_support_url)
     rescue ActiveRecord::RecordNotFound
       render_404
     end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -64,7 +64,7 @@ module ProviderInterface
     def set_user_context
       return unless current_provider_user
 
-      Raven.user_context(id: "provider_#{current_provider_user.id}")
+      Sentry.set_user(id: "provider_#{current_provider_user.id}")
       Raven.extra_context(current_user_details)
     end
 

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -148,7 +148,7 @@ module RefereeInterface
     def set_user_context
       return if reference.blank?
 
-      Raven.extra_context(
+      Sentry.set_extras(
         application_support_url: support_interface_application_form_url(reference.application_form),
         reference_id: reference.id,
       )

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -33,7 +33,7 @@ module SupportInterface
     def set_user_context
       return unless current_support_user
 
-      Raven.user_context(id: "support_#{current_support_user.id}")
+      Sentry.set_user(id: "support_#{current_support_user.id}")
     end
 
     def append_info_to_payload(payload)

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -57,7 +57,7 @@ module VendorAPI
       render_application
 
       e = Exception.new("Vendor API token ##{@current_vendor_api_token.id} tried to enrol application choice ##{application_choice.id}, but enrolment is not supported")
-      Raven.capture_exception(e)
+      Sentry.capture_exception(e)
     end
 
   private

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -88,7 +88,7 @@ module VendorAPI
     end
 
     def set_user_context
-      Raven.user_context(id: "api_token_#{@current_vendor_api_token&.id}")
+      Sentry.set_user(id: "api_token_#{@current_vendor_api_token&.id}")
     end
 
     def append_info_to_payload(payload)

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -411,7 +411,7 @@ private
     end
     choice.audits.last&.update_columns(created_at: time)
   rescue IdenticalOfferError => e
-    Raven.capture_exception(e)
+    Sentry.capture_exception(e)
     nil
   end
 

--- a/app/models/teacher_training_public_api/course.rb
+++ b/app/models/teacher_training_public_api/course.rb
@@ -38,7 +38,7 @@ module TeacherTrainingPublicAPI
     rescue JsonApiClient::Errors::NotFound
       nil
     rescue JsonApiClient::Errors::ServerError, JsonApiClient::Errors::ConnectionError => e
-      Raven.capture_exception(e)
+      Sentry.capture_exception(e)
       nil
     end
   end

--- a/app/models/teacher_training_public_api/location.rb
+++ b/app/models/teacher_training_public_api/location.rb
@@ -18,7 +18,7 @@ module TeacherTrainingPublicAPI
     rescue JsonApiClient::Errors::NotFound
       nil
     rescue JsonApiClient::Errors::ServerError, JsonApiClient::Errors::ConnectionError => e
-      Raven.capture_exception(e)
+      Sentry.capture_exception(e)
       nil
     end
   end

--- a/app/models/teacher_training_public_api/provider.rb
+++ b/app/models/teacher_training_public_api/provider.rb
@@ -9,7 +9,7 @@ module TeacherTrainingPublicAPI
     rescue JsonApiClient::Errors::NotFound
       nil
     rescue JsonApiClient::Errors::ServerError, JsonApiClient::Errors::ConnectionError => e
-      Raven.capture_exception(e)
+      Sentry.capture_exception(e)
       nil
     end
   end

--- a/app/services/save_and_invite_provider_user.rb
+++ b/app/services/save_and_invite_provider_user.rb
@@ -22,7 +22,7 @@ class SaveAndInviteProviderUser
         :base,
         'A problem occurred inviting this user. Please try again. If problems persist, please contact support.',
       )
-      Raven.capture_exception(e)
+      Sentry.capture_exception(e)
 
       return false
     end

--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -29,7 +29,7 @@ class DetectInvariantsDailyCheck
         #{urls.join("\n")}
       MSG
 
-      Raven.capture_exception(OutstandingReferencesOnSubmittedApplication.new(message))
+      Sentry.capture_exception(OutstandingReferencesOnSubmittedApplication.new(message))
     end
   end
 
@@ -50,7 +50,7 @@ class DetectInvariantsDailyCheck
         #{urls.join("\n")}
       MSG
 
-      Raven.capture_exception(ApplicationHasCourseChoiceInPreviousCycle.new(message))
+      Sentry.capture_exception(ApplicationHasCourseChoiceInPreviousCycle.new(message))
     end
   end
 
@@ -72,7 +72,7 @@ class DetectInvariantsDailyCheck
         #{urls.join("\n")}
       MSG
 
-      Raven.capture_exception(ApplicationWithADifferentCyclesCourse.new(message))
+      Sentry.capture_exception(ApplicationWithADifferentCyclesCourse.new(message))
     end
   end
 
@@ -95,7 +95,7 @@ class DetectInvariantsDailyCheck
         #{urls.join("\n")}
       MSG
 
-      Raven.capture_exception(ApplicationSubmittedWithMoreThanTwoSelectedReferences.new(message))
+      Sentry.capture_exception(ApplicationSubmittedWithMoreThanTwoSelectedReferences.new(message))
     end
   end
 
@@ -116,7 +116,7 @@ class DetectInvariantsDailyCheck
         #{urls.join("\n")}
       MSG
 
-      Raven.capture_exception(ApplicationSubmittedWithTheSameCourse.new(message))
+      Sentry.capture_exception(ApplicationSubmittedWithTheSameCourse.new(message))
     end
   end
 
@@ -137,7 +137,7 @@ class DetectInvariantsDailyCheck
         #{urls.join("\n")}
       MSG
 
-      Raven.capture_exception(SubmittedApplicationHasMoreThanThreeChoices.new(message))
+      Sentry.capture_exception(SubmittedApplicationHasMoreThanThreeChoices.new(message))
     end
   end
 

--- a/app/workers/detect_invariants_hourly_check.rb
+++ b/app/workers/detect_invariants_hourly_check.rb
@@ -25,7 +25,7 @@ class DetectInvariantsHourlyCheck
         #{urls.join("\n")}
       MSG
 
-      Raven.capture_exception(ApplicationInRemovedState.new(message))
+      Sentry.capture_exception(ApplicationInRemovedState.new(message))
     end
   end
 
@@ -47,13 +47,13 @@ class DetectInvariantsHourlyCheck
         #{urls.join("\n")}
       MSG
 
-      Raven.capture_exception(ApplicationEditedByWrongCandidate.new(message))
+      Sentry.capture_exception(ApplicationEditedByWrongCandidate.new(message))
     end
   end
 
   def detect_course_sync_not_succeeded_for_an_hour
     unless TeacherTrainingPublicAPI::SyncCheck.check
-      Raven.capture_exception(
+      Sentry.capture_exception(
         CourseSyncNotSucceededForAnHour.new(
           'The course sync via the Teacher training public API has not succeeded for an hour',
         ),
@@ -64,7 +64,7 @@ class DetectInvariantsHourlyCheck
   def detect_high_sidekiq_retries_queue_length
     retries_queue_length = Sidekiq::RetrySet.new.size
     if retries_queue_length > 50
-      Raven.capture_exception(
+      Sentry.capture_exception(
         SidekiqRetriesQueueHigh.new(
           "Sidekiq pending retries depth is high (#{retries_queue_length}). Suggests high error rate",
         ),

--- a/app/workers/ucas_integration_check.rb
+++ b/app/workers/ucas_integration_check.rb
@@ -10,7 +10,7 @@ class UCASIntegrationCheck
     file_download.check
     return if file_download.success?
 
-    Raven.capture_exception(UCASMatchingFileDownloadFailure.new(file_download.message))
+    Sentry.capture_exception(UCASMatchingFileDownloadFailure.new(file_download.message))
   end
 
   class UCASMatchingFileDownloadFailure < StandardError; end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -6,7 +6,7 @@ require 'clockwork'
 class Clock
   include Clockwork
 
-  error_handler { |error| Raven.capture_exception(error) if defined? Raven }
+  error_handler { |error| Sentry.capture_exception(error) if defined? Sentry }
 
   # More-than-hourly jobs
   every(10.minutes, 'IncrementalSyncAllFromTeacherTrainingPublicAPI') { TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async }

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,4 @@
-Raven.configure do |config|
+Sentry.configure do |config|
   config.silence_ready = true
   config.current_environment = HostingEnvironment.environment_name
   config.release = ENV['SHA']

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,8 +1,12 @@
-Sentry.configure do |config|
-  config.silence_ready = true
-  config.current_environment = HostingEnvironment.environment_name
+Sentry.init do |config|
+  config.environment = HostingEnvironment.environment_name
   config.release = ENV['SHA']
-  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+  filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+
+  config.before_send = lambda do |event, _hint|
+    filter.filter(event.to_hash)
+  end
+
   config.inspect_exception_causes_for_exclusion = true
 
   config.excluded_exceptions += [

--- a/lib/email_log_interceptor.rb
+++ b/lib/email_log_interceptor.rb
@@ -22,7 +22,7 @@ class EmailLogInterceptor
   rescue StandardError => e
     # Email logging should not stop the actual email sending
     Rails.logger.info("Exception occured when trying to log email: #{e.message}")
-    Raven.capture_exception(e)
+    Sentry.capture_exception(e)
   end
 
   def self.generate_reference

--- a/lib/modules/aws_ip_ranges.rb
+++ b/lib/modules/aws_ip_ranges.rb
@@ -15,7 +15,7 @@ module AWSIpRanges
       parse_json_for_ips(response.body)
     end
   rescue StandardError => e
-    Raven.capture_exception(e)
+    Sentry.capture_exception(e)
     []
   end
 

--- a/spec/lib/modules/aws_ip_ranges_spec.rb
+++ b/spec/lib/modules/aws_ip_ranges_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe AWSIpRanges do
       end
 
       it 'logs a warning to sentry' do
-        allow(Raven).to receive(:capture_exception)
+        allow(Sentry).to receive(:capture_exception)
         AWSIpRanges.cloudfront_ips
-        expect(Raven).to have_received(:capture_exception)
+        expect(Sentry).to have_received(:capture_exception)
       end
     end
 
@@ -41,9 +41,9 @@ RSpec.describe AWSIpRanges do
       end
 
       it 'logs a warning to sentry' do
-        allow(Raven).to receive(:capture_exception)
+        allow(Sentry).to receive(:capture_exception)
         AWSIpRanges.cloudfront_ips
-        expect(Raven).to have_received(:capture_exception)
+        expect(Sentry).to have_received(:capture_exception)
       end
     end
 
@@ -60,9 +60,9 @@ RSpec.describe AWSIpRanges do
       end
 
       it 'logs a warning' do
-        allow(Raven).to receive(:capture_exception)
+        allow(Sentry).to receive(:capture_exception)
         AWSIpRanges.cloudfront_ips
-        expect(Raven).to have_received(:capture_exception)
+        expect(Sentry).to have_received(:capture_exception)
       end
     end
   end

--- a/spec/requests/vendor_api/post_confirm_enrolment_spec.rb
+++ b/spec/requests/vendor_api/post_confirm_enrolment_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-enrolmen
   it 'notifies Sentry' do
     application_choice = create_application_choice_for_currently_authenticated_provider(status: 'recruited')
 
-    allow(Raven).to receive(:capture_exception)
+    allow(Sentry).to receive(:capture_exception)
 
     post_api_request "/api/v1/applications/#{application_choice.id}/confirm-enrolment"
 
-    expect(Raven).to have_received(:capture_exception)
+    expect(Sentry).to have_received(:capture_exception)
   end
 
   it 'returns a not found error when the application was not found' do

--- a/spec/services/save_and_invite_provider_user_spec.rb
+++ b/spec/services/save_and_invite_provider_user_spec.rb
@@ -76,9 +76,9 @@ RSpec.describe SaveAndInviteProviderUser do
       end
 
       it 'notifies Sentry' do
-        allow(Raven).to receive(:capture_exception)
+        allow(Sentry).to receive(:capture_exception)
         service.call
-        expect(Raven).to have_received(:capture_exception)
+        expect(Sentry).to have_received(:capture_exception)
       end
 
       it 'populates form errors' do

--- a/spec/workers/detect_invariants_daily_check_spec.rb
+++ b/spec/workers/detect_invariants_daily_check_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe DetectInvariantsDailyCheck do
   before do
-    allow(Raven).to receive(:capture_exception)
+    allow(Sentry).to receive(:capture_exception)
 
     # or unwanted exceptions will be thrown by this check
     TeacherTrainingPublicAPI::SyncCheck.set_last_sync(Time.zone.now)
@@ -24,7 +24,7 @@ RSpec.describe DetectInvariantsDailyCheck do
 
       described_class.new.perform
 
-      expect(Raven).to have_received(:capture_exception).with(
+      expect(Sentry).to have_received(:capture_exception).with(
         described_class::OutstandingReferencesOnSubmittedApplication.new(
           <<~MSG,
             One or more references are still pending on these applications,
@@ -50,7 +50,7 @@ RSpec.describe DetectInvariantsDailyCheck do
 
       described_class.new.perform
 
-      expect(Raven).to have_received(:capture_exception).with(
+      expect(Sentry).to have_received(:capture_exception).with(
         described_class::ApplicationHasCourseChoiceInPreviousCycle.new(
           <<~MSG,
             The following application forms have course choices from the previous recruitment cycle
@@ -64,7 +64,7 @@ RSpec.describe DetectInvariantsDailyCheck do
     it 'doesn’t alert when the course sync has succeeded recently' do
       described_class.new.perform
 
-      expect(Raven).not_to have_received(:capture_exception)
+      expect(Sentry).not_to have_received(:capture_exception)
     end
 
     it 'detects applications submitted with the same course' do
@@ -78,7 +78,7 @@ RSpec.describe DetectInvariantsDailyCheck do
 
       described_class.new.perform
 
-      expect(Raven).to have_received(:capture_exception).with(
+      expect(Sentry).to have_received(:capture_exception).with(
         described_class::ApplicationSubmittedWithTheSameCourse.new(
           <<~MSG,
             The following applications have been submitted containing the same course choice multiple times
@@ -103,7 +103,7 @@ RSpec.describe DetectInvariantsDailyCheck do
 
       described_class.new.perform
 
-      expect(Raven).to have_received(:capture_exception).with(
+      expect(Sentry).to have_received(:capture_exception).with(
         described_class::ApplicationSubmittedWithMoreThanTwoSelectedReferences.new(
           <<~MSG,
             The following applications have been submitted with more than two selected references
@@ -130,7 +130,7 @@ RSpec.describe DetectInvariantsDailyCheck do
 
       described_class.new.perform
 
-      expect(Raven).to have_received(:capture_exception).with(
+      expect(Sentry).to have_received(:capture_exception).with(
         described_class::ApplicationWithADifferentCyclesCourse.new(
           <<~MSG,
             The following applications have an application choice with a course from a different recruitment cycle
@@ -147,8 +147,8 @@ RSpec.describe DetectInvariantsDailyCheck do
 
       described_class.new.perform
 
-      expect(Raven).to have_received(:capture_exception).once
-      expect(Raven).to have_received(:capture_exception).with(
+      expect(Sentry).to have_received(:capture_exception).once
+      expect(Sentry).to have_received(:capture_exception).with(
         described_class::SubmittedApplicationHasMoreThanThreeChoices.new(
           <<~MSG,
             The following application forms have been submitted with more than three course choices

--- a/spec/workers/detect_invariants_hourly_check_spec.rb
+++ b/spec/workers/detect_invariants_hourly_check_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe DetectInvariantsHourlyCheck do
   before do
-    allow(Raven).to receive(:capture_exception)
+    allow(Sentry).to receive(:capture_exception)
 
     # or unwanted exceptions will be thrown by this check
     TeacherTrainingPublicAPI::SyncCheck.set_last_sync(Time.zone.now)
@@ -17,7 +17,7 @@ RSpec.describe DetectInvariantsHourlyCheck do
 
       described_class.new.perform
 
-      expect(Raven).to have_received(:capture_exception).with(
+      expect(Sentry).to have_received(:capture_exception).with(
         described_class::ApplicationInRemovedState.new(
           <<~MSG,
             One or more application choices are still in `awaiting_references` or
@@ -50,7 +50,7 @@ RSpec.describe DetectInvariantsHourlyCheck do
 
       described_class.new.perform
 
-      expect(Raven).to have_received(:capture_exception).with(
+      expect(Sentry).to have_received(:capture_exception).with(
         described_class::ApplicationEditedByWrongCandidate.new(
           <<~MSG,
             The following application forms have had edits by a candidate who is not the owner of the application:
@@ -74,7 +74,7 @@ RSpec.describe DetectInvariantsHourlyCheck do
 
       described_class.new.perform
 
-      expect(Raven).not_to have_received(:capture_exception)
+      expect(Sentry).not_to have_received(:capture_exception)
     end
 
     it 'detects when the course sync hasn’t succeeded for an hour' do
@@ -82,7 +82,7 @@ RSpec.describe DetectInvariantsHourlyCheck do
 
       described_class.new.perform
 
-      expect(Raven).to have_received(:capture_exception).with(
+      expect(Sentry).to have_received(:capture_exception).with(
         described_class::CourseSyncNotSucceededForAnHour.new(
           'The course sync via the Teacher training public API has not succeeded for an hour',
         ),
@@ -92,7 +92,7 @@ RSpec.describe DetectInvariantsHourlyCheck do
     it 'doesn’t alert when the course sync has succeeded recently' do
       described_class.new.perform
 
-      expect(Raven).not_to have_received(:capture_exception)
+      expect(Sentry).not_to have_received(:capture_exception)
     end
 
     it 'detects when the sidekiq retries queue is high' do
@@ -100,7 +100,7 @@ RSpec.describe DetectInvariantsHourlyCheck do
       allow(Sidekiq::RetrySet).to receive(:new).and_return(sidekiq_retries)
       described_class.new.perform
 
-      expect(Raven).to have_received(:capture_exception).with(
+      expect(Sentry).to have_received(:capture_exception).with(
         described_class::SidekiqRetriesQueueHigh.new(
           'Sidekiq pending retries depth is high (100). Suggests high error rate',
         ),
@@ -112,7 +112,7 @@ RSpec.describe DetectInvariantsHourlyCheck do
       allow(Sidekiq::RetrySet).to receive(:new).and_return(sidekiq_retries)
       described_class.new.perform
 
-      expect(Raven).not_to have_received(:capture_exception)
+      expect(Sentry).not_to have_received(:capture_exception)
     end
   end
 end

--- a/spec/workers/ucas_integration_check_spec.rb
+++ b/spec/workers/ucas_integration_check_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe UCASIntegrationCheck do
-  before { allow(Raven).to receive(:capture_exception) }
+  before { allow(Sentry).to receive(:capture_exception) }
 
   describe '#perform' do
     context 'detect_ucas_match_upload_failure' do
@@ -10,7 +10,7 @@ RSpec.describe UCASIntegrationCheck do
 
         UCASIntegrationCheck.new.perform
 
-        expect(Raven).to have_received(:capture_exception).with(
+        expect(Sentry).to have_received(:capture_exception).with(
           UCASIntegrationCheck::UCASMatchingFileDownloadFailure.new(
             'There was no UCAS file download taking place yesterday',
           ),
@@ -22,7 +22,7 @@ RSpec.describe UCASIntegrationCheck do
 
         UCASIntegrationCheck.new.perform
 
-        expect(Raven).not_to have_received(:capture_exception)
+        expect(Sentry).not_to have_received(:capture_exception)
       end
     end
   end


### PR DESCRIPTION
## Context

The `sentry-raven` library is deprecated. We need to move to the new version, `sentry-ruby`.

## Changes proposed in this pull request

Follow migration guide at https://docs.sentry.io/platforms/ruby/migration/ and other links (see commit messages). The `sentry.rb` file has the most interesting changes.

## Link to Trello card

https://trello.com/c/yhL4krwN/463-migrate-from-sentry-raven-to-sentry-ruby

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
