### PR TITLE
Use `find_by` to avoid error on offerable courses

### DIFF
--- a/app/queries/get_change_offer_options.rb
+++ b/app/queries/get_change_offer_options.rb
@@ -21,7 +21,7 @@ class GetChangeOfferOptions
   def available_study_modes(course:)
     CourseOption
       .selectable
-      .where(course: offerable_courses.find(course.id))
+      .where(course: offerable_courses.find_by(id: course.id))
       .group('study_mode')
       .pluck(:study_mode)
   end
@@ -30,7 +30,7 @@ class GetChangeOfferOptions
     CourseOption
       .selectable
       .where(
-        course: offerable_courses.find(course.id),
+        course: offerable_courses.find_by(id: course.id),
         study_mode: study_mode,
       )
   end

--- a/app/queries/get_change_offer_options.rb
+++ b/app/queries/get_change_offer_options.rb
@@ -46,7 +46,6 @@ class GetChangeOfferOptions
 
   def offerable_courses
     make_decisions_courses
-    .open_on_apply
     .where(recruitment_cycle_year: recruitment_cycle_year)
     .where(ratifying_provider_is_preserved)
   end

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -9,15 +9,10 @@ class OfferValidations
   attr_accessor :application_choice, :course_option, :conditions
 
   validates :course_option, presence: true
-  validate :course_option_open_on_apply, if: :course_option
   validate :conditions_count, if: :conditions
   validate :conditions_length, if: :conditions
   validate :identical_to_existing_offer?, if: %i[application_choice course_option]
   validate :ratifying_provider_changed?, if: %i[application_choice course_option]
-
-  def course_option_open_on_apply
-    errors.add(:course_option, :not_open_on_apply) unless course_option.course.open_on_apply?
-  end
 
   def conditions_count
     return if conditions.count <= MAX_CONDITIONS_COUNT

--- a/spec/queries/get_change_offer_options_spec.rb
+++ b/spec/queries/get_change_offer_options_spec.rb
@@ -171,6 +171,13 @@ RSpec.describe GetChangeOfferOptions do
         expect(service.available_study_modes(course: self_ratified_course))
             .to match_array(%w[part_time])
       end
+
+      it 'returns no study modes if there are no offerable courses' do
+        create(:course_option, :part_time, course: self_ratified_course)
+        allow(service).to receive(:offerable_courses).and_return(Course.none)
+
+        expect(service.available_study_modes(course: self_ratified_course)).to be_empty
+      end
     end
 
     describe '#available_course_options' do
@@ -185,6 +192,12 @@ RSpec.describe GetChangeOfferOptions do
 
         expect(service.available_course_options(course: self_ratified_course, study_mode: 'part_time'))
             .to match_array([valid_course_option])
+      end
+
+      it 'returns no course options if there are no offerable courses' do
+        allow(service).to receive(:offerable_courses).and_return(Course.none)
+
+        expect(service.available_course_options(course: self_ratified_course, study_mode: 'part_time')).to be_empty
       end
     end
 

--- a/spec/queries/get_change_offer_options_spec.rb
+++ b/spec/queries/get_change_offer_options_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe GetChangeOfferOptions do
   include CourseOptionHelpers
 
   let(:ratifying_provider) { create(:provider) }
-  let(:self_ratified_course) { create(:course, :open_on_apply, provider: ratifying_provider) }
-  let(:externally_ratified_course) { create(:course, :open_on_apply, accredited_provider: ratifying_provider) }
+  let(:self_ratified_course) { create(:course, provider: ratifying_provider) }
+  let(:externally_ratified_course) { create(:course, accredited_provider: ratifying_provider) }
   let(:provider_user) { create(:provider_user) }
 
   def service(provider_user, course)
@@ -82,14 +82,6 @@ RSpec.describe GetChangeOfferOptions do
   end
 
   describe '#offerable_courses' do
-    it 'returns only courses which are open on apply and exposed in find' do
-      service = service(provider_user, externally_ratified_course)
-      create(:course, accredited_provider: ratifying_provider)
-      create(:course, accredited_provider: ratifying_provider, open_on_apply: true, exposed_in_find: false)
-      allow(service).to receive(:make_decisions_courses).and_return(Course.all)
-      expect(service.offerable_courses).to eq([externally_ratified_course])
-    end
-
     it 'returns only courses which are in the same recruitment cycle' do
       service = service(provider_user, externally_ratified_course)
       create(:course, :previous_year, accredited_provider: ratifying_provider)
@@ -99,14 +91,14 @@ RSpec.describe GetChangeOfferOptions do
 
     it 'returns all courses ratified by the same ratifying provider as the externally ratified course' do
       service = service(provider_user, externally_ratified_course)
-      create(:course, :open_on_apply)
+      create(:course)
       allow(service).to receive(:make_decisions_courses).and_return(Course.all)
       expect(service.offerable_courses).to match_array([externally_ratified_course, self_ratified_course])
     end
 
     it 'returns externally and self-ratified courses based on an self-ratified course' do
       service = service(provider_user, self_ratified_course)
-      create(:course, :open_on_apply)
+      create(:course)
       allow(service).to receive(:make_decisions_courses).and_return(Course.all)
       expect(service.offerable_courses).to match_array([externally_ratified_course, self_ratified_course])
     end

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -165,26 +165,6 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       expect(logged_error).to eq('NotAuthorisedError')
     end
 
