### PR TITLE
Notify in slack when an application is withdrawn at a candidates request

### DIFF
--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -1,5 +1,5 @@
 class StateChangeNotifier
-  APPLICATION_OUTCOME_EVENTS = %i[declined declined_by_default withdrawn rejected rejected_by_default recruited].freeze
+  APPLICATION_OUTCOME_EVENTS = %i[declined declined_by_default withdrawn rejected rejected_by_default recruited withdrawn_at_candidates_request].freeze
 
   attr_reader :application_choice, :event
 
@@ -103,6 +103,7 @@ private
     applications.inject(APPLICATION_OUTCOME_EVENTS.index_with { |_| [] }) do |grouped, application|
       status = :rejected_by_default if application.rejected? && application.rejected_by_default?
       status = :declined_by_default if application.declined? && application.declined_by_default?
+      status = :withdrawn_at_candidates_request if application.withdrawn_at_candidates_request?
       status ||= application.status.to_sym
 
       grouped[status] << application if grouped.key?(status)

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -174,6 +174,17 @@ class ApplicationChoice < ApplicationRecord
     unconditional_offer?
   end
 
+  def withdrawn_at_candidates_request?
+    (declined? || withdrawn?) && Audited::Audit.exists?(
+      user_type: 'ProviderUser',
+      auditable: self,
+      comment: [
+        I18n.t('transient_application_states.withdrawn_at_candidates_request.declined.audit_comment'),
+        I18n.t('transient_application_states.withdrawn_at_candidates_request.withdrawn.audit_comment'),
+      ],
+    )
+  end
+
 private
 
   def set_initial_status

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -69,6 +69,12 @@ en:
     withdrawn: Application withdrawn
     conditions_not_met: Conditions not met
     offer_deferred: Deferred
+  transient_application_states:
+    withdrawn_at_candidates_request:
+      declined:
+        audit_comment: Declined on behalf of the candidate
+      withdrawn:
+        audit_comment: Withdrawn on behalf of the candidate
 
   performance_dashboard_other_metrics:
     apply_again_submitted:

--- a/config/locales/support_interface/slack_notifications.yml
+++ b/config/locales/support_interface/slack_notifications.yml
@@ -21,6 +21,14 @@ en:
           one: ":runner: %{applicant} withdrew their application from %{providers}"
           other: ":runner: %{applicant} withdrew their applications from %{providers}"
         other_applications: "withdrew from %{providers}"
+    withdrawn_at_candidates_request:
+      message:
+        primary:
+          one: ":runner: %{applicant} requested that their application be withdrawn from %{providers}"
+          other: ":runner: %{applicant} requested that their applications be withdrawn from %{providers}"
+        other_applications:
+          one: "requested that their application be withdrawn from %{providers}"
+          other: "requested that their applications be withdrawn from %{providers}"
     recruited:
       message:
         primary: ":handshake: %{applicant} was recruited to %{providers}"

--- a/spec/factories/audit.rb
+++ b/spec/factories/audit.rb
@@ -1,4 +1,24 @@
 FactoryBot.define do
+  factory :withdrawn_at_candidates_request_audit, class: 'Audited::Audit' do
+    action { 'update' }
+    user { create(:provider_user) }
+    version { 1 }
+    request_uuid { SecureRandom.uuid }
+    comment { 'Withdrawn on behalf of the candidate' }
+    created_at { Time.zone.now }
+
+    transient do
+      application_choice { build_stubbed(:application_choice, :withdrawn) }
+      changes { {} }
+    end
+
+    after(:build) do |audit, evaluator|
+      audit.auditable_type = 'ApplicationChoice'
+      audit.auditable_id = evaluator.application_choice.id
+      audit.audited_changes = evaluator.changes
+    end
+  end
+
   factory :interview_audit, class: 'Audited::Audit' do
     action { 'create' }
     user { create(:provider_user) }

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -282,4 +282,19 @@ RSpec.describe ApplicationChoice, type: :model do
       end
     end
   end
+
+  describe '#withdrawn_at_candidates_request?' do
+    it 'is false when the application has been withdrawn by the candidate' do
+      application_choice = build_stubbed(:application_choice, :withdrawn)
+
+      expect(application_choice.withdrawn_at_candidates_request?).to be false
+    end
+
+    it 'is true when the application has been withdrawn at the candidate\'s request' do
+      application_choice = build_stubbed(:application_choice, :withdrawn)
+      create(:withdrawn_at_candidates_request_audit, application_choice: application_choice)
+
+      expect(application_choice.withdrawn_at_candidates_request?).to be true
+    end
+  end
 end


### PR DESCRIPTION
## Context

We have released the feature _Withdraw application at candidate's request_ so we'd like to receive support notifications when these events occur.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds a way to determine if an application has been withdrawn at the candidate's request.
- Modifies `StateChangeNotifier` to handle `:withdraw_at_candidates_request` events

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

How we identify applications which have been withdrawn at the candidate's request is based on the audit user type and the audit comment. 
I had concerns that this is brittle, we could alternatively determine this transient state from the audit changes and type of user making the change but at the cost of a much more complex query.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

3994-notification-in-slack-when-an-application-is-withdrawn-at-a-candidates-request
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
