### PR TITLE
Add load test ENV

### DIFF
--- a/app/components/phase_banner_component.rb
+++ b/app/components/phase_banner_component.rb
@@ -24,6 +24,8 @@ class PhaseBannerComponent < ViewComponent::Base
       'This is a review environment used to test a pull request'
     when 'research'
       'This is the user research environment for the Apply service'
+    when 'load-test'
+      'This is the user load-test environment for the Apply service'
     when 'unknown-environment'
       'This is a unknown version of the Apply service'
     end

--- a/app/frontend/styles/_header.scss
+++ b/app/frontend/styles/_header.scss
@@ -24,6 +24,11 @@
   border-bottom-color: govuk-colour("turquoise");
 }
 
+.app-header--load-test .govuk-header__container,
+.app-header--load-test.app-header--full-border {
+  border-bottom-color: govuk-colour("pink");
+}
+
 .app-header--development .govuk-header__container,
 .app-header--development.app-header--full-border,
 .app-header--unknown-environment .govuk-header__container,

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -1,10 +1,11 @@
 module HostingEnvironment
-  TEST_ENVIRONMENTS = %w[development test qa review research].freeze
+  TEST_ENVIRONMENTS = %w[development test qa review research load-test].freeze
   PRODUCTION_URL = 'https://apply-for-teacher-training.service.gov.uk'.freeze
   ENVIRONMENT_COLOR = {
     development: 'grey',
     review: 'purple',
     research: 'turquoise',
+    'load-test': 'pink',
     qa: 'orange',
     staging: 'red',
     'unknown-environment': 'yellow',
@@ -60,6 +61,10 @@ module HostingEnvironment
 
   def self.research?
     environment_name == 'research'
+  end
+
+  def self.load_test?
+    environment_name == 'load-test'
   end
 
   def self.staging?

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -26,7 +26,7 @@ options = {
 # it cannot just be a local function as other parts of the codebase depend on it
 module ::DfESignIn
   def self.bypass?
-    (HostingEnvironment.review? || Rails.env.development?) && ENV['BYPASS_DFE_SIGN_IN'] == 'true'
+    (HostingEnvironment.load_test? || HostingEnvironment.review? || Rails.env.development?) && ENV['BYPASS_DFE_SIGN_IN'] == 'true'
   end
 end
 


### PR DESCRIPTION
## Context

To send logs and tag events correctly, we need to add a new `load-test` environment.

## Changes proposed in this pull request

- Add `load-test` to environment hosts
- Add `load-test` to test environments
- Add specific colour and settings for this env
- Allow DFE sign in bypass on this env

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
