### PR TITLE
Invariant check for full ttapi sync

### DIFF
--- a/app/services/concerns/full_sync_error_handler.rb
+++ b/app/services/concerns/full_sync_error_handler.rb
@@ -1,0 +1,7 @@
+module FullSyncErrorHandler
+  def raise_update_error(updates = {})
+    return if updates.none?
+
+    Sentry.capture_exception(TeacherTrainingPublicAPI::FullSyncUpdateError.new("#{updates.keys.to_sentence} have been updated"))
+  end
+end

--- a/app/services/teacher_training_public_api/full_sync_update_error.rb
+++ b/app/services/teacher_training_public_api/full_sync_update_error.rb
@@ -1,0 +1,3 @@
+module TeacherTrainingPublicAPI
+  class FullSyncUpdateError < StandardError; end
+end

--- a/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
+++ b/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
@@ -13,7 +13,7 @@ module TeacherTrainingPublicAPI
         delay_by = calculate_offset(page_number + 1, incremental_sync)
         response = scope.all
 
-        sync_providers(response, recruitment_cycle_year, delay_by)
+        sync_providers(response, recruitment_cycle_year, delay_by, incremental_sync)
 
         is_last_page = true if response.links.links['next'].nil?
       end
@@ -23,12 +23,13 @@ module TeacherTrainingPublicAPI
       raise TeacherTrainingPublicAPI::SyncError
     end
 
-    def self.sync_providers(providers_from_api, recruitment_cycle_year, delay_by)
+    def self.sync_providers(providers_from_api, recruitment_cycle_year, delay_by, incremental_sync)
       providers_from_api.each do |provider_from_api|
         TeacherTrainingPublicAPI::SyncProvider.new(
           provider_from_api: provider_from_api,
           recruitment_cycle_year: recruitment_cycle_year,
           delay_by: delay_by,
+          incremental_sync: incremental_sync,
         ).call
       end
     end

--- a/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
+++ b/app/services/teacher_training_public_api/sync_all_providers_and_courses.rb
@@ -1,6 +1,6 @@
 module TeacherTrainingPublicAPI
   class SyncAllProvidersAndCourses
-    def self.call(recruitment_cycle_year: ::RecruitmentCycle.current_year, incremental_sync: true)
+    def self.call(recruitment_cycle_year: ::RecruitmentCycle.current_year, incremental_sync: true, suppress_sync_update_errors: false)
       is_last_page = false
       page_number = 0
       until is_last_page
@@ -13,7 +13,7 @@ module TeacherTrainingPublicAPI
         delay_by = calculate_offset(page_number + 1, incremental_sync)
         response = scope.all
 
-        sync_providers(response, recruitment_cycle_year, delay_by, incremental_sync)
+        sync_providers(response, recruitment_cycle_year, delay_by, incremental_sync, suppress_sync_update_errors)
 
         is_last_page = true if response.links.links['next'].nil?
       end
@@ -23,13 +23,14 @@ module TeacherTrainingPublicAPI
       raise TeacherTrainingPublicAPI::SyncError
     end
 
-    def self.sync_providers(providers_from_api, recruitment_cycle_year, delay_by, incremental_sync)
+    def self.sync_providers(providers_from_api, recruitment_cycle_year, delay_by, incremental_sync, suppress_sync_update_errors)
       providers_from_api.each do |provider_from_api|
         TeacherTrainingPublicAPI::SyncProvider.new(
           provider_from_api: provider_from_api,
           recruitment_cycle_year: recruitment_cycle_year,
           delay_by: delay_by,
           incremental_sync: incremental_sync,
+          suppress_sync_update_errors: suppress_sync_update_errors,
         ).call
       end
     end

--- a/app/services/teacher_training_public_api/sync_provider.rb
+++ b/app/services/teacher_training_public_api/sync_provider.rb
@@ -2,12 +2,13 @@ module TeacherTrainingPublicAPI
   class SyncProvider
     include FullSyncErrorHandler
 
