### PR TITLE
Fix when editing course providers can select courses with no valid sites

### DIFF
--- a/app/queries/get_change_offer_options.rb
+++ b/app/queries/get_change_offer_options.rb
@@ -48,6 +48,9 @@ class GetChangeOfferOptions
     make_decisions_courses
     .where(recruitment_cycle_year: recruitment_cycle_year)
     .where(ratifying_provider_is_preserved)
+    .joins(:course_options)
+    .where(course_options: { site_still_valid: true })
+    .distinct
   end
 
   def make_decisions_courses

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -65,5 +65,11 @@ FactoryBot.define do
         new_course.save
       end
     end
+
+    trait :with_valid_course_option do
+      after(:create) do |course|
+        create(:course_option, course: course)
+      end
+    end
   end
 end

--- a/spec/queries/get_change_offer_options_spec.rb
+++ b/spec/queries/get_change_offer_options_spec.rb
@@ -82,14 +82,6 @@ RSpec.describe GetChangeOfferOptions do
   end
 
   describe '#offerable_courses' do
-    it 'returns only courses which are open on apply and exposed in find' do
-      service = service(provider_user, externally_ratified_course)
-      create(:course, accredited_provider: ratifying_provider)
-      create(:course, accredited_provider: ratifying_provider, open_on_apply: true, exposed_in_find: false)
-      allow(service).to receive(:make_decisions_courses).and_return(Course.all)
-      expect(service.offerable_courses).to eq([externally_ratified_course])
-    end
-
     it 'returns only courses that have valid sites' do
       service = service(provider_user, self_ratified_course)
       create(:course_option, course: self_ratified_course, site_still_valid: false)

--- a/spec/queries/get_change_offer_options_spec.rb
+++ b/spec/queries/get_change_offer_options_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe GetChangeOfferOptions do
 
   let(:ratifying_provider) { create(:provider) }
   let(:self_ratified_course) { create(:course, provider: ratifying_provider) }
-  let(:externally_ratified_course) { create(:course, accredited_provider: ratifying_provider) }
+  let(:externally_ratified_course) { create(:course, :with_valid_course_option, accredited_provider: ratifying_provider) }
   let(:provider_user) { create(:provider_user) }
 
   def service(provider_user, course)
@@ -82,6 +82,22 @@ RSpec.describe GetChangeOfferOptions do
   end
 
   describe '#offerable_courses' do
+    it 'returns only courses which are open on apply and exposed in find' do
+      service = service(provider_user, externally_ratified_course)
+      create(:course, accredited_provider: ratifying_provider)
+      create(:course, accredited_provider: ratifying_provider, open_on_apply: true, exposed_in_find: false)
+      allow(service).to receive(:make_decisions_courses).and_return(Course.all)
+      expect(service.offerable_courses).to eq([externally_ratified_course])
+    end
+
+    it 'returns only courses that have valid sites' do
+      service = service(provider_user, self_ratified_course)
+      create(:course_option, course: self_ratified_course, site_still_valid: false)
+      create(:course, :open_on_apply)
+      allow(service).to receive(:make_decisions_courses).and_return(Course.all)
+      expect(service.offerable_courses).to match_array([externally_ratified_course])
+    end
+
     it 'returns only courses which are in the same recruitment cycle' do
       service = service(provider_user, externally_ratified_course)
       create(:course, :previous_year, accredited_provider: ratifying_provider)
@@ -91,6 +107,7 @@ RSpec.describe GetChangeOfferOptions do
 
     it 'returns all courses ratified by the same ratifying provider as the externally ratified course' do
       service = service(provider_user, externally_ratified_course)
+      create(:course_option, course: self_ratified_course)
       create(:course)
       allow(service).to receive(:make_decisions_courses).and_return(Course.all)
       expect(service.offerable_courses).to match_array([externally_ratified_course, self_ratified_course])
@@ -98,6 +115,7 @@ RSpec.describe GetChangeOfferOptions do
 
     it 'returns externally and self-ratified courses based on an self-ratified course' do
       service = service(provider_user, self_ratified_course)
+      create(:course_option, course: self_ratified_course)
       create(:course)
       allow(service).to receive(:make_decisions_courses).and_return(Course.all)
       expect(service.offerable_courses).to match_array([externally_ratified_course, self_ratified_course])

--- a/spec/system/provider_interface/change_existing_offer_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_spec.rb
@@ -41,6 +41,7 @@ RSpec.feature 'Provider changes an existing offer' do
 
     when_i_select_a_different_provider
     and_i_click_continue
+    then_i_can_only_select_valid_courses
 
     when_i_select_a_different_course
     and_i_click_continue
@@ -91,13 +92,14 @@ RSpec.feature 'Provider changes an existing offer' do
   def given_the_provider_user_can_offer_multiple_provider_courses
     @selected_provider = create(:provider, :with_signed_agreement)
     create(:provider_permissions, provider: @selected_provider, provider_user: provider_user, make_decisions: true)
