### PR TITLE
Add times to cycle dates

### DIFF
--- a/app/components/candidate_interface/deadline_banner_component.html.erb
+++ b/app/components/candidate_interface/deadline_banner_component.html.erb
@@ -1,4 +1,4 @@
 <%= govuk_notification_banner(title: t('notification_banner.important')) do |notification_banner| %>
-  <%= notification_banner.slot(:heading, text: "The deadline for applying to courses starting in the #{academic_year} academic year is 6pm on #{deadline}") %>
+  <%= notification_banner.slot(:heading, text: "The deadline for applying to courses starting in the #{academic_year} academic year is #{deadline[:time]} on #{deadline[:date]}") %>
   <p class="govuk-body">Courses may fill up before then. Check course availability with your provider.</p>
 <% end %>

--- a/app/components/candidate_interface/deadline_banner_component.rb
+++ b/app/components/candidate_interface/deadline_banner_component.rb
@@ -29,11 +29,17 @@ private
   end
 
   def apply_1_deadline
-    CycleTimetable.date(:apply_1_deadline).to_s(:govuk_date)
+    {
+      date: CycleTimetable.date(:apply_1_deadline).to_s(:govuk_date),
+      time: CycleTimetable.date(:apply_1_deadline).to_s(:govuk_time),
+    }
   end
 
   def apply_2_deadline
-    CycleTimetable.date(:apply_2_deadline).to_s(:govuk_date)
+    {
+      date: CycleTimetable.date(:apply_2_deadline).to_s(:govuk_date),
+      time: CycleTimetable.date(:apply_2_deadline).to_s(:govuk_time),
+    }
   end
 
   def application_form_recruitment_cycle_year

--- a/app/components/candidate_interface/reopen_banner_component.html.erb
+++ b/app/components/candidate_interface/reopen_banner_component.html.erb
@@ -1,4 +1,4 @@
 <%= govuk_notification_banner(title: t('notification_banner.important')) do |notification_banner| %>
   <%= notification_banner.slot(:heading, text: "Applications for courses starting in the #{CycleTimetable.cycle_year_range(cycle_year)} academic year are closed") %>
-  <p class="govuk-body">Submit your application from 9am on <%= reopen_date %> for courses starting in the <%= CycleTimetable.cycle_year_range(cycle_year + 1) %> academic year.</p>
+  <p class="govuk-body">Submit your application from <%= reopen_date[:time] %> on <%= reopen_date[:date] %> for courses starting in the <%= CycleTimetable.cycle_year_range(cycle_year + 1) %> academic year.</p>
 <% end %>

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -31,9 +31,15 @@ private
 
   def reopen_date
     if Time.zone.now < CycleTimetable.date(:apply_opens)
-      CycleTimetable.apply_opens.to_s(:govuk_date)
+      {
+        date: CycleTimetable.apply_opens.to_s(:govuk_date),
+        time: CycleTimetable.apply_opens.to_s(:govuk_time),
+      }
     else
-      CycleTimetable.apply_reopens.to_s(:govuk_date)
+      {
+        date: CycleTimetable.apply_reopens.to_s(:govuk_date),
+        time: CycleTimetable.apply_reopens.to_s(:govuk_time),
+      }
     end
   end
 

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -99,10 +99,6 @@ module ViewHelper
     boolean ? 'Yes' : 'No'
   end
 
-  def days_until_find_reopens
-    (CycleTimetable.find_reopens.to_date - Time.zone.today).to_i
-  end
-
   def percent_of(numerator, denominator)
     numerator.to_f / denominator * 100.0
   end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -100,7 +100,7 @@ module ViewHelper
   end
 
   def days_until_find_reopens
-    (CycleTimetable.find_reopens - Time.zone.today).to_i
+    (CycleTimetable.find_reopens.to_date - Time.zone.today).to_i
   end
 
   def percent_of(numerator, denominator)

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -84,6 +84,10 @@ class CycleTimetable
     Time.zone.now.between?(find_closes, find_reopens)
   end
 