-    def initialize(provider_from_api:, recruitment_cycle_year:, delay_by: nil, incremental_sync: true)
+    def initialize(provider_from_api:, recruitment_cycle_year:, delay_by: nil, incremental_sync: true, suppress_sync_update_errors: false)
       @provider_from_api = provider_from_api
       @recruitment_cycle_year = recruitment_cycle_year
       @delay_by = delay_by
       @incremental_sync = incremental_sync
       @updates = {}
+      @suppress_sync_update_errors = suppress_sync_update_errors
     end
 
     def call(run_in_background: true)
@@ -15,14 +16,14 @@ module TeacherTrainingPublicAPI
       provider = create_or_update_provider(provider_attrs)
       sync_courses(run_in_background, provider)
 
-      raise_update_error(@updates)
+      raise_update_error(@updates) unless @suppress_sync_update_errors
     end
 
     def sync_courses(run_in_background, provider)
       if run_in_background
-        TeacherTrainingPublicAPI::SyncCourses.perform_in(@delay_by, provider.id, @recruitment_cycle_year, @incremental_sync)
+        TeacherTrainingPublicAPI::SyncCourses.perform_in(@delay_by, provider.id, @recruitment_cycle_year, @incremental_sync, @suppress_sync_update_errors)
       else
-        TeacherTrainingPublicAPI::SyncCourses.new.perform(provider.id, @recruitment_cycle_year, @incremental_sync, run_in_background: false)
+        TeacherTrainingPublicAPI::SyncCourses.new.perform(provider.id, @recruitment_cycle_year, @incremental_sync, @suppress_sync_update_errors, run_in_background: false)
       end
     end
 

--- a/app/services/teacher_training_public_api/sync_provider.rb
+++ b/app/services/teacher_training_public_api/sync_provider.rb
@@ -1,22 +1,28 @@
 module TeacherTrainingPublicAPI
   class SyncProvider
-    def initialize(provider_from_api:, recruitment_cycle_year:, delay_by: nil)
+    include FullSyncErrorHandler
+
+    def initialize(provider_from_api:, recruitment_cycle_year:, delay_by: nil, incremental_sync: true)
       @provider_from_api = provider_from_api
       @recruitment_cycle_year = recruitment_cycle_year
       @delay_by = delay_by
+      @incremental_sync = incremental_sync
+      @updates = {}
     end
 
     def call(run_in_background: true)
       provider_attrs = provider_attrs_from(@provider_from_api)
       provider = create_or_update_provider(provider_attrs)
       sync_courses(run_in_background, provider)
+
+      raise_update_error(@updates)
     end
 
     def sync_courses(run_in_background, provider)
       if run_in_background
-        TeacherTrainingPublicAPI::SyncCourses.perform_in(@delay_by, provider.id, @recruitment_cycle_year)
+        TeacherTrainingPublicAPI::SyncCourses.perform_in(@delay_by, provider.id, @recruitment_cycle_year, @incremental_sync)
       else
-        TeacherTrainingPublicAPI::SyncCourses.new.perform(provider.id, @recruitment_cycle_year, run_in_background: false)
+        TeacherTrainingPublicAPI::SyncCourses.new.perform(provider.id, @recruitment_cycle_year, @incremental_sync, run_in_background: false)
       end
     end
 
@@ -35,17 +41,23 @@ module TeacherTrainingPublicAPI
     end
 
     def existing_provider
-      ::Provider.find_by(code: @provider_from_api.code)
+      @existing_provider ||= ::Provider.find_by(code: @provider_from_api.code)
     end
 
     def create_or_update_provider(attrs)
       # Prefer this to find_or_create_by as it results in 3x fewer audits
       if existing_provider
-        existing_provider.update!(attrs)
+        existing_provider.assign_attributes(attrs)
 
+        @updates.merge!(providers: true) if !@incremental_sync && existing_provider.changed?
+
+        existing_provider.save!
         existing_provider
       else
