### PR TITLE
Implement emails to let user know of changes to organisational permissions

### DIFF
--- a/app/controllers/provider_interface/organisation_permissions_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_controller.rb
@@ -26,6 +26,8 @@ module ProviderInterface
 
     def update
       if @relationship.update(new_relationship_permissions)
+        SendOrganisationPermissionsEmails.new(provider_user: current_provider_user, permissions: @relationship).call
+
         flash[:success] = 'Organisation permissions updated'
         redirect_to provider_interface_organisation_settings_organisation_organisation_permissions_path(params[:organisation_id])
       else

--- a/app/controllers/provider_interface/organisation_permissions_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_controller.rb
@@ -13,11 +13,10 @@ module ProviderInterface
     end
 
     def index
-      @provider = current_provider_user.providers.find(params[:organisation_id])
-      render_403 unless current_provider_user.authorisation.can_manage_organisation?(provider: @provider)
+      render_403 unless current_provider_user.authorisation.can_manage_organisation?(provider: provider)
 
-      unsorted_provider_relationships = ProviderRelationshipPermissions.all_relationships_for_providers([@provider]).where.not(setup_at: nil)
-      @provider_relationships = sort_relationships_by_provider_name(unsorted_provider_relationships, @provider)
+      unsorted_provider_relationships = ProviderRelationshipPermissions.all_relationships_for_providers([provider]).where.not(setup_at: nil)
+      @provider_relationships = sort_relationships_by_provider_name(unsorted_provider_relationships, provider)
     rescue ActiveRecord::RecordNotFound
       render_404
     end
@@ -26,7 +25,7 @@ module ProviderInterface
 
     def update
       if @relationship.update(new_relationship_permissions)
-        SendOrganisationPermissionsEmails.new(provider_user: current_provider_user, permissions: @relationship).call
+        SendOrganisationPermissionsEmails.new(provider_user: current_provider_user, provider: provider, permissions: @relationship).call
 
         flash[:success] = 'Organisation permissions updated'
         redirect_to provider_interface_organisation_settings_organisation_organisation_permissions_path(params[:organisation_id])
@@ -37,6 +36,10 @@ module ProviderInterface
     end
 
   private
+
+    def provider
+      @provider ||= current_provider_user.providers.find(params[:organisation_id])
+    end
 
     def manageable_providers
       @_manageable_providers ||= current_provider_user.authorisation.providers_that_actor_can_manage_organisations_for(with_set_up_permissions: true)

--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -62,6 +62,7 @@ module ProviderInterface
     def commit
       wizard = OrganisationPermissionsSetupWizard.new(organisation_permissions_wizard_store)
       if SetupProviderRelationshipPermissions.call(wizard.relationships)
+        send_organisation_permissions_emails(wizard.relationships)
         wizard.clear_state!
         redirect_to success_provider_interface_organisation_permissions_setup_index_path
       else
@@ -123,6 +124,14 @@ module ProviderInterface
         check_provider_interface_organisation_permissions_setup_index_path
       else
         provider_interface_organisation_permissions_setup_index_path
+      end
+    end
+
+    def send_organisation_permissions_emails(relationships)
+      relationships.each do |permissions|
+        SendOrganisationPermissionsEmails.new(
+          provider_user: current_provider_user, permissions: permissions, set_up: true,
+        ).call
       end
     end
 

--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -129,9 +129,7 @@ module ProviderInterface
 
     def send_organisation_permissions_emails(relationships)
       relationships.each do |permissions|
-        SendOrganisationPermissionsEmails.new(
-          provider_user: current_provider_user, permissions: permissions, set_up: true,
-        ).call
+        SendOrganisationPermissionsEmails.new(provider_user: current_provider_user, permissions: permissions).call
       end
     end
 

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -163,11 +163,11 @@ class ProviderMailer < ApplicationMailer
     notify_email(to: provider_user.email_address)
   end
 
-  def organisation_permissions_set_up(provider_user, permissions)
+  def organisation_permissions_set_up(provider_user, provider, permissions)
     @provider_user = provider_user
+    @recipient_organisation = provider
     @permissions = permissions
