### PR TITLE
Validate that an award year is in the future for an incomplete degree

### DIFF
--- a/app/forms/candidate_interface/degree_year_form.rb
+++ b/app/forms/candidate_interface/degree_year_form.rb
@@ -33,11 +33,7 @@ module CandidateInterface
     end
 
     def award_year_is_before_the_end_of_next_year
-      upper_year_limit = if degree.predicted_grade? && start_year.present?
-                           start_year.to_i + 4
-                         else
-                           Time.zone.now.year.to_i + 2
-                         end
+      upper_year_limit = RecruitmentCycle.current_year + 10
 
       errors.add(:award_year, :greater_than_limit, date: upper_year_limit) if award_year.to_i >= upper_year_limit
     end

--- a/app/forms/candidate_interface/degree_year_form.rb
+++ b/app/forms/candidate_interface/degree_year_form.rb
@@ -8,6 +8,7 @@ module CandidateInterface
     validates :award_year, year: true, presence: true
     validate :start_year_is_before_the_award_year, unless: ->(c) { c.errors.attribute_names.include?(:start_year) }
     validate :award_year_is_before_the_end_of_next_year, unless: ->(c) { c.errors.attribute_names.include?(:award_year) }
+    validate :award_year_is_in_the_future_for_incomplete_degree, unless: ->(c) { c.errors.attribute_names.include?(:award_year) }
 
     def save
       return false unless valid?
@@ -27,8 +28,16 @@ module CandidateInterface
       errors.add(:start_year, :greater_than_award_year, date: award_year) if award_year.present? && award_year.to_i < start_year.to_i
     end
 
+    def award_year_is_in_the_future_for_incomplete_degree
+      errors.add(:award_year, :in_the_future) if start_year.present? && degree.predicted_grade? && award_year.to_i < RecruitmentCycle.current_year
+    end
+
     def award_year_is_before_the_end_of_next_year
-      upper_year_limit = Time.zone.now.year.to_i + 2
+      upper_year_limit = if degree.predicted_grade? && start_year.present?
+                           start_year.to_i + 4
+                         else
+                           Time.zone.now.year.to_i + 2
+                         end
 
       errors.add(:award_year, :greater_than_limit, date: upper_year_limit) if award_year.to_i >= upper_year_limit
     end

--- a/app/forms/candidate_interface/degree_year_form.rb
+++ b/app/forms/candidate_interface/degree_year_form.rb
@@ -9,6 +9,7 @@ module CandidateInterface
     validate :start_year_is_before_the_award_year, unless: ->(c) { c.errors.attribute_names.include?(:start_year) }
     validate :award_year_is_before_the_end_of_next_year, unless: ->(c) { c.errors.attribute_names.include?(:award_year) }
     validate :award_year_is_in_the_future_for_incomplete_degree, unless: ->(c) { c.errors.attribute_names.include?(:award_year) }
+    validate :award_year_is_before_training_starts, unless: ->(c) { c.errors.attribute_names.include?(:award_year) }
 
     def save
       return false unless valid?
@@ -36,6 +37,10 @@ module CandidateInterface
       upper_year_limit = RecruitmentCycle.current_year + 10
 
       errors.add(:award_year, :greater_than_limit, date: upper_year_limit) if award_year.to_i >= upper_year_limit
+    end
+
+    def award_year_is_before_training_starts
+      errors.add(:award_year, :in_time_for_training) if degree.predicted_grade? && award_year.to_i > RecruitmentCycle.current_year
     end
   end
 end

--- a/app/views/candidate_interface/degrees/year/edit.html.erb
+++ b/app/views/candidate_interface/degrees/year/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.when_did_you_study_for_your_degree'), @degree_year_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_degrees_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -145,3 +145,4 @@ en:
               invalid_year: Enter a real graduation year
               greater_than_limit: Enter a year before %{date}
               in_the_future: Enter a year that is in the future
+              in_time_for_training: The date you graduate must be before the start of your teacher training

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -144,3 +144,4 @@ en:
               blank: Enter your graduation year
               invalid_year: Enter a real graduation year
               greater_than_limit: Enter a year before %{date}
+              in_the_future: Enter a year that is in the future

--- a/spec/forms/candidate_interface/degree_year_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_year_form_spec.rb
@@ -10,23 +10,21 @@ RSpec.describe CandidateInterface::DegreeYearForm, type: :model do
       include_examples 'year validations', :award_year
     end
 
-    it 'is invalid if the award year is more than one year into the future' do
-      Timecop.freeze(Time.zone.local(2008, 1, 1)) do
-        degree = build(
-          :degree_qualification,
-          qualification_type: 'BSc',
-          predicted_grade: false,
-          start_year: '2008',
-        )
+    it 'is invalid if the award year is more than ten years into the future' do
+      degree = build(
+        :degree_qualification,
+        qualification_type: 'BSc',
+        predicted_grade: false,
+        start_year: RecruitmentCycle.current_year,
+      )
 