+  def self.days_until_find_reopens
+    (find_reopens.to_date - Time.zone.today).to_i
+  end
+
   def self.apply_opens(year = current_year)
     date(:apply_opens, year)
   end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -3,31 +3,31 @@ class CycleTimetable
   # The 2019 dates are made up so we can generate sensible test data
   CYCLE_DATES = {
     2019 => {
-      find_opens: Date.new(2018, 10, 6),
-      apply_opens: Date.new(2018, 10, 13),
-      apply_1_deadline: Date.new(2019, 8, 24),
-      apply_2_deadline: Date.new(2019, 9, 18),
-      find_closes: Date.new(2019, 10, 3),
+      find_opens: Time.zone.local(2018, 10, 6, 9),
+      apply_opens: Time.zone.local(2018, 10, 13, 9),
+      apply_1_deadline: Time.zone.local(2019, 8, 24, 18),
+      apply_2_deadline: Time.zone.local(2019, 9, 18, 18),
+      find_closes: Time.zone.local(2019, 10, 3),
     },
     2020 => {
-      find_opens: Date.new(2019, 10, 6),
-      apply_opens: Date.new(2019, 10, 13),
-      show_deadline_banner: Date.new(2020, 8, 1),
-      apply_1_deadline: Date.new(2020, 8, 24),
-      apply_2_deadline: Date.new(2020, 9, 18),
-      find_closes: Date.new(2020, 10, 3),
+      find_opens: Time.zone.local(2019, 10, 6, 9),
+      apply_opens: Time.zone.local(2019, 10, 13, 9),
+      show_deadline_banner: Time.zone.local(2020, 8, 1, 9),
+      apply_1_deadline: Time.zone.local(2020, 8, 24, 18),
+      apply_2_deadline: Time.zone.local(2020, 9, 18, 18),
+      find_closes: Time.zone.local(2020, 10, 3),
     },
     2021 => {
-      find_opens: Date.new(2020, 10, 6),
-      apply_opens: Date.new(2020, 10, 13),
-      show_deadline_banner: Date.new(2021, 8, 1),
-      apply_1_deadline: Date.new(2021, 9, 7),
-      apply_2_deadline: Date.new(2021, 9, 20),
-      find_closes: Date.new(2021, 10, 3),
+      find_opens: Time.zone.local(2020, 10, 6, 9),
+      apply_opens: Time.zone.local(2020, 10, 13, 9),
+      show_deadline_banner: Time.zone.local(2021, 8, 1, 9),
+      apply_1_deadline: Time.zone.local(2021, 9, 7, 18),
+      apply_2_deadline: Time.zone.local(2021, 9, 20, 18),
+      find_closes: Time.zone.local(2021, 10, 3),
     },
     2022 => {
-      find_opens: Date.new(2021, 10, 5),
-      apply_opens: Date.new(2021, 10, 12),
+      find_opens: Time.zone.local(2021, 10, 5, 9),
+      apply_opens: Time.zone.local(2021, 10, 12, 9),
     },
   }.freeze
 
@@ -50,13 +50,13 @@ class CycleTimetable
   end
 
   def self.show_apply_1_deadline_banner?(application_form)
-    Time.zone.now.between?(date(:show_deadline_banner), date(:apply_1_deadline).end_of_day) &&
+    Time.zone.now.between?(date(:show_deadline_banner), date(:apply_1_deadline)) &&
       application_form.phase == 'apply_1' &&
       !application_form.successful?
   end
 
   def self.show_apply_2_deadline_banner?(application_form)
-    Time.zone.now.between?(date(:show_deadline_banner), date(:apply_2_deadline).end_of_day) &&
+    Time.zone.now.between?(date(:show_deadline_banner), date(:apply_2_deadline)) &&
       (application_form.phase == 'apply_2' || application_form.phase == 'apply_1' && application_form.ended_without_success?)
   end
 
@@ -81,7 +81,7 @@ class CycleTimetable
   end
 
   def self.find_down?
-    Time.zone.now.between?(find_closes.end_of_day, find_reopens.beginning_of_day)
+    Time.zone.now.between?(find_closes, find_reopens)
   end
 
   def self.apply_opens(year = current_year)
@@ -109,13 +109,13 @@ class CycleTimetable
   end
 
   def self.between_cycles_apply_1?
