### PR TITLE
Remove provider `sync_courses` field requirement when syncing from the TTAPI

### DIFF
--- a/app/services/sync_provider.rb
+++ b/app/services/sync_provider.rb
@@ -4,7 +4,6 @@ class SyncProvider
   end
 
   def call
-    @provider.update!(sync_courses: true)
     TeacherTrainingPublicAPI::SyncProviderWorker.perform_async(@provider.code)
   end
 end

--- a/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
+++ b/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
@@ -8,11 +8,12 @@ module TeacherTrainingPublicAPI
 
         scope = TeacherTrainingPublicAPI::Provider
           .where(year: recruitment_cycle_year)
-          .paginate(page: page_number, per_page: 500)
+          .paginate(page: page_number, per_page: 250)
         scope = scope.where(updated_since: TeacherTrainingPublicAPI::SyncCheck.updated_since) if incremental_sync
+        delay_by = calculate_offset(page_number + 1, incremental_sync)
         response = scope.all
 
-        sync_providers(response, recruitment_cycle_year)
+        sync_providers(response, recruitment_cycle_year, delay_by)
 
         is_last_page = true if response.links.links['next'].nil?
       end
@@ -22,15 +23,22 @@ module TeacherTrainingPublicAPI
       raise TeacherTrainingPublicAPI::SyncError
     end
 
-    def self.sync_providers(providers_from_api, recruitment_cycle_year)
+    def self.sync_providers(providers_from_api, recruitment_cycle_year, delay_by)
       providers_from_api.each do |provider_from_api|
         TeacherTrainingPublicAPI::SyncProvider.new(
           provider_from_api: provider_from_api,
           recruitment_cycle_year: recruitment_cycle_year,
+          delay_by: delay_by,
         ).call
       end
     end
 
-    private_class_method :sync_providers
+    def self.calculate_offset(index, incremental_sync)
+      return if incremental_sync
+
+      (index * 3).minutes
+    end
+
+    private_class_method :sync_providers, :calculate_offset
   end
 end

--- a/app/services/teacher_training_public_api/sync_provider.rb
+++ b/app/services/teacher_training_public_api/sync_provider.rb
@@ -1,8 +1,9 @@
 module TeacherTrainingPublicAPI
   class SyncProvider
-    def initialize(provider_from_api:, recruitment_cycle_year:)
+    def initialize(provider_from_api:, recruitment_cycle_year:, delay_by: nil)
       @provider_from_api = provider_from_api
       @recruitment_cycle_year = recruitment_cycle_year
+      @delay_by = delay_by
     end
 
     def call(run_in_background: true)
@@ -13,7 +14,7 @@ module TeacherTrainingPublicAPI
 
     def sync_courses(run_in_background, provider)
       if run_in_background
-        TeacherTrainingPublicAPI::SyncCourses.perform_async(provider.id, @recruitment_cycle_year)
+        TeacherTrainingPublicAPI::SyncCourses.perform_in(@delay_by, provider.id, @recruitment_cycle_year)
       else
         TeacherTrainingPublicAPI::SyncCourses.new.perform(provider.id, @recruitment_cycle_year, run_in_background: false)
       end

--- a/app/services/teacher_training_public_api/sync_provider.rb
+++ b/app/services/teacher_training_public_api/sync_provider.rb
@@ -5,17 +5,8 @@ module TeacherTrainingPublicAPI
       @recruitment_cycle_year = recruitment_cycle_year
     end
 
-    def call(run_in_background: true, force_sync_courses: false)
-      @force_sync_courses = force_sync_courses
-
-      provider_attrs = if existing_provider
-                         provider_attrs_from(@provider_from_api)
-                       else
-                         provider_attrs_from(@provider_from_api).merge(
-                           sync_courses: force_sync_courses,
-                         )
-                       end
-
+    def call(run_in_background: true)
+      provider_attrs = provider_attrs_from(@provider_from_api)
       provider = create_or_update_provider(provider_attrs)
       sync_courses(run_in_background, provider)
     end
@@ -33,7 +24,7 @@ module TeacherTrainingPublicAPI
   private
 
     def sync_courses?
