### PR TITLE
Short-circuit reject/withdraw mailer calls if required data is missing

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -92,30 +92,38 @@ class CandidateMailer < ApplicationMailer
   end
 
   def application_rejected_one_offer_one_awaiting_decision(application_choice)
+    @awaiting_decision = application_choice.self_and_siblings.find(&:decision_pending?)
+    return if @awaiting_decision.reject_by_default_at.blank?
+
     @course = application_choice.course_option.course
     @application_choice = RejectedApplicationChoicePresenter.new(application_choice)
     @offer = application_choice.self_and_siblings.find(&:offer?)
-    @awaiting_decision = application_choice.self_and_siblings.find(&:decision_pending?)
-    @awaiting_decision_by = @awaiting_decision.reject_by_default_at.to_s(:govuk_date)
     @candidate_magic_link = candidate_magic_link(@application_choice.application_form.candidate)
+    @awaiting_decision_by = @awaiting_decision.reject_by_default_at.to_s(:govuk_date)
 
     email_for_candidate(application_choice.application_form)
   end
 
   def application_rejected_awaiting_decision_only(application_choice)
+    @awaiting_decision = application_choice.self_and_siblings.select(&:decision_pending?)
+    reject_by_default_at = @awaiting_decision.sort_by(&:reject_by_default_at).map(&:reject_by_default_at).last
+    return if reject_by_default_at.blank?
+
     @course = application_choice.course_option.course
     @application_choice = RejectedApplicationChoicePresenter.new(application_choice)
-    @awaiting_decision = application_choice.self_and_siblings.select(&:decision_pending?)
-    @awaiting_decisions_by = @awaiting_decision.sort_by(&:reject_by_default_at).map(&:reject_by_default_at).last.to_s(:govuk_date)
+    @awaiting_decisions_by = reject_by_default_at.to_s(:govuk_date)
 
     email_for_candidate(application_choice.application_form)
   end
 
   def application_rejected_offers_only(application_choice)
+    @offers = application_choice.self_and_siblings.select(&:offer?)
+    decline_by_default_at = @offers.sort_by(&:decline_by_default_at).map(&:decline_by_default_at).first
+    return if decline_by_default_at.blank?
+
     @course = application_choice.course_option.course
     @application_choice = RejectedApplicationChoicePresenter.new(application_choice)
-    @offers = application_choice.self_and_siblings.select(&:offer?)
-    @respond_by_date = @offers.sort_by(&:decline_by_default_at).map(&:decline_by_default_at).first.to_s(:govuk_date)
+    @respond_by_date = decline_by_default_at.to_s(:govuk_date)
     @candidate_magic_link = candidate_magic_link(@application_choice.application_form.candidate)
 
     email_for_candidate(
@@ -134,10 +142,12 @@ class CandidateMailer < ApplicationMailer
   end
 
   def application_withdrawn_on_request_one_offer_one_awaiting_decision(application_choice)
+    @awaiting_decision = application_choice.self_and_siblings.find(&:decision_pending?)
+    return if @awaiting_decision.reject_by_default_at.blank?
+
     @course = application_choice.course_option.course
     @application_choice = application_choice
     @offer = application_choice.self_and_siblings.find(&:offer?)
-    @awaiting_decision = application_choice.self_and_siblings.find(&:decision_pending?)
     @awaiting_decision_by = @awaiting_decision.reject_by_default_at.to_s(:govuk_date)
     @candidate_magic_link = candidate_magic_link(@application_choice.application_form.candidate)
 
@@ -145,19 +155,25 @@ class CandidateMailer < ApplicationMailer
   end
 
   def application_withdrawn_on_request_awaiting_decision_only(application_choice)
+    @awaiting_decision = application_choice.self_and_siblings.select(&:decision_pending?)
+    reject_by_default_at = @awaiting_decision.sort_by(&:reject_by_default_at).map(&:reject_by_default_at).last
+    return if reject_by_default_at.blank?
+
     @course = application_choice.course_option.course
     @application_choice = application_choice
-    @awaiting_decision = application_choice.self_and_siblings.select(&:decision_pending?)
-    @awaiting_decisions_by = @awaiting_decision.sort_by(&:reject_by_default_at).map(&:reject_by_default_at).last.to_s(:govuk_date)
+    @awaiting_decisions_by = reject_by_default_at.to_s(:govuk_date)
 
     email_for_candidate(application_choice.application_form)
   end
 
   def application_withdrawn_on_request_offers_only(application_choice)
+    @offers = application_choice.self_and_siblings.select(&:offer?)
+    decline_by_default_at = @offers.sort_by(&:decline_by_default_at).map(&:decline_by_default_at).first
+    return if decline_by_default_at.blank?
+
     @course = application_choice.course_option.course
     @application_choice = application_choice
-    @offers = application_choice.self_and_siblings.select(&:offer?)
-    @respond_by_date = @offers.sort_by(&:decline_by_default_at).map(&:decline_by_default_at).first.to_s(:govuk_date)
+    @respond_by_date = decline_by_default_at.to_s(:govuk_date)
     @candidate_magic_link = candidate_magic_link(@application_choice.application_form.candidate)
 
     email_for_candidate(


### PR DESCRIPTION
## Context

When we generate test applications it's possible we move application states before the `CandidateMailer` sends a notification. [This has resulted in Sentry errors due to missing data, usually on date fields](https://sentry.io/organizations/dfe-bat/issues/2098925959/?project=1765973&query=is%3Aunresolved).


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Refactor rejection / withdrawal emails which are sensitive to missing dates so that they return on missing data.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/91ZcKyb4/3884-test-data-generator-creating-email-bugs

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