-    @partner_organisation = permissions.partner_organisation(provider_user)
-    @recipient_organisation = provider_user.providers.find { |provider| provider == permissions.training_provider || provider == permissions.ratifying_provider }
+    @partner_organisation = permissions.partner_organisation(provider)
 
     notify_email(
       to: @provider_user.email_address,
@@ -175,11 +175,11 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
-  def organisation_permissions_updated(provider_user, permissions)
+  def organisation_permissions_updated(provider_user, provider, permissions)
     @provider_user = provider_user
+    @recipient_organisation = provider
     @permissions = permissions
-    @partner_organisation = permissions.partner_organisation(provider_user)
-    @recipient_organisation = provider_user.providers.find { |provider| provider == permissions.training_provider || provider == permissions.ratifying_provider }
+    @partner_organisation = permissions.partner_organisation(provider)
 
     notify_email(
       to: @provider_user.email_address,

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -163,6 +163,30 @@ class ProviderMailer < ApplicationMailer
     notify_email(to: provider_user.email_address)
   end
 
+  def organisation_permissions_set_up(provider_user, permissions)
+    @provider_user = provider_user
+    @permissions = permissions
+    @partner_organisation = permissions.partner_organisation(provider_user)
+    @recipient_organisation = provider_user.providers.find { |provider| provider == permissions.training_provider || provider == permissions.ratifying_provider }
+
+    notify_email(
+      to: @provider_user.email_address,
+      subject: I18n.t!('provider_mailer.organisation_permissions_set_up.subject', provider: @partner_organisation.name),
+    )
+  end
+
+  def organisation_permissions_updated(provider_user, permissions)
+    @provider_user = provider_user
+    @permissions = permissions
+    @partner_organisation = permissions.partner_organisation(provider_user)
+    @recipient_organisation = provider_user.providers.find { |provider| provider == permissions.training_provider || provider == permissions.ratifying_provider }
+
+    notify_email(
+      to: @provider_user.email_address,
+      subject: I18n.t!('provider_mailer.organisation_permissions_updated.subject', provider: @partner_organisation.name),
+    )
+  end
+
 private
 
   def email_for_provider(provider_user, application_form, args = {})

--- a/app/models/provider_relationship_permissions.rb
+++ b/app/models/provider_relationship_permissions.rb
@@ -29,6 +29,18 @@ class ProviderRelationshipPermissions < ApplicationRecord
     PERMISSIONS.map { |permission| send("ratifying_provider_can_#{permission}") }.all?(false)
   end
 
+  def partner_organisation(provider_user)
+    provider_user.providers.include?(ratifying_provider) ? training_provider : ratifying_provider
+  end
+
+  def permit?(permission, provider)
+    if provider == training_provider
+      send("training_provider_can_#{permission}")
+    else
+      send("ratifying_provider_can_#{permission}")
+    end
+  end
+
 private
 
   def at_least_one_active_permission_in_pair

--- a/app/models/provider_relationship_permissions.rb
+++ b/app/models/provider_relationship_permissions.rb
@@ -29,8 +29,11 @@ class ProviderRelationshipPermissions < ApplicationRecord
     PERMISSIONS.map { |permission| send("ratifying_provider_can_#{permission}") }.all?(false)
   end
 
-  def partner_organisation(provider_user)
-    provider_user.providers.include?(ratifying_provider) ? training_provider : ratifying_provider
+  def partner_organisation(provider)
+    return training_provider if provider == ratifying_provider
+    return ratifying_provider if provider == training_provider
+
+    nil
   end
 
   def permit?(permission, provider)

--- a/app/services/provider_interface/send_organisation_permissions_emails.rb
+++ b/app/services/provider_interface/send_organisation_permissions_emails.rb
@@ -1,0 +1,29 @@
+module ProviderInterface
+  class SendOrganisationPermissionsEmails
+    def initialize(provider_user:, permissions:, set_up: false)
+      @provider_user = provider_user
+      @permissions = permissions
+      @partner_organisation = @permissions.partner_organisation(provider_user)
+      @set_up = set_up
+    end
+
+    def call
+      managing_users.each do |user|
+        next if user == @provider_user
+
+        ProviderMailer.send("organisation_permissions_#{email_to_send}", user, @permissions).deliver_later
+      end
+    end
+
+  private
+
+    def managing_users
+      ProviderUser.joins(:provider_permissions)
+        .where(ProviderPermissions.table_name => { provider_id: @partner_organisation.id, manage_organisations: true })
+    end
+
+    def email_to_send
+      @set_up ? 'set_up' : 'updated'
+    end
+  end
+end

--- a/app/services/provider_interface/send_organisation_permissions_emails.rb
+++ b/app/services/provider_interface/send_organisation_permissions_emails.rb
@@ -1,29 +1,52 @@
 module ProviderInterface
   class SendOrganisationPermissionsEmails
-    def initialize(provider_user:, permissions:, set_up: false)
+    def initialize(provider_user:, permissions:, provider: nil)
       @provider_user = provider_user
       @permissions = permissions
-      @partner_organisation = @permissions.partner_organisation(provider_user)
-      @set_up = set_up
+      @provider = provider
     end
 
     def call
-      managing_users.each do |user|
-        next if user == @provider_user
-
-        ProviderMailer.send("organisation_permissions_#{email_to_send}", user, @permissions).deliver_later
+      managing_users.uniq.each do |user|
+        ProviderMailer.send("organisation_permissions_#{email_to_send}", user, partner_organisation, @permissions).deliver_later
       end
     end
 
   private
 
+    attr_reader :permissions, :provider, :provider_user
+
     def managing_users
       ProviderUser.joins(:provider_permissions)
-        .where(ProviderPermissions.table_name => { provider_id: @partner_organisation.id, manage_organisations: true })
+        .where(ProviderPermissions.table_name => { provider: partner_organisation, manage_organisations: true })
     end
 
     def email_to_send
-      @set_up ? 'set_up' : 'updated'
+      provider.nil? ? 'set_up' : 'updated'
+    end
+
+    def partner_organisation
+      if provider.present?
+        permissions.partner_organisation(provider)
+      elsif provider_user_belongs_to_both_providers?
+        alphabetically_first_provider_in_relationship
+      elsif provider_user.providers.include?(permissions.ratifying_provider)
+        permissions.training_provider
+      else
+        permissions.ratifying_provider
+      end
+    end
+
+    def provider_user_belongs_to_both_providers?
+      (providers_in_relationship & provider_user.providers) == providers_in_relationship
+    end
+
+    def providers_in_relationship
+      @providers_in_relationship ||= [permissions.training_provider, permissions.ratifying_provider]
+    end
+
+    def alphabetically_first_provider_in_relationship
+      providers_in_relationship.min_by(&:name)
     end
   end
 end

--- a/app/views/provider_mailer/organisation_permissions_set_up.text.erb
+++ b/app/views/provider_mailer/organisation_permissions_set_up.text.erb
@@ -6,20 +6,13 @@ You can now manage applications made through GOV.UK for the courses you work on 
 
 They have set up the following organisation permissions.
 
-Make offers and reject applications:
+<% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| -%>
+<%= I18n.t("provider_relationship_permissions.#{permission_name}.description") %>:
 
-<%= "- #{@recipient_organisation.name}" if @permissions.permit?(:make_decisions, @recipient_organisation) %>
-<%= "- #{@partner_organisation.name}" if @permissions.permit?(:make_decisions, @partner_organisation) %>
+<%= "- #{@recipient_organisation.name}" if @permissions.permit?(permission_name, @recipient_organisation) %>
+<%= "- #{@partner_organisation.name}" if @permissions.permit?(permission_name, @partner_organisation) %>
 
-View criminal convictions and professional misconduct:
-
-<%= "- #{@recipient_organisation.name}" if @permissions.permit?(:view_safeguarding_information, @recipient_organisation) %>
-<%= "- #{@partner_organisation.name}" if @permissions.permit?(:view_safeguarding_information, @partner_organisation) %>
-
-View sex, disability and ethnicity information:
-
-<%= "- #{@recipient_organisation.name}" if @permissions.permit?(:view_diversity_information, @recipient_organisation) %>
-<%= "- #{@partner_organisation.name}" if @permissions.permit?(:view_diversity_information, @partner_organisation) %>
+<% end -%>
 
 # Change organisation permissions
 

--- a/app/views/provider_mailer/organisation_permissions_set_up.text.erb
+++ b/app/views/provider_mailer/organisation_permissions_set_up.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @provider_user.first_name %>
+Dear <%= @provider_user.full_name %>
 
 # <%= @partner_organisation.name %> has set up organisation permissions for teacher training courses you work on with them
 
@@ -8,21 +8,21 @@ They have set up the following organisation permissions.
 
 Make offers and reject applications:
 
-<%= @partner_organisation.name if @permissions.permit?(:make_decisions, @partner_organisation) %>
-<%= @recipient_organisation.name if @permissions.permit?(:make_decisions, @recipient_organisation) %>
+<%= "- #{@recipient_organisation.name}" if @permissions.permit?(:make_decisions, @recipient_organisation) %>
+<%= "- #{@partner_organisation.name}" if @permissions.permit?(:make_decisions, @partner_organisation) %>
 
 View criminal convictions and professional misconduct:
 
-<%= @partner_organisation.name if @permissions.permit?(:view_safeguarding_information, @partner_organisation) %>
-<%= @recipient_organisation.name if @permissions.permit?(:view_safeguarding_information, @recipient_organisation) %>
+<%= "- #{@recipient_organisation.name}" if @permissions.permit?(:view_safeguarding_information, @recipient_organisation) %>
+<%= "- #{@partner_organisation.name}" if @permissions.permit?(:view_safeguarding_information, @partner_organisation) %>
 
 View sex, disability and ethnicity information:
 
-<%= @partner_organisation.name if @permissions.permit?(:view_diversity_information, @partner_organisation) %>
-<%= @recipient_organisation.name if @permissions.permit?(:view_diversity_information, @recipient_organisation) %>
+<%= "- #{@recipient_organisation.name}" if @permissions.permit?(:view_diversity_information, @recipient_organisation) %>
+<%= "- #{@partner_organisation.name}" if @permissions.permit?(:view_diversity_information, @partner_organisation) %>
 
-Change organisation permissions
+# Change organisation permissions
 
 You can change these organisation permissions in your organisation settings:
 
-((link))
+<%= provider_interface_organisation_settings_organisation_organisation_permissions_url(@recipient_organisation) %>

--- a/app/views/provider_mailer/organisation_permissions_set_up.text.erb
+++ b/app/views/provider_mailer/organisation_permissions_set_up.text.erb
@@ -1,0 +1,28 @@
+Dear <%= @provider_user.first_name %>
+
+# <%= @partner_organisation.name %> has set up organisation permissions for teacher training courses you work on with them
+
+You can now manage applications made through GOV.UK for the courses you work on with <%= @partner_organisation.name %>.
+
+They have set up the following organisation permissions.
+
+Make offers and reject applications:
+
+<%= @partner_organisation.name if @permissions.permit?(:make_decisions, @partner_organisation) %>
+<%= @recipient_organisation.name if @permissions.permit?(:make_decisions, @recipient_organisation) %>
+
+View criminal convictions and professional misconduct:
+
+<%= @partner_organisation.name if @permissions.permit?(:view_safeguarding_information, @partner_organisation) %>
+<%= @recipient_organisation.name if @permissions.permit?(:view_safeguarding_information, @recipient_organisation) %>
+
+View sex, disability and ethnicity information:
+
+<%= @partner_organisation.name if @permissions.permit?(:view_diversity_information, @partner_organisation) %>
+<%= @recipient_organisation.name if @permissions.permit?(:view_diversity_information, @recipient_organisation) %>
+
+Change organisation permissions
+
+You can change these organisation permissions in your organisation settings:
+
+((link))

--- a/app/views/provider_mailer/organisation_permissions_updated.text.erb
+++ b/app/views/provider_mailer/organisation_permissions_updated.text.erb
@@ -4,20 +4,13 @@ Dear <%= @provider_user.full_name %>
 
 <%= @partner_organisation.name %> has set the following organisation permissions.
 
-Make offers and reject applications:
+<% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| -%>
+<%= I18n.t("provider_relationship_permissions.#{permission_name}.description") %>:
 
-<%= "- #{@recipient_organisation.name}" if @permissions.permit?(:make_decisions, @recipient_organisation) %>
-<%= "- #{@partner_organisation.name}" if @permissions.permit?(:make_decisions, @partner_organisation) %>
+<%= "- #{@recipient_organisation.name}" if @permissions.permit?(permission_name, @recipient_organisation) %>
+<%= "- #{@partner_organisation.name}" if @permissions.permit?(permission_name, @partner_organisation) %>
 
-View criminal convictions and professional misconduct:
-
-<%= "- #{@recipient_organisation.name}" if @permissions.permit?(:view_safeguarding_information, @recipient_organisation) %>
-<%= "- #{@partner_organisation.name}" if @permissions.permit?(:view_safeguarding_information, @partner_organisation) %>
-
-View sex, disability and ethnicity information:
-
-<%= "- #{@recipient_organisation.name}" if @permissions.permit?(:view_diversity_information, @recipient_organisation) %>
-<%= "- #{@partner_organisation.name}" if @permissions.permit?(:view_diversity_information, @partner_organisation) %>
+<% end -%>
 
 # Change organisation permissions
 

--- a/app/views/provider_mailer/organisation_permissions_updated.text.erb
+++ b/app/views/provider_mailer/organisation_permissions_updated.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @provider_user.first_name %>
+Dear <%= @provider_user.full_name %>
 
 # <%= @partner_organisation.name %> has changed organisation permissions for teacher training courses you work on with them
 
@@ -6,21 +6,21 @@ Dear <%= @provider_user.first_name %>
 
 Make offers and reject applications:
 
-<%= @partner_organisation.name if @permissions.permit?(:make_decisions, @partner_organisation) %>
-<%= @recipient_organisation.name if @permissions.permit?(:make_decisions, @recipient_organisation) %>
+<%= "- #{@recipient_organisation.name}" if @permissions.permit?(:make_decisions, @recipient_organisation) %>
+<%= "- #{@partner_organisation.name}" if @permissions.permit?(:make_decisions, @partner_organisation) %>
 
 View criminal convictions and professional misconduct:
 
-<%= @partner_organisation.name if @permissions.permit?(:view_safeguarding_information, @partner_organisation) %>
-<%= @recipient_organisation.name if @permissions.permit?(:view_safeguarding_information, @recipient_organisation) %>
+<%= "- #{@recipient_organisation.name}" if @permissions.permit?(:view_safeguarding_information, @recipient_organisation) %>
+<%= "- #{@partner_organisation.name}" if @permissions.permit?(:view_safeguarding_information, @partner_organisation) %>
 
 View sex, disability and ethnicity information:
 
-<%= @partner_organisation.name if @permissions.permit?(:view_diversity_information, @partner_organisation) %>
-<%= @recipient_organisation.name if @permissions.permit?(:view_diversity_information, @recipient_organisation) %>
+<%= "- #{@recipient_organisation.name}" if @permissions.permit?(:view_diversity_information, @recipient_organisation) %>
+<%= "- #{@partner_organisation.name}" if @permissions.permit?(:view_diversity_information, @partner_organisation) %>
 
-Change organisation permissions
+# Change organisation permissions
 
 You can change these organisation permissions in your organisation settings:
 
-((link))
+<%= provider_interface_organisation_settings_organisation_organisation_permissions_url(@recipient_organisation) %>

--- a/app/views/provider_mailer/organisation_permissions_updated.text.erb
+++ b/app/views/provider_mailer/organisation_permissions_updated.text.erb
@@ -1,0 +1,26 @@
+Dear <%= @provider_user.first_name %>
+
+# <%= @partner_organisation.name %> has changed organisation permissions for teacher training courses you work on with them
+
+<%= @partner_organisation.name %> has set the following organisation permissions.
+
+Make offers and reject applications:
+
+<%= @partner_organisation.name if @permissions.permit?(:make_decisions, @partner_organisation) %>
+<%= @recipient_organisation.name if @permissions.permit?(:make_decisions, @recipient_organisation) %>
+
+View criminal convictions and professional misconduct:
+
+<%= @partner_organisation.name if @permissions.permit?(:view_safeguarding_information, @partner_organisation) %>
+<%= @recipient_organisation.name if @permissions.permit?(:view_safeguarding_information, @recipient_organisation) %>
+
+View sex, disability and ethnicity information:
+
+<%= @partner_organisation.name if @permissions.permit?(:view_diversity_information, @partner_organisation) %>
+<%= @recipient_organisation.name if @permissions.permit?(:view_diversity_information, @recipient_organisation) %>
+
+Change organisation permissions
+
+You can change these organisation permissions in your organisation settings:
+
+((link))

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -29,4 +29,8 @@ en:
     courses_open_on_apply:
       subject: Your courses are live on Apply and you have access to Manage
     confirm_sign_in:
-      subject: New sign in to Manage teacher training applications  
+      subject: New sign in to Manage teacher training applications
+    organisation_permissions_set_up:
+      subject: "%{provider} has set up organisation permissions for teacher training courses you work on with them"
+    organisation_permissions_updated:
+      subject: "%{provider} has changed organisation permissions for teacher training courses you work on with them"

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -76,6 +76,39 @@ class ProviderMailerPreview < ActionMailer::Preview
     ProviderMailer.unconditional_offer_accepted(provider_user, application_choice)
   end
 
+  def organisation_permissions_set_up
+    training_provider = FactoryBot.create(:provider)
+    ratifying_provider = FactoryBot.create(:provider)
+    provider_user = FactoryBot.create(:provider_user, providers: [ratifying_provider])
+    provider_user.provider_permissions.update_all(manage_organisations: true)
+    permissions = FactoryBot.create(
+      :provider_relationship_permissions,
+      training_provider: training_provider,
+      ratifying_provider: ratifying_provider,
+      ratifying_provider_can_make_decisions: true,
+      training_provider_can_view_safeguarding_information: false,
+      ratifying_provider_can_view_safeguarding_information: true,
+      ratifying_provider_can_view_diversity_information: true,
+    )
+    ProviderMailer.organisation_permissions_set_up(provider_user, permissions)
+  end
+
+  def organisation_permissions_updated
+    training_provider = FactoryBot.create(:provider)
+    ratifying_provider = FactoryBot.create(:provider)
+    provider_user = FactoryBot.create(:provider_user, providers: [ratifying_provider])
+    provider_user.provider_permissions.update_all(manage_organisations: true)
+    permissions = FactoryBot.create(
+      :provider_relationship_permissions,
+      training_provider: training_provider,
+      ratifying_provider: ratifying_provider,
+      ratifying_provider_can_make_decisions: true,
+      training_provider_can_make_decisions: false,
+      ratifying_provider_can_view_safeguarding_information: true,
+    )
+    ProviderMailer.organisation_permissions_updated(provider_user, permissions)
+  end
+
 private
 
   def provider

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -90,7 +90,7 @@ class ProviderMailerPreview < ActionMailer::Preview
       ratifying_provider_can_view_safeguarding_information: true,
       ratifying_provider_can_view_diversity_information: true,
     )
-    ProviderMailer.organisation_permissions_set_up(provider_user, permissions)
+    ProviderMailer.organisation_permissions_set_up(provider_user, ratifying_provider, permissions)
   end
 
   def organisation_permissions_updated
@@ -106,7 +106,7 @@ class ProviderMailerPreview < ActionMailer::Preview
       training_provider_can_make_decisions: false,
       ratifying_provider_can_view_safeguarding_information: true,
     )
