### PR TITLE
Organisation Permissions Setup Wizard part 1

### DIFF
--- a/app/components/provider_interface/organisation_permissions_form_component.html.erb
+++ b/app/components/provider_interface/organisation_permissions_form_component.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(
   model: permission_model,
   url: form_url,
-  method: form_method,
+  method: :patch,
 ) do |f| %>
   <%= f.govuk_error_summary %>
 

--- a/app/components/provider_interface/organisation_permissions_form_component.html.erb
+++ b/app/components/provider_interface/organisation_permissions_form_component.html.erb
@@ -13,7 +13,7 @@
   <p class="govuk-body"><%= t('.explanation') %></p>
 
   <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| %>
-    <div class="govuk-form-group">
+    <div class="govuk-form-group" data-qa="<%= permission_name.to_s.dasherize %>">
       <%= f.govuk_check_boxes_fieldset permission_name, legend: { text: label_for(permission_name) } do %>
         <% presenter.checkbox_details_for_providers.each_with_index do |checkbox_details, index| %>
           <%= f.govuk_check_box(

--- a/app/components/provider_interface/organisation_permissions_form_component.rb
+++ b/app/components/provider_interface/organisation_permissions_form_component.rb
@@ -30,14 +30,6 @@ module ProviderInterface
       t('provider_relationship_permissions.question', permission_description: permission_description.downcase)
     end
 
-    def form_method
-      if mode == :edit
-        :patch
-      elsif mode == :setup
-        :post
-      end
-    end
-
     class PermissionFormModel
       include ActiveModel::Model
 

--- a/app/components/provider_interface/organisation_permissions_review_card_component.html.erb
+++ b/app/components/provider_interface/organisation_permissions_review_card_component.html.erb
@@ -1,5 +1,5 @@
 <%= render SummaryCardComponent.new(rows: permission_rows) do %>
-  <%= render SummaryCardHeaderComponent.new(title: presenter.provider_relationship_description, heading_level: 2) do %>
+  <%= render SummaryCardHeaderComponent.new(title: presenter.provider_relationship_description, heading_level: summary_card_heading_level) do %>
     <% if change_path %>
       <div class="app-summary-card__actions">
         <%= govuk_link_to 'Change', change_path %>

--- a/app/components/provider_interface/organisation_permissions_review_card_component.rb
+++ b/app/components/provider_interface/organisation_permissions_review_card_component.rb
@@ -1,10 +1,11 @@
 module ProviderInterface
   class OrganisationPermissionsReviewCardComponent < ViewComponent::Base
-    attr_reader :presenter, :provider_relationship_permission, :change_path
+    attr_reader :presenter, :provider_relationship_permission, :summary_card_heading_level, :change_path
 
-    def initialize(provider_user:, provider_relationship_permission:, change_path: nil)
+    def initialize(provider_user:, provider_relationship_permission:, summary_card_heading_level: 2, change_path: nil)
       @provider_relationship_permission = provider_relationship_permission
       @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(provider_relationship_permission, provider_user)
+      @summary_card_heading_level = summary_card_heading_level
       @change_path = change_path
     end
 

--- a/app/components/provider_interface/organisation_permissions_setup_check_component.html.erb
+++ b/app/components/provider_interface/organisation_permissions_setup_check_component.html.erb
@@ -1,0 +1,13 @@
+<% grouped_relationships_by_name.each do |main_provider_name, relationship_list| %>
+  <% if multiple_providers_to_set_up? %>
+    <h2 class="govuk-heading-m"><%= main_provider_name %></h2>
+  <% end %>
+  <% relationship_list.each do |relationship| %>
+    <%= render ProviderInterface::OrganisationPermissionsReviewCardComponent.new(
+      provider_user: current_provider_user,
+      provider_relationship_permission: relationship,
+      summary_card_heading_level: summary_card_heading_level,
+      change_path: edit_provider_interface_organisation_permissions_setup_path(relationship, checking_answers: true),
+    ) %>
+  <% end %>
+<% end %>

--- a/app/components/provider_interface/organisation_permissions_setup_check_component.rb
+++ b/app/components/provider_interface/organisation_permissions_setup_check_component.rb
@@ -1,0 +1,22 @@
+module ProviderInterface
+  class OrganisationPermissionsSetupCheckComponent < ViewComponent::Base
+    attr_reader :current_provider_user, :grouped_relationships_by_name
+
+    def initialize(relationships:, current_provider_user:)
+      @grouped_relationships_by_name = ProviderRelationshipPermissionSetupPresenter.new(relationships, current_provider_user).grouped_provider_permissions_by_name
+      @current_provider_user = current_provider_user
+    end
+
+    def multiple_providers_to_set_up?
+      @multiple_providers_to_set_up ||= grouped_relationships_by_name.length > 1
+    end
+
+    def summary_card_heading_level
+      if multiple_providers_to_set_up?
+        3
+      else
+        2
+      end
+    end
+  end
+end

--- a/app/components/provider_interface/organisation_permissions_setup_list_component.html.erb
+++ b/app/components/provider_interface/organisation_permissions_setup_list_component.html.erb
@@ -36,6 +36,6 @@
       </p>
     <% end %>
 
-    <%= govuk_button_to t('.continue_button'), continue_button_path %>
+    <%= govuk_link_to t('.continue_button'), continue_button_path, button: true %>
   </div>
 </div>

--- a/app/controllers/provider_interface/organisation_permissions_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_controller.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class OrganisationPermissionsController < ProviderInterfaceController
+    include ProviderRelationshipPermissionsParamsHelper
+
     before_action :require_accredited_provider_setting_permissions_flag
     before_action :set_up_relationship_objects, except: %i[organisations index]
     before_action :organisation_id_and_permission_check, except: %i[organisations index]
@@ -48,11 +50,7 @@ module ProviderInterface
     end
 
     def new_relationship_permissions
-      ProviderRelationshipPermissions::PERMISSIONS.inject({}) do |hash, permission|
-        hash["training_provider_can_#{permission}"] = permissions_params[permission].include? 'training'
-        hash["ratifying_provider_can_#{permission}"] = permissions_params[permission].include? 'ratifying'
-        hash
-      end
+      translate_params_for_model(permissions_params)
     end
 
     def set_up_relationship_objects

--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -49,11 +49,7 @@ module ProviderInterface
 
     def check
       wizard = OrganisationPermissionsSetupWizard.new(organisation_permissions_wizard_store, current_step: :check)
-      permission_setup_presenter = ProviderRelationshipPermissionSetupPresenter.new(
-        wizard.relationships,
-        current_provider_user,
-      )
-      @grouped_relationships_by_name = permission_setup_presenter.grouped_provider_permissions_by_name
+      @relationships = wizard.relationships
       @previous_page_path = previous_page_path(wizard)
     end
 

--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -18,6 +18,7 @@ module ProviderInterface
         organisation_permissions_wizard_store,
         current_relationship_id: params[:id],
         current_step: :relationship,
+        checking_answers: params[:checking_answers] == 'true',
       )
       wizard.save_state!
 