-    Time.zone.now > apply_1_deadline.end_of_day &&
-      Time.zone.now < apply_reopens.beginning_of_day
+    Time.zone.now > apply_1_deadline &&
+      Time.zone.now < apply_reopens
   end
 
   def self.between_cycles_apply_2?
-    Time.zone.now > apply_2_deadline.end_of_day &&
-      Time.zone.now < apply_reopens.beginning_of_day
+    Time.zone.now > apply_2_deadline &&
+      Time.zone.now < apply_reopens
   end
 
   def self.date(name, year = current_year)
@@ -252,7 +252,7 @@ class CycleTimetable
   end
 
   def self.before_find_reopens?
-    return true if Time.zone.now.to_date <= find_reopens.beginning_of_day
+    return true if Time.zone.now.to_date <= find_reopens
 
     false
   end
@@ -273,20 +273,20 @@ class CycleTimetable
   def self.apply_1_deadline_has_passed?(application_form)
     recruitment_cycle_year = application_form.recruitment_cycle_year
 
-    Time.zone.now.to_date > apply_1_deadline(recruitment_cycle_year).beginning_of_day
+    Time.zone.now > apply_1_deadline(recruitment_cycle_year)
   end
 
   def self.apply_2_deadline_has_passed?(application_form)
     recruitment_cycle_year = application_form.recruitment_cycle_year
 
-    Time.zone.now.to_date > apply_2_deadline(recruitment_cycle_year).beginning_of_day
+    Time.zone.now > apply_2_deadline(recruitment_cycle_year)
   end
 
   private_class_method :last_recruitment_cycle_year?
 
   def self.need_to_send_deadline_reminder?
-    return :apply_1 if Time.zone.now.to_date == apply_1_deadline_first_reminder || Time.zone.now.to_date == apply_1_deadline_second_reminder
-    return :apply_2 if Time.zone.now.to_date == apply_2_deadline_first_reminder || Time.zone.now.to_date == apply_2_deadline_second_reminder
+    return :apply_1 if Time.zone.now.to_date == apply_1_deadline_first_reminder.to_date || Time.zone.now.to_date == apply_1_deadline_second_reminder.to_date
+    return :apply_2 if Time.zone.now.to_date == apply_2_deadline_first_reminder.to_date || Time.zone.now.to_date == apply_2_deadline_second_reminder.to_date
   end
 
   def self.cycle_year_range(year = current_year)

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -22,7 +22,7 @@ class CycleTimetable
       apply_opens: Time.zone.local(2020, 10, 13, 9),
       show_deadline_banner: Time.zone.local(2021, 8, 1, 9),
       apply_1_deadline: Time.zone.local(2021, 9, 7, 18),