-    ProviderMailer.organisation_permissions_updated(provider_user, permissions)
+    ProviderMailer.organisation_permissions_updated(provider_user, ratifying_provider, permissions)
   end
 
 private

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe ProviderMailer, type: :mailer do
         ratifying_provider_can_view_diversity_information: true,
       )
     end
-    let(:email) { ProviderMailer.organisation_permissions_set_up(provider_user, permissions) }
+    let(:email) { described_class.organisation_permissions_set_up(provider_user, training_provider, permissions) }
 
     it_behaves_like(
       'a mail with subject and content',
@@ -258,7 +258,7 @@ RSpec.describe ProviderMailer, type: :mailer do
         ratifying_provider_can_view_diversity_information: true,
       )
     end
-    let(:email) { ProviderMailer.organisation_permissions_updated(provider_user, permissions) }
+    let(:email) { described_class.organisation_permissions_updated(provider_user, training_provider, permissions) }
 
     it_behaves_like(
       'a mail with subject and content',

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -218,4 +218,56 @@ RSpec.describe ProviderMailer, type: :mailer do
                     I18n.t!('provider_mailer.courses_open_on_apply.subject'),
                     'recruitment_cycle_year' => RecruitmentCycle.current_year)
   end
+
+  describe 'organisation_permissions_set_up' do
+    let(:training_provider) { build_stubbed(:provider, name: 'University of Purley') }
+    let(:ratifying_provider) { build_stubbed(:provider, name: 'University of Croydon') }
+    let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English', providers: [training_provider]) }
+    let(:permissions) do
+      build_stubbed(
+        :provider_relationship_permissions,
+        ratifying_provider: ratifying_provider,
+        training_provider: training_provider,
+        ratifying_provider_can_view_safeguarding_information: true,
+        ratifying_provider_can_view_diversity_information: true,
+      )
+    end
+    let(:email) { ProviderMailer.organisation_permissions_set_up(provider_user, permissions) }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'University of Croydon has set up organisation permissions for teacher training courses you work on with them',
+      'salutation' => 'Dear Johny',
+      'heading' => 'University of Croydon has set up organisation permissions for teacher training courses you work on with them',
+      'make offers' => /Make offers and reject applications:\s+University of Purley/,
+      'view safeguarding' => /View criminal convictions and professional misconduct:\s+University of Croydon\s+University of Purley/,
+      'view diversity' => /View criminal convictions and professional misconduct:\s+University of Croydon\s+University of Purley/,
+    )
+  end
+
+  describe 'organisation_permissions_updated' do
+    let(:training_provider) { build_stubbed(:provider, name: 'University of Purley') }
+    let(:ratifying_provider) { build_stubbed(:provider, name: 'University of Croydon') }
+    let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English', providers: [training_provider]) }
+    let(:permissions) do
+      build_stubbed(
+        :provider_relationship_permissions,
+        ratifying_provider: ratifying_provider,
+        training_provider: training_provider,
+        ratifying_provider_can_view_safeguarding_information: true,
+        ratifying_provider_can_view_diversity_information: true,
+      )
+    end
+    let(:email) { ProviderMailer.organisation_permissions_updated(provider_user, permissions) }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'University of Croydon has changed organisation permissions for teacher training courses you work on with them',
+      'salutation' => 'Dear Johny',
+      'heading' => 'University of Croydon has changed organisation permissions for teacher training courses you work on with them',
+      'make offers' => /Make offers and reject applications:\s+University of Purley/,
+      'view safeguarding' => /View criminal convictions and professional misconduct:\s+University of Croydon\s+University of Purley/,
+      'view diversity' => /View criminal convictions and professional misconduct:\s+University of Croydon\s+University of Purley/,
+    )
+  end
 end

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -237,11 +237,11 @@ RSpec.describe ProviderMailer, type: :mailer do
     it_behaves_like(
       'a mail with subject and content',
       'University of Croydon has set up organisation permissions for teacher training courses you work on with them',
-      'salutation' => 'Dear Johny',
+      'salutation' => 'Dear Johny English',
       'heading' => 'University of Croydon has set up organisation permissions for teacher training courses you work on with them',
-      'make offers' => /Make offers and reject applications:\s+University of Purley/,
-      'view safeguarding' => /View criminal convictions and professional misconduct:\s+University of Croydon\s+University of Purley/,
-      'view diversity' => /View criminal convictions and professional misconduct:\s+University of Croydon\s+University of Purley/,
+      'make offers' => /Make offers and reject applications:\s+- University of Purley/,
+      'view safeguarding' => /View criminal convictions and professional misconduct:\s+- University of Purley\s+- University of Croydon/,
+      'view diversity' => /View criminal convictions and professional misconduct:\s+- University of Purley\s+- University of Croydon/,
     )
   end
 
