### PR TITLE
Simplify apply and find reopening content on the application show & review pages

### DIFF
--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -5,10 +5,8 @@
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.courses') %></h2>
   <% if !@application_form.submitted? && !CycleTimetable.can_add_course_choice?(@application_form) %>
-    <p class="govuk-body">
-      You’ll be able to find courses in <%= CycleTimetable.days_until_find_reopens %> <%= 'day'.pluralize(CycleTimetable.days_until_find_reopens) %>
-      (<%= CycleTimetable.find_reopens.to_s(:govuk_date) %>).
-      You can keep making changes to the rest of your application until then.
+    <p class="govuk-body govuk-!-width-two-thirds">
+      You can find courses from 9am on <%= CycleTimetable.find_reopens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.
     </p>
   <% else %>
     <%= render(

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -12,14 +12,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if !CycleTimetable.can_add_course_choice?(@application_form) %>
-    <section class="govuk-!-margin-bottom-8">
-      <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.courses') %></h2>
-
-      <p class="govuk-body">
-        You’ll be able to find courses in <%= CycleTimetable.days_until_find_reopens %> <%= 'day'.pluralize(CycleTimetable.days_until_find_reopens) %>
-        (<%= CycleTimetable.find_reopens.to_s(:govuk_date) %>). You can keep making changes to the rest of your application until then.
-      </p>
-    </section>
+      <section class="govuk-!-margin-bottom-8">
+        <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.courses') %></h2>
+          <p class="govuk-body">
+            You can find courses from 9am on <%= CycleTimetable.find_reopens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.
+          </p>
+      </section>
     <% else %>
       <% if @application_form.candidate_has_previously_applied? && @application_form.previous_application_form.application_choices.rejected.any? %>
         <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @application_form.previous_application_form)) %>
@@ -256,7 +254,7 @@
     <section>
       <% if CycleTimetable.between_cycles?(@application_form.phase) %>
         <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.review') %></h2>
-        <p class="govuk-body">You cannot submit your application until <%= CycleTimetable.apply_reopens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.</p>
+        <p class="govuk-body">You cannot submit your application until 9am on <%= CycleTimetable.apply_opens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.</p>
         <%= govuk_link_to 'Review your application', candidate_interface_application_review_path, button: true %>
       <% elsif CycleTimetable.can_submit?(@application_form) %>
         <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.check_and_submit') %></h2>

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_and_needs_to_select_course_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_and_needs_to_select_course_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature 'Carry over' do
   end
 
   def then_i_can_see_that_i_need_to_select_courses_when_apply_reopens
-    expect(page).to have_content "You’ll be able to find courses in #{CycleTimetable.days_until_find_reopens} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You can find courses from 9am on #{CycleTimetable.find_reopens.to_s(:govuk_date)}. You can keep making changes to the rest of your application until then."
     expect(page).not_to have_link 'Choose your courses'
   end
 end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_can_see_that_no_courses_are_selected_and_i_cannot_add_any_yet
-    expect(page).to have_content "You’ll be able to find courses in #{CycleTimetable.days_until_find_reopens} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You can find courses from 9am on #{CycleTimetable.find_reopens.to_s(:govuk_date)}. You can keep making changes to the rest of your application until then."
     expect(page).not_to have_link 'Course choice'
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Candidate vists their application form after the cycle has ended
   end
 
   def then_i_see_that_i_can_add_new_course_choices_in_october
-    expect(page).to have_content "You’ll be able to find courses in #{CycleTimetable.days_until_find_reopens} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You can find courses from 9am on #{CycleTimetable.find_reopens.to_s(:govuk_date)}. You can keep making changes to the rest of your application until then."
   end
 
   def and_there_is_not_a_link_to_the_course_choices_section


### PR DESCRIPTION
## Context

This PR updates the content on the application show and review pages.

## Changes proposed in this pull request

1. It specifies the hour which Apply reopens (9am) in the review section of the app show page

|Before|After|
|-------------|-------------|
|![image](https://user-images.githubusercontent.com/42515961/126611023-fb8d0c48-768d-4e08-a0f2-8288d3b7d4f1.png)|![image](https://user-images.githubusercontent.com/42515961/126610878-955197d0-70d1-4f30-aba3-9f645c106896.png)|

2. It removes the Find courses in x days and replaces it with the date when Find reopens

application show page 

|Before|After|
|-------------|-------------|
|![image](https://user-images.githubusercontent.com/42515961/126611149-50856a57-9ff6-4fc6-9663-949407235b10.png)|![image](https://user-images.githubusercontent.com/42515961/126611203-13914f1e-3908-4b40-b049-f20f090b326b.png)|

application review page 

|Before|After|
|-------------|-------------|
|![image](https://user-images.githubusercontent.com/42515961/126611313-7fd8ac44-1713-4a65-8796-c201e2a86877.png)|![image](https://user-images.githubusercontent.com/42515961/126611267-89ccb689-0665-4571-b089-51f68a5a9e81.png)|


## Guidance to review

The rest of the behaviour on the Trello cards is working as expected

## Link to Trello card

https://trello.com/c/icvBptoD/3708-%F0%9F%94%81-eoc-dev-apply-course-choices-are-removed-check-this-works-as-intended-and-make-content-change

https://trello.com/c/pEH62SGo/3709-%F0%9F%94%81-eoc-dev-apply-submit-function-is-disabled-check-this-works-as-intended-and-make-content-change

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