-      apply_2_deadline: Time.zone.local(2021, 9, 20, 18),
+      apply_2_deadline: Time.zone.local(2021, 9, 21, 18),
       find_closes: Time.zone.local(2021, 10, 3),
     },
     2022 => {

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -6,7 +6,7 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.courses') %></h2>
   <% if !@application_form.submitted? && !CycleTimetable.can_add_course_choice?(@application_form) %>
     <p class="govuk-body">
-      You’ll be able to find courses in <%= days_until_find_reopens %> <%= 'day'.pluralize(days_until_find_reopens) %>
+      You’ll be able to find courses in <%= CycleTimetable.days_until_find_reopens %> <%= 'day'.pluralize(CycleTimetable.days_until_find_reopens) %>
       (<%= CycleTimetable.find_reopens.to_s(:govuk_date) %>).
       You can keep making changes to the rest of your application until then.
     </p>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -16,7 +16,7 @@
       <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.courses') %></h2>
 
       <p class="govuk-body">
-        You’ll be able to find courses in <%= days_until_find_reopens %> <%= 'day'.pluralize(days_until_find_reopens) %>
+        You’ll be able to find courses in <%= CycleTimetable.days_until_find_reopens %> <%= 'day'.pluralize(CycleTimetable.days_until_find_reopens) %>
         (<%= CycleTimetable.find_reopens.to_s(:govuk_date) %>). You can keep making changes to the rest of your application until then.
       </p>
     </section>

--- a/app/views/candidate_mailer/eoc_deadline_reminder.erb
+++ b/app/views/candidate_mailer/eoc_deadline_reminder.erb
@@ -8,8 +8,8 @@ Submit your application as soon as you can to get on a course starting in the <%
 
 <%= candidate_magic_link(@application_form.candidate) %>
 
-<% apply_1_copy =  "The deadline to submit your application is 6pm on #{CycleTimetable.apply_1_deadline.to_s(:govuk_date)} but courses may fill up before then." %>
-<% apply_2_copy =  "The deadline to submit your application is 6pm on #{CycleTimetable.apply_2_deadline.to_s(:govuk_date)} but courses may fill up before then." %>
+<% apply_1_copy =  "The deadline to submit your application is #{CycleTimetable.date(:apply_1_deadline).to_s(:govuk_time)} on #{CycleTimetable.apply_1_deadline.to_s(:govuk_date)} but courses may fill up before then." %>
+<% apply_2_copy =  "The deadline to submit your application is #{CycleTimetable.date(:apply_2_deadline).to_s(:govuk_time)} on #{CycleTimetable.apply_2_deadline.to_s(:govuk_date)} but courses may fill up before then." %>
 
 <%= apply_1_copy if @application_form.phase == 'apply_1' %>
 <%= apply_2_copy if @application_form.phase == 'apply_2' %>

--- a/spec/components/candidate_interface/carry_over_inset_text_component_spec.rb
+++ b/spec/components/candidate_interface/carry_over_inset_text_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CandidateInterface::CarryOverInsetTextComponent do
 
   context 'application is unsuccessful and apply 2 deadline has passed' do
     it 'renders the component' do
-      Timecop.freeze(CycleTimetable.apply_2_deadline) do
+      Timecop.freeze(CycleTimetable.apply_2_deadline + 1.hour) do
         application_choice = build(:application_choice, :with_rejection)
         application_form = build(:completed_application_form, application_choices: [application_choice])
         result = render_inline(described_class.new(application_form: application_form))

--- a/spec/components/candidate_interface/deadline_banner_component_spec.rb
+++ b/spec/components/candidate_interface/deadline_banner_component_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
 
       result = render_inline(described_class.new(application_form: application_form, flash_empty: flash.empty?))
 
-      expect(result.text).to include("The deadline for applying to courses starting in the #{application_form.recruitment_cycle_year} to #{application_form.recruitment_cycle_year + 1} academic year is 6pm on #{CycleTimetable.date(:apply_1_deadline).to_s(:govuk_date)}")
+      expect(result.text).to include(
+        "The deadline for applying to courses starting in the #{academic_year} academic year is #{deadline_time(:apply_1_deadline)} on #{deadline_date(:apply_1_deadline)}",
+      )
     end
 
     it 'renders the Apply 2 banner when the right conditions are met' do
@@ -42,7 +44,21 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
 
       result = render_inline(described_class.new(application_form: application_form, flash_empty: flash.empty?))
 
-      expect(result.text).to include("The deadline for applying to courses starting in the #{application_form.recruitment_cycle_year} to #{application_form.recruitment_cycle_year + 1} academic year is 6pm on #{CycleTimetable.date(:apply_2_deadline).to_s(:govuk_date)}")
+      expect(result.text).to include(
+        "The deadline for applying to courses starting in the #{academic_year} academic year is #{deadline_time(:apply_2_deadline)} on #{deadline_date(:apply_2_deadline)}",
+      )
     end
+  end
+
+  def academic_year
+    "#{application_form.recruitment_cycle_year} to #{application_form.recruitment_cycle_year + 1}"
+  end
+
+  def deadline_time(deadline)
+    CycleTimetable.date(deadline).to_s(:govuk_time)
+  end
+
+  def deadline_date(deadline)
+    CycleTimetable.date(deadline).to_s(:govuk_date)
   end
 end

--- a/spec/components/candidate_interface/offer_review_component_spec.rb
+++ b/spec/components/candidate_interface/offer_review_component_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
            course_option: course_option,
            application_form: application_form)
   end
-  let(:find_closes) { CycleTimetable.find_closes(RecruitmentCycle.previous_year) }
 
   it 'renders component with correct values for the provider' do
     result = render_inline(described_class.new(course_choice: application_choice))
