### PR TITLE
Adjust think times for manage and vendor load plans; add credentials

### DIFF
--- a/jmeter/plans/manage.rb
+++ b/jmeter/plans/manage.rb
@@ -14,44 +14,41 @@ end
 test do
   cookies clear_each_iteration: true
 
-  # Expected Oct usage per hour: 50 users, 12 sessions/user, 5 minutes per session
-  # Providers on average have 2-3 users
-  # Section below must have 25 uids, each belonging to a different provider
-  %w[
-    dev-support
-  ].each do |uid|
+  # Easiest way to adjust the load is adjusting this
+  random_timer 1000, 300000
 
-    # Each thread below must take 5 minutes
-    # The total number of sessions for each uid (below) should be 12
+  # Expected Oct usage per hour: 50 users, 12 sessions/user, 5 minutes per session
+  # Providers on average have 2-3 users, but re-using same user for each provider is ok
+  # Section below must have 50 uids, each belonging to a different provider
+  %w[
+    2KL 28E 2BD 2KM 1XO B28 1KN 1E5 1CS 1AV
+    1MN 2FR 2JH 1NA B38 1K2 2CG 13E 19C B25
+    1R3 25F 17U 2CF 1QN B20 14B 2KH 1PE 2BU
+    1JH 1KH 1HQ 1Y1 2AT 2CJ 2KA 1JD 24R 2AX
+    1F6 135 2BP 24L 1KU C10 1LA 1UH 2GG 18C
+  ].each do |uid|
+    # The total number of sessions for each uid (below) should be 6
 
     # See interviewing application and interview information
-    threads count: 2, continue_forever: true, duration: 3600 do
+    threads count: 1, continue_forever: true, duration: 3600 do
       log_in uid
-      think_time 3000
       visit name: 'Filter by interviewing', url: BASEURL + '/provider/applications?commit=Apply+filters&status%5B%5D=interviewing' do
         extract name: 'application_id', regex: 'href="/provider/applications/(\d+)"', match_number: 0
       end
-      think_time 2000
       visit name: 'Load interviewing application', url: BASEURL + '/provider/applications/${application_id}'
-      think_time 1000
       visit name: 'See application interviews', url: BASEURL + '/provider/applications/${application_id}/interviews'
-      think_time 295000
     end
 
     # Start making an offer
-    threads count: 2, continue_forever: true, duration: 3600 do
+    threads count: 1, continue_forever: true, duration: 3600 do
       log_in uid
-      think_time 1000
       visit name: 'Filter by awaiting_provider_decision', url: BASEURL + '/provider/applications?commit=Apply+filters&status%5B%5D=awaiting_provider_decision' do
         extract name: 'application_id', regex: 'href="/provider/applications/(\d+)"', match_number: 0
       end
-      think_time 1000
       visit name: 'Load received application', url: BASEURL + '/provider/applications/${application_id}'
-      think_time 1000
       visit name: 'Load make decision page', url: BASEURL + '/provider/applications/${application_id}/decision/new' do
         extract name: 'authenticity_token', regex: 'name="authenticity_token" value="(.+?)"'
       end
-      think_time 1000
       submit name: 'Start make offer flow', url: BASEURL + '/provider/applications/${application_id}/decision',
         'DO_MULTIPART_POST': 'true',
         fill_in: {
@@ -59,54 +56,39 @@ test do
           'authenticity_token' => '${authenticity_token}',
           commit: 'Continue'
         }
-      think_time 295000
     end
 
     # See rejected application
-    threads count: 2, continue_forever: true, duration: 3600 do
+    threads count: 1, continue_forever: true, duration: 3600 do
       log_in uid
-      think_time 2000
       visit name: 'Filter by rejected', url: BASEURL + '/provider/applications?commit=Apply+filters&status%5B%5D=rejected' do
         extract name: 'application_id', regex: 'href="/provider/applications/(\d+)"', match_number: 0
       end
-      think_time 1000
-
       visit name: 'Load rejected application', url: BASEURL + '/provider/applications/${application_id}'
-      think_time 1000
       visit name: 'View application timeline', url: BASEURL + '/provider/applications/${application_id}/timeline'
-      think_time 1000
       visit name: 'View application notes', url: BASEURL + '/provider/applications/${application_id}/notes'
-      think_time 295000
     end
 
     # See provider interview schedule
-    threads count: 2, continue_forever: true, duration: 3600 do
+    threads count: 1, continue_forever: true, duration: 3600 do
       log_in uid
-      think_time 3000
       visit name: 'See interview schedule', url: BASEURL + '/provider/interview-schedule'
-      think_time 3000
       visit name: 'See past interview schedule', url: BASEURL + '/provider/interview-schedule/past'
-      think_time 295000
     end
 
     # See provider activity log
-    threads count: 2, continue_forever: true, duration: 3600 do
+    threads count: 1, continue_forever: true, duration: 3600 do
       log_in uid
-      think_time 10000
       visit name: 'Load activity log', url: BASEURL + '/provider/activity'
-      think_time 290000
     end
 
     # Data export
-     threads count: 2, continue_forever: true, duration: 3600 do
+     threads count: 1, continue_forever: true, duration: 3600 do
       log_in uid
-      think_time 3000
       visit name: 'Load provider data export form', url: BASEURL + '/provider/applications/data-export/new' do
         extract name: 'provider_id', regex: 'value="(\d+)" name="provider_interface_application_data_export_form\[provider_ids\]', match_number: 0
       end
