### PR TITLE
SPIKE Make carry over flow consistent with apply again [DO NOT MERGE]

### DIFF
--- a/app/components/candidate_interface/application_dashboard_component.html.erb
+++ b/app/components/candidate_interface/application_dashboard_component.html.erb
@@ -1,7 +1,3 @@
-<% if @application_form.ended_without_success? %>
-  <%= render CandidateInterface::CarryOverBannerComponent.new(application_form: @application_form) %>
-<% end %>
-
 <h1 class="govuk-heading-xl"><%= title %></h1>
 
 <div class="govuk-grid-row">
@@ -9,6 +5,7 @@
     <%= render(CandidateInterface::ApplicationDashboardGuidanceComponent.new(application_form: @application_form)) %>
     <% if @application_form.ended_without_success? %>
       <%= render CandidateInterface::ApplyAgainCallToActionComponent.new(application_form: @application_form) %>
+      <%= render CandidateInterface::CarryOverCallToActionComponent.new(application_form: @application_form) %>
     <% elsif offers_received_and_all_providers_responded? %>
       <%= render CandidateInterface::OffersCallToActionComponent.new(application_form: @application_form) %>
     <% end %>

--- a/app/components/candidate_interface/carry_over_call_to_action_component.html.erb
+++ b/app/components/candidate_interface/carry_over_call_to_action_component.html.erb
@@ -1,0 +1,17 @@
+<%= govuk_inset_text(classes: 'govuk-!-margin-top-0') do %>
+  <% if references_did_not_come_back_in_time? %>
+    <h2 class="govuk-heading-m">Courses for the 2020 to 2021 academic year are now closed</h2>
+    <p class="govuk-body">Your references did not come back in time, but you can <%= govuk_link_to 'apply again', start_path, class: 'govuk-notification-banner__link' %></p>
+  <% elsif between_cycles? %>
+    <h2 class="govuk-heading-m">Courses for the 2020 to 2021 academic year are now closed</h2>
+    <p class="govuk-body">Your application did not lead to a place, but you can <%= govuk_link_to 'apply again', start_path, class: 'govuk-notification-banner__link' %></p>
+  <% else %>
+    <h2 class="govuk-heading-m">Do you want to continue applying?</h2>
+    <p class="govuk-body">Applications are open for courses starting academic year <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %>.</p>
+    <%= govuk_button_to(
+      'Continue your application',
+      create_path,
+      class: 'govuk-!-margin-bottom-0',
+    ) %>
+  <% end %>
+<% end %>

--- a/app/components/candidate_interface/carry_over_call_to_action_component.rb
+++ b/app/components/candidate_interface/carry_over_call_to_action_component.rb
@@ -1,0 +1,30 @@
+module CandidateInterface
+  class CarryOverCallToActionComponent < ViewComponent::Base
+    include ViewHelper
+    attr_reader :application_form
+
+    def initialize(application_form:)
+      @application_form = application_form
+    end
+
+    def render?
+      application_form.recruitment_cycle_year != RecruitmentCycle.current_year
+    end
+
+    def references_did_not_come_back_in_time?
+      @application_form.references_did_not_come_back_in_time?
+    end
+
+    def between_cycles?
+      CycleTimetable.between_cycles_apply_2?
+    end
+
+    def start_path
+      candidate_interface_start_carry_over_path
+    end
+
+    def create_path
+      candidate_interface_carry_over_path
+    end
+  end
+end


### PR DESCRIPTION
## Context

The flow for carry over is quite different to apply again due to the changes that were made to apply again in https://github.com/DFE-Digital/apply-for-teacher-training/pull/3656.

This PR is a **spike** to propose a new flow based on the changes we made to apply again.

## Changes proposed in this pull request

- [x] Change the call to action for carry over to use an inset component rather than a link in a notification banner.
<img width="919" alt="image" src="https://user-images.githubusercontent.com/450843/126328659-df79eca8-98ca-4ffd-a924-5db6c69e6a01.png">

- [x] Skip the first interstitial page that basically asks candidates to confirm that they want to continue their application.

<img width="992" alt="image" src="https://user-images.githubusercontent.com/450843/126329155-855b912e-33cb-4a35-b45f-434a49d48405.png">

Note that feedback (structured reasons for rejection) are already shown on the application dashboard for the new application.

<img width="992" alt="image" src="https://user-images.githubusercontent.com/450843/126329259-4d396f8b-e0a0-4f01-8cd8-dab21c94b8cd.png">


## Guidance to review

- Does the UX make sense?
- Can we go ahead and implement this spike properly? (tests are needed)

## Link to Trello card

https://trello.com/c/wqO0anzG/3587-🔁-eoc-tech-spike-carry-over-should-show-r4r-from-previous-cycle

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