@@ -24,7 +23,7 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
 
   context 'when Find is open' do
     it 'renders component with correct values for the course' do
-      Timecop.freeze(find_closes) do
+      Timecop.freeze(CycleTimetable.find_opens + 1.hour) do
         result = render_inline(described_class.new(course_choice: application_choice))
 
         expect(result.css('.govuk-summary-list__key').text).to include('Course')
@@ -38,7 +37,7 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
 
   context 'when Find is closed' do
     it 'renders component with correct values for the course' do
-      Timecop.freeze(find_closes + 1.day) do
+      Timecop.freeze(CycleTimetable.find_closes) do
         result = render_inline(described_class.new(course_choice: application_choice))
 
         expect(result.css('.govuk-summary-list__key').text).to include('Course')

--- a/spec/components/candidate_interface/reopen_banner_component_spec.rb
+++ b/spec/components/candidate_interface/reopen_banner_component_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
       allow(CycleTimetable).to receive(:current_year).and_return(2021)
       allow(CycleTimetable).to receive(:cycle_year_range).with(2021).and_return('2021 to 2022')
       allow(CycleTimetable).to receive(:cycle_year_range).with(2022).and_return('2022 to 2023')
-      allow(CycleTimetable).to receive(:apply_opens).and_return(Date.new(2020, 10, 13))
-      allow(CycleTimetable).to receive(:apply_reopens).and_return(Date.new(2021, 10, 12))
+      allow(CycleTimetable).to receive(:apply_opens).and_return(Time.zone.local(2020, 10, 13, 9))
+      allow(CycleTimetable).to receive(:apply_reopens).and_return(Time.zone.local(2021, 10, 12, 9))
     end
 
     context 'before find reopens' do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -653,7 +653,7 @@ RSpec.describe ApplicationForm do
 
     context 'phase 2 application ended without success and apply 2 deadline has passed' do
       it 'returns true' do
-        Timecop.travel(CycleTimetable.apply_2_deadline) do
+        Timecop.travel(CycleTimetable.apply_2_deadline + 1.hour) do
           application_choice = build(:application_choice, :with_rejection)
           application_form = build(:application_form, phase: 'apply_2', application_choices: [application_choice])
 
@@ -664,7 +664,7 @@ RSpec.describe ApplicationForm do
 
     context 'phase 2 application ended without success and apply 2 deadline has not passed' do
       it 'returns false' do
-        Timecop.travel(CycleTimetable.apply_1_deadline) do
+        Timecop.travel(CycleTimetable.apply_1_deadline + 1.hour) do
           application_choice = build(:application_choice, :with_rejection)
           application_form = build(:application_form, phase: 'apply_2', application_choices: [application_choice])
 

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -1,35 +1,39 @@
 require 'rails_helper'
 
 RSpec.describe CycleTimetable do
-  let(:one_hour_before_apply1_deadline) { Time.zone.local(2020, 8, 24, 23, 0, 0) }
-  let(:one_hour_after_apply1_deadline) { Time.zone.local(2020, 8, 25, 1, 0, 0) }
-  let(:one_hour_before_apply2_deadline) { Time.zone.local(2020, 9, 18, 23, 0, 0) }
-  let(:one_hour_after_apply2_deadline) { Time.zone.local(2020, 9, 19, 1, 0, 0) }
-  let(:one_hour_after_2021_cycle_opens) { Time.zone.local(2020, 10, 13, 1, 0, 0) }
+  let(:one_hour_before_apply1_deadline) { CycleTimetable.apply_1_deadline(2020) - 1.hour }
+  let(:one_hour_after_apply1_deadline) { CycleTimetable.apply_1_deadline(2020) + 1.hour  }
+  let(:one_hour_before_apply2_deadline) { CycleTimetable.apply_2_deadline(2020) - 1.hour }
+  let(:one_hour_after_apply2_deadline) { CycleTimetable.apply_2_deadline(2020) + 1.hour  }
+  let(:one_hour_after_2020_cycle_opens) { CycleTimetable.apply_opens(2020) + 1.hour }
+  let(:one_hour_after_2021_cycle_opens) { CycleTimetable.apply_opens(2021) + 1.hour }
+  let(:one_hour_before_find_closes) { CycleTimetable.find_closes(2020) - 1.hour }
+  let(:one_hour_after_find_closes) { CycleTimetable.find_closes(2020) + 1.hour }
+  let(:one_hour_after_find_opens) { CycleTimetable.find_opens(2020) + 1.hour }
 
   describe '.current_year' do
     it 'is 2020 if we are in the middle of the 2020 cycle' do