@@ -44,6 +45,12 @@ module ProviderInterface
       else
         redirect_to check_provider_interface_organisation_permissions_setup_index_path
       end
+    end
+
+    def check
+      wizard = OrganisationPermissionsSetupWizard.new(organisation_permissions_wizard_store, current_step: :check)
+      @relationships = wizard.relationships
+      @previous_page_path = previous_page_path(wizard)
     end
 
   private

--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -49,7 +49,11 @@ module ProviderInterface
 
     def check
       wizard = OrganisationPermissionsSetupWizard.new(organisation_permissions_wizard_store, current_step: :check)
-      @relationships = wizard.relationships
+      permission_setup_presenter = ProviderRelationshipPermissionSetupPresenter.new(
+        wizard.relationships,
+        current_provider_user,
+      )
+      @grouped_relationships_by_name = permission_setup_presenter.grouped_provider_permissions_by_name
       @previous_page_path = previous_page_path(wizard)
     end
 

--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -9,7 +9,14 @@ module ProviderInterface
         current_provider_user,
       )
       @sorted_and_grouped_provider_names = permission_setup_presenter.grouped_provider_names
-      @sorted_permission_ids = permission_setup_presenter.sorted_provider_permission_ids
+      @sorted_relationship_ids = permission_setup_presenter.sorted_provider_permission_ids
+      OrganisationPermissionsSetupWizard.new(organisation_permissions_wizard_store, relationship_ids: @sorted_relationship_ids).save_state!
+    end
+
+    def edit
+      wizard = OrganisationPermissionsSetupWizard.new(organisation_permissions_wizard_store, current_relationship_id: params[:id])
+      @current_relationship = wizard.current_relationship
+      @current_relationship_description = ProviderRelationshipPermissionAsProviderUserPresenter.new(@current_relationship, current_provider_user).provider_relationship_description
     end
 
   private
@@ -31,6 +38,11 @@ module ProviderInterface
 
     def require_manage_organisations_permission!
       render_404 unless current_provider_user.authorisation.can_manage_organisations_for_at_least_one_provider?
+    end
+
+    def organisation_permissions_wizard_store
+      key = "organisation_permissions_wizard_store_#{current_provider_user.id}"
+      WizardStateStores::RedisStore.new(key: key)
     end
   end
 end

--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -14,7 +14,11 @@ module ProviderInterface
     end
 
     def edit
-      wizard = OrganisationPermissionsSetupWizard.new(organisation_permissions_wizard_store, current_relationship_id: params[:id])
+      wizard = OrganisationPermissionsSetupWizard.new(
+        organisation_permissions_wizard_store,
+        current_relationship_id: params[:id],
+        current_step: :relationship,
+      )
       wizard.save_state!
 
       @current_relationship = wizard.current_relationship
@@ -24,6 +28,7 @@ module ProviderInterface
       wizard = OrganisationPermissionsSetupWizard.new(
         organisation_permissions_wizard_store,
         current_relationship_id: params[:id],
+        current_step: :relationship,
         provider_relationship_attrs: relationship_hash,
       )
 

--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -22,6 +22,7 @@ module ProviderInterface
       wizard.save_state!
 
       @current_relationship = wizard.current_relationship
+      @previous_page_path = previous_page_path(wizard)
     end
 
     def update
@@ -76,6 +77,17 @@ module ProviderInterface
     end
 
     helper_method :current_relationship_description
+
+    def previous_page_path(wizard)
+      previous_step, previous_relationship_id = wizard.previous_step
+      if previous_step == :relationship
+        edit_provider_interface_organisation_permissions_setup_path(previous_relationship_id)
+      elsif previous_step == :check
+        check_provider_interface_organisation_permissions_setup_index_path
+      else
+        provider_interface_organisation_permissions_setup_index_path
+      end
+    end
 
     def relationship_hash
       { params[:id] => permissions_params }

--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -36,7 +36,11 @@ module ProviderInterface
       )
 
       @current_relationship = wizard.current_relationship
-      render :edit and return if @current_relationship.invalid?(:setup)
+
+      if @current_relationship.invalid?(:setup)
+        track_validation_error(@current_relationship)
+        render :edit and return
+      end
 
       wizard.save_state!
 

--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -2,6 +2,7 @@ module ProviderInterface
   class OrganisationPermissionsSetupController < ProviderInterfaceController
     before_action :require_manage_organisations_permission!
     before_action :redirect_unless_permissions_to_setup