@@ -263,11 +263,11 @@ RSpec.describe ProviderMailer, type: :mailer do
     it_behaves_like(
       'a mail with subject and content',
       'University of Croydon has changed organisation permissions for teacher training courses you work on with them',
-      'salutation' => 'Dear Johny',
+      'salutation' => 'Dear Johny English',
       'heading' => 'University of Croydon has changed organisation permissions for teacher training courses you work on with them',
-      'make offers' => /Make offers and reject applications:\s+University of Purley/,
-      'view safeguarding' => /View criminal convictions and professional misconduct:\s+University of Croydon\s+University of Purley/,
-      'view diversity' => /View criminal convictions and professional misconduct:\s+University of Croydon\s+University of Purley/,
+      'make offers' => /Make offers and reject applications:\s+- University of Purley/,
+      'view safeguarding' => /View criminal convictions and professional misconduct:\s+- University of Purley\s+- University of Croydon/,
+      'view diversity' => /View criminal convictions and professional misconduct:\s+- University of Purley\s+- University of Croydon/,
     )
   end
 end

--- a/spec/models/provider_relationship_permissions_spec.rb
+++ b/spec/models/provider_relationship_permissions_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe ProviderRelationshipPermissions do
     end
   end
 
-  describe '#partner_organisation' do
+  describe '#partner_organisations' do
     let(:training_provider) { create(:provider) }
     let(:ratifying_provider) { create(:provider) }
     let!(:relationship) do