-      Timecop.travel(CycleTimetable.apply_opens(2020) + 1.day) do
+      Timecop.travel(one_hour_after_2020_cycle_opens) do
         expect(CycleTimetable.current_year).to eq(2020)
       end
     end
 
     it 'is 2021 if we are in the middle of the 2021 cycle' do
-      Timecop.travel(CycleTimetable.apply_opens(2021) + 1.day) do
+      Timecop.travel(one_hour_after_2021_cycle_opens) do
         expect(CycleTimetable.current_year).to eq(2021)
       end
     end
   end
 
   describe '.next_year' do
-    it 'is 2020 if we are in the middle of the 2020 cycle' do
-      Timecop.travel(CycleTimetable.apply_opens(2020) + 1.day) do
+    it 'is 2021 if we are in the middle of the 2020 cycle' do
+      Timecop.travel(one_hour_after_2020_cycle_opens) do
         expect(CycleTimetable.next_year).to eq(2021)
       end
     end
 
-    it 'is 2021 if we are in the middle of the 2021 cycle' do
-      Timecop.travel(CycleTimetable.apply_opens(2021) + 1.day) do
+    it 'is 2022 if we are in the middle of the 2021 cycle' do
+      Timecop.travel(one_hour_after_2021_cycle_opens) do
         expect(CycleTimetable.next_year).to eq(2022)
       end
     end
@@ -139,19 +143,19 @@ RSpec.describe CycleTimetable do
 
   describe '.find_down?' do
     it 'returns false before find closes' do
-      Timecop.travel(CycleTimetable.find_closes(2020).beginning_of_day - 1.hour) do
+      Timecop.travel(one_hour_before_find_closes) do
         expect(CycleTimetable.find_down?).to be false
       end
     end
 
     it 'returns false after find_reopens' do
-      Timecop.travel(CycleTimetable.find_opens(2020).end_of_day + 1.hour) do
+      Timecop.travel(one_hour_after_find_opens) do
         expect(CycleTimetable.find_down?).to be false
       end
     end
 
     it 'returns true between find_closes and find_reopens' do
-      Timecop.travel(CycleTimetable.find_closes(2020).end_of_day + 1.hour) do
+      Timecop.travel(one_hour_after_find_closes) do
         expect(CycleTimetable.find_down?).to be true
       end
     end
@@ -183,7 +187,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is after the apply1 submission deadline' do
         it 'returns false' do
-          Timecop.travel(CycleTimetable.apply_1_deadline(2020) + 1.day) do
+          Timecop.travel(one_hour_after_apply1_deadline) do
             expect(execute_service).to eq false
           end
         end
@@ -191,7 +195,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is before the apply1 submission deadline' do
         it 'returns true' do
-          Timecop.travel(CycleTimetable.apply_1_deadline(2020) - 1.day) do
+          Timecop.travel(one_hour_before_apply1_deadline) do
             expect(execute_service).to eq true
           end
         end
@@ -203,7 +207,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is after the apply again submission deadline' do
         it 'returns false' do
-          Timecop.travel(CycleTimetable.apply_2_deadline(2020) + 1.day) do
+          Timecop.travel(one_hour_after_apply2_deadline) do
             expect(execute_service).to eq false
           end
         end
@@ -211,7 +215,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is before the apply again submission deadline' do
         it 'returns true' do
-          Timecop.travel(CycleTimetable.apply_2_deadline(2020) - 1.day) do
+          Timecop.travel(one_hour_before_apply2_deadline) do
             expect(execute_service).to eq true
           end
         end

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe CycleTimetable do
   let(:one_hour_before_find_closes) { CycleTimetable.find_closes(2020) - 1.hour }
   let(:one_hour_after_find_closes) { CycleTimetable.find_closes(2020) + 1.hour }
   let(:one_hour_after_find_opens) { CycleTimetable.find_opens(2020) + 1.hour }