-        ::Provider.create!(attrs.merge(code: @provider_from_api.code))
+        provider = ::Provider.create!(attrs.merge(code: @provider_from_api.code))
+        @updates.merge!(providers: true) if !@incremental_sync
+
+        provider
       end
     end
   end

--- a/app/services/teacher_training_public_api/sync_sites.rb
+++ b/app/services/teacher_training_public_api/sync_sites.rb
@@ -1,13 +1,17 @@
 module TeacherTrainingPublicAPI
   class SyncSites
+    include FullSyncErrorHandler
+
     attr_reader :provider, :course
 
     include Sidekiq::Worker
     sidekiq_options retry: 3, queue: :low_priority
 
-    def perform(provider_id, recruitment_cycle_year, course_id)
+    def perform(provider_id, recruitment_cycle_year, course_id, incremental_sync = true)
       @provider = ::Provider.find(provider_id)
       @course = ::Course.find(course_id)
+      @incremental_sync = incremental_sync
+      @updates = {}
 
       sites = TeacherTrainingPublicAPI::Location.where(
         year: recruitment_cycle_year,
@@ -24,6 +28,9 @@ module TeacherTrainingPublicAPI
         end
 
         assign_site_attributes(site, site_from_api)
+
+        @updates.merge!(site: true) if site.changed? && !@incremental_sync
+
         site.save!
 
         site_status = site_from_api.location_status
@@ -35,6 +42,8 @@ module TeacherTrainingPublicAPI
 
       handle_course_options_with_invalid_sites(sites)
       handle_course_options_with_reinstated_sites(sites)
+
+      raise_update_error(@updates)
     rescue JsonApiClient::Errors::ApiError
       raise TeacherTrainingPublicAPI::SyncError
     end
@@ -69,7 +78,12 @@ module TeacherTrainingPublicAPI
       )
 
       vacancy_status = vacancy_status(site_status.vacancy_status, study_mode)
-      course_option.update!(vacancy_status: vacancy_status) if course_option.vacancy_status != vacancy_status
+
+      if course_option.vacancy_status != vacancy_status.to_s
+        course_option.update!(vacancy_status: vacancy_status)
+
+        @updates.merge!(course_option: true) if !@incremental_sync
+      end
     end
 
     def vacancy_status(vacancy_status_from_api, study_mode)

--- a/app/services/teacher_training_public_api/sync_sites.rb
+++ b/app/services/teacher_training_public_api/sync_sites.rb
@@ -7,7 +7,7 @@ module TeacherTrainingPublicAPI
     include Sidekiq::Worker
     sidekiq_options retry: 3, queue: :low_priority
 
-    def perform(provider_id, recruitment_cycle_year, course_id, incremental_sync = true)
+    def perform(provider_id, recruitment_cycle_year, course_id, incremental_sync = true, suppress_sync_update_errors = false)
       @provider = ::Provider.find(provider_id)
       @course = ::Course.find(course_id)
       @incremental_sync = incremental_sync
@@ -43,7 +43,7 @@ module TeacherTrainingPublicAPI
       handle_course_options_with_invalid_sites(sites)
       handle_course_options_with_reinstated_sites(sites)
 
-      raise_update_error(@updates)
+      raise_update_error(@updates) unless suppress_sync_update_errors
     rescue JsonApiClient::Errors::ApiError
       raise TeacherTrainingPublicAPI::SyncError
     end

--- a/config/rubocop/config/style.yml
+++ b/config/rubocop/config/style.yml
@@ -91,3 +91,7 @@ Style/IdenticalConditionalBranches:
   Exclude:
     # wizard.clear_state! duplication in commit method conditional
     - 'app/controllers/provider_interface/organisation_permissions_setup_controller.rb'
+
+Style/OptionalBooleanParameter:
+  AllowedMethods:
+    - perform