-    it 'returns an error when specifying a course that is not open on Apply' do
-      application_choice = create_application_choice_for_currently_authenticated_provider(
-        status: 'awaiting_provider_decision',
-      )
-
-      course = create(:course, provider: currently_authenticated_provider)
-      other_course_option = course_option_for_provider(provider: currently_authenticated_provider, course: course)
-
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
-        'data' => {
-          'conditions' => [],
-          'course' => course_option_to_course_payload(other_course_option),
-        },
-      }
-
-      expect(response).to have_http_status(422)
-      expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-      expect(error_response['message']).to match 'The requested course is not open for applications via the Apply service'
-    end
-
     it 'returns an error when specifying a course that does not exist' do
       application_choice = create_application_choice_for_currently_authenticated_provider(
         status: 'awaiting_provider_decision',

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -53,24 +53,6 @@ RSpec.describe ChangeOffer do
       end
     end
 
-    describe 'if the new offer is for a course not open on apply' do
-      let(:course_option) do
-        course_option_for_provider(
-          provider: application_choice.course_option.provider,
-          course: create(:course, provider: application_choice.course_option.provider, open_on_apply: false),
-        )
-      end
-
-      it 'raises a Course Validation Exception' do
-        expect {
-          change_offer.save!
-        }.to raise_error(
-          ValidationException,
-          'The requested course is not open for applications via the Apply service',
-        )
-      end
-    end
-
     describe 'if the provided details are correct' do
       let(:application_choice) { create(:application_choice, status: :awaiting_provider_decision) }
       let(:provider_user) do

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -10,28 +10,6 @@ RSpec.describe OfferValidations, type: :model do
   context 'validations' do
     it { is_expected.to validate_presence_of(:course_option) }
 
-    describe '#course_option_open_on_apply' do
-      context 'when no course_option' do
-        let(:course_option) { nil }
-
-        it 'does not add a :not_open_on_apply error' do
-          offer.valid?
-
-          expect(offer.errors[:course_option]).not_to contain_exactly('is not open for applications via the Apply service')
-        end
-      end
-
-      context 'when not open on apply' do
-        let(:course) { create(:course, :ucas_only) }
-
-        it 'adds a :not_open_on_apply error' do
-          expect(offer).to be_invalid
-
-          expect(offer.errors[:course_option]).to contain_exactly('The requested course is not open for applications via the Apply service')
-        end
-      end
-    end
-
     describe '#conditions_count' do
       context 'when more than MAX_CONDITIONS_COUNT' do
         let(:conditions) { (OfferValidations::MAX_CONDITIONS_COUNT + 1).times.map { Faker::Coffee.blend_name } }

--- a/spec/system/provider_interface/change_existing_offer_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Provider changes an existing offer' do
            current_course_option: course_option)
   end
   let(:course) do
-    build(:course, :open_on_apply, :full_time, provider: provider, accredited_provider: ratifying_provider)
+    build(:course, :full_time, provider: provider, accredited_provider: ratifying_provider)
   end
   let(:course_option) { build(:course_option, course: course) }
 
@@ -91,7 +91,7 @@ RSpec.feature 'Provider changes an existing offer' do
   def given_the_provider_user_can_offer_multiple_provider_courses
     @selected_provider = create(:provider, :with_signed_agreement)
     create(:provider_permissions, provider: @selected_provider, provider_user: provider_user, make_decisions: true)
-    courses = create_list(:course, 2, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)
+    courses = create_list(:course, 2, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)
     @selected_course = courses.sample
 
     course_options = [create(:course_option, :part_time, course: @selected_course),

--- a/spec/system/provider_interface/change_make_offer_spec.rb
+++ b/spec/system/provider_interface/change_make_offer_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Provider makes an offer' do
            course_option: course_option)
   end
   let(:course) do
-    build(:course, :open_on_apply, :full_time, provider: provider, accredited_provider: ratifying_provider)
+    build(:course, :full_time, provider: provider, accredited_provider: ratifying_provider)
   end
   let(:course_option) { build(:course_option, course: course) }
 
@@ -149,7 +149,7 @@ RSpec.feature 'Provider makes an offer' do
   def given_the_provider_user_can_offer_multiple_provider_courses
     @selected_provider = create(:provider, :with_signed_agreement)
     create(:provider_permissions, provider: @selected_provider, provider_user: provider_user, make_decisions: true)
-    courses = [create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider),
+    courses = [create(:course, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider),
                create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)]
     @selected_course = courses.sample
 

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Provider makes an offer' do
            course_option: course_option)
   end
   let(:course) do
-    build(:course, :open_on_apply, :full_time, provider: provider, accredited_provider: ratifying_provider)
+    build(:course, :full_time, provider: provider, accredited_provider: ratifying_provider)
   end
   let(:course_option) { build(:course_option, course: course) }
 
@@ -206,7 +206,7 @@ RSpec.feature 'Provider makes an offer' do
   def given_the_provider_user_can_offer_multiple_provider_courses
     @available_provider = create(:provider, :with_signed_agreement)
     create(:provider_permissions, provider: @available_provider, provider_user: provider_user, make_decisions: true)
-    courses = [create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider),
+    courses = [create(:course, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider),
                create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider)]
     @selected_provider_available_course = courses.sample
 


### PR DESCRIPTION
## Context

When a provider attempts to make an offer on/view the offer tab for a course that is not open on apply and not exposed on find they are getting a 404. This is because the queries are using `find` which errors if we cannot find the `id` of the course in the `offerable_courses` collection.

## Changes proposed in this pull request

Change `find` to `find_by` to avoid an error. This now returns an empty collection instead, and the pages will load.
This means that we can now do the following:
1) Make an offer to a course that is not exposed in find
2) We cannot make on offer to a course that is not open on apply though, and we will still see an error
3) View the offers tab on an application that has been offered, regardless of the course being open on apply or exposed in find
4) Can edit an offer when it is not exposed in find
5) Cannot edit an offer when it is not open on apply

## Guidance to review

Let me know if I missed anything, we should tackle the open on apply issue separately


## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
