### PR TITLE
Use travel instead of freeze for failing AA tests

### DIFF
--- a/spec/system/candidate_interface/apply_again/candidate_applies_again_and_reviews_rejection_reasons_from_previous_applications_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_applies_again_and_reviews_rejection_reasons_from_previous_applications_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Apply again' do
   include CycleTimetableHelper
 
   around do |example|
-    Timecop.freeze(mid_cycle) do
+    Timecop.travel(mid_cycle) do
       example.run
     end
   end

--- a/spec/system/candidate_interface/apply_again/candidate_applies_again_during_mid_cycle_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_applies_again_during_mid_cycle_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Apply again' do
   include CycleTimetableHelper
 
   around do |example|
-    Timecop.freeze(mid_cycle) do
+    Timecop.travel(mid_cycle) do
       example.run
     end
   end
@@ -64,10 +64,6 @@ RSpec.feature 'Apply again' do
 
   def and_i_click_on_apply_again
     click_on 'Apply again'
-  end
-
-  def and_i_click_go_to_my_application_form
-    click_link 'Go to your application form'
   end
 
   def then_i_am_redirected_to_the_new_application_form


### PR DESCRIPTION
## Context

A couple of the Apply Again tests are failing as they're using `Timecop.freeze` instead of `Timecop.travel`

This is causing issues with the `current_application` method as they have the same created_at

## Changes proposed in this pull request

- Use travel instead of freeze for the apply again system specs 

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
