### PR TITLE
Saving and succeeding when setting up organisation permissions Part 2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,3 +59,8 @@ Govuk/GovukLinkTo:
     # link_to for kaminari pagination links
     - 'app/views/kaminari/_next_page.html.erb'
     - 'app/views/kaminari/_prev_page.html.erb'
+
+Style/IdenticalConditionalBranches:
+  Exclude:
+    # wizard.clear_state! duplication in commit method conditional
+    - 'app/controllers/provider_interface/organisation_permissions_setup_controller.rb'

--- a/app/components/provider_interface/dsa_success_page_component.html.erb
+++ b/app/components/provider_interface/dsa_success_page_component.html.erb
@@ -1,11 +1,11 @@
 <% if FeatureFlag.active?(:accredited_provider_setting_permissions) %>
   <%= govuk_panel(title: t('.success_message'), body: nil) %>
 
-  <% if provider_permission_setup_pending %>
-    <h2 class="govuk-heading-m">
-      <%= t('.next_steps') %>
-    </h2>
+  <h2 class="govuk-heading-m">
+    <%= t('.next_steps') %>
+  </h2>
 
+  <% if provider_permission_setup_pending %>
     <p class="govuk-body">
       <%= t('.setup_permissions_message') %>
     </p>
@@ -14,27 +14,7 @@
       <%= govuk_link_to t('continue'), provider_interface_organisation_permissions_setup_index_path, button: true %>
     </p>
   <% else %>
-    <h2 class="govuk-heading-m">
-      <%= t('.next_steps') %>
-    </h2>
-
-    <p class="govuk-body">
-      <%= t('.options_list_description') %>
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        <%= govuk_link_to t('.view_applications'), provider_interface_applications_path %>
-      </li>
-      <% if user_can_manage_users? %>
-        <li>
-          <%= govuk_link_to t('.invite_or_manage_users'), provider_interface_provider_users_path %>
-        </li>
-      <% end %>
-      <li>
-        <%= govuk_link_to t('.manage_email_notifications'), provider_interface_notifications_path %>
-      </li>
-    </ul>
+   <%= render ProviderInterface::SetupCompleteNextStepsComponent.new(provider_user: provider_user) %>
   <% end %>
 <% else %>
   <%= govuk_panel(title: t('.old.success_message'), body: nil) %>

--- a/app/components/provider_interface/setup_complete_next_steps_component.html.erb
+++ b/app/components/provider_interface/setup_complete_next_steps_component.html.erb
@@ -1,0 +1,17 @@
+<p class="govuk-body">
+  <%= t('.options_list_description') %>
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    <%= govuk_link_to t('.view_applications'), provider_interface_applications_path %>
+  </li>
+  <% if user_can_manage_users? %>
+    <li>
+      <%= govuk_link_to t('.invite_or_manage_users'), provider_interface_provider_users_path %>
+    </li>
+  <% end %>
+  <li>
+    <%= govuk_link_to t('.manage_email_notifications'), provider_interface_notifications_path %>
+  </li>
+</ul>

--- a/app/components/provider_interface/setup_complete_next_steps_component.rb
+++ b/app/components/provider_interface/setup_complete_next_steps_component.rb
@@ -1,0 +1,13 @@
+module ProviderInterface
+  class SetupCompleteNextStepsComponent < ViewComponent::Base
+    attr_reader :provider_user
+
+    def initialize(provider_user:)
+      @provider_user = provider_user
+    end
+
+    def user_can_manage_users?
+      provider_user.authorisation.can_manage_users_for_at_least_one_provider?
+    end
+  end
+end

--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -58,6 +58,8 @@ module ProviderInterface
       @previous_page_path = previous_page_path(wizard)
     end
 
+    def success; end
+
   private
 
     def require_access_to_manage_provider_relationship_permissions!

--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   class OrganisationPermissionsSetupController < ProviderInterfaceController
     before_action :require_manage_organisations_permission!
     before_action :redirect_unless_permissions_to_setup, except: :success