@@ -107,19 +107,15 @@ RSpec.describe ProviderRelationshipPermissions do
       )
     end
 
-    context 'for a user from ratifying provider' do
-      let(:provider_user) { create(:provider_user, providers: [ratifying_provider]) }
-
+    context 'for a ratifying provider' do
       it 'is the training provider' do
-        expect(relationship.partner_organisation(provider_user)).to eq(training_provider)
+        expect(relationship.partner_organisation(ratifying_provider)).to eq(training_provider)
       end
     end
 
-    context 'for a user from training provider' do
-      let(:provider_user) { create(:provider_user, providers: [training_provider]) }
-
+    context 'for a training provider' do
       it 'is the ratifying provider' do
-        expect(relationship.partner_organisation(provider_user)).to eq(ratifying_provider)
+        expect(relationship.partner_organisation(training_provider)).to eq(ratifying_provider)
       end
     end
   end

--- a/spec/services/provider_interface/send_organisation_permissions_emails_spec.rb
+++ b/spec/services/provider_interface/send_organisation_permissions_emails_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::SendOrganisationPermissionsEmails do
   describe '#call' do
-    let(:training_provider) { create(:provider, :with_signed_agreement) }
-    let(:ratifying_provider) { create(:provider, :with_signed_agreement) }
+    let(:training_provider) { create(:provider, :with_signed_agreement, name: 'University of Croydon') }
+    let(:ratifying_provider) { create(:provider, :with_signed_agreement, name: 'University of Purley') }
     let!(:training_provider_users) { create_list(:provider_user, 3, providers: [training_provider]) }
     let!(:ratifying_provider_users) { create_list(:provider_user, 3, providers: [ratifying_provider]) }
     let(:message_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
 
-    subject(:service) { described_class.new(provider_user: provider_user, permissions: permissions, set_up: set_up) }
+    subject(:service) { described_class.new(provider_user: provider_user, provider: provider, permissions: permissions) }
 
     before do
       allow(ProviderMailer).to receive(:organisation_permissions_set_up).and_return(message_delivery)
@@ -20,63 +20,124 @@ RSpec.describe ProviderInterface::SendOrganisationPermissionsEmails do
     end
 
     context 'when permissions have not been set up' do
-      let(:set_up) { true }
       let(:permissions) do
         create(:provider_relationship_permissions, :not_set_up_yet, training_provider: training_provider, ratifying_provider: ratifying_provider)
       end
 
       context 'when the user is setting up permissions on behalf of the training provider' do
-        let(:provider_user) { training_provider_users.last }
+        let(:provider) { nil }
+        let(:provider_user) { training_provider_users.first }
 
-        it 'sends a set up email to users for the ratifying provider' do
+        it 'sends a set up email to managing users for the ratifying provider' do
           service.call
 
-          expect(ProviderMailer).to have_received(:organisation_permissions_set_up).with(ratifying_provider_users.first, permissions)
-          expect(ProviderMailer).not_to have_received(:organisation_permissions_set_up).with(ratifying_provider_users.second, permissions)
-          expect(ProviderMailer).to have_received(:organisation_permissions_set_up).with(ratifying_provider_users.last, permissions)
+          expect(ProviderMailer).to have_received(:organisation_permissions_set_up).with(ratifying_provider_users.first, ratifying_provider, permissions)
+          expect(ProviderMailer).not_to have_received(:organisation_permissions_set_up).with(ratifying_provider_users.second, ratifying_provider, permissions)
+          expect(ProviderMailer).to have_received(:organisation_permissions_set_up).with(ratifying_provider_users.last, ratifying_provider, permissions)
         end
       end
 
       context 'when the user is setting up permissions on behalf of the ratifying provider' do
-        let(:provider_user) { ratifying_provider_users.last }
+        let(:provider) { nil }
+        let(:provider_user) { ratifying_provider_users.first }
 
-        it 'sends a set up email to users for the training provider' do
+        it 'sends a set up email to managing users for the training provider' do
           service.call
 
-          expect(ProviderMailer).to have_received(:organisation_permissions_set_up).with(training_provider_users.first, permissions)
-          expect(ProviderMailer).not_to have_received(:organisation_permissions_set_up).with(training_provider_users.second, permissions)
-          expect(ProviderMailer).to have_received(:organisation_permissions_set_up).with(training_provider_users.last, permissions)
+          expect(ProviderMailer).to have_received(:organisation_permissions_set_up).with(training_provider_users.first, training_provider, permissions)
+          expect(ProviderMailer).not_to have_received(:organisation_permissions_set_up).with(training_provider_users.second, training_provider, permissions)
+          expect(ProviderMailer).to have_received(:organisation_permissions_set_up).with(training_provider_users.last, training_provider, permissions)
+        end
+      end
+
+      context 'when the user setting up permissions belongs to both orgs in the permissions relationship' do
+        let(:provider) { nil }
+        let(:provider_user) { ratifying_provider_users.first }
+
+        before do
+          training_provider_users.first.providers << ratifying_provider
+          training_provider_users.last.providers << ratifying_provider
+          ratifying_provider_users.first.providers << training_provider
+          ratifying_provider_users.last.providers << training_provider
+        end
+
+        it 'sends a set up email to managing users for alphabetically first provider' do
+          service.call
+
+          expect(ProviderMailer).to have_received(:organisation_permissions_set_up).with(training_provider_users.first, training_provider, permissions)
+          expect(ProviderMailer).not_to have_received(:organisation_permissions_set_up).with(training_provider_users.second, training_provider, permissions)
+          expect(ProviderMailer).to have_received(:organisation_permissions_set_up).with(training_provider_users.last, training_provider, permissions)
         end
       end
     end
 
     context 'when permissions have already been set up' do
-      let(:set_up) { false }
       let(:permissions) do
         create(:provider_relationship_permissions, training_provider: training_provider, ratifying_provider: ratifying_provider)
       end
 
       context 'when the user is making changes on behalf of the training provider' do
-        let(:provider_user) { training_provider_users.last }
+        let(:provider) { training_provider }
+        let(:provider_user) { training_provider_users.first }
 
-        it 'sends an update email to the users for the ratifying provider' do
+        it 'sends an update email to managing users for the ratifying provider' do
           service.call
 
-          expect(ProviderMailer).to have_received(:organisation_permissions_updated).with(ratifying_provider_users.first, permissions)
-          expect(ProviderMailer).not_to have_received(:organisation_permissions_updated).with(ratifying_provider_users.second, permissions)
-          expect(ProviderMailer).to have_received(:organisation_permissions_updated).with(ratifying_provider_users.last, permissions)
+          expect(ProviderMailer).to have_received(:organisation_permissions_updated).with(ratifying_provider_users.first, ratifying_provider, permissions)
+          expect(ProviderMailer).not_to have_received(:organisation_permissions_updated).with(ratifying_provider_users.second, ratifying_provider, permissions)
+          expect(ProviderMailer).to have_received(:organisation_permissions_updated).with(ratifying_provider_users.last, ratifying_provider, permissions)
         end
       end
 
       context 'when the user is making changes on behalf of the ratifying provider' do
-        let(:provider_user) { ratifying_provider_users.last }
+        let(:provider) { ratifying_provider }
+        let(:provider_user) { ratifying_provider_users.first }
 
-        it 'sends an update email to the users for the training provider' do
+        it 'sends an update email to managing users for the training provider' do
           service.call
 
-          expect(ProviderMailer).to have_received(:organisation_permissions_updated).with(training_provider_users.first, permissions)
-          expect(ProviderMailer).not_to have_received(:organisation_permissions_updated).with(training_provider_users.second, permissions)
-          expect(ProviderMailer).to have_received(:organisation_permissions_updated).with(training_provider_users.last, permissions)
+          expect(ProviderMailer).to have_received(:organisation_permissions_updated).with(training_provider_users.first, training_provider, permissions)
+          expect(ProviderMailer).not_to have_received(:organisation_permissions_updated).with(training_provider_users.second, training_provider, permissions)
+          expect(ProviderMailer).to have_received(:organisation_permissions_updated).with(training_provider_users.last, training_provider, permissions)
+        end
+      end
+    end
+
+    context 'when the user changing permissions belongs to both orgs in the permissions relationship' do
+      let(:permissions) do
+        create(:provider_relationship_permissions, training_provider: training_provider, ratifying_provider: ratifying_provider)
+      end
+
+      before do
+        training_provider_users.first.providers << ratifying_provider
+        training_provider_users.last.providers << ratifying_provider
+        ratifying_provider_users.first.providers << training_provider
+        ratifying_provider_users.last.providers << training_provider
+      end
+
+      context 'when the context of the change is from the training provider' do
+        let(:provider) { training_provider }
+        let(:provider_user) { training_provider_users.first }
+
+        it 'sends an update email to managing users for the ratifying provider' do
+          service.call
+
+          expect(ProviderMailer).to have_received(:organisation_permissions_updated).with(ratifying_provider_users.first, ratifying_provider, permissions)
+          expect(ProviderMailer).not_to have_received(:organisation_permissions_updated).with(ratifying_provider_users.second, ratifying_provider, permissions)
+          expect(ProviderMailer).to have_received(:organisation_permissions_updated).with(ratifying_provider_users.last, ratifying_provider, permissions)
+        end
+      end
+
+      context 'when the context of the change is from the ratifying provider' do
+        let(:provider) { ratifying_provider }
+        let(:provider_user) { ratifying_provider_users.first }
+
+        it 'sends an update email to managing users for the training provider' do
+          service.call
+
+          expect(ProviderMailer).to have_received(:organisation_permissions_updated).with(training_provider_users.first, training_provider, permissions)
+          expect(ProviderMailer).not_to have_received(:organisation_permissions_updated).with(training_provider_users.second, training_provider, permissions)
+          expect(ProviderMailer).to have_received(:organisation_permissions_updated).with(training_provider_users.last, training_provider, permissions)
         end
       end
     end

--- a/spec/services/provider_interface/send_organisation_permissions_emails_spec.rb
+++ b/spec/services/provider_interface/send_organisation_permissions_emails_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::SendOrganisationPermissionsEmails do
+  describe '#call' do
+    let(:training_provider) { create(:provider, :with_signed_agreement) }
+    let(:ratifying_provider) { create(:provider, :with_signed_agreement) }
+    let!(:training_provider_users) { create_list(:provider_user, 3, providers: [training_provider]) }
+    let!(:ratifying_provider_users) { create_list(:provider_user, 3, providers: [ratifying_provider]) }
+    let(:message_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+    subject(:service) { described_class.new(provider_user: provider_user, permissions: permissions, set_up: set_up) }
+
+    before do
+      allow(ProviderMailer).to receive(:organisation_permissions_set_up).and_return(message_delivery)
+      allow(ProviderMailer).to receive(:organisation_permissions_updated).and_return(message_delivery)
+      training_provider_users.first.provider_permissions.update_all(manage_organisations: true)
+      training_provider_users.last.provider_permissions.update_all(manage_organisations: true)
+      ratifying_provider_users.first.provider_permissions.update_all(manage_organisations: true)
+      ratifying_provider_users.last.provider_permissions.update_all(manage_organisations: true)
+    end
+
+    context 'when permissions have not been set up' do
+      let(:set_up) { true }
+      let(:permissions) do
+        create(:provider_relationship_permissions, :not_set_up_yet, training_provider: training_provider, ratifying_provider: ratifying_provider)
+      end
+
+      context 'when the user is setting up permissions on behalf of the training provider' do
+        let(:provider_user) { training_provider_users.last }
+
+        it 'sends a set up email to users for the ratifying provider' do
+          service.call
+
+          expect(ProviderMailer).to have_received(:organisation_permissions_set_up).with(ratifying_provider_users.first, permissions)
+          expect(ProviderMailer).not_to have_received(:organisation_permissions_set_up).with(ratifying_provider_users.second, permissions)
+          expect(ProviderMailer).to have_received(:organisation_permissions_set_up).with(ratifying_provider_users.last, permissions)
+        end
+      end
+
+      context 'when the user is setting up permissions on behalf of the ratifying provider' do
+        let(:provider_user) { ratifying_provider_users.last }
+
+        it 'sends a set up email to users for the training provider' do
+          service.call
+
+          expect(ProviderMailer).to have_received(:organisation_permissions_set_up).with(training_provider_users.first, permissions)
+          expect(ProviderMailer).not_to have_received(:organisation_permissions_set_up).with(training_provider_users.second, permissions)
+          expect(ProviderMailer).to have_received(:organisation_permissions_set_up).with(training_provider_users.last, permissions)
+        end
+      end
+    end
+
+    context 'when permissions have already been set up' do
+      let(:set_up) { false }
+      let(:permissions) do
+        create(:provider_relationship_permissions, training_provider: training_provider, ratifying_provider: ratifying_provider)
+      end
+
+      context 'when the user is making changes on behalf of the training provider' do
+        let(:provider_user) { training_provider_users.last }
+
+        it 'sends an update email to the users for the ratifying provider' do
+          service.call
+
+          expect(ProviderMailer).to have_received(:organisation_permissions_updated).with(ratifying_provider_users.first, permissions)
+          expect(ProviderMailer).not_to have_received(:organisation_permissions_updated).with(ratifying_provider_users.second, permissions)
+          expect(ProviderMailer).to have_received(:organisation_permissions_updated).with(ratifying_provider_users.last, permissions)
+        end
+      end
+
+      context 'when the user is making changes on behalf of the ratifying provider' do
+        let(:provider_user) { ratifying_provider_users.last }
+
+        it 'sends an update email to the users for the training provider' do
+          service.call
+
+          expect(ProviderMailer).to have_received(:organisation_permissions_updated).with(training_provider_users.first, permissions)
+          expect(ProviderMailer).not_to have_received(:organisation_permissions_updated).with(training_provider_users.second, permissions)
+          expect(ProviderMailer).to have_received(:organisation_permissions_updated).with(training_provider_users.last, permissions)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/mailers.rb
+++ b/spec/support/shared_examples/mailers.rb
@@ -3,8 +3,12 @@ RSpec.shared_examples 'a mail with subject and content' do |email_subject, conte
     expect(email.subject).to include(email_subject)
 
     content.each do |_, expectation|
-      expectation = expectation.call if expectation.respond_to?(:call)
-      expect(email.body).to include(expectation)
+      if expectation.is_a?(Regexp)
+        expect(email.body).to match(expectation)
+      else
+        expectation = expectation.call if expectation.respond_to?(:call)
+        expect(email.body).to include(expectation)
+      end
     end
   end
 end

--- a/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
@@ -35,6 +35,7 @@ RSpec.feature 'Setting up organisation permissions' do
 
     when_i_click_on_save_organisation_permissions
     then_i_see_the_success_page
+    and_an_email_is_sent_to_managing_users_in_the_partner_organisations
     and_the_permissions_have_been_set_up_correctly
   end
 
@@ -49,8 +50,14 @@ RSpec.feature 'Setting up organisation permissions' do
     @ratifying_provider = Provider.find_by(code: 'DEF')
 
     @another_ratifying_provider = create(:provider, :with_signed_agreement)
+    @another_ratifying_provider_users = create_list(:provider_user, 2, providers: [@another_ratifying_provider])
     @another_training_provider = create(:provider, :with_signed_agreement)
+    @another_training_provider_users = create_list(:provider_user, 2, providers: [@another_training_provider])
+
     @provider_user.provider_permissions.update_all(manage_organisations: true)
+    (@another_training_provider_users + @another_ratifying_provider_users).each do |user|
+      user.provider_permissions.update_all(manage_organisations: true)
+    end
   end
 
   def and_my_organisations_have_not_had_permissions_setup
@@ -138,6 +145,18 @@ RSpec.feature 'Setting up organisation permissions' do
 
   def then_i_see_the_success_page
     expect(page).to have_content('Organisation permissions set up')
+  end
+
+  def and_an_email_is_sent_to_managing_users_in_the_partner_organisations
+    @another_training_provider_users.each do |user|
+      open_email(user.email_address)
+      expect(current_email.subject).to have_content t('provider_mailer.organisation_permissions_set_up.subject', provider: @ratifying_provider.name)
+    end
+
+    @another_ratifying_provider_users.each do |user|
+      open_email(user.email_address)
+      expect(current_email.subject).to have_content t('provider_mailer.organisation_permissions_set_up.subject', provider: @training_provider.name)
+    end
   end
 
   def and_the_permissions_have_been_set_up_correctly

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -54,6 +54,8 @@ RSpec.feature 'Docs' do
       candidate_mailer-unconditional_offer_accepted
       provider_mailer-unconditional_offer_accepted
       provider_mailer-confirm_sign_in
+      provider_mailer-organisation_permissions_set_up
+      provider_mailer-organisation_permissions_updated
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"


### PR DESCRIPTION
## Context

Provider users need better notifications when their organisational permissions have changed.

We want to notify users about what permissions have changed.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds a service to find valid recipients in the partner organisation when organisational permissions are set up or changed.
- Adds 2 new emails to notify users with _manage organisations_ permissions that permissions have either been set up or changed by the partner organisation

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/qxtXxvCi/4003-implement-emails-to-let-user-know-of-changes-to-organisational-permissions
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
