### PR TITLE
Update Makefile for console access; add application_choices metric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ research:
 load-test:
 	$(eval APP_ENV=loadtest)
 	$(eval APP_NAME_SUFFIX=load-test)
-	$(eval SPACE=bat-qa)
+	$(eval SPACE=bat-prod)
 	$(eval AZURE_SUBSCRIPTION=s121-findpostgraduateteachertraining-development)
 
 azure-login:

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -14,3 +14,14 @@ if ENV.key?('VCAP_APPLICATION')
     default_tag :space, space_name
   end
 end
+
+# Custom metrics
+Yabeda.configure do
+  group :apply_db do
+    gauge :application_choices,  comment: "Number of application choices in database"
+  end
+
+  collect do
+    apply_db.application_choices.set({}, ApplicationChoice.count)
+  end
+end


### PR DESCRIPTION
Just a few tweaks for the load-testing environment.

Fixes access to `rails c` for the `load-test` environment.

Allows graphing of number of application choices on the system.

```
# TYPE apply_db_application_choices gauge
# HELP apply_db_application_choices Number of application choices in database
apply_db_application_choices 592.0
```