-      @force_sync_courses || existing_provider&.sync_courses
+      existing_provider&.sync_courses
     end
 
     def provider_attrs_from(provider_from_api)

--- a/app/services/teacher_training_public_api/sync_provider.rb
+++ b/app/services/teacher_training_public_api/sync_provider.rb
@@ -12,24 +12,18 @@ module TeacherTrainingPublicAPI
     end
 
     def sync_courses(run_in_background, provider)
-      if sync_courses?
-        if run_in_background
-          TeacherTrainingPublicAPI::SyncCourses.perform_async(provider.id, @recruitment_cycle_year)
-        else
-          TeacherTrainingPublicAPI::SyncCourses.new.perform(provider.id, @recruitment_cycle_year, run_in_background: false)
-        end
+      if run_in_background
+        TeacherTrainingPublicAPI::SyncCourses.perform_async(provider.id, @recruitment_cycle_year)
+      else
+        TeacherTrainingPublicAPI::SyncCourses.new.perform(provider.id, @recruitment_cycle_year, run_in_background: false)
       end
     end
 
   private
 
-    def sync_courses?
-      existing_provider&.sync_courses
-    end
-
     def provider_attrs_from(provider_from_api)
       {
-        sync_courses: sync_courses?,
+        sync_courses: true,
         region_code: provider_from_api.region_code&.strip,
         postcode: provider_from_api.postcode&.strip,
         name: provider_from_api.name,

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -49,5 +49,5 @@ class Clock
 
   every(1.day, 'SendEocDeadlineReminderEmailToCandidatesWorker', at: '12:00') { SendEocDeadlineReminderEmailToCandidatesWorker.new.perform }
 
-  every(3.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: '00:59') { TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false) }
+  every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: '00:59') { TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false) }
 end

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -31,13 +31,13 @@ task sync_dev_providers_and_open_courses: :environment do
 
     TeacherTrainingPublicAPI::SyncProvider.new(
       provider_from_api: provider_from_api, recruitment_cycle_year: RecruitmentCycle.previous_year,
-    ).call(run_in_background: false, force_sync_courses: true)
+    ).call(run_in_background: false)
 
     Provider.find_by_code(code).courses.previous_cycle.exposed_in_find.update_all(open_on_apply: true, opened_on_apply_at: Time.zone.now)
 
     TeacherTrainingPublicAPI::SyncProvider.new(
       provider_from_api: provider_from_api, recruitment_cycle_year: RecruitmentCycle.current_year,
-    ).call(run_in_background: false, force_sync_courses: true)
+    ).call(run_in_background: false)
   end
 
   puts 'Making all the courses open on Apply...'

--- a/spec/services/sync_provider_spec.rb
+++ b/spec/services/sync_provider_spec.rb
@@ -1,19 +1,21 @@
 require 'rails_helper'
 
-RSpec.describe SyncProvider do
+RSpec.describe SyncProvider, sidekiq: true do
   include TeacherTrainingPublicAPIHelper
   let(:provider) { create(:provider, code: 'ABC', sync_courses: false) }
 
-  it 'enables course syncing' do
-    SyncProvider.new(provider: provider).call
-
-    expect(provider.sync_courses).to be true
-  end
-
-  it 'syncs the provider', sidekiq: true do
+  before do
     stub_teacher_training_api_provider(provider_code: 'ABC', specified_attributes: { code: 'ABC' })
     stub_teacher_training_api_course_with_site(provider_code: 'ABC', course_code: '123', site_code: 'A', course_attributes: [{ accredited_body_code: nil }])
+  end
 
+  it 'enables course syncing during sync' do
+    SyncProvider.new(provider: provider).call
+
+    expect(provider.reload.sync_courses).to be true
+  end
+
+  it 'syncs the provider' do
     expect(provider.courses.count).to be 0
 
     SyncProvider.new(provider: provider).call

--- a/spec/services/teacher_training_public_api/sync_all_providers_and_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_all_providers_and_courses_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCourses, sidekiq: tr
         allow(sync_provider).to receive(:call)
         allow(TeacherTrainingPublicAPI::SyncProvider)
           .to receive(:new)
