### PR TITLE
Show application withdrawn by provider at candidate’s request

### DIFF
--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -1,8 +1,12 @@
 <%= govuk_tag(text: text, colour: colour) %>
 
 <% if @application_choice.application_not_sent? %>
-  <p class="govuk-body govuk-body govuk-!-margin-top-2">
+  <p class="govuk-body govuk-bod govuk-!-margin-top-2">
     Your application was not sent for this course because references were not given before the deadline.
+  </p>
+<% elsif @application_choice.withdrawn_at_candidates_request? %>
+  <p class="govuk-body govuk-!-margin-top-2">
+    You requested to withdraw your application. If you did not request this, email <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.
   </p>
 <% elsif  @application_choice.offer_deferred? %>
   <p class="govuk-body govuk-body govuk-!-margin-top-2">

--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -1,7 +1,7 @@
 <%= govuk_tag(text: text, colour: colour) %>
 
 <% if @application_choice.application_not_sent? %>
-  <p class="govuk-body govuk-bod govuk-!-margin-top-2">
+  <p class="govuk-body govuk-!-margin-top-2">
     Your application was not sent for this course because references were not given before the deadline.
   </p>
 <% elsif @application_choice.withdrawn_at_candidates_request? %>
@@ -9,7 +9,7 @@
     You requested to withdraw your application. If you did not request this, email <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.
   </p>
 <% elsif  @application_choice.offer_deferred? %>
-  <p class="govuk-body govuk-body govuk-!-margin-top-2">
+  <p class="govuk-body govuk-!-margin-top-2">
     Your training will now start in <%= (@application_choice.course_option.course.start_date + 1.year).to_s(:month_and_year) %>.
   </p>
 <% elsif @application_choice.pending_conditions? || @application_choice.recruited? || @application_choice.offer? %>

--- a/spec/components/candidate_interface/application_status_tag_component_spec.rb
+++ b/spec/components/candidate_interface/application_status_tag_component_spec.rb
@@ -53,4 +53,32 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
       end
     end
   end
+
+  context 'provider withdraws an application choice on behalf of the candidate' do
+    it 'displays additional guidance' do
+      application_choice = create(:application_choice, :with_offer)
+
+      allow(application_choice).to receive(:withdrawn_at_candidates_request?).and_return(true)
+
+      result = render_inline(described_class.new(application_choice: application_choice))
+
+      expect(result.text).to include(
+        'You requested to withdraw your application. If you did not request this, email becomingateacher@digital.education.gov.uk.',
+      )
+    end
+  end
+
+  context 'candidate withdraws their own application' do
+    it 'does not display additional guidance' do
+      application_choice = create(:application_choice, :with_offer)
+
+      allow(application_choice).to receive(:withdrawn_at_candidates_request?).and_return(false)
+
+      result = render_inline(described_class.new(application_choice: application_choice.reload))
+
+      expect(result.text).not_to include(
+        'You requested to withdraw your application. If you did not request this, email becomingateacher@digital.education.gov.uk.',
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Context

The Manage service recently added a feature to let providers withdraw an application on behalf of a candidates (instead of rejecting).

To make this clear to candidates, where this happens, we should add a note to the dashboard, including a link to contact support if this was done in error for some reason.

## Changes proposed in this pull request

- When an application is withdrawn by a provider on behalf of the provider we now show additional guidance on the dashboard i.e. what to do if this was done in error.

## Guidance to review

|Application withdrawn by candidate |Application withdrawn by provider|
--- | --- |
|<img width="765" alt="candidate_withdrew_application" src="https://user-images.githubusercontent.com/5256922/127122686-df9a1b9e-c7ba-4cd7-aa32-a758e090df3e.png">|<img width="747" alt="provider_withdrew_application" src="https://user-images.githubusercontent.com/5256922/127122766-78724678-da97-46ed-958d-2618c05abca3.png">|

### To test this
- Turn on the 'Withdraw at candidates request' feature flag
- Sign in to the provider console, choose and application and withdraw it on the candidate's behalf
- When you sign in as the candidate you should see the additional guidance


## Link to Trello card
https://trello.com/c/hc8NevP9/3648-show-application-withdrawn-by-provider-at-candidates-request

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
