### PR TITLE
Wait for smoke tests to conclude before finishing the deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,7 +117,18 @@ jobs:
           repo: DFE-Digital/apply-for-teacher-training-tests
           ref: refs/heads/main
           token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
-          inputs: '{"environment": "${{ matrix.environment }}"}'
+          inputs: '{"environment": "${{ matrix.environment }}", "sha": "${{ github.event.inputs.sha }}"}'
+
+      - name: Wait for smoke test
+        id: wait_for_smoke_test
+        uses: vigneshmsft/wait-for-status-check-action@v0.1.0
+        with:
+          sha: ${{ github.event.inputs.sha }}
+          status-checks: smoke-test-${{ matrix.environment }}
+
+      - name: Exit if smoke test failed
+        if: steps.wait_for_smoke_test.outputs.conclusion != 'success'
+        run: exit 1
 
       - name: Start Clockwork container
         if: always()


### PR DESCRIPTION
## Context

Smoke Tests are async ie. run in a different repo and post failures to slack.

## Changes proposed in this pull request

Wait for smoke-tests to complete in the triggering deployment pipeline and fail the deployment if smoke tests fail.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