-          .with(provider_from_api: anything, recruitment_cycle_year: recruitment_cycle_year)
+          .with(provider_from_api: anything, recruitment_cycle_year: recruitment_cycle_year, delay_by: 6.minutes)
           .and_return(sync_provider)
       end
 
@@ -47,7 +47,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCourses, sidekiq: tr
         allow(sync_provider).to receive(:call)
         allow(TeacherTrainingPublicAPI::SyncProvider)
           .to receive(:new)
-            .with(provider_from_api: anything, recruitment_cycle_year: recruitment_cycle_year)
+            .with(provider_from_api: anything, recruitment_cycle_year: recruitment_cycle_year, delay_by: nil)
             .and_return(sync_provider)
         stub_teacher_training_api_providers(
           recruitment_cycle_year: recruitment_cycle_year,

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
   include TeacherTrainingPublicAPIHelper
 
   describe '.call' do
-    context 'ingesting an existing provider configured to sync courses, sites and course_options' do
+    context 'ingesting an existing provider, sites and course_options' do
       let(:existing_provider) do
-        create(:provider, code: 'ABC', sync_courses: true, provider_type: 'scitt', region_code: 'south_west', postcode: 'SK2 6AA')
+        create(:provider, code: 'ABC', provider_type: 'scitt', region_code: 'south_west', postcode: 'SK2 6AA')
       end
 
       it 'correctly creates all the entities' do
@@ -321,7 +321,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
     end
 
     context 'ingesting a provider when it existed in the previous recruitment cycle' do
-      let(:existing_provider) { create(:provider, code: 'ABC', sync_courses: true) }
+      let(:existing_provider) { create(:provider, code: 'ABC') }
 
       before do
         stub_teacher_training_api_course_with_site(provider_code: 'ABC',

--- a/spec/services/teacher_training_public_api/sync_provider_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_provider_spec.rb
@@ -4,58 +4,39 @@ RSpec.describe TeacherTrainingPublicAPI::SyncProvider, sidekiq: true do
   include TeacherTrainingPublicAPIHelper
 
   describe '.call' do
-    context 'ingesting a brand new provider' do
-      it 'just creates the provider without any courses' do
-        provider_from_api = fake_api_provider({ code: 'ABC' })
-        described_class.new(provider_from_api: provider_from_api, recruitment_cycle_year: stubbed_recruitment_cycle_year).call
+    before do
+      allow(TeacherTrainingPublicAPI::SyncCourses).to receive(:perform_async).and_return(true)
+      described_class.new(provider_from_api: provider_from_api, recruitment_cycle_year: stubbed_recruitment_cycle_year).call(run_in_background: true)
+    end
 
+    context 'ingesting a brand new provider' do
+      let(:provider_from_api) { fake_api_provider({ code: 'ABC' }) }
+
+      it 'creates the provider' do
         provider = Provider.find_by(code: 'ABC')
         expect(provider).to be_present
-        expect(provider.courses).to be_blank
+      end
+
+      it 'syncs the provider courses' do
+        expect(TeacherTrainingPublicAPI::SyncCourses).to have_received(:perform_async).exactly(1).time
       end
     end
 
-    context 'ingesting an existing provider not configured to sync courses' do
-      before do
-        @existing_provider = create :provider, code: 'ABC', sync_courses: false, name: 'Foobar College'
+    context 'ingesting an existing provider' do
+      let!(:existing_provider) do
+        create(:provider, code: 'ABC', name: 'Foobar College', region_code: 'london')
       end
+      let(:provider_from_api) { fake_api_provider(id: existing_provider.id, code: existing_provider.code, name: 'ABC College', region_code: 'north_west') }
 
-      it 'correctly updates the provider but does not import any courses' do
-        provider_from_api = fake_api_provider(code: 'ABC', name: 'ABC College')
-        described_class.new(provider_from_api: provider_from_api, recruitment_cycle_year: stubbed_recruitment_cycle_year).call
-
-        expect(@existing_provider.reload.courses).to be_blank
-        expect(@existing_provider.reload.name).to eq 'ABC College'
+      it 'correctly updates the provider' do
+        expect(existing_provider.reload.name).to eq('ABC College')
       end
 
       it 'correctly updates the Provider#region_code' do
-        provider_from_api = fake_api_provider(code: 'ABC', region_code: 'north_west')
-        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
-                                                   course_code: 'ABC1',
-                                                   course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
-                                                   site_code: 'A',
-                                                   vacancy_status: 'full_time_vacancies')
-
-        described_class.new(provider_from_api: provider_from_api, recruitment_cycle_year: stubbed_recruitment_cycle_year).call
-        expect(Provider.count).to eq 1
-        Provider.first.update!(region_code: 'london')
-
-        described_class.new(provider_from_api: provider_from_api, recruitment_cycle_year: stubbed_recruitment_cycle_year).call
-        expect(Provider.count).to eq 1
-        expect(Provider.first.region_code).to eq 'north_west'
+        expect(existing_provider.reload.region_code).to eq('north_west')
       end
-    end
 
-    context 'ingesting an existing provider configured to sync courses, sites and course_options' do
       it 'calls the Sync Courses job with the correct parameters' do
-        existing_provider = create(:provider, sync_courses: true)
-        provider_from_api = fake_api_provider(id: existing_provider.id, code: existing_provider.code)
-
-        allow(TeacherTrainingPublicAPI::SyncCourses).to receive(:perform_async).and_return(true)
-
-        sync_job = described_class.new(provider_from_api: provider_from_api, recruitment_cycle_year: stubbed_recruitment_cycle_year)
-        sync_job.call(run_in_background: true)
-
         expect(TeacherTrainingPublicAPI::SyncCourses).to have_received(:perform_async).with(
           provider_from_api.id,
           stubbed_recruitment_cycle_year,

--- a/spec/support/test_helpers/teacher_training_public_api_helper.rb
+++ b/spec/support/test_helpers/teacher_training_public_api_helper.rb
@@ -10,7 +10,7 @@ module TeacherTrainingPublicAPIHelper
       :get,
       "#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers",
     ).with(
-      query: { page: { page: 1, per_page: 500 } },
+      query: { page: { page: 1, per_page: 250 } },
     )
 
     scope = scope.with(query: filter_option) if filter_option
@@ -170,7 +170,7 @@ private
       :get,
       "#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers",
     ).with(
-      query: { page: { page: page_number, per_page: 500 } },
+      query: { page: { page: page_number, per_page: 250 } },
     ).to_return(
       status: 200,
       headers: { 'Content-Type': 'application/vnd.api+json' },

--- a/spec/system/find_sync/syncing_providers_spec.rb
+++ b/spec/system/find_sync/syncing_providers_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Syncing providers', sidekiq: true do
 
   def given_there_is_an_existing_provider_and_course_in_apply
     @course_uuid = SecureRandom.uuid
-    @existing_provider = create :provider, code: 'ABC', sync_courses: true
+    @existing_provider = create :provider, code: 'ABC'
     create :course, code: 'ABC1', provider: @existing_provider, subjects: %w[], uuid: @course_uuid
   end
 

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -109,6 +109,10 @@ RSpec.feature 'Providers and courses' do
           name: 'Gorse SCITT',
         },
         {
+          code: 'DOF',
+          name: 'An Unsynced Provider',
+        },
+        {
           code: 'GHI',
           name: 'Somerset SCITT Consortium',
         },
