### PR TITLE
Automate apply deadline banners rendering & update the copy on the app closed banner

### DIFF
--- a/app/components/candidate_interface/reopen_banner_component.html.erb
+++ b/app/components/candidate_interface/reopen_banner_component.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_notification_banner(title: t('notification_banner.info')) do |notification_banner| %>
-  <%= notification_banner.slot(:heading, text: 'Applications for courses starting this academic year have now closed') %>
-  <p class="govuk-body">Submit your application from <%= reopen_date %> for courses starting in the next academic year.</p>
+<%= govuk_notification_banner(title: t('notification_banner.important')) do |notification_banner| %>
+  <%= notification_banner.slot(:heading, text: "Applications for courses starting in the #{CycleTimetable.cycle_year_range(cycle_year)} academic year are closed") %>
+  <p class="govuk-body">Submit your application from <%= reopen_date %> for courses starting in the <%= CycleTimetable.cycle_year_range(cycle_year + 1) %> academic year.</p>
 <% end %>

--- a/app/components/candidate_interface/reopen_banner_component.html.erb
+++ b/app/components/candidate_interface/reopen_banner_component.html.erb
@@ -1,4 +1,4 @@
 <%= govuk_notification_banner(title: t('notification_banner.important')) do |notification_banner| %>
   <%= notification_banner.slot(:heading, text: "Applications for courses starting in the #{CycleTimetable.cycle_year_range(cycle_year)} academic year are closed") %>
-  <p class="govuk-body">Submit your application from <%= reopen_date %> for courses starting in the <%= CycleTimetable.cycle_year_range(cycle_year + 1) %> academic year.</p>
+  <p class="govuk-body">Submit your application from 9am on <%= reopen_date %> for courses starting in the <%= CycleTimetable.cycle_year_range(cycle_year + 1) %> academic year.</p>
 <% end %>

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -14,13 +14,11 @@ class CandidateInterface::ReopenBannerComponent < ViewComponent::Base
 private
 
   def show_apply_1_reopen_banner?
-    apply_1? &&
-      CycleTimetable.between_cycles_apply_1?
+    apply_1? && CycleTimetable.between_cycles_apply_1?
   end
 
   def show_apply_2_reopen_banner?
-    apply_2? &&
-      CycleTimetable.between_cycles_apply_2?
+    apply_2? && CycleTimetable.between_cycles_apply_2?
   end
 
   def apply_1?
@@ -32,6 +30,18 @@ private
   end
 
   def reopen_date
-    CycleTimetable.apply_reopens.to_s(:govuk_date)
+    if Time.zone.now < CycleTimetable.date(:apply_opens)
+      CycleTimetable.apply_opens.to_s(:govuk_date)
+    else
+      CycleTimetable.apply_reopens.to_s(:govuk_date)
+    end
+  end
+
+  def cycle_year
+    @_cycle_year ||= if Time.zone.now < CycleTimetable.apply_opens
+                       CycleTimetable.current_year - 1
+                     else
+                       CycleTimetable.current_year
+                     end
   end
 end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -286,4 +286,8 @@ class CycleTimetable
     return :apply_1 if Time.zone.now.to_date == apply_1_deadline_first_reminder || Time.zone.now.to_date == apply_1_deadline_second_reminder
     return :apply_2 if Time.zone.now.to_date == apply_2_deadline_first_reminder || Time.zone.now.to_date == apply_2_deadline_second_reminder
   end
+
+  def self.cycle_year_range(year = current_year)
+    "#{year} to #{year + 1}"
+  end
 end

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -1,6 +1,8 @@
 <% content_for :title, title_with_error_prefix(t('review_application.title'), @incomplete_sections && @incomplete_sections.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
+<%= render(CandidateInterface::ReopenBannerComponent.new(phase: @application_form.phase, flash_empty: flash.empty?)) %>
+
 <% if @incomplete_sections.present? || @application_choice_errors.present? || @reference_section_errors.present? %>
   <div class="govuk-error-summary" tabindex="-1" role="alert" data-module="govuk-error-summary" aria-labelledby="error-summary-title">
     <h2 id="error-summary-title" class="govuk-error-summary__title">

--- a/config/locales/notification_banner.yml
+++ b/config/locales/notification_banner.yml
@@ -3,3 +3,4 @@ en:
     info: Information
     warning: Warning
     success: Success
+    important: Important

--- a/spec/components/candidate_interface/reopen_banner_component_spec.rb
+++ b/spec/components/candidate_interface/reopen_banner_component_spec.rb
@@ -54,5 +54,14 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
 
       expect(result.text).not_to include('Applications for courses starting this academic year have now closed')
     end
+
+    it 'renders nothing if the flash contains something' do
+      configure_conditions_for_rendering_banner('apply_1')
+      allow(flash).to receive(:empty?).and_return false
+
+      result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
+
+      expect(result.text).to be_blank
+    end
   end
 end

--- a/spec/components/candidate_interface/reopen_banner_component_spec.rb
+++ b/spec/components/candidate_interface/reopen_banner_component_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
         )
 
         expect(result.text).to include('Applications for courses starting in the 2021 to 2022 academic year are closed')
