### PR TITLE
Add provider type tag to provider list page in support

### DIFF
--- a/app/components/support_interface/provider_type_tag_component.html.erb
+++ b/app/components/support_interface/provider_type_tag_component.html.erb
@@ -1,0 +1,1 @@
+<%= govuk_tag(text: text, colour: colour) %>

--- a/app/components/support_interface/provider_type_tag_component.rb
+++ b/app/components/support_interface/provider_type_tag_component.rb
@@ -1,0 +1,25 @@
+module SupportInterface
+  class ProviderTypeTagComponent < ViewComponent::Base
+    PROVIDER_TYPES = {
+      'lead_school' => { text: 'School Direct', colour: 'green' },
+      'scitt' => { text: 'SCITT', colour: 'yellow' },
+      'university' => { text: 'HEI', colour: 'blue' },
+    }.freeze
+
+    def initialize(provider:)
+      @provider_type = provider.provider_type
+    end
+
+    def render?
+      @provider_type.present?
+    end
+
+    def text
+      PROVIDER_TYPES.dig(@provider_type, :text)
+    end
+
+    def colour
+      PROVIDER_TYPES.dig(@provider_type, :colour)
+    end
+  end
+end

--- a/app/views/support_interface/providers/index.html.erb
+++ b/app/views/support_interface/providers/index.html.erb
@@ -23,6 +23,7 @@
             <span class="govuk-!-display-block govuk-!-margin-bottom-1">
               <%= govuk_link_to provider.name_and_code, support_interface_provider_path(provider) %>
             </span>
+            <%= render SupportInterface::ProviderTypeTagComponent.new(provider: provider) %>
             <% if provider.lacks_admin_users? %>
               <span class="govuk-caption-m">No admin user</span>
             <% end %>

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -15,6 +15,7 @@
 <%= render(SummaryListComponent.new(rows: {
   'Name' => @provider.name,
   'Code' => @provider.code,
+  'Provider type' => render(SupportInterface::ProviderTypeTagComponent.new(provider: @provider)),
   'Last updated' => @provider.updated_at.to_s(:govuk_date_and_time),
   'Data sharing agreement' => dsa,
   'Average distance to sites' => format_average_distance(@provider, @provider.sites),

--- a/spec/components/support_interface/provider_type_tag_component_spec.rb
+++ b/spec/components/support_interface/provider_type_tag_component_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ProviderTypeTagComponent do
+  let(:provider) { build_stubbed(:provider, provider_type: provider_type) }
+
+  subject!(:render) { render_inline(described_class.new(provider: provider)) }
+
+  context 'when provider type is nil' do
+    let(:provider_type) { nil }
+
+    it 'does not render the component' do
+      expect(render.text).to be_empty
+    end
+  end
+
+  context 'when provider type is lead_school' do
+    let(:provider_type) { :lead_school }
+
+    it 'renders the a green tag with the correct text' do
+      expect(page).to have_css('.govuk-tag--green', text: 'School Direct')
+    end
+  end
+
+  context 'when provider type is scitt' do
+    let(:provider_type) { :scitt }
+
+    it 'renders the a yellow tag with the correct text' do
+      expect(page).to have_css('.govuk-tag--yellow', text: 'SCITT')
+    end
+  end
+
+  context 'when provider type is university' do
+    let(:provider_type) { :university }
+
+    it 'renders the a blue tag with the correct text' do
+      expect(page).to have_css('.govuk-tag--blue', text: 'HEI')
+    end
+  end
+end


### PR DESCRIPTION


## Context
Support users would like to be able to quickly determine provider type in the console.

## Changes proposed in this pull request
Add a component to render a tag for providers detailing the type (School Direct, SCITT, or HEI)

<img width="763" alt="Screenshot 2021-07-26 at 17 00 36" src="https://user-images.githubusercontent.com/30071178/127021055-8a7c6cd7-5499-42ea-a957-720b34b2ff60.png">

## Link to Trello card
https://trello.com/c/NLqOdjaI/4026-add-hinttext-for-whether-a-provider-is-scitt-schooldirect-or-hei

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