@@ -119,7 +123,6 @@ RSpec.feature 'Providers and courses' do
       ],
       filter_option: { 'filter[updated_since]' => @updated_since },
     )
-
     stub_teacher_training_api_provider(
       provider_code: 'XYZ',
       specified_attributes: {
@@ -142,6 +145,14 @@ RSpec.feature 'Providers and courses' do
                                                course_code: 'GHI1',
                                                course_attributes: [{ accredited_body_code: 'GHI' }],
                                                site_code: 'C')
+    stub_teacher_training_api_course_with_site(provider_code: 'DOF',
+                                               course_code: 'DOF1',
+                                               course_attributes: [{ accredited_body_code: 'DOF' }],
+                                               site_code: 'D')
+    stub_teacher_training_api_course_with_site(provider_code: 'XYZ',
+                                               course_code: 'XYZ1',
+                                               course_attributes: [{ accredited_body_code: 'XYZ' }],
+                                               site_code: 'E')
 
     Sidekiq::Testing.inline! do
       click_button 'Sync providers'
@@ -156,6 +167,8 @@ RSpec.feature 'Providers and courses' do
     expect(page).to have_content('Royal Academy of Dance')
     expect(page).to have_content('Gorse SCITT')
     expect(page).to have_content('Somerset SCITT Consortium')
+    expect(page).to have_content('University of Chester')
+    expect(page).to have_content('An Unsynced Provider')
   end
 
   def when_i_search_a_provider

--- a/spec/system/teacher_training_public_api/site_is_deleted_spec.rb
+++ b/spec/system/teacher_training_public_api/site_is_deleted_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Sync sites' do
   end
 
   def given_there_is_a_provider_and_course_on_apply
-    @provider = create :provider, code: 'ABC', sync_courses: true
+    @provider = create :provider, code: 'ABC'
     @course = create(:course, code: 'ABC1', provider: @provider, name: 'Secondary')
   end
 

--- a/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
+++ b/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Sync from Teacher Training API' do
   end
 
   def given_there_is_a_full_time_course_on_the_teacher_training_api
-    @provider = create :provider, code: 'ABC', sync_courses: true
+    @provider = create :provider, code: 'ABC'
     stub_teacher_training_api_course_with_site(provider_code: 'ABC',
                                                course_code: 'ABC1',
                                                course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],

--- a/spec/system/teacher_training_public_api/sync_course_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_course_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe 'Sync courses', sidekiq: true do
   end
 
   def and_one_of_the_courses_exists_already
-    provider = create :provider, code: 'ABC', sync_courses: true
-    create :provider, code: 'DEF', sync_courses: true
+    provider = create :provider, code: 'ABC'
+    create :provider, code: 'DEF'
     create(:course, code: 'ABC1', provider: provider, name: 'Secondary', uuid: @course_uuid)
   end
 

--- a/spec/system/teacher_training_public_api/sync_provider_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_provider_spec.rb
@@ -29,6 +29,14 @@ RSpec.describe 'Sync provider', sidekiq: true do
       ],
       filter_option: { 'filter[updated_since]' => @updated_since },
     )