-        expect(result.text).to include('Submit your application from 12 October 2021 for courses starting in the 2022 to 2023 academic year.')
+        expect(result.text).to include('Submit your application from 9am on 12 October 2021 for courses starting in the 2022 to 2023 academic year.')
       end
 
       it 'renders the banner for an Apply 2 app' do
@@ -50,7 +50,7 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
         )
 
         expect(result.text).to include('Applications for courses starting in the 2021 to 2022 academic year are closed')
-        expect(result.text).to include('Submit your application from 12 October 2021 for courses starting in the 2022 to 2023 academic year.')
+        expect(result.text).to include('Submit your application from 9am on 12 October 2021 for courses starting in the 2022 to 2023 academic year.')
       end
     end
 
@@ -72,7 +72,7 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
         )
 
         expect(result.text).to include('Applications for courses starting in the 2021 to 2022 academic year are closed')
-        expect(result.text).to include('Submit your application from 12 October 2021 for courses starting in the 2022 to 2023 academic year.')
+        expect(result.text).to include('Submit your application from 9am on 12 October 2021 for courses starting in the 2022 to 2023 academic year.')
       end
 
       it 'renders the banner for an Apply 2 app' do
@@ -86,7 +86,7 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
         )
 
         expect(result.text).to include('Applications for courses starting in the 2021 to 2022 academic year are closed')
-        expect(result.text).to include('Submit your application from 12 October 2021 for courses starting in the 2022 to 2023 academic year.')
+        expect(result.text).to include('Submit your application from 9am on 12 October 2021 for courses starting in the 2022 to 2023 academic year.')
       end
     end
 

--- a/spec/components/candidate_interface/reopen_banner_component_spec.rb
+++ b/spec/components/candidate_interface/reopen_banner_component_spec.rb
@@ -11,34 +11,83 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
       allow(flash).to receive(:empty?).and_return true
       allow(CycleTimetable).to receive(:between_cycles_apply_1?).and_return(true)
       allow(CycleTimetable).to receive(:between_cycles_apply_2?).and_return(true)
+      allow(CycleTimetable).to receive(:current_year).and_return(2021)
+      allow(CycleTimetable).to receive(:cycle_year_range).with(2021).and_return('2021 to 2022')
+      allow(CycleTimetable).to receive(:cycle_year_range).with(2022).and_return('2022 to 2023')
+      allow(CycleTimetable).to receive(:apply_opens).and_return(Date.new(2020, 10, 13))
+      allow(CycleTimetable).to receive(:apply_reopens).and_return(Date.new(2021, 10, 12))
     end
 
-    it 'renders the banner for an Apply 1 app' do
-      configure_conditions_for_rendering_banner('apply_1')
+    context 'before find reopens' do
+      around do |example|
+        Timecop.freeze(CycleTimetable.apply_2_deadline + 1.day) do
+          example.run
+        end
+      end
 
-      result = render_inline(
-        described_class.new(
-          phase: application_form.phase,
-          flash_empty: flash.empty?,
-        ),
-      )
+      it 'renders the banner for an Apply 1 app with the correct details' do
+        configure_conditions_for_rendering_banner('apply_1')
 
