### PR TITLE
Fix form error linking in the provider relationship permissions form

### DIFF
--- a/app/components/provider_interface/organisation_permissions_form_component.html.erb
+++ b/app/components/provider_interface/organisation_permissions_form_component.html.erb
@@ -14,12 +14,14 @@
 
   <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| %>
     <div class="govuk-form-group">
-      <%= f.govuk_fieldset legend: { text: label_for(permission_name) } do %>
-        <% presenter.checkbox_details_for_providers.each_with_index do |checkbox_details, index| %>
+      <%= f.govuk_check_boxes_fieldset permission_name, legend: { text: label_for(permission_name) } do %>
+        <% presenter.checkbox_details_for_providers(permission_name).each_with_index do |checkbox_details, index| %>
           <%= f.govuk_check_box(
-            "#{checkbox_details[:type]}_provider_can_#{permission_name}",
-            true,
-            label: { text: checkbox_details[:name] },
+            permission_name,
+            checkbox_details[:field_name],
+            label: { text: checkbox_details[:label] },
+            name: checkbox_details[:name],
+            checked: checkbox_details[:checked],
             link_errors: index.zero?,
           ) %>
         <% end %>

--- a/app/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter.rb
+++ b/app/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter.rb
@@ -10,11 +10,15 @@ module ProviderInterface
       provider_names.join(' and ')
     end
 
-    def checkbox_details_for_providers
+    def checkbox_details_for_providers(permission_name)
       ordered_provider_types.map do |provider_type|
+        field_name = "#{provider_type}_provider_can_#{permission_name}"
+
         {
-          name: name_for_provider_of_type(provider_type),
-          type: provider_type,
+          field_name: field_name,
+          label: name_for_provider_of_type(provider_type),
+          name: "provider_relationship_permissions[#{field_name}][]",
+          checked: provider_relationship_permission.send(field_name),
         }
       end
     end

--- a/spec/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter_spec.rb
+++ b/spec/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter_spec.rb
@@ -47,27 +47,65 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionAsProviderUserPr
   end
 
   describe '#checkbox_details_for_providers' do
+    let(:permission_name) { 'make_decisions' }
+
     context 'when the provider user is part of the training provider' do
       let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider]) }
 
-      it 'returns the training provider checkbox first' do
-        expect(presenter.checkbox_details_for_providers.first[:type]).to eq('training')
+      it 'returns the training provider relationship permission `field_name`' do
+        expect(presenter.checkbox_details_for_providers(permission_name).first[:field_name]).to eq('training_provider_can_make_decisions')
+      end
+
+      it 'returns the training provider `label`' do
+        expect(presenter.checkbox_details_for_providers(permission_name).first[:label]).to eq(training_provider.name)
+      end
+
+      it 'returns the training provider checkbox name' do
+        expect(presenter.checkbox_details_for_providers(permission_name).first[:name]).to eq('provider_relationship_permissions[training_provider_can_make_decisions][]')
+      end
+
+      it 'returns the input checkbox value' do
+        expect(presenter.checkbox_details_for_providers(permission_name).first[:checked]).to eq(provider_relationship_permission.training_provider_can_make_decisions)
       end
     end
 
     context 'when the provider user is part of the ratifying provider' do
       let(:provider_user) { build_stubbed(:provider_user, providers: [ratifying_provider]) }
 
-      it 'returns the ratifying provider checkbox first' do
-        expect(presenter.checkbox_details_for_providers.first[:type]).to eq('ratifying')
+      it 'returns the ratifying provider relationship permission `field_name`' do
+        expect(presenter.checkbox_details_for_providers(permission_name).first[:field_name]).to eq('ratifying_provider_can_make_decisions')
+      end
+
+      it 'returns the ratifying provider `label`' do
+        expect(presenter.checkbox_details_for_providers(permission_name).first[:label]).to eq(ratifying_provider.name)
+      end
+
+      it 'returns the ratifying provider checkbox name' do
+        expect(presenter.checkbox_details_for_providers(permission_name).first[:name]).to eq('provider_relationship_permissions[ratifying_provider_can_make_decisions][]')
+      end
+
+      it 'returns the input checkbox checked value' do
+        expect(presenter.checkbox_details_for_providers(permission_name).first[:checked]).to eq(provider_relationship_permission.ratifying_provider_can_make_decisions)
       end
     end
 
     context 'when the provider user is part of both of the providers' do
-      let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider, ratifying_provider]) }
+      let(:provider_user) { build_stubbed(:provider_user, providers: [ratifying_provider, training_provider]) }
 
-      it 'returns the training provider checkbox first' do
-        expect(presenter.checkbox_details_for_providers.first[:type]).to eq('training')
+      it 'returns the training provider relationship permission `field_name`' do
+        expect(presenter.checkbox_details_for_providers(permission_name).first[:field_name]).to eq('training_provider_can_make_decisions')
+      end
+
+      it 'returns the training provider `label`' do
+        expect(presenter.checkbox_details_for_providers(permission_name).first[:label]).to eq(training_provider.name)
+      end
+
+      it 'returns the training provider checkbox name' do
+        expect(presenter.checkbox_details_for_providers(permission_name).first[:name]).to eq('provider_relationship_permissions[training_provider_can_make_decisions][]')
+      end
+
+      it 'returns the input checkbox checked value' do
+        expect(presenter.checkbox_details_for_providers(permission_name).first[:checked]).to eq(provider_relationship_permission.training_provider_can_make_decisions)
       end
     end
   end


### PR DESCRIPTION
## Context

When a validation error occurs on the provider relationship permission form, the Gov UK error summary appears, but the page does not correctly show (in red) which section of the form is invalid, nor do the error links anchor to the correct place on the page.

## Changes proposed in this pull request

Use the `govuk_check_boxes_fieldset` to allow the grouping of permission checkboxes, which will auto link them to the error correctly.

Pass in a custom name and checked value to the checkbox inbox field to allow it to behave correctly when pre-filling and on form submission.

## Guidance to review

Although we are setting the `name`/`checked` on the checkbox `input` field we can still use the `ProviderRelationshipPermissions` model on the forms.

## Link to Trello card

https://trello.com/c/jyduUkbk/3975-errors-are-not-linked-correctly-when-changing-organisation-permissions

<img width="1090" alt="Screenshot 2021-07-18 at 20 38 59" src="https://user-images.githubusercontent.com/2732945/126080071-ea866549-1580-4704-8e3b-ebc9477f9197.png">

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
