### PR TITLE
V1.1 of the Candidate API – add an application form

### DIFF
--- a/config/candidate-api.yml
+++ b/config/candidate-api.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: v1
+  version: v1.1
   title: Apply candidate API
   contact:
     name: DfE
@@ -87,6 +87,7 @@ components:
         - email_address
         - created_at
         - updated_at
+        - application_forms
       properties:
         email_address:
          type: string
@@ -102,6 +103,59 @@ components:
          format: date-time
          description: Time of last change
          example: 2021-05-20T12:34:00Z
+        application_forms:
+         "$ref": "#/components/schemas/ApplicationForms"
+    ApplicationForms:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+         type: array
+         items:
+          "$ref": "#/components/schemas/ApplicationForm"
+    ApplicationForm:
+      type: object
+      required:
+        - id
+        - created_at
+        - application_status
+        - application_phase
+      properties:
+        id:
+         type: integer
+         description: The unique ID of the candidates application form
+         example: 10
+        created_at:
+         type: string
+         format: date-time
+         description: The date an application was created
+         example: 2021-05-20T12:34:00Z
+        application_status:
+         type: string
+         description: The status of the candidates application form
+         enum:
+          - never_signed_in
+          - unsubmitted_not_started_form
+          - unsubmitted_in_progress
+          - awaiting_provider_decisions
+          - awaiting_candidate_response
+          - recruited
+          - pending_conditions
+          - offer_deferred
+          - ended_without_success
+          - unknown_state
+         example: awaiting_provider_decisions
+        application_phase:
+         type: string
+         description: The phase of this application. In the first phase, "Apply 1", the
+            candidate can choose up to 3 courses. If all of those choices are rejected,
+            declined, or withdrawn, the user can go into "Apply 2". This means
+            they can choose 1 course at a time.
+         enum:
+          - apply_1
+          - apply_2
+         example: apply_1
     UnauthorizedResponse:
       type: object
       required:


### PR DESCRIPTION
## Context

For V1.1 of the API we need in some additional fields so that GIT can either send/not send notifications which are tailored to the phase of application that the candidate is in.

## Changes proposed in this pull request

Include an application form with the following attributes:
- id
- created_at
- application_status
- application_phase

![image](https://user-images.githubusercontent.com/47917431/127185406-fa921584-6011-4552-bf63-7bfd03115f09.png)

## Guidance to review

Use Swagger to verify the API spec and Postman to check the API

## Link to Trello card

https://trello.com/c/XRzdPo2q

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
