### PR TITLE
Map exceptional HESA degctry codes which don't match the iso3166 inst…

### DIFF
--- a/app/presenters/hesa_qualification_fields_presenter.rb
+++ b/app/presenters/hesa_qualification_fields_presenter.rb
@@ -9,13 +9,20 @@ class HesaQualificationFieldsPresenter
     hesa_degenddt: { attr: :award_year, pad_to: :iso8601 },
   }.freeze
 
+  # Cyprus, Kosovo and UK have codes different to iso3166
+  HESA_DEGCTRY_MAPPING = {
+    'CY' => 'XC',
+    'GB' => 'XK',
+    'XK' => 'QO',
+  }.freeze
+
   def initialize(qualification)
     @qualification = qualification
   end
 
   def to_hash
     if @qualification.level == 'degree'
-      HESA_MAPPING.keys.index_with do |k|
+      hesa_data = HESA_MAPPING.keys.index_with do |k|
         pad_to = HESA_MAPPING[k][:pad_to]
         value = @qualification.send(HESA_MAPPING[k][:attr])
         case pad_to
@@ -25,8 +32,14 @@ class HesaQualificationFieldsPresenter
           value&.to_s&.rjust(pad_to, '0')
         end
       end
+
+      hesa_data.merge(hesa_degctry)
     else
       HESA_MAPPING.keys.index_with { nil }
     end
+  end
+
+  def hesa_degctry
+    { hesa_degctry: HESA_DEGCTRY_MAPPING.fetch(@qualification.institution_country, @qualification.institution_country) }
   end
 end

--- a/spec/presenters/hesa_qualification_fields_presenter_spec.rb
+++ b/spec/presenters/hesa_qualification_fields_presenter_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe HesaQualificationFieldsPresenter do
       hesa_degsbj: { attr: :subject_hesa_code, zeropad: 6 },
       hesa_degclss: { attr: :grade_hesa_code, zeropad: 2 },
       hesa_degest: { attr: :institution_hesa_code, zeropad: 4 },
-      hesa_degctry: { attr: :institution_country, zeropad: 2 },
     }
 
     direct_mappings.each do |hesa_field, data|
@@ -19,6 +18,23 @@ RSpec.describe HesaQualificationFieldsPresenter do
 
       it "#{hesa_field} is #{our_field} zero-padded to #{pad_to} chars" do
         expect(presenter.to_hash[hesa_field]).to eq(qualification.send(our_field)&.to_s&.rjust(pad_to, '0'))
+      end
+    end
+
+    context 'when iso3166 institution country code differs from HESA degctry code' do
+      described_class::HESA_DEGCTRY_MAPPING.each do |iso3166_code, hesa_degctry_code|
+        it "maps #{iso3166_code} to #{hesa_degctry_code}" do
+          presenter = described_class.new(build(:degree_qualification, institution_country: iso3166_code))
+          expect(presenter.to_hash[:hesa_degctry]).to eq(hesa_degctry_code)
+        end
+      end
+    end
+
+    context 'when iso3166 institution country code matches HESA degctry code' do
+      it 'returns the institution country code' do
+        iso3166_code = COUNTRIES.except(described_class::HESA_DEGCTRY_MAPPING.keys).keys.sample
+        presenter = described_class.new(build(:degree_qualification, institution_country: iso3166_code))
+        expect(presenter.to_hash[:hesa_degctry]).to eq(iso3166_code)
       end
     end
 


### PR DESCRIPTION
…itution country value

## Context

We store an ISO3166 code for `Qualification#institution_country` which in most cases matches the HESA **DEGCTRY** code.
There are exceptions though and these have been raised by vendors are we are not currently returning the correct value.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Maps the ISO3166 country codes which do not match the HESA values so that the API presents the correct HESA code.

References:

https://www.hesa.ac.uk/collection/c21053/e/degctry
https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/config/initializers/countries.rb

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

I used the 2021 HESA guidance and cross referenced this with the list of countries we use to populate ISO3166 institution country codes. The Apply/Manage list of countries is a subset of the HESA list so I've only attempted to map values we actually allow the candidate to select.
 
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/iBddCxXN/3971-hesa-degctry-code-in-api-does-not-match-documented-values
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
