### PR TITLE
Load testing extend manage offer scenario to make an offer

### DIFF
--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -171,11 +171,11 @@ a.application_choices.select(&:conditions_not_met?).first.update!(status: :pendi
 
 Providers may need to revert a rejection so that they can offer a different course or if it was done in error.
 
-If less than five working days have passed since the application has been submitted, then the rejection can be reverted via the 
+If less than five working days have passed since the application has been submitted, then the rejection can be reverted via the
 Support UI when viewing the application choice.
 
 If a candidate has had a course rejected in error but wishes to replace their course option with another offered by a _different_ provider,
-then following reverting the rejection via the Support UI, you will need to [withdraw the course option via the console](#change-providercourse), 
+then following reverting the rejection via the Support UI, you will need to [withdraw the course option via the console](#change-providercourse),
 before adding a new course choice via the Support UI.
 
 ### Revert a withdrawn offer


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Load testing scenario only used to cover the beginning of the make offer flow, it now covers the full flow. 

## Link to Trello card

https://trello.com/c/I1pMHS8T/4020-load-testing-extend-manage-offer-scenario-to-make-an-offer

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
