### PR TITLE
Backfill references_completed field on submitted applications

### DIFF
--- a/app/services/data_migrations/backfill_references_completed.rb
+++ b/app/services/data_migrations/backfill_references_completed.rb
@@ -1,0 +1,12 @@
+module DataMigrations
+  class BackfillReferencesCompleted
+    TIMESTAMP = 20210726160211
+    MANUAL_RUN = false
+
+    def change
+      ApplicationForm.where.not(submitted_at: nil).where(references_completed: nil).in_batches do |forms|
+        forms.update_all(references_completed: true)
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillReferencesCompleted',
   'DataMigrations::CleanseEocChasersSentData',
   'DataMigrations::BackfillSetupInterviewsPermission',
   'DataMigrations::FixEmptyOfferConditions',

--- a/spec/services/data_migrations/backfill_references_completed_spec.rb
+++ b/spec/services/data_migrations/backfill_references_completed_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillReferencesCompleted do
+  it 'sets references_completed to true for all submitted applications where it is nil' do
+    submitted_with_nil_field = create(:application_form, submitted_at: Time.zone.now, references_completed: nil)
+    submitted_with_field_marked = create(:application_form, submitted_at: Time.zone.now, references_completed: true)
+    not_submitted = create(:application_form, submitted_at: nil, references_completed: nil)
+
+    described_class.new.change
+
+    expect(submitted_with_nil_field.reload.references_completed).to eq true
+    expect(submitted_with_field_marked.reload.references_completed).to eq true
+    expect(not_submitted.reload.references_completed).to eq nil
+  end
+end


### PR DESCRIPTION


## Context
Clean-up work following the recent upgrade of the references
functionality. A nil value in this field doesn't affect functionality,
but making this change keeps the data consistent with the expected
behaviour of the system.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Add a data migration that looks for submitted apps with a nil `references_completed` in batches and sets the value of the field to true.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/VP9tK6GI
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
