### PR TITLE
Trigger smoke tests after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,15 @@ jobs:
           TF_VAR_azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           TF_VAR_paas_docker_image: ${{ env.DOCKER_IMAGE }}
 
+      - name: Trigger Smoke Test
+        uses: benc-uk/workflow-dispatch@v1.1
+        with:
+          workflow: Smoke tests
+          repo: DFE-Digital/apply-for-teacher-training-tests
+          ref: refs/heads/main
+          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          inputs: '{"environment": "${{ matrix.environment }}"}'
+
       - name: Start Clockwork container
         if: always()
         run: cf start apply-clock-${{ env.SPACE_SUFFIX || matrix.environment }}


### PR DESCRIPTION
## Context

Smoke Tests aren't being triggered after each deploy

## Changes proposed in this pull request

Trigger smoke tests in the apply-for-teacher-training-tests repo after a deployment to an environment

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
