### PR TITLE
Update `conditions_met` mailer to use `current_course` instead of `coures`

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -254,7 +254,7 @@ class CandidateMailer < ApplicationMailer
 
   def conditions_met(application_choice)
     @application_choice = application_choice
-    course = application_choice.course_option.course
+    course = application_choice.current_course_option.course
     course_name = "#{course.name_and_code} at #{course.provider.name}"
 
     email_for_candidate(

--- a/app/views/candidate_mailer/conditions_met.text.erb
+++ b/app/views/candidate_mailer/conditions_met.text.erb
@@ -2,8 +2,8 @@ Dear <%= @application_form.first_name %>,
 
 # You’ve met your conditions
 
-Congratulations, <%= @application_choice.course_option.course.provider.name %> has confirmed that you’ve met your conditions for <%= @application_choice.course_option.course.name_and_code %>.
+Congratulations, <%= @application_choice.current_course_option.course.provider.name %> has confirmed that you’ve met your conditions for <%= @application_choice.current_course_option.course.name_and_code %>.
 
 # Next steps
 
-If they have not already, <%= @application_choice.course_option.course.provider.name %> should be in contact about enrolling on the course. You can contact them directly if you have any questions about this process.
+If they have not already, <%= @application_choice.current_course_option.course.provider.name %> should be in contact about enrolling on the course. You can contact them directly if you have any questions about this process.

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -315,6 +315,21 @@ RSpec.describe CandidateMailer, type: :mailer do
     end
   end
 
+  describe '.conditions_met' do
+    let(:email) { mailer.conditions_met(application_choices.first) }
+    let(:application_choice) { build_stubbed(:submitted_application_choice, :with_changed_offer, course_option: course_option, current_course_option: other_option, decline_by_default_at: 10.business_days.from_now) }
+    let(:application_choices) { [application_choice] }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'You have met your conditions for Forensic Science (E0FO) at Falconholt Technical College: next steps',
+      'heading' => 'Dear Bob',
+      'title' => 'You’ve met your conditions',
+      'name and code for course' => 'Forensic Science (E0FO)',
+      'provider name' => 'Falconholt Technical College',
+    )
+  end
+
   describe '.changed_offer' do
     let(:email) { mailer.changed_offer(application_choices.first) }
     let(:application_choice) { build_stubbed(:submitted_application_choice, :with_changed_offer, course_option: course_option, current_course_option: other_option, decline_by_default_at: 10.business_days.from_now) }


### PR DESCRIPTION
## Context

The email a candidate gets when a changed offer has been made and conditions are met refers to the original (applied-to) courses details and not the changed to course details

## Changes proposed in this pull request
Use `current_course_option` instead of `course_option` and add spec to verify behavior

## Link to Trello card

https://trello.com/c/ev2lCA8u/3987-wrong-details-in-email-when-conditions-met

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