-        degree_form = described_class.new(degree: degree, award_year: '2010')
+      degree_form = described_class.new(degree: degree, award_year: RecruitmentCycle.current_year + 11)
 
-        degree_form.validate(:award_year)
+      degree_form.validate(:award_year)
 
-        expect(degree_form.errors.full_messages_for(:award_year)).to eq(
-          ['Award year Enter a year before 2010'],
-        )
-      end
+      expect(degree_form.errors.full_messages_for(:award_year)).to eq(
+        ["Award year Enter a year before #{RecruitmentCycle.current_year + 10}"],
+      )
     end
 
     it 'is invalid if the degree is incomplete and the award year is in the past' do

--- a/spec/forms/candidate_interface/degree_year_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_year_form_spec.rb
@@ -44,6 +44,22 @@ RSpec.describe CandidateInterface::DegreeYearForm, type: :model do
         )
       end
     end
+
+    it 'is invalid if the degree is incomplete and the award year is 2 or more years into the future' do
+      degree = build(
+        :degree_qualification,
+        qualification_type: 'BSc',
+        predicted_grade: true,
+      )
+
+      degree_form = described_class.new(degree: degree, start_year: RecruitmentCycle.current_year, award_year: RecruitmentCycle.next_year)
+
+      degree_form.validate(:award_year)
+
+      expect(degree_form.errors.full_messages_for(:award_year)).to eq(
+        ['Award year The date you graduate must be before the start of your teacher training'],
+      )
+    end
   end
 
   describe 'start year' do

--- a/spec/forms/candidate_interface/degree_year_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_year_form_spec.rb
@@ -12,7 +12,14 @@ RSpec.describe CandidateInterface::DegreeYearForm, type: :model do
 
     it 'is invalid if the award year is more than one year into the future' do
       Timecop.freeze(Time.zone.local(2008, 1, 1)) do
-        degree_form = described_class.new(award_year: '2010')
+        degree = build(
+          :degree_qualification,
+          qualification_type: 'BSc',
+          predicted_grade: false,
+          start_year: '2008',
+        )
+
+        degree_form = described_class.new(degree: degree, award_year: '2010')
 
         degree_form.validate(:award_year)
 
@@ -21,11 +28,35 @@ RSpec.describe CandidateInterface::DegreeYearForm, type: :model do
         )
       end
     end
+
+    it 'is invalid if the degree is incomplete and the award year is in the past' do
+      Timecop.freeze(Time.zone.local(2012, 1, 1)) do
+        degree = build(
+          :degree_qualification,
+          qualification_type: 'BSc',
+          predicted_grade: true,
+        )
+
+        degree_form = described_class.new(degree: degree, start_year: '2008', award_year: '2009')
+
+        degree_form.validate(:award_year)
+
+        expect(degree_form.errors.full_messages_for(:award_year)).to eq(
+          ['Award year Enter a year that is in the future'],
+        )
+      end
+    end
   end
 
   describe 'start year' do
     it 'is invalid if greater than the award year' do
-      degree_form = described_class.new(start_year: '2009', award_year: '2008')
+      degree = build(
+        :degree_qualification,
+        qualification_type: 'BSc',
+        predicted_grade: false,
+      )
+
+      degree_form = described_class.new(degree: degree, start_year: '2009', award_year: '2008')
       error_message = t('activemodel.errors.models.candidate_interface/degree_year_form.attributes.start_year.greater_than_award_year')
 
       degree_form.validate(:start_year)

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
@@ -54,6 +54,7 @@ RSpec.feature 'Editing a degree' do
            qualification_type: 'BSc',
            start_year: '2006',
            award_year: '2009',
+           predicted_grade: false,
            subject: 'Computer Science',
            institution_name: 'MIT',
            application_form: @application_form)

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degree_with_predicted_grade_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degree_with_predicted_grade_spec.rb
@@ -35,8 +35,13 @@ RSpec.feature 'Entering their degrees' do
     choose 'Third-class honours'
     click_on_save_and_continue
 
-    fill_in 'Year started course', with: 2017
-    fill_in 'Graduation year', with: 2020
+    fill_in 'Year started course', with: RecruitmentCycle.previous_year - 3
+    fill_in 'Graduation year', with: RecruitmentCycle.previous_year
+    click_on_save_and_continue
+    expect(page).to have_content('Enter a year that is in the future')
+
+    fill_in 'Year started course', with: RecruitmentCycle.current_year - 3
+    fill_in 'Graduation year', with: RecruitmentCycle.current_year
     click_on_save_and_continue
   end
 


### PR DESCRIPTION
## Context

If a candidate has not completed their degree, the graduation date must be in the future. 

At the moment a candidate can say they they haven't completed their degree and then add a graduation date in the past.

This PR adds a validation to check for this condition.

## Changes proposed in this pull request

With an incomplete degree:

![image](https://user-images.githubusercontent.com/47917431/126791275-35b4a201-988f-4a2a-b0a1-fc46c57827d0.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
