### PR TITLE
Fix nested `govuk-summary-list__actions` markup in summary lists

### DIFF
--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -30,8 +30,6 @@ class SummaryListComponent < ViewComponent::Base
         end
       end
       links.join('<br>').html_safe
-    elsif any_row_has_action_span?
-      tag.dd(class: 'govuk-summary-list__actions')
     end
   end
 
@@ -54,9 +52,5 @@ private
         value: value,
       }
     end
-  end
-
-  def any_row_has_action_span?
-    rows.select { |row| row.key?(:action) }.any?
   end
 end

--- a/spec/components/summary_list_component_spec.rb
+++ b/spec/components/summary_list_component_spec.rb
@@ -73,37 +73,6 @@ RSpec.describe SummaryListComponent do
     expect(result.css('[data-qa="ice-cream-man"]')).to be_present
   end
 
-  it 'does not render an extra dd if no row has an action' do
-    rows = [{ key: 'Job',
-              value: ['Teacher', 'Clearcourt High'] },
-            { key: 'Working pattern',
-              value: "Full time\n Omnis itaque rerum. Velit in ." },
-            { key: 'Description',
-              value: 'Cumque autem veritatis..'  },
-            { key: 'Dates',
-              value: 'May 2003 - November 2019'  }]
-
-    result = render_inline(SummaryListComponent.new(rows: rows))
-
-    expect(result.to_html).not_to include('<dd class="govuk-summary-list__actions"></dd>')
-  end
-
-  it 'does render an extra dd if any row has an action' do
-    rows = [{ key: 'Job',
-              value: ['Teacher', 'Clearcourt High'] },
-            { key: 'Working pattern',
-              value: "Full time\n Omnis itaque rerum. Velit in ." },
-            { key: 'Description',
-              value: 'Cumque autem veritatis..' },
-            { key: 'Dates',
-              value: 'May 2003 - November 2019',
-              action: 'dates for Teacher, Clearcourt High' }]
-
-    result = render_inline(SummaryListComponent.new(rows: rows))
-
-    expect(result.to_html).to include('<dd class="govuk-summary-list__actions"></dd>')
-  end
-
   it 'handles rows with multiple actions' do
     rows = [
       { key: 'Role',


### PR DESCRIPTION
## Context

The summary list component from GOV.UK Components automatically adds an empty `govuk-summary-list__actions` `dd` to a summary row if one or more of the other summary list rows contains actions, and this row doesn’t.

This means we no longer need to output the same markup. This PR addresses the issue spotted here when we moved over to using the GOV.UK Component: https://github.com/DFE-Digital/apply-for-teacher-training/pull/5018#pullrequestreview-691555047

## Changes proposed in this pull request

The current method generates the following markup:

```html
<dd class="govuk-summary-list__actions">
  <dd class="govuk-summary-list__actions"></dd>
</dd>
```

Updating `SummaryListComponent` to output `nil` for rows without actions, fixes the layout issue. 

Also removes the related tests for this component, as these are no longer our concern.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/813383/126182007-1c56a9a2-163e-4870-b14a-9bea378f1e23.png) | ![after](https://user-images.githubusercontent.com/813383/126182001-1f361bca-5768-4fe4-949c-d12d0e107573.png) |

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