+    before_action :restart_if_wizard_store_empty, only: %i[edit update check]
 
     def index
       permission_setup_presenter = ProviderRelationshipPermissionSetupPresenter.new(
@@ -64,6 +65,14 @@ module ProviderInterface
 
     def redirect_unless_permissions_to_setup
       redirect_to provider_interface_applications_path if provider_relationship_permissions_needing_setup.blank?
+    end
+
+    def restart_if_wizard_store_empty
+      wizard_store = organisation_permissions_wizard_store.read
+      hash = wizard_store.present? ? JSON.parse(wizard_store) : {}
+      return if hash['relationship_ids'].present?
+
+      redirect_to provider_interface_organisation_permissions_setup_index_path
     end
 
     def provider_relationship_permissions_needing_setup

--- a/app/forms/provider_interface/organisation_permissions_setup_wizard.rb
+++ b/app/forms/provider_interface/organisation_permissions_setup_wizard.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     include ActiveModel::Model
     include ProviderRelationshipPermissionsParamsHelper
 
-    attr_accessor :relationship_ids, :current_relationship_id, :checking_answers
+    attr_accessor :relationship_ids, :current_relationship_id, :current_step, :checking_answers
     attr_writer :state_store, :provider_relationship_attrs
 
     def initialize(state_store, attrs = {})
@@ -24,6 +24,14 @@ module ProviderInterface
       [:relationship, next_relationship_id]
     end
 
+    def previous_step
+      return [:relationship, relationship_ids.last] if current_step == :check
+
+      return [:check] if checking_answers
+
+      [:relationship, previous_relationship_id] if previous_relationship_id.present?
+    end
+
     def save_state!
       @state_store.write(state)
     end
@@ -37,6 +45,13 @@ module ProviderInterface
     def next_relationship_id
       next_relationship_index = relationship_ids.find_index(current_relationship_id.to_i) + 1
       relationship_ids[next_relationship_index]
+    end
+
+    def previous_relationship_id
+      previous_relationship_index = relationship_ids.find_index(current_relationship_id.to_i) - 1
+      return nil if previous_relationship_index < 0
+
+      relationship_ids[previous_relationship_index]
     end
 
     def provider_relationship_attrs

--- a/app/forms/provider_interface/organisation_permissions_setup_wizard.rb
+++ b/app/forms/provider_interface/organisation_permissions_setup_wizard.rb
@@ -46,8 +46,8 @@ module ProviderInterface
 
   private
 
-    def build_relationship_for_id(id)
-      relationship = ProviderRelationshipPermissions.find(id)
+    def build_relationship_for_id(relationship_id)
+      relationship = ProviderRelationshipPermissions.find(relationship_id)
       assign_wizard_attrs_to_relationship(relationship)
       relationship
     end
@@ -59,7 +59,7 @@ module ProviderInterface
 
     def previous_relationship_id
       previous_relationship_index = relationship_ids.find_index(current_relationship_id.to_i) - 1
-      return nil if previous_relationship_index < 0
+      return nil if previous_relationship_index.negative?
 
       relationship_ids[previous_relationship_index]
     end

--- a/app/forms/provider_interface/organisation_permissions_setup_wizard.rb
+++ b/app/forms/provider_interface/organisation_permissions_setup_wizard.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     include ActiveModel::Model
     include ProviderRelationshipPermissionsParamsHelper
 
-    attr_accessor :relationship_ids, :current_relationship_id
+    attr_accessor :relationship_ids, :current_relationship_id, :checking_answers
     attr_writer :state_store, :provider_relationship_attrs
 
     def initialize(state_store, attrs = {})
@@ -18,6 +18,12 @@ module ProviderInterface
       relationship
     end
 
+    def next_step
+      return [:check] if checking_answers || next_relationship_id.nil?
+
+      [:relationship, next_relationship_id]
+    end
+
     def save_state!
       @state_store.write(state)
     end
@@ -27,6 +33,11 @@ module ProviderInterface
     end
 
   private
+
+    def next_relationship_id
+      next_relationship_index = relationship_ids.find_index(current_relationship_id.to_i) + 1
+      relationship_ids[next_relationship_index]
+    end
 
     def provider_relationship_attrs
       @provider_relationship_attrs.presence || {}

--- a/app/forms/provider_interface/organisation_permissions_setup_wizard.rb
+++ b/app/forms/provider_interface/organisation_permissions_setup_wizard.rb
@@ -10,12 +10,12 @@ module ProviderInterface
       @state_store = state_store
 
       super(last_saved_state.deep_merge(attrs))
+
+      self.checking_answers = false if current_step == :check
     end
 
     def current_relationship
-      relationship = ProviderRelationshipPermissions.find(current_relationship_id)
-      assign_wizard_attrs_to_relationship(relationship)
-      relationship
+      build_relationship_for_id(current_relationship_id)
     end
 
     def next_step
@@ -40,7 +40,17 @@ module ProviderInterface
       @state_store.delete
     end
 
+    def relationships
+      relationship_ids.map { |id| build_relationship_for_id(id) }
+    end
+
   private
+
+    def build_relationship_for_id(id)
+      relationship = ProviderRelationshipPermissions.find(id)
+      assign_wizard_attrs_to_relationship(relationship)
+      relationship
+    end
 
     def next_relationship_id
       next_relationship_index = relationship_ids.find_index(current_relationship_id.to_i) + 1

--- a/app/forms/provider_interface/organisation_permissions_setup_wizard.rb
+++ b/app/forms/provider_interface/organisation_permissions_setup_wizard.rb
@@ -1,0 +1,61 @@
+module ProviderInterface
+  class OrganisationPermissionsSetupWizard
+    include ActiveModel::Model
+    include ProviderRelationshipPermissionsParamsHelper
+
+    attr_accessor :relationship_ids, :current_relationship_id
+    attr_writer :state_store, :provider_relationship_attrs
+
+    def initialize(state_store, attrs = {})
+      @state_store = state_store
+
+      super(last_saved_state.deep_merge(attrs))
+    end
+
+    def current_relationship
+      relationship = ProviderRelationshipPermissions.find(current_relationship_id)
+      assign_wizard_attrs_to_relationship(relationship)
+      relationship
+    end
+
+    def save_state!
+      @state_store.write(state)
+    end
+
+    def clear_state!
+      @state_store.delete
+    end
+
+  private
+
+    def provider_relationship_attrs
+      @provider_relationship_attrs.presence || {}
+    end
+
+    def state
+      as_json(except: %w[state_store errors validation_context]).to_json
+    end
+
+    def last_saved_state
+      state = @state_store.read
+
+      if state
+        JSON.parse(state).with_indifferent_access
+      else
+        {}
+      end
+    end
+
+    def assign_wizard_attrs_to_relationship(relationship)
+      relationship.assign_attributes(wizard_attrs_for_relationship(relationship))
+      relationship
+    end
+
+    def wizard_attrs_for_relationship(relationship)
+      permission_attrs = provider_relationship_attrs[relationship.id.to_s]
+      return {} if permission_attrs.blank?
+
+      translate_params_for_model(permission_attrs)
+    end
+  end
+end

--- a/app/helpers/provider_relationship_permissions_params_helper.rb
+++ b/app/helpers/provider_relationship_permissions_params_helper.rb
@@ -1,0 +1,9 @@
+module ProviderRelationshipPermissionsParamsHelper
+  def translate_params_for_model(permissions_params)
+    ProviderRelationshipPermissions::PERMISSIONS.inject({}) do |hash, permission|
+      hash["training_provider_can_#{permission}"] = permissions_params[permission.to_s].include? 'training'
+      hash["ratifying_provider_can_#{permission}"] = permissions_params[permission.to_s].include? 'ratifying'
+      hash
+    end
+  end
+end

--- a/app/models/provider_relationship_permissions.rb
+++ b/app/models/provider_relationship_permissions.rb
@@ -4,7 +4,7 @@ class ProviderRelationshipPermissions < ApplicationRecord
 
   PERMISSIONS = %i[make_decisions view_safeguarding_information view_diversity_information].freeze
 
-  validate :at_least_one_active_permission_in_pair, if: -> { setup_at.present? }
+  validate :at_least_one_active_permission_in_pair, if: -> { setup_at.present? || validation_context == :setup }
   audited associated_with: :training_provider
 
   def self.all_relationships_for_providers(providers)

--- a/app/models/provider_relationship_permissions.rb
+++ b/app/models/provider_relationship_permissions.rb
@@ -34,8 +34,17 @@ private
   def at_least_one_active_permission_in_pair
     PERMISSIONS.each do |permission|
       if !send("training_provider_can_#{permission}") && !send("ratifying_provider_can_#{permission}")
-        errors.add(permission, "Select which organisations can #{permission.to_s.humanize.downcase}")
+        errors.add(permission, error_message_for_permission(permission))
       end
+    end
+  end
+
+  def error_message_for_permission(permission)
+    if FeatureFlag.active?(:accredited_provider_setting_permissions)
+      permission_description = I18n.t("provider_relationship_permissions.#{permission}.description")
+      "Select who can #{permission_description.downcase}"
+    else
+      "Select which organisations can #{permission.to_s.humanize.downcase}"
     end
   end
 end

--- a/app/presenters/provider_interface/provider_relationship_permission_setup_presenter.rb
+++ b/app/presenters/provider_interface/provider_relationship_permission_setup_presenter.rb
@@ -11,9 +11,15 @@ module ProviderInterface
       end
     end
 
+    def grouped_provider_permissions_by_name
+      sorted_and_grouped_provider_names_with_relationships.transform_values do |array|
+        array.map { |permission| permission[:organisation_permission] }
+      end
+    end
+
     def sorted_provider_permission_ids
       sorted_and_grouped_provider_names_with_relationships.values.flat_map do |array|
-        array.map { |permission| permission[:organisation_permission_id] }
+        array.map { |permission| permission[:organisation_permission].id }
       end
     end
 
@@ -36,7 +42,7 @@ module ProviderInterface
         main_provider = presenter.ordered_providers.first
         other_provider = presenter.ordered_providers.second
         h[main_provider.name] ||= []
-        h[main_provider.name] << { other_provider_name: other_provider.name, organisation_permission_id: prp.id }
+        h[main_provider.name] << { other_provider_name: other_provider.name, organisation_permission: prp }
       end
     end
   end

--- a/app/views/provider_interface/organisation_permissions_setup/check.html.erb
+++ b/app/views/provider_interface/organisation_permissions_setup/check.html.erb
@@ -5,17 +5,6 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l"><%= t('.caption') %></span>
     <h1 class="govuk-heading-l"><%= t('.title') %></h1>
-    <% @grouped_relationships_by_name.each do |main_provider_name, relationship_list| %>
-      <% if @grouped_relationships_by_name.length > 1 %>
-        <h2 class="govuk-heading-m"><%= main_provider_name %></h2>
-      <% end %>
-      <% relationship_list.each do |relationship| %>
-        <%= render ProviderInterface::OrganisationPermissionsReviewCardComponent.new(
-          provider_user: current_provider_user,
-          provider_relationship_permission: relationship,
-          change_path: edit_provider_interface_organisation_permissions_setup_path(relationship, checking_answers: true),
-        ) %>
-      <% end %>
-    <% end %>
+    <%= render ProviderInterface::OrganisationPermissionsSetupCheckComponent.new(relationships: @relationships, current_provider_user: current_provider_user) %>
   </div>
 </div>

--- a/app/views/provider_interface/organisation_permissions_setup/check.html.erb
+++ b/app/views/provider_interface/organisation_permissions_setup/check.html.erb
@@ -1,0 +1,16 @@
+<% content_for :browser_title, t('.title') %>
+<% content_for :before_content, govuk_back_link_to(@previous_page_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= t('.caption') %></span>
+    <h1 class="govuk-heading-l"><%= t('.title') %></h1>
+    <% @relationships.each do |relationship| %>
+      <%= render ProviderInterface::OrganisationPermissionsReviewCardComponent.new(
+        provider_user: current_provider_user,
+        provider_relationship_permission: relationship,
+        change_path: edit_provider_interface_organisation_permissions_setup_path(relationship, checking_answers: true),
+      ) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/organisation_permissions_setup/check.html.erb
+++ b/app/views/provider_interface/organisation_permissions_setup/check.html.erb
@@ -5,12 +5,17 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l"><%= t('.caption') %></span>
     <h1 class="govuk-heading-l"><%= t('.title') %></h1>
-    <% @relationships.each do |relationship| %>
-      <%= render ProviderInterface::OrganisationPermissionsReviewCardComponent.new(
-        provider_user: current_provider_user,
-        provider_relationship_permission: relationship,
-        change_path: edit_provider_interface_organisation_permissions_setup_path(relationship, checking_answers: true),
-      ) %>
+    <% @grouped_relationships_by_name.each do |main_provider_name, relationship_list| %>
+      <% if @grouped_relationships_by_name.length > 1 %>
+        <h2 class="govuk-heading-m"><%= main_provider_name %></h2>
+      <% end %>
+      <% relationship_list.each do |relationship| %>
+        <%= render ProviderInterface::OrganisationPermissionsReviewCardComponent.new(
+          provider_user: current_provider_user,
+          provider_relationship_permission: relationship,
+          change_path: edit_provider_interface_organisation_permissions_setup_path(relationship, checking_answers: true),
+        ) %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/provider_interface/organisation_permissions_setup/edit.html.erb
+++ b/app/views/provider_interface/organisation_permissions_setup/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, title_with_error_prefix(@current_relationship_description, @current_relationship.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(current_relationship_description, @current_relationship.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/organisation_permissions_setup/edit.html.erb
+++ b/app/views/provider_interface/organisation_permissions_setup/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for :browser_title, title_with_error_prefix(@current_relationship_description, @current_relationship.errors.any?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render ProviderInterface::OrganisationPermissionsFormComponent.new(
+      provider_user: current_provider_user,
+      provider_relationship_permission: @current_relationship,
+      mode: :setup,
+      form_url: provider_interface_organisation_permissions_setup_path(@current_relationship),
+    ) %>
+  </div>
+</div>

--- a/app/views/provider_interface/organisation_permissions_setup/edit.html.erb
+++ b/app/views/provider_interface/organisation_permissions_setup/edit.html.erb
@@ -1,4 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(current_relationship_description, @current_relationship.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(@previous_page_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/organisation_permissions_setup/index.html.erb
+++ b/app/views/provider_interface/organisation_permissions_setup/index.html.erb
@@ -2,5 +2,5 @@
 
 <%= render ProviderInterface::OrganisationPermissionsSetupListComponent.new(
   grouped_provider_names: @sorted_and_grouped_provider_names,
-  continue_button_path: edit_provider_interface_organisation_permissions_setup_path(@sorted_permission_ids.first),
+  continue_button_path: edit_provider_interface_organisation_permissions_setup_path(@sorted_relationship_ids.first),
 ) %>

--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -22,6 +22,9 @@ en:
     organisation_permissions_setup:
       index:
         title: Set up organisation permissions
+      check:
+        title: Check and save organisation permissions
+        caption: Set up organisation permissions
     organisation_permissions_setup_list_component:
       single:
         introduction: 'Candidates can now apply through GOV.UK for courses %{provider_name} works on with:'

--- a/spec/components/provider_interface/organisation_permissions_review_card_component_spec.rb
+++ b/spec/components/provider_interface/organisation_permissions_review_card_component_spec.rb
@@ -17,6 +17,36 @@ RSpec.describe ProviderInterface::OrganisationPermissionsReviewCardComponent do
     )
   end
 
+  describe 'heading levels' do
+    let(:component_attrs) do
+      {
+        provider_user: provider_user,
+        provider_relationship_permission: provider_relationship_permission,
+      }
+    end
+
+    subject!(:render) { render_inline(described_class.new(component_attrs)) }
+
+    it 'renders headings as h2 by default' do
+      expect(page).to have_css('h2.app-summary-card__title')
+    end
+
+    context 'when heading level is specified' do
+      let(:component_attrs) do
+        {
+          provider_user: provider_user,
+          provider_relationship_permission: provider_relationship_permission,
+          summary_card_heading_level: 4,
+        }
+      end
+
+      it 'renders headings at the level specified' do
+        expect(page).to have_css('h4.app-summary-card__title')
+        expect(page).not_to have_css('h2.app-summary-card__title')
+      end
+    end
+  end
+
   describe 'change link' do
     context 'when the change path is not provided' do
       it 'does not render an action link' do

--- a/spec/components/provider_interface/organisation_permissions_setup_check_component_spec.rb
+++ b/spec/components/provider_interface/organisation_permissions_setup_check_component_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::OrganisationPermissionsSetupCheckComponent do
+  subject!(:render) do
+    render_inline(
+      described_class.new(
+        relationships: relationships,
+        current_provider_user: current_provider_user,
+      ),
+    )
+  end
+
+  context 'when there are relationships from multiple providers' do
+    let(:relationships) { create_list(:provider_relationship_permissions, 2) }
+    let(:current_provider_user) { create(:provider_user, providers: relationships.map(&:training_provider)) }
+
+    it 'renders each provider name per relationship group' do
+      sorted_main_provider_names = relationships.map(&:training_provider).map(&:name).sort
+      expect(render.css('h2.govuk-heading-m')[0].text.squish).to eq(sorted_main_provider_names.first)
+      expect(render.css('h2.govuk-heading-m')[1].text.squish).to eq(sorted_main_provider_names.second)
+    end
+
+    it 'renders the summary card headings with an h3 tag' do
+      expect(page).to have_css('h3.app-summary-card__title')
+    end
+  end
+
+  context 'when there are only relationships from a single provider' do
+    let(:current_provider_user) { create(:provider_user, :with_provider) }
+    let(:relationships) { create_list(:provider_relationship_permissions, 2, training_provider:current_provider_user.providers.first) }
+
+    it 'should not render the provider name' do
+      expect(page).not_to have_css('h2.govuk-heading-m')
+    end
+
+    it 'renders the summary card headings with an h2 tag' do
+      expect(page).to have_css('h2.app-summary-card__title')
+    end
+  end
+end

--- a/spec/components/provider_interface/organisation_permissions_setup_check_component_spec.rb
+++ b/spec/components/provider_interface/organisation_permissions_setup_check_component_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe ProviderInterface::OrganisationPermissionsSetupCheckComponent do
 
   context 'when there are only relationships from a single provider' do
     let(:current_provider_user) { create(:provider_user, :with_provider) }
-    let(:relationships) { create_list(:provider_relationship_permissions, 2, training_provider:current_provider_user.providers.first) }
+    let(:relationships) { create_list(:provider_relationship_permissions, 2, training_provider: current_provider_user.providers.first) }
 
-    it 'should not render the provider name' do
+    it 'does not render the provider name' do
       expect(page).not_to have_css('h2.govuk-heading-m')
     end
 

--- a/spec/components/provider_interface/organisation_permissions_setup_list_component_spec.rb
+++ b/spec/components/provider_interface/organisation_permissions_setup_list_component_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe ProviderInterface::OrganisationPermissionsSetupListComponent do
   end
 
   it 'renders a button with the correct path' do
-    form = render.css('form').first
-    expect(form.attributes['action'].value).to eq(path)
-    expect(form.css('input').first.attributes['value'].value).to eq('Set up organisation permissions')
+    continue_link = render.css('a').first
+    expect(continue_link.attributes['href'].value).to eq(path)
+    expect(continue_link.text).to eq('Set up organisation permissions')
   end
 
   context 'when there is a single main provider' do

--- a/spec/forms/provider_interface/organisation_permissions_setup_wizard_spec.rb
+++ b/spec/forms/provider_interface/organisation_permissions_setup_wizard_spec.rb
@@ -106,4 +106,61 @@ RSpec.describe ProviderInterface::OrganisationPermissionsSetupWizard do
       end
     end
   end
+
+  describe '#previous_step' do
+    context 'when there is a relationship before the current one in the list' do
+      let(:wizard_attrs) do
+        {
+          relationship_ids: relationship_ids,
+          current_relationship_id: relationship_ids.second,
+          current_step: :relationship,
+        }
+      end
+
+      it 'returns :relationship and the id of the previous relationship' do
+        expect(wizard.previous_step).to eq([:relationship, relationship_ids.first])
+      end
+    end
+
+    context 'when the current relationship is the first' do
+      let(:wizard_attrs) do
+        {
+          relationship_ids: relationship_ids,
+          current_relationship_id: relationship_ids.first,
+          current_step: :relationship,
+        }
+      end
+
+      it 'returns nil' do
+        expect(wizard.previous_step).to be_nil
+      end
+    end
+
+    context 'when the current step is :check' do
+      let(:wizard_attrs) do
+        {
+          relationship_ids: relationship_ids,
+          current_step: :check,
+        }
+      end
+
+      it 'returns :relationship and the id of the last relationship' do
+        expect(wizard.previous_step).to eq([:relationship, relationship_ids.last])
+      end
+    end
+
+    context 'when checking_answers is true' do
+      let(:wizard_attrs) do
+        {
+          relationship_ids: relationship_ids,
+          current_relationship_id: relationship_ids.first,
+          checking_answers: true,
+        }
+      end
+
+      it 'returns :check' do
+        expect(wizard.previous_step).to eq([:check])
+      end
+    end
+  end
 end

--- a/spec/forms/provider_interface/organisation_permissions_setup_wizard_spec.rb
+++ b/spec/forms/provider_interface/organisation_permissions_setup_wizard_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::OrganisationPermissionsSetupWizard do
+  let(:store) { instance_double(WizardStateStores::RedisStore) }
+  let(:relationships) { create_list(:provider_relationship_permissions, 3).shuffle }
+  let(:relationship_ids) { relationships.pluck(:id) }
+  let(:wizard_attrs) do
+    {
+      relationship_ids: relationship_ids,
+    }
+  end
+
+  let(:wizard) do
+    described_class.new(
+      store,
+      wizard_attrs,
+    )
+  end
+
+  before { allow(store).to receive(:read) }
+
+  describe '#current_relationship' do
+    context 'when the wizard has no stored information for the relationship' do
+      let(:wizard_attrs) do
+        {
+          relationship_ids: relationship_ids,
+          current_relationship_id: relationship_ids.last
+        }
+      end
+
+      it 'returns the relationship with the given id in the list' do
+        expect(wizard.current_relationship).to eq(relationships.last)
+      end
+    end
+
+    context 'when the wizard has stored changes to a relationship' do
+      let(:provider_relationship_attrs) do
+        {
+          relationship_ids.first.to_s => {
+            'make_decisions' => %w[ratifying],
+            'view_safeguarding_information' => %w[training ratifying],
+            'view_diversity_information' => %w[training],
+          },
+        }
+      end
+      let(:wizard_attrs) do
+        {
+          relationship_ids: relationship_ids,
+          provider_relationship_attrs: provider_relationship_attrs,
+        }
+      end
+
+      it 'returns the relationship with the changes applied but not saved' do
+        current_relationship = wizard.current_relationship
+        expect(current_relationship).to be_changed
+
+        expect(current_relationship.training_provider_can_make_decisions).to eq(false)
+        expect(current_relationship.ratifying_provider_can_make_decisions).to eq(true)
+        expect(current_relationship.training_provider_can_view_safeguarding_information).to eq(true)
+        expect(current_relationship.ratifying_provider_can_view_safeguarding_information).to eq(true)
+        expect(current_relationship.training_provider_can_view_diversity_information).to eq(true)
+        expect(current_relationship.ratifying_provider_can_view_diversity_information).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/forms/provider_interface/organisation_permissions_setup_wizard_spec.rb
+++ b/spec/forms/provider_interface/organisation_permissions_setup_wizard_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ProviderInterface::OrganisationPermissionsSetupWizard do
       let(:wizard_attrs) do
         {
           relationship_ids: relationship_ids,
-          current_relationship_id: relationship_ids.last
+          current_relationship_id: relationship_ids.last,
         }
       end
 
@@ -47,6 +47,7 @@ RSpec.describe ProviderInterface::OrganisationPermissionsSetupWizard do
         {
           relationship_ids: relationship_ids,
           provider_relationship_attrs: provider_relationship_attrs,
+          current_relationship_id: relationship_ids.first,
         }
       end
 
@@ -60,6 +61,48 @@ RSpec.describe ProviderInterface::OrganisationPermissionsSetupWizard do
         expect(current_relationship.ratifying_provider_can_view_safeguarding_information).to eq(true)
         expect(current_relationship.training_provider_can_view_diversity_information).to eq(true)
         expect(current_relationship.ratifying_provider_can_view_diversity_information).to eq(false)
+      end
+    end
+  end
+
+  describe '#next_step' do
+    context 'when there is a relationship next in the list' do
+      let(:wizard_attrs) do
+        {
+          relationship_ids: relationship_ids,
+          current_relationship_id: relationship_ids.first,
+        }
+      end
+
+      it 'returns :relationship and the id of the next relationship' do
+        expect(wizard.next_step).to eq([:relationship, relationship_ids.second])
+      end
+    end
+
+    context 'when there are no further relationships in the list' do
+      let(:wizard_attrs) do
+        {
+          relationship_ids: relationship_ids,
+          current_relationship_id: relationship_ids.last,
+        }
+      end
+
+      it 'returns :check' do
+        expect(wizard.next_step).to eq([:check])
+      end
+    end
+
+    context 'when checking_answers is true' do
+      let(:wizard_attrs) do
+        {
+          relationship_ids: relationship_ids,
+          current_relationship_id: relationship_ids.first,
+          checking_answers: true,
+        }
+      end
+
+      it 'returns :check' do
+        expect(wizard.next_step).to eq([:check])
       end
     end
   end

--- a/spec/helpers/provider_relationship_permissions_params_helper_spec.rb
+++ b/spec/helpers/provider_relationship_permissions_params_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ProviderRelationshipPermissionsParamsHelper do
+  describe '#translate_params_for_model' do
+    let(:permissions_params) do
+      {
+        'make_decisions' => %w[training],
+        'view_safeguarding_information' => %w[ratifying],
+        'view_diversity_information' => %w[training ratifying],
+      }
+    end
+    let(:translated_params) { helper.translate_params_for_model(permissions_params) }
+
+    it 'translates form-style parameters into model compatible attributes' do
+      expect(translated_params['training_provider_can_make_decisions']).to be true
+      expect(translated_params['ratifying_provider_can_make_decisions']).to be false
+      expect(translated_params['training_provider_can_view_safeguarding_information']).to be false
+      expect(translated_params['ratifying_provider_can_view_safeguarding_information']).to be true
+      expect(translated_params['training_provider_can_view_diversity_information']).to be true
+      expect(translated_params['ratifying_provider_can_view_diversity_information']).to be true
+    end
+  end
+end

--- a/spec/models/provider_relationship_permissions_spec.rb
+++ b/spec/models/provider_relationship_permissions_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe ProviderRelationshipPermissions do
       it 'skips validation' do
         expect(permissions.valid?).to be true
       end
+
+      context 'when the :setup context is used' do
+        it 'ensures at least one permission in each pair is active' do
+          expect(permissions.valid?(:setup)).to be false
+          expect(permissions.errors.attribute_names).to eq(%i[make_decisions])
+        end
+      end
     end
 
     context 'when at least one permission in each pair is active' do

--- a/spec/presenters/provider_interface/provider_relationship_permission_setup_presenter_spec.rb
+++ b/spec/presenters/provider_interface/provider_relationship_permission_setup_presenter_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionSetupPresenter d
     end
   end
 
+  describe '#grouped_provider_permissions_by_name' do
+    it 'returns a hash with the main provider names as keys sorted alphabetically' do
+      sorted_names = [provider_1.name, provider_2.name].sort
+      expect(presenter.grouped_provider_permissions_by_name.keys).to eq(sorted_names)
+    end
+
+    it 'returns a hash with the sorted provider relationships as values' do
+      grouped_provider_permissions_by_name = presenter.grouped_provider_permissions_by_name
+      expect(grouped_provider_permissions_by_name[provider_1.name]).to eq([org_permissions_list.second, org_permissions_list.first])
+      expect(grouped_provider_permissions_by_name[provider_2.name]).to contain_exactly(org_permissions_list.last)
+    end
+  end
+
   describe '#sorted_provider_permission_ids' do
     it 'returns the ids of the permissions objects sorted by main provider name and then by other provider name' do
       expect(presenter.sorted_provider_permission_ids).to eq([

--- a/spec/requests/provider_interface/organisation_permissions_setup_controller_spec.rb
+++ b/spec/requests/provider_interface/organisation_permissions_setup_controller_spec.rb
@@ -36,6 +36,36 @@ RSpec.describe ProviderInterface::OrganisationPermissionsSetupController do
 
         expect(response.status).to eq(200)
       end
+
+      context 'when the wizard state store has not been set up' do
+        let(:store) { instance_double(WizardStateStores::RedisStore) }
+
+        before do
+          allow(store).to receive(:read).and_return(nil)
+          allow(WizardStateStores::RedisStore).to receive(:new).and_return(store)
+        end
+
+        it 'redirects edit to the index action' do
+          get edit_provider_interface_organisation_permissions_setup_path(permissions)
+
+          expect(response.status).to eq(302)
+          expect(response.redirect_url).to eq(provider_interface_organisation_permissions_setup_index_url)
+        end
+
+        it 'redirects update to the index action' do
+          patch provider_interface_organisation_permissions_setup_path(permissions), params: {}
+
+          expect(response.status).to eq(302)
+          expect(response.redirect_url).to eq(provider_interface_organisation_permissions_setup_index_url)
+        end
+
+        it 'redirects check to the index action' do
+          get check_provider_interface_organisation_permissions_setup_index_path
+
+          expect(response.status).to eq(302)
+          expect(response.redirect_url).to eq(provider_interface_organisation_permissions_setup_index_url)
+        end
+      end
     end
 
     context 'when the accredited_provider_setting_permissions flag is off' do

--- a/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Managing provider to provider relationship permissions' do
   include DfESignInHelpers
 
+  before { FeatureFlag.deactivate(:accredited_provider_setting_permissions) }
+
   scenario 'Provider manages permissions for their organisation' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_sign_in_to_the_provider_interface

--- a/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
@@ -12,6 +12,26 @@ RSpec.feature 'Setting up organisation permissions' do
 
     when_i_sign_in_to_the_provider_interface
     then_i_can_see_the_organisations_needing_permissions_setup
+
+    when_i_click_set_up_organisation_permissions
+    then_i_see_the_first_relationship
+
+    when_i_select_a_provider_for_each_permission
+    and_i_click_on_continue
+    then_i_see_the_next_relationship
+
+    when_i_do_not_complete_the_permissions_details
+    and_i_click_on_continue
+    then_i_see_the_error_message
+
+    when_i_complete_the_permissions_details
+    and_i_click_on_continue
+    then_i_see_the_check_relationship_permissions_page
+
+    when_i_click_on_change
+    and_i_change_the_provider_permission
+    and_i_click_on_continue
+    then_i_see_the_check_relationship_permissions_page
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -62,5 +82,55 @@ RSpec.feature 'Setting up organisation permissions' do
     expect(page).to have_content(@another_ratifying_provider.name)
     expect(page).to have_content("For #{@ratifying_provider.name}, you need to set up permissions for courses you work on with:")
     expect(page).to have_content(@another_training_provider.name)
+  end
+
+  def when_i_click_set_up_organisation_permissions
+    click_on 'Set up organisation permissions'
+  end
+
+  def then_i_see_the_first_relationship
+    expect(page).to have_content("#{@ratifying_provider.name} and #{@another_training_provider.name}")
+  end
+
+  def when_i_select_a_provider_for_each_permission
+    within('[data-qa="make-decisions"]') { check @ratifying_provider.name }
+    within('[data-qa="view-safeguarding-information"]') { check @ratifying_provider.name }
+    within('[data-qa="view-safeguarding-information"]') { check @another_training_provider.name }
+    within('[data-qa="view-diversity-information"]') { check @ratifying_provider.name }
+  end
+
+  def and_i_click_on_continue
+    click_on 'Continue'
+  end
+
+  def then_i_see_the_next_relationship
+    expect(page).to have_content("#{@training_provider.name} and #{@another_ratifying_provider.name}")
+  end
+
+  def when_i_do_not_complete_the_permissions_details
+    within('[data-qa="view-safeguarding-information"]') { check @training_provider.name }
+    within('[data-qa="view-diversity-information"]') { check @another_ratifying_provider.name }
+  end
+
+  def then_i_see_the_error_message
+    expect(page).to have_content('Select which organisations can make decisions')
+  end
+
+  def when_i_complete_the_permissions_details
+    within('[data-qa="make-decisions"]') { check @another_ratifying_provider.name }
+  end
+
+  def then_i_see_the_check_relationship_permissions_page
+    expect(page).to have_content('Check and save organisation permissions')
+  end
+
+  def when_i_click_on_change
+    click_on 'Change', match: :first
+  end
+
+  def and_i_change_the_provider_permission
+    within('[data-qa="make-decisions"]') { check @another_training_provider.name }
+    within('[data-qa="view-safeguarding-information"]') { check @another_training_provider.name }
+    within('[data-qa="view-diversity-information"]') { check @another_training_provider.name }
   end
 end

--- a/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
@@ -113,7 +113,7 @@ RSpec.feature 'Setting up organisation permissions' do
   end
 
   def then_i_see_the_error_message
-    expect(page).to have_content('Select which organisations can make decisions')
+    expect(page).to have_content('Select who can make offers and reject applications')
   end
 
   def when_i_complete_the_permissions_details

--- a/spec/system/support_interface/managing_provider_permissions_spec.rb
+++ b/spec/system/support_interface/managing_provider_permissions_spec.rb
@@ -44,7 +44,13 @@ RSpec.feature 'Managing provider-provider permissions via support' do
   end
 
   def then_i_should_see_an_error
-    expect(page).to have_content 'Select which organisations can make decisions'
+    error_message = if FeatureFlag.active?(:accredited_provider_setting_permissions)
+                      'Select who can make offers and reject applications'
+                    else
+                      'Select which organisations can make decisions'
+                    end
+
+    expect(page).to have_content error_message
   end
 
   def when_i_set_valid_relationships


### PR DESCRIPTION
## Context
https://trello.com/c/ugaq5iLu/3899-add-new-flow-for-permissions-setup-wizard

We've added a set of pages to the permission setup flow. This is not covering the full ticket's requirements though - instead, this PR covers the permission edit pages which are iterated over, and the final check page before submitting all the setup permissions to the db. We have yet to implement the final submission and success page, which will be in another PR.

## Changes proposed in this pull request
Added a wizard, which handles the setting up of permissions, and displaying all the proposed permission setups in a check page.

![image](https://user-images.githubusercontent.com/25597009/126631988-a4e7a846-939e-4bfc-b363-9c0e42c62190.png)

If you have permissions to set up based on more than one provider you're associated with, then each provider will have its own section on the check page (separated with h2 provider name elements). Each card has a `Change` link, which goes to the edit page for that relationship. The checkboxes should be persistent here, and submitting changes should bring you straight back to the check page.

![image](https://user-images.githubusercontent.com/25597009/126632262-2ca6218d-ca67-469f-bd6f-b42441028e6d.png)

We've also got validation working on each edit page, where you must select at least one provider that's permitted in each category

![image](https://user-images.githubusercontent.com/25597009/126632393-db41df1a-4ba0-47e9-b319-e3a659264bea.png)


## Guidance to review

Make sure to turn on the feature flag `accredited_provider_setting_permissions`

You can probably sign in as `dev-support`, and in a console, run something like `ProviderRelationshipPermissions.all.update(setup_at: nil)` which should reset all the permissions so that they need setting up. When you log in, you'll be prompted to go through the setup flow. 

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