-      think_time 2000
       visit name: 'Download data export', url: BASEURL + '/provider/applications/data-export?provider_interface_application_data_export_form[recruitment_cycle_years][]=&provider_interface_application_data_export_form[recruitment_cycle_years][]=2021&provider_interface_application_data_export_form[recruitment_cycle_years][]=2020&provider_interface_application_data_export_form[application_status_choice]=all&provider_interface_application_data_export_form[statuses][]=&provider_interface_application_data_export_form[provider_ids][]=&provider_interface_application_data_export_form[provider_ids][]=${provider_id}&commit=Export+data+(CSV)'
-      think_time 295000
     end
   end
 end.jmx

--- a/jmeter/plans/vendor.rb
+++ b/jmeter/plans/vendor.rb
@@ -12,9 +12,28 @@ end
 # Expected Oct usage per hour:
 #   71 SRS systems polling every hour for 90 days of data
 test do
+  random_timer 1000, 900000 # this is 4x that
+
   # Section below must have 71 api keys, each belonging to a different provider
   %w[
-    Xp9jU2_2BeDqsRP8Yy8C
+    Ze4rL4Nz8hzm_t7aJdBG BG8Fd1jW2JCs3J6fCzzs yKbesemkdx3hM4hTRu1C pwkZVZWa9tVk393htbnT
+    Y3NpsFdmymsnZ6VzFt4M 1v2qjH-WhN88GhyUD9XG YWA6iXCjQjspU7LjriWA kzwcj6_k_LdCGpGWR2t5
+    VGBukaCmfcyQzVYbMXkt Pz37P_-nfE_dAR23cUaH JXQsKX_xt9-UymkJJskZ AskVr7zn9aqU81sFBTg7
+    S5QAmftkyjQBxY3aCfwR sWQ-vsX1xyUMqAhbUJBg F1J1y9keyHTG-nNRveex rqn7vxdxspCRGu22KdU4
+    pDqPLmWKRKiLJ_eoAcbi xqD73UWiHRKfFSpzsVse d7t_bEP-VQAAX-Jn4QYf dRhH5t7bFjd2xjCFK_Gi
+    Fhbx-Lw5furyHiq4Y6Jx Djszj57PMjbJSixQrMB5 5xYfJmxy5soijFEgt2kS C73PQGBRkWrzi3K3QDRx
+    cLipzwEFa5aZtsftcyuz -gmi8s5-EFZm1NVjX4tb H9xRezgjhtPV4vHekEBm b2VD8tVFAf4DBYqPRW7R
+    1ymXFa5JLMy48yk8nfpo 5ADYN5bx9psxmUncsbgC n_3qhmyMGKfjuzsUPCfq Ap7W7jpf-4rNUxajoqRd
+    VnKExzTJhFZrC6VRQdUa R_R5H3TUdamY_BQaZ-iP LRrpz1T14AoGQmgYx9Us K2DmpxowvzACatPod954
+    RU8cvyU2zCho2MqnKqT6 WGrnxEf7ve865DQssBRY T7LEmbskCAF_iXn-HxNo XycE5hVGs-kygxJcLyeQ
+    xiQD7LTx5Lpjq5whTfYU x_E29nDFybnhZ-yGZZ-Z DYyZzJYFHY51fP5SsVHQ 17EKux-mKM-27MfMs1fB
+    b62f_KxBohDUyUQWz2Yd teu5kTxNioHuDMwSuPT1 hxcC2HxZcrZpqACwvshP q8feJSgxb4Uy9evr3xjX
+    ZT3g-H2eQmLJttYu9ZrE J-8i-zhxzxZTuisYB6yr 3XpPv6PVnTf-s_F5Wcig X_yMBMyXdDNWvDnmzCju
+    XMCzFb2MokKMcSD4n4a9 H__7vQyptW_ibtCLoHbs MuptqFe1UptZRK5kbTWt 8BbRkVEC4y5y5RGqhr-Z
+    yxFw6ukJFSzygyMv9sXP DxeRM-dz_4mw_69ZioCH WszpjMzdv7s84dpbEgog FsLTWQwTM5UcKqbnQzzp
+    cWzXTqL1mbndSp31khkQ XLZWLQA7E3rRGys3jDAL Rx9so9s5aNQqFUkvbkEz erf3Cz982m3nYas1jcUq
+    RG5wzV3K1zEx3JVz84Rx ekXu2tjgtJVSKtfyGPP9 sWi2j2siVXvc_NL6Hiam TTxwCzaWJhHeb3ux1TXq
+    6EFn5ZRhFUwTELxG72bo FC8_dFugs-gXDU-__B3r oujZY_1YeyfWCiwoYzdx
   ].each do |api_key|
 
     # Sync applications (last 90 days) once every hour
@@ -27,8 +46,6 @@ test do
         raw_body: params.to_json do
           with_xhr
         end
-
-      think_time 1800000
     end
 
     # Make offer
@@ -65,8 +82,6 @@ test do
         raw_body: offer_payload.to_json do
           with_xhr
         end
-
-      think_time 30000
     end
   end
 end.jmx


### PR DESCRIPTION
Think times do not seem to work the way I expected. Fix this by introducing a top-level `random_timer`.

Add Manage user UIDs and vendor api keys for the load-test environment.
