### PR TITLE
Don’t use emoji to indicate selected references

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -47,7 +47,7 @@ module SupportInterface
     def selected_row
       {
         key: 'Selected?',
-        value: reference.selected? ? '✅' : '❌',
+        value: reference.selected? ? 'Yes' : 'No',
       }
     end
 

--- a/spec/components/support_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/support_interface/reference_with_feedback_component_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
       render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
 
       within_summary_row('Selected?') do
-        expect(page).to include '✅'
+        expect(page).to include 'Yes'
       end
     end
 
@@ -54,7 +54,7 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
       render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
 
       within_summary_row('Selected?') do
-        expect(page).to include '❌'
+        expect(page).to include 'No'
       end
     end
   end


### PR DESCRIPTION
## Context

We currently indicate whether a reference has been selected or not by using ❌ or ✅ emoji in the reference summary list. However, emoji can be difficult for screen reader users as the full Unicode name is read out (`Cross Mark` and `Check Mark Button`) which may verbose or not accurate (i.e. it is not a button). Elsewhere we use ‘Yes’ and ‘No’, so should use the same here.

## Changes proposed in this pull request

Replace ❌ with ‘No’ and ✅ with ‘Yes’

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