--- a/spec/services/teacher_training_public_api/sync_all_providers_and_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_all_providers_and_courses_spec.rb
@@ -17,6 +17,22 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCourses, sidekiq: tr
       end
     end
 
+    context 'when intremental sync is off' do
+      before do
+        allow(Sentry).to receive(:capture_exception)
+        stub_teacher_training_api_providers_with_multiple_pages
+        allow(TeacherTrainingPublicAPI::SyncCourses).to receive(:perform_in)
+      end
+
+      it 'raises an error when there are any updates' do
+        described_class.call(incremental_sync: false)
+
+        expect(Sentry).to have_received(:capture_exception)
+                          .with(TeacherTrainingPublicAPI::FullSyncUpdateError.new('providers have been updated'))
+                          .at_least(:once)
+      end
+    end
+
     context 'a previous year recruitment cycle' do
       let(:recruitment_cycle_year) { RecruitmentCycle.previous_year }
       let(:sync_provider) { instance_double(TeacherTrainingPublicAPI::SyncProvider) }
@@ -25,7 +41,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCourses, sidekiq: tr
         allow(sync_provider).to receive(:call)
         allow(TeacherTrainingPublicAPI::SyncProvider)
           .to receive(:new)
-          .with(provider_from_api: anything, recruitment_cycle_year: recruitment_cycle_year, delay_by: 6.minutes)
+          .with(provider_from_api: anything, recruitment_cycle_year: recruitment_cycle_year, delay_by: 6.minutes, incremental_sync: false)
           .and_return(sync_provider)
       end
 
@@ -47,7 +63,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCourses, sidekiq: tr
         allow(sync_provider).to receive(:call)
         allow(TeacherTrainingPublicAPI::SyncProvider)
           .to receive(:new)
-            .with(provider_from_api: anything, recruitment_cycle_year: recruitment_cycle_year, delay_by: nil)
+            .with(provider_from_api: anything, recruitment_cycle_year: recruitment_cycle_year, delay_by: nil, incremental_sync: true)
             .and_return(sync_provider)
         stub_teacher_training_api_providers(
           recruitment_cycle_year: recruitment_cycle_year,

--- a/spec/services/teacher_training_public_api/sync_provider_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_provider_spec.rb
@@ -53,6 +53,19 @@ RSpec.describe TeacherTrainingPublicAPI::SyncProvider, sidekiq: true do
         expect(Sentry).to have_received(:capture_exception)
                           .with(TeacherTrainingPublicAPI::FullSyncUpdateError.new('providers have been updated'))
       end
+
+      it 'when errors are suppressed it does not raise a FullSync error' do
+        described_class.new(
+          provider_from_api: provider_from_api,
+          recruitment_cycle_year: stubbed_recruitment_cycle_year,
+          delay_by: delay_by,
+          incremental_sync: incremental_sync,
+          suppress_sync_update_errors: true,
+        ).call(run_in_background: true)
+
+        expect(Sentry).not_to have_received(:capture_exception)
+          .with(TeacherTrainingPublicAPI::FullSyncUpdateError.new('providers have been updated'))
+      end
     end
 
     context 'ingesting an existing provider' do
@@ -84,6 +97,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncProvider, sidekiq: true do
           provider_from_api.id,
           stubbed_recruitment_cycle_year,
           true,
+          false,
         ).exactly(1).time
       end
 
@@ -96,6 +110,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncProvider, sidekiq: true do
             provider_from_api.id,
             stubbed_recruitment_cycle_year,
             true,
+            false,
           ).exactly(1).time
         end
       end


### PR DESCRIPTION
## Context

If we get changes in the full sync it potentially means that there is a bug or something else we have missed in the incremental sync. In order to identify any issues, we want to raise errors when any updates take place as part of the full sync.

## Changes proposed in this pull request

Raise an error when any of the following are updated
- providers
- courses
- course options
- sites
- provider relationship permissions

## Link to Trello card

https://trello.com/c/XLctyABe/3949-invariant-check-for-full-ttapi-sync

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