-      expect(result.text).to include('Applications for courses starting this academic year have now closed')
-      expect(result.text).to include('Submit your application from 12 October 2021 for courses starting in the next academic year.')
+        result = render_inline(
+          described_class.new(
+            phase: application_form.phase,
+            flash_empty: flash.empty?,
+          ),
+        )
+
+        expect(result.text).to include('Applications for courses starting in the 2021 to 2022 academic year are closed')
+        expect(result.text).to include('Submit your application from 12 October 2021 for courses starting in the 2022 to 2023 academic year.')
+      end
+
+      it 'renders the banner for an Apply 2 app' do
+        configure_conditions_for_rendering_banner('apply_2')
+
+        result = render_inline(
+          described_class.new(
+            phase: application_form.phase,
+            flash_empty: flash.empty?,
+          ),
+        )
+
+        expect(result.text).to include('Applications for courses starting in the 2021 to 2022 academic year are closed')
+        expect(result.text).to include('Submit your application from 12 October 2021 for courses starting in the 2022 to 2023 academic year.')
+      end
     end
 
-    it 'renders the banner for an Apply 2 app' do
-      configure_conditions_for_rendering_banner('apply_2')
+    context 'after find opens' do
+      around do |example|
+        Timecop.freeze(CycleTimetable.find_reopens + 1.day) do
+          example.run
+        end
+      end
 
-      result = render_inline(
-        described_class.new(
-          phase: application_form.phase,
-          flash_empty: flash.empty?,
-        ),
-      )
+      it 'renders the banner for an Apply 1 app with the correct details' do
+        configure_conditions_for_rendering_banner('apply_1')
 
-      expect(result.text).to include('Applications for courses starting this academic year have now closed')
-      expect(result.text).to include('Submit your application from 12 October 2021 for courses starting in the next academic year.')
+        result = render_inline(
+          described_class.new(
+            phase: application_form.phase,
+            flash_empty: flash.empty?,
+          ),
+        )
+
+        expect(result.text).to include('Applications for courses starting in the 2021 to 2022 academic year are closed')
+        expect(result.text).to include('Submit your application from 12 October 2021 for courses starting in the 2022 to 2023 academic year.')
+      end
+
+      it 'renders the banner for an Apply 2 app' do
+        configure_conditions_for_rendering_banner('apply_2')
+
+        result = render_inline(
+          described_class.new(
+            phase: application_form.phase,
+            flash_empty: flash.empty?,
+          ),
+        )
+
+        expect(result.text).to include('Applications for courses starting in the 2021 to 2022 academic year are closed')
+        expect(result.text).to include('Submit your application from 12 October 2021 for courses starting in the 2022 to 2023 academic year.')
+      end
     end
 
     it 'does not render when we are not between cycles' do

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -294,5 +294,5 @@ RSpec.describe CycleTimetable do
         expect(described_class.cycle_year_range(2022)).to eq '2022 to 2023'
       end
     end
-  end 
+  end
 end

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -280,4 +280,19 @@ RSpec.describe CycleTimetable do
       end
     end
   end
+
+  describe '.cycle_year_range' do
+    context 'with no year passed in' do
+      it 'returns the `current_year to next_year`' do
+        allow(CycleTimetable).to receive(:current_year).and_return(2021)
+        expect(described_class.cycle_year_range).to eq '2021 to 2022'
+      end
+    end
+
+    context 'with a year passed in' do
+      it 'returns `year to year + 1`' do
+        expect(described_class.cycle_year_range(2022)).to eq '2022 to 2023'
+      end
+    end
+  end 
 end


### PR DESCRIPTION
## Context

At the moment we rely on showing the apply1 and apply2 deadline banners via a feature flag. We should automate this so we don't have to worry about it going foward.

Additionally, there are some copy updates for the `ReopenBannerComponent` 

## Changes proposed in this pull request

- Deadline banner 
1. show the apply1 deadline banner for 1 month before the apply1 deadline
2.  show the apply2 deadline banner between the apply1 deadline and the apply2 deadline 
3. remove the feature flag 

- Reopen banner
1. Update the copy (see the Trello card)

![image](https://user-images.githubusercontent.com/42515961/126340387-789d231b-b9ec-465c-9a5a-63b5dfaa4e56.png)

## Guidance to review

Definitely worth giving it a manual test.

These should really be merged but we need this done for the demo this afternoon

I'll add a tech debt card

## Link to Trello card

https://trello.com/c/ggMFA1WY/3660-%F0%9F%94%81-eoc-automate-the-rendering-of-the-deadline-banners-on-apply

https://trello.com/c/FScRXNyN/3639-%F0%9F%94%81-eoc-dev-fixes-for-eoc-applications-are-closed-banners

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
