### PR TITLE
Fix `OkComputer::SidekiqLatencyCheck` check

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -15,9 +15,9 @@ OkComputer.mount_at = 'integrations/monitoring'
 
 OkComputer::Registry.register 'postgres', OkComputer::ActiveRecordCheck.new
 OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ENV['REDIS_URL'])
-OkComputer::Registry.register 'sidekiq_low_priority_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'low_priority', threshold: 100) # threshold in seconds
-OkComputer::Registry.register 'sidekiq_default_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'default', threshold: 100) # threshold in seconds
-OkComputer::Registry.register 'sidekiq_mailers_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'mailers', threshold: 100) # threshold in seconds
+OkComputer::Registry.register 'sidekiq_low_priority_queue', OkComputer::SidekiqLatencyCheck.new('low_priority', 100) # threshold in seconds
+OkComputer::Registry.register 'sidekiq_default_queue', OkComputer::SidekiqLatencyCheck.new('default', 100) # threshold in seconds
+OkComputer::Registry.register 'sidekiq_mailers_queue', OkComputer::SidekiqLatencyCheck.new('mailers', 100) # threshold in seconds
 OkComputer::Registry.register 'simulated_failure', SimulatedFailureCheck.new
 OkComputer::Registry.register 'version', OkComputer::AppVersionCheck.new
 


### PR DESCRIPTION
## Context
We noticed that our Sidekiq latency check using [OkComputer](https://github.com/sportngin/okcomputer) gem wasn't alerting as expected, even when we know we went over the latency threshold which is set to alert at 100.

Looking into the gem implementation: https://github.com/sportngin/okcomputer/blob/master/lib/ok_computer/built_in_checks/sidekiq_latency_check.rb#L24 
if we run this, this will always return 0:
```
[4] pry(main)> Sidekiq::Queue.new(queue: 'default').latency
=> 0
[1] pry(main)> OkComputer::SidekiqLatencyCheck.new(queue: 'default', threshold: 100).check
=> "Sidekiq queue '{:queue=>\"default\", :threshold=>100}' latency at reasonable level (0)"
```
which is what we are passing into the check.
Removing the hash will now return the expected value and alert accordingly:
```
[5] pry(main)> Sidekiq::Queue.new('default').latency
=> 292644.28556227684
[2] pry(main)> OkComputer::SidekiqLatencyCheck.new('default', 100).check
=> "Sidekiq queue 'default' latency is 292623.28391599655 over threshold! (292723.28391599655)"
```

## Changes proposed in this pull request

Change hash to normal parameters to pass into the `OkComputer::SidekiqLatencyCheck` check

## Guidance to review

Did I miss anything?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
