### PR TITLE
Ensure `predicted_grade` is false for gcses and other qualifications

### DIFF
--- a/spec/factories/application_qualification.rb
+++ b/spec/factories/application_qualification.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
       qualification_type { 'gcse' }
       subject { %w[maths english science].sample }
       grade { %w[A B C].sample }
+      predicted_grade { false }
 
       trait :non_uk do
         qualification_type { 'non_uk' }
@@ -30,6 +31,7 @@ FactoryBot.define do
       trait :missing do
         qualification_type { 'missing' }
         grade { nil }
+        predicted_grade { nil }
         missing_explanation { 'I will be taking an equivalency test in a few weeks' }
       end
 
@@ -62,6 +64,7 @@ FactoryBot.define do
       subject { Faker::Educator.subject }
       institution_name { Faker::University.name }
       grade { %w[pass merit distinction].sample }
+      predicted_grade { false }
       institution_country { 'GB' }
 
       trait :non_uk do


### PR DESCRIPTION
## Context

The application qualifications factory is randomly assigning the boolean `predicted_grade` where the qualification might be a completed gcse or a degree with a valid grade.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Update `ApplicationQualification` factory so that qualifications with actual grades are not marked as being predicted grades.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ZG1sztVV/3970-test-data-generator-creates-gcses-with-predicted-grades
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