+  let(:three_days_before_find_reopens) { CycleTimetable.find_reopens(2020) - 3.days }
 
   describe '.current_year' do
     it 'is 2020 if we are in the middle of the 2020 cycle' do
@@ -157,6 +158,14 @@ RSpec.describe CycleTimetable do
     it 'returns true between find_closes and find_reopens' do
       Timecop.travel(one_hour_after_find_closes) do
         expect(CycleTimetable.find_down?).to be true
+      end
+    end
+  end
+
+  describe '.days_until_find_reopens' do
+    it 'returns the number of days until Find reopens' do
+      Timecop.travel(three_days_before_find_reopens) do
+        expect(CycleTimetable.days_until_find_reopens).to eq(3)
       end
     end
   end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_and_needs_to_select_course_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_and_needs_to_select_course_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature 'Carry over' do
   end
 
   def then_i_can_see_that_i_need_to_select_courses_when_apply_reopens
-    expect(page).to have_content "You’ll be able to find courses in #{(CycleTimetable.find_reopens - Time.zone.today).to_i} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You’ll be able to find courses in #{(CycleTimetable.find_reopens.to_date - Time.zone.today).to_i} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
     expect(page).not_to have_link 'Choose your courses'
   end
 end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_and_needs_to_select_course_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_and_needs_to_select_course_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature 'Carry over' do
   end
 
   def then_i_can_see_that_i_need_to_select_courses_when_apply_reopens
-    expect(page).to have_content "You’ll be able to find courses in #{(CycleTimetable.find_reopens.to_date - Time.zone.today).to_i} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You’ll be able to find courses in #{CycleTimetable.days_until_find_reopens} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
     expect(page).not_to have_link 'Choose your courses'
   end
 end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_can_see_that_no_courses_are_selected_and_i_cannot_add_any_yet
-    expect(page).to have_content "You’ll be able to find courses in #{(CycleTimetable.find_reopens.to_date - Time.zone.today).to_i} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You’ll be able to find courses in #{CycleTimetable.days_until_find_reopens} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
     expect(page).not_to have_link 'Course choice'
   end
 

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_can_see_that_no_courses_are_selected_and_i_cannot_add_any_yet
-    expect(page).to have_content "You’ll be able to find courses in #{(CycleTimetable.find_reopens - Time.zone.today).to_i} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You’ll be able to find courses in #{(CycleTimetable.find_reopens.to_date - Time.zone.today).to_i} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
     expect(page).not_to have_link 'Course choice'
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Candidate vists their application form after the cycle has ended
   end
 
   def then_i_see_that_i_can_add_new_course_choices_in_october
-    expect(page).to have_content "You’ll be able to find courses in #{(CycleTimetable.find_reopens.to_date - Time.zone.today).to_i} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You’ll be able to find courses in #{CycleTimetable.days_until_find_reopens} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
   end
 
   def and_there_is_not_a_link_to_the_course_choices_section

--- a/spec/system/candidate_interface/course_selection/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Candidate vists their application form after the cycle has ended
   end
 
   def then_i_see_that_i_can_add_new_course_choices_in_october
-    expect(page).to have_content "You’ll be able to find courses in #{(CycleTimetable.find_reopens - Time.zone.today).to_i} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You’ll be able to find courses in #{(CycleTimetable.find_reopens.to_date - Time.zone.today).to_i} days (#{CycleTimetable.find_reopens.to_s(:govuk_date)}). You can keep making changes to the rest of your application until then."
   end
 
   def and_there_is_not_a_link_to_the_course_choices_section


### PR DESCRIPTION
## Context

Currently we hardcode times associated with cycle dates throughout the codebase, or we call `beginning_of_day` or `end_of_day` on a cycle date

## Changes proposed in this pull request

- Update cycle dates to include times where required and fix broken specs
- Don't hardcode times associated with cycle dates
- Move calculation for 'days until Find reopens' to the `CycleTimetable` class
- Change 2021 `apply_2` deadline to 21 September

## Guidance to review

Make sense?

## Link to Trello card

https://trello.com/c/xK28lY7G/3707-use-actual-deadlines-to-the-hour-in-the-cycle-timetable-helper

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