-    before_action :restart_if_wizard_store_empty, only: %i[edit update check]
+    before_action :restart_if_wizard_store_empty, only: %i[edit update check commit]
 
     def index
       permission_setup_presenter = ProviderRelationshipPermissionSetupPresenter.new(
@@ -65,8 +65,9 @@ module ProviderInterface
         wizard.clear_state!
         redirect_to success_provider_interface_organisation_permissions_setup_index_path
       else
+        wizard.clear_state!
         redirect_to(
-          check_provider_interface_organisation_permissions_setup_index_path,
+          provider_interface_organisation_permissions_setup_index_path,
           warning: 'Unable to save permissions, please try again. If problems persist please contact support',
         )
       end

--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -1,7 +1,7 @@
 module ProviderInterface
   class OrganisationPermissionsSetupController < ProviderInterfaceController
     before_action :require_manage_organisations_permission!
-    before_action :redirect_unless_permissions_to_setup
+    before_action :redirect_unless_permissions_to_setup, except: :success
     before_action :restart_if_wizard_store_empty, only: %i[edit update check]
 
     def index
@@ -54,8 +54,22 @@ module ProviderInterface
 
     def check
       wizard = OrganisationPermissionsSetupWizard.new(organisation_permissions_wizard_store, current_step: :check)
+      wizard.save_state!
       @relationships = wizard.relationships
       @previous_page_path = previous_page_path(wizard)
+    end
+
+    def commit
+      wizard = OrganisationPermissionsSetupWizard.new(organisation_permissions_wizard_store)
+      if SetupProviderRelationshipPermissions.call(wizard.relationships)
+        wizard.clear_state!
+        redirect_to success_provider_interface_organisation_permissions_setup_index_path
+      else
+        redirect_to(
+          check_provider_interface_organisation_permissions_setup_index_path,
+          warning: 'Unable to save permissions, please try again. If problems persist please contact support',
+        )
+      end
     end
 
     def success; end

--- a/app/views/provider_interface/organisation_permissions_setup/check.html.erb
+++ b/app/views/provider_interface/organisation_permissions_setup/check.html.erb
@@ -6,5 +6,6 @@
     <span class="govuk-caption-l"><%= t('.caption') %></span>
     <h1 class="govuk-heading-l"><%= t('.title') %></h1>
     <%= render ProviderInterface::OrganisationPermissionsSetupCheckComponent.new(relationships: @relationships, current_provider_user: current_provider_user) %>
+    <%= govuk_button_to t('.submit_button'), commit_provider_interface_organisation_permissions_setup_index_path %>
   </div>
 </div>

--- a/app/views/provider_interface/organisation_permissions_setup/success.html.erb
+++ b/app/views/provider_interface/organisation_permissions_setup/success.html.erb
@@ -1,0 +1,17 @@
+<% content_for :browser_title, t('.success_message') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_panel(title: t('.success_message'), body: nil) %>
+
+    <p class="govuk-body">
+      You can change organisation permissions in <%= govuk_link_to 'organisation settings', provider_interface_organisation_settings_path %>.
+    </p>
+
+    <h2 class="govuk-heading-m">
+      <%= t('.next_steps') %>
+    </h2>
+
+    <%= render ProviderInterface::SetupCompleteNextStepsComponent.new(provider_user: current_provider_user) %>
+  </div>
+</div>

--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -38,13 +38,12 @@ en:
       success_message: Data sharing agreement signed
       setup_permissions_message: Either you or your partner organisations must set up organisation permissions before you can manage teacher training applications.
       next_steps: Next steps
-      options_list_description: 'You can now:'
-      view_applications: view applications
-      invite_or_manage_users: invite or manage users
-      manage_email_notifications: manage your email notifications
       old:
         success_message: You’ve successfully signed the data sharing agreement
         setup_permissions_message: You need to set up permissions for your organisation before you do anything else. We’ll guide you through this process.
         setup_permissions_action: Set up permissions
-
-
+    setup_complete_next_steps_component:
+      options_list_description: 'You can now:'
+      view_applications: view applications
+      invite_or_manage_users: invite or manage users
+      manage_email_notifications: manage your email notifications

--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -25,9 +25,9 @@ en:
       check:
         title: Check and save organisation permissions
         caption: Set up organisation permissions
+        submit_button: Save organisation permissions
       success:
         success_message: Organisation permissions set up
-        change_settings_explanation: You can change organisation permissions in %{settings_path}
         next_steps: Next steps
     organisation_permissions_setup_list_component:
       single:

--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -25,6 +25,10 @@ en:
       check:
         title: Check and save organisation permissions
         caption: Set up organisation permissions
+      success:
+        success_message: Organisation permissions set up
+        change_settings_explanation: You can change organisation permissions in %{settings_path}
+        next_steps: Next steps
     organisation_permissions_setup_list_component:
       single:
         introduction: 'Candidates can now apply through GOV.UK for courses %{provider_name} works on with:'

--- a/spec/components/provider_interface/dsa_success_page_component_spec.rb
+++ b/spec/components/provider_interface/dsa_success_page_component_spec.rb
@@ -28,29 +28,11 @@ RSpec.describe ProviderInterface::DsaSuccessPageComponent do
   context 'when permissions have been set up' do
     let(:permissions_require_setup) { false }
 
-    it 'shows a link to the applications page' do
-      expect(render.css('a')[0].text).to eq('view applications')
-      expect(render.css('a')[0].attributes['href'].value).to eq('/provider/applications')
-    end
+    before { allow(ProviderInterface::SetupCompleteNextStepsComponent).to receive(:new).with(provider_user: provider_user).and_call_original }
 
-    context 'when the provider can manage users' do
-      let(:provider_user) { create(:provider_user, :with_provider, :with_manage_users) }
-
-      it 'shows a link to the users page' do
-        expect(render.css('a')[1].text).to eq('invite or manage users')
-        expect(render.css('a')[1].attributes['href'].value).to eq('/provider/account/users')
-      end
-    end
-
-    context 'when the provider can not manage users' do
-      it 'does not show a link to the users page' do
-        expect(render.css('a').text).not_to include('invite or manage users')
-      end
-    end
-
-    it 'shows a link to the notifications page' do
-      expect(render.css('a').last.text).to eq('manage your email notifications')
-      expect(render.css('a').last.attributes['href'].value).to eq('/provider/account/notification-settings')
+    it 'renders the next steps component' do
+      render
+      expect(ProviderInterface::SetupCompleteNextStepsComponent).to have_received(:new)
     end
   end
 

--- a/spec/components/provider_interface/setup_complete_next_steps_component_spec.rb
+++ b/spec/components/provider_interface/setup_complete_next_steps_component_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::SetupCompleteNextStepsComponent do
+  let(:provider_user) { create(:provider_user) }
+  let(:render) { render_inline(described_class.new(provider_user: provider_user)) }
+
+  it 'shows a link to the applications page' do
+    expect(render.css('a')[0].text).to eq('view applications')
+    expect(render.css('a')[0].attributes['href'].value).to eq('/provider/applications')
+  end
+
+  context 'when the provider can manage users' do
+    let(:provider_user) { create(:provider_user, :with_provider, :with_manage_users) }
+
+    it 'shows a link to the users page' do
+      expect(render.css('a')[1].text).to eq('invite or manage users')
+      expect(render.css('a')[1].attributes['href'].value).to eq('/provider/account/users')
+    end
+  end
+
+  context 'when the provider can not manage users' do
+    it 'does not show a link to the users page' do
+      expect(render.css('a').text).not_to include('invite or manage users')
+    end
+  end
+
+  it 'shows a link to the notifications page' do
+    expect(render.css('a').last.text).to eq('manage your email notifications')
+    expect(render.css('a').last.attributes['href'].value).to eq('/provider/account/notification-settings')
+  end
+end

--- a/spec/requests/provider_interface/organisation_permissions_setup_controller_spec.rb
+++ b/spec/requests/provider_interface/organisation_permissions_setup_controller_spec.rb
@@ -80,6 +80,13 @@ RSpec.describe ProviderInterface::OrganisationPermissionsSetupController do
           expect(response.status).to eq(302)
           expect(response.redirect_url).to eq(provider_interface_organisation_permissions_setup_index_url)
         end
+
+        it 'redirects commit to the index action' do
+          patch commit_provider_interface_organisation_permissions_setup_index_path
+
+          expect(response.status).to eq(302)
+          expect(response.redirect_url).to eq(provider_interface_organisation_permissions_setup_index_url)
+        end
       end
     end
 

--- a/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
@@ -32,6 +32,10 @@ RSpec.feature 'Setting up organisation permissions' do
     and_i_change_the_provider_permission
     and_i_click_on_continue
     then_i_see_the_check_relationship_permissions_page
+
+    when_i_click_on_save_organisation_permissions
+    then_i_see_the_success_page
+    and_the_permissions_have_been_set_up_correctly
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -50,25 +54,19 @@ RSpec.feature 'Setting up organisation permissions' do
   end
 
   def and_my_organisations_have_not_had_permissions_setup
-    create(
+    @training_provider_relationship = create(
       :provider_relationship_permissions,
+      :not_set_up_yet,
       ratifying_provider: @another_ratifying_provider,
       training_provider: @training_provider,
-      training_provider_can_make_decisions: false,
-      training_provider_can_view_safeguarding_information: false,
-      training_provider_can_view_diversity_information: false,
-      setup_at: nil,
     )
     create(:course, :open_on_apply, provider: @training_provider, accredited_provider: @another_ratifying_provider)
 
-    create(
+    @ratifying_provider_relationship = create(
       :provider_relationship_permissions,
+      :not_set_up_yet,
       ratifying_provider: @ratifying_provider,
       training_provider: @another_training_provider,
-      training_provider_can_make_decisions: false,
-      training_provider_can_view_safeguarding_information: false,
-      training_provider_can_view_diversity_information: false,
-      setup_at: nil,
     )
     create(:course, :open_on_apply, provider: @another_training_provider, accredited_provider: @ratifying_provider)
   end
@@ -132,5 +130,31 @@ RSpec.feature 'Setting up organisation permissions' do
     within('[data-qa="make-decisions"]') { check @another_training_provider.name }
     within('[data-qa="view-safeguarding-information"]') { check @another_training_provider.name }
     within('[data-qa="view-diversity-information"]') { check @another_training_provider.name }
+  end
+
+  def when_i_click_on_save_organisation_permissions
+    click_on 'Save organisation permissions'
+  end
+
+  def then_i_see_the_success_page
+    expect(page).to have_content('Organisation permissions set up')
+  end
+
+  def and_the_permissions_have_been_set_up_correctly
+    expect(@training_provider_relationship.reload.training_provider_can_make_decisions).to be(false)
+    expect(@training_provider_relationship.ratifying_provider_can_make_decisions).to be(true)
+    expect(@training_provider_relationship.training_provider_can_view_safeguarding_information).to be(true)
+    expect(@training_provider_relationship.ratifying_provider_can_view_safeguarding_information).to be(false)
+    expect(@training_provider_relationship.training_provider_can_view_diversity_information).to be(false)
+    expect(@training_provider_relationship.ratifying_provider_can_view_diversity_information).to be(true)
+    expect(@training_provider_relationship.setup_at).not_to be_nil
+
+    expect(@ratifying_provider_relationship.reload.training_provider_can_make_decisions).to be(true)
+    expect(@ratifying_provider_relationship.ratifying_provider_can_make_decisions).to be(true)
+    expect(@ratifying_provider_relationship.training_provider_can_view_safeguarding_information).to be(true)
+    expect(@ratifying_provider_relationship.ratifying_provider_can_view_safeguarding_information).to be(true)
+    expect(@ratifying_provider_relationship.training_provider_can_view_diversity_information).to be(true)
+    expect(@ratifying_provider_relationship.ratifying_provider_can_view_diversity_information).to be(true)
+    expect(@ratifying_provider_relationship.setup_at).not_to be_nil
   end
 end


### PR DESCRIPTION
## Context

https://trello.com/c/ugaq5iLu/3899-add-new-flow-for-permissions-setup-wizard

This is the second PR for the ticket, the first being here - https://github.com/DFE-Digital/apply-for-teacher-training/pull/5203
## Changes proposed in this pull request
This PR adds a commit method to the setup permissions controller, which saves all of the newly established relationship permissions as part of the setup flow. 

The user is then shown a success page which indicates the permissions have been set up. 

![image](https://user-images.githubusercontent.com/25597009/127018290-fc8d4e8c-d351-4123-a323-e5a403b824ce.png)

## Guidance to review

Logging in as a user who has to set up permissions, with the feature flag enabled; go through the permissions setup, and submit your relationships. 
