### PR TITLE
Drop number of providers per page for TTAPI sync

### DIFF
--- a/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
+++ b/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
@@ -8,7 +8,7 @@ module TeacherTrainingPublicAPI
 
         scope = TeacherTrainingPublicAPI::Provider
           .where(year: recruitment_cycle_year)
-          .paginate(page: page_number, per_page: 250)
+          .paginate(page: page_number, per_page: 200)
         scope = scope.where(updated_since: TeacherTrainingPublicAPI::SyncCheck.updated_since) if incremental_sync
         delay_by = calculate_offset(page_number + 1, incremental_sync)
         response = scope.all

--- a/spec/support/test_helpers/teacher_training_public_api_helper.rb
+++ b/spec/support/test_helpers/teacher_training_public_api_helper.rb
@@ -10,7 +10,7 @@ module TeacherTrainingPublicAPIHelper
       :get,
       "#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers",
     ).with(
-      query: { page: { page: 1, per_page: 250 } },
+      query: { page: { page: 1, per_page: 200 } },
     )
 
     scope = scope.with(query: filter_option) if filter_option
@@ -170,7 +170,7 @@ private
       :get,
       "#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers",
     ).with(
-      query: { page: { page: page_number, per_page: 250 } },
+      query: { page: { page: page_number, per_page: 200 } },
     ).to_return(
       status: 200,
       headers: { 'Content-Type': 'application/vnd.api+json' },


### PR DESCRIPTION
## Context

Be kinder to the TTAPI sync since we're syncing all courses now. The page number determines the number of providers we batch to run every 3 minutes.

## Changes proposed in this pull request

Drop the page number so we schedule less per batch on syncing to the TTAPI

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