+    stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                               course_code: 'ABC1',
+                                               course_attributes: [{ accredited_body_code: 'ABC' }],
+                                               site_code: 'D')
+    stub_teacher_training_api_course_with_site(provider_code: 'DEF',
+                                               course_code: 'DEF1',
+                                               course_attributes: [{ accredited_body_code: 'DEF' }],
+                                               site_code: 'E')
   end
 
   def and_the_last_sync_was_two_hours_ago

--- a/spec/system/teacher_training_public_api/sync_site_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_site_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Sync sites', sidekiq: true do
   end
 
   def and_one_of_the_sites_exists_already
-    provider = create :provider, code: 'ABC', sync_courses: true
+    provider = create :provider, code: 'ABC'
     create(:course, code: 'ABC1', provider: provider, uuid: @course_uuid)
     create(:site, code: 'A', provider: provider, name: 'Hogwarts School of Witchcraft and Wizardry')
   end


### PR DESCRIPTION
## Context
We would like to start syncing all courses from the TTAPI. We have done this manually on sandbox/prod but we'd like to continue doing this for any new providers that are synced. Before cleaning up and removing the `sync_courses` field which will no longer be relevant. Always sync courses for providers in the API

## Changes proposed in this pull request

- Remove logic for forcing syncing courses
- Remove logic to check if a provider has the flag `sync_courses` set to sync courses

## Guidance to review

There is logic in the support interface for syncing courses, we will remove this shortly after. This PR will ensure for now that all new providers will have their courses synced

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
