### PR TITLE
Fix grid layout bugs in Manage

### DIFF
--- a/app/views/provider_interface/interview_schedules/past.html.erb
+++ b/app/views/provider_interface/interview_schedules/past.html.erb
@@ -1,7 +1,7 @@
 <% content_for :browser_title, "Interview schedule - #{t('provider_interface.interviews.past')}" %>
 
 <div class="govuk-grid-row govuk-body">
-  <div class="govuk-grid-column-two-third">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Interview schedule</h1>
 
     <%= render TabNavigationComponent.new(items: [

--- a/app/views/provider_interface/interview_schedules/show.html.erb
+++ b/app/views/provider_interface/interview_schedules/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :browser_title, "Interview schedule - #{t('provider_interface.interviews.upcoming')}" %>
 
 <div class="govuk-grid-row govuk-body">
-  <div class="govuk-grid-column-two-third">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Interview schedule</h1>
 
     <%= render TabNavigationComponent.new(items: [

--- a/app/views/provider_interface/organisation_permissions/organisations.html.erb
+++ b/app/views/provider_interface/organisation_permissions/organisations.html.erb
@@ -7,8 +7,8 @@
   }) %>
 <% end %>
 
-<div class="govuk-grid">
-  <div class="govuk-grid-column-two-third">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('page_titles.provider.organisation_permissions') %></h1>
     <% @manageable_providers.each do |provider| %>
       <div class="app-application-card">

--- a/app/views/provider_interface/organisations/index.html.erb
+++ b/app/views/provider_interface/organisations/index.html.erb
@@ -7,8 +7,8 @@
   }) %>
 <% end %>
 
-<div class="govuk-grid">
-  <div class="govuk-grid-column-two-third">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('page_titles.provider.org_permissions') %></h1>
     <p class="govuk-body">Use this section to change permissions between your own organisations and your partner organisations.</p>
     <% @manageable_providers.each do |provider| %>


### PR DESCRIPTION
## Context

There are a few places in the Manage interface where the incorrect grid classes have been used, which mean the layout renders incorrectly.

## Changes proposed in this pull request

* Use `govuk-grid-row` not `govuk-grid`
* Use `govuk-grid-column-two-thirds` not `govuk-grid-column-two-third`

## Guidance to review

| Before | After |
| - | - |
| <img width="480" alt="Screenshot 2021-07-26 at 10 40 01" src="https://user-images.githubusercontent.com/813383/126968793-fafe7c4c-2e4e-41f7-a24d-b25297664d0b.png"> | <img width="480" alt="Screenshot 2021-07-26 at 10 42 43" src="https://user-images.githubusercontent.com/813383/126968799-7978f87b-4e1d-4a81-a049-df33dff13305.png"> |

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
