### PR TITLE
Ensure hesa codes match equality and diversity data

### DIFF
--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -46,16 +46,17 @@ FactoryBot.define do
 
     trait :with_equality_and_diversity_data do
       equality_and_diversity do
+        sex = ['male', 'female', 'intersex', 'Prefer not to say'].sample
         ethnicity = Class.new.extend(EthnicBackgroundHelper).all_combinations.sample
         other_disability = 'Acquired brain injury'
         all_disabilities = DisabilityHelper::STANDARD_DISABILITIES.map(&:second) << other_disability
         disabilities = rand < 0.85 ? all_disabilities.sample([*0..3].sample) : ['Prefer not to say']
-        hesa_sex = %w[1 2 3].sample
-        hesa_disabilities = disabilities ? [HESA_DISABILITIES.map(&:first).sample] : %w[00]
-        hesa_ethnicity = HESA_ETHNICITIES_2020_2021.map(&:first).sample
+        hesa_sex = sex == 'Prefer not to say' ? nil : Hesa::Sex.find(sex)['hesa_code']
+        hesa_disabilities = disabilities == ['Prefer not to say'] ? %w[00] : disabilities.map { |disability| Hesa::Disability.find(disability)['hesa_code'] }
+        hesa_ethnicity = Hesa::Ethnicity.find(ethnicity.last, 2021)['hesa_code']
 
         {
-          sex: ['male', 'female', 'intersex', 'Prefer not to say'].sample,
+          sex: sex,
           ethnic_group: ethnicity.first,
           ethnic_background: ethnicity.last,
           disabilities: disabilities,


### PR DESCRIPTION
## Context

We sample data in order to effect 'randomness' when generating equality and diversity information on an application form.
We also randomly generate hesa codes stored against the application form and this rarely matches the other generated equality and diversity values.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Ensure that the generated equality and diversity data values are reflected with accurate hesa codes for these values.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/QkPC4C7k/3985-test-data-generator-creating-incorrect-hesa-codes
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