-    courses = create_list(:course, 2, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)
-    @selected_course = courses.sample
+    courses = create_list(:course, 3, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)
+    @selected_course, @invalid_course = courses.sample(2)
 
     course_options = [create(:course_option, :part_time, course: @selected_course),
                       create(:course_option, :full_time, course: @selected_course),
                       create(:course_option, :full_time, course: @selected_course),
                       create(:course_option, :part_time, course: @selected_course)]
+    create(:course_option, :full_time, course: @invalid_course, site_still_valid: false)
 
     create(
       :provider_relationship_permissions,
@@ -149,6 +151,11 @@ RSpec.feature 'Provider changes an existing offer' do
 
   def and_i_click_continue
     click_on t('continue')
+  end
+
+  def then_i_can_only_select_valid_courses
+    expect(page).not_to have_content(@invalid_course.name_and_code)
+    expect(page).to have_content(@selected_course.name_and_code)
   end
 
   def when_i_select_a_different_course

--- a/spec/system/provider_interface/change_existing_offer_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_spec.rb
@@ -93,12 +93,13 @@ RSpec.feature 'Provider changes an existing offer' do
     @selected_provider = create(:provider, :with_signed_agreement)
     create(:provider_permissions, provider: @selected_provider, provider_user: provider_user, make_decisions: true)
     courses = create_list(:course, 3, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)
-    @selected_course, @invalid_course = courses.sample(2)
+    @selected_course, @invalid_course, @other_valid_course = courses.sample(3)
 
     course_options = [create(:course_option, :part_time, course: @selected_course),
                       create(:course_option, :full_time, course: @selected_course),
                       create(:course_option, :full_time, course: @selected_course),
                       create(:course_option, :part_time, course: @selected_course)]
+    create(:course_option, :full_time, course: @other_valid_course)
     create(:course_option, :full_time, course: @invalid_course, site_still_valid: false)
 
     create(

--- a/spec/system/provider_interface/change_make_offer_spec.rb
+++ b/spec/system/provider_interface/change_make_offer_spec.rb
@@ -151,12 +151,13 @@ RSpec.feature 'Provider makes an offer' do
     create(:provider_permissions, provider: @selected_provider, provider_user: provider_user, make_decisions: true)
     courses = [create(:course, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider),
                create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)]
-    @selected_course = courses.sample
+    @selected_course, other_course = courses.sample(2)
 
     course_options = [create(:course_option, :part_time, course: @selected_course),
                       create(:course_option, :full_time, course: @selected_course),
                       create(:course_option, :full_time, course: @selected_course),
                       create(:course_option, :part_time, course: @selected_course)]
+    create(:course_option, :part_time, course: other_course)
 
     create(
       :provider_relationship_permissions,

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -170,7 +170,7 @@ RSpec.feature 'Provider makes an offer' do
 
   def given_the_provider_has_multiple_courses
     @provider_available_course = create(:course, :open_on_apply, study_mode: :full_time, provider: provider, accredited_provider: ratifying_provider)
-    create(:course, :open_on_apply, provider: provider)
+    create(:course, :open_on_apply, :with_valid_course_option, provider: provider)
     course_options = [create(:course_option, :full_time, course: @provider_available_course),
                       create(:course_option, :full_time, course: @provider_available_course),
                       create(:course_option, :full_time, course: @provider_available_course)]
@@ -208,12 +208,13 @@ RSpec.feature 'Provider makes an offer' do
     create(:provider_permissions, provider: @available_provider, provider_user: provider_user, make_decisions: true)
     courses = [create(:course, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider),
                create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider)]
-    @selected_provider_available_course = courses.sample
+    @selected_provider_available_course, other_course = courses.sample(2)
 
     course_options = [create(:course_option, :part_time, course: @selected_provider_available_course),
                       create(:course_option, :full_time, course: @selected_provider_available_course),
                       create(:course_option, :full_time, course: @selected_provider_available_course),
                       create(:course_option, :part_time, course: @selected_provider_available_course)]
+    create(:course_option, :part_time, course: other_course)
 
     create(
       :provider_relationship_permissions,


### PR DESCRIPTION
## Context

If a course is valid but has sites that are all have false values for `site_still_valid` (despite having vacancies) then a provider can select that course when editing an offer. However when they get to the page to select a course option the list is empty leading to a validation error if they try to continue.

We shouldn't allow a provider to pick a course with no valid sites. (i.e. check `site_still_valid` as well as vacancy_status.)

## Changes proposed in this pull request

- [x] Add extra condition to `GetChangeOfferOptions#offerable_courses` query so that courses that
don't have any valid course options are not shown
- [x] Update appropriate system and unit tests

## Guidance to review

Not much to this but per commit is probably easiest. To manually test find a course that has sites with vacancies that are no longer valid.

## Link to Trello card

https://trello.com/c/QUZjrn5O/3569-when-editing-course-providers-can-select-courses-with-no-valid-sites

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
