### PR TITLE
Add withdrawn at candidate's request stats to performance dashboard

### DIFF
--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -187,6 +187,36 @@ class PerformanceStatistics
     [defaults, by_ratifier_type, by_training_provider_type].reduce(:merge)
   end
 
+  def withdrawn_at_candidates_request_count
+    audits_joins_sql = <<-SQL.squish
+      INNER JOIN audits ON audits.auditable_type = 'ApplicationChoice'
+      AND audits.auditable_id = application_choices.id
+      AND audits.user_type = 'ProviderUser'
+      AND audits.comment IN ('Declined on behalf of the candidate', 'Withdrawn on behalf of the candidate')
+    SQL
+
+    @withdrawn_at_candidates_request_count ||= begin
+      scope = ApplicationForm
+        .joins(:application_choices)
+        .joins(audits_joins_sql)
+        .where('application_choices.status': %w[declined withdrawn])
+        .distinct
+
+      scope = scope.where('application_forms.recruitment_cycle_year': year) if year.present?
+      scope.count
+    end
+  end
+
+  def withdrawn_by_candidate_count
+    scope = ApplicationForm
+      .joins(:application_choices)
+      .where('application_choices.status': %w[declined withdrawn])
+      .distinct
+
+    scope = scope.where('application_forms.recruitment_cycle_year': year) if year.present?
+    scope.count - withdrawn_at_candidates_request_count
+  end
+
 private
 
   def application_choices

--- a/app/views/support_interface/performance/service_performance_dashboard.html.erb
+++ b/app/views/support_interface/performance/service_performance_dashboard.html.erb
@@ -223,6 +223,16 @@
         <td class="govuk-table__cell govuk-table__cell--numeric"><%= @statistics.rejected_by_default_count %></td>
         <td class="govuk-table__cell govuk-!-width-two-thirds"><%= t('performance_dashboard_other_metrics.rejected_by_default.description') %></td>
       </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header govuk-!-width-one-quarter"><%= t('performance_dashboard_other_metrics.withdrawn_at_candidates_request.name') %></th>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%= @statistics.withdrawn_at_candidates_request_count %></td>
+        <td class="govuk-table__cell govuk-!-width-two-thirds"><%= t('performance_dashboard_other_metrics.withdrawn_at_candidates_request.description') %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header govuk-!-width-one-quarter"><%= t('performance_dashboard_other_metrics.withdrawn_by_candidate.name') %></th>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%= @statistics.withdrawn_by_candidate_count %></td>
+        <td class="govuk-table__cell govuk-!-width-two-thirds"><%= t('performance_dashboard_other_metrics.withdrawn_by_candidate.description') %></td>
+      </tr>
     </tbody>
   </table>
 

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -83,6 +83,12 @@ en:
     rejected_by_default:
       name: Rejected by default
       description: The candidate had one or more application choices rejected by default because the provider took too long to respond.
+    withdrawn_at_candidates_request:
+      name: Withdrawn at candidate's request
+      description: The candidate requested their application be withdrawn from the provider.
+    withdrawn_by_candidate:
+      name: Withdrawn by the candidate
+      description: The candidate withdrew their own application.
 
   application_states:
     unsubmitted:

--- a/spec/factories/audit.rb
+++ b/spec/factories/audit.rb
@@ -1,4 +1,24 @@
 FactoryBot.define do
+  factory :withdrawn_at_candidates_request_audit, class: 'Audited::Audit' do
+    action { 'update' }
+    user { create(:provider_user) }
+    version { 1 }
+    request_uuid { SecureRandom.uuid }
+    comment { 'Withdrawn on behalf of the candidate' }
+    created_at { Time.zone.now }
+
+    transient do
+      application_choice { build_stubbed(:application_choice, :withdrawn) }
+      changes { {} }
+    end
+
+    after(:build) do |audit, evaluator|
+      audit.auditable_type = 'ApplicationChoice'
+      audit.auditable_id = evaluator.application_choice.id
+      audit.audited_changes = evaluator.changes
+    end
+  end
+
   factory :interview_audit, class: 'Audited::Audit' do
     action { 'create' }
     user { create(:provider_user) }

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -216,6 +216,32 @@ RSpec.describe PerformanceStatistics, type: :model do
     end
   end
 
+  describe '#withdrawn_at_candidates_request_count and #withdrawn_by_candidate_count' do
+    let(:declined_choice) { create(:application_choice, :declined, application_form: create(:application_form, recruitment_cycle_year: 2021)) }
+    let(:withdrawn_choice) { create(:application_choice, :withdrawn, application_form: create(:application_form, recruitment_cycle_year: 2021)) }
+    let!(:choice_withdrawn_by_candidate) { create(:application_choice, :withdrawn, application_form: create(:application_form, recruitment_cycle_year: 2021)) }
+    let!(:declined_audit) do
+      create(
+        :withdrawn_at_candidates_request_audit,
+        application_choice: declined_choice,
+        comment: 'Declined on behalf of the candidate',
+      )
+    end
+    let!(:withdrawn_audit) { create(:withdrawn_at_candidates_request_audit, application_choice: withdrawn_choice) }
+
+    it '#withdrawn_at_candidates_request_count returns a count of applications which have been declined or withdrawn at the candidates request' do
+      stats = PerformanceStatistics.new(2021)
+
+      expect(stats.withdrawn_at_candidates_request_count).to eq(2)
+    end
+
+    it '#withdrawn_by_candidate_count returns a count of applications which have been declined or withdrawn by the candidate' do
+      stats = PerformanceStatistics.new(2021)
+
+      expect(stats.withdrawn_by_candidate_count).to eq(1)
+    end
+  end
+
   def count_for_process_state(process_state)
     PerformanceStatistics.new(nil)[process_state]
   end


### PR DESCRIPTION
## Context

We've enabled the _Withdraw at the candidate's request_ feature, so report on withdrawals in the performance dashboard.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds withdrawn by candidate and withdrawn at candidate's request counts to performance dashboard.

![image](https://user-images.githubusercontent.com/93511/126622260-abdcf5a0-a658-4ddf-bab5-727de9bc3295.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Mpn0QYAd/4002-track-applications-withdrawn-at-a-candidates-request-on-the-performance-dashboard
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
