### PR TITLE
Rollover: make visible in support, and prepare to turn on sync in production

### DIFF
--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -21,7 +21,7 @@ module RecruitmentCycle
   end
 
   def self.years_visible_in_support
-    [2021, 2020, 2019]
+    [2022, 2021, 2020, 2019]
   end
 
   def self.cycle_name(year = current_year)

--- a/app/workers/teacher_training_public_api/sync_all_providers_and_courses_worker.rb
+++ b/app/workers/teacher_training_public_api/sync_all_providers_and_courses_worker.rb
@@ -3,13 +3,9 @@ module TeacherTrainingPublicAPI
     include Sidekiq::Worker
     sidekiq_options retry: 3, queue: :low_priority
 
-    def perform(incremental = true)
+    def perform(incremental = true, year = ::RecruitmentCycle.current_year)
       SyncSubjects.new.perform
-      SyncAllProvidersAndCourses.call(incremental_sync: incremental)
-
-      if FeatureFlag.active?(:sync_next_cycle)
-        SyncAllProvidersAndCourses.call(recruitment_cycle_year: ::RecruitmentCycle.next_year, incremental_sync: incremental)
-      end
+      SyncAllProvidersAndCourses.call(recruitment_cycle_year: year, incremental_sync: incremental)
     end
   end
 end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -10,7 +10,7 @@ class Clock
 
   # More-than-hourly jobs
   every(10.minutes, 'IncrementalSyncAllFromTeacherTrainingPublicAPI') { TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async }
-  every(10.minutes, 'IncrementalSyncNextCycleFromTeacherTrainingPublicAPI') do
+  every(11.minutes, 'IncrementalSyncNextCycleFromTeacherTrainingPublicAPI') do
     if FeatureFlag.active?(:sync_next_cycle)
       TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(true, RecruitmentCycle.next_year)
     end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -10,6 +10,11 @@ class Clock
 
   # More-than-hourly jobs
   every(10.minutes, 'IncrementalSyncAllFromTeacherTrainingPublicAPI') { TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async }
+  every(10.minutes, 'IncrementalSyncNextCycleFromTeacherTrainingPublicAPI') do
+    if FeatureFlag.active?(:sync_next_cycle)
+      TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(true, RecruitmentCycle.next_year)
+    end
+  end
 
   # Hourly jobs
   every(1.hour, 'RejectApplicationsByDefault', at: '**:10') { RejectApplicationsByDefaultWorker.perform_async }
@@ -49,5 +54,13 @@ class Clock
 
   every(1.day, 'SendEocDeadlineReminderEmailToCandidatesWorker', at: '12:00') { SendEocDeadlineReminderEmailToCandidatesWorker.new.perform }
 
-  every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: '00:59') { TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false) }
+  every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: '00:59') do
+    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false)
+  end
+
+  every(7.days, 'FullSyncNextCycleFromTeacherTrainingPublicAPI', at: '03:59') do
+    if FeatureFlag.active?(:sync_next_cycle)
+      TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false, RecruitmentCycle.next_year)
+    end
+  end
 end

--- a/spec/workers/teacher_training_public_api/sync_all_providers_and_courses_worker_spec.rb
+++ b/spec/workers/teacher_training_public_api/sync_all_providers_and_courses_worker_spec.rb
@@ -19,26 +19,12 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker do
 
     it 'calls the SyncAllProvidersAndCourses service with the correct args for an incremental sync' do
       described_class.new.perform
-      expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCourses).to have_received(:call).with(incremental_sync: true)
+      expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCourses).to have_received(:call).with(incremental_sync: true, recruitment_cycle_year: RecruitmentCycle.current_year)
     end
 
     it 'calls the SyncAllProvidersAndCourses service with the correct args for a full sync' do
       described_class.new.perform(false)
-      expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCourses).to have_received(:call).with(incremental_sync: false)
-    end
-
-    context 'the sync_next_cycle feature flag is on' do
-      before do
-        FeatureFlag.activate(:sync_next_cycle)
-      end
-
-      it 'calls the SyncAllProvidersAndCourses service passing in the next cycle' do
-        Timecop.travel(2021, 1, 1) do
-          described_class.new.perform
-        end
-
-        expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCourses).to have_received(:call).with(incremental_sync: true, recruitment_cycle_year: 2022)
-      end
+      expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCourses).to have_received(:call).with(incremental_sync: false, recruitment_cycle_year: RecruitmentCycle.current_year)
     end
   end
 end


### PR DESCRIPTION
## Context

We've run a parallel sync for 2022 in the rollover evironment for a few days and it seems to be pulling in courses fine.

Support lacks lists for 2022 courses, so add those now in preparation for turning on the flag in production.

Also in prep for production, split out the this- and next-cycle syncs so they don't run simultaneously and risk overwhelming the API.

## Changes proposed in this pull request

- add 2022 to the list of years to show in support (in practice this just means which courses)
- Parameterize `year` when syncing, and pass it in from Clockwork

## Link to Trello card

https://trello.com/c/2bFnG9pR/3542-start-syncing-2022-courses

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
