### PR TITLE
Fix org permissions edit form error linking

### DIFF
--- a/app/components/provider_interface/organisation_permissions_form_component.html.erb
+++ b/app/components/provider_interface/organisation_permissions_form_component.html.erb
@@ -1,5 +1,5 @@
 <%= form_with(
-  model: provider_relationship_permission,
+  model: permission_model,
   url: form_url,
   method: form_method,
 ) do |f| %>
@@ -14,11 +14,11 @@
 
   <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| %>
     <div class="govuk-form-group">
-      <%= f.govuk_fieldset legend: { text: label_for(permission_name) } do %>
+      <%= f.govuk_check_boxes_fieldset permission_name, legend: { text: label_for(permission_name) } do %>
         <% presenter.checkbox_details_for_providers.each_with_index do |checkbox_details, index| %>
           <%= f.govuk_check_box(
-            "#{checkbox_details[:type]}_provider_can_#{permission_name}",
-            true,
+            permission_name,
+            checkbox_details[:type],
             label: { text: checkbox_details[:name] },
             link_errors: index.zero?,
           ) %>

--- a/app/components/provider_interface/organisation_permissions_form_component.rb
+++ b/app/components/provider_interface/organisation_permissions_form_component.rb
@@ -1,9 +1,9 @@
 module ProviderInterface
   class OrganisationPermissionsFormComponent < ViewComponent::Base
-    attr_reader :presenter, :provider_relationship_permission, :mode, :form_url
+    attr_reader :presenter, :permission_model, :mode, :form_url
 
     def initialize(provider_user:, provider_relationship_permission:, mode:, form_url:)
-      @provider_relationship_permission = provider_relationship_permission
+      @permission_model = PermissionFormModel.new(provider_relationship_permission)
       @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(provider_relationship_permission, provider_user)
       @mode = mode
       @form_url = form_url
@@ -35,6 +35,24 @@ module ProviderInterface
         :patch
       elsif mode == :setup
         :post
+      end
+    end
+
+    class PermissionFormModel
+      include ActiveModel::Model
+
+      attr_reader :provider_relationship_permissions
+
+      delegate :model_name, :errors, to: :provider_relationship_permissions
+
+      def initialize(provider_relationship_permissions)
+        @provider_relationship_permissions = provider_relationship_permissions
+      end
+
+      ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name|
+        define_method(permission_name) do
+          %w[training ratifying].select { |provider_type| provider_relationship_permissions.send("#{provider_type}_provider_can_#{permission_name}") }
+        end
       end
     end
   end

--- a/app/controllers/provider_interface/organisation_permissions_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_controller.rb
@@ -42,17 +42,15 @@ module ProviderInterface
       return {} unless params.key?(:provider_relationship_permissions)
 
       params.require(:provider_relationship_permissions)
-            .permit(training_provider_can_make_decisions: [],
-                    ratifying_provider_can_make_decisions: [],
-                    training_provider_can_view_safeguarding_information: [],
-                    ratifying_provider_can_view_safeguarding_information: [],
-                    training_provider_can_view_diversity_information: [],
-                    ratifying_provider_can_view_diversity_information: []).to_h
+            .permit(make_decisions: [],
+                    view_safeguarding_information: [],
+                    view_diversity_information: []).to_h
     end
 
     def new_relationship_permissions
-      ProviderRelationshipPermissions.possible_permissions.inject({}) do |hash, permission|
-        hash[permission] = permissions_params[permission].present?
+      ProviderRelationshipPermissions::PERMISSIONS.inject({}) do |hash, permission|
+        hash["training_provider_can_#{permission}"] = permissions_params[permission].include? 'training'
+        hash["ratifying_provider_can_#{permission}"] = permissions_params[permission].include? 'ratifying'
         hash
       end
     end

--- a/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature 'Provider edits organisation permissions' do
   end
 
   def and_i_give_my_organisation_permission_to_make_decisions
-    check 'provider-relationship-permissions-ratifying-provider-can-make-decisions-true-field'
+    check 'provider-relationship-permissions-make-decisions-ratifying-field'
     click_on 'Save organisation permissions'
   end
 


### PR DESCRIPTION
## Context
Currently, the parameters are not set up correctly to work with the formbuilder error summary.

## Changes proposed in this pull request
Modify the form so that the field names correctly link up with the error summary

## Guidance to review
Test in the review app

This doesn't fix the concern about tracking validation errors in the controller. We agreed that we can leave that as-is and save the value as nil in the validation error.

## Link to Trello card
https://trello.com/c/jyduUkbk/3975-errors-are-not-linked-correctly-when-changing-organisation-permissions

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
