### PR TITLE
Ensure application forms are created in the correct cycle on first sign in

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -28,8 +28,11 @@ class Candidate < ApplicationRecord
 
   def current_application
     application_form = application_forms.order(:created_at).last
-    application_form ||= application_forms.create!
-    application_form
+    application_form || if Time.zone.now > CycleTimetable.apply_1_deadline
+                          application_forms.create!(recruitment_cycle_year: CycleTimetable.next_year)
+                        else
+                          application_forms.create!
+                        end
   end
 
   def last_updated_application


### PR DESCRIPTION
## Context

Currently, if someone signs in for the first time after the apply_1 deadline, the current_application method creates a new application form for them in the 2021 cycle. They then hit the carry over interstitial which creates a new application form in the 2022 cycle. 

Instead, if it is after the apply1 deadline, we should just create an application form for the candidate in the next cycle.

## Changes proposed in this pull request

- Update the current_application method to create an application form in the next cycle if the first sign in is after the apply1 deadline


## Guidance to review

Does this seem reasonable? Am i missing anything?

## Link to Trello card

https://trello.com/c/fVQJHy7F/3705-ensure-new-candidates-application-forms-are-created-apply1-and-created

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
