### PR TITLE
Update Apply JMeter plan to simulate arriving from Find

### DIFF
--- a/jmeter-courses.csv
+++ b/jmeter-courses.csv
@@ -1,0 +1,3 @@
+courseCode,providerCode
+3285,1JA
+V252,1JA

--- a/jmeter-courses.csv
+++ b/jmeter-courses.csv
@@ -1,3 +1,3 @@
 courseCode,providerCode
-3285,1JA
-V252,1JA
+3369,1V7
+2MFP,1R3

--- a/jmeter/plans/apply.rb
+++ b/jmeter/plans/apply.rb
@@ -7,7 +7,6 @@ def url(path)
   BASEURL + path
 end
 
-# 975 concurrent users, 15 minute run time
 test do
   cookies clear_each_iteration: true
   view_results_tree
@@ -16,7 +15,7 @@ test do
   thread_count = 975
   csv_data_set_config filename: 'jmeter-courses.csv'
 
-  threads count: thread_count, continue_forever: true, duration: 900 do
+  threads count: thread_count, continue_forever: true, duration: 3600 do
     #-> Sign up
     visit name: 'Account page', url: url('/candidate/account') do
       extract name: 'authenticity_token', regex: 'name="authenticity_token" value="(.+?)"'


### PR DESCRIPTION
## Context
To ensure our Jmeter tests are as close as possible to user behaviour we should add in the common journeys that candidates will take when creating an account.

Nearly all candidates will arrive from Find with course params in the query string.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Use a CSV file to decide which course each user applies to
- Use the values provided by the CSV to set course params when
  submitting the sign up form
- Use a unique email address for each iteration of each thread, so that
  the entire test can loop indefinitely (not doing this means that the
  same course gets added more than once to an application)
- Extract the page titles off the study mode and site pages, so that we
  can conditionally make the correct POST actions depending on which
  page we end up navigating to

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Note that this plan relies on an auth bypass that currently only exists on the `load-test` branch. If running locally, you'll need to rebase on to that.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/O8WRFDnm
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
