### PR TITLE
Use more descriptive labels for international address

### DIFF
--- a/app/forms/candidate_interface/contact_details_form.rb
+++ b/app/forms/candidate_interface/contact_details_form.rb
@@ -68,7 +68,7 @@ module CandidateInterface
     end
 
     def label_for(attr)
-      I18n.t("application_form.contact_details.#{attr}.#{address_type}.label")
+      I18n.t("application_form.contact_details.#{attr}.label.#{address_type}")
     end
   end
 end

--- a/app/forms/support_interface/application_forms/edit_address_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_address_details_form.rb
@@ -66,7 +66,7 @@ module SupportInterface
       end
 
       def label_for(attr)
-        I18n.t("application_form.contact_details.#{attr}.#{address_type}.label")
+        I18n.t("application_form.contact_details.#{attr}.label.#{address_type}")
       end
     end
   end

--- a/app/views/support_interface/application_forms/address_details/edit.html.erb
+++ b/app/views/support_interface/application_forms/address_details/edit.html.erb
@@ -39,22 +39,22 @@
         <% else %>
           <%= f.govuk_text_field(
             :address_line1,
-            label: { text: t('application_form.contact_details.address_line1.international.label') },
+            label: { text: t('application_form.contact_details.address_line1.label.international') },
             autocomplete: 'address-line1',
           ) %>
           <%= f.govuk_text_field(
             :address_line2,
-            label: { text: t('application_form.contact_details.address_line2.international.label') },
+            label: { text: t('application_form.contact_details.address_line2.label.international') },
             autocomplete: 'address-line2',
           ) %>
           <%= f.govuk_text_field(
             :address_line3,
-            label: { text: t('application_form.contact_details.address_line3.international.label') },
+            label: { text: t('application_form.contact_details.address_line3.label.international') },
             autocomplete: 'address-level2',
           ) %>
           <%= f.govuk_text_field(
             :address_line4,
-            label: { text: t('application_form.contact_details.address_line4.international.label') },
+            label: { text: t('application_form.contact_details.address_line4.label.international') },
             autocomplete: 'address-level1',
           ) %>
         <% end %>

--- a/config/locales/candidate_interface/contact_details.yml
+++ b/config/locales/candidate_interface/contact_details.yml
@@ -9,31 +9,26 @@ en:
         label: Address
         change_action: address
       address_line1:
-        uk:
-          label: Building and street
-        international:
-          label: Address 1
+        label:
+          uk: Building and street
+          international: Address line 1
         hidden: line 1 of 2
       address_line2:
-        uk:
-          label: Building and street line 2 of 2
-        international:
-          label: Address 2
+        label:
+          uk: Building and street line 2 of 2
+          international: Address line 2
       address_line3:
-        uk:
-          label: Town or city
-        international:
-          label: Address 3
+        label:
+          uk: Town or city
+          international: Address line 3
       address_line4:
-        uk:
-          label: County
-        international:
-          label: Address 4
+        label:
+          uk: County
+          international: Address line 4
       postcode:
-        uk:
-          label: Postcode
-        international:
-          label: ZIP or postal code
+        label:
+          uk: Postcode
+          international: ZIP or postal code
       address_type:
         label: Where do you live?
         change_action: where I live

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -226,8 +226,8 @@ module CandidateHelper
     choose 'In the UK'
     click_button t('save_and_continue')
     find(:css, "[autocomplete='address-line1']").fill_in with: '42 Much Wow Street'
-    fill_in t('application_form.contact_details.address_line3.uk.label'), with: 'London'
-    fill_in t('application_form.contact_details.postcode.uk.label'), with: 'SW1P 3BT'
+    fill_in t('application_form.contact_details.address_line3.label.uk'), with: 'London'
+    fill_in t('application_form.contact_details.postcode.label.uk'), with: 'SW1P 3BT'
     click_button t('save_and_continue')
 
     choose t('application_form.completed_radio')

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
@@ -99,8 +99,8 @@ RSpec.feature 'Entering their contact information' do
   end
 
   def and_i_incorrectly_fill_in_my_address
-    fill_in t('application_form.contact_details.address_line3.uk.label'), with: 'London'
-    fill_in t('application_form.contact_details.postcode.uk.label'), with: 'MUCH W0W'
+    fill_in t('application_form.contact_details.address_line3.label.uk'), with: 'London'
+    fill_in t('application_form.contact_details.postcode.label.uk'), with: 'MUCH W0W'
   end
 
   def then_i_should_see_validation_errors_for_my_address
@@ -110,8 +110,8 @@ RSpec.feature 'Entering their contact information' do
 
   def when_i_fill_in_my_address
     find(:css, "[autocomplete='address-line1']").fill_in with: '42 Much Wow Street'
-    fill_in t('application_form.contact_details.address_line3.uk.label'), with: 'London'
-    fill_in t('application_form.contact_details.postcode.uk.label'), with: 'SW1P 3BT'
+    fill_in t('application_form.contact_details.address_line3.label.uk'), with: 'London'
+    fill_in t('application_form.contact_details.postcode.label.uk'), with: 'SW1P 3BT'
   end
 
   def and_i_submit_my_address

--- a/spec/system/support_interface/editing_address_details_spec.rb
+++ b/spec/system/support_interface/editing_address_details_spec.rb
@@ -79,8 +79,8 @@ RSpec.feature 'Editing address' do
 
   def when_i_complete_the_details_form
     find(:css, "[autocomplete='address-line1']").fill_in with: '42 Much Wow Street'
-    fill_in t('application_form.contact_details.address_line3.uk.label'), with: 'London'
-    fill_in t('application_form.contact_details.postcode.uk.label'), with: 'SW1P 3BT'
+    fill_in t('application_form.contact_details.address_line3.label.uk'), with: 'London'
+    fill_in t('application_form.contact_details.postcode.label.uk'), with: 'SW1P 3BT'
     fill_in 'support_interface_application_forms_edit_address_details_form[audit_comment]', with: 'Updated as part of Zen Desk ticket #12345'
   end
 
@@ -107,7 +107,7 @@ RSpec.feature 'Editing address' do
 
   def then_i_should_see_the_international_address_details_form
     expect(page).to have_content('What is the candidate’s address?')
-    expect(page).to have_content('Address 1')
+    expect(page).to have_content('Address line 1')
   end
 
   def then_i_should_see_blank_error_messages


### PR DESCRIPTION
## Context

Use slightly more descriptive labels for international address fields, so rather than ‘Address 1’, say ‘Address line 1’.

## Changes proposed in this pull request

* Update labels
* Adjust string lookup, so that `uk`/`international` value is a child of `label`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
