### PR TITLE
Hide 'Chat' launcher button on user support webchat

### DIFF
--- a/app/frontend/packs/application-provider.js
+++ b/app/frontend/packs/application-provider.js
@@ -5,7 +5,7 @@ import filter from './components/paginated_filter'
 import checkboxSearchFilter from './components/checkbox_search_filter'
 import '../styles/application-provider.scss'
 import cookieBanners from './cookies/cookie-banners'
-import userSupportWebchat from './user-support-webchat'
+import userSupportWebchat from './user_support_webchat'
 
 require.context('govuk-frontend/govuk/assets')
 

--- a/app/frontend/packs/user_support_webchat/__snapshots__/index.spec.js.snap
+++ b/app/frontend/packs/user_support_webchat/__snapshots__/index.spec.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`userSupportWebchat should instantiate a user support webchat 1`] = `
+<div
+  id="test-container"
+>
+  
+          
+  <div
+    id="app-web-chat"
+  >
+    
+            
+    <span
+      class="app-web-chat__unavailable"
+    />
+    
+          
+    <span
+      class="moj-hidden"
+    >
+      <a
+        class="govuk-link govuk-footer__link app-web-chat__button"
+        href="#"
+      >
+        Speak to an adviser now (opens in new window)
+      </a>
+    </span>
+    <span
+      class="app-web-chat__offline moj-hidden"
+    >
+      Available Monday to Friday, 10am to midday (except public holidays).
+    </span>
+  </div>
+  
+          
+  <div
+    id="launcher"
+  />
+  
+        
+</div>
+`;

--- a/app/frontend/packs/user_support_webchat/index.js
+++ b/app/frontend/packs/user_support_webchat/index.js
@@ -48,6 +48,7 @@ UserSupportWebchat.prototype.addButtonListener = function () {
 UserSupportWebchat.prototype.addStatusChangeListener = function () {
   zE('webWidget:on', 'chat:status', function (status) {
     this.defaultContainer.classList.add('moj-hidden')
+    this.hideLauncher()
 
     if (status === 'online') {
       this.enableChat()
@@ -65,6 +66,14 @@ UserSupportWebchat.prototype.enableChat = function () {
 UserSupportWebchat.prototype.disableChat = function () {
   this.disabledContainer.classList.remove('moj-hidden')
   this.enabledContainer.classList.add('moj-hidden')
+}
+
+UserSupportWebchat.prototype.hideLauncher = function () {
+  this.launcher = document.getElementById('launcher')
+
+  if (this.launcher != null) {
+    this.launcher.classList.add('moj-hidden')
+  }
 }
 
 const userSupportWebchat = () => new UserSupportWebchat()

--- a/app/frontend/packs/user_support_webchat/index.spec.js
+++ b/app/frontend/packs/user_support_webchat/index.spec.js
@@ -1,0 +1,28 @@
+import userSupportWebchat from './index.js'
+require('./../zendesk-stub.js')
+
+describe('userSupportWebchat', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+        <div id="test-container">
+          <div id="app-web-chat">
+            <span class="app-web-chat__unavailable"></span>
+          </div>
+          <div id="launcher"></div>
+        </div>
+      `
+    userSupportWebchat()
+  })
+
+  it('should instantiate a user support webchat', () => {
+    expect(document.querySelector('#test-container')).toMatchSnapshot()
+  })
+
+  describe('hideLauncher', () => {
+    it('should hide the default launcher element', () => {
+      expect(document.querySelector('#launcher').classList).not.toContain('moj-hidden')
+      window.setZendeskStatus('online')
+      expect(document.querySelector('#launcher').classList).toContain('moj-hidden')
+    })
+  })
+})


### PR DESCRIPTION
## Context

We don't need the chat launcher button as there's a custom link in the footer so hide the one provided by the chat widget.
This commit also moves user-support-webchat libraries into a more test-friendly directory structure.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Hides the `#launcher` DOM Element injected by the Zendesk Web Widget libraries as this contains the chat button.
- Refactors the `user-support-webchat` library so that we have a snapshot and spec.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Worth checking the webchat still loads as expected as I've moved the library:

- Visit `/provider/applications`
- If necessary run `window.setZendeskStatus("online")` in the browser console (if the footer link to chat is not enabled)
- Click footer link to webchat, start a chat (explain that this is just a test), the blue 'Chat' button should **not** appear (previously in bottom right hand corner or page)

See [this video](https://trello-attachments.s3.amazonaws.com/5c4d992b3e446a2f221b7c97/60e82a8d89f1694bd8336cec/b25f4049833a160f0259f140a2b287a8/Screen_Recording_2021-07-09_at_12.18.24.mov) for current behaviour.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/xQwHD5vf/3967-remove-the-blue-button-on-webchat-reappearing
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
