### PR TITLE
Update blank error message on the sign up page

### DIFF
--- a/config/locales/candidate_interface/create_account_or_sign_in.yml
+++ b/config/locales/candidate_interface/create_account_or_sign_in.yml
@@ -1,0 +1,8 @@
+en:
+  activemodel:
+    errors:
+      models:
+        candidate_interface/create_account_or_sign_in_form:
+          attributes:
+            existing_account:
+              blank: Select if you already have an account

--- a/spec/forms/candidate_interface/create_account_or_sign_in_form_spec.rb
+++ b/spec/forms/candidate_interface/create_account_or_sign_in_form_spec.rb
@@ -1,6 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::CreateAccountOrSignInForm, type: :model do
+  describe '#validations' do
+    it 'validates presence of existing account' do
+      form = described_class.new
+      expect(form).not_to be_valid
+      expect(form.errors.full_messages).to include 'Existing account Select if you already have an account'
+    end
+
+    it 'validates presence and format of email if they already have an account' do
+      form = described_class.new
+      allow(form).to receive(:existing_account).and_return true
+      expect(form).not_to be_valid
+      expect(form.errors.full_messages).to include 'Email Enter your email address'
+      expect(form.errors.full_messages).to include 'Email Enter an email address in the correct format, like name@example.com'
+    end
+  end
+
   describe '#existing_account?' do
     it "returns false if existing_account is 'false'" do
       form = described_class.new(existing_account: 'false')


### PR DESCRIPTION
## Context

At the moment we don't have a customised error message on the sign up form. We should.

## Changes proposed in this pull request

- Add a custom error message and some tests

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/126987978-c037da77-5dc3-49aa-a127-e3680c30788e.png)
|![image](https://user-images.githubusercontent.com/42515961/126987894-84847ea1-ad1e-4964-8e5e-44f78f105bd6.png)|

## Guidance to review

Needs a content review please!

## Link to Trello card

https://trello.com/c/4KHfu0yX/3719-bug-missing-validation-string-for-do-you-already-have-an-account

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
