### PR TITLE
Rubocop cleanup - Rails & RSpec cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,8 +59,3 @@ Govuk/GovukLinkTo:
     # link_to for kaminari pagination links
     - 'app/views/kaminari/_next_page.html.erb'
     - 'app/views/kaminari/_prev_page.html.erb'
-
-Style/IdenticalConditionalBranches:
-  Exclude:
-    # wizard.clear_state! duplication in commit method conditional
-    - 'app/controllers/provider_interface/organisation_permissions_setup_controller.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -61,7 +61,3 @@ Rails/ReversibleMigration:
 # Configuration parameters: AllowImplicitReturn, AllowedReceivers.
 Rails/SaveBang:
   Enabled: false
-
-Style/CombinableLoops:
-  Exclude:
-    - 'app/presenters/support_interface/provider_relationships_diagram.rb'

--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -6,7 +6,7 @@ module SupportInterface
 
     def course_options
       @course_options = CourseOption
-        .where('vacancy_status != ?', 'vacancies')
+        .where.not('vacancy_status = ?', 'vacancies')
         .includes(:course, :site)
         .page(params[:page] || 1)
         .per(30)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -17,7 +17,7 @@ class Course < ApplicationRecord
   scope :in_cycle, ->(year) { where(recruitment_cycle_year: year) }
   scope :with_subjects, ->(subject_ids) { joins(:subjects).merge(Subject.where(id: subject_ids)) }
 
-  scope :with_course_options, -> { left_outer_joins(:course_options).where('course_options.id IS NOT NULL') }
+  scope :with_course_options, -> { left_outer_joins(:course_options).where.not(course_options: { id: nil }) }
   CODE_LENGTH = 4
 
   # This enum is copied verbatim from Find to maintain consistency

--- a/app/services/data_api/tad_export.rb
+++ b/app/services/data_api/tad_export.rb
@@ -11,7 +11,7 @@ module DataAPI
     def self.all
       DataExport
         .where(export_type: :tad_applications)
-        .where('completed_at IS NOT NULL')
+        .where.not(completed_at: nil)
     end
 
     def self.latest

--- a/app/services/support_interface/application_monitor.rb
+++ b/app/services/support_interface/application_monitor.rb
@@ -28,7 +28,7 @@ module SupportInterface
       ApplicationForm
         .includes(%i[candidate application_choices])
         .joins(application_choices: [:course_option])
-        .where('application_choices.status NOT IN (?)', ApplicationStateChange::TERMINAL_STATES)
+        .where.not(application_choices: { status: ApplicationStateChange::TERMINAL_STATES })
         .order('application_forms.id desc')
         .distinct
     end

--- a/app/workers/cancel_unsubmitted_applications_worker.rb
+++ b/app/workers/cancel_unsubmitted_applications_worker.rb
@@ -15,10 +15,7 @@ private
     ApplicationForm
       .where(submitted_at: nil)
       .where(recruitment_cycle_year: RecruitmentCycle.current_year)
-      .where(
-        'application_forms.candidate_id NOT IN (:hidden_candidates)',
-        hidden_candidates: Candidate.where(hide_in_reporting: true).select(:id),
-      )
+      .where.not(application_forms: { candidate_id: Candidate.where(hide_in_reporting: true).select(:id) })
       .where(application_forms: { id: ApplicationChoice.unsubmitted.select(:application_form_id) })
       .includes(:application_choices)
       .distinct

--- a/config/rubocop/config/rails.yml
+++ b/config/rubocop/config/rails.yml
@@ -85,7 +85,7 @@ Rails/WhereExists:
   Enabled: true
 
 Rails/WhereNot:
-  Enabled: false
+  Enabled: true
 
 Rails/EnvironmentVariableAccess:
   Enabled: false

--- a/config/rubocop/config/rspec.yml
+++ b/config/rubocop/config/rspec.yml
@@ -47,9 +47,6 @@ RSpec/MultipleMemoizedHelpers:
 RSpec/StubbedMock:
   Enabled: true
 
-RSpec/Rails/HttpStatus:
-  Enabled: false
-
 RSpec/Capybara/FeatureMethods:
   EnabledMethods:
     - feature

--- a/config/rubocop/config/rspec.yml
+++ b/config/rubocop/config/rspec.yml
@@ -23,10 +23,6 @@ RSpec/EmptyLineAfterSubject:
 RSpec/LetSetup:
   Enabled: false
 
-# It's better to be explicit about the class that's being tested
-RSpec/DescribedClass:
-  Enabled: false
-
 # This cop wants us to use `expect().to change(Candidate, :count)` instead
 # of `expect().to change { Candidate.count }`, which does not seem better.
 RSpec/ExpectChange:

--- a/config/rubocop/config/rspec.yml
+++ b/config/rubocop/config/rspec.yml
@@ -47,9 +47,6 @@ RSpec/MultipleMemoizedHelpers:
 RSpec/StubbedMock:
   Enabled: true
 
-RSpec/FactoryBot/CreateList:
-  Enabled: false
-
 RSpec/Rails/HttpStatus:
   Enabled: false
 
@@ -57,3 +54,7 @@ RSpec/Capybara/FeatureMethods:
   EnabledMethods:
     - feature
     - scenario
+
+RSpec/FactoryBot/CreateList:
+  Exclude:
+    - 'spec/services/generate_test_applications_for_provider_spec.rb'

--- a/config/rubocop/config/style.yml
+++ b/config/rubocop/config/style.yml
@@ -82,3 +82,12 @@ Style/ExplicitBlockArgument:
 Style/NilLambda:
   Exclude:
     - app/views/provider_interface/interviews/cancel.html.erb
+
+Style/CombinableLoops:
+  Exclude:
+    - 'app/presenters/support_interface/provider_relationships_diagram.rb'
+
+Style/IdenticalConditionalBranches:
+  Exclude:
+    # wizard.clear_state! duplication in commit method conditional
+    - 'app/controllers/provider_interface/organisation_permissions_setup_controller.rb'

--- a/db/migrate/20201215211124_backfill_authentication_tokens.rb
+++ b/db/migrate/20201215211124_backfill_authentication_tokens.rb
@@ -1,6 +1,6 @@
 class BackfillAuthenticationTokens < ActiveRecord::Migration[6.0]
   def up
-    Candidate.where('magic_link_token IS NOT NULL').find_each do |candidate|
+    Candidate.where.not(magic_link_token: nil).find_each do |candidate|
       candidate.authentication_tokens.create!(
         hashed_token: candidate.magic_link_token,
         created_at: candidate.magic_link_token_sent_at,

--- a/spec/components/candidate_interface/application_status_tag_component_spec.rb
+++ b/spec/components/candidate_interface/application_status_tag_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
 
   ApplicationStateChange.valid_states.each do |state_name|
     it "renders with a #{state_name} application choice" do
-      render_inline CandidateInterface::ApplicationStatusTagComponent.new(application_choice: create(:application_choice, course: course, status: state_name))
+      render_inline described_class.new(application_choice: create(:application_choice, course: course, status: state_name))
     end
 
     context 'when the application choice is in the application_not_sent state' do

--- a/spec/components/candidate_interface/break_in_work_history_component_spec.rb
+++ b/spec/components/candidate_interface/break_in_work_history_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CandidateInterface::BreakInWorkHistoryComponent do
   end
 
   it 'renders the component with the break length, reason and dates' do
-    result = render_inline(CandidateInterface::BreakInWorkHistoryComponent.new(work_break: work_break))
+    result = render_inline(described_class.new(work_break: work_break))
 
     expect(result.text).to include('Break in work history (1 month)')
     expect(result.text).to include('I fell asleep.')
@@ -23,13 +23,13 @@ RSpec.describe CandidateInterface::BreakInWorkHistoryComponent do
 
   context 'when editable' do
     it 'renders the component with a delete link' do
-      result = render_inline(CandidateInterface::BreakInWorkHistoryComponent.new(work_break: work_break, editable: true))
+      result = render_inline(described_class.new(work_break: work_break, editable: true))
 
       expect(result.text).to include('Delete entry for break between February 2019 and April 2019')
     end
 
     it 'renders the component with change links' do
-      result = render_inline(CandidateInterface::BreakInWorkHistoryComponent.new(work_break: work_break, editable: true))
+      result = render_inline(described_class.new(work_break: work_break, editable: true))
 
       expect(result.text).to include('Change description for break between February 2019 and April 2019')
       expect(result.text).to include('Change dates for break between February 2019 and April 2019')
@@ -38,13 +38,13 @@ RSpec.describe CandidateInterface::BreakInWorkHistoryComponent do
 
   context 'when not editable' do
     it 'renders the component without a delete link' do
-      result = render_inline(CandidateInterface::BreakInWorkHistoryComponent.new(work_break: work_break, editable: false))
+      result = render_inline(described_class.new(work_break: work_break, editable: false))
 
       expect(result.text).not_to include('Delete entry for break between February 2019 and April 2019')
     end
 
     it 'renders the component without change links' do
-      result = render_inline(CandidateInterface::BreakInWorkHistoryComponent.new(work_break: work_break, editable: false))
+      result = render_inline(described_class.new(work_break: work_break, editable: false))
 
       expect(result.text).not_to include('Change description for break between February 2019 and April 2019')
       expect(result.text).not_to include('Change dates for break between February 2019 and April 2019')

--- a/spec/components/candidate_interface/break_placeholder_in_work_history_component_spec.rb
+++ b/spec/components/candidate_interface/break_placeholder_in_work_history_component_spec.rb
@@ -10,19 +10,19 @@ RSpec.describe CandidateInterface::BreakPlaceholderInWorkHistoryComponent do
   end
 
   it 'renders the component with a link to explain break' do
-    result = render_inline(CandidateInterface::BreakPlaceholderInWorkHistoryComponent.new(work_break: work_break))
+    result = render_inline(described_class.new(work_break: work_break))
 
     expect(result.text).to include('Explain break between January 2020 and May 2020')
   end
 
   it 'renders the component with a link to add another job' do
-    result = render_inline(CandidateInterface::BreakPlaceholderInWorkHistoryComponent.new(work_break: work_break))
+    result = render_inline(described_class.new(work_break: work_break))
 
     expect(result.text).to include('add another job between January 2020 and May 2020')
   end
 
   it 'renders the component with the break length' do
-    result = render_inline(CandidateInterface::BreakPlaceholderInWorkHistoryComponent.new(work_break: work_break))
+    result = render_inline(described_class.new(work_break: work_break))
 
     expect(result.text).to include('You have a break in your work history in the last 5 years (3 months)')
   end

--- a/spec/components/candidate_interface/gcse_grade_guidance_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_grade_guidance_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
     it 'displays the guidance around the expectation of providers' do
       subject = 'maths'
 
-      result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
+      result = render_inline(described_class.new(subject, nil))
 
       expect(result.text).to include(t('gcse_edit_grade.guidance.main'))
     end
@@ -13,7 +13,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
     it 'does not display the guidance around triple science' do
       subject = 'maths'
 
-      result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
+      result = render_inline(described_class.new(subject, nil))
 
       expect(result.text).not_to include(t('gcse_edit_grade.guidance.o_level_triple_gcse_science'))
     end
@@ -21,7 +21,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
     it 'does not display the guidance around english literature and multiple english qualifications' do
       subject = 'maths'
 
-      result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
+      result = render_inline(described_class.new(subject, nil))
 
       expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_gcses.main'))
       expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_gcses.secondary'))
@@ -32,7 +32,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
     it 'displays the guidance around the expectation of providers' do
       subject = 'science'
 
-      result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
+      result = render_inline(described_class.new(subject, nil))
 
       expect(result.text).to include(t('gcse_edit_grade.guidance.main'))
     end
@@ -40,7 +40,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
     it 'does not display the guidance around english literature and multiple english qualifications' do
       subject = 'science'
 
-      result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
+      result = render_inline(described_class.new(subject, nil))
 
       expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_gcses.main'))
       expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_gcses.secondary'))
@@ -51,7 +51,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
         subject = 'science'
         qualification_type = 'gcse'
 
-        result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
+        result = render_inline(described_class.new(subject, qualification_type))
 
         expect(result.text).to include(t('gcse_edit_grade.guidance.o_level_triple_gcse_science'))
         expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_scottish_national_science'))
@@ -63,7 +63,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
         subject = 'science'
         qualification_type = 'gce_o_level'
 
-        result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
+        result = render_inline(described_class.new(subject, qualification_type))
 
         expect(result.text).to include(t('gcse_edit_grade.guidance.o_level_triple_gcse_science'))
         expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_scottish_national_science'))
@@ -75,7 +75,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
         subject = 'science'
         qualification_type = 'scottish_national_5'
 
-        result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
+        result = render_inline(described_class.new(subject, qualification_type))
 
         expect(result.text).to include(t('gcse_edit_grade.guidance.triple_scottish_national_science'))
         expect(result.text).not_to include(t('gcse_edit_grade.guidance.o_level_triple_gcse_science'))
@@ -87,7 +87,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
         subject = 'science'
         qualification_type = 'other_uk'
 
-        result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
+        result = render_inline(described_class.new(subject, qualification_type))
 
         expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_scottish_national_science'))
         expect(result.text).not_to include(t('gcse_edit_grade.guidance.o_level_triple_gcse_science'))
@@ -99,7 +99,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
     it 'displays the guidance around the expectation of providers for multiple English GCSEs' do
       subject = 'english'
 
-      result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, 'gcse'))
+      result = render_inline(described_class.new(subject, 'gcse'))
 
       expect(result.text).to include(t('gcse_edit_grade.guidance.multiple_english_gcses.main'))
       expect(result.text).to include(t('gcse_edit_grade.guidance.multiple_english_gcses.secondary'))
@@ -108,7 +108,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
     it 'does not display the guidance around triple science' do
       subject = 'english'
 
-      result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
+      result = render_inline(described_class.new(subject, nil))
 
       expect(result.text).not_to include(t('gcse_edit_grade.guidance.o_level_triple_gcse_science'))
     end
@@ -118,7 +118,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
         subject = 'english'
         qualification_type = 'scottish_national_5'
 
-        result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
+        result = render_inline(described_class.new(subject, qualification_type))
 
         expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_gcses.main'))
         expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_gcses.secondary'))
@@ -130,7 +130,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
         subject = 'english'
         qualification_type = 'other_uk'
 
-        result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
+        result = render_inline(described_class.new(subject, qualification_type))
 
         expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_gcses.main'))
         expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_gcses.secondary'))

--- a/spec/components/candidate_interface/safeguarding_review_component_spec.rb
+++ b/spec/components/candidate_interface/safeguarding_review_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CandidateInterface::SafeguardingReviewComponent do
         safeguarding_issues_status: :has_safeguarding_issues_to_declare,
       )
 
-      result = render_inline(CandidateInterface::SafeguardingReviewComponent.new(application_form: application_form))
+      result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.text).to include('Do you want to share any safeguarding issues?')
       expect(result.text).to include('Yes')
@@ -26,7 +26,7 @@ RSpec.describe CandidateInterface::SafeguardingReviewComponent do
         safeguarding_issues_status: :no_safeguarding_issues_to_declare,
       )
 
-      result = render_inline(CandidateInterface::SafeguardingReviewComponent.new(application_form: application_form))
+      result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.text).to include('Do you want to share any safeguarding issues?')
       expect(result.text).to include('No')
@@ -42,7 +42,7 @@ RSpec.describe CandidateInterface::SafeguardingReviewComponent do
         safeguarding_issues_status: :has_safeguarding_issues_to_declare,
       )
 
-      result = render_inline(CandidateInterface::SafeguardingReviewComponent.new(application_form: application_form))
+      result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.text).to include('Do you want to share any safeguarding issues?')
       expect(result.text).to include('Yes')
@@ -59,7 +59,7 @@ RSpec.describe CandidateInterface::SafeguardingReviewComponent do
         safeguarding_issues_status: :has_safeguarding_issues_to_declare,
       )
 
-      result = render_inline(CandidateInterface::SafeguardingReviewComponent.new(application_form: application_form, editable: true))
+      result = render_inline(described_class.new(application_form: application_form, editable: true))
 
       expect(result.text).to include('Change if you want to share any safeguarding issues')
       expect(result.text).to include('Change relevant information for safeguarding issues')
@@ -74,7 +74,7 @@ RSpec.describe CandidateInterface::SafeguardingReviewComponent do
         safeguarding_issues_status: :has_safeguarding_issues_to_declare,
       )
 
-      result = render_inline(CandidateInterface::SafeguardingReviewComponent.new(application_form: application_form, editable: false))
+      result = render_inline(described_class.new(application_form: application_form, editable: false))
 
       expect(result.text).not_to include('Change if you want to share any safeguarding issues')
       expect(result.text).not_to include('Change relevant information for safeguarding issues')

--- a/spec/components/candidate_interface/ucas_downtime_component_spec.rb
+++ b/spec/components/candidate_interface/ucas_downtime_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CandidateInterface::UCASDowntimeComponent do
     it 'renders the banner' do
       FeatureFlag.activate('banner_for_ucas_downtime')
 
-      result = render_inline(CandidateInterface::UCASDowntimeComponent.new)
+      result = render_inline(described_class.new)
 
       expect(result.text).to include('UCAS services will not be available from 6pm on Friday 24 April until Sunday 26 April.')
     end
@@ -15,7 +15,7 @@ RSpec.describe CandidateInterface::UCASDowntimeComponent do
     it 'does not render the banner' do
       FeatureFlag.deactivate('banner_for_ucas_downtime')
 
-      result = render_inline(CandidateInterface::UCASDowntimeComponent.new)
+      result = render_inline(described_class.new)
 
       expect(result.text).to eq('')
     end

--- a/spec/components/header_component_spec.rb
+++ b/spec/components/header_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe HeaderComponent do
   let(:navigation_items) { [] }
 
   subject(:rendered_component) do
-    render_inline(HeaderComponent.new(navigation_items: navigation_items, service_name: '', service_link: '#'))
+    render_inline(described_class.new(navigation_items: navigation_items, service_name: '', service_link: '#'))
   end
 
   describe 'rendering NavigationItems' do

--- a/spec/components/phase_banner_component_spec.rb
+++ b/spec/components/phase_banner_component_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe PhaseBannerComponent do
     end
 
     it 'renders a feedback link' do
-      result = render_inline(PhaseBannerComponent.new)
+      result = render_inline(described_class.new)
 
       expect(result.css('.govuk-link').attribute('href').value).to eq('mailto:becomingateacher@digital.education.gov.uk?subject=Feedback%20about%20Apply%20for%20teacher%20training')
     end
 
     specify 'the feedback link can be overridden' do
-      result = render_inline(PhaseBannerComponent.new(feedback_link: 'http://geocities.com'))
+      result = render_inline(described_class.new(feedback_link: 'http://geocities.com'))
 
       expect(result.css('.govuk-link').attribute('href').value).to eq('http://geocities.com')
     end

--- a/spec/components/provider_interface/application_status_tag_component_spec.rb
+++ b/spec/components/provider_interface/application_status_tag_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ProviderInterface::ApplicationStatusTagComponent do
   ApplicationStateChange.valid_states.each do |state_name|
     it "renders with a #{state_name} application choice" do
-      render_inline ProviderInterface::ApplicationStatusTagComponent.new(application_choice: FactoryBot.build_stubbed(:application_choice, status: state_name))
+      render_inline described_class.new(application_choice: FactoryBot.build_stubbed(:application_choice, status: state_name))
     end
   end
 end

--- a/spec/components/provider_interface/personal_details_component_spec.rb
+++ b/spec/components/provider_interface/personal_details_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ProviderInterface::PersonalDetailsComponent do
     )
   end
 
-  subject(:result) { render_inline(ProviderInterface::PersonalDetailsComponent.new(application_form: application_form)) }
+  subject(:result) { render_inline(described_class.new(application_form: application_form)) }
 
   it 'renders component with correct labels' do
     ['First name', 'Last name', 'Date of birth', 'Nationality', 'Phone number', 'Email address', 'Address'].each do |key|
@@ -66,7 +66,7 @@ RSpec.describe ProviderInterface::PersonalDetailsComponent do
     it 'renders their right to work or study status' do
       ProviderInterface::PersonalDetailsComponent::RIGHT_TO_WORK_OR_STUDY_DISPLAY_VALUES.each do |key, value|
         application_form.right_to_work_or_study = key
-        result = render_inline(ProviderInterface::PersonalDetailsComponent.new(application_form: application_form))
+        result = render_inline(described_class.new(application_form: application_form))
         row_title = result.css('.govuk-summary-list__row')[4].css('dt').text
         row_value = result.css('.govuk-summary-list__row')[4].css('dd').text
         expect(row_title).to include 'Has the right to work or study in the UK?'

--- a/spec/components/provider_interface/summer_recruitment_banner_spec.rb
+++ b/spec/components/provider_interface/summer_recruitment_banner_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ProviderInterface::SummerRecruitmentBanner do
   before { FeatureFlag.activate('summer_recruitment_banner') }
 
-  subject(:result) { render_inline(ProviderInterface::SummerRecruitmentBanner.new) }
+  subject(:result) { render_inline(described_class.new) }
 
   context 'when the provider information banner feature flag is on' do
     it 'renders the banner title' do

--- a/spec/components/restructured_work_history/gap_component_spec.rb
+++ b/spec/components/restructured_work_history/gap_component_spec.rb
@@ -10,21 +10,21 @@ RSpec.describe RestructuredWorkHistory::GapComponent do
   end
 
   it 'renders the component with a link to explain break' do
-    result = render_inline(RestructuredWorkHistory::GapComponent.new(break_period: break_period))
+    result = render_inline(described_class.new(break_period: break_period))
 
     expect(result.text).to include('Add another job between January 2020 and May 2020')
     expect(result.css('a').last.attributes['href'].value).to eq '/candidate/application/restructured-work-history/explain-break/new?end_date=2020-05-01&start_date=2020-01-01'
   end
 
   it 'renders the component with a link to add another job' do
-    result = render_inline(RestructuredWorkHistory::GapComponent.new(break_period: break_period))
+    result = render_inline(described_class.new(break_period: break_period))
 
     expect(result.text).to include('Add another job between January 2020 and May 2020')
     expect(result.css('a').first.attributes['href'].value).to eq '/candidate/application/restructured-work-history/new'
   end
 
   it 'renders the component with the break length' do
-    result = render_inline(RestructuredWorkHistory::GapComponent.new(break_period: break_period))
+    result = render_inline(described_class.new(break_period: break_period))
 
     expect(result.text).to include('You have a break in your work history (3 months)')
   end

--- a/spec/components/restructured_work_history/work_break_component_spec.rb
+++ b/spec/components/restructured_work_history/work_break_component_spec.rb
@@ -14,33 +14,33 @@ RSpec.describe RestructuredWorkHistory::WorkBreakComponent do
   end
 
   it 'renders the component with the break length, reason and dates' do
-    result = render_inline(RestructuredWorkHistory::WorkBreakComponent.new(work_break: work_break))
+    result = render_inline(described_class.new(work_break: work_break))
 
     expect(result.text).to include('I fell asleep.')
     expect(result.text).to include('Feb 2019 to Apr 2019')
   end
 
   it 'renders the component with a delete link' do
-    result = render_inline(RestructuredWorkHistory::WorkBreakComponent.new(work_break: work_break))
+    result = render_inline(described_class.new(work_break: work_break))
 
     expect(result.css('a').first.text).to include('Change entry for break between Feb 2019 and Apr 2019')
   end
 
   it 'renders the component with change links' do
-    result = render_inline(RestructuredWorkHistory::WorkBreakComponent.new(work_break: work_break))
+    result = render_inline(described_class.new(work_break: work_break))
 
     expect(result.css('a').last.text).to include('Delete entry for break between Feb 2019 and Apr 2019')
   end
 
   context 'when not editable' do
     it 'renders the component without a delete link' do
-      result = render_inline(RestructuredWorkHistory::WorkBreakComponent.new(work_break: work_break, editable: false))
+      result = render_inline(described_class.new(work_break: work_break, editable: false))
 
       expect(result.text).not_to include('Delete entry for break between Feb 2019 and Apr 2019')
     end
 
     it 'renders the component without change links' do
-      result = render_inline(RestructuredWorkHistory::WorkBreakComponent.new(work_break: work_break, editable: false))
+      result = render_inline(described_class.new(work_break: work_break, editable: false))
 
       expect(result.text).not_to include('Change description for break between Feb 2019 and Apr 2019')
       expect(result.text).not_to include('Change dates for break between Feb 2019 and Apr 2019')

--- a/spec/components/service_information_banner_spec.rb
+++ b/spec/components/service_information_banner_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ServiceInformationBanner do
 
   before { FeatureFlag.activate('service_information_banner') }
 
-  subject(:result) { render_inline(ServiceInformationBanner.new(namespace: namespace)) }
+  subject(:result) { render_inline(described_class.new(namespace: namespace)) }
 
   context 'in the provider namespace' do
     it 'renders the banner' do

--- a/spec/components/service_unavailable_component_spec.rb
+++ b/spec/components/service_unavailable_component_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ServiceUnavailableComponent do
-  subject(:result) { render_inline(ServiceUnavailableComponent.new) }
+  subject(:result) { render_inline(described_class.new) }
 
   it 'renders the page title' do
     expect(result.text).to include('Sorry, this service is unavailable')

--- a/spec/components/summary_card_component_spec.rb
+++ b/spec/components/summary_card_component_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe SummaryCardComponent do
   end
 
   it 'renders a summary list component for rows' do
-    result = render_inline(SummaryCardComponent.new(rows: rows))
+    result = render_inline(described_class.new(rows: rows))
     expect(result.css('.govuk-summary-list__value').text).to include('Lando Calrissian')
     expect(result.css('.govuk-summary-list__key').text).to include('Character')
   end
 
   it 'renders content at the top of a summary card' do
-    result = render_inline(SummaryCardComponent.new(rows: rows)) { 'In a galaxy' }
+    result = render_inline(described_class.new(rows: rows)) { 'In a galaxy' }
     expect(result.text).to include('In a galaxy')
   end
 end

--- a/spec/components/summary_card_header_component_spec.rb
+++ b/spec/components/summary_card_header_component_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe SummaryCardHeaderComponent do
   it 'renders a summary card header component with a title only' do
-    result = render_inline(SummaryCardHeaderComponent.new(title: 'Lando Calrissian'))
+    result = render_inline(described_class.new(title: 'Lando Calrissian'))
     expect(result.css('.app-summary-card__title').text).to include('Lando Calrissian')
     expect(result.css('.app-summary-card__meta').text).not_to be_present
     expect(result.css('.app-icon').text).not_to be_present
   end
 
   it 'renders a summary card header component with a custom heading level' do
-    result = render_inline(SummaryCardHeaderComponent.new(title: 'Lando Calrissian', heading_level: 6))
+    result = render_inline(described_class.new(title: 'Lando Calrissian', heading_level: 6))
     expect(result.css('h6.app-summary-card__title')).to be_present
   end
 end

--- a/spec/components/summary_list_component_spec.rb
+++ b/spec/components/summary_list_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SummaryListComponent do
       action: 'Name',
       change_path: '/some/url',
     ]
-    result = render_inline(SummaryListComponent.new(rows: rows))
+    result = render_inline(described_class.new(rows: rows))
 
     expect(result.css('.govuk-summary-list__key').text).to include('Name:')
     expect(result.css('.govuk-summary-list__value').text).to include('Lando Calrissian')
@@ -24,7 +24,7 @@ RSpec.describe SummaryListComponent do
         action: 'Name',
         change_path: '/some/url',
       ]
-      result = render_inline(SummaryListComponent.new(rows: rows))
+      result = render_inline(described_class.new(rows: rows))
 
       expect(result.css('.govuk-summary-list__value').to_html).to include('Whoa Drive<br>Wewvile<br>London')
     end
@@ -35,7 +35,7 @@ RSpec.describe SummaryListComponent do
         value: %w[A list of items],
         bulleted_format: true,
       ]
-      result = render_inline(SummaryListComponent.new(rows: rows))
+      result = render_inline(described_class.new(rows: rows))
 
       expect(result.to_html).to include(<<~HTML)
         <ul class="govuk-list govuk-list--bullet">
@@ -53,7 +53,7 @@ RSpec.describe SummaryListComponent do
         value: ['<script></script>', '<br>'],
         bulleted_format: true,
       ]
-      result = render_inline(SummaryListComponent.new(rows: rows))
+      result = render_inline(described_class.new(rows: rows))
 
       expect(result.to_html).to include(<<~HTML)
         <ul class="govuk-list govuk-list--bullet">
@@ -71,7 +71,7 @@ RSpec.describe SummaryListComponent do
       action: 'Enter cat sounds',
       action_path: '/cat/sounds',
     ]
-    result = render_inline(SummaryListComponent.new(rows: rows))
+    result = render_inline(described_class.new(rows: rows))
 
     expect(result.css('.govuk-summary-list__key').text).to include('Please enter the sound a cat makes')
     expect(result.css('.govuk-summary-list__value').text).to include('Meow')
@@ -85,7 +85,7 @@ RSpec.describe SummaryListComponent do
       value: '<span class="safe-html">This is safe</span>'.html_safe,
     ]
 
-    result = render_inline(SummaryListComponent.new(rows: rows))
+    result = render_inline(described_class.new(rows: rows))
     expect(result.css('.govuk-summary-list__value > .safe-html').text).to include('This is safe')
   end
 
@@ -95,7 +95,7 @@ RSpec.describe SummaryListComponent do
       value: '<span class="unsafe-html"><script>Unsafe</script></span>',
     ]
 
-    result = render_inline(SummaryListComponent.new(rows: rows))
+    result = render_inline(described_class.new(rows: rows))
     expect(result.css('.govuk-summary-list__value p').to_html).to eq('<p class="govuk-body">Unsafe</p>')
   end
 
@@ -104,7 +104,7 @@ RSpec.describe SummaryListComponent do
               value: 'Ice cream man',
               data_qa: 'ice-cream-man' }]
 
-    result = render_inline(SummaryListComponent.new(rows: rows))
+    result = render_inline(described_class.new(rows: rows))
 
     expect(result.css('[data-qa="ice-cream-man"]')).to be_present
   end
@@ -119,7 +119,7 @@ RSpec.describe SummaryListComponent do
         ] },
     ]
 
-    result = render_inline(SummaryListComponent.new(rows: rows))
+    result = render_inline(described_class.new(rows: rows))
 
     links = result.css('.govuk-summary-list__actions a')
 

--- a/spec/components/support_interface/application_status_tag_component_spec.rb
+++ b/spec/components/support_interface/application_status_tag_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportInterface::ApplicationStatusTagComponent do
   ApplicationStateChange.valid_states.each do |state_name|
     it "renders with a #{state_name} application choice" do
-      render_inline SupportInterface::ApplicationStatusTagComponent.new(status: state_name.to_s)
+      render_inline described_class.new(status: state_name.to_s)
     end
   end
 end

--- a/spec/components/support_interface/personal_details_component_spec.rb
+++ b/spec/components/support_interface/personal_details_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SupportInterface::PersonalDetailsComponent do
     )
   end
 
-  subject(:result) { render_inline(SupportInterface::PersonalDetailsComponent.new(application_form: application_form)) }
+  subject(:result) { render_inline(described_class.new(application_form: application_form)) }
 
   it 'renders component with correct labels' do
     ['First name', 'Last name', 'Date of birth', 'Nationality', 'Phone number', 'Email address', 'Address'].each do |key|
@@ -66,7 +66,7 @@ RSpec.describe SupportInterface::PersonalDetailsComponent do
     it 'renders their right to work or study status' do
       SupportInterface::PersonalDetailsComponent::RIGHT_TO_WORK_OR_STUDY_DISPLAY_VALUES.each do |key, value|
         application_form.right_to_work_or_study = key
-        result = render_inline(SupportInterface::PersonalDetailsComponent.new(application_form: application_form))
+        result = render_inline(described_class.new(application_form: application_form))
         row_title = result.css('.govuk-summary-list__row')[5].css('dt').text
         row_value = result.css('.govuk-summary-list__row')[5].css('dd').text
         expect(row_title).to include 'Has the right to work or study in the UK?'

--- a/spec/components/support_interface/provider_courses_table_component_spec.rb
+++ b/spec/components/support_interface/provider_courses_table_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
       course_option = create(:course_option, course: course)
       provider = course_option.course.provider
 
-      render_result = render_inline(SupportInterface::ProviderCoursesTableComponent.new(provider: provider, courses: provider.courses))
+      render_result = render_inline(described_class.new(provider: provider, courses: provider.courses))
 
       # Make a mapping colname -> colvalue
       fields = render_result.css('th').map(&:text).zip(
@@ -36,7 +36,7 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
                                             accredited_provider: provider,
                                             name: 'Accredited course'))
 
-      render_result = render_inline(SupportInterface::ProviderCoursesTableComponent.new(provider: provider, courses: provider.accredited_courses))
+      render_result = render_inline(described_class.new(provider: provider, courses: provider.accredited_courses))
 
       expect(render_result.text).to include('Accredited course')
       expect(render_result.text).to include('Other provider')
@@ -75,7 +75,7 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
       end
 
       it 'may include accredited providers' do
-        render_result = render_inline(SupportInterface::ProviderCoursesTableComponent.new(provider: provider, courses: provider.courses))
+        render_result = render_inline(described_class.new(provider: provider, courses: provider.courses))
 
         with_accredited = render_result.at_css("[data-qa=\"course-#{course_with_accredited_provider.id}\"]").text
         expect(with_accredited).to include('No users on Apply')

--- a/spec/components/support_interface/provider_user_summary_component_spec.rb
+++ b/spec/components/support_interface/provider_user_summary_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SupportInterface::ProviderUserSummaryComponent do
 
   subject(:rendered_component) do
     render_inline(
-      SupportInterface::ProviderUserSummaryComponent.new(provider_user),
+      described_class.new(provider_user),
     ).text
   end
 

--- a/spec/components/support_interface/provider_users_table_component_spec.rb
+++ b/spec/components/support_interface/provider_users_table_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportInterface::ProviderUsersTableComponent do
   subject(:rendered_component) do
     render_inline(
-      SupportInterface::ProviderUsersTableComponent.new(provider_users: provider_users),
+      described_class.new(provider_users: provider_users),
     ).text
   end
 

--- a/spec/components/support_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/support_interface/reference_with_feedback_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
     it 'is present when the reference is refused' do
       reference = create(:reference, feedback_status: 'feedback_refused')
 
-      render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
+      render_inline(described_class.new(reference: reference, reference_number: 1))
 
       expect(rendered_component).to include('Undo refusal')
     end
@@ -17,7 +17,7 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
     it 'includes the supplied reference number' do
       reference = create(:reference)
 
-      render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
+      render_inline(described_class.new(reference: reference, reference_number: 1))
 
       expect(rendered_component).to include('1st reference')
     end
@@ -25,7 +25,7 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
     it 'says if the reference is a replacement' do
       reference = create(:reference, replacement: true)
 
-      render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
+      render_inline(described_class.new(reference: reference, reference_number: 1))
 
       expect(rendered_component).to include('(replacement)')
     end
@@ -33,7 +33,7 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
     it 'includes the id of the reference' do
       reference = create(:reference)
 
-      render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
+      render_inline(described_class.new(reference: reference, reference_number: 1))
 
       expect(rendered_component).to include("##{reference.id}")
     end
@@ -42,7 +42,7 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
   describe 'selected row' do
     it 'indicates selected when the reference is selected' do
       reference = create(:reference, selected: true)
-      render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
+      render_inline(described_class.new(reference: reference, reference_number: 1))
 
       within_summary_row('Selected?') do
         expect(page).to include 'Yes'
@@ -51,7 +51,7 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
 
     it 'indicates not selected when the reference is not selected' do
       reference = create(:reference, selected: false)
-      render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
+      render_inline(described_class.new(reference: reference, reference_number: 1))
 
       within_summary_row('Selected?') do
         expect(page).to include 'No'

--- a/spec/errors/validation_exception_spec.rb
+++ b/spec/errors/validation_exception_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe ValidationException do
   it 'contains the correct error messages' do
     model = TestValidationException.new(name: name, surname: surname)
 
-    expect { model.execute }.to raise_error(ValidationException, 'Name can\'t be blank, Surname can\'t be blank')
+    expect { model.execute }.to raise_error(described_class, 'Name can\'t be blank, Surname can\'t be blank')
   end
 
   it 'can return the error messages in json format' do
     TestValidationException.new(name: name, surname: surname).execute
-  rescue ValidationException => e
+  rescue described_class => e
     expect(e.as_json).to eq(errors: [{ error: 'ValidationError', message: 'Name can\'t be blank' },
                                      { error: 'ValidationError', message: 'Surname can\'t be blank' }])
   end

--- a/spec/forms/candidate_interface/apply_on_ucas_or_apply_form_spec.rb
+++ b/spec/forms/candidate_interface/apply_on_ucas_or_apply_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CandidateInterface::ApplyOnUCASOrApplyForm, type: :model do
   describe '#apply?' do
     context 'when service is apply' do
       it 'returns true' do
-        form = CandidateInterface::ApplyOnUCASOrApplyForm.new(service: 'apply')
+        form = described_class.new(service: 'apply')
 
         expect(form.apply?).to eq(true)
       end
@@ -14,7 +14,7 @@ RSpec.describe CandidateInterface::ApplyOnUCASOrApplyForm, type: :model do
 
     context 'when service is ucas' do
       it 'returns false' do
-        form = CandidateInterface::ApplyOnUCASOrApplyForm.new(service: 'ucas')
+        form = described_class.new(service: 'ucas')
 
         expect(form.apply?).to eq(false)
       end

--- a/spec/forms/candidate_interface/becoming_a_teacher_form_spec.rb
+++ b/spec/forms/candidate_interface/becoming_a_teacher_form_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CandidateInterface::BecomingATeacherForm, type: :model do
   describe '.build_from_application' do
     it 'creates an object based on the provided ApplicationForm' do
       application_form = ApplicationForm.new(data)
-      becoming_a_teacher = CandidateInterface::BecomingATeacherForm.build_from_application(
+      becoming_a_teacher = described_class.build_from_application(
         application_form,
       )
 
@@ -26,14 +26,14 @@ RSpec.describe CandidateInterface::BecomingATeacherForm, type: :model do
 
   describe '#save' do
     it 'returns false if not valid' do
-      becoming_a_teacher = CandidateInterface::BecomingATeacherForm.new
+      becoming_a_teacher = described_class.new
 
       expect(becoming_a_teacher.save(ApplicationForm.new)).to eq(false)
     end
 
     it 'updates the provided ApplicationForm if valid' do
       application_form = FactoryBot.create(:application_form)
-      becoming_a_teacher = CandidateInterface::BecomingATeacherForm.new(form_data)
+      becoming_a_teacher = described_class.new(form_data)
 
       expect(becoming_a_teacher.save(application_form)).to eq(true)
       expect(application_form).to have_attributes(data)

--- a/spec/forms/candidate_interface/contact_details_form_spec.rb
+++ b/spec/forms/candidate_interface/contact_details_form_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
         postcode: Faker::Address.postcode,
       }
       application_form = build_stubbed(:application_form, data)
-      contact_details = CandidateInterface::ContactDetailsForm.build_from_application(application_form)
+      contact_details = described_class.build_from_application(application_form)
 
       expect(contact_details).to have_attributes(data)
     end
@@ -20,7 +20,7 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
 
   describe '#save_base' do
     it 'returns false if not valid' do
-      contact_details = CandidateInterface::ContactDetailsForm.new
+      contact_details = described_class.new
 
       expect(contact_details.save_base(ApplicationForm.new)).to eq(false)
     end
@@ -28,7 +28,7 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
     it 'updates the provided ApplicationForm if valid' do
       form_data = { phone_number: Faker::PhoneNumber.cell_phone }
       application_form = build(:application_form)
-      contact_details = CandidateInterface::ContactDetailsForm.new(form_data)
+      contact_details = described_class.new(form_data)
 
       expect(contact_details.save_base(application_form)).to eq(true)
       expect(application_form).to have_attributes(form_data)
@@ -37,7 +37,7 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
 
   describe '#save_address' do
     it 'returns false if not valid' do
-      contact_details = CandidateInterface::ContactDetailsForm.new
+      contact_details = described_class.new
 
       expect(contact_details.save_address(ApplicationForm.new)).to eq(false)
     end
@@ -52,7 +52,7 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
         postcode: 'bn1 1aa',
       }
       application_form = build(:application_form, international_address: 'some old address')
-      contact_details = CandidateInterface::ContactDetailsForm.new(form_data)
+      contact_details = described_class.new(form_data)
 
       form_data[:postcode] = 'BN1 1AA'
 
@@ -67,7 +67,7 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
         address_line4: '110006',
       }
       application_form = build(:application_form)
-      contact_details = CandidateInterface::ContactDetailsForm.new(form_data)
+      contact_details = described_class.new(form_data)
 
       expect(contact_details.save_address(application_form)).to eq(true)
       expect(application_form).to have_attributes(form_data)
@@ -83,7 +83,7 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
         address_type: 'uk',
       }
       application_form = build(:application_form)
-      contact_details = CandidateInterface::ContactDetailsForm.new(form_data)
+      contact_details = described_class.new(form_data)
 
       expect(contact_details.save_address_type(application_form)).to eq(true)
       expect(application_form).to have_attributes(form_data)
@@ -95,7 +95,7 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
         country: 'India',
       }
       application_form = build(:application_form)
-      contact_details = CandidateInterface::ContactDetailsForm.new(form_data)
+      contact_details = described_class.new(form_data)
 
       expect(contact_details.save_address_type(application_form)).to eq(true)
       expect(application_form).to have_attributes(form_data)
@@ -106,7 +106,7 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
         address_type: 'international',
       }
       application_form = build(:application_form)
-      contact_details = CandidateInterface::ContactDetailsForm.new(form_data)
+      contact_details = described_class.new(form_data)
 
       expect(contact_details.save_address_type(application_form)).to eq(false)
     end

--- a/spec/forms/candidate_interface/english_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/english_gcse_grade_form_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CandidateInterface::EnglishGcseGradeForm, type: :model do
           level: 'gcse',
         )
       end
-      let(:form) { CandidateInterface::EnglishGcseGradeForm.build_from_qualification(qualification) }
+      let(:form) { described_class.build_from_qualification(qualification) }
 
       it 'returns validation error if no GCSE is selected' do
         form.english_gcses = []
@@ -65,7 +65,7 @@ RSpec.describe CandidateInterface::EnglishGcseGradeForm, type: :model do
 
     context 'when qualification type is GCE O LEVEL' do
       let(:qualification) { build_stubbed(:application_qualification, qualification_type: 'gce_o_level', level: 'gcse', subject: 'english') }
-      let(:form) { CandidateInterface::EnglishGcseGradeForm.build_from_qualification(qualification) }
+      let(:form) { described_class.build_from_qualification(qualification) }
 
       it 'returns no errors if grade is valid' do
         valid_grades = ['ABC', 'AB', 'AA', 'abc', 'A B C', 'A-B-C']
@@ -97,7 +97,7 @@ RSpec.describe CandidateInterface::EnglishGcseGradeForm, type: :model do
                       level: 'gcse',
                       subject: 'english')
       end
-      let(:form) { CandidateInterface::EnglishGcseGradeForm.build_from_qualification(qualification) }
+      let(:form) { described_class.build_from_qualification(qualification) }
 
       it 'returns no errors if grade is valid' do
         valid_grades = ['AAA', 'AAB', '765', 'CBD', 'aaa', 'C B D', 'C-B-D']

--- a/spec/forms/candidate_interface/equality_and_diversity/choice_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/choice_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe CandidateInterface::EqualityAndDiversity::ChoiceForm, type: :model do
   describe '#initialize' do
     it 'defaults to yes' do
-      form = CandidateInterface::EqualityAndDiversity::ChoiceForm.new
+      form = described_class.new
 
       expect(form.choice).to eq('yes')
     end

--- a/spec/forms/candidate_interface/equality_and_diversity/disabilities_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/disabilities_form_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilitiesForm, type:
   describe '.build_from_application' do
     it 'creates an object based on the application form' do
       application_form = build_stubbed(:application_form, equality_and_diversity: { 'disabilities' => %w[Blind Deaf] })
-      form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.build_from_application(application_form)
+      form = described_class.build_from_application(application_form)
 
       expect(form.disabilities).to eq(%w[Blind Deaf])
     end
 
     it 'creates an object with other disability based on the application form' do
       application_form = build_stubbed(:application_form, equality_and_diversity: { 'disabilities' => ['Blind', 'Deaf', 'Other disability'] })
-      form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.build_from_application(application_form)
+      form = described_class.build_from_application(application_form)
 
       expect(form.disabilities).to eq(%w[Blind Deaf Other])
       expect(form.other_disability).to eq('Other disability')
@@ -19,7 +19,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilitiesForm, type:
 
     it 'allows other disability to be undisclosed' do
       application_form = build_stubbed(:application_form, equality_and_diversity: { 'disabilities' => %w[Blind Deaf Other] })
-      form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.build_from_application(application_form)
+      form = described_class.build_from_application(application_form)
 
       expect(form.disabilities).to eq(%w[Blind Deaf Other])
       expect(form.other_disability).to eq(nil)
@@ -27,7 +27,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilitiesForm, type:
 
     it 'returns nil if equality and diversity is nil' do
       application_form = build_stubbed(:application_form, equality_and_diversity: nil)
-      form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.build_from_application(application_form)
+      form = described_class.build_from_application(application_form)
 
       expect(form.disabilities).to eq(nil)
     end
@@ -38,7 +38,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilitiesForm, type:
 
     context 'when disabilities field is blank' do
       it 'returns false' do
-        form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new
+        form = described_class.new
 
         expect(form.save(application_form)).to be(false)
       end
@@ -46,13 +46,13 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilitiesForm, type:
 
     context 'when disabilities field has a value' do
       it 'returns true' do
-        form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Blind])
+        form = described_class.new(disabilities: %w[Blind])
 
         expect(form.save(application_form)).to be(true)
       end
 
       it 'updates the equality and diversity information on the application form' do
-        form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Blind Other], other_disability: 'Other disability')
+        form = described_class.new(disabilities: %w[Blind Other], other_disability: 'Other disability')
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
@@ -62,7 +62,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilitiesForm, type:
       end
 
       it 'allows other_disability field to be optional' do
-        form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Blind Other], other_disability: '')
+        form = described_class.new(disabilities: %w[Blind Other], other_disability: '')
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
@@ -73,7 +73,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilitiesForm, type:
 
       it 'updates the existing record of equality and diversity information' do
         application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male' })
-        form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Blind])
+        form = described_class.new(disabilities: %w[Blind])
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
@@ -83,7 +83,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilitiesForm, type:
 
       it 'does not update disabilities with other disability if Other is not selected' do
         application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male' })
-        form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Blind], other_disability: 'Other disability')
+        form = described_class.new(disabilities: %w[Blind], other_disability: 'Other disability')
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(

--- a/spec/forms/candidate_interface/equality_and_diversity/disability_status_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/disability_status_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
     context 'when an application form disabilities set to: Prefer not to say' do
       it 'creates an new disability status form with disability status set to Prefer not to say' do
         application_form = build_stubbed(:application_form, equality_and_diversity: { 'disabilities' => ['Prefer not to say'] })
-        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.build_from_application(application_form)
+        form = described_class.build_from_application(application_form)
 
         expect(form.disability_status).to eq('Prefer not to say')
       end
@@ -14,7 +14,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
     context 'when an application form has no disabilities' do
       it 'creates an new disability status form with disability status set to no' do
         application_form = build_stubbed(:application_form, equality_and_diversity: { 'disabilities' => [] })
-        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.build_from_application(application_form)
+        form = described_class.build_from_application(application_form)
 
         expect(form.disability_status).to eq('no')
       end
@@ -23,7 +23,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
     context 'when an application form has disabilities' do
       it 'creates an new disability status form with disability status set to yes' do
         application_form = build_stubbed(:application_form, equality_and_diversity: { 'disabilities' => %w[stuff] })
-        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.build_from_application(application_form)
+        form = described_class.build_from_application(application_form)
 
         expect(form.disability_status).to eq('yes')
       end
@@ -31,14 +31,14 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
 
     it 'returns nil if equality and diversity is nil' do
       application_form = build_stubbed(:application_form, equality_and_diversity: nil)
-      form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.build_from_application(application_form)
+      form = described_class.build_from_application(application_form)
 
       expect(form.disability_status).to eq(nil)
     end
 
     it 'returns nil if disabilities field is missing in equality and diversity' do
       application_form = build_stubbed(:application_form, equality_and_diversity: { 'sex' => 'male' })
-      form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.build_from_application(application_form)
+      form = described_class.build_from_application(application_form)
 
       expect(form.disability_status).to eq(nil)
     end
@@ -49,7 +49,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
 
     context 'when disabilty status is blank' do
       it 'returns false' do
-        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new
+        form = described_class.new
 
         expect(form.save(application_form)).to be(false)
       end
@@ -57,13 +57,13 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
 
     context 'when disability status has a value' do
       it 'returns true' do
-        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'yes')
+        form = described_class.new(disability_status: 'yes')
 
         expect(form.save(application_form)).to be(true)
       end
 
       it 'updates the equality and diversity information on the application form' do
-        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'no')
+        form = described_class.new(disability_status: 'no')
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
@@ -74,7 +74,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
 
       it 'amends the equality and diversity information on the application form' do
         application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male' })
-        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'no')
+        form = described_class.new(disability_status: 'no')
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
@@ -86,7 +86,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
 
       it 'updates the existing record of equality and diversity information' do
         application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male' })
-        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'yes')
+        form = described_class.new(disability_status: 'yes')
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
@@ -98,7 +98,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
 
       it 'updates the existing disabilities of equality and diversity information' do
         application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => %w[Blind] })
-        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'yes')
+        form = described_class.new(disability_status: 'yes')
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
@@ -109,7 +109,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
 
       it 'resets the disabilities of equality and diversity information if disability status is no' do
         application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => %w[Blind] })
-        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'no')
+        form = described_class.new(disability_status: 'no')
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
@@ -121,7 +121,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
 
       it 'resets the disabilities of equality and diversity information if disability status is Prefer not to say' do
         application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => %w[Blind], 'hesa_disabilities' => %w[58] })
-        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'Prefer not to say')
+        form = described_class.new(disability_status: 'Prefer not to say')
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
@@ -133,7 +133,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
 
       it 'resets the disabilities of equality and diversity information if disability status is yes' do
         application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => ['Prefer not to say'] })
-        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'yes')
+        form = described_class.new(disability_status: 'yes')
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(

--- a/spec/forms/candidate_interface/equality_and_diversity/ethnic_background_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/ethnic_background_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
       it 'creates an object with ethnic background' do
         application_form = build_stubbed(:application_form, equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Chinese' })
 
-        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.build_from_application(application_form)
+        form = described_class.build_from_application(application_form)
 
         expect(form.ethnic_background).to eq('Chinese')
         expect(form.other_background).to eq(nil)
@@ -18,7 +18,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
         application_form = build_stubbed(:application_form,
                                          equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Unlisted ethnic background' })
 
-        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.build_from_application(application_form)
+        form = described_class.build_from_application(application_form)
 
         expect(form.ethnic_background).to eq('Another Asian background')
         expect(form.other_background).to eq('Unlisted ethnic background')
@@ -30,7 +30,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
         application_form = build_stubbed(:application_form,
                                          equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Another Asian background' })
 
-        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.build_from_application(application_form)
+        form = described_class.build_from_application(application_form)
 
         expect(form.ethnic_background).to eq('Another Asian background')
         expect(form.other_background).to eq(nil)
@@ -41,7 +41,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
       it 'creates an object with empty ethnic background' do
         application_form = build_stubbed(:application_form, equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British', 'ethnic_background' => nil })
 
-        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.build_from_application(application_form)
+        form = described_class.build_from_application(application_form)
 
         expect(form.ethnic_background).to eq(nil)
         expect(form.other_background).to eq(nil)
@@ -54,7 +54,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
 
     context 'when ethnic background field is blank' do
       it 'returns false' do
-        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new
+        form = described_class.new
 
         expect(form.save(application_form)).to be(false)
       end
@@ -62,13 +62,13 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
 
     context 'when ethnic background is listed' do
       it 'returns true' do
-        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new(ethnic_background: 'Bangladeshi')
+        form = described_class.new(ethnic_background: 'Bangladeshi')
 
         expect(form.save(application_form)).to be(true)
       end
 
       it 'updates the application form with the ethnic background value' do
-        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new(ethnic_background: 'Bangladeshi')
+        form = described_class.new(ethnic_background: 'Bangladeshi')
 
         form.save(application_form)
 
@@ -81,7 +81,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
 
       it 'updates the existing record of equality and diversity information' do
         application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male', 'ethnic_group' => 'Asian or Asian British' })
-        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new(ethnic_background: 'Bangladeshi')
+        form = described_class.new(ethnic_background: 'Bangladeshi')
 
         form.save(application_form)
 
@@ -96,7 +96,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
 
     context 'when ethnic background is another background' do
       it 'updates the application form with the other background value if other background provided' do
-        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new(ethnic_background: 'Another Asian background', other_background: 'Unlisted ethnic background')
+        form = described_class.new(ethnic_background: 'Another Asian background', other_background: 'Unlisted ethnic background')
 
         form.save(application_form)
 
@@ -108,7 +108,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
       end
 
       it 'updates the application form with the ethnic background value if other background is not provided' do
-        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new(ethnic_background: 'Another Asian background', other_background: nil)
+        form = described_class.new(ethnic_background: 'Another Asian background', other_background: nil)
 
         form.save(application_form)
 

--- a/spec/forms/candidate_interface/equality_and_diversity/ethnic_group_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/ethnic_group_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicGroupForm, type: 
       it 'creates a new ethnic group form with ethnic group of the application' do
         application_form = build_stubbed(:application_form, equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British' })
 
-        form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.build_from_application(application_form)
+        form = described_class.build_from_application(application_form)
 
         expect(form.ethnic_group).to eq('Asian or Asian British')
       end
@@ -15,7 +15,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicGroupForm, type: 
     it 'returns nil if equality and diversity is nil' do
       application_form = build_stubbed(:application_form, equality_and_diversity: nil)
 
-      form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.build_from_application(application_form)
+      form = described_class.build_from_application(application_form)
 
       expect(form.ethnic_group).to eq(nil)
     end
@@ -23,7 +23,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicGroupForm, type: 
     it 'returns nil if ethnic group field is missing in equality and diversity' do
       application_form = build_stubbed(:application_form, equality_and_diversity: { 'sex' => 'male' })
 
-      form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.build_from_application(application_form)
+      form = described_class.build_from_application(application_form)
 
       expect(form.ethnic_group).to eq(nil)
     end
@@ -34,7 +34,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicGroupForm, type: 
 
     context 'when ethnic group is blank' do
       it 'returns false' do
-        form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.new
+        form = described_class.new
 
         expect(form.save(application_form)).to be(false)
       end
@@ -42,13 +42,13 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicGroupForm, type: 
 
     context 'when ethnic group has a value' do
       it 'returns true' do
-        form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.new(ethnic_group: 'Prefer not to say')
+        form = described_class.new(ethnic_group: 'Prefer not to say')
 
         expect(form.save(application_form)).to be(true)
       end
 
       it 'updates the equality and diversity information on the application form' do
-        form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.new(ethnic_group: 'White')
+        form = described_class.new(ethnic_group: 'White')
 
         form.save(application_form)
 
@@ -57,7 +57,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicGroupForm, type: 
 
       it 'updates the existing record of equality and diversity information' do
         application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male' })
-        form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.new(ethnic_group: 'Black, African, Black British or Caribbean')
+        form = described_class.new(ethnic_group: 'Black, African, Black British or Caribbean')
 
         form.save(application_form)
 
@@ -76,7 +76,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicGroupForm, type: 
             'hesa_ethnicity' => '50',
           },
         )
-        form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.new(ethnic_group: 'Prefer not to say')
+        form = described_class.new(ethnic_group: 'Prefer not to say')
 
         form.save(application_form)
 

--- a/spec/forms/candidate_interface/equality_and_diversity/sex_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/sex_form_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::SexForm, type: :model d
   describe '#build_from_application' do
     it 'creates an object based on the application form' do
       application_form = build_stubbed(:application_form, equality_and_diversity: { 'sex' => 'male' })
-      form = CandidateInterface::EqualityAndDiversity::SexForm.build_from_application(application_form)
+      form = described_class.build_from_application(application_form)
 
       expect(form.sex).to eq('male')
     end
 
     it 'returns nil if equality and diversity is nil' do
       application_form = build_stubbed(:application_form, equality_and_diversity: nil)
-      form = CandidateInterface::EqualityAndDiversity::SexForm.build_from_application(application_form)
+      form = described_class.build_from_application(application_form)
 
       expect(form.sex).to eq(nil)
     end
@@ -22,7 +22,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::SexForm, type: :model d
 
     context 'when sex is blank' do
       it 'returns false' do
-        form = CandidateInterface::EqualityAndDiversity::SexForm.new
+        form = described_class.new
 
         expect(form.save(application_form)).to be(false)
       end
@@ -30,13 +30,13 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::SexForm, type: :model d
 
     context 'when sex has a value' do
       it 'returns true' do
-        form = CandidateInterface::EqualityAndDiversity::SexForm.new(sex: 'male')
+        form = described_class.new(sex: 'male')
 
         expect(form.save(application_form)).to be(true)
       end
 
       it 'updates the equality and diversity information on the application form' do
-        form = CandidateInterface::EqualityAndDiversity::SexForm.new(sex: 'male')
+        form = described_class.new(sex: 'male')
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq('sex' => 'male', 'hesa_sex' => '1')
@@ -44,7 +44,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::SexForm, type: :model d
 
       it 'updates the existing record of equality and diversity information' do
         application_form = build(:application_form, equality_and_diversity: { 'disabilities' => [] })
-        form = CandidateInterface::EqualityAndDiversity::SexForm.new(sex: 'female')
+        form = described_class.new(sex: 'female')
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
@@ -55,7 +55,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::SexForm, type: :model d
 
     context "sex is 'intersex'" do
       it 'updates equality and diversity information with the correct HESA code' do
-        form = CandidateInterface::EqualityAndDiversity::SexForm.new(sex: 'intersex')
+        form = described_class.new(sex: 'intersex')
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq('sex' => 'intersex', 'hesa_sex' => '3')

--- a/spec/forms/candidate_interface/further_information_form_spec.rb
+++ b/spec/forms/candidate_interface/further_information_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe CandidateInterface::FurtherInformationForm, type: :model do
   describe '#save' do
     it 'returns false if not valid' do
-      further_information = CandidateInterface::FurtherInformationForm.new
+      further_information = described_class.new
 
       expect(further_information.save(ApplicationForm.new)).to eq(false)
     end
@@ -17,7 +17,7 @@ RSpec.describe CandidateInterface::FurtherInformationForm, type: :model do
         further_information: 'Much wow.',
       }
       application_form = FactoryBot.build(:application_form)
-      further_information = CandidateInterface::FurtherInformationForm.new(form_data)
+      further_information = described_class.new(form_data)
 
       expect(further_information.save(application_form)).to eq(true)
       expect(application_form).to have_attributes(data)
@@ -32,7 +32,7 @@ RSpec.describe CandidateInterface::FurtherInformationForm, type: :model do
         further_information: '',
       }
       application_form = FactoryBot.build(:application_form)
-      further_information = CandidateInterface::FurtherInformationForm.new(form_data)
+      further_information = described_class.new(form_data)
 
       further_information.save(application_form)
 
@@ -44,7 +44,7 @@ RSpec.describe CandidateInterface::FurtherInformationForm, type: :model do
     it { is_expected.to validate_presence_of(:further_information) }
 
     it 'validates further information details if chosen to add further information' do
-      further_information = CandidateInterface::FurtherInformationForm.new(further_information: 'true')
+      further_information = described_class.new(further_information: 'true')
       error_message = t('activemodel.errors.models.candidate_interface/further_information_form.attributes.further_information_details.blank')
 
       further_information.validate

--- a/spec/forms/candidate_interface/gcse_enic_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_enic_form_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CandidateInterface::GcseEnicForm do
     describe '#build_from_qualification' do
       it 'creates an object based on the provided ApplicationQualification' do
         qualification = ApplicationQualification.new(qualification_data)
-        enic_form = CandidateInterface::GcseEnicForm.build_from_qualification(
+        enic_form = described_class.build_from_qualification(
           qualification,
         )
 
@@ -48,14 +48,14 @@ RSpec.describe CandidateInterface::GcseEnicForm do
       end
 
       it 'returns false if not valid' do
-        enic_form = CandidateInterface::GcseEnicForm.new
+        enic_form = described_class.new
 
         expect(enic_form.save(ApplicationQualification.new)).to eq(false)
       end
 
       it 'updates the provided ApplicationQualification if valid' do
         qualification = build(:gcse_qualification)
-        enic_form = CandidateInterface::GcseEnicForm.new(form_data)
+        enic_form = described_class.new(form_data)
 
         expect(enic_form.save(qualification)).to eq(true)
         expect(qualification.enic_reference).to eq form_data[:enic_reference]
@@ -64,7 +64,7 @@ RSpec.describe CandidateInterface::GcseEnicForm do
 
       it 'updates enic_reference and comparable_uk_qualification to nil if they choose no' do
         qualification = build(:gcse_qualification)
-        enic_form = CandidateInterface::GcseEnicForm.new(
+        enic_form = described_class.new(
           have_enic_reference: 'No',
           enic_reference: '12345',
           comparable_uk_qualification: 'GCSE (grades A*-C / 9-4)',

--- a/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
     it { is_expected.to validate_presence_of(:institution_country) }
 
     it 'validates nationalities against the COUNTRIES list' do
-      invalid_country = CandidateInterface::GcseInstitutionCountryForm.new(
+      invalid_country = described_class.new(
         institution_country: 'QQ',
       )
-      valid_country = CandidateInterface::GcseInstitutionCountryForm.new(
+      valid_country = described_class.new(
         institution_country: COUNTRIES.keys.sample,
       )
       valid_country.validate
@@ -23,7 +23,7 @@ RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
   describe '#build_from_qualification' do
     it 'sets the institution_country attribute on the form the to qualifications institution_country' do
       application_qualification = build(:application_qualification)
-      institution_country_form = CandidateInterface::GcseInstitutionCountryForm.build_from_qualification(application_qualification)
+      institution_country_form = described_class.build_from_qualification(application_qualification)
 
       expect(institution_country_form.institution_country).to eq application_qualification.institution_country
     end
@@ -31,14 +31,14 @@ RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
 
   describe '#save' do
     it 'returns false if not valid' do
-      institution_country_form = CandidateInterface::GcseInstitutionCountryForm.new
+      institution_country_form = described_class.new
 
       expect(institution_country_form.save(ApplicationQualification.new)).to eq(false)
     end
 
     it 'updates the provided ApplicationForm if valid' do
       application_qualification = build(:application_qualification)
-      institution_country_form = CandidateInterface::GcseInstitutionCountryForm.new(form_data)
+      institution_country_form = described_class.new(form_data)
 
       expect(institution_country_form.save(application_qualification)).to eq(true)
       expect(application_qualification.institution_country).to eq form_data[:institution_country]

--- a/spec/forms/candidate_interface/gcse_qualification_type_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_qualification_type_form_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
     it 'return false if not valid' do
       application_form = double
 
-      form = CandidateInterface::GcseQualificationTypeForm.new({})
+      form = described_class.new({})
       expect(form.save(application_form)).to eq(false)
     end
 
     it 'creates a new qualification if valid' do
       application_form = create(:application_form)
 
-      form = CandidateInterface::GcseQualificationTypeForm
+      form = described_class
                                   .new(subject: 'maths', level: 'gcse', qualification_type: 'gcse')
 
       form.save(application_form)
@@ -41,7 +41,7 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
         non_uk_qualification_type: 'High School Diploma',
       )
 
-      form = CandidateInterface::GcseQualificationTypeForm.build_from_qualification(qualification)
+      form = described_class.build_from_qualification(qualification)
       form.save(application_form)
 
       expect(application_form.application_qualifications.first.qualification_type).to eq 'non_uk'
@@ -57,7 +57,7 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
           qualification_type: 'other_uk',
         )
 
-        form = CandidateInterface::GcseQualificationTypeForm.build_from_qualification(qualification)
+        form = described_class.build_from_qualification(qualification)
 
         expect(form.valid?).to eq false
         expect(form.errors[:other_uk_qualification_type]).to include('Enter the type of qualification')
@@ -73,7 +73,7 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
           qualification_type: 'non_uk',
         )
 
-        form = CandidateInterface::GcseQualificationTypeForm.build_from_qualification(qualification)
+        form = described_class.build_from_qualification(qualification)
 
         expect(form.valid?).to eq false
         expect(form.errors[:non_uk_qualification_type]).to include('Enter the type of qualification')
@@ -90,7 +90,7 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
         qualification_type: 'gcse',
       )
 
-      form = CandidateInterface::GcseQualificationTypeForm.build_from_qualification(qualification)
+      form = described_class.build_from_qualification(qualification)
 
       expect(form.level).to eq 'gcse'
       expect(form.subject).to eq 'maths'
@@ -103,7 +103,7 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
     it 'return false if not valid' do
       application_form = double
 
-      form = CandidateInterface::GcseQualificationTypeForm.new({})
+      form = described_class.new({})
       expect(form.update(application_form)).to eq(false)
     end
 
@@ -115,7 +115,7 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
         qualification_type: 'gcse',
       )
 
-      form = CandidateInterface::GcseQualificationTypeForm.build_from_qualification(qualification)
+      form = described_class.build_from_qualification(qualification)
 
       form.qualification_type = 'gce_o_level'
 

--- a/spec/forms/candidate_interface/interview_preferences_form_spec.rb
+++ b/spec/forms/candidate_interface/interview_preferences_form_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CandidateInterface::InterviewPreferencesForm, type: :model do
   describe '.build_from_application' do
     it 'creates an object based on the provided ApplicationForm' do
       application_form = ApplicationForm.new(data)
-      interview_preferences = CandidateInterface::InterviewPreferencesForm.build_from_application(
+      interview_preferences = described_class.build_from_application(
         application_form,
       )
 
@@ -28,7 +28,7 @@ RSpec.describe CandidateInterface::InterviewPreferencesForm, type: :model do
       application_form = ApplicationForm.new(
         interview_preferences: '',
       )
-      interview_preferences = CandidateInterface::InterviewPreferencesForm.build_from_application(
+      interview_preferences = described_class.build_from_application(
         application_form,
       )
 
@@ -37,7 +37,7 @@ RSpec.describe CandidateInterface::InterviewPreferencesForm, type: :model do
 
     it 'returns nil for any preferences if interview preferences is nil' do
       application_form = ApplicationForm.new(interview_preferences: nil)
-      interview_preferences = CandidateInterface::InterviewPreferencesForm.build_from_application(
+      interview_preferences = described_class.build_from_application(
         application_form,
       )
 
@@ -47,14 +47,14 @@ RSpec.describe CandidateInterface::InterviewPreferencesForm, type: :model do
 
   describe '#save' do
     it 'returns false if not valid' do
-      interview_preferences = CandidateInterface::InterviewPreferencesForm.new
+      interview_preferences = described_class.new
 
       expect(interview_preferences.save(ApplicationForm.new)).to eq(false)
     end
 
     it 'updates the provided ApplicationForm if valid' do
       application_form = FactoryBot.build(:application_form)
-      interview_preferences = CandidateInterface::InterviewPreferencesForm.new(form_data)
+      interview_preferences = described_class.new(form_data)
 
       expect(interview_preferences.save(application_form)).to eq(true)
       expect(application_form).to have_attributes(data)
@@ -62,7 +62,7 @@ RSpec.describe CandidateInterface::InterviewPreferencesForm, type: :model do
 
     it 'updates the provided ApplicationForm with an empty string if no is selected' do
       application_form = build(:application_form)
-      interview_preferences = CandidateInterface::InterviewPreferencesForm.new(
+      interview_preferences = described_class.new(
         any_preferences: 'no',
         interview_preferences: '',
       )
@@ -84,7 +84,7 @@ RSpec.describe CandidateInterface::InterviewPreferencesForm, type: :model do
     it { is_expected.not_to allow_value(invalid_text).for(:interview_preferences) }
 
     it 'validates the presence of interview preferences if chosen to add any' do
-      interview_preferences = CandidateInterface::InterviewPreferencesForm.new(any_preferences: 'yes')
+      interview_preferences = described_class.new(any_preferences: 'yes')
       error_message = t('activemodel.errors.models.candidate_interface/interview_preferences_form.attributes.interview_preferences.blank')
 
       interview_preferences.validate

--- a/spec/forms/candidate_interface/languages_form_spec.rb
+++ b/spec/forms/candidate_interface/languages_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CandidateInterface::LanguagesForm, type: :model do
         english_language_details: nil,
         other_language_details: 'I speak French',
       )
-      languages_form = CandidateInterface::LanguagesForm.build_from_application(
+      languages_form = described_class.build_from_application(
         application_form,
       )
 
@@ -21,7 +21,7 @@ RSpec.describe CandidateInterface::LanguagesForm, type: :model do
 
     it "initialises english_main_language to nil when it's nil in the application form" do
       application_form = ApplicationForm.new(english_main_language: nil)
-      languages_form = CandidateInterface::LanguagesForm.build_from_application(
+      languages_form = described_class.build_from_application(
         application_form,
       )
 
@@ -31,7 +31,7 @@ RSpec.describe CandidateInterface::LanguagesForm, type: :model do
 
   describe '#save' do
     it 'returns false if not valid' do
-      languages_form = CandidateInterface::LanguagesForm.new
+      languages_form = described_class.new
 
       expect(languages_form.save(ApplicationForm.new)).to eq(false)
     end
@@ -43,7 +43,7 @@ RSpec.describe CandidateInterface::LanguagesForm, type: :model do
         other_language_details: 'I also speak French',
       }
       application_form = FactoryBot.build(:application_form)
-      languages_form = CandidateInterface::LanguagesForm.new(form_data)
+      languages_form = described_class.new(form_data)
 
       languages_form.save(application_form)
 
@@ -58,7 +58,7 @@ RSpec.describe CandidateInterface::LanguagesForm, type: :model do
         other_language_details: 'I also speak French',
       }
       application_form = FactoryBot.build(:application_form)
-      languages_form = CandidateInterface::LanguagesForm.new(form_data)
+      languages_form = described_class.new(form_data)
 
       languages_form.save(application_form)
 
@@ -82,13 +82,13 @@ RSpec.describe CandidateInterface::LanguagesForm, type: :model do
 
   describe '#english_main_language?' do
     it 'returns true if "yes"' do
-      languages_form = CandidateInterface::LanguagesForm.new(english_main_language: 'yes')
+      languages_form = described_class.new(english_main_language: 'yes')
 
       expect(languages_form).to be_english_main_language
     end
 
     it 'returns false if "no"' do
-      languages_form = CandidateInterface::LanguagesForm.new(english_main_language: 'no')
+      languages_form = described_class.new(english_main_language: 'no')
 
       expect(languages_form).not_to be_english_main_language
     end

--- a/spec/forms/candidate_interface/nationalities_form_spec.rb
+++ b/spec/forms/candidate_interface/nationalities_form_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
 
     it 'creates an object based on the provided ApplicationForm' do
       application_form = ApplicationForm.new(data)
-      nationalities = CandidateInterface::NationalitiesForm.build_from_application(
+      nationalities = described_class.build_from_application(
         application_form,
       )
 
@@ -48,7 +48,7 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
   describe '.candidates_nationalties' do
     context 'when other is true' do
       it 'returns a unique array of the candidates selected nationalties' do
-        nationalities = CandidateInterface::NationalitiesForm.new(
+        nationalities = described_class.new(
           british: 'British',
           irish: 'Irish',
           other: 'other',
@@ -62,7 +62,7 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
 
     context 'when other is nil' do
       it 'returns a unique array of the candidates selected nationalties' do
-        nationalities = CandidateInterface::NationalitiesForm.new(
+        nationalities = described_class.new(
           british: 'British',
           irish: 'Irish',
           other: nil,
@@ -77,7 +77,7 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
 
   describe '#save' do
     it 'returns false if not valid' do
-      nationalities = CandidateInterface::NationalitiesForm.new
+      nationalities = described_class.new
 
       expect(nationalities.save(ApplicationForm.new)).to eq(false)
     end
@@ -96,7 +96,7 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
 
       it 'updates the provided ApplicationForms nationalities and resets the right to work fields to nil' do
         application_form = FactoryBot.build(:application_form, right_to_work_or_study: 'yes', right_to_work_or_study_details: 'I have a visa.')
-        nationalities = CandidateInterface::NationalitiesForm.new(form_data)
+        nationalities = described_class.new(form_data)
 
         expect(nationalities.save(application_form)).to eq(true)
         expect(application_form.first_nationality).to eq 'British'
@@ -121,7 +121,7 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
 
       it 'updates the provided ApplicationForms nationalities and retains the right to work fields' do
         application_form = FactoryBot.build(:application_form, right_to_work_or_study: 'yes', right_to_work_or_study_details: 'I have a visa.')
-        nationalities = CandidateInterface::NationalitiesForm.new(form_data)
+        nationalities = described_class.new(form_data)
 
         expect(nationalities.save(application_form)).to eq(true)
         expect(application_form.first_nationality).to eq 'Belgian'
@@ -136,7 +136,7 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
   describe 'validations' do
     context 'with no nationality option selected' do
       it 'validates the candidate has provided a nationality' do
-        details_with_invalid_nationality = CandidateInterface::NationalitiesForm.new
+        details_with_invalid_nationality = described_class.new
 
         details_with_invalid_nationality.validate
 
@@ -146,7 +146,7 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
 
     context "with 'Other' nationality option selected but first nationality is not selected" do
       it 'validates the candidate has provided a first nationality' do
-        details_with_invalid_nationality = CandidateInterface::NationalitiesForm.new(other: 'other')
+        details_with_invalid_nationality = described_class.new(other: 'other')
 
         details_with_invalid_nationality.validate
 
@@ -157,7 +157,7 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
 
     context "with 'Other' nationality option and and first nationality selected" do
       it 'is valid' do
-        details_with_valid_nationality = CandidateInterface::NationalitiesForm.new(
+        details_with_valid_nationality = described_class.new(
           other: 'other',
           other_nationality1: 'New Zealander',
         )
@@ -167,13 +167,13 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
     end
 
     it 'validates nationalities against the NATIONALITY_DEMONYMS list' do
-      details_with_invalid_nationality = CandidateInterface::NationalitiesForm.new(
+      details_with_invalid_nationality = described_class.new(
         other_nationality1: 'Tralfamadorian',
         other_nationality2: NATIONALITY_DEMONYMS.sample,
         other_nationality3: 'Tribbel',
       )
 
-      details_with_valid_nationality = CandidateInterface::NationalitiesForm.new(
+      details_with_valid_nationality = described_class.new(
         other_nationality1: NATIONALITY_DEMONYMS.sample,
         other_nationality2: NATIONALITY_DEMONYMS.sample,
         other_nationality3: NATIONALITY_DEMONYMS.sample,

--- a/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
 
     describe 'subject' do
       it 'validates presence except for non-uk and other qualifications' do
-        non_uk_qualification = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'non_uk', subject: nil)
-        other_uk_qualification = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'Other', subject: nil)
-        gcse = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'GCSE', subject: nil)
+        non_uk_qualification = described_class.new(nil, nil, qualification_type: 'non_uk', subject: nil)
+        other_uk_qualification = described_class.new(nil, nil, qualification_type: 'Other', subject: nil)
+        gcse = described_class.new(nil, nil, qualification_type: 'GCSE', subject: nil)
 
         non_uk_qualification.valid?(:details)
         other_uk_qualification.valid?(:details)
@@ -30,9 +30,9 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
 
     describe 'grade' do
       it 'validates presence except for non-uk and other qualifications' do
-        non_uk_qualification = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'non_uk', grade: nil)
-        other_uk_qualification = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'Other', grade: nil)
-        gcse = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'GCSE', grade: nil)
+        non_uk_qualification = described_class.new(nil, nil, qualification_type: 'non_uk', grade: nil)
+        other_uk_qualification = described_class.new(nil, nil, qualification_type: 'Other', grade: nil)
+        gcse = described_class.new(nil, nil, qualification_type: 'GCSE', grade: nil)
 
         non_uk_qualification.valid?(:details)
         other_uk_qualification.valid?(:details)
@@ -44,11 +44,11 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
       end
 
       it 'validates grade format for A/AS levels, sanitizing the string in the process' do
-        valid_a_level = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'A level', grade: 'a* a*')
-        valid_as_level = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'AS level', grade: 'b  b')
-        valid_other_qualification = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'Other', grade: 'Gold star')
-        invalid_a_level = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'A level', grade: 'a* a* b')
-        invalid_as_level = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'AS level', grade: '85%')
+        valid_a_level = described_class.new(nil, nil, qualification_type: 'A level', grade: 'a* a*')
+        valid_as_level = described_class.new(nil, nil, qualification_type: 'AS level', grade: 'b  b')
+        valid_other_qualification = described_class.new(nil, nil, qualification_type: 'Other', grade: 'Gold star')
+        invalid_a_level = described_class.new(nil, nil, qualification_type: 'A level', grade: 'a* a* b')
+        invalid_as_level = described_class.new(nil, nil, qualification_type: 'AS level', grade: '85%')
 
         [valid_a_level, valid_as_level, invalid_a_level, invalid_as_level, valid_other_qualification].each { |q| q.valid?(:details) }
 
@@ -65,10 +65,10 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
     end
 
     it 'validates grade format for GCSE, sanitizing the string in the process' do
-      valid_gcse_one = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'GCSE', grade: '9 - 8')
-      valid_gcse_two = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'GCSE', grade: 'e   e')
-      valid_other_qualification = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'Other', grade: 'Gold star')
-      invalid_gcse = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'GCSE', grade: '5%')
+      valid_gcse_one = described_class.new(nil, nil, qualification_type: 'GCSE', grade: '9 - 8')
+      valid_gcse_two = described_class.new(nil, nil, qualification_type: 'GCSE', grade: 'e   e')
+      valid_other_qualification = described_class.new(nil, nil, qualification_type: 'Other', grade: 'Gold star')
+      invalid_gcse = described_class.new(nil, nil, qualification_type: 'GCSE', grade: '5%')
 
       [valid_gcse_one, valid_gcse_two, valid_other_qualification, invalid_gcse].each { |q| q.valid?(:details) }
 
@@ -88,9 +88,9 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
     describe 'institution country' do
       context 'when it is a non-uk qualification' do
         it 'validates for presence and inclusion in the COUNTY_NAMES constant' do
-          valid_qualification = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'non_uk', institution_country: 'GB')
-          blank_country_qualification = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'non_uk')
-          inavlid_country_qualification = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, qualification_type: 'non_uk', institution_country: 'QQ')
+          valid_qualification = described_class.new(nil, nil, qualification_type: 'non_uk', institution_country: 'GB')
+          blank_country_qualification = described_class.new(nil, nil, qualification_type: 'non_uk')
+          inavlid_country_qualification = described_class.new(nil, nil, qualification_type: 'non_uk', institution_country: 'QQ')
 
           valid_qualification.valid?(:details)
           blank_country_qualification.valid?(:details)
@@ -138,7 +138,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
     end
 
     it 'creates an array of objects based on the provided ApplicationForm' do
-      qualifications = CandidateInterface::OtherQualificationDetailsForm.build_all(application_form)
+      qualifications = described_class.build_all(application_form)
 
       expect(qualifications).to include(
         have_attributes(
@@ -151,13 +151,13 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
     end
 
     it 'only includes other qualifications and not degrees or GCSEs' do
-      qualifications = CandidateInterface::OtherQualificationDetailsForm.build_all(application_form)
+      qualifications = described_class.build_all(application_form)
 
       expect(qualifications.count).to eq(2)
     end
 
     it 'orders other qualifications by created at' do
-      qualifications = CandidateInterface::OtherQualificationDetailsForm.build_all(application_form)
+      qualifications = described_class.build_all(application_form)
 
       expect(qualifications.last).to have_attributes(
         qualification_type: 'BTEC',
@@ -178,7 +178,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
         award_year: '2010',
       )
 
-      qualification = CandidateInterface::OtherQualificationDetailsForm.build_from_qualification(application_qualification)
+      qualification = described_class.build_from_qualification(application_qualification)
 
       expect(qualification).to have_attributes(qualification_type: 'BTEC', subject: 'Being a Sidekick')
     end
@@ -190,7 +190,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
         :application_qualification,
       )
 
-      last_qualification = CandidateInterface::OtherQualificationDetailsForm.new(
+      last_qualification = described_class.new(
         nil,
         nil,
       )
@@ -202,7 +202,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
 
     context 'blank qualifications' do
       it 'returns nil' do
-        last_qualification = CandidateInterface::OtherQualificationDetailsForm.new
+        last_qualification = described_class.new
         expect(last_qualification.initialize_from_last_qualification([])).to be_nil
       end
     end
@@ -216,7 +216,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
           qualification_type: qualification_type,
         )
 
-        last_qualification = CandidateInterface::OtherQualificationDetailsForm.new(
+        last_qualification = described_class.new(
           nil,
           nil,
           qualification_type: qualification_type,
@@ -238,7 +238,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
           qualification_type: non_uk,
         )
 
-        last_qualification = CandidateInterface::OtherQualificationDetailsForm.new(
+        last_qualification = described_class.new(
           nil,
           nil,
           qualification_type: 'foo',
@@ -259,7 +259,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
           qualification_type: 'foo',
         )
 
-        last_qualification = CandidateInterface::OtherQualificationDetailsForm.new(
+        last_qualification = described_class.new(
           nil,
           nil,
           qualification_type: other,
@@ -275,7 +275,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
   describe '#title' do
     context 'for a non-uk qualification' do
       it 'concatenates the non_uk_qualification_type and subject' do
-        qualification = CandidateInterface::OtherQualificationDetailsForm.new(
+        qualification = described_class.new(
           nil,
           nil,
           qualification_type: 'non_uk',
@@ -289,7 +289,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
 
     context 'for an other uk qualification' do
       it 'concatenates the other_uk_qualification_type and subject' do
-        qualification = CandidateInterface::OtherQualificationDetailsForm.new(
+        qualification = described_class.new(
           nil,
           nil,
           qualification_type: 'Other',
@@ -303,7 +303,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
 
     context 'for other uk qualificaitons and GCSEs and A-levels' do
       it 'concatenates the qualification type and subject' do
-        qualification = CandidateInterface::OtherQualificationDetailsForm.new(
+        qualification = described_class.new(
           nil,
           nil,
           qualification_type: 'BTEC',
@@ -318,7 +318,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
   describe '#qualification_type_name' do
     context 'for a non-uk qualification' do
       it 'returns the non_uk_qualification_type' do
-        qualification = CandidateInterface::OtherQualificationDetailsForm.new(
+        qualification = described_class.new(
           nil,
           nil,
           qualification_type: 'non_uk',
@@ -331,7 +331,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
 
     context 'for an other uk qualification with the qualification type Other' do
       it 'returns the other_uk_qualification_type' do
-        qualification = CandidateInterface::OtherQualificationDetailsForm.new(
+        qualification = described_class.new(
           nil,
           nil,
           qualification_type: 'Other',
@@ -344,7 +344,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
 
     context 'for other uk qualifications and GCSEs and A-levels' do
       it 'returns the qualification type' do
-        qualification = CandidateInterface::OtherQualificationDetailsForm.new(
+        qualification = described_class.new(
           nil,
           nil,
           qualification_type: 'BTEC',

--- a/spec/forms/candidate_interface/other_qualification_type_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_type_form_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe CandidateInterface::OtherQualificationTypeForm do
   describe '#initialize' do
     context 'the qualification type is being updated from a non-uk qualification to a uk qualification' do
       it 'assigns an empty string to the non_uk attributes' do
-        form = CandidateInterface::OtherQualificationTypeForm.new(
+        form = described_class.new(
           current_application,
           intermediate_data_service,
           'qualification_type' => 'GCSE',
@@ -96,7 +96,7 @@ RSpec.describe CandidateInterface::OtherQualificationTypeForm do
     end
 
     it 'updates the application forms no_other_qualifications to true' do
-      form = CandidateInterface::OtherQualificationTypeForm.new(
+      form = described_class.new(
         current_application,
         intermediate_data_service,
         'qualification_type' => 'no_other_qualifications',

--- a/spec/forms/candidate_interface/personal_details_form_spec.rb
+++ b/spec/forms/candidate_interface/personal_details_form_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
 
   describe '#name' do
     it 'concatenates the first name and last name' do
-      personal_details = CandidateInterface::PersonalDetailsForm.new(first_name: 'Bruce', last_name: 'Wayne')
+      personal_details = described_class.new(first_name: 'Bruce', last_name: 'Wayne')
 
       expect(personal_details.name).to eq('Bruce Wayne')
     end
@@ -30,7 +30,7 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
   describe '.build_from_application' do
     it 'creates an object based on the provided ApplicationForm' do
       application_form = ApplicationForm.new(data)
-      personal_details = CandidateInterface::PersonalDetailsForm.build_from_application(
+      personal_details = described_class.build_from_application(
         application_form,
       )
 
@@ -40,14 +40,14 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
 
   describe '#save' do
     it 'returns false if not valid' do
-      personal_details = CandidateInterface::PersonalDetailsForm.new
+      personal_details = described_class.new
 
       expect(personal_details.save(ApplicationForm.new)).to eq(false)
     end
 
     it 'updates the provided ApplicationForm if valid' do
       application_form = FactoryBot.create(:application_form)
-      personal_details = CandidateInterface::PersonalDetailsForm.new(form_data)
+      personal_details = described_class.new(form_data)
 
       expect(personal_details.save(application_form)).to eq(true)
       expect(application_form).to have_attributes(data)

--- a/spec/forms/candidate_interface/pick_site_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_site_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CandidateInterface::PickSiteForm, type: :model do
       application_form.application_choices << create(:application_choice)
       application_form.application_choices << create(:application_choice)
 
-      pick_site_form = CandidateInterface::PickSiteForm.new(
+      pick_site_form = described_class.new(
         application_form: application_form,
         course_option_id: create(:course_option).id,
       )
@@ -27,7 +27,7 @@ RSpec.describe CandidateInterface::PickSiteForm, type: :model do
 
       pick_site_form.save
 
-      pick_site_form = CandidateInterface::PickSiteForm.new(
+      pick_site_form = described_class.new(
         application_form: application_form,
         course_option_id: create(:course_option).id,
       )
@@ -41,7 +41,7 @@ RSpec.describe CandidateInterface::PickSiteForm, type: :model do
       application_form = create(:application_form)
       course_option = create(:course_option)
 
-      CandidateInterface::PickSiteForm.new(
+      described_class.new(
         application_form: application_form,
         course_option_id: course_option.id,
       ).save
@@ -59,7 +59,7 @@ RSpec.describe CandidateInterface::PickSiteForm, type: :model do
 
       expect(application_choice.course_option.id).not_to eq(new_course_option.id)
 
-      CandidateInterface::PickSiteForm.new(
+      described_class.new(
         application_form: application_choice.application_form,
         course_option_id: new_course_option.id,
       ).update(application_choice)

--- a/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
     it 'does not accept negative integers in the year field' do
       form_data[:start_date_year] = -1999
       form_data[:end_date_year]   = -1999
-      job = CandidateInterface::RestructuredWorkHistory::JobForm.new(form_data)
+      job = described_class.new(form_data)
 
       expect(job).not_to be_valid
       errors = job.errors.messages
@@ -85,14 +85,14 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
 
   describe '#save' do
     it 'returns false if not valid' do
-      job = CandidateInterface::RestructuredWorkHistory::JobForm.new
+      job = described_class.new
 
       expect(job.save(ApplicationForm.new)).to eq(false)
     end
 
     it 'creates a new job if valid' do
       application_form = FactoryBot.create(:application_form)
-      job = CandidateInterface::RestructuredWorkHistory::JobForm.new(form_data)
+      job = described_class.new(form_data)
 
       saved_job = job.save(application_form)
       expect(saved_job).to have_attributes(data)
@@ -102,14 +102,14 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
 
   describe '#update' do
     it 'returns false if not valid' do
-      job = CandidateInterface::RestructuredWorkHistory::JobForm.new
+      job = described_class.new
 
       expect(job.update(ApplicationWorkExperience.new)).to eq(false)
     end
 
     it 'updates an existing job if valid' do
       application_form = FactoryBot.create(:application_form)
-      job = CandidateInterface::RestructuredWorkHistory::JobForm.new(form_data)
+      job = described_class.new(form_data)
       saved_job = job.save(application_form)
 
       job.role = 'Something else'
@@ -128,7 +128,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
       form_data[:start_date_unknown] = data[:start_date_unknown]
       form_data[:end_date_unknown] = data[:end_date_unknown]
       application_work_experience = ApplicationWorkExperience.new(data)
-      job_form = CandidateInterface::RestructuredWorkHistory::JobForm.build_form(application_work_experience)
+      job_form = described_class.build_form(application_work_experience)
 
       expect(job_form).to have_attributes(form_data)
     end
@@ -136,7 +136,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
     it 'returns an empty string if end date is nil' do
       data[:end_date] = nil
       application_work_experience = ApplicationWorkExperience.new(data)
-      job_form = CandidateInterface::RestructuredWorkHistory::JobForm.build_form(
+      job_form = described_class.build_form(
         application_work_experience,
       )
 

--- a/spec/forms/candidate_interface/restructured_work_history/work_history_break_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/work_history_break_form_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm
   describe '.build_from_break' do
     it 'creates an object based on the work history break' do
       application_work_history_break = build_stubbed(:application_work_history_break, attributes: data)
-      work_break = CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm.build_from_break(
+      work_break = described_class.build_from_break(
         application_work_history_break,
       )
 
@@ -79,14 +79,14 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm
 
   describe '#save' do
     it 'returns false if not valid' do
-      work_break = CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm.new
+      work_break = described_class.new
 
       expect(work_break.save(ApplicationForm.new)).to eq(false)
     end
 
     it 'creates a new work experience if valid' do
       application_form = create(:application_form)
-      work_break = CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm.new(form_data)
+      work_break = described_class.new(form_data)
       saved_work_break = work_break.save(application_form)
 
       expect(saved_work_break).to have_attributes(data)
@@ -95,7 +95,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm
 
   describe '#update' do
     it 'returns false if not valid' do
-      work_break = CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm.new
+      work_break = described_class.new
 
       expect(work_break.save(ApplicationForm.new)).to eq(false)
     end
@@ -106,7 +106,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm
         application_form: create(:application_form),
         attributes: data,
       )
-      work_break = CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm.new(form_data)
+      work_break = described_class.new(form_data)
       work_break.reason = 'Updated reason.'
 
       work_break.update(application_work_history_break)

--- a/spec/forms/candidate_interface/right_to_work_or_study_form_spec.rb
+++ b/spec/forms/candidate_interface/right_to_work_or_study_form_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CandidateInterface::RightToWorkOrStudyForm, type: :model do
 
       it 'creates an object based on the provided ApplicationForm' do
         application_form = ApplicationForm.new(form_data)
-        right_to_work_form = CandidateInterface::RightToWorkOrStudyForm.build_from_application(
+        right_to_work_form = described_class.build_from_application(
           application_form,
         )
         expect(right_to_work_form).to have_attributes(form_data)
@@ -43,14 +43,14 @@ RSpec.describe CandidateInterface::RightToWorkOrStudyForm, type: :model do
       end
 
       it 'returns false if not valid' do
-        right_to_work_form = CandidateInterface::RightToWorkOrStudyForm.new
+        right_to_work_form = described_class.new
 
         expect(right_to_work_form.save(ApplicationForm.new)).to eq(false)
       end
 
       it 'updates the provided ApplicationForm if valid' do
         application_form = FactoryBot.create(:application_form)
-        right_to_work_form = CandidateInterface::RightToWorkOrStudyForm.new(form_data)
+        right_to_work_form = described_class.new(form_data)
 
         expect(right_to_work_form.save(application_form)).to eq(true)
         expect(application_form.right_to_work_or_study).to eq 'no'

--- a/spec/forms/candidate_interface/safeguarding_issues_declaration_form_spec.rb
+++ b/spec/forms/candidate_interface/safeguarding_issues_declaration_form_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
           safeguarding_issues_status: :not_answered_yet,
         )
 
-        form = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
+        form = described_class.build_from_application(application_form)
 
         expect(form.share_safeguarding_issues).to eq(nil)
         expect(form.safeguarding_issues).to eq(nil)
@@ -25,7 +25,7 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
           safeguarding_issues_status: :has_safeguarding_issues_to_declare,
         )
 
-        form = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
+        form = described_class.build_from_application(application_form)
 
         expect(form.share_safeguarding_issues).to eq('Yes')
         expect(form.safeguarding_issues).to eq(nil)
@@ -40,7 +40,7 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
           safeguarding_issues_status: :no_safeguarding_issues_to_declare,
         )
 
-        form = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
+        form = described_class.build_from_application(application_form)
 
         expect(form.share_safeguarding_issues).to eq('No')
         expect(form.safeguarding_issues).to eq(nil)
@@ -55,7 +55,7 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
           safeguarding_issues_status: :has_safeguarding_issues_to_declare,
         )
 
-        form = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
+        form = described_class.build_from_application(application_form)
 
         expect(form.share_safeguarding_issues).to eq('Yes')
         expect(form.safeguarding_issues).to eq('I have a criminal conviction')
@@ -68,7 +68,7 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
 
     context 'when sharing safeguarding issues is blank' do
       it 'returns false' do
-        form = CandidateInterface::SafeguardingIssuesDeclarationForm.new
+        form = described_class.new
 
         expect(form.save(application_form)).to be(false)
       end
@@ -76,13 +76,13 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
 
     context 'when sharing safeguarding issues is "No"' do
       it 'returns true' do
-        form = CandidateInterface::SafeguardingIssuesDeclarationForm.new(share_safeguarding_issues: 'No')
+        form = described_class.new(share_safeguarding_issues: 'No')
 
         expect(form.save(application_form)).to be(true)
       end
 
       it 'updates safeguarding issues of the application form to "No"' do
-        form = CandidateInterface::SafeguardingIssuesDeclarationForm.new(share_safeguarding_issues: 'No')
+        form = described_class.new(share_safeguarding_issues: 'No')
 
         form.save(application_form)
 
@@ -93,7 +93,7 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
 
     context 'when sharing safeguarding issues is "Yes" but no details provided' do
       it 'returns true' do
-        form = CandidateInterface::SafeguardingIssuesDeclarationForm.new(
+        form = described_class.new(
           share_safeguarding_issues: 'Yes',
           safeguarding_issues: '',
         )
@@ -102,7 +102,7 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
       end
 
       it 'updates safeguarding issues of the application form to provided issues if empty string' do
-        form = CandidateInterface::SafeguardingIssuesDeclarationForm.new(
+        form = described_class.new(
           share_safeguarding_issues: 'Yes',
           safeguarding_issues: '',
         )
@@ -114,7 +114,7 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
       end
 
       it 'updates safeguarding issues of the application form to provided issues if nil' do
-        form = CandidateInterface::SafeguardingIssuesDeclarationForm.new(
+        form = described_class.new(
           share_safeguarding_issues: 'Yes',
           safeguarding_issues: nil,
         )
@@ -128,7 +128,7 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
 
     context 'when sharing safeguarding issues is "Yes" and details provided' do
       it 'returns true' do
-        form = CandidateInterface::SafeguardingIssuesDeclarationForm.new(
+        form = described_class.new(
           share_safeguarding_issues: 'Yes',
           safeguarding_issues: 'I have a criminal conviction.',
         )
@@ -137,7 +137,7 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
       end
 
       it 'updates safeguarding issues of the application form to provided issues' do
-        form = CandidateInterface::SafeguardingIssuesDeclarationForm.new(
+        form = described_class.new(
           share_safeguarding_issues: 'Yes',
           safeguarding_issues: 'I have a criminal conviction.',
         )

--- a/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
             level: 'gcse',
           )
         end
-        let(:form) { CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification) }
+        let(:form) { described_class.build_from_qualification(qualification) }
 
         it 'returns no errors if grade is valid' do
           mistyped_grades = %w[a b c]
@@ -72,7 +72,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
             level: 'gcse',
           )
         end
-        let(:form) { CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification) }
+        let(:form) { described_class.build_from_qualification(qualification) }
 
         it 'returns no errors if grade is valid' do
           mistyped_grades = ['A a', 'A    a', 'b b', 'A-a', 'B/b', 'C,c']
@@ -123,7 +123,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
             level: 'gcse',
           )
         end
-        let(:form) { CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification) }
+        let(:form) { described_class.build_from_qualification(qualification) }
 
         it 'returns no errors if all grades are valid' do
           form.subject = ApplicationQualification::SCIENCE_TRIPLE_AWARD
@@ -172,7 +172,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
 
     context 'when qualification type is GCE O LEVEL' do
       let(:qualification) { FactoryBot.build_stubbed(:application_qualification, qualification_type: 'gce_o_level', level: 'gcse', subject: 'science') }
-      let(:form) { CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification) }
+      let(:form) { described_class.build_from_qualification(qualification) }
 
       it 'returns no errors if grade is valid' do
         valid_grades = ['ABC', 'AB', 'AA', 'abc', 'A B C', 'A-B-C']
@@ -198,7 +198,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
     end
 
     context 'when qualification type is Scottish National 5' do
-      let(:form) { CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification) }
+      let(:form) { described_class.build_from_qualification(qualification) }
       let(:qualification) do
         FactoryBot.build_stubbed(:application_qualification,
                                  qualification_type: 'scottish_national_5',
@@ -232,7 +232,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
 
   context 'when saving qualification details' do
     qualification = ApplicationQualification.new
-    form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+    form = described_class.build_from_qualification(qualification)
 
     describe '#save' do
       it 'return false if not valid' do
@@ -242,7 +242,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
       it 'updates qualification details if valid' do
         application_form = build(:application_form)
         qualification = ApplicationQualification.create(level: 'gcse', application_form: application_form)
-        details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+        details_form = described_class.build_from_qualification(qualification)
 
         details_form.grade = 'AB'
 
@@ -255,7 +255,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
       it 'sets grade to other_grade if candidate selected "other"' do
         application_form = build(:application_form)
         qualification = ApplicationQualification.create(level: 'gcse', application_form: application_form)
-        details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+        details_form = described_class.build_from_qualification(qualification)
 
         details_form.grade = 'other'
         details_form.other_grade = 'D'
@@ -273,7 +273,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
           application_form: application_form,
         )
 
-        details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+        details_form = described_class.build_from_qualification(qualification)
 
         details_form.subject = ApplicationQualification::SCIENCE_SINGLE_AWARD
         details_form.grade = 'a*'
@@ -291,7 +291,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
           application_form: application_form,
         )
 
-        details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+        details_form = described_class.build_from_qualification(qualification)
 
         details_form.subject = ApplicationQualification::SCIENCE_DOUBLE_AWARD
         details_form.grade = 'a* -/, a*'
@@ -309,7 +309,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
           application_form: application_form,
         )
 
-        details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+        details_form = described_class.build_from_qualification(qualification)
 
         details_form.subject = ApplicationQualification::SCIENCE_DOUBLE_AWARD
         details_form.grade = '43'
@@ -327,7 +327,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
           application_form: application_form,
         )
 
-        details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+        details_form = described_class.build_from_qualification(qualification)
 
         details_form.subject = ApplicationQualification::SCIENCE_TRIPLE_AWARD
         details_form.biology_grade = ' a* '
@@ -353,7 +353,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
             subject: ApplicationQualification::SCIENCE_SINGLE_AWARD,
             application_form: application_form,
           )
-          details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+          details_form = described_class.build_from_qualification(qualification)
 
           details_form.subject = ApplicationQualification::SCIENCE_TRIPLE_AWARD
           details_form.biology_grade = 'B'
@@ -378,7 +378,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
             subject: ApplicationQualification::SCIENCE_TRIPLE_AWARD,
             application_form: application_form,
           )
-          details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+          details_form = described_class.build_from_qualification(qualification)
 
           details_form.subject = ApplicationQualification::SCIENCE_SINGLE_AWARD
           details_form.grade = 'A'
@@ -396,7 +396,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
       context 'when the qualification_type is non_uk and grade is not_applicable' do
         it 'sets grade to not_applicable and other grade to nil' do
           qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'n/a')
-          gcse_details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+          gcse_details_form = described_class.build_from_qualification(qualification)
 
           expect(gcse_details_form.grade).to eq 'not_applicable'
           expect(gcse_details_form.other_grade).to eq nil
@@ -406,7 +406,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
       context 'when the grade is unknown' do
         it 'sets grade to not_applicable and other grade to nil' do
           qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'unknown')
-          gcse_details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+          gcse_details_form = described_class.build_from_qualification(qualification)
 
           expect(gcse_details_form.grade).to eq 'unknown'
           expect(gcse_details_form.other_grade).to eq nil
@@ -416,7 +416,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
       context 'when the grade is another value' do
         it 'sets grade to other and other grade to grades value' do
           qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'D')
-          gcse_details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+          gcse_details_form = described_class.build_from_qualification(qualification)
 
           expect(gcse_details_form.grade).to eq 'other'
           expect(gcse_details_form.other_grade).to eq 'D'

--- a/spec/forms/candidate_interface/subject_knowledge_form_spec.rb
+++ b/spec/forms/candidate_interface/subject_knowledge_form_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CandidateInterface::SubjectKnowledgeForm, type: :model do
   describe '.build_from_application' do
     it 'creates an object based on the provided ApplicationForm' do
       application_form = ApplicationForm.new(data)
-      subject_knowledge = CandidateInterface::SubjectKnowledgeForm.build_from_application(
+      subject_knowledge = described_class.build_from_application(
         application_form,
       )
 
@@ -26,14 +26,14 @@ RSpec.describe CandidateInterface::SubjectKnowledgeForm, type: :model do
 
   describe '#save' do
     it 'returns false if not valid' do
-      subject_knowledge = CandidateInterface::SubjectKnowledgeForm.new
+      subject_knowledge = described_class.new
 
       expect(subject_knowledge.save(ApplicationForm.new)).to eq(false)
     end
 
     it 'updates the provided ApplicationForm if valid' do
       application_form = FactoryBot.create(:application_form)
-      subject_knowledge = CandidateInterface::SubjectKnowledgeForm.new(form_data)
+      subject_knowledge = described_class.new(form_data)
 
       expect(subject_knowledge.save(application_form)).to eq(true)
       expect(application_form).to have_attributes(data)

--- a/spec/forms/candidate_interface/training_with_a_disability_form_spec.rb
+++ b/spec/forms/candidate_interface/training_with_a_disability_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CandidateInterface::TrainingWithADisabilityForm, type: :model do
         disability_disclosure: 'I have difficulty climbing stairs',
       }
       application_form = build_stubbed(:application_form, data)
-      disability_form = CandidateInterface::TrainingWithADisabilityForm.build_from_application(application_form)
+      disability_form = described_class.build_from_application(application_form)
 
       expect(disability_form).to have_attributes(
         disclose_disability: 'yes',
@@ -20,7 +20,7 @@ RSpec.describe CandidateInterface::TrainingWithADisabilityForm, type: :model do
   describe '#save' do
     let(:application_form) { build(:application_form) }
     let(:disability_form) do
-      CandidateInterface::TrainingWithADisabilityForm.new(form_data)
+      described_class.new(form_data)
     end
 
     context 'when not valid' do

--- a/spec/forms/candidate_interface/volunteering_experience_form_spec.rb
+++ b/spec/forms/candidate_interface/volunteering_experience_form_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 RSpec.describe CandidateInterface::VolunteeringExperienceForm, type: :model do
   describe '#save' do
     it 'returns false if not valid' do
-      volunteering_experience = CandidateInterface::VolunteeringExperienceForm.new
+      volunteering_experience = described_class.new
 
       expect(volunteering_experience.save(ApplicationForm.new)).to eq(false)
     end
 
     it 'updates volunteering experience if valid' do
       application_form = create(:application_form, volunteering_experience: true)
-      volunteering_experience = CandidateInterface::VolunteeringExperienceForm.new(experience: 'true')
+      volunteering_experience = described_class.new(experience: 'true')
 
       expect(volunteering_experience.save(application_form)).to eq(true)
       expect(application_form.volunteering_experience).to eq(true)

--- a/spec/forms/candidate_interface/volunteering_role_form_feature_flag_on_spec.rb
+++ b/spec/forms/candidate_interface/volunteering_role_form_feature_flag_on_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
         )
       end
 
-      volunteering_roles = CandidateInterface::VolunteeringRoleForm.build_all_from_application(application_form)
+      volunteering_roles = described_class.build_all_from_application(application_form)
 
       expect(volunteering_roles).to match_array([
         have_attributes(form_data),
@@ -77,7 +77,7 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
     it 'returns a new VolunteeringRoleForm object using an application experience' do
       application_experience = build_stubbed(:application_volunteering_experience, attributes: data)
 
-      volunteering_role = CandidateInterface::VolunteeringRoleForm.build_from_experience(application_experience)
+      volunteering_role = described_class.build_from_experience(application_experience)
 
       expect(volunteering_role).to have_attributes(form_data)
     end
@@ -85,7 +85,7 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
 
   describe '#save' do
     it 'returns false if not valid' do
-      volunteering_role = CandidateInterface::VolunteeringRoleForm.new
+      volunteering_role = described_class.new
 
       expect(volunteering_role.save(ApplicationForm.new)).to eq(false)
     end
@@ -93,7 +93,7 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
     context 'when a valid volunteering role' do
       let(:application_form) { create(:application_form, volunteering_experience: false) }
       let(:application_experience) { build(:application_volunteering_experience, attributes: data) }
-      let(:volunteering_role) { CandidateInterface::VolunteeringRoleForm.build_from_experience(application_experience) }
+      let(:volunteering_role) { described_class.build_from_experience(application_experience) }
 
       it 'creates a new work experience if valid' do
         expect(volunteering_role.save(application_form)).to eq(true)
@@ -113,7 +113,7 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
     let(:application_form) { create(:application_form) }
     let(:existing_volunteering) { application_form.application_volunteering_experiences.create(attributes: data) }
 
-    let(:volunteering_role) { CandidateInterface::VolunteeringRoleForm.new(id: existing_volunteering.id) }
+    let(:volunteering_role) { described_class.new(id: existing_volunteering.id) }
 
     it 'returns false if not valid' do
       expect(volunteering_role.update(ApplicationForm.new)).to eq(false)

--- a/spec/forms/candidate_interface/volunteering_role_form_spec.rb
+++ b/spec/forms/candidate_interface/volunteering_role_form_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
         )
       end
 
-      volunteering_roles = CandidateInterface::VolunteeringRoleForm.build_all_from_application(application_form)
+      volunteering_roles = described_class.build_all_from_application(application_form)
 
       expect(volunteering_roles).to match_array([
         have_attributes(form_data),
@@ -65,7 +65,7 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
     it 'returns a new VolunteeringRoleForm object using an application experience' do
       application_experience = build_stubbed(:application_volunteering_experience, attributes: data)
 
-      volunteering_role = CandidateInterface::VolunteeringRoleForm.build_from_experience(application_experience)
+      volunteering_role = described_class.build_from_experience(application_experience)
 
       expect(volunteering_role).to have_attributes(form_data)
     end
@@ -73,14 +73,14 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
 
   describe '#save' do
     it 'returns false if not valid' do
-      volunteering_role = CandidateInterface::VolunteeringRoleForm.new
+      volunteering_role = described_class.new
 
       expect(volunteering_role.save(ApplicationForm.new)).to eq(false)
     end
 
     context 'when a valid volunteering role' do
       let(:application_form) { create(:application_form, volunteering_experience: false) }
-      let(:volunteering_role) { CandidateInterface::VolunteeringRoleForm.new(form_data) }
+      let(:volunteering_role) { described_class.new(form_data) }
 
       it 'creates a new work experience if valid' do
         expect(volunteering_role.save(application_form)).to eq(true)
@@ -101,7 +101,7 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
     let(:existing_volunteering) do
       application_form.application_volunteering_experiences.create(attributes: data)
     end
-    let(:volunteering_role) { CandidateInterface::VolunteeringRoleForm.new(id: existing_volunteering.id) }
+    let(:volunteering_role) { described_class.new(id: existing_volunteering.id) }
 
     it 'returns false if not valid' do
       expect(volunteering_role.update(ApplicationForm.new)).to eq(false)

--- a/spec/forms/candidate_interface/work_experience_form_spec.rb
+++ b/spec/forms/candidate_interface/work_experience_form_spec.rb
@@ -68,14 +68,14 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
 
   describe '#save' do
     it 'returns false if not valid' do
-      work_experience = CandidateInterface::WorkExperienceForm.new
+      work_experience = described_class.new
 
       expect(work_experience.save(ApplicationForm.new)).to eq(false)
     end
 
     it 'creates a new work experience if valid' do
       application_form = FactoryBot.create(:application_form)
-      work_experience = CandidateInterface::WorkExperienceForm.new(form_data)
+      work_experience = described_class.new(form_data)
 
       saved_work_experience = work_experience.save(application_form)
       expect(saved_work_experience).to have_attributes(data)
@@ -84,14 +84,14 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
 
   describe '#update' do
     it 'returns false if not valid' do
-      work_experience = CandidateInterface::WorkExperienceForm.new
+      work_experience = described_class.new
 
       expect(work_experience.update(ApplicationWorkExperience.new)).to eq(false)
     end
 
     it 'updates an existing work experience if valid' do
       application_form = FactoryBot.create(:application_form)
-      work_experience = CandidateInterface::WorkExperienceForm.new(form_data)
+      work_experience = described_class.new(form_data)
 
       saved_work_experience = work_experience.save(application_form)
 
@@ -106,7 +106,7 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
   describe '.build_from_experience' do
     it 'creates an object based on the provided experience' do
       application_work_experience = ApplicationWorkExperience.new(data)
-      work_experience_form = CandidateInterface::WorkExperienceForm.build_from_experience(
+      work_experience_form = described_class.build_from_experience(
         application_work_experience,
       )
 
@@ -116,7 +116,7 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
     it 'returns an empty string if end date is nil' do
       data[:end_date] = nil
       application_work_experience = ApplicationWorkExperience.new(data)
-      work_experience_form = CandidateInterface::WorkExperienceForm.build_from_experience(
+      work_experience_form = described_class.build_from_experience(
         application_work_experience,
       )
 

--- a/spec/forms/candidate_interface/work_explanation_form_spec.rb
+++ b/spec/forms/candidate_interface/work_explanation_form_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe CandidateInterface::WorkExplanationForm, type: :model do
 
   describe '#save' do
     it 'returns false if not valid' do
-      work_explanation_form = CandidateInterface::WorkExplanationForm.new
+      work_explanation_form = described_class.new
 
       expect(work_explanation_form.save(ApplicationForm.new)).to eq(false)
     end
 
     it 'creates a new work experience if valid' do
       application_form = FactoryBot.create(:application_form)
-      work_explanation_form = CandidateInterface::WorkExplanationForm.new(form_data)
+      work_explanation_form = described_class.new(form_data)
 
       work_explanation_form.save(application_form)
       expect(application_form.reload).to have_attributes(data)
@@ -42,7 +42,7 @@ RSpec.describe CandidateInterface::WorkExplanationForm, type: :model do
   describe '.build_from_application' do
     it 'creates an object based on the provided application form' do
       application_form = ApplicationForm.new(data)
-      work_explanation_form = CandidateInterface::WorkExplanationForm.build_from_application(
+      work_explanation_form = described_class.build_from_application(
         application_form,
       )
 

--- a/spec/forms/candidate_interface/work_history_break_form_spec.rb
+++ b/spec/forms/candidate_interface/work_history_break_form_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe CandidateInterface::WorkHistoryBreakForm, type: :model do
   describe '.build_from_break' do
     it 'creates an object based on the work history break' do
       application_work_history_break = build_stubbed(:application_work_history_break, attributes: data)
-      work_break = CandidateInterface::WorkHistoryBreakForm.build_from_break(
+      work_break = described_class.build_from_break(
         application_work_history_break,
       )
 
@@ -62,14 +62,14 @@ RSpec.describe CandidateInterface::WorkHistoryBreakForm, type: :model do
 
   describe '#save' do
     it 'returns false if not valid' do
-      work_break = CandidateInterface::WorkHistoryBreakForm.new
+      work_break = described_class.new
 
       expect(work_break.save(ApplicationForm.new)).to eq(false)
     end
 
     it 'creates a new work experience if valid' do
       application_form = create(:application_form)
-      work_break = CandidateInterface::WorkHistoryBreakForm.new(form_data)
+      work_break = described_class.new(form_data)
 
       saved_work_break = work_break.save(application_form)
 
@@ -79,7 +79,7 @@ RSpec.describe CandidateInterface::WorkHistoryBreakForm, type: :model do
 
   describe '#update' do
     it 'returns false if not valid' do
-      work_break = CandidateInterface::WorkHistoryBreakForm.new
+      work_break = described_class.new
 
       expect(work_break.save(ApplicationForm.new)).to eq(false)
     end
@@ -90,7 +90,7 @@ RSpec.describe CandidateInterface::WorkHistoryBreakForm, type: :model do
         application_form: create(:application_form),
         attributes: data,
       )
-      work_break = CandidateInterface::WorkHistoryBreakForm.new(form_data)
+      work_break = described_class.new(form_data)
       work_break.reason = 'Updated reason.'
 
       work_break.update(application_work_history_break)

--- a/spec/forms/referee_interface/reference_relationship_form_spec.rb
+++ b/spec/forms/referee_interface/reference_relationship_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RefereeInterface::ReferenceRelationshipForm, type: :model do
   describe '#build_from_application' do
     it 'creates an object based on the application reference' do
       reference = build_stubbed(:reference, relationship_correction: 'Leader of the MS Paint course')
-      form = RefereeInterface::ReferenceRelationshipForm.build_from_reference(reference: reference)
+      form = described_class.build_from_reference(reference: reference)
 
       expect(form.relationship_correction).to eq('Leader of the MS Paint course')
     end
@@ -12,7 +12,7 @@ RSpec.describe RefereeInterface::ReferenceRelationshipForm, type: :model do
     context 'when there is no relationship_correction' do
       it 'sets the relationship_confirmation true' do
         reference = build_stubbed(:reference, relationship_correction: '')
-        form = RefereeInterface::ReferenceRelationshipForm.build_from_reference(reference: reference)
+        form = described_class.build_from_reference(reference: reference)
 
         expect(form.relationship_confirmation).to eq('yes')
       end
@@ -21,7 +21,7 @@ RSpec.describe RefereeInterface::ReferenceRelationshipForm, type: :model do
     context 'when there is a relationship_correction' do
       it 'sets the relationship_confirmation false' do
         reference = build_stubbed(:reference, relationship_correction: 'She did not attend my MS Paint course')
-        form = RefereeInterface::ReferenceRelationshipForm.build_from_reference(reference: reference)
+        form = described_class.build_from_reference(reference: reference)
 
         expect(form.relationship_confirmation).to eq('no')
       end
@@ -30,7 +30,7 @@ RSpec.describe RefereeInterface::ReferenceRelationshipForm, type: :model do
     context 'when there is a relationship_correction is nil' do
       it 'sets the relationship_confirmation nil' do
         reference = build_stubbed(:reference)
-        form = RefereeInterface::ReferenceRelationshipForm.build_from_reference(reference: reference)
+        form = described_class.build_from_reference(reference: reference)
 
         expect(form.relationship_confirmation).to eq(nil)
       end
@@ -42,7 +42,7 @@ RSpec.describe RefereeInterface::ReferenceRelationshipForm, type: :model do
 
     context 'when relationship_confirmation is blank' do
       it 'return false' do
-        form = RefereeInterface::ReferenceRelationshipForm.new
+        form = described_class.new
 
         expect(form.save(application_reference)).to be(false)
       end
@@ -50,7 +50,7 @@ RSpec.describe RefereeInterface::ReferenceRelationshipForm, type: :model do
 
     context 'when relationship_confirmation has value "no"' do
       it 'updates the application reference with the correction' do
-        form = RefereeInterface::ReferenceRelationshipForm.new(relationship_confirmation: 'no', relationship_correction: 'I dont know this person')
+        form = described_class.new(relationship_confirmation: 'no', relationship_correction: 'I dont know this person')
 
         form.save(application_reference)
 
@@ -60,7 +60,7 @@ RSpec.describe RefereeInterface::ReferenceRelationshipForm, type: :model do
 
     context 'when relationship_confirmation has value "yes' do
       it 'resets the relationship_correction' do
-        form = RefereeInterface::ReferenceRelationshipForm.new(relationship_confirmation: 'yes')
+        form = described_class.new(relationship_confirmation: 'yes')
 
         form.save(application_reference)
 
@@ -74,7 +74,7 @@ RSpec.describe RefereeInterface::ReferenceRelationshipForm, type: :model do
 
     context 'when relationship_confirmation has value "no"' do
       it 'validates presence of relationship_correction' do
-        form = RefereeInterface::ReferenceRelationshipForm.new(relationship_confirmation: 'no', candidate: 'Tim Tamagotchi')
+        form = described_class.new(relationship_confirmation: 'no', candidate: 'Tim Tamagotchi')
         expected_error_message = I18n.t('activemodel.errors.models.referee_interface/reference_relationship_form.attributes.relationship_correction.blank', candidate: 'Tim Tamagotchi')
 
         form.validate
@@ -85,7 +85,7 @@ RSpec.describe RefereeInterface::ReferenceRelationshipForm, type: :model do
       end
 
       it 'does not show error when there is relationship_correction' do
-        form = RefereeInterface::ReferenceRelationshipForm.new(relationship_correction: 'Fixed')
+        form = described_class.new(relationship_correction: 'Fixed')
         form.validate
 
         expect(form.errors.full_messages_for(:relationship_correction)).to be_empty

--- a/spec/forms/referee_interface/reference_safeguarding_form_spec.rb
+++ b/spec/forms/referee_interface/reference_safeguarding_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RefereeInterface::ReferenceSafeguardingForm, type: :model do
   describe '.build_from_application' do
     it 'creates an object based on the application reference' do
       reference = build_stubbed(:reference, safeguarding_concerns: 'Very unreliable')
-      form = RefereeInterface::ReferenceSafeguardingForm.build_from_reference(reference: reference)
+      form = described_class.build_from_reference(reference: reference)
 
       expect(form.safeguarding_concerns).to eq('Very unreliable')
     end
@@ -12,7 +12,7 @@ RSpec.describe RefereeInterface::ReferenceSafeguardingForm, type: :model do
     context 'when safeguarding concern is blank' do
       it 'sets the any_safeguarding_concerns attribute to no' do
         reference = build_stubbed(:reference, safeguarding_concerns: '')
-        form = RefereeInterface::ReferenceSafeguardingForm.build_from_reference(reference: reference)
+        form = described_class.build_from_reference(reference: reference)
 
         expect(form.any_safeguarding_concerns).to eq('no')
       end
@@ -21,7 +21,7 @@ RSpec.describe RefereeInterface::ReferenceSafeguardingForm, type: :model do
     context 'when safeguarding concern has a value' do
       it 'sets the any_safeguarding_concerns attribute to yes' do
         reference = build_stubbed(:reference, safeguarding_concerns: 'Very unreliable')
-        form = RefereeInterface::ReferenceSafeguardingForm.build_from_reference(reference: reference)
+        form = described_class.build_from_reference(reference: reference)
 
         expect(form.any_safeguarding_concerns).to eq('yes')
       end
@@ -30,7 +30,7 @@ RSpec.describe RefereeInterface::ReferenceSafeguardingForm, type: :model do
     context 'when safeguarding concern is nil' do
       it 'sets the any_safeguarding_concerns attribute to nil' do
         reference = build_stubbed(:reference, safeguarding_concerns: nil)
-        form = RefereeInterface::ReferenceSafeguardingForm.build_from_reference(reference: reference)
+        form = described_class.build_from_reference(reference: reference)
 
         expect(form.any_safeguarding_concerns).to eq(nil)
       end
@@ -42,7 +42,7 @@ RSpec.describe RefereeInterface::ReferenceSafeguardingForm, type: :model do
 
     context 'when any_safeguarding_concerns is blank' do
       it 'return false' do
-        form = RefereeInterface::ReferenceSafeguardingForm.new
+        form = described_class.new
 
         expect(form.save(application_reference)).to be(false)
       end
@@ -50,7 +50,7 @@ RSpec.describe RefereeInterface::ReferenceSafeguardingForm, type: :model do
 
     context 'when any_safeguarding_concerns has value "no"' do
       it 'updates the safeguarding_concerns' do
-        form = RefereeInterface::ReferenceSafeguardingForm.new(any_safeguarding_concerns: 'no')
+        form = described_class.new(any_safeguarding_concerns: 'no')
         form.save(application_reference)
 
         expect(application_reference.safeguarding_concerns).to eq('')
@@ -59,7 +59,7 @@ RSpec.describe RefereeInterface::ReferenceSafeguardingForm, type: :model do
 
     context 'when any_safeguarding_concerns has value "yes"' do
       it 'updates the safeguarding_concerns' do
-        form = RefereeInterface::ReferenceSafeguardingForm.new(any_safeguarding_concerns: 'yes', safeguarding_concerns: 'rude')
+        form = described_class.new(any_safeguarding_concerns: 'yes', safeguarding_concerns: 'rude')
         form.save(application_reference)
 
         expect(application_reference.safeguarding_concerns).to eq('rude')
@@ -69,7 +69,7 @@ RSpec.describe RefereeInterface::ReferenceSafeguardingForm, type: :model do
 
   describe 'validations' do
     it 'validate presence of any_safeguarding_concerns' do
-      form = RefereeInterface::ReferenceSafeguardingForm.new(candidate: 'Donald Trump')
+      form = described_class.new(candidate: 'Donald Trump')
       expected_error_message = 'Select if you know of any reason why Donald Trump should not work with children'
 
       form.validate
@@ -82,7 +82,7 @@ RSpec.describe RefereeInterface::ReferenceSafeguardingForm, type: :model do
     context 'when other any_safeguarding_concerns is nil or has value "no"' do
       it 'does not validate presence of safeguarding_concerns' do
         any_safeguarding_concerns = [nil, 'no'].sample
-        form = RefereeInterface::ReferenceSafeguardingForm.new(any_safeguarding_concerns: any_safeguarding_concerns)
+        form = described_class.new(any_safeguarding_concerns: any_safeguarding_concerns)
         form.validate
 
         expect(form.errors.full_messages_for(:safeguarding_concerns)).to be_empty
@@ -91,7 +91,7 @@ RSpec.describe RefereeInterface::ReferenceSafeguardingForm, type: :model do
 
     context 'when both any_safeguarding_concerns and safeguarding_concerns present' do
       it 'does not show error messages' do
-        form = RefereeInterface::ReferenceSafeguardingForm.new(any_safeguarding_concerns: 'yes', safeguarding_concerns: 'rude')
+        form = described_class.new(any_safeguarding_concerns: 'yes', safeguarding_concerns: 'rude')
 
         form.validate
 

--- a/spec/forms/support_interface/application_forms/edit_address_details_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_address_details_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
         postcode: Faker::Address.postcode,
         audit_comment: 'Updated as part of Zendesk ticket 12345',
       }
-      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.new(data)
+      details_form = described_class.new(data)
 
       expect(details_form).to have_attributes(data)
     end
@@ -19,7 +19,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
 
   describe '#save_address' do
     it 'returns false if not valid' do
-      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.new
+      details_form = described_class.new
 
       expect(details_form.save_address(ApplicationForm.new)).to eq(false)
     end
@@ -35,7 +35,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
         audit_comment: 'Updated as part of Zendesk ticket 12345',
       }
       application_form = build(:application_form)
-      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.new(data)
+      details_form = described_class.new(data)
       data[:postcode] = 'BN1 1AA'
       data.except!(:audit_comment)
 
@@ -52,7 +52,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
         audit_comment: 'Updated as part of Zendesk ticket 12345',
       }
       application_form = build(:application_form)
-      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.new(data.merge(address_type: 'international'))
+      details_form = described_class.new(data.merge(address_type: 'international'))
       data.except!(:audit_comment)
 
       expect(details_form.save_address(application_form)).to eq(true)
@@ -68,7 +68,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
         address_type: 'uk',
       }
       application_form = build(:application_form)
-      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.new(data)
+      details_form = described_class.new(data)
 
       expect(details_form.save_address_type(application_form)).to eq(true)
       expect(application_form).to have_attributes(data)
@@ -80,7 +80,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
         country: 'India',
       }
       application_form = build(:application_form)
-      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.new(data)
+      details_form = described_class.new(data)
 
       expect(details_form.save_address_type(application_form)).to eq(true)
       expect(application_form).to have_attributes(data)
@@ -91,7 +91,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
         address_type: 'international',
       }
       application_form = build(:application_form)
-      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.new(data)
+      details_form = described_class.new(data)
 
       expect(details_form.save_address_type(application_form)).to eq(false)
     end

--- a/spec/forms/support_interface/application_forms/reinstate_declined_offer_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/reinstate_declined_offer_form_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe SupportInterface::ApplicationForms::ReinstateDeclinedOfferForm, t
 
     it 'returns false if not valid' do
       course_choice = create(:application_choice, status: :offer)
-      declined_offer_form = SupportInterface::ApplicationForms::ReinstateDeclinedOfferForm.new
+      declined_offer_form = described_class.new
 
       expect(declined_offer_form.save(course_choice)).to eq(false)
     end
@@ -30,7 +30,7 @@ RSpec.describe SupportInterface::ApplicationForms::ReinstateDeclinedOfferForm, t
       Timecop.freeze do
         course_choice = create(:application_choice, :with_declined_offer)
 
-        declined_offer_form = SupportInterface::ApplicationForms::ReinstateDeclinedOfferForm.new(
+        declined_offer_form = described_class.new(
           { status: :declined,
             audit_comment_ticket: zendesk_ticket,
             accept_guidance: true },

--- a/spec/forms/support_interface/application_forms/revert_rejection_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/revert_rejection_form_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SupportInterface::ApplicationForms::RevertRejectionForm, type: :m
       Timecop.freeze do
         application_choice = create(:application_choice, :with_rejection)
 
-        form = SupportInterface::ApplicationForms::RevertRejectionForm.new(
+        form = described_class.new(
           audit_comment_ticket: zendesk_ticket,
           accept_guidance: true,
         )

--- a/spec/lib/backup_and_restore_support_users_spec.rb
+++ b/spec/lib/backup_and_restore_support_users_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe BackupAndRestoreSupportUsers do
   it 'backs up and restores support users' do
     create(:support_user)
-    BackupAndRestoreSupportUsers.backup!
+    described_class.backup!
 
     SupportUser.destroy_all
     expect(SupportUser.count).to eq 0
 
-    expect { BackupAndRestoreSupportUsers.restore! }
+    expect { described_class.restore! }
       .to change { SupportUser.count }.from(0).to(1)
   end
 
@@ -16,10 +16,10 @@ RSpec.describe BackupAndRestoreSupportUsers do
     it 'does not overwrite the backup' do
       create(:support_user)
 
-      BackupAndRestoreSupportUsers.backup!
+      described_class.backup!
       SupportUser.destroy_all
-      BackupAndRestoreSupportUsers.backup!
-      BackupAndRestoreSupportUsers.restore!
+      described_class.backup!
+      described_class.restore!
 
       expect(SupportUser.count).to eq 1
     end

--- a/spec/lib/create_example_provider_users_with_permissions_spec.rb
+++ b/spec/lib/create_example_provider_users_with_permissions_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CreateExampleProviderUsersWithPermissions do
     end
 
     expect {
-      CreateExampleProviderUsersWithPermissions.call
+      described_class.call
     }.to(change { ProviderUser.count })
   end
 end

--- a/spec/lib/dsi_profile_spec.rb
+++ b/spec/lib/dsi_profile_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DsiProfile do
     context 'local_user\'s email_address' do
       it 'is updated if uid is previously known' do
         expect {
-          DsiProfile.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
+          described_class.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
         }.to change(provider_user, :email_address).to(email_address)
       end
 
@@ -25,7 +25,7 @@ RSpec.describe DsiProfile do
         provider_user.update(dfe_sign_in_uid: nil)
 
         expect {
-          DsiProfile.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
+          described_class.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
         }.not_to change(provider_user, :email_address)
       end
 
@@ -38,7 +38,7 @@ RSpec.describe DsiProfile do
         )
 
         expect {
-          DsiProfile.update_profile_from_dfe_sign_in dfe_user: dfe_user_no_email, local_user: provider_user
+          described_class.update_profile_from_dfe_sign_in dfe_user: dfe_user_no_email, local_user: provider_user
         }.not_to change(provider_user, :email_address)
       end
     end
@@ -46,19 +46,19 @@ RSpec.describe DsiProfile do
     context 'local_user\'s profile fields' do
       it 'updates first_name if supplied' do
         dfe_user.first_name = 'New name'
-        DsiProfile.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
+        described_class.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
         expect(provider_user.first_name).to eq('New name')
         dfe_user.first_name = ' '
-        DsiProfile.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
+        described_class.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
         expect(provider_user.first_name).to eq('New name')
       end
 
       it 'updates last_name if supplied' do
         dfe_user.last_name = 'New name'
-        DsiProfile.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
+        described_class.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
         expect(provider_user.last_name).to eq('New name')
         dfe_user.last_name = ' '
-        DsiProfile.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
+        described_class.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
         expect(provider_user.last_name).to eq('New name')
       end
     end

--- a/spec/lib/events/event_spec.rb
+++ b/spec/lib/events/event_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Events::Event do
   it 'can append request details' do
-    event = Events::Event.new
+    event = described_class.new
     output = event.with_request_details(fake_request).as_json
 
     expect(output).to match a_hash_including({
@@ -22,7 +22,7 @@ RSpec.describe Events::Event do
         user_agent: user_agent,
       )
 
-      event = Events::Event.new
+      event = described_class.new
       event.with_request_details(request).as_json['anonymised_user_agent_and_ip']
     end
 
@@ -57,7 +57,7 @@ RSpec.describe Events::Event do
 
   describe 'data pairs' do
     it 'converts booleans to strings' do
-      event = Events::Event.new
+      event = described_class.new
       output = event.with_data(key: true).as_json
       expect(output['data'].first['value']).to eq ['true']
     end

--- a/spec/lib/modules/aws_ip_ranges_spec.rb
+++ b/spec/lib/modules/aws_ip_ranges_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe AWSIpRanges do
     it 'returns the CLOUDFRONT ip in the GLOBAL or eu-west-2 area' do
       expected_result = %w[13.32.0.0/15 13.35.0.0/16 52.56.127.0/25]
 
-      expect(AWSIpRanges.cloudfront_ips).to eq(expected_result)
+      expect(described_class.cloudfront_ips).to eq(expected_result)
     end
 
     context 'when there was any connectivity issue' do
@@ -21,12 +21,12 @@ RSpec.describe AWSIpRanges do
       end
 
       it 'returns an empty array' do
-        expect(AWSIpRanges.cloudfront_ips).to eq([])
+        expect(described_class.cloudfront_ips).to eq([])
       end
 
       it 'logs a warning to sentry' do
         allow(Sentry).to receive(:capture_exception)
-        AWSIpRanges.cloudfront_ips
+        described_class.cloudfront_ips
         expect(Sentry).to have_received(:capture_exception)
       end
     end
@@ -37,12 +37,12 @@ RSpec.describe AWSIpRanges do
       end
 
       it 'returns an empty array' do
-        expect(AWSIpRanges.cloudfront_ips).to eq([])
+        expect(described_class.cloudfront_ips).to eq([])
       end
 
       it 'logs a warning to sentry' do
         allow(Sentry).to receive(:capture_exception)
-        AWSIpRanges.cloudfront_ips
+        described_class.cloudfront_ips
         expect(Sentry).to have_received(:capture_exception)
       end
     end
@@ -56,12 +56,12 @@ RSpec.describe AWSIpRanges do
       end
 
       it 'returns an empty array' do
-        expect(AWSIpRanges.cloudfront_ips).to eq([])
+        expect(described_class.cloudfront_ips).to eq([])
       end
 
       it 'logs a warning' do
         allow(Sentry).to receive(:capture_exception)
-        AWSIpRanges.cloudfront_ips
+        described_class.cloudfront_ips
         expect(Sentry).to have_received(:capture_exception)
       end
     end

--- a/spec/lib/sandbox_interceptor_spec.rb
+++ b/spec/lib/sandbox_interceptor_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SandboxInterceptor do
       it 'aborts delivery by default' do
         message = email_with_mailer_and_template_headers('provider_mailer', 'anything')
 
-        SandboxInterceptor.delivering_email(message)
+        described_class.delivering_email(message)
 
         expect(message.perform_deliveries).to be false
       end
@@ -14,7 +14,7 @@ RSpec.describe SandboxInterceptor do
       it 'still permits fallback_sign_in_email' do
         message = email_with_mailer_and_template_headers('provider_mailer', 'fallback_sign_in_email')
 
-        SandboxInterceptor.delivering_email(message)
+        described_class.delivering_email(message)
 
         expect(message.perform_deliveries).to be true
       end
@@ -22,7 +22,7 @@ RSpec.describe SandboxInterceptor do
       it 'still permits account_created' do
         message = email_with_mailer_and_template_headers('provider_mailer', 'account_created')
 
-        SandboxInterceptor.delivering_email(message)
+        described_class.delivering_email(message)
 
         expect(message.perform_deliveries).to be true
       end
@@ -31,7 +31,7 @@ RSpec.describe SandboxInterceptor do
     it 'allows delivery when rails_mailer is not set to provider_mailer' do
       message = email_with_mailer_and_template_headers('authentication_mailer', 'sign_in_email')
 
-      SandboxInterceptor.delivering_email(message)
+      described_class.delivering_email(message)
 
       expect(message.perform_deliveries).to be true
     end
@@ -40,7 +40,7 @@ RSpec.describe SandboxInterceptor do
   it 'does nothing outside sandbox mode' do
     message = email_with_mailer_and_template_headers('provider_mailer', 'anything')
 
-    SandboxInterceptor.delivering_email(message)
+    described_class.delivering_email(message)
 
     expect(message.perform_deliveries).to be true
   end

--- a/spec/lib/state_change_notifier_spec.rb
+++ b/spec/lib/state_change_notifier_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe StateChangeNotifier do
     let(:course_name)         { application_choice.course.name_and_code }
 
     describe ':change_an_offer' do
-      before { StateChangeNotifier.call(:change_an_offer, application_choice: application_choice) }
+      before { described_class.call(:change_an_offer, application_choice: application_choice) }
 
       it 'mentions applicant\'s first name and provider name' do
         arg1 = ":love_letter: #{provider_name} has changed an offer for #{applicant}’s application"
@@ -35,7 +35,7 @@ RSpec.describe StateChangeNotifier do
     before do
       fake_relation = instance_double('ActiveRecord::Relation', count: candidate_count)
       allow(Candidate).to receive(:where).and_return fake_relation
-      StateChangeNotifier.sign_up(create(:candidate))
+      described_class.sign_up(create(:candidate))
     end
 
     context 'every 100 candidate' do
@@ -79,7 +79,7 @@ RSpec.describe StateChangeNotifier do
       it 'all rejected' do
         rejected_choice
 
-        StateChangeNotifier.new(:rejected, application_choice).application_outcome_notification
+        described_class.new(:rejected, application_choice).application_outcome_notification
 
         message = /:broken_heart: #{applicant}'s application was rejected by #{provider_name} and #{rejected_choice.provider.name}/
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
@@ -92,7 +92,7 @@ RSpec.describe StateChangeNotifier do
       it 'all rejected by default' do
         rejected_by_default_choice
 
-        StateChangeNotifier.new(:rejected_by_default, application_choice).application_outcome_notification
+        described_class.new(:rejected_by_default, application_choice).application_outcome_notification
 
         message = /:broken_heart: #{applicant}'s applications to #{provider_name} and #{rejected_by_default_choice.provider.name} were rejected by default/
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
@@ -105,7 +105,7 @@ RSpec.describe StateChangeNotifier do
       it 'all declined' do
         declined_choice
 
-        StateChangeNotifier.new(:declined, application_choice).application_outcome_notification
+        described_class.new(:declined, application_choice).application_outcome_notification
 
         message = /:no_good: #{applicant} declined offers from #{provider_name} and #{declined_choice.provider.name}/
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
@@ -118,7 +118,7 @@ RSpec.describe StateChangeNotifier do
       it 'all declined_by_default' do
         declined_by_default_choice
 
-        StateChangeNotifier.new(:declined_by_default, application_choice).application_outcome_notification
+        described_class.new(:declined_by_default, application_choice).application_outcome_notification
 
         message = /:no_good: #{applicant} declined by default offers from #{provider_name} and #{declined_by_default_choice.provider.name}/
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
@@ -131,7 +131,7 @@ RSpec.describe StateChangeNotifier do
       it 'all withdrawn' do
         withdrawn_choice
 
-        StateChangeNotifier.new(:withdrawn, application_choice).application_outcome_notification
+        described_class.new(:withdrawn, application_choice).application_outcome_notification
 
         message = /:runner: #{applicant} withdrew their applications from #{provider_name} and #{withdrawn_choice.provider.name}/
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
@@ -142,7 +142,7 @@ RSpec.describe StateChangeNotifier do
       let(:application_choice) { create(:application_choice, :recruited, application_form: application_form) }
 
       it 'and no other applications' do
-        StateChangeNotifier.new(:recruited, application_choice).application_outcome_notification
+        described_class.new(:recruited, application_choice).application_outcome_notification
 
         message = /:handshake: #{applicant} was recruited to #{provider_name}/
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
@@ -156,7 +156,7 @@ RSpec.describe StateChangeNotifier do
         create(:withdrawn_at_candidates_request_audit, application_choice: withdrawn_choice)
         create(:withdrawn_at_candidates_request_audit, application_choice: application_choice)
 
-        StateChangeNotifier.new(:withdrawn_at_candidates_request, application_choice).application_outcome_notification
+        described_class.new(:withdrawn_at_candidates_request, application_choice).application_outcome_notification
 
         message = /:runner: #{applicant} requested that their applications be withdrawn from #{provider_name} and #{withdrawn_choice.provider.name}/
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
@@ -174,46 +174,46 @@ RSpec.describe StateChangeNotifier do
       let(:application_choice) { create(:application_choice, application_form: application_form) }
 
       it 'other applications have been rejected' do
-        status = (StateChangeNotifier::APPLICATION_OUTCOME_EVENTS - %i[rejected withdrawn_at_candidates_request]).sample
+        status = (described_class::APPLICATION_OUTCOME_EVENTS - %i[rejected withdrawn_at_candidates_request]).sample
         params = status_params.key?(status) ? status_params[status] : { status: status }
         application_choice.update(params)
 
         rejected_choice
 
-        StateChangeNotifier.new(status.to_sym, application_choice).application_outcome_notification
+        described_class.new(status.to_sym, application_choice).application_outcome_notification
 
         message = /.+#{applicant} previously was rejected by #{rejected_choice.provider.name}./
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
       end
 
       it 'other applications have been declined' do
-        status = (StateChangeNotifier::APPLICATION_OUTCOME_EVENTS - %i[declined withdrawn_at_candidates_request]).sample
+        status = (described_class::APPLICATION_OUTCOME_EVENTS - %i[declined withdrawn_at_candidates_request]).sample
         params = status_params.key?(status) ? status_params[status] : { status: status }
         application_choice.update(params)
 
         declined_choice
 
-        StateChangeNotifier.new(status.to_sym, application_choice).application_outcome_notification
+        described_class.new(status.to_sym, application_choice).application_outcome_notification
 
         message = /.+#{applicant} previously declined an offer from #{declined_choice.provider.name}./
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
       end
 
       it 'other applications have been withdrawn' do
-        status = (StateChangeNotifier::APPLICATION_OUTCOME_EVENTS - %i[withdrawn withdrawn_at_candidates_request]).sample
+        status = (described_class::APPLICATION_OUTCOME_EVENTS - %i[withdrawn withdrawn_at_candidates_request]).sample
         params = status_params.key?(status) ? status_params[status] : { status: status }
         application_choice.update(params)
 
         withdrawn_choice
 
-        StateChangeNotifier.new(status.to_sym, application_choice).application_outcome_notification
+        described_class.new(status.to_sym, application_choice).application_outcome_notification
 
         message = /.+#{applicant} previously withdrew from #{withdrawn_choice.provider.name}./
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
       end
 
       it 'other applications have been rejected, declined and withdrawn' do
-        status = (StateChangeNotifier::APPLICATION_OUTCOME_EVENTS - %i[withdrawn rejected declined withdrawn_at_candidates_request]).sample
+        status = (described_class::APPLICATION_OUTCOME_EVENTS - %i[withdrawn rejected declined withdrawn_at_candidates_request]).sample
         params = status_params.key?(status) ? status_params[status] : { status: status }
         application_choice.update(params)
 
@@ -221,14 +221,14 @@ RSpec.describe StateChangeNotifier do
         declined_choice
         withdrawn_choice
 
-        StateChangeNotifier.new(status.to_sym, application_choice).application_outcome_notification
+        described_class.new(status.to_sym, application_choice).application_outcome_notification
 
         message = /.+#{applicant} previously declined an offer from #{declined_choice.provider.name}, withdrew from #{withdrawn_choice.provider.name}, and was rejected by #{rejected_choice.provider.name}/
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
       end
 
       it 'other applications have been declined, declined_by_default, rejected, rejected_by_default and withdrawn' do
-        status = (StateChangeNotifier::APPLICATION_OUTCOME_EVENTS - %i[withdrawn rejected rejected_by_default declined declined_by_default withdrawn_at_candidates_request]).sample
+        status = (described_class::APPLICATION_OUTCOME_EVENTS - %i[withdrawn rejected rejected_by_default declined declined_by_default withdrawn_at_candidates_request]).sample
         params = status_params.key?(status) ? status_params[status] : { status: status }
         application_choice.update(params)
 
@@ -238,7 +238,7 @@ RSpec.describe StateChangeNotifier do
         rejected_by_default_choice
         declined_by_default_choice
 
-        StateChangeNotifier.new(status.to_sym, application_choice).application_outcome_notification
+        described_class.new(status.to_sym, application_choice).application_outcome_notification
 
         message = /.+#{applicant} previously declined an offer from #{declined_choice.provider.name}, declined by default an offer from #{declined_by_default_choice.provider.name}, withdrew from #{withdrawn_choice.provider.name}, was rejected by #{rejected_choice.provider.name}, and was rejected by default from #{rejected_by_default_choice.provider.name}/
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
@@ -249,7 +249,7 @@ RSpec.describe StateChangeNotifier do
 
         create(:withdrawn_at_candidates_request_audit, application_choice: declined_choice, comment: 'Declined on behalf of the candidate')
 
-        StateChangeNotifier.new(:rejected, application_choice).application_outcome_notification
+        described_class.new(:rejected, application_choice).application_outcome_notification
 
         message = /:broken_heart: #{applicant}'s application was rejected by #{application_choice.provider.name}. #{applicant} previously requested that their application be withdrawn from #{declined_choice.provider.name}/
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
@@ -262,7 +262,7 @@ RSpec.describe StateChangeNotifier do
         create(:application_choice, :awaiting_provider_decision, application_form: application_form)
         rejected_choice
 
-        StateChangeNotifier.new(:recruited, recruited_application_choice).application_outcome_notification
+        described_class.new(:recruited, recruited_application_choice).application_outcome_notification
 
         message = /:handshake: #{applicant} was recruited to #{recruited_application_choice.provider.name}. #{applicant} previously was rejected by #{rejected_choice.provider.name}/
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)

--- a/spec/lib/strip_whitespace_spec.rb
+++ b/spec/lib/strip_whitespace_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe StripWhitespace do
   describe '.from_string' do
     it 'removes whitespace characters from the string argument' do
       expect(
-        StripWhitespace.from_string(
+        described_class.from_string(
           "\u180E\u200B\u200C\u200D\u2060\uFEFF test \u180E\u200B\u200C\u200D\u2060\uFEFF",
         ),
       ).to eq('test')

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe TestApplications do
     create(:course_option, course: create(:course, :open_on_apply))
     create(:course_option, course: create(:course, :open_on_apply))
 
-    choices = TestApplications.new.create_application(recruitment_cycle_year: 2020, states: %i[offer rejected], courses_to_apply_to: Course.all)
+    choices = described_class.new.create_application(recruitment_cycle_year: 2020, states: %i[offer rejected], courses_to_apply_to: Course.all)
 
     expect(choices.count).to eq(2)
   end
@@ -13,7 +13,7 @@ RSpec.describe TestApplications do
   it 'creates a realistic timeline for a recruited application' do
     courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
 
-    application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2020, states: %i[recruited], courses_to_apply_to: courses_we_want).first
+    application_choice = described_class.new.create_application(recruitment_cycle_year: 2020, states: %i[recruited], courses_to_apply_to: courses_we_want).first
 
     application_form = application_choice.application_form
     candidate = application_form.candidate
@@ -28,7 +28,7 @@ RSpec.describe TestApplications do
   it 'creates a realistic timeline for an offered application' do
     courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
 
-    application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2020, states: %i[offer], courses_to_apply_to: courses_we_want).first
+    application_choice = described_class.new.create_application(recruitment_cycle_year: 2020, states: %i[offer], courses_to_apply_to: courses_we_want).first
 
     application_form = application_choice.application_form
     candidate = application_form.candidate
@@ -45,7 +45,7 @@ RSpec.describe TestApplications do
     create(:course_option, course: create(:course, :open_on_apply, provider: provider, accredited_provider: ratifying_provider)).course
     create(:course_option, course: create(:course, :open_on_apply, provider: provider))
 
-    application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2020, states: %i[offer_changed], courses_to_apply_to: [course_to_make_original_offer_for]).first
+    application_choice = described_class.new.create_application(recruitment_cycle_year: 2020, states: %i[offer_changed], courses_to_apply_to: [course_to_make_original_offer_for]).first
 
     expect(application_choice.current_course.ratifying_provider).to eq(ratifying_provider)
   end
@@ -53,7 +53,7 @@ RSpec.describe TestApplications do
   it 'attributes actions to candidates', with_audited: true do
     courses_we_want = create_list(:course_option, 1, course: create(:course, :open_on_apply)).map(&:course)
 
-    application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2020, states: %i[recruited], courses_to_apply_to: courses_we_want).first
+    application_choice = described_class.new.create_application(recruitment_cycle_year: 2020, states: %i[recruited], courses_to_apply_to: courses_we_want).first
     application_form = application_choice.application_form
     candidate = application_form.candidate
 
@@ -65,7 +65,7 @@ RSpec.describe TestApplications do
   it 'attributes actions to provider users', with_audited: true do
     courses_we_want = create_list(:course_option, 1, course: create(:course, :open_on_apply)).map(&:course)
 
-    application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2020, states: %i[recruited], courses_to_apply_to: courses_we_want).first
+    application_choice = described_class.new.create_application(recruitment_cycle_year: 2020, states: %i[recruited], courses_to_apply_to: courses_we_want).first
     provider_user = application_choice.provider.provider_users.first
 
     recruited_audit = application_choice.reload.audits.where("audited_changes @> '{\"status\": [\"recruited\"]}'").first
@@ -77,7 +77,7 @@ RSpec.describe TestApplications do
     expected_candidate = create(:candidate)
     courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
 
-    application_choice = TestApplications.new.create_application(
+    application_choice = described_class.new.create_application(
       recruitment_cycle_year: 2021,
       states: %i[unsubmitted_with_completed_references],
       courses_to_apply_to: courses_we_want,
@@ -91,13 +91,13 @@ RSpec.describe TestApplications do
 
   it 'throws an exception if there are not enough courses to apply to' do
     expect {
-      TestApplications.new.create_application(recruitment_cycle_year: 2020, states: %i[offer], courses_to_apply_to: [])
+      described_class.new.create_application(recruitment_cycle_year: 2020, states: %i[offer], courses_to_apply_to: [])
     }.to raise_error(/Not enough distinct courses/)
   end
 
   it 'throws an exception if zero courses are specified per application' do
     expect {
-      TestApplications.new.create_application(recruitment_cycle_year: 2020, states: [], courses_to_apply_to: [])
+      described_class.new.create_application(recruitment_cycle_year: 2020, states: [], courses_to_apply_to: [])
     }.to raise_error(/You cannot have zero courses per application/)
   end
 
@@ -105,7 +105,7 @@ RSpec.describe TestApplications do
     it 'creates applications only for the supplied courses' do
       course_we_want = create(:course_option, course: create(:course, :open_on_apply)).course
 
-      choices = TestApplications.new.create_application(recruitment_cycle_year: 2020, states: %i[offer], courses_to_apply_to: [course_we_want])
+      choices = described_class.new.create_application(recruitment_cycle_year: 2020, states: %i[offer], courses_to_apply_to: [course_we_want])
 
       expect(choices.first.course).to eq(course_we_want)
     end
@@ -113,7 +113,7 @@ RSpec.describe TestApplications do
     it 'creates the right number of applications' do
       courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
 
-      choices = TestApplications.new.create_application(recruitment_cycle_year: 2020, states: %i[offer], courses_to_apply_to: courses_we_want)
+      choices = described_class.new.create_application(recruitment_cycle_year: 2020, states: %i[offer], courses_to_apply_to: courses_we_want)
 
       expect(choices.count).to eq(1)
     end
@@ -123,7 +123,7 @@ RSpec.describe TestApplications do
     it 'creates applications with work experience as well as explained and unexplained breaks' do
       create(:course_option, course: create(:course, :open_on_apply))
 
-      choices = TestApplications.new.create_application(recruitment_cycle_year: 2020, courses_to_apply_to: Course.all, states: %i[awaiting_provider_decision])
+      choices = described_class.new.create_application(recruitment_cycle_year: 2020, courses_to_apply_to: Course.all, states: %i[awaiting_provider_decision])
 
       expect(choices.count).to eq(1)
       expect(choices.first.application_form.application_work_experiences.count).to eq(2)
@@ -135,7 +135,7 @@ RSpec.describe TestApplications do
     it 'generates a representative collection of references' do
       courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
 
-      application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision], courses_to_apply_to: courses_we_want).first
+      application_choice = described_class.new.create_application(recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision], courses_to_apply_to: courses_we_want).first
 
       references = application_choice.application_form.application_references
 
@@ -145,7 +145,7 @@ RSpec.describe TestApplications do
     it 'does not complete any references for unsubmitted applications' do
       courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
 
-      application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2021, states: %i[unsubmitted], courses_to_apply_to: courses_we_want).first
+      application_choice = described_class.new.create_application(recruitment_cycle_year: 2021, states: %i[unsubmitted], courses_to_apply_to: courses_we_want).first
 
       references = application_choice.application_form.application_references
 
@@ -157,7 +157,7 @@ RSpec.describe TestApplications do
     it 'generates an interview for application choices in the interviewing state' do
       courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
 
-      application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2021, states: %i[interviewing], courses_to_apply_to: courses_we_want).first
+      application_choice = described_class.new.create_application(recruitment_cycle_year: 2021, states: %i[interviewing], courses_to_apply_to: courses_we_want).first
 
       expect(application_choice.interviews.count).to eq(1)
     end
@@ -168,7 +168,7 @@ RSpec.describe TestApplications do
       create(:course_option, course: create(:course, :open_on_apply))
       create(:course_option, course: create(:course, :open_on_apply, :previous_year))
 
-      TestApplications.new.create_application(recruitment_cycle_year: RecruitmentCycle.current_year, states: %i[awaiting_provider_decision], courses_to_apply_to: Course.current_cycle, carry_over: true)
+      described_class.new.create_application(recruitment_cycle_year: RecruitmentCycle.current_year, states: %i[awaiting_provider_decision], courses_to_apply_to: Course.current_cycle, carry_over: true)
 
       previous_form = ApplicationForm.where(recruitment_cycle_year: RecruitmentCycle.previous_year).first
       new_form = ApplicationForm.current_cycle.first
@@ -183,7 +183,7 @@ RSpec.describe TestApplications do
   it 'marks any submitted application choices as just updated', with_audited: true do
     create(:course_option, course: create(:course, :open_on_apply))
 
-    choices = TestApplications.new.create_application(recruitment_cycle_year: 2020, courses_to_apply_to: Course.all, states: %i[awaiting_provider_decision])
+    choices = described_class.new.create_application(recruitment_cycle_year: 2020, courses_to_apply_to: Course.all, states: %i[awaiting_provider_decision])
 
     expect(choices.count).to eq(1)
     expect(choices.first.reload.updated_at).to be_within(1.second).of(Time.zone.now)

--- a/spec/lib/text_cardinalizer_spec.rb
+++ b/spec/lib/text_cardinalizer_spec.rb
@@ -2,20 +2,20 @@ require 'rails_helper'
 
 RSpec.describe TextCardinalizer do
   it 'can return the cardinal text value of a number up to ten' do
-    expect(TextCardinalizer.call(0)).to match('zero')
-    expect(TextCardinalizer.call(1)).to match('one')
-    expect(TextCardinalizer.call(2)).to match('two')
-    expect(TextCardinalizer.call(3)).to match('three')
-    expect(TextCardinalizer.call(4)).to match('four')
-    expect(TextCardinalizer.call(5)).to match('five')
-    expect(TextCardinalizer.call(6)).to match('six')
-    expect(TextCardinalizer.call(7)).to match('seven')
-    expect(TextCardinalizer.call(8)).to match('eight')
-    expect(TextCardinalizer.call(9)).to match('nine')
-    expect(TextCardinalizer.call(10)).to match('ten')
+    expect(described_class.call(0)).to match('zero')
+    expect(described_class.call(1)).to match('one')
+    expect(described_class.call(2)).to match('two')
+    expect(described_class.call(3)).to match('three')
+    expect(described_class.call(4)).to match('four')
+    expect(described_class.call(5)).to match('five')
+    expect(described_class.call(6)).to match('six')
+    expect(described_class.call(7)).to match('seven')
+    expect(described_class.call(8)).to match('eight')
+    expect(described_class.call(9)).to match('nine')
+    expect(described_class.call(10)).to match('ten')
   end
 
   it 'will revert to number literal written numbers after ten' do
-    expect(TextCardinalizer.call(11)).to match('11')
+    expect(described_class.call(11)).to match('11')
   end
 end

--- a/spec/lib/text_ordinalizer_spec.rb
+++ b/spec/lib/text_ordinalizer_spec.rb
@@ -2,20 +2,20 @@ require 'rails_helper'
 
 RSpec.describe TextOrdinalizer do
   it 'can return the text value of a number up to ten' do
-    expect(TextOrdinalizer.call(0)).to match('zeroth')
-    expect(TextOrdinalizer.call(1)).to match('first')
-    expect(TextOrdinalizer.call(2)).to match('second')
-    expect(TextOrdinalizer.call(3)).to match('third')
-    expect(TextOrdinalizer.call(4)).to match('fourth')
-    expect(TextOrdinalizer.call(5)).to match('fifth')
-    expect(TextOrdinalizer.call(6)).to match('sixth')
-    expect(TextOrdinalizer.call(7)).to match('seventh')
-    expect(TextOrdinalizer.call(8)).to match('eighth')
-    expect(TextOrdinalizer.call(9)).to match('ninth')
-    expect(TextOrdinalizer.call(10)).to match('tenth')
+    expect(described_class.call(0)).to match('zeroth')
+    expect(described_class.call(1)).to match('first')
+    expect(described_class.call(2)).to match('second')
+    expect(described_class.call(3)).to match('third')
+    expect(described_class.call(4)).to match('fourth')
+    expect(described_class.call(5)).to match('fifth')
+    expect(described_class.call(6)).to match('sixth')
+    expect(described_class.call(7)).to match('seventh')
+    expect(described_class.call(8)).to match('eighth')
+    expect(described_class.call(9)).to match('ninth')
+    expect(described_class.call(10)).to match('tenth')
   end
 
   it 'will revert to "Nth" written numbers after ten' do
-    expect(TextOrdinalizer.call(11)).to match('11th')
+    expect(described_class.call(11)).to match('11th')
   end
 end

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -3,31 +3,31 @@ require 'rails_helper'
 RSpec.describe TimeLimitConfig do
   describe '#limits_for' do
     it ':reject_by_default returns a default limit of 40 days' do
-      expect(TimeLimitConfig.limits_for(:reject_by_default).first.limit).to eq(40)
+      expect(described_class.limits_for(:reject_by_default).first.limit).to eq(40)
     end
 
     it ':decline_by_default returns a default limit of 10 days' do
-      expect(TimeLimitConfig.limits_for(:decline_by_default).first.limit).to eq(10)
+      expect(described_class.limits_for(:decline_by_default).first.limit).to eq(10)
     end
 
     it ':chase_provider_before_rbd returns a default limit of 20 days' do
-      expect(TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit).to eq(20)
+      expect(described_class.limits_for(:chase_provider_before_rbd).first.limit).to eq(20)
     end
 
     it ':chase_candidate_before_dbd returns a default limit of 5 days' do
-      expect(TimeLimitConfig.limits_for(:chase_candidate_before_dbd).first.limit).to eq(5)
+      expect(described_class.limits_for(:chase_candidate_before_dbd).first.limit).to eq(5)
     end
 
     it ':ucas_match_candidate_withdrawal_request returns a default limit of 10 days' do
-      expect(TimeLimitConfig.limits_for(:ucas_match_candidate_withdrawal_request).first.limit).to eq(10)
+      expect(described_class.limits_for(:ucas_match_candidate_withdrawal_request).first.limit).to eq(10)
     end
 
     it ':ucas_match_candidate_withdrawal_request_reminder returns a default limit of 5 days' do
-      expect(TimeLimitConfig.limits_for(:ucas_match_candidate_withdrawal_request_reminder).first.limit).to eq(5)
+      expect(described_class.limits_for(:ucas_match_candidate_withdrawal_request_reminder).first.limit).to eq(5)
     end
 
     it ':ucas_match_ucas_withdrawal_request returns a default limit of 5 days' do
-      expect(TimeLimitConfig.limits_for(:ucas_match_ucas_withdrawal_request).first.limit).to eq(5)
+      expect(described_class.limits_for(:ucas_match_ucas_withdrawal_request).first.limit).to eq(5)
     end
   end
 end

--- a/spec/lib/vendor_api_specification_spec.rb
+++ b/spec/lib/vendor_api_specification_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe VendorAPISpecification do
   describe '.as_yaml' do
     it 'includes /test-data paths' do
-      advertised_paths = VendorAPISpecification.as_hash['paths'].keys
+      advertised_paths = described_class.as_hash['paths'].keys
       expect(advertised_paths.filter { |path| path.include?('test-data') }).not_to be_empty
     end
   end

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe 'Send account created email' do
-    let(:email) { ProviderMailer.account_created(provider_user) }
+    let(:email) { described_class.account_created(provider_user) }
 
     it_behaves_like('a mail with subject and content',
                     I18n.t!('provider_mailer.account_created.subject'),
@@ -39,7 +39,7 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe 'Send application received email' do
-    let(:email) { ProviderMailer.application_submitted(provider_user, application_choice) }
+    let(:email) { described_class.application_submitted(provider_user, application_choice) }
 
     it_behaves_like('a mail with subject and content',
                     I18n.t!('provider_mailer.application_submitted.subject',
@@ -52,7 +52,7 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe 'Send application rejected by default email' do
-    let(:email) { ProviderMailer.application_rejected_by_default(provider_user, application_choice) }
+    let(:email) { described_class.application_rejected_by_default(provider_user, application_choice) }
 
     it_behaves_like('a mail with subject and content',
                     I18n.t!('provider_mailer.application_rejected_by_default.subject',
@@ -65,7 +65,7 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe 'Send provider decision chaser email' do
-    let(:email) { ProviderMailer.chase_provider_decision(provider_user, application_choice) }
+    let(:email) { described_class.chase_provider_decision(provider_user, application_choice) }
     let(:application_choice) do
       build_stubbed(:submitted_application_choice, course_option: course_option,
                                                    current_course_option: current_course_option,
@@ -86,7 +86,7 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe '.offer_accepted' do
-    let(:email) { ProviderMailer.offer_accepted(provider_user, application_choice) }
+    let(:email) { described_class.offer_accepted(provider_user, application_choice) }
 
     it_behaves_like('a mail with subject and content',
                     'Harry Potter (123A) has accepted your offer',
@@ -105,7 +105,7 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe '.unconditional_offer_accepted' do
-    let(:email) { ProviderMailer.unconditional_offer_accepted(provider_user, application_choice) }
+    let(:email) { described_class.unconditional_offer_accepted(provider_user, application_choice) }
 
     it_behaves_like('a mail with subject and content',
                     'Harry Potter (123A) has accepted your offer',
@@ -124,7 +124,7 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe '.declined_by_default' do
-    let(:email) { ProviderMailer.declined_by_default(provider_user, application_choice) }
+    let(:email) { described_class.declined_by_default(provider_user, application_choice) }
 
     it_behaves_like('a mail with subject and content',
                     'Harry Potter’s (123A) application withdrawn automatically',
@@ -144,7 +144,7 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe 'Send email when the application withdrawn' do
-    let(:email) { ProviderMailer.application_withdrawn(provider_user, application_choice) }
+    let(:email) { described_class.application_withdrawn(provider_user, application_choice) }
 
     it_behaves_like('a mail with subject and content',
                     'Harry Potter (123A) withdrew their application',
@@ -164,7 +164,7 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe '.declined' do
-    let(:email) { ProviderMailer.declined(provider_user, application_choice) }
+    let(:email) { described_class.declined(provider_user, application_choice) }
 
     it_behaves_like('a mail with subject and content',
                     'Harry Potter (123A) declined an offer',
@@ -174,7 +174,7 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe '.ucas_match_initial_email_duplicate_applications' do
-    let(:email) { ProviderMailer.ucas_match_initial_email_duplicate_applications(provider_user, application_choice) }
+    let(:email) { described_class.ucas_match_initial_email_duplicate_applications(provider_user, application_choice) }
 
     it_behaves_like('a mail with subject and content',
                     'Duplicate application identified',
@@ -184,7 +184,7 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe '.ucas_match_resolved_on_ucas_email' do
-    let(:email) { ProviderMailer.ucas_match_resolved_on_ucas_email(provider_user, application_choice) }
+    let(:email) { described_class.ucas_match_resolved_on_ucas_email(provider_user, application_choice) }
 
     before do
       allow(application_choice).to receive(:course).and_return(course)
@@ -198,7 +198,7 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe '.ucas_match_resolved_on_apply_email' do
-    let(:email) { ProviderMailer.ucas_match_resolved_on_apply_email(provider_user, application_choice) }
+    let(:email) { described_class.ucas_match_resolved_on_apply_email(provider_user, application_choice) }
 
     before do
       allow(application_choice).to receive(:course).and_return(course)
@@ -212,7 +212,7 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe '.courses_open_on_apply' do
-    let(:email) { ProviderMailer.courses_open_on_apply(provider_user) }
+    let(:email) { described_class.courses_open_on_apply(provider_user) }
 
     it_behaves_like('a mail with subject and content',
                     I18n.t!('provider_mailer.courses_open_on_apply.subject'),

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe ApplicationChoice, type: :model do
 
     context 'all other statuses' do
       it 'returns false' do
-        statuses = ApplicationChoice.statuses.values.reject { |value| value == 'recruited' }
+        statuses = described_class.statuses.values.reject { |value| value == 'recruited' }
 
         statuses.each do |status|
           application_choice = build_stubbed(:application_choice, status: status)

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ApplicationForm do
         it 'does not throw an exception' do
           application_form = create(:completed_application_form, recruitment_cycle_year: RecruitmentCycle.previous_year, application_choices_count: 1)
 
-          ApplicationForm.with_unsafe_application_choice_touches do
+          described_class.with_unsafe_application_choice_touches do
             expect { application_form.update(first_name: 'Maria') }
               .not_to raise_error
           end

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ApplicationQualification, type: :model do
   it 'includes the fields for a degree, GCSE and other qualification level' do
-    qualification = ApplicationQualification.new
+    qualification = described_class.new
 
     expect(qualification.attributes).to include(
       'level',
@@ -21,12 +21,12 @@ RSpec.describe ApplicationQualification, type: :model do
   describe 'level' do
     it 'only accepts degree, gcse and other' do
       %w[degree gcse other].each do |level|
-        expect { ApplicationQualification.new(level: level) }.not_to raise_error
+        expect { described_class.new(level: level) }.not_to raise_error
       end
     end
 
     it 'raises an error when level is invalid' do
-      expect { ApplicationQualification.new(level: 'invalid_level') }
+      expect { described_class.new(level: 'invalid_level') }
         .to raise_error ArgumentError, "'invalid_level' is not a valid level"
     end
   end

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ApplicationReference, type: :model do
 
     context 'when the unhashed token does not match an unhashed sign in token on a reference' do
       it 'returns nil' do
-        reference = ApplicationReference.find_by_unhashed_token('unhashed_token')
+        reference = described_class.find_by_unhashed_token('unhashed_token')
 
         expect(reference).to eq(nil)
       end
@@ -58,7 +58,7 @@ RSpec.describe ApplicationReference, type: :model do
         chandler = create(:reference, name: 'Chandler Bing')
         create(:reference_token, application_reference: chandler, hashed_token: 'hashed_token')
 
-        reference = ApplicationReference.find_by_unhashed_token('unhashed_token')
+        reference = described_class.find_by_unhashed_token('unhashed_token')
 
         expect(reference.name).to eq('Chandler Bing')
       end
@@ -67,10 +67,10 @@ RSpec.describe ApplicationReference, type: :model do
 
   describe '#pending_feedback_or_failed' do
     it 'returns references in every state except not_requested_yet and feedback_provided' do
-      expected_states = ApplicationReference.feedback_statuses.values - %w[not_requested_yet feedback_provided]
+      expected_states = described_class.feedback_statuses.values - %w[not_requested_yet feedback_provided]
       expected_states.each { |s| create(:reference, feedback_status: s) }
 
-      expect(ApplicationReference.pending_feedback_or_failed.size).to eq expected_states.size
+      expect(described_class.pending_feedback_or_failed.size).to eq expected_states.size
     end
   end
 

--- a/spec/models/course_option_spec.rb
+++ b/spec/models/course_option_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CourseOption, type: :model do
       expected_course_option = create(:course_option, site_still_valid: true)
       create(:course_option, site_still_valid: false)
 
-      expect(CourseOption.selectable).to match_array [expected_course_option]
+      expect(described_class.selectable).to match_array [expected_course_option]
     end
   end
 

--- a/spec/models/df_e_sign_in_user_spec.rb
+++ b/spec/models/df_e_sign_in_user_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe DfESignInUser, type: :model do
     it 'returns the DfE User when the user has signed in and has been recently active' do
       session = { 'dfe_sign_in_user' => { 'last_active_at' => Time.zone.now } }
 
-      user = DfESignInUser.load_from_session(session)
+      user = described_class.load_from_session(session)
 
       expect(user).not_to be_nil
     end
@@ -13,7 +13,7 @@ RSpec.describe DfESignInUser, type: :model do
     it 'returns nil when the user has signed in and has not been recently active' do
       session = { 'dfe_sign_in_user' => { 'last_active_at' => Time.zone.now - 1.day } }
 
-      user = DfESignInUser.load_from_session(session)
+      user = described_class.load_from_session(session)
 
       expect(user).to be_nil
     end
@@ -21,7 +21,7 @@ RSpec.describe DfESignInUser, type: :model do
     it 'returns nil when the user has not signed in' do
       session = { 'dfe_sign_in_user' => nil }
 
-      user = DfESignInUser.load_from_session(session)
+      user = described_class.load_from_session(session)
 
       expect(user).to be_nil
     end
@@ -29,7 +29,7 @@ RSpec.describe DfESignInUser, type: :model do
     it 'returns nil when the user does not have a last active timestamp' do
       session = { 'dfe_sign_in_user' => { 'last_active_at' => nil } }
 
-      user = DfESignInUser.load_from_session(session)
+      user = described_class.load_from_session(session)
 
       expect(user).to be_nil
     end
@@ -41,11 +41,11 @@ RSpec.describe DfESignInUser, type: :model do
         'dfe_sign_in_user' => { 'last_active_at' => Time.zone.now },
         'impersonated_provider_user' => { 'provider_user_id' => provider_user.id },
       }
-      user = DfESignInUser.load_from_session(session)
+      user = described_class.load_from_session(session)
       expect(user.impersonated_provider_user).to eq(provider_user)
 
       session = { 'dfe_sign_in_user' => { 'last_active_at' => Time.zone.now } }
-      user = DfESignInUser.load_from_session(session)
+      user = described_class.load_from_session(session)
       expect(user.impersonated_provider_user).to be_nil
     end
   end
@@ -53,7 +53,7 @@ RSpec.describe DfESignInUser, type: :model do
   describe '#begin_impersonation!' do
     let(:provider_user) { create(:provider_user) }
     let(:dsi_user) do
-      DfESignInUser.new(email_address: nil, dfe_sign_in_uid: nil, first_name: nil, last_name: nil)
+      described_class.new(email_address: nil, dfe_sign_in_uid: nil, first_name: nil, last_name: nil)
     end
 
     it 'adds an impersonated_provider_user section to the session' do
@@ -71,7 +71,7 @@ RSpec.describe DfESignInUser, type: :model do
 
   describe '#end_impersonation!' do
     let(:dsi_user) do
-      DfESignInUser.new(email_address: nil, dfe_sign_in_uid: nil, first_name: nil, last_name: nil)
+      described_class.new(email_address: nil, dfe_sign_in_uid: nil, first_name: nil, last_name: nil)
     end
 
     it 'deletes the impersonated_provider_user section' do

--- a/spec/models/interview_spec.rb
+++ b/spec/models/interview_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Interview, type: :model do
-  subject(:interview) { Interview.new }
+  subject(:interview) { described_class.new }
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:application_choice) }

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe PerformanceStatistics, type: :model do
       create(:application_choice, status: 'recruited')
       create(:application_choice, status: 'pending_conditions')
 
-      stats = PerformanceStatistics.new(nil)
+      stats = described_class.new(nil)
 
       expect(stats.total_form_count(only: %i[recruited])).to eq(2)
       expect(stats.total_form_count(except: %i[pending_conditions])).to eq(2)
@@ -155,7 +155,7 @@ RSpec.describe PerformanceStatistics, type: :model do
       create(:application_choice, status: 'pending_conditions')
       create(:candidate)
 
-      stats = PerformanceStatistics.new(nil)
+      stats = described_class.new(nil)
 
       expect(stats.total_form_count(only: %i[recruited])).to eq(2)
       expect(stats.total_form_count(only: %i[recruited], phase: :apply_1)).to eq(1)
@@ -170,7 +170,7 @@ RSpec.describe PerformanceStatistics, type: :model do
       create(:application_choice, status: 'recruited', application_form: create(:application_form, recruitment_cycle_year: 2020))
       create(:application_choice, status: 'recruited', application_form: create(:application_form, recruitment_cycle_year: 2021))
 
-      stats = PerformanceStatistics.new(2021)
+      stats = described_class.new(2021)
 
       expect(stats.total_form_count).to eq(1)
     end
@@ -182,13 +182,13 @@ RSpec.describe PerformanceStatistics, type: :model do
       synced_providers = create_list(:provider, 2, sync_courses: true)
       create_list(:course, 3, provider: synced_providers.first, open_on_apply: true)
 
-      stats = PerformanceStatistics.new(2021)
+      stats = described_class.new(2021)
 
       expect(stats.percentage_of_providers_onboarded).to eq('33%')
     end
 
     it 'returns "-" when there are no providers' do
-      stats = PerformanceStatistics.new(2021)
+      stats = described_class.new(2021)
 
       expect(stats.percentage_of_providers_onboarded).to eq('-')
     end
@@ -200,7 +200,7 @@ RSpec.describe PerformanceStatistics, type: :model do
       create_list(:application_choice, 2, status: 'rejected', rejected_by_default: true, application_form: create(:application_form, recruitment_cycle_year: 2021))
       create(:application_choice, status: 'rejected', rejected_by_default: false, application_form: create(:application_form, recruitment_cycle_year: 2021))
 
-      stats = PerformanceStatistics.new(nil)
+      stats = described_class.new(nil)
 
       expect(stats.rejected_by_default_count).to eq(2)
     end
@@ -210,7 +210,7 @@ RSpec.describe PerformanceStatistics, type: :model do
       create_list(:application_choice, 2, status: 'rejected', rejected_by_default: true, application_form: create(:application_form, recruitment_cycle_year: 2021))
       create(:application_choice, status: 'rejected', rejected_by_default: false, application_form: create(:application_form, recruitment_cycle_year: 2021))
 
-      stats = PerformanceStatistics.new(2021)
+      stats = described_class.new(2021)
 
       expect(stats.rejected_by_default_count).to eq(1)
     end
@@ -230,20 +230,20 @@ RSpec.describe PerformanceStatistics, type: :model do
     let!(:withdrawn_audit) { create(:withdrawn_at_candidates_request_audit, application_choice: withdrawn_choice) }
 
     it '#withdrawn_at_candidates_request_count returns a count of applications which have been declined or withdrawn at the candidates request' do
-      stats = PerformanceStatistics.new(2021)
+      stats = described_class.new(2021)
 
       expect(stats.withdrawn_at_candidates_request_count).to eq(2)
     end
 
     it '#withdrawn_by_candidate_count returns a count of applications which have been declined or withdrawn by the candidate' do
-      stats = PerformanceStatistics.new(2021)
+      stats = described_class.new(2021)
 
       expect(stats.withdrawn_by_candidate_count).to eq(1)
     end
   end
 
   def count_for_process_state(process_state)
-    PerformanceStatistics.new(nil)[process_state]
+    described_class.new(nil)[process_state]
   end
 
   it 'excludes candidates marked as hidden from reporting' do
@@ -252,7 +252,7 @@ RSpec.describe PerformanceStatistics, type: :model do
     create(:application_form, candidate: hidden_candidate)
     create(:application_form, candidate: visible_candidate)
 
-    stats = PerformanceStatistics.new(nil)
+    stats = described_class.new(nil)
 
     expect(stats.total_form_count).to eq(1)
   end
@@ -263,10 +263,10 @@ RSpec.describe PerformanceStatistics, type: :model do
       create(:application_choice, :awaiting_provider_decision, application_form: create(:application_form, recruitment_cycle_year: 2021))
       create(:application_choice, :unsubmitted, application_form: create(:application_form, recruitment_cycle_year: 2019)) # should not be counted bc unsubmitted
 
-      expect(PerformanceStatistics.new(2021).total_application_choice_count).to eq 1
-      expect(PerformanceStatistics.new(2020).total_application_choice_count).to eq 1
+      expect(described_class.new(2021).total_application_choice_count).to eq 1
+      expect(described_class.new(2020).total_application_choice_count).to eq 1
 
-      expect(PerformanceStatistics.new(nil).total_application_choice_count).to eq 2
+      expect(described_class.new(nil).total_application_choice_count).to eq 2
     end
   end
 
@@ -308,21 +308,21 @@ RSpec.describe PerformanceStatistics, type: :model do
                                   course_option: sd_scitt_course_2021,
                                   application_form: create(:application_form, recruitment_cycle_year: 2021))
 
-      expect(PerformanceStatistics.new(2021).application_choices_by_provider_type).to eq({
+      expect(described_class.new(2021).application_choices_by_provider_type).to eq({
         'scitt' => 1,
         'university' => 1,
         'lead_school' => 2,
         'ratified_by_scitt' => 1,
         'ratified_by_university' => 1,
       })
-      expect(PerformanceStatistics.new(2020).application_choices_by_provider_type).to eq({
+      expect(described_class.new(2020).application_choices_by_provider_type).to eq({
         'scitt' => 1,
         'university' => 1,
         'lead_school' => 0,
         'ratified_by_scitt' => 0,
         'ratified_by_university' => 0,
       })
-      expect(PerformanceStatistics.new(nil).application_choices_by_provider_type).to eq({
+      expect(described_class.new(nil).application_choices_by_provider_type).to eq({
         'scitt' => 2,
         'university' => 2,
         'lead_school' => 2,

--- a/spec/models/provider_agreement_spec.rb
+++ b/spec/models/provider_agreement_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ProviderAgreement, type: :model do
     it 'is validated in the model' do
       provider = create(:provider)
       provider_user = create(:provider_user)
-      agreement = ProviderAgreement.create(agreement_type: :data_sharing_agreement, provider: provider, provider_user: provider_user, accept_agreement: true)
+      agreement = described_class.create(agreement_type: :data_sharing_agreement, provider: provider, provider_user: provider_user, accept_agreement: true)
       expect(agreement).not_to be_valid
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe ProviderAgreement, type: :model do
       provider = create(:provider)
       provider_user = create(:provider_user)
       provider.provider_users << provider_user
-      agreement = ProviderAgreement.create(agreement_type: :data_sharing_agreement, provider: provider, provider_user: provider_user, accept_agreement: true)
+      agreement = described_class.create(agreement_type: :data_sharing_agreement, provider: provider, provider_user: provider_user, accept_agreement: true)
       expect(agreement.accepted_at).not_to be_nil
     end
   end
@@ -33,8 +33,8 @@ RSpec.describe ProviderAgreement, type: :model do
     it 'returns only data_sharing_agreements' do
       create(:provider_agreement, agreement_type: :data_sharing_agreement)
       create(:provider_agreement, agreement_type: :other_type)
-      expect(ProviderAgreement.count).to eq(2)
-      expect(ProviderAgreement.data_sharing_agreements.count).to eq(1)
+      expect(described_class.count).to eq(2)
+      expect(described_class.data_sharing_agreements.count).to eq(1)
     end
   end
 
@@ -43,8 +43,8 @@ RSpec.describe ProviderAgreement, type: :model do
       data_sharing_agreement = create(:provider_agreement, agreement_type: :data_sharing_agreement)
       other_provider = create(:provider, code: 'ZZZ', name: 'Other')
       create(:provider_agreement, provider: other_provider)
-      expect(ProviderAgreement.count).to eq(2)
-      expect(ProviderAgreement.for_provider(data_sharing_agreement.provider).count).to eq(1)
+      expect(described_class.count).to eq(2)
+      expect(described_class.for_provider(data_sharing_agreement.provider).count).to eq(1)
     end
   end
 end

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ProviderUser, type: :model do
         first_name: nil,
         last_name: nil,
       )
-      ProviderUser.onboard!(dsi_user)
+      described_class.onboard!(dsi_user)
       expect(provider_user.reload.dfe_sign_in_uid).to eq 'ABC123'
     end
 
@@ -29,7 +29,7 @@ RSpec.describe ProviderUser, type: :model do
         first_name: nil,
         last_name: nil,
       )
-      ProviderUser.onboard!(dsi_user)
+      described_class.onboard!(dsi_user)
       expect(provider_user.reload.dfe_sign_in_uid).to eq 'ABC123'
     end
   end
@@ -86,8 +86,8 @@ RSpec.describe ProviderUser, type: :model do
       user_b = create(:provider_user, providers: [provider])
       create(:provider_permissions, provider_user: user_a, provider: provider, manage_users: true)
 
-      expect(ProviderUser.visible_to(user_a)).to include(user_b)
-      expect(ProviderUser.visible_to(user_a).count).to eq(2) # user_a can see themselves plus user_b
+      expect(described_class.visible_to(user_a)).to include(user_b)
+      expect(described_class.visible_to(user_a).count).to eq(2) # user_a can see themselves plus user_b
     end
 
     it 'returns only one record per user' do
@@ -100,8 +100,8 @@ RSpec.describe ProviderUser, type: :model do
       create(:provider_permissions, provider_user: user_a, provider: provider_a, manage_users: true)
       create(:provider_permissions, provider_user: user_a, provider: provider_b, manage_users: true)
 
-      expect(ProviderUser.visible_to(user_a)).to include(user_b)
-      expect(ProviderUser.visible_to(user_a).count).to eq(2) # user_a can see themselves plus user_b
+      expect(described_class.visible_to(user_a)).to include(user_b)
+      expect(described_class.visible_to(user_a).count).to eq(2) # user_a can see themselves plus user_b
     end
 
     it 'returns only users for providers for which the passed user has manage_users permission' do
@@ -114,8 +114,8 @@ RSpec.describe ProviderUser, type: :model do
       user_b = create(:provider_user, providers: [provider_a])
       user_c = create(:provider_user, providers: [provider_b])
 
-      expect(ProviderUser.visible_to(user_a)).to include(user_b)
-      expect(ProviderUser.visible_to(user_a)).not_to include(user_c)
+      expect(described_class.visible_to(user_a)).to include(user_b)
+      expect(described_class.visible_to(user_a)).not_to include(user_c)
     end
   end
 
@@ -123,13 +123,13 @@ RSpec.describe ProviderUser, type: :model do
     let(:dsi_user) { build(:dfe_sign_in_user) }
 
     it 'returns nil if there is no DfESignInUser session' do
-      provider_user = ProviderUser.load_from_session({})
+      provider_user = described_class.load_from_session({})
       expect(provider_user).to be_nil
     end
 
     it 'returns nil if there is no associated ProviderUser' do
       allow(DfESignInUser).to receive(:load_from_session).and_return(dsi_user)
-      provider_user = ProviderUser.load_from_session({})
+      provider_user = described_class.load_from_session({})
       expect(provider_user).to be_nil
     end
 
@@ -142,7 +142,7 @@ RSpec.describe ProviderUser, type: :model do
         first_name: dsi_user.first_name,
         last_name: dsi_user.last_name,
       )
-      expect(ProviderUser.load_from_session({})).to eq(provider_user)
+      expect(described_class.load_from_session({})).to eq(provider_user)
     end
 
     it 'returns impersonated_provider_user from SupportUser, if available' do
@@ -153,7 +153,7 @@ RSpec.describe ProviderUser, type: :model do
       support_user.impersonated_provider_user = provider_user
       allow(SupportUser).to receive(:load_from_session).and_return(support_user)
 
-      loaded_user = ProviderUser.load_from_session({})
+      loaded_user = described_class.load_from_session({})
 
       expect(loaded_user).to eq(provider_user)
       expect(loaded_user.impersonator).to eq(support_user)

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RecruitmentCycle do
     it 'delegates to CycleTimetable' do
       allow(CycleTimetable).to receive(:current_year)
 
-      RecruitmentCycle.current_year
+      described_class.current_year
 
       expect(CycleTimetable).to have_received(:current_year)
     end
@@ -15,7 +15,7 @@ RSpec.describe RecruitmentCycle do
     it 'delegates to CycleTimetable' do
       allow(CycleTimetable).to receive(:next_year).and_return(2020)
 
-      RecruitmentCycle.next_year
+      described_class.next_year
 
       expect(CycleTimetable).to have_received(:next_year)
     end
@@ -25,7 +25,7 @@ RSpec.describe RecruitmentCycle do
     it 'is 2019 if the current year is 2020' do
       allow(CycleTimetable).to receive(:current_year).and_return(2020)
 
-      expect(RecruitmentCycle.previous_year).to eq(2019)
+      expect(described_class.previous_year).to eq(2019)
     end
   end
 
@@ -33,11 +33,11 @@ RSpec.describe RecruitmentCycle do
     it 'defaults from current year to the following year' do
       allow(CycleTimetable).to receive(:current_year).and_return(2020)
 
-      expect(RecruitmentCycle.cycle_name).to eq('2019 to 2020')
+      expect(described_class.cycle_name).to eq('2019 to 2020')
     end
 
     it 'is from argument(year) to the following year' do
-      expect(RecruitmentCycle.cycle_name(2021)).to eq('2020 to 2021')
+      expect(described_class.cycle_name(2021)).to eq('2020 to 2021')
     end
   end
 end

--- a/spec/models/support_user_spec.rb
+++ b/spec/models/support_user_spec.rb
@@ -41,14 +41,14 @@ RSpec.describe SupportUser, type: :model do
         last_name: dsi_user.last_name,
       )
 
-      support_user = SupportUser.load_from_session({})
+      support_user = described_class.load_from_session({})
       expect(support_user.dfe_sign_in_uid).to eq(dsi_user.dfe_sign_in_uid)
       expect(support_user.impersonated_provider_user).to eq(provider_user)
     end
 
     it 'returns nil if there is no associated SupportUser' do
       allow(DfESignInUser).to receive(:load_from_session).and_return(dsi_user)
-      support_user = SupportUser.load_from_session({})
+      support_user = described_class.load_from_session({})
       expect(support_user).to be_nil
     end
   end

--- a/spec/models/teacher_training_public_api/provider_spec.rb
+++ b/spec/models/teacher_training_public_api/provider_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TeacherTrainingPublicAPI::Provider do
     it 'returns a provider that exists' do
       stub_teacher_training_api_provider(provider_code: 'MMM')
 
-      provider = TeacherTrainingPublicAPI::Provider.fetch('MMM')
+      provider = described_class.fetch('MMM')
 
       expect(provider).to be_present
     end
@@ -15,7 +15,7 @@ RSpec.describe TeacherTrainingPublicAPI::Provider do
     it 'returns nil when the provider does not exist' do
       stub_teacher_training_api_provider_404(provider_code: 'OOO')
 
-      provider = TeacherTrainingPublicAPI::Provider.fetch('OOO')
+      provider = described_class.fetch('OOO')
 
       expect(provider).to be_nil
     end

--- a/spec/models/ucas_matched_application_spec.rb
+++ b/spec/models/ucas_matched_application_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
     end
 
     it 'returns the course for the correct recruitment cycle' do
-      ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, course.recruitment_cycle_year)
+      ucas_matching_application = described_class.new(ucas_matching_data, course.recruitment_cycle_year)
 
       expect(ucas_matching_application.course).to eq(course)
     end
@@ -34,7 +34,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
       end
 
       it 'returns the correct course details' do
-        ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, course.recruitment_cycle_year)
+        ucas_matching_application = described_class.new(ucas_matching_data, course.recruitment_cycle_year)
 
         expect(ucas_matching_application.course.code).to eq('123')
         expect(ucas_matching_application.course.name).to eq('Not on Apply')
@@ -51,7 +51,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
         end
 
         it 'returns a missing data string' do
-          ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+          ucas_matching_application = described_class.new(ucas_matching_data, recruitment_cycle_year)
 
           expect(ucas_matching_application.course.code).to eq('Missing course code')
           expect(ucas_matching_application.course.name).to eq('Missing course name')
@@ -74,7 +74,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
       end
 
       it 'returns the application status' do
-        ucas_matching_application = UCASMatchedApplication.new(apply_matching_data, recruitment_cycle_year)
+        ucas_matching_application = described_class.new(apply_matching_data, recruitment_cycle_year)
         allow(ucas_matching_application).to receive(:application_choice).and_return(application_choice)
 
         expect(ucas_matching_application.status).to eq(application_choice.status)
@@ -94,7 +94,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
       end
 
       it 'returns the ucas status' do
-        ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+        ucas_matching_application = described_class.new(ucas_matching_data, recruitment_cycle_year)
 
         expect(ucas_matching_application.status).to eq('rejected')
         expect(ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.map(&:to_s)).to include(ucas_matching_application.status)
@@ -113,7 +113,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
       end
 
       it 'returns the application status' do
-        ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+        ucas_matching_application = described_class.new(ucas_matching_data, recruitment_cycle_year)
         allow(ucas_matching_application).to receive(:application_choice).and_return(application_choice)
 
         expect(ucas_matching_application.status).to eq(application_choice.status)
@@ -140,7 +140,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
         let(:matching_data) { ucas_matching_data }
 
         it 'returns true' do
-          ucas_matching_application = UCASMatchedApplication.new(matching_data, recruitment_cycle_year)
+          ucas_matching_application = described_class.new(matching_data, recruitment_cycle_year)
 
           expect(ucas_matching_application.application_in_progress_on_ucas?).to eq(true)
         end
@@ -150,7 +150,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
         let(:matching_data) { ucas_matching_data.merge('Withdrawns' => '1') }
 
         it 'returns false' do
-          ucas_matching_application = UCASMatchedApplication.new(matching_data, recruitment_cycle_year)
+          ucas_matching_application = described_class.new(matching_data, recruitment_cycle_year)
 
           expect(ucas_matching_application.application_in_progress_on_ucas?).to eq(false)
         end
@@ -160,7 +160,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
         let(:ucas_matching_data) { { 'Scheme' => 'D' } }
 
         it 'returns false' do
-          ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+          ucas_matching_application = described_class.new(ucas_matching_data, recruitment_cycle_year)
 
           expect(ucas_matching_application.application_in_progress_on_ucas?).to eq(false)
         end
@@ -171,7 +171,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
       let(:ucas_matching_data) { { 'Scheme' => 'U', 'Provider code' => 'WELSH PROVIDER CODE' } }
 
       it 'returns false' do
-        ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+        ucas_matching_application = described_class.new(ucas_matching_data, recruitment_cycle_year)
 
         expect(ucas_matching_application.application_in_progress_on_ucas?).to eq(false)
       end
@@ -193,7 +193,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
         let(:application_choice) { build_stubbed(:application_choice, :with_accepted_offer) }
 
         it 'returns true' do
-          ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+          ucas_matching_application = described_class.new(ucas_matching_data, recruitment_cycle_year)
           allow(ucas_matching_application).to receive(:application_choice).and_return(application_choice)
 
           expect(ucas_matching_application.application_in_progress_on_apply?).to eq(true)
@@ -204,7 +204,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
         let(:application_choice) { build_stubbed(:application_choice, :with_rejection) }
 
         it 'returns false' do
-          ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+          ucas_matching_application = described_class.new(ucas_matching_data, recruitment_cycle_year)
           allow(ucas_matching_application).to receive(:application_choice).and_return(application_choice)
 
           expect(ucas_matching_application.application_in_progress_on_apply?).to eq(false)
@@ -216,7 +216,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
       let(:ucas_matching_data) { { 'Scheme' => 'U' } }
 
       it 'returns false' do
-        ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+        ucas_matching_application = described_class.new(ucas_matching_data, recruitment_cycle_year)
 
         expect(ucas_matching_application.application_in_progress_on_apply?).to eq(false)
       end
@@ -242,7 +242,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
         let(:matching_data) { ucas_matching_data.merge('Offers' => '1', 'Unconditional firm' => '1') }
 
         it 'returns true' do
-          ucas_matching_application = UCASMatchedApplication.new(matching_data, recruitment_cycle_year)
+          ucas_matching_application = described_class.new(matching_data, recruitment_cycle_year)
 
           expect(ucas_matching_application.application_accepted_on_ucas?).to eq(true)
         end
@@ -252,7 +252,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
         let(:matching_data) { ucas_matching_data.merge('Offers' => '1', 'Conditional firm' => '1') }
 
         it 'returns true' do
-          ucas_matching_application = UCASMatchedApplication.new(matching_data, recruitment_cycle_year)
+          ucas_matching_application = described_class.new(matching_data, recruitment_cycle_year)
 
           expect(ucas_matching_application.application_accepted_on_ucas?).to eq(true)
         end
@@ -262,7 +262,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
         let(:matching_data) { ucas_matching_data.merge('Withdrawns' => '1') }
 
         it 'returns false' do
-          ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+          ucas_matching_application = described_class.new(ucas_matching_data, recruitment_cycle_year)
 
           expect(ucas_matching_application.application_accepted_on_ucas?).to eq(false)
         end
@@ -273,7 +273,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
       let(:ucas_matching_data) { { 'Scheme' => 'D' } }
 
       it 'returns false' do
-        ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+        ucas_matching_application = described_class.new(ucas_matching_data, recruitment_cycle_year)
 
         expect(ucas_matching_application.application_accepted_on_ucas?).to eq(false)
       end
@@ -283,7 +283,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
       let(:ucas_matching_data) { { 'Scheme' => 'U', 'Provider code' => 'WELSH PROVIDER CODE' } }
 
       it 'returns false' do
-        ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+        ucas_matching_application = described_class.new(ucas_matching_data, recruitment_cycle_year)
 
         expect(ucas_matching_application.application_accepted_on_ucas?).to eq(false)
       end
@@ -305,7 +305,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
         let(:application_choice) { build_stubbed(:application_choice, :pending_conditions) }
 
         it 'returns true' do
-          ucas_matching_application = UCASMatchedApplication.new(matching_data, recruitment_cycle_year)
+          ucas_matching_application = described_class.new(matching_data, recruitment_cycle_year)
           allow(ucas_matching_application).to receive(:application_choice).and_return(application_choice)
 
           expect(ucas_matching_application.application_accepted_on_apply?).to eq(true)
@@ -316,7 +316,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
         let(:application_choice) { build_stubbed(:application_choice, :declined) }
 
         it 'returns false' do
-          ucas_matching_application = UCASMatchedApplication.new(matching_data, recruitment_cycle_year)
+          ucas_matching_application = described_class.new(matching_data, recruitment_cycle_year)
           allow(ucas_matching_application).to receive(:application_choice).and_return(application_choice)
 
           expect(ucas_matching_application.application_accepted_on_apply?).to eq(false)
@@ -328,7 +328,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
       let(:ucas_matching_data) { { 'Scheme' => 'U' } }
 
       it 'returns false' do
-        ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+        ucas_matching_application = described_class.new(ucas_matching_data, recruitment_cycle_year)
 
         expect(ucas_matching_application.application_in_progress_on_apply?).to eq(false)
       end
@@ -350,7 +350,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
     end
 
     it 'returns the application_choice related with the candidate and course option' do
-      ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+      ucas_matching_application = described_class.new(ucas_matching_data, recruitment_cycle_year)
 
       expect(ucas_matching_application.application_choice).to eq(application_choice)
     end
@@ -361,7 +361,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
       let(:ucas_matching_data) { { 'Withdrawns' => '1' } }
 
       it 'returns true' do
-        ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+        ucas_matching_application = described_class.new(ucas_matching_data, recruitment_cycle_year)
 
         expect(ucas_matching_application.application_withdrawn_on_ucas?).to eq(true)
       end
@@ -371,7 +371,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
       let(:ucas_matching_data) { { 'Withdrawns' => '' } }
 
       it 'returns false' do
-        ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+        ucas_matching_application = described_class.new(ucas_matching_data, recruitment_cycle_year)
 
         expect(ucas_matching_application.application_withdrawn_on_ucas?).to eq(false)
       end
@@ -391,7 +391,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
       let(:application_choice) { build_stubbed(:application_choice, course_option: course_option, status: 'withdrawn') }
 
       it 'retuns true' do
-        ucas_matching_application = UCASMatchedApplication.new(matching_data, recruitment_cycle_year)
+        ucas_matching_application = described_class.new(matching_data, recruitment_cycle_year)
         allow(ucas_matching_application).to receive(:application_choice).and_return(application_choice)
 
         expect(ucas_matching_application.application_withdrawn_on_apply?).to eq(true)
@@ -408,7 +408,7 @@ RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: 
       end
 
       it 'retuns false' do
-        ucas_matching_application = UCASMatchedApplication.new(matching_data, recruitment_cycle_year)
+        ucas_matching_application = described_class.new(matching_data, recruitment_cycle_year)
         allow(ucas_matching_application).to receive(:application_choice).and_return(application_choice)
 
         expect(ucas_matching_application.application_withdrawn_on_apply?).to eq(false)

--- a/spec/models/vendor_api/attribution_meta_spec.rb
+++ b/spec/models/vendor_api/attribution_meta_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe VendorAPI::AttributionMeta do
-  subject { VendorAPI::AttributionMeta.new({}) }
+  subject { described_class.new({}) }
 
   it { is_expected.to validate_presence_of :full_name }
   it { is_expected.to validate_presence_of :email }

--- a/spec/models/vendor_api/metadata_spec.rb
+++ b/spec/models/vendor_api/metadata_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe VendorAPI::Metadata do
-  subject { VendorAPI::Metadata.new }
+  subject { described_class.new }
 
   it { is_expected.to validate_presence_of :attribution }
   it { is_expected.to validate_presence_of :timestamp }
@@ -10,7 +10,7 @@ RSpec.describe VendorAPI::Metadata do
     it 'is invalid when the attribution is present but invalid' do
       attribution = { full_name: nil, cold: :bananas }
 
-      metadata = VendorAPI::Metadata.new(attribution: attribution, timestamp: Time.zone.now)
+      metadata = described_class.new(attribution: attribution, timestamp: Time.zone.now)
 
       expect(metadata).not_to be_valid
     end

--- a/spec/models/vendor_api_token_spec.rb
+++ b/spec/models/vendor_api_token_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe VendorAPIToken, type: :model do
   it 'generates a hashed token that can be used' do
-    unhashed_token = VendorAPIToken.create_with_random_token!(provider: create(:provider))
+    unhashed_token = described_class.create_with_random_token!(provider: create(:provider))
 
     expect(
-      VendorAPIToken.find_by_unhashed_token(unhashed_token),
-    ).to eql(VendorAPIToken.last)
+      described_class.find_by_unhashed_token(unhashed_token),
+    ).to eql(described_class.last)
   end
 end

--- a/spec/presenters/api_docs/api_schema_spec.rb
+++ b/spec/presenters/api_docs/api_schema_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe APIDocs::APISchema do
     let :schema do
       @document = Openapi3Parser.load(VendorAPISpecification.as_hash)
       _schema_name, raw_schema = @document.components.schemas.find { |schema_name, _schema| schema_name == 'ApplicationAttributes' }
-      APIDocs::APISchema.new(raw_schema)
+      described_class.new(raw_schema)
     end
 
     it 'finds the object_schema_name specified with $ref' do

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#personal_details_completed?' do
     it 'returns true if personal details section is completed' do
       application_form = FactoryBot.build(:application_form, personal_details_completed: true)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_personal_details_completed
     end
 
     it 'returns false if personal details section is incomplete' do
       application_form = FactoryBot.build(:application_form, personal_details_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
       expect(presenter).not_to be_personal_details_completed
     end
   end
@@ -19,14 +19,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#contact_details_completed?' do
     it 'returns true if contact details section is completed' do
       application_form = FactoryBot.build(:application_form, contact_details_completed: true)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_contact_details_completed
     end
 
     it 'returns false if contact details section is incomplete' do
       application_form = FactoryBot.build(:application_form, contact_details_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_contact_details_completed
     end
@@ -35,14 +35,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#contact_details_valid?' do
     it 'returns true if contact details section is completed' do
       application_form = FactoryBot.build(:completed_application_form, contact_details_completed: true)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_contact_details_valid
     end
 
     it 'returns false if contact details section is invalid' do
       application_form = FactoryBot.build(:completed_application_form, phone_number: '')
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_contact_details_valid
     end
@@ -51,14 +51,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#maths_gcse_completed?' do
     it 'returns true if maths gcse section is completed' do
       application_form = FactoryBot.build(:application_form, maths_gcse_completed: true)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_maths_gcse_completed
     end
 
     it 'returns false if maths gcse section is incomplete' do
       application_form = FactoryBot.build(:application_form, maths_gcse_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_maths_gcse_completed
     end
@@ -67,14 +67,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#maths_gcse_added?' do
     it 'returns true if maths gcse has been added' do
       application_form = FactoryBot.create(:application_form, :with_gcses)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_maths_gcse_added
     end
 
     it 'returns false if maths gcse has been not been added' do
       application_form = FactoryBot.build(:application_form)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_maths_gcse_added
     end
@@ -83,14 +83,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#english_gcse_completed?' do
     it 'returns true if english gcse section is completed' do
       application_form = FactoryBot.build(:application_form, english_gcse_completed: true)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_english_gcse_completed
     end
 
     it 'returns false if english gcse section is incomplete' do
       application_form = FactoryBot.build(:application_form, english_gcse_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_english_gcse_completed
     end
@@ -99,14 +99,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#english_gcse_added?' do
     it 'returns true if english gcse has been added' do
       application_form = FactoryBot.create(:application_form, :with_gcses)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_english_gcse_added
     end
 
     it 'returns false if english gcse has been not been added' do
       application_form = FactoryBot.build(:application_form)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_english_gcse_added
     end
@@ -115,14 +115,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#science_gcse_completed?' do
     it 'returns true if science gcse section is completed' do
       application_form = FactoryBot.build(:application_form, science_gcse_completed: true)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_science_gcse_completed
     end
 
     it 'returns false if science gcse section is incomplete' do
       application_form = FactoryBot.build(:application_form, science_gcse_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_science_gcse_completed
     end
@@ -131,14 +131,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#science_gcse_added?' do
     it 'returns true if science gcse has been added' do
       application_form = FactoryBot.create(:application_form, :with_gcses)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_science_gcse_added
     end
 
     it 'returns false if science gcse has been not been added' do
       application_form = FactoryBot.build(:application_form)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_science_gcse_added
     end
@@ -147,14 +147,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#degrees_completed?' do
     it 'returns true if degrees section is completed' do
       application_form = FactoryBot.build(:application_form, degrees_completed: true)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_degrees_completed
     end
 
     it 'returns false if degrees section is incomplete' do
       application_form = FactoryBot.build(:application_form, degrees_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_degrees_completed
     end
@@ -174,14 +174,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
           award_year: '2008',
         )
       end
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_degrees_added
     end
 
     it 'returns false if no degrees are added' do
       application_form = FactoryBot.create(:application_form)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_degrees_added
     end
@@ -190,14 +190,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#other_qualifications_completed?' do
     it 'returns true if other qualifications section is completed and there are no incompleted qualifications' do
       application_form = FactoryBot.build(:application_form, other_qualifications_completed: true)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_other_qualifications_completed
     end
 
     it 'returns false if other qualifications section is incomplete' do
       application_form = FactoryBot.build(:application_form, other_qualifications_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_other_qualifications_completed
     end
@@ -209,7 +209,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
              grade: nil,
              application_form: application_form)
 
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_other_qualifications_completed
     end
@@ -220,14 +220,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
       application_form = create(:application_form) do |form|
         form.application_qualifications.create(level: 'other')
       end
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter.other_qualifications_added?).to eq(true)
     end
 
     it 'returns false if no other qualifications are added' do
       application_form = FactoryBot.create(:application_form)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter.other_qualifications_added?).to eq(false)
     end
@@ -236,14 +236,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#application_choices_added?' do
     it 'returns true if application choices are added' do
       application_form = create(:completed_application_form, application_choices_count: 1)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_application_choices_added
     end
 
     it 'returns false if no application choices are added' do
       application_form = FactoryBot.build(:application_form)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_application_choices_added
     end
@@ -252,14 +252,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#training_with_a_disability_completed?' do
     it 'returns true if training with a disabilitty section is completed' do
       application_form = FactoryBot.build(:completed_application_form)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_training_with_a_disability_completed
     end
 
     it 'returns false if maths training with a disabilitty section is incomplete' do
       application_form = FactoryBot.build(:application_form)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_training_with_a_disability_completed
     end
@@ -268,14 +268,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#training_with_a_disability_valid?' do
     it 'returns true if training with a disability section is completed' do
       application_form = FactoryBot.build(:completed_application_form)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_training_with_a_disability_valid
     end
 
     it 'returns true if training with a disability section is incomplete' do
       application_form = FactoryBot.build(:completed_application_form, disclose_disability: '')
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_training_with_a_disability_valid
     end
@@ -284,14 +284,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#volunteering_completed?' do
     it 'returns true if volunteering section is completed' do
       application_form = build(:application_form, volunteering_completed: true)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_volunteering_completed
     end
 
     it 'returns false if volunteering section is incomplete' do
       application_form = build(:application_form, volunteering_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_volunteering_completed
     end
@@ -300,14 +300,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#volunteering_added?' do
     it 'returns true if volunteering have been added' do
       application_form = create(:completed_application_form, volunteering_experiences_count: 1)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_volunteering_added
     end
 
     it 'returns false if no volunteering are added' do
       application_form = build(:completed_application_form, volunteering_experiences_count: 0)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_volunteering_added
     end
@@ -316,13 +316,13 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#references_completed?' do
     it 'returns true if application form references_completed is true' do
       application_form = build(:application_form, references_completed: true)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
       expect(presenter).to be_references_completed
     end
 
     it 'returns false if application form references_completed is false' do
       application_form = build(:application_form, references_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
       expect(presenter).not_to be_references_completed
     end
   end
@@ -330,14 +330,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#safeguarding_completed?' do
     it 'returns true if the safeguarding section is completed' do
       application_form = FactoryBot.build(:application_form, safeguarding_issues_completed: true)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_safeguarding_completed
     end
 
     it 'returns false if safeguarding section is incomplete' do
       application_form = FactoryBot.build(:application_form, safeguarding_issues_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_safeguarding_completed
     end
@@ -346,14 +346,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#safeguarding_valid?' do
     it 'returns true if safeguarding section is completed' do
       application_form = FactoryBot.build(:completed_application_form, :with_safeguarding_issues_disclosed)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_safeguarding_valid
     end
 
     it 'returns true if safeguarding section is incomplete' do
       application_form = FactoryBot.build(:application_form)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_safeguarding_valid
     end
@@ -367,7 +367,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
       it 'returns the length path if no work experience' do
         application_form = build(:completed_application_form, work_experiences_count: 0, work_history_explanation: '')
-        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+        presenter = described_class.new(application_form)
 
         expect(presenter.work_experience_path).to eq(
           Rails.application.routes.url_helpers.candidate_interface_work_history_length_path,
@@ -376,7 +376,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
       it 'returns the review path if work experience' do
         application_form = create(:completed_application_form, work_experiences_count: 1, work_history_explanation: '')
-        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+        presenter = described_class.new(application_form)
 
         expect(presenter.work_experience_path).to eq(
           Rails.application.routes.url_helpers.candidate_interface_work_history_show_path,
@@ -385,7 +385,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
       it 'returns the review path if not recently worked' do
         application_form = build_stubbed(:application_form, work_history_explanation: 'I was on a career break.')
-        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+        presenter = described_class.new(application_form)
 
         expect(presenter.work_experience_path).to eq(
           Rails.application.routes.url_helpers.candidate_interface_work_history_show_path,
@@ -400,7 +400,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
       it 'returns the length path if no work experience and feature_restructured_work_history is "false"' do
         application_form = build(:completed_application_form, work_experiences_count: 0, work_history_explanation: '', feature_restructured_work_history: false)
-        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+        presenter = described_class.new(application_form)
 
         expect(presenter.work_experience_path).to eq(
           Rails.application.routes.url_helpers.candidate_interface_work_history_length_path,
@@ -409,7 +409,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
       it 'returns the review path if work experience and feature_restructured_work_history is "false"' do
         application_form = create(:completed_application_form, work_experiences_count: 1, work_history_explanation: '', feature_restructured_work_history: false)
-        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+        presenter = described_class.new(application_form)
 
         expect(presenter.work_experience_path).to eq(
           Rails.application.routes.url_helpers.candidate_interface_work_history_show_path,
@@ -418,7 +418,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
       it 'returns the review path if not recently worked and feature_restructured_work_history is "false"' do
         application_form = build_stubbed(:application_form, work_history_explanation: 'I was on a career break.', feature_restructured_work_history: false)
-        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+        presenter = described_class.new(application_form)
 
         expect(presenter.work_experience_path).to eq(
           Rails.application.routes.url_helpers.candidate_interface_work_history_show_path,
@@ -427,7 +427,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
       it 'returns the length path if no work experience' do
         application_form = build(:completed_application_form, work_experiences_count: 0, work_history_explanation: '')
-        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+        presenter = described_class.new(application_form)
 
         expect(presenter.work_experience_path).to eq(
           Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_path,
@@ -436,7 +436,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
       it 'returns the review path if work experience' do
         application_form = create(:completed_application_form, work_experiences_count: 1, work_history_explanation: '')
-        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+        presenter = described_class.new(application_form)
 
         expect(presenter.work_experience_path).to eq(
           Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_review_path,
@@ -448,7 +448,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#volunteering_path' do
     it 'returns the experience path if volunteering experience is not set' do
       application_form = build(:completed_application_form, volunteering_completed: false, volunteering_experience: nil)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter.volunteering_path).to eq(
         Rails.application.routes.url_helpers.candidate_interface_volunteering_experience_path,
@@ -457,7 +457,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
     it 'returns the review path if candidate has no volunteering experience' do
       application_form = build(:completed_application_form, volunteering_completed: false, volunteering_experience: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter.volunteering_path).to eq(
         Rails.application.routes.url_helpers.candidate_interface_review_volunteering_path,
@@ -467,7 +467,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     it 'returns the review path if candidate has volunteering experience' do
       application_form = create(:completed_application_form, volunteering_completed: false, volunteering_experience: true, volunteering_experiences_count: 1)
 
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter.volunteering_path).to eq(
         Rails.application.routes.url_helpers.candidate_interface_review_volunteering_path,
@@ -477,7 +477,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     it 'returns the review path if volunteering section is completed' do
       application_form = build(:completed_application_form, volunteering_completed: true, volunteering_experiences_count: 1)
 
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter.volunteering_path).to eq(
         Rails.application.routes.url_helpers.candidate_interface_review_volunteering_path,
@@ -626,7 +626,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
         references_completed?: true,
         selected_incorrect_number_of_references?: true,
       )
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter.reference_section_errors).to eq(
         [OpenStruct.new(message: 'You need to have exactly 2 references selected before submitting your application', anchor: '#references')],
@@ -639,14 +639,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
         references_completed?: true,
         selected_incorrect_number_of_references?: false,
       )
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter.reference_section_errors).to eq []
     end
 
     it 'returns an empty array if the application form is not references_completed' do
       application_form = instance_double(ApplicationForm, references_completed?: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter.reference_section_errors).to eq []
     end
@@ -655,14 +655,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#becoming_a_teacher_completed?' do
     it 'returns true if the becoming a teacher section is completed' do
       application_form = FactoryBot.build(:application_form, becoming_a_teacher_completed: true)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_becoming_a_teacher_completed
     end
 
     it 'returns false if the becoming a teacher section is incomplete' do
       application_form = FactoryBot.build(:application_form, becoming_a_teacher_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_becoming_a_teacher_completed
     end
@@ -671,14 +671,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#becoming_a_teacher_valid?' do
     it 'returns true if the becoming a teacher section is valid' do
       application_form = FactoryBot.build(:completed_application_form, becoming_a_teacher_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_becoming_a_teacher_valid
     end
 
     it 'returns false if the becoming a teacher section is invalid' do
       application_form = FactoryBot.build(:application_form, becoming_a_teacher_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_becoming_a_teacher_valid
     end
@@ -687,14 +687,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#subject_knowledge_completed?' do
     it 'returns true if the interview prefrences section is completed' do
       application_form = FactoryBot.build(:application_form, subject_knowledge_completed: true)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_subject_knowledge_completed
     end
 
     it 'returns false if the subject knowledge section is incomplete' do
       application_form = FactoryBot.build(:application_form, subject_knowledge_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_subject_knowledge_completed
     end
@@ -703,14 +703,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#subject_knowledge_valid?' do
     it 'returns true if the subject knowledge section is valid' do
       application_form = FactoryBot.build(:completed_application_form, subject_knowledge_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_subject_knowledge_valid
     end
 
     it 'returns false if the subject knowledge section is invalid' do
       application_form = FactoryBot.build(:application_form, subject_knowledge_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_subject_knowledge_valid
     end
@@ -719,14 +719,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#interview_preferences_completed?' do
     it 'returns true if the interview preferences section is completed' do
       application_form = FactoryBot.build(:application_form, interview_preferences_completed: true)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_interview_preferences_completed
     end
 
     it 'returns false if the interview preferences section is incomplete' do
       application_form = FactoryBot.build(:application_form, interview_preferences_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_interview_preferences_completed
     end
@@ -735,14 +735,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#interview_preferences_valid?' do
     it 'returns true if the intervew preference section is valid' do
       application_form = FactoryBot.build(:completed_application_form, interview_preferences_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_interview_preferences_valid
     end
 
     it 'returns false if the interview preferences section is invalid' do
       application_form = FactoryBot.build(:application_form, interview_preferences_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_interview_preferences_valid
     end
@@ -752,7 +752,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     it 'returns true if there are no incomplete qualifications' do
       application_form = create(:application_form)
       create(:other_qualification, application_form: application_form)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_no_incomplete_qualifications
     end
@@ -760,7 +760,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     it 'allows optional grades for Other UK qualifications to be empty' do
       application_form = create(:application_form)
       create(:other_qualification, application_form: application_form, grade: nil)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).to be_no_incomplete_qualifications
     end
@@ -768,7 +768,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     it 'returns false if there is an incomplete qualification' do
       application_form = create(:application_form)
       create(:other_qualification, application_form: application_form, award_year: nil)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+      presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_no_incomplete_qualifications
     end

--- a/spec/presenters/rejected_application_choice_presenter_spec.rb
+++ b/spec/presenters/rejected_application_choice_presenter_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe RejectedApplicationChoicePresenter do
   describe '#rejection_reasons' do
     let(:application_choice) { build_stubbed(:application_choice) }
-    let(:rejected_application_choice) { RejectedApplicationChoicePresenter.new(application_choice) }
+    let(:rejected_application_choice) { described_class.new(application_choice) }
 
     describe 'when there is a rejection_reason set' do
       it 'returns that reason only' do
@@ -34,7 +34,7 @@ RSpec.describe RejectedApplicationChoicePresenter do
           candidate_behaviour_what_to_improve: 'Do not swear',
         }
         application_choice.structured_rejection_reasons = reasons_for_rejection
-        rejected_application_choice = RejectedApplicationChoicePresenter.new(application_choice)
+        rejected_application_choice = described_class.new(application_choice)
 
         expect(rejected_application_choice.rejection_reasons).to eq(
           { 'Something you did' => ['Bad language',
@@ -52,7 +52,7 @@ RSpec.describe RejectedApplicationChoicePresenter do
           quality_of_application_subject_knowledge_what_to_improve: 'Write in the first person',
         }
         application_choice.structured_rejection_reasons = reasons_for_rejection
-        rejected_application_choice = RejectedApplicationChoicePresenter.new(application_choice)
+        rejected_application_choice = described_class.new(application_choice)
         expect(rejected_application_choice.rejection_reasons).to eq(
           { 'Quality of application' => ['Do not refer to yourself in the third person',
                                          'Write in the first person'] },
@@ -67,7 +67,7 @@ RSpec.describe RejectedApplicationChoicePresenter do
           qualifications_which_qualifications: %w[no_english_gcse no_science_gcse no_degree],
         }
         application_choice.structured_rejection_reasons = reasons_for_rejection
-        rejected_application_choice = RejectedApplicationChoicePresenter.new(application_choice)
+        rejected_application_choice = described_class.new(application_choice)
 
         expect(rejected_application_choice.rejection_reasons).to eq(
           { 'Qualifications' => ['No English GCSE grade 4 (C) or above, or valid equivalent',
@@ -84,7 +84,7 @@ RSpec.describe RejectedApplicationChoicePresenter do
           performance_at_interview_what_to_improve: 'There was no need to do all those pressups',
         }
         application_choice.structured_rejection_reasons = reasons_for_rejection
-        rejected_application_choice = RejectedApplicationChoicePresenter.new(application_choice)
+        rejected_application_choice = described_class.new(application_choice)
 
         expect(rejected_application_choice.rejection_reasons).to eq(
           { 'Performance at interview' => ['There was no need to do all those pressups'] },
@@ -102,7 +102,7 @@ RSpec.describe RejectedApplicationChoicePresenter do
           cannot_sponsor_visa_details: 'You misspelled visa as viza',
         }
         application_choice.structured_rejection_reasons = reasons_for_rejection
-        rejected_application_choice = RejectedApplicationChoicePresenter.new(application_choice)
+        rejected_application_choice = described_class.new(application_choice)
 
         expect(rejected_application_choice.rejection_reasons).to eq(
           { 'Course full' => ["We're sorry to tell you the course you applied to was full"],
@@ -120,7 +120,7 @@ RSpec.describe RejectedApplicationChoicePresenter do
           honesty_and_professionalism_concerns_references_details: 'The reference email you provided does not exist',
         }
         application_choice.structured_rejection_reasons = reasons_for_rejection
-        rejected_application_choice = RejectedApplicationChoicePresenter.new(application_choice)
+        rejected_application_choice = described_class.new(application_choice)
 
         expect(rejected_application_choice.rejection_reasons).to eq(
           { 'Honesty and professionalism' => ['The year you graduated can not be in the future',
@@ -136,7 +136,7 @@ RSpec.describe RejectedApplicationChoicePresenter do
           safeguarding_concerns_other_details: 'Other safeguarding details',
         }
         application_choice.structured_rejection_reasons = reasons_for_rejection
-        rejected_application_choice = RejectedApplicationChoicePresenter.new(application_choice)
+        rejected_application_choice = described_class.new(application_choice)
 
         expect(rejected_application_choice.rejection_reasons).to eq(
           { 'Safeguarding issues' => ['Other safeguarding details'] },
@@ -151,7 +151,7 @@ RSpec.describe RejectedApplicationChoicePresenter do
           other_advice_or_feedback_details: 'That zoom background...',
         }
         application_choice.structured_rejection_reasons = reasons_for_rejection
-        rejected_application_choice = RejectedApplicationChoicePresenter.new(application_choice)
+        rejected_application_choice = described_class.new(application_choice)
 
         expect(rejected_application_choice.rejection_reasons).to eq(
           { 'Additional advice' => ['That zoom background...'] },
@@ -169,7 +169,7 @@ RSpec.describe RejectedApplicationChoicePresenter do
           interested_in_future_applications_y_n: 'Yes',
         }
         application_choice.structured_rejection_reasons = reasons_for_rejection
-        rejected_application_choice = RejectedApplicationChoicePresenter.new(application_choice)
+        rejected_application_choice = described_class.new(application_choice)
 
         expect(rejected_application_choice.rejection_reasons).to eq(
           { 'Future applications' => ['UoG would be interested in future applications from you.'] },

--- a/spec/presenters/vendor_api/rejection_reason_presenter_spec.rb
+++ b/spec/presenters/vendor_api/rejection_reason_presenter_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe VendorAPI::RejectionReasonPresenter do
     let(:course_option) { build_stubbed(:course_option, course: build_stubbed(:course, provider: provider)) }
     let(:provider) { build_stubbed(:provider, name: 'UoG') }
 
-    subject(:presenter) { VendorAPI::RejectionReasonPresenter.new(application_choice) }
+    subject(:presenter) { described_class.new(application_choice) }
 
     it 'returns a formatted string from structured rejection reasons field' do
       expect(presenter.present.split("\n\n")).to eq([

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                 :minimum_info)
       application_choice = create(:application_choice, status: 'withdrawn', application_form: application_form, withdrawn_at: withdrawn_at)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.to_json).to be_valid_against_openapi_schema('Application')
       expect(response[:attributes][:withdrawal]).to eq(reason: nil, date: withdrawn_at.iso8601)
@@ -27,7 +27,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                 :minimum_info)
       application_choice = create(:application_choice, status: 'rejected', application_form: application_form, rejected_at: rejected_at, rejection_reason: 'Course full')
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.to_json).to be_valid_against_openapi_schema('Application')
       expect(response[:attributes][:rejection]).to eq(reason: 'Course full', date: rejected_at.iso8601)
@@ -41,7 +41,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                 :minimum_info)
       application_choice = create(:application_choice, status: 'rejected', application_form: application_form, offer_withdrawn_at: withdrawn_at, offer_withdrawal_reason: 'Course full')
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.to_json).to be_valid_against_openapi_schema('Application')
       expect(response[:attributes][:rejection]).to eq(reason: 'Course full', date: withdrawn_at.iso8601)
@@ -55,7 +55,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                 :minimum_info)
       application_choice = create(:application_choice, :with_rejection_by_default, application_form: application_form, rejected_at: rejected_at)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.to_json).to be_valid_against_openapi_schema('Application')
       expect(response[:attributes][:rejection]).to eq(reason: 'Not entered', date: rejected_at.iso8601)
@@ -87,7 +87,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       it 'returns the hesa_itt_data attribute of an application' do
         equality_and_diversity_data = application_choice.application_form.equality_and_diversity
 
-        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+        response = described_class.new(application_choice).as_json
 
         expect(response.dig(:attributes, :hesa_itt_data)).to eq(
           disability: equality_and_diversity_data['hesa_disabilities'],
@@ -106,7 +106,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       it 'returns the other disability in the other_disability_details field' do
         equality_and_diversity_data = application_choice.application_form.equality_and_diversity
 
-        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+        response = described_class.new(application_choice).as_json
 
         expect(response.dig(:attributes, :hesa_itt_data)).to eq(
           disability: equality_and_diversity_data['hesa_disabilities'],
@@ -124,7 +124,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       it 'returns no the disability or ethnicity details' do
         equality_and_diversity_data = application_choice.application_form.equality_and_diversity
 
-        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+        response = described_class.new(application_choice).as_json
 
         expect(response.dig(:attributes, :hesa_itt_data)).to eq(
           disability: equality_and_diversity_data['hesa_disabilities'],
@@ -143,7 +143,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       it 'returns the other ethnicity in the other_ethnicity_details field' do
         equality_and_diversity_data = application_choice.application_form.equality_and_diversity
 
-        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+        response = described_class.new(application_choice).as_json
 
         expect(response.dig(:attributes, :hesa_itt_data)).to eq(
           disability: equality_and_diversity_data['hesa_disabilities'],
@@ -162,7 +162,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       it 'does not return the other ethnicity in the other_ethnicity_details field' do
         equality_and_diversity_data = application_choice.application_form.equality_and_diversity
 
-        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+        response = described_class.new(application_choice).as_json
 
         expect(response.dig(:attributes, :hesa_itt_data)).to eq(
           disability: equality_and_diversity_data['hesa_disabilities'],
@@ -181,7 +181,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       it 'does not return the other ethnicity in the other_ethnicity_details field' do
         equality_and_diversity_data = application_choice.application_form.equality_and_diversity
 
-        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+        response = described_class.new(application_choice).as_json
 
         expect(response.dig(:attributes, :hesa_itt_data)).to eq(
           disability: equality_and_diversity_data['hesa_disabilities'],
@@ -202,7 +202,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       end
 
       it 'the hesa_itt_data attribute of an application is nil' do
-        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+        response = described_class.new(application_choice).as_json
 
         expect(response[:attributes][:hesa_itt_data]).to be_nil
       end
@@ -226,7 +226,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         )
         application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+        response = described_class.new(application_choice).as_json
 
         expect(response.to_json).to be_valid_against_openapi_schema('Application')
         expect(response[:attributes][:work_experience][:work_history_break_explanation]).to eq('I was sleeping.')
@@ -246,7 +246,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         )
         application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+        response = described_class.new(application_choice).as_json
 
         expect(response.to_json).to be_valid_against_openapi_schema('Application')
         expect(response[:attributes][:work_experience][:work_history_break_explanation]).to eq(
@@ -266,7 +266,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         )
         application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+        response = described_class.new(application_choice).as_json
 
         expect(response.to_json).to be_valid_against_openapi_schema('Application')
         expect(response[:attributes][:work_experience][:work_history_break_explanation]).to eq('')
@@ -282,7 +282,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                 second_nationality: 'Scottish')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :nationality)).to eq %w[GB]
     end
@@ -294,7 +294,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                 second_nationality: 'American')
       application_choice = create(:application_choice, :awaiting_provider_decision, application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.to_json).to be_valid_against_openapi_schema('Application')
       expect(response[:attributes][:candidate][:nationality]).to eq(%w[GB US])
@@ -309,7 +309,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                 fourth_nationality: 'Welsh')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :nationality)).to eq(%w[GB IE CA ES])
     end
@@ -320,7 +320,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       application_form = create(:application_form, :minimum_info)
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :domicile)).to eq(application_form.domicile)
     end
@@ -334,7 +334,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                 second_nationality: 'British')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :uk_residency_status)).to eq('UK Citizen')
     end
@@ -346,7 +346,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                 second_nationality: 'Irish')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :uk_residency_status)).to eq('Irish Citizen')
     end
@@ -359,7 +359,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                 right_to_work_or_study_details: 'I have Settled status')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :uk_residency_status)).to eq('I have Settled status')
     end
@@ -371,7 +371,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                 right_to_work_or_study: 'no')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :uk_residency_status)).to eq('Candidate needs to apply for permission to work and study in the UK')
     end
@@ -383,7 +383,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                 right_to_work_or_study: 'decide_later')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :uk_residency_status)).to eq('Candidate needs to apply for permission to work and study in the UK')
     end
@@ -397,7 +397,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                        second_nationality: 'British')
       application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :uk_residency_status_code)).to eq('A')
     end
@@ -409,7 +409,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                        second_nationality: 'Irish')
       application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :uk_residency_status_code)).to eq('B')
     end
@@ -421,7 +421,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                        right_to_work_or_study: 'no')
       application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :uk_residency_status_code)).to eq('C')
     end
@@ -433,7 +433,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                        right_to_work_or_study: 'decide_later')
       application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :uk_residency_status_code)).to eq('C')
     end
@@ -446,7 +446,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
                                        right_to_work_or_study_details: 'I have Settled status')
       application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :uk_residency_status_code)).to eq('D')
     end
@@ -457,7 +457,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       application_form = create(:application_form, :minimum_info, first_nationality: 'British')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :fee_payer)).to eq('02')
     end
@@ -466,7 +466,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       application_form = create(:application_form, :minimum_info, first_nationality: 'Swiss', right_to_work_or_study: 'yes')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :fee_payer)).to eq('02')
     end
@@ -475,7 +475,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       application_form = create(:application_form, :minimum_info, first_nationality: 'Canadian')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :fee_payer)).to eq('99')
     end
@@ -484,7 +484,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       application_form = create(:application_form, :minimum_info, first_nationality: 'Swiss', right_to_work_or_study: 'no')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :fee_payer)).to eq('99')
     end
@@ -493,7 +493,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       application_form = create(:application_form, :minimum_info, :international_address, first_nationality: 'Swiss', right_to_work_or_study: 'yes')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :fee_payer)).to eq('99')
     end
@@ -505,7 +505,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
       application_choice = create(:application_choice, :awaiting_provider_decision, application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :english_language_qualifications)).to eq('Name: TOEFL, Grade: 20, Awarded: 1999')
     end
@@ -519,7 +519,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
       application_choice = create(:application_choice, :awaiting_provider_decision, application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :english_language_qualifications)).to eq('Name: TOEFL, Grade: 20, Awarded: 1999')
     end
@@ -532,7 +532,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
       application_choice = create(:application_choice, :awaiting_provider_decision, application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :candidate, :english_language_qualifications)).to eq('I have taken some exams but I do not remember the names')
     end
@@ -560,7 +560,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         application_form: application_form,
       )
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expected_contact_details = application_form_attributes.merge(email: application_form.candidate.email_address)
       expect(response.to_json).to be_valid_against_openapi_schema('Application')
@@ -589,7 +589,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         application_form: application_form,
       )
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.to_json).to be_valid_against_openapi_schema('Application')
       expect(response.dig(:attributes, :contact_details)).to eq({
@@ -625,7 +625,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         application_form: application_form,
       )
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.to_json).to be_valid_against_openapi_schema('Application')
       expect(response.dig(:attributes, :contact_details)).to eq({
@@ -645,7 +645,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       application_form = create(:application_form, :minimum_info, :with_safeguarding_issues_disclosed)
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :safeguarding_issues_status)).to eq('has_safeguarding_issues_to_declare')
     end
@@ -656,7 +656,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       application_form = create(:application_form, :minimum_info, :with_safeguarding_issues_disclosed)
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :safeguarding_issues_details_url)).to include("/provider/applications/#{application_choice.id}#criminal-convictions-and-professional-misconduct")
     end
@@ -665,7 +665,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       application_form = build(:application_form, :minimum_info)
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :safeguarding_issues_details_url)).to eq(nil)
     end
@@ -674,7 +674,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       application_form = create(:application_form, :minimum_info, :with_safeguarding_issues_never_asked)
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
 
       expect(response.dig(:attributes, :safeguarding_issues_details_url)).to eq(nil)
     end
@@ -701,7 +701,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         application_form: application_choice.application_form,
       )
 
-      presenter = VendorAPI::SingleApplicationPresenter.new(application_choice)
+      presenter = described_class.new(application_choice)
       expect(presenter.as_json[:attributes][:references].map { |r| r[:id] }).to include(with_feedback_and_selected.id)
       expect(presenter.as_json[:attributes][:references].map { |r| r[:id] }).not_to include(with_feedback_but_not_selected.id)
       expect(presenter.as_json[:attributes][:references].map { |r| r[:id] }).not_to include(refused.id)
@@ -712,7 +712,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         :selected_reference,
         application_form: application_choice.application_form,
       )
-      presenter = VendorAPI::SingleApplicationPresenter.new(application_choice)
+      presenter = described_class.new(application_choice)
       expect(presenter.as_json[:attributes][:references].first[:id]).to eq(reference.id)
     end
 
@@ -729,7 +729,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         application_form: application_choice.application_form,
       )
 
-      presenter = VendorAPI::SingleApplicationPresenter.new(application_choice)
+      presenter = described_class.new(application_choice)
       expect(presenter.as_json[:attributes][:references].map { |r| r[:safeguarding_concerns] })
         .to match_array [true, false]
     end
@@ -737,7 +737,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
   describe 'attributes.qualifications' do
     let(:application_choice) { create(:application_choice, :with_completed_application_form, :with_offer) }
-    let(:presenter) { VendorAPI::SingleApplicationPresenter.new(application_choice) }
+    let(:presenter) { described_class.new(application_choice) }
 
     it 'uses the public_id of a qualification as the id' do
       qualification = create(
@@ -1043,21 +1043,21 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     it 'includes an offer_made_at date for offers' do
       choice = create(:application_choice, :with_completed_application_form, :with_offer)
 
-      presenter = VendorAPI::SingleApplicationPresenter.new(choice)
+      presenter = described_class.new(choice)
       expect(presenter.as_json[:attributes][:offer][:offer_made_at]).to be_present
     end
 
     it 'includes an accepted_at date for accepted offers' do
       choice = create(:application_choice, :with_completed_application_form, :with_accepted_offer)
 
-      presenter = VendorAPI::SingleApplicationPresenter.new(choice)
+      presenter = described_class.new(choice)
       expect(presenter.as_json[:attributes][:offer][:offer_accepted_at]).to be_present
     end
 
     it 'includes a declined_at date for declined offers' do
       choice = create(:application_choice, :with_completed_application_form, :with_declined_offer)
 
-      presenter = VendorAPI::SingleApplicationPresenter.new(choice)
+      presenter = described_class.new(choice)
       expect(presenter.as_json[:attributes][:offer][:offer_declined_at]).to be_present
     end
   end
@@ -1066,7 +1066,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     it 'includes the date the candidate was recruited' do
       choice = create(:application_choice, :with_completed_application_form, :with_recruited)
 
-      presenter = VendorAPI::SingleApplicationPresenter.new(choice)
+      presenter = described_class.new(choice)
       expect(presenter.as_json[:attributes][:recruited_at]).to be_present
     end
   end
@@ -1074,7 +1074,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
   describe 'attributes.status' do
     it 'returns awaiting_provider_decision when status is interviewing' do
       application_choice = build_stubbed(:application_choice, :with_completed_application_form, status: :interviewing)
-      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+      response = described_class.new(application_choice).as_json
       expect(response[:attributes][:status]).to eq('awaiting_provider_decision')
     end
   end
@@ -1101,8 +1101,8 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         allow(application_choice.application_form).to receive(field).and_call_original
       end
 
-      VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
-      VendorAPI::SingleApplicationPresenter.new(non_uk_application_choice).as_json
+      described_class.new(application_choice).as_json
+      described_class.new(non_uk_application_choice).as_json
 
       (ApplicationForm::PUBLISHED_FIELDS - %w[postcode equality_and_diversity]).each do |field|
         expect(non_uk_application_form).to have_received(field).at_least(:once)
@@ -1119,8 +1119,8 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         allow(application_choice.application_form).to receive(field).and_call_original
       end
 
-      VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
-      VendorAPI::SingleApplicationPresenter.new(non_uk_application_choice).as_json
+      described_class.new(application_choice).as_json
+      described_class.new(non_uk_application_choice).as_json
 
       (ApplicationForm.attribute_names - %w[id] - ApplicationForm::PUBLISHED_FIELDS).each do |field|
         expect(non_uk_application_form).not_to have_received(field)

--- a/spec/queries/get_activity_log_events_spec.rb
+++ b/spec/queries/get_activity_log_events_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GetActivityLogEvents, with_audited: true do
 
   let(:provider_user) { create(:provider_user, :with_two_providers) }
   let(:application_choices_for_provider_user) { GetApplicationChoicesForProviders.call(providers: provider_user.providers) }
-  let(:service_call) { GetActivityLogEvents.call(application_choices: application_choices_for_provider_user) }
+  let(:service_call) { described_class.call(application_choices: application_choices_for_provider_user) }
 
   let(:course_provider_a) { create(:course, provider: provider_user.providers.first) }
   let(:course_provider_b) { create(:course, provider: provider_user.providers.second) }
@@ -56,7 +56,7 @@ RSpec.describe GetActivityLogEvents, with_audited: true do
         created_at: 1.day.from_now,
       )
 
-      result = GetActivityLogEvents.call(
+      result = described_class.call(
         application_choices: application_choices_for_provider_user,
         since: 6.hours.from_now,
       )
@@ -199,7 +199,7 @@ RSpec.describe GetActivityLogEvents, with_audited: true do
     let(:application_choice) { create(:application_choice, :with_scheduled_interview) }
 
     it 'returns events associated with interviews' do
-      result = GetActivityLogEvents.call(application_choices: ApplicationChoice.where(id: application_choice.id))
+      result = described_class.call(application_choices: ApplicationChoice.where(id: application_choice.id))
 
       expect(result.first.auditable).to eq(application_choice.interviews.first)
       expect(result.first.associated).to eq(application_choice)
@@ -225,7 +225,7 @@ RSpec.describe GetActivityLogEvents, with_audited: true do
         auditable: application_choice,
         audited_changes: { status: %w[interviewing awaiting_provider_decision] },
       )
-      result = GetActivityLogEvents.call(application_choices: ApplicationChoice.where(id: application_choice.id))
+      result = described_class.call(application_choices: ApplicationChoice.where(id: application_choice.id))
 
       expect(excluded).to exist
       expect(result).not_to include(excluded)

--- a/spec/queries/get_all_change_options_from_offered_option_spec.rb
+++ b/spec/queries/get_all_change_options_from_offered_option_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GetAllChangeOptionsFromOfferedOption do
   let(:application_choice) { create(:application_choice, :with_offer, course_option: course_option) }
 
   let(:service) do
-    GetAllChangeOptionsFromOfferedOption.new(
+    described_class.new(
       application_choice: application_choice,
       available_providers: available_providers,
     )

--- a/spec/queries/get_application_choices_for_providers_spec.rb
+++ b/spec/queries/get_application_choices_for_providers_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe GetApplicationChoicesForProviders do
 
   it 'raises an exception when the provider is nil' do
     expect {
-      GetApplicationChoicesForProviders.call(providers: nil)
+      described_class.call(providers: nil)
     }.to raise_error(MissingProvider)
   end
 
@@ -25,7 +25,7 @@ RSpec.describe GetApplicationChoicesForProviders do
       status: 'awaiting_provider_decision',
     )
 
-    returned_applications = GetApplicationChoicesForProviders.call(providers: current_provider)
+    returned_applications = described_class.call(providers: current_provider)
     expect(returned_applications.size).to eq(2)
   end
 
@@ -39,7 +39,7 @@ RSpec.describe GetApplicationChoicesForProviders do
       status: 'awaiting_provider_decision',
     )
 
-    returned_applications = GetApplicationChoicesForProviders.call(providers: current_provider)
+    returned_applications = described_class.call(providers: current_provider)
 
     expect(returned_applications.first.association(:site)).to be_loaded
     expect(returned_applications.first.association(:application_form)).to be_loaded
@@ -68,26 +68,26 @@ RSpec.describe GetApplicationChoicesForProviders do
       status: 'awaiting_provider_decision',
     )
 
-    returned_applications = GetApplicationChoicesForProviders.call(providers: [bat_provider, man_provider])
+    returned_applications = described_class.call(providers: [bat_provider, man_provider])
 
     expect(returned_applications.map(&:id)).to match_array([bat_choice.id, man_choice.id])
   end
 
   it 'raises an error if the provider argument is missing' do
     expect {
-      GetApplicationChoicesForProviders.call(providers: [])
+      described_class.call(providers: [])
     }.to raise_error(MissingProvider)
 
     expect {
-      GetApplicationChoicesForProviders.call(providers: [''])
+      described_class.call(providers: [''])
     }.to raise_error(MissingProvider)
 
     expect {
-      GetApplicationChoicesForProviders.call(providers: '')
+      described_class.call(providers: '')
     }.to raise_error(MissingProvider)
 
     expect {
-      GetApplicationChoicesForProviders.call(providers: nil)
+      described_class.call(providers: nil)
     }.to raise_error(MissingProvider)
   end
 
@@ -115,7 +115,7 @@ RSpec.describe GetApplicationChoicesForProviders do
       status: 'offer_deferred',
     )
 
-    returned_applications = GetApplicationChoicesForProviders.call(providers: current_provider)
+    returned_applications = described_class.call(providers: current_provider)
     expect(returned_applications.size).to eq(5)
   end
 
@@ -157,7 +157,7 @@ RSpec.describe GetApplicationChoicesForProviders do
       application_form: create(:application_form, first_name: 'Alex'),
     )
 
-    returned_applications = GetApplicationChoicesForProviders.call(providers: current_provider)
+    returned_applications = described_class.call(providers: current_provider)
     returned_application_names = returned_applications.map { |a| a.application_form.first_name }
 
     expect(returned_application_names).to include('Aaron', 'Jim', 'Harry')
@@ -195,7 +195,7 @@ RSpec.describe GetApplicationChoicesForProviders do
       course_option: ratified_course_option_for_past_cycle,
     )
 
-    returned_applications = GetApplicationChoicesForProviders.call(providers: current_provider)
+    returned_applications = described_class.call(providers: current_provider)
 
     expect(returned_applications.map(&:id)).to include(choice_for_this_cycle.id)
     expect(returned_applications.map(&:id)).not_to include(choice_for_past_cycle.id)
@@ -236,7 +236,7 @@ RSpec.describe GetApplicationChoicesForProviders do
       course_option: ratified_course_option_for_previous_cycle,
     )
 
-    returned_applications = GetApplicationChoicesForProviders.call(providers: current_provider, recruitment_cycle_year: RecruitmentCycle.current_year)
+    returned_applications = described_class.call(providers: current_provider, recruitment_cycle_year: RecruitmentCycle.current_year)
 
     expect(returned_applications.map(&:id)).to include(choice_for_current_cycle.id)
     expect(returned_applications.map(&:id)).not_to include(choice_for_previous_cycle.id)
@@ -260,7 +260,7 @@ RSpec.describe GetApplicationChoicesForProviders do
         status: 'offer_deferred',
       )
 
-      returned_applications = GetApplicationChoicesForProviders.call(providers: current_provider, vendor_api: true)
+      returned_applications = described_class.call(providers: current_provider, vendor_api: true)
       expect(returned_applications.size).to eq(1)
     end
   end
@@ -276,7 +276,7 @@ RSpec.describe GetApplicationChoicesForProviders do
         status: 'awaiting_provider_decision',
       )
 
-      returned_applications = GetApplicationChoicesForProviders.call(providers: current_provider, includes: [course_option: :course])
+      returned_applications = described_class.call(providers: current_provider, includes: [course_option: :course])
 
       expect(returned_applications.first.association(:site)).not_to be_loaded
       expect(returned_applications.first.association(:application_form)).not_to be_loaded

--- a/spec/queries/get_course_option_from_codes_spec.rb
+++ b/spec/queries/get_course_option_from_codes_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe GetCourseOptionFromCodes do
   let(:course_option) { create(:course_option) }
 
   let(:service) do
-    GetCourseOptionFromCodes.new(
+    described_class.new(
       provider_code: course_option.course.provider.code,
       course_code: course_option.course.code,
       study_mode: course_option.course.study_mode,

--- a/spec/queries/get_duplicate_candidate_matches_spec.rb
+++ b/spec/queries/get_duplicate_candidate_matches_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe GetDuplicateCandidateMatches do
   end
 
   describe '#call' do
-    let(:returned_array_of_hashes) { GetDuplicateCandidateMatches.call }
+    let(:returned_array_of_hashes) { described_class.call }
 
     it 'returns an array of hashes with the correct keys' do
       expect(returned_array_of_hashes.count).to eq(2)

--- a/spec/queries/reasons_for_rejection_count_query_spec.rb
+++ b/spec/queries/reasons_for_rejection_count_query_spec.rb
@@ -56,32 +56,32 @@ RSpec.describe ReasonsForRejectionCountQuery do
 
   describe '#reason_counts' do
     it 'returns correct values' do
-      counts = ReasonsForRejectionCountQuery.new.reason_counts
+      counts = described_class.new.reason_counts
       expect(counts[:candidate_behaviour_y_n]).to eq(
-        ReasonsForRejectionCountQuery::Result.new(3, 2, {}),
+        described_class::Result.new(3, 2, {}),
       )
       expect(counts[:qualifications_y_n]).to eq(
-        ReasonsForRejectionCountQuery::Result.new(1, 1, {}),
+        described_class::Result.new(1, 1, {}),
       )
     end
   end
 
   describe '#sub_reason_counts' do
     it 'returns correct values' do
-      counts = ReasonsForRejectionCountQuery.new.sub_reason_counts
+      counts = described_class.new.sub_reason_counts
       expect(counts[:candidate_behaviour_y_n].sub_reasons[:other]).to eq(
-        ReasonsForRejectionCountQuery::Result.new(3, 2, nil),
+        described_class::Result.new(3, 2, nil),
       )
       expect(counts[:quality_of_application_y_n].sub_reasons[:personal_statement]).to eq(
-        ReasonsForRejectionCountQuery::Result.new(2, 1, nil),
+        described_class::Result.new(2, 1, nil),
       )
     end
 
     it 'includes zero values' do
-      counts = ReasonsForRejectionCountQuery.new.sub_reason_counts
+      counts = described_class.new.sub_reason_counts
       expect(counts[:qualifications_y_n].sub_reasons.count).to be(5)
       expect(counts[:qualifications_y_n].sub_reasons[:no_english_gcse]).to eq(
-        ReasonsForRejectionCountQuery::Result.new(0, 0, nil),
+        described_class::Result.new(0, 0, nil),
       )
     end
   end

--- a/spec/requests/api_docs/get_spec_spec.rb
+++ b/spec/requests/api_docs/get_spec_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'API Docs - GET /api-docs/spec.yml', type: :request do
   it 'returns the spec in YAML format' do
     get '/api-docs/spec.yml'
 
-    expect(response).to have_http_status(200)
+    expect(response).to have_http_status(:ok)
     expect(response.body).to match 'openapi: 3.0.0'
   end
 end

--- a/spec/requests/candidate_api/get_candidates_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'GET /candidate-api/candidates', type: :request do
   it 'returns an error if the `updated_since` parameter is missing' do
     get_api_request '/candidate-api/candidates', token: candidate_api_token
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
     expect(error_response['message']).to eql('param is missing or the value is empty: updated_since')
     expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse')
   end
@@ -36,7 +36,7 @@ RSpec.describe 'GET /candidate-api/candidates', type: :request do
 
     get_api_request "/candidate-api/candidates?updated_since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}", token: candidate_api_token
 
-    expect(response).to have_http_status(200)
+    expect(response).to have_http_status(:ok)
     expect(parsed_response['data'].size).to eq(1)
   end
 
@@ -48,7 +48,7 @@ RSpec.describe 'GET /candidate-api/candidates', type: :request do
 
     get_api_request "/candidate-api/candidates?updated_since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}", token: candidate_api_token
 
-    expect(response).to have_http_status(200)
+    expect(response).to have_http_status(:ok)
     expect(parsed_response['data'].size).to eq(2)
   end
 
@@ -83,21 +83,21 @@ RSpec.describe 'GET /candidate-api/candidates', type: :request do
   it 'returns an error if the token is incorrect' do
     get "/candidate-api/candidates?updated_since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}", headers: { Authorization: 'invalid-token' }
 
-    expect(response).to have_http_status(401)
+    expect(response).to have_http_status(:unauthorized)
     expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
   end
 
   it 'returns an error if no API token is present' do
     get "/candidate-api/candidates?updated_since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}", headers: { Authorization: nil }
 
-    expect(response).to have_http_status(401)
+    expect(response).to have_http_status(:unauthorized)
     expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
   end
 
   it 'returns HTTP status 422 given an unparseable `updated_since` date value' do
     get_api_request '/candidate-api/candidates?updated_since=17/07/2020T12:00:42Z', token: candidate_api_token
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
     expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): updated_since')
     expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
   end
@@ -105,7 +105,7 @@ RSpec.describe 'GET /candidate-api/candidates', type: :request do
   it 'returns HTTP status 422 when encountering a KeyError from ActiveSupport::TimeZone' do
     get_api_request '/candidate-api/candidates?updated_since=12936', token: candidate_api_token
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
     expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): updated_since')
     expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
   end
@@ -113,7 +113,7 @@ RSpec.describe 'GET /candidate-api/candidates', type: :request do
   it 'returns HTTP status 422 given a parseable but nonsensensical `updated_since` date value' do
     get_api_request '/candidate-api/candidates?updated_since=-004713-03-23T11:52:19.448Z', token: candidate_api_token
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
     expect(error_response['message']).to eql('Parameter is invalid (date is nonsense): updated_since')
     expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
   end

--- a/spec/requests/candidate_interface/authentication_spec.rb
+++ b/spec/requests/candidate_interface/authentication_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe 'Authentication for candidates', type: :request do
   it 'redirects the user if the token is invalid' do
     get candidate_interface_application_form_url(token: '123')
 
-    expect(response).to have_http_status(302)
+    expect(response).to have_http_status(:found)
   end
 
   it 'redirects the user if the token is missing from the URL' do
     get candidate_interface_application_form_url
 
-    expect(response).to have_http_status(302)
+    expect(response).to have_http_status(:found)
   end
 
   it 'redirects the user if the token is expired' do
@@ -19,6 +19,6 @@ RSpec.describe 'Authentication for candidates', type: :request do
 
     get candidate_interface_application_form_url(token: magic_link_token.raw)
 
-    expect(response).to have_http_status(302)
+    expect(response).to have_http_status(:found)
   end
 end

--- a/spec/requests/provider_interface/account_creation_in_progress_spec.rb
+++ b/spec/requests/provider_interface/account_creation_in_progress_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'GET /provider/applications' do
     it 'returns 403 with the email-address-not-recognised page' do
       get '/provider/applications'
 
-      expect(response).to have_http_status 403
+      expect(response).to have_http_status :forbidden
       expect(response.body).to include('Your email address is not recognised')
     end
   end

--- a/spec/requests/provider_interface/landing_page_redirect_spec.rb
+++ b/spec/requests/provider_interface/landing_page_redirect_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'GET /provider' do
     it 'redirects them to the Provider Interface' do
       get '/provider'
 
-      expect(response).to have_http_status 302
+      expect(response).to have_http_status :found
     end
   end
 
@@ -24,7 +24,7 @@ RSpec.describe 'GET /provider' do
     it 'returns 200' do
       get '/provider'
 
-      expect(response).to have_http_status 200
+      expect(response).to have_http_status :ok
     end
   end
 end

--- a/spec/requests/provider_interface/provider_user_impersonates_candidate_spec.rb
+++ b/spec/requests/provider_interface/provider_user_impersonates_candidate_spec.rb
@@ -28,20 +28,20 @@ RSpec.describe 'POST /provider/candidates/:id/impersonate' do
 
     it 'redirects to Candidate Interface if candidate associated with user’s providers' do
       post provider_interface_impersonate_candidate_path(application_choice.application_form.candidate)
-      expect(response).to have_http_status 302
+      expect(response).to have_http_status :found
 
       get candidate_interface_application_complete_path
-      expect(response).to have_http_status 200 # a 200 response suggests a candidate session
+      expect(response).to have_http_status :ok # a 200 response suggests a candidate session
     end
 
     it 'redirects back to Provider Interface if candidate is not associated with user’s providers' do
       unrelated_application = create(:application_choice, status: 'awaiting_provider_decision')
 
       post provider_interface_impersonate_candidate_path(unrelated_application.application_form.candidate)
-      expect(response).to have_http_status 302
+      expect(response).to have_http_status :found
 
       get candidate_interface_application_form_path
-      expect(response).to have_http_status 302 # no candidate session redirects to candidate_interface_path
+      expect(response).to have_http_status :found # no candidate session redirects to candidate_interface_path
     end
 
     it 'returns 404 on production' do
@@ -49,7 +49,7 @@ RSpec.describe 'POST /provider/candidates/:id/impersonate' do
 
       post provider_interface_impersonate_candidate_path(application_choice.application_form.candidate)
 
-      expect(response).to have_http_status 404
+      expect(response).to have_http_status :not_found
     end
   end
 end

--- a/spec/requests/register_api/get_multiple_applications_spec.rb
+++ b/spec/requests/register_api/get_multiple_applications_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'GET /register-api/applications', type: :request do
   it 'returns an error if the `recruitment_cycle_year` parameter is missing' do
     get_api_request '/register-api/applications', token: register_api_token
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
     expect(error_response['message']).to eql('param is missing or the value is empty: recruitment_cycle_year')
     expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse')
   end
@@ -44,7 +44,7 @@ RSpec.describe 'GET /register-api/applications', type: :request do
   it 'returns an error if the `recruitment_cycle_year` parameter is incorrect year' do
     get_api_request '/register-api/applications?recruitment_cycle_year=2008', token: register_api_token
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
     expect(error_response['message']).to eql('Parameter is invalid: recruitment_cycle_year')
     expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
   end
@@ -52,7 +52,7 @@ RSpec.describe 'GET /register-api/applications', type: :request do
   it 'returns HTTP status 422 given an unparseable `changed_since` date value' do
     get_api_request "/register-api/applications?changed_since=17/07/2020T12:00:42Z&recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: register_api_token
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
     expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): changed_since')
     expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
   end
@@ -60,7 +60,7 @@ RSpec.describe 'GET /register-api/applications', type: :request do
   it 'returns HTTP status 422 when encountering a KeyError from ActiveSupport::TimeZone' do
     get_api_request "/register-api/applications?changed_since=12936&recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: register_api_token
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
     expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): changed_since')
     expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
   end
@@ -68,7 +68,7 @@ RSpec.describe 'GET /register-api/applications', type: :request do
   it 'returns HTTP status 422 given a parseable but nonsensensical `changed_since` date value' do
     get_api_request "/register-api/applications?changed_since=-004713-03-23T11:52:19.448Z&recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: register_api_token
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
     expect(error_response['message']).to eql('Parameter is invalid (date is nonsense): changed_since')
     expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
   end

--- a/spec/requests/vendor_api/api_authentication_spec.rb
+++ b/spec/requests/vendor_api/api_authentication_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'API Authentication', type: :request do
 
     get '/api/v1/ping', headers: { Authorization: "Bearer #{unhashed_token}" }
 
-    expect(response).to have_http_status(200)
+    expect(response).to have_http_status(:ok)
   end
 
   it 'remembers when a token was last used' do
@@ -24,21 +24,21 @@ RSpec.describe 'API Authentication', type: :request do
   it 'returns an error if no Authorization header is present' do
     get '/api/v1/ping'
 
-    expect(response).to have_http_status(401)
+    expect(response).to have_http_status(:unauthorized)
     expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
   end
 
   it 'returns an error if the token is incorrect' do
     get '/api/v1/ping', headers: { Authorization: 'invalid-token' }
 
-    expect(response).to have_http_status(401)
+    expect(response).to have_http_status(:unauthorized)
     expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
   end
 
   it 'returns an error if no API token is present' do
     get '/api/v1/ping', headers: { Authorization: nil }
 
-    expect(response).to have_http_status(401)
+    expect(response).to have_http_status(:unauthorized)
     expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
   end
 end

--- a/spec/requests/vendor_api/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/get_multiple_applications_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
   it 'returns an error if the `since` parameter is missing' do
     get_api_request '/api/v1/applications'
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
 
     expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse')
 
@@ -65,7 +65,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
   it 'returns HTTP status 422 given an unparseable `since` date value' do
     get_api_request '/api/v1/applications?since=17/07/2020T12:00:42Z'
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
 
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
 
@@ -75,7 +75,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
   it 'returns HTTP status 422 when encountering a KeyError from ActiveSupport::TimeZone' do
     get_api_request '/api/v1/applications?since=12936'
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
 
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
 
@@ -85,7 +85,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
   it 'returns HTTP status 422 given a parseable but nonsensensical `since` date value' do
     get_api_request '/api/v1/applications?since=-004713-03-23T11:52:19.448Z' # this happened
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
 
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
 

--- a/spec/requests/vendor_api/get_single_application_spec.rb
+++ b/spec/requests/vendor_api/get_single_application_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications/:application_id', type: :r
   it 'returns a not found error if the application cannot be found' do
     get_api_request '/api/v1/applications/asu7dvt87asd'
 
-    expect(response).to have_http_status(404)
+    expect(response).to have_http_status(:not_found)
 
     expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
 
@@ -29,7 +29,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications/:application_id', type: :r
 
     get_api_request "/api/v1/applications/#{application_choice.id}"
 
-    expect(response).to have_http_status(404)
+    expect(response).to have_http_status(:not_found)
     expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
     expect(error_response['message']).to eql("Could not find an application with ID #{application_choice.id}")
   end

--- a/spec/requests/vendor_api/post_conditions_met_spec.rb
+++ b/spec/requests/vendor_api/post_conditions_met_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-conditio
 
     post_api_request "/api/v1/applications/#{application_choice.id}/confirm-conditions-met"
 
-    expect(response).to have_http_status(200)
+    expect(response).to have_http_status(:ok)
     expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
     expect(parsed_response['data']['attributes']['status']).to eq 'recruited'
   end
@@ -23,7 +23,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-conditio
 
     post_api_request "/api/v1/applications/#{application_choice.id}/confirm-conditions-met", params: {}
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
     expect(error_response['message']).to eq 'The application is not ready for that action'
   end
@@ -31,7 +31,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-conditio
   it 'returns not found error when the application was not found' do
     post_api_request '/api/v1/applications/non-existent-id/confirm-conditions-met'
 
-    expect(response).to have_http_status(404)
+    expect(response).to have_http_status(:not_found)
     expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
     expect(error_response['message']).to eql('Could not find an application with ID non-existent-id')
   end

--- a/spec/requests/vendor_api/post_conditions_not_met_spec.rb
+++ b/spec/requests/vendor_api/post_conditions_not_met_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/conditions-not-m
 
     post_api_request "/api/v1/applications/#{application_choice.id}/conditions-not-met"
 
-    expect(response).to have_http_status(200)
+    expect(response).to have_http_status(:ok)
     expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
     expect(parsed_response['data']['attributes']['status']).to eq 'conditions_not_met'
   end

--- a/spec/requests/vendor_api/post_confirm_enrolment_spec.rb
+++ b/spec/requests/vendor_api/post_confirm_enrolment_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-enrolmen
 
     post_api_request "/api/v1/applications/#{application_choice.id}/confirm-enrolment"
 
-    expect(response).to have_http_status(200)
+    expect(response).to have_http_status(:ok)
     expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
     expect(parsed_response['data']['attributes']['status']).to eq 'recruited'
   end
@@ -29,7 +29,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-enrolmen
   it 'returns a not found error when the application was not found' do
     post_api_request '/api/v1/applications/non-existent-id/confirm-enrolment'
 
-    expect(response).to have_http_status(404)
+    expect(response).to have_http_status(:not_found)
     expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
     expect(error_response['message']).to eql('Could not find an application with ID non-existent-id')
   end

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
         },
       }
 
-      expect(response).to have_http_status(422)
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
       expect(error_response['message']).to match 'The specified course is not associated with any of your organisations.'
     end
@@ -158,7 +158,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
         }
       }.to change(VendorAPIRequest, :count)
 
-      expect(response).to have_http_status(422)
+      expect(response).to have_http_status(:unprocessable_entity)
 
       logged_error = VendorAPIRequest.first.response_body['errors'].first['error']
 
@@ -183,7 +183,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
         },
       }
 
-      expect(response).to have_http_status(422)
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
       expect(error_response['message']).to match 'The requested course could not be found'
     end
@@ -195,7 +195,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: { data: { conditions: [] } }
 
-      expect(response).to have_http_status(422)
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
       expect(error_response['message']).to eq 'The application is not ready for that action'
     end
@@ -212,7 +212,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       post_api_request '/api/v1/applications/non-existent-id/offer', params: request_body
 
-      expect(response).to have_http_status(404)
+      expect(response).to have_http_status(:not_found)
       expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
       expect(error_response['message']).to eql('Could not find an application with ID non-existent-id')
     end
@@ -397,7 +397,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
         post_api_request "/api/v1/applications/#{choice.id}/offer", params: request_body
       }.not_to(change { choice.reload })
 
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
     end
   end
 

--- a/spec/requests/vendor_api/post_reject_application_spec.rb
+++ b/spec/requests/vendor_api/post_reject_application_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
 
       post_api_request "/api/v1/applications/#{application_choice.id}/reject", params: request_body
 
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
       expect(parsed_response['data']['attributes']['status']).to eq 'rejected'
       expect(parsed_response['data']['attributes']['rejection']).to match a_hash_including(
@@ -40,7 +40,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
 
       post_api_request "/api/v1/applications/#{application_choice.id}/reject", params: request_body
 
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
       expect(parsed_response['data']['attributes']['status']).to eq 'rejected'
       expect(parsed_response['data']['attributes']['rejection']).to match a_hash_including(
@@ -61,7 +61,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
 
     post_api_request "/api/v1/applications/#{application_choice.id}/reject", params: request_body
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
     expect(error_response['message']).to eq 'The application is not ready for that action'
   end
@@ -77,7 +77,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
       },
     }
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
     expect(error_response['message']).to eql 'Rejection reason Explain why you’re rejecting the application'
   end
@@ -85,7 +85,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
   it 'returns not found error when the application was not found' do
     post_api_request '/api/v1/applications/non-existent-id/reject'
 
-    expect(response).to have_http_status(404)
+    expect(response).to have_http_status(:not_found)
     expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
     expect(error_response['message']).to eql('Could not find an application with ID non-existent-id')
   end

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -4,26 +4,26 @@ RSpec.describe ApplicationStateChange do
   context 'when the interview flag is active' do
     describe '.valid_states' do
       it 'has human readable translations' do
-        expect(ApplicationStateChange.valid_states)
+        expect(described_class.valid_states)
           .to match_array(I18n.t('application_states').keys)
 
-        expect(ApplicationStateChange.valid_states)
+        expect(described_class.valid_states)
           .to match_array(I18n.t('candidate_application_states').keys)
 
-        expect(ApplicationStateChange.valid_states)
+        expect(described_class.valid_states)
           .to match_array(I18n.t('provider_application_states').keys)
       end
 
       it 'has corresponding entries in the ApplicationChoice#status enum' do
-        expect(ApplicationStateChange.valid_states)
+        expect(described_class.valid_states)
           .to match_array(ApplicationChoice.statuses.keys.map(&:to_sym))
       end
     end
 
     describe '.states_visible_to_provider' do
       it 'matches the valid states and states not visible' do
-        expect(ApplicationStateChange.states_visible_to_provider)
-          .to match_array(ApplicationStateChange.valid_states - ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER)
+        expect(described_class.states_visible_to_provider)
+          .to match_array(described_class.valid_states - described_class::STATES_NOT_VISIBLE_TO_PROVIDER)
       end
     end
   end
@@ -32,14 +32,14 @@ RSpec.describe ApplicationStateChange do
     it 'has corresponding entries in the OpenAPI spec - excluding the interview state' do
       valid_states_in_openapi = VendorAPISpecification.as_hash['components']['schemas']['ApplicationAttributes']['properties']['status']['enum']
 
-      expect(ApplicationStateChange.states_visible_to_provider_without_deferred - %i[interviewing offer_withdrawn])
+      expect(described_class.states_visible_to_provider_without_deferred - %i[interviewing offer_withdrawn])
         .to match_array(valid_states_in_openapi.map(&:to_sym))
     end
   end
 
   describe '::STATES_NOT_VISIBLE_TO_PROVIDER' do
     it 'contains the correct states to filter by' do
-      expect(ApplicationStateChange.valid_states).to include(*ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER)
+      expect(described_class.valid_states).to include(*described_class::STATES_NOT_VISIBLE_TO_PROVIDER)
     end
   end
 end

--- a/spec/services/cancel_interview_spec.rb
+++ b/spec/services/cancel_interview_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CancelInterview do
   describe '#save!' do
     describe 'when there are no other interviews' do
       it 'transitions the application_choice state to `awaiting_provider_decision` if successful' do
-        service = CancelInterview.new(service_params)
+        service = described_class.new(service_params)
 
         expect { service.save! }.to change { application_choice.status }.to('awaiting_provider_decision')
       end
@@ -30,14 +30,14 @@ RSpec.describe CancelInterview do
     describe 'when there are other interviews' do
       it 'does not change the application_choice state' do
         create(:interview, application_choice: application_choice)
-        service = CancelInterview.new(service_params)
+        service = described_class.new(service_params)
 
         expect { service.save! }.not_to(change { application_choice.status })
       end
     end
 
     it 'creates an audit entry and sends an email', with_audited: true, sidekiq: true do
-      CancelInterview.new(service_params).save!
+      described_class.new(service_params).save!
 
       associated_audit = application_choice.associated_audits.last
       expect(associated_audit.auditable).to eq(application_choice.interviews.first)

--- a/spec/services/check_breaks_in_work_history_spec.rb
+++ b/spec/services/check_breaks_in_work_history_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe CheckBreaksInWorkHistory do
       it 'returns false' do
         application_form = build_stubbed(:application_form)
 
-        breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+        breaks_in_work_history = described_class.call(application_form)
 
         expect(breaks_in_work_history).to eq(false)
       end
@@ -39,7 +39,7 @@ RSpec.describe CheckBreaksInWorkHistory do
           )
         end
 
-        breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+        breaks_in_work_history = described_class.call(application_form)
 
         expect(breaks_in_work_history).to eq(false)
       end
@@ -55,7 +55,7 @@ RSpec.describe CheckBreaksInWorkHistory do
             )
           end
 
-          breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+          breaks_in_work_history = described_class.call(application_form)
 
           expect(breaks_in_work_history).to eq(false)
         end
@@ -72,7 +72,7 @@ RSpec.describe CheckBreaksInWorkHistory do
             )
           end
 
-          breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+          breaks_in_work_history = described_class.call(application_form)
 
           expect(breaks_in_work_history).to eq(true)
         end
@@ -89,7 +89,7 @@ RSpec.describe CheckBreaksInWorkHistory do
             )
           end
 
-          breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+          breaks_in_work_history = described_class.call(application_form)
 
           expect(breaks_in_work_history).to eq(true)
         end
@@ -110,7 +110,7 @@ RSpec.describe CheckBreaksInWorkHistory do
           )
         end
 
-        breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+        breaks_in_work_history = described_class.call(application_form)
 
         expect(breaks_in_work_history).to eq(true)
       end
@@ -128,7 +128,7 @@ RSpec.describe CheckBreaksInWorkHistory do
           )
         end
 
-        breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+        breaks_in_work_history = described_class.call(application_form)
 
         expect(breaks_in_work_history).to eq(true)
       end
@@ -146,7 +146,7 @@ RSpec.describe CheckBreaksInWorkHistory do
           )
         end
 
-        breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+        breaks_in_work_history = described_class.call(application_form)
 
         expect(breaks_in_work_history).to eq(true)
       end
@@ -164,7 +164,7 @@ RSpec.describe CheckBreaksInWorkHistory do
           )
         end
 
-        breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+        breaks_in_work_history = described_class.call(application_form)
 
         expect(breaks_in_work_history).to eq(false)
       end
@@ -182,7 +182,7 @@ RSpec.describe CheckBreaksInWorkHistory do
           )
         end
 
-        breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+        breaks_in_work_history = described_class.call(application_form)
 
         expect(breaks_in_work_history).to eq(true)
       end
@@ -207,7 +207,7 @@ RSpec.describe CheckBreaksInWorkHistory do
           )
         end
 
-        breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+        breaks_in_work_history = described_class.call(application_form)
 
         expect(breaks_in_work_history).to eq(false)
       end
@@ -240,7 +240,7 @@ RSpec.describe CheckBreaksInWorkHistory do
           )
         end
 
-        breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+        breaks_in_work_history = described_class.call(application_form)
 
         expect(breaks_in_work_history).to eq(true)
       end
@@ -268,7 +268,7 @@ RSpec.describe CheckBreaksInWorkHistory do
           )
         end
 
-        breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+        breaks_in_work_history = described_class.call(application_form)
 
         expect(breaks_in_work_history).to eq(false)
       end
@@ -296,7 +296,7 @@ RSpec.describe CheckBreaksInWorkHistory do
           )
         end
 
-        breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+        breaks_in_work_history = described_class.call(application_form)
 
         expect(breaks_in_work_history).to eq(false)
       end

--- a/spec/services/create_interview_spec.rb
+++ b/spec/services/create_interview_spec.rb
@@ -21,13 +21,13 @@ RSpec.describe CreateInterview do
 
   describe '#save!' do
     it 'transitions the application_choice state to `interviewing` if successful' do
-      service = CreateInterview.new(service_params)
+      service = described_class.new(service_params)
 
       expect { service.save! }.to change { application_choice.status }.to('interviewing')
     end
 
     it 'creates an audit entry and sends an email', with_audited: true, sidekiq: true do
-      CreateInterview.new(service_params).save!
+      described_class.new(service_params).save!
 
       associated_audit = application_choice.associated_audits.first
       expect(associated_audit.auditable).to eq(application_choice.interviews.first)

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -1,27 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe CycleTimetable do
-  let(:one_hour_before_apply1_deadline) { CycleTimetable.apply_1_deadline(2020) - 1.hour }
-  let(:one_hour_after_apply1_deadline) { CycleTimetable.apply_1_deadline(2020) + 1.hour  }
-  let(:one_hour_before_apply2_deadline) { CycleTimetable.apply_2_deadline(2020) - 1.hour }
-  let(:one_hour_after_apply2_deadline) { CycleTimetable.apply_2_deadline(2020) + 1.hour  }
-  let(:one_hour_after_2020_cycle_opens) { CycleTimetable.apply_opens(2020) + 1.hour }
-  let(:one_hour_after_2021_cycle_opens) { CycleTimetable.apply_opens(2021) + 1.hour }
-  let(:one_hour_before_find_closes) { CycleTimetable.find_closes(2020) - 1.hour }
-  let(:one_hour_after_find_closes) { CycleTimetable.find_closes(2020) + 1.hour }
-  let(:one_hour_after_find_opens) { CycleTimetable.find_opens(2020) + 1.hour }
-  let(:three_days_before_find_reopens) { CycleTimetable.find_reopens(2020) - 3.days }
+  let(:one_hour_before_apply1_deadline) { described_class.apply_1_deadline(2020) - 1.hour }
+  let(:one_hour_after_apply1_deadline) { described_class.apply_1_deadline(2020) + 1.hour  }
+  let(:one_hour_before_apply2_deadline) { described_class.apply_2_deadline(2020) - 1.hour }
+  let(:one_hour_after_apply2_deadline) { described_class.apply_2_deadline(2020) + 1.hour  }
+  let(:one_hour_after_2020_cycle_opens) { described_class.apply_opens(2020) + 1.hour }
+  let(:one_hour_after_2021_cycle_opens) { described_class.apply_opens(2021) + 1.hour }
+  let(:one_hour_before_find_closes) { described_class.find_closes(2020) - 1.hour }
+  let(:one_hour_after_find_closes) { described_class.find_closes(2020) + 1.hour }
+  let(:one_hour_after_find_opens) { described_class.find_opens(2020) + 1.hour }
+  let(:three_days_before_find_reopens) { described_class.find_reopens(2020) - 3.days }
 
   describe '.current_year' do
     it 'is 2020 if we are in the middle of the 2020 cycle' do
       Timecop.travel(one_hour_after_2020_cycle_opens) do
-        expect(CycleTimetable.current_year).to eq(2020)
+        expect(described_class.current_year).to eq(2020)
       end
     end
 
     it 'is 2021 if we are in the middle of the 2021 cycle' do
       Timecop.travel(one_hour_after_2021_cycle_opens) do
-        expect(CycleTimetable.current_year).to eq(2021)
+        expect(described_class.current_year).to eq(2021)
       end
     end
   end
@@ -29,13 +29,13 @@ RSpec.describe CycleTimetable do
   describe '.next_year' do
     it 'is 2021 if we are in the middle of the 2020 cycle' do
       Timecop.travel(one_hour_after_2020_cycle_opens) do
-        expect(CycleTimetable.next_year).to eq(2021)
+        expect(described_class.next_year).to eq(2021)
       end
     end
 
     it 'is 2022 if we are in the middle of the 2021 cycle' do
       Timecop.travel(one_hour_after_2021_cycle_opens) do
-        expect(CycleTimetable.next_year).to eq(2022)
+        expect(described_class.next_year).to eq(2022)
       end
     end
   end
@@ -45,7 +45,7 @@ RSpec.describe CycleTimetable do
       application_form = build(:application_form, phase: 'apply_1')
 
       Timecop.travel(one_hour_before_apply1_deadline) do
-        expect(CycleTimetable.show_apply_1_deadline_banner?(application_form)).to be true
+        expect(described_class.show_apply_1_deadline_banner?(application_form)).to be true
       end
     end
 
@@ -53,7 +53,7 @@ RSpec.describe CycleTimetable do
       application_form = build(:application_form, phase: 'apply_2')
 
       Timecop.travel(one_hour_before_apply1_deadline) do
-        expect(CycleTimetable.show_apply_1_deadline_banner?(application_form)).to be false
+        expect(described_class.show_apply_1_deadline_banner?(application_form)).to be false
       end
     end
 
@@ -62,7 +62,7 @@ RSpec.describe CycleTimetable do
       application_form = build(:application_form, phase: 'apply_1', application_choices: [application_choice])
 
       Timecop.travel(one_hour_before_apply1_deadline) do
-        expect(CycleTimetable.show_apply_1_deadline_banner?(application_form)).to be false
+        expect(described_class.show_apply_1_deadline_banner?(application_form)).to be false
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe CycleTimetable do
       application_form = build(:application_form, phase: 'apply_1')
 
       Timecop.travel(one_hour_after_apply1_deadline) do
-        expect(CycleTimetable.show_apply_1_deadline_banner?(application_form)).to be false
+        expect(described_class.show_apply_1_deadline_banner?(application_form)).to be false
       end
     end
   end
@@ -80,7 +80,7 @@ RSpec.describe CycleTimetable do
       application_form = build(:application_form, phase: 'apply_2')
 
       Timecop.travel(one_hour_before_apply2_deadline) do
-        expect(CycleTimetable.show_apply_2_deadline_banner?(application_form)).to be true
+        expect(described_class.show_apply_2_deadline_banner?(application_form)).to be true
       end
     end
 
@@ -89,7 +89,7 @@ RSpec.describe CycleTimetable do
       application_form = build(:application_form, phase: 'apply_1', application_choices: [application_choice])
 
       Timecop.travel(one_hour_before_apply2_deadline) do
-        expect(CycleTimetable.show_apply_2_deadline_banner?(application_form)).to be false
+        expect(described_class.show_apply_2_deadline_banner?(application_form)).to be false
       end
     end
 
@@ -97,7 +97,7 @@ RSpec.describe CycleTimetable do
       unsuccessful_application_form = build(:application_form, phase: 'apply_2', application_choices: [build(:application_choice, :with_rejection)])
 
       Timecop.travel(one_hour_after_apply2_deadline) do
-        expect(CycleTimetable.show_apply_2_deadline_banner?(unsuccessful_application_form)).to be false
+        expect(described_class.show_apply_2_deadline_banner?(unsuccessful_application_form)).to be false
       end
     end
   end
@@ -105,19 +105,19 @@ RSpec.describe CycleTimetable do
   describe '.between_cycles_apply_1?' do
     it 'returns false before the configured date' do
       Timecop.travel(one_hour_before_apply1_deadline) do
-        expect(CycleTimetable.between_cycles_apply_1?).to be false
+        expect(described_class.between_cycles_apply_1?).to be false
       end
     end
 
     it 'returns true after the configured date' do
       Timecop.travel(one_hour_after_apply1_deadline) do
-        expect(CycleTimetable.between_cycles_apply_1?).to be true
+        expect(described_class.between_cycles_apply_1?).to be true
       end
     end
 
     it 'returns false after the new cycle opens' do
       Timecop.travel(one_hour_after_2021_cycle_opens) do
-        expect(CycleTimetable.between_cycles_apply_1?).to be false
+        expect(described_class.between_cycles_apply_1?).to be false
       end
     end
   end
@@ -125,19 +125,19 @@ RSpec.describe CycleTimetable do
   describe '.between_cycles_apply_2?' do
     it 'returns false before the configured date' do
       Timecop.travel(one_hour_before_apply2_deadline) do
-        expect(CycleTimetable.between_cycles_apply_2?).to be false
+        expect(described_class.between_cycles_apply_2?).to be false
       end
     end
 
     it 'returns true after the configured date' do
       Timecop.travel(one_hour_after_apply2_deadline) do
-        expect(CycleTimetable.between_cycles_apply_2?).to be true
+        expect(described_class.between_cycles_apply_2?).to be true
       end
     end
 
     it 'returns false after the new cycle opens' do
       Timecop.travel(one_hour_after_2021_cycle_opens) do
-        expect(CycleTimetable.between_cycles_apply_2?).to be false
+        expect(described_class.between_cycles_apply_2?).to be false
       end
     end
   end
@@ -145,19 +145,19 @@ RSpec.describe CycleTimetable do
   describe '.find_down?' do
     it 'returns false before find closes' do
       Timecop.travel(one_hour_before_find_closes) do
-        expect(CycleTimetable.find_down?).to be false
+        expect(described_class.find_down?).to be false
       end
     end
 
     it 'returns false after find_reopens' do
       Timecop.travel(one_hour_after_find_opens) do
-        expect(CycleTimetable.find_down?).to be false
+        expect(described_class.find_down?).to be false
       end
     end
 
     it 'returns true between find_closes and find_reopens' do
       Timecop.travel(one_hour_after_find_closes) do
-        expect(CycleTimetable.find_down?).to be true
+        expect(described_class.find_down?).to be true
       end
     end
   end
@@ -165,7 +165,7 @@ RSpec.describe CycleTimetable do
   describe '.days_until_find_reopens' do
     it 'returns the number of days until Find reopens' do
       Timecop.travel(three_days_before_find_reopens) do
-        expect(CycleTimetable.days_until_find_reopens).to eq(3)
+        expect(described_class.days_until_find_reopens).to eq(3)
       end
     end
   end
@@ -235,7 +235,7 @@ RSpec.describe CycleTimetable do
       let(:application_form) { build_stubbed(:application_form, recruitment_cycle_year: 2020) }
 
       it 'returns false' do
-        Timecop.travel(CycleTimetable.apply_opens) do
+        Timecop.travel(described_class.apply_opens) do
           expect(execute_service).to eq false
         end
       end
@@ -258,31 +258,31 @@ RSpec.describe CycleTimetable do
 
   describe '.need_to_send_deadline_reminder?' do
     it 'does not return for a non deadline date' do
-      Timecop.travel(CycleTimetable.apply_1_deadline_first_reminder - 1.day) do
+      Timecop.travel(described_class.apply_1_deadline_first_reminder - 1.day) do
         expect(described_class.need_to_send_deadline_reminder?).to be nil
       end
     end
 
     it 'returns apply_1 when it is the first apply 1 deadline' do
-      Timecop.travel(CycleTimetable.apply_1_deadline_first_reminder) do
+      Timecop.travel(described_class.apply_1_deadline_first_reminder) do
         expect(described_class.need_to_send_deadline_reminder?).to be :apply_1
       end
     end
 
     it 'returns apply_1 when it is the second apply 1 deadline' do
-      Timecop.travel(CycleTimetable.apply_1_deadline_second_reminder) do
+      Timecop.travel(described_class.apply_1_deadline_second_reminder) do
         expect(described_class.need_to_send_deadline_reminder?).to be :apply_1
       end
     end
 
     it 'returns apply_2 when it is the first apply 2 deadline' do
-      Timecop.travel(CycleTimetable.apply_2_deadline_first_reminder) do
+      Timecop.travel(described_class.apply_2_deadline_first_reminder) do
         expect(described_class.need_to_send_deadline_reminder?).to be :apply_2
       end
     end
 
     it 'returns apply_2 when it is the second apply 2 deadline' do
-      Timecop.travel(CycleTimetable.apply_2_deadline_second_reminder) do
+      Timecop.travel(described_class.apply_2_deadline_second_reminder) do
         expect(described_class.need_to_send_deadline_reminder?).to be :apply_2
       end
     end
@@ -291,7 +291,7 @@ RSpec.describe CycleTimetable do
   describe 'apply_1_deadline_has_passed?' do
     context 'it is before the apply 1 deadline' do
       it 'returns false' do
-        Timecop.travel(CycleTimetable.apply_opens) do
+        Timecop.travel(described_class.apply_opens) do
           application_form = build(:application_form)
           expect(described_class.apply_1_deadline_has_passed?(application_form)).to be(false)
         end
@@ -300,7 +300,7 @@ RSpec.describe CycleTimetable do
 
     context 'it is after the apply 1 deadline' do
       it 'returns true' do
-        Timecop.travel(CycleTimetable.apply_2_deadline) do
+        Timecop.travel(described_class.apply_2_deadline) do
           application_form = build(:application_form)
           expect(described_class.apply_1_deadline_has_passed?(application_form)).to be(true)
         end
@@ -311,7 +311,7 @@ RSpec.describe CycleTimetable do
   describe 'apply_2_deadline_has_passed?' do
     context 'it is before the apply 2 deadline' do
       it 'returns false' do
-        Timecop.travel(CycleTimetable.apply_opens) do
+        Timecop.travel(described_class.apply_opens) do
           application_form = build(:application_form)
           expect(described_class.apply_1_deadline_has_passed?(application_form)).to be(false)
         end
@@ -320,7 +320,7 @@ RSpec.describe CycleTimetable do
 
     context 'it is after the apply 1 deadline' do
       it 'returns true' do
-        Timecop.travel(CycleTimetable.find_closes) do
+        Timecop.travel(described_class.find_closes) do
           application_form = build(:application_form)
           expect(described_class.apply_1_deadline_has_passed?(application_form)).to be(true)
         end
@@ -331,7 +331,7 @@ RSpec.describe CycleTimetable do
   describe '.cycle_year_range' do
     context 'with no year passed in' do
       it 'returns the `current_year to next_year`' do
-        allow(CycleTimetable).to receive(:current_year).and_return(2021)
+        allow(described_class).to receive(:current_year).and_return(2021)
         expect(described_class.cycle_year_range).to eq '2021 to 2022'
       end
     end

--- a/spec/services/defer_offer_spec.rb
+++ b/spec/services/defer_offer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe DeferOffer do
     it 'changes the state of an accepted offer to "offer_deferred"' do
       application_choice = create(:application_choice, :with_accepted_offer)
 
-      DeferOffer.new(
+      described_class.new(
         actor: create(:support_user),
         application_choice: application_choice,
       ).save!
@@ -16,7 +16,7 @@ RSpec.describe DeferOffer do
     it 'sets offer_deferred_at' do
       application_choice = create(:application_choice, :with_accepted_offer)
 
-      DeferOffer.new(
+      described_class.new(
         actor: create(:support_user),
         application_choice: application_choice,
       ).save!
@@ -27,7 +27,7 @@ RSpec.describe DeferOffer do
     it 'changes the state of a recruited application choice to "offer_deferred"' do
       application_choice = create(:application_choice, :with_recruited)
 
-      DeferOffer.new(
+      described_class.new(
         actor: create(:support_user),
         application_choice: application_choice,
       ).save!
@@ -40,7 +40,7 @@ RSpec.describe DeferOffer do
       provider_user = create(:provider_user)
       provider_user.providers << application_choice.current_course.provider
 
-      service = DeferOffer.new(
+      service = described_class.new(
         actor: provider_user,
         application_choice: application_choice,
       )
@@ -55,7 +55,7 @@ RSpec.describe DeferOffer do
       deliverer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
       allow(CandidateMailer).to receive(:deferred_offer).and_return(deliverer)
 
-      DeferOffer.new(actor: create(:support_user), application_choice: application_choice).save!
+      described_class.new(actor: create(:support_user), application_choice: application_choice).save!
 
       expect(CandidateMailer).to have_received(:deferred_offer).once.with(application_choice)
     end
@@ -64,7 +64,7 @@ RSpec.describe DeferOffer do
       application_choice = create(:application_choice, :with_recruited)
       allow(StateChangeNotifier).to receive(:call)
 
-      DeferOffer.new(actor: create(:support_user), application_choice: application_choice).save!
+      described_class.new(actor: create(:support_user), application_choice: application_choice).save!
 
       expect(StateChangeNotifier).to have_received(:call).with(:defer_offer, application_choice: application_choice)
     end

--- a/spec/services/encryptor_spec.rb
+++ b/spec/services/encryptor_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Encryptor do
   it 'returns the original string when decrypting an encrypted string' do
-    encrypted_data = Encryptor.encrypt('example')
+    encrypted_data = described_class.encrypt('example')
 
-    expect(Encryptor.decrypt(encrypted_data)).to eq('example')
+    expect(described_class.decrypt(encrypted_data)).to eq('example')
   end
 
   it 'returns false given an invalid encrypted string' do
-    expect(Encryptor.decrypt('invalid-input')).to be false
+    expect(described_class.decrypt('invalid-input')).to be false
   end
 
   it 'returns false when the encrypted string fails verification' do
@@ -18,6 +18,6 @@ RSpec.describe Encryptor do
 
     stub_const('Encryptor::ENCRYPTOR', encryptor_that_cannot_verify_the_message)
 
-    expect(Encryptor.decrypt('any-old-thing')).to be false
+    expect(described_class.decrypt('any-old-thing')).to be false
   end
 end

--- a/spec/services/feature_flag_spec.rb
+++ b/spec/services/feature_flag_spec.rb
@@ -3,15 +3,15 @@ require 'rails_helper'
 RSpec.describe FeatureFlag do
   describe '.activate' do
     it 'activates a feature' do
-      expect { FeatureFlag.activate('pilot_open') }.to(
-        change { FeatureFlag.active?('pilot_open') }.from(false).to(true),
+      expect { described_class.activate('pilot_open') }.to(
+        change { described_class.active?('pilot_open') }.from(false).to(true),
       )
     end
 
     it 'records the change in the database' do
       feature = Feature.create_or_find_by(name: 'pilot_open')
       feature.update!(active: false)
-      expect { FeatureFlag.activate('pilot_open') }.to(
+      expect { described_class.activate('pilot_open') }.to(
         change { feature.reload.active }.from(false).to(true),
       )
     end
@@ -19,16 +19,16 @@ RSpec.describe FeatureFlag do
 
   describe '.deactivate' do
     it 'deactivates a feature' do
-      FeatureFlag.activate('pilot_open')
-      expect { FeatureFlag.deactivate('pilot_open') }.to(
-        change { FeatureFlag.active?('pilot_open') }.from(true).to(false),
+      described_class.activate('pilot_open')
+      expect { described_class.deactivate('pilot_open') }.to(
+        change { described_class.active?('pilot_open') }.from(true).to(false),
       )
     end
 
     it 'records the change in the database' do
       feature = Feature.create_or_find_by(name: 'pilot_open')
       feature.update!(active: true)
-      expect { FeatureFlag.deactivate('pilot_open') }.to(
+      expect { described_class.deactivate('pilot_open') }.to(
         change { feature.reload.active }.from(true).to(false),
       )
     end

--- a/spec/services/generate_test_applications_for_provider_spec.rb
+++ b/spec/services/generate_test_applications_for_provider_spec.rb
@@ -20,12 +20,8 @@ RSpec.describe GenerateTestApplicationsForProvider, sidekiq: true do
 
   before do
     create(:course_option)
-    3.times do
-      create(:course_option, course: create(:course, :open_on_apply, provider: provider))
-    end
-    3.times do
-      create(:course_option, course: create(:course, :open_on_apply, accredited_provider: provider))
-    end
+    3.times { create(:course_option, course: create(:course, :open_on_apply, provider: provider)) }
+    3.times { create(:course_option, course: create(:course, :open_on_apply, accredited_provider: provider)) }
   end
 
   describe '#call' do

--- a/spec/services/invite_provider_user_spec.rb
+++ b/spec/services/invite_provider_user_spec.rb
@@ -16,19 +16,19 @@ RSpec.describe InviteProviderUser, sidekiq: true do
 
   describe '#initialize' do
     it 'requires a provider_user:' do
-      expect { InviteProviderUser.new }.to raise_error(ArgumentError)
-      expect { InviteProviderUser.new(provider_user: ProviderUser.new) }.not_to raise_error
+      expect { described_class.new }.to raise_error(ArgumentError)
+      expect { described_class.new(provider_user: ProviderUser.new) }.not_to raise_error
     end
 
     it 'blows up when DSI_API_URL ENV var is missing' do
       ClimateControl.modify(DSI_API_SECRET: 'something', DSI_API_URL: nil) do
-        expect { InviteProviderUser.new(provider_user: ProviderUser.new) }.to raise_error(KeyError, /DSI_API_URL/)
+        expect { described_class.new(provider_user: ProviderUser.new) }.to raise_error(KeyError, /DSI_API_URL/)
       end
     end
 
     it 'blows up when DSI_API_SECRET ENV var is missing' do
       ClimateControl.modify(DSI_API_SECRET: nil, DSI_API_URL: 'something') do
-        expect { InviteProviderUser.new(provider_user: ProviderUser.new) }.to raise_error(KeyError, /DSI_API_SECRET/)
+        expect { described_class.new(provider_user: ProviderUser.new) }.to raise_error(KeyError, /DSI_API_SECRET/)
       end
     end
   end
@@ -36,7 +36,7 @@ RSpec.describe InviteProviderUser, sidekiq: true do
   describe '#call! if API response is successful' do
     before do
       dsi_api_response(success: true)
-      InviteProviderUser.new(provider_user: provider_user).call!
+      described_class.new(provider_user: provider_user).call!
     end
 
     it 'a provider user is created' do
@@ -51,7 +51,7 @@ RSpec.describe InviteProviderUser, sidekiq: true do
     end
 
     it 'raises DfeSignInAPIError with errors from the API' do
-      expect { InviteProviderUser.new(provider_user: provider_user).call! }.to raise_error(DfeSignInAPIError)
+      expect { described_class.new(provider_user: provider_user).call! }.to raise_error(DfeSignInAPIError)
     end
 
     it 'does not queue an email' do
@@ -65,7 +65,7 @@ RSpec.describe InviteProviderUser, sidekiq: true do
 
   describe '#notify' do
     before do
-      InviteProviderUser.new(provider_user: provider_user).notify
+      described_class.new(provider_user: provider_user).notify
     end
 
     it 'queues an email' do

--- a/spec/services/notifications_list_spec.rb
+++ b/spec/services/notifications_list_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe NotificationsList do
     it 'raises an error for an undefined type of event' do
       application_choice = build(:application_choice)
 
-      expect { NotificationsList.for(application_choice, event: 'application_exploded') }.to raise_error('Undefined type of notification event')
+      expect { described_class.for(application_choice, event: 'application_exploded') }.to raise_error('Undefined type of notification event')
     end
 
     it 'returns training provider users for the application choice for a given type of event' do
@@ -14,7 +14,7 @@ RSpec.describe NotificationsList do
 
       create(:provider_user_notification_preferences, :all_off, provider_user: create(:provider_user, providers: [application_choice.course.provider]))
 
-      expect(NotificationsList.for(application_choice, event: :offer_accepted).to_a).to eql([provider_user])
+      expect(described_class.for(application_choice, event: :offer_accepted).to_a).to eql([provider_user])
     end
 
     it 'returns training and ratifying provider users for the application choice for a given type of event' do
@@ -26,7 +26,7 @@ RSpec.describe NotificationsList do
       training_provider_user = create(:provider_user, :with_notifications_enabled, providers: [application_choice.course.provider])
 
       create(:provider_user_notification_preferences, :all_off, provider_user: create(:provider_user, providers: [application_choice.course.provider]))
-      expect(NotificationsList.for(application_choice, include_ratifying_provider: true, event: :offer_accepted).to_a).to match_array([training_provider_user, ratifying_provider_user])
+      expect(described_class.for(application_choice, include_ratifying_provider: true, event: :offer_accepted).to_a).to match_array([training_provider_user, ratifying_provider_user])
     end
 
     it 'returns a provider user who is a member of the training and ratifying providers without duplicates' do
@@ -35,7 +35,7 @@ RSpec.describe NotificationsList do
       provider_user = create(:provider_user, :with_notifications_enabled, providers: [training_provider, ratifying_provider])
       application_choice = create(:application_choice, course_option: create(:course_option, course: create(:course, provider: training_provider, accredited_provider: ratifying_provider)))
 
-      expect(NotificationsList.for(
+      expect(described_class.for(
         application_choice,
         include_ratifying_provider: true,
         event: :offer_accepted,

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 RSpec.describe OfferValidations, type: :model do
-  subject(:offer) { OfferValidations.new(application_choice: application_choice, course_option: course_option, conditions: conditions) }
+  subject(:offer) { described_class.new(application_choice: application_choice, course_option: course_option, conditions: conditions) }
 
   let(:application_choice) { nil }
   let(:course_option) { create(:course_option, course: course) }

--- a/spec/services/process_notify_callback_spec.rb
+++ b/spec/services/process_notify_callback_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.shared_examples 'a callback that does not change the feedback status of a reference' do
   it 'does not update the feedback status of the reference' do
-    process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
+    process_notify_callback = described_class.new(notify_reference: notify_reference, status: status)
 
     process_notify_callback.call
 
@@ -30,7 +30,7 @@ RSpec.describe ProcessNotifyCallback do
       let(:status) { 'permanent-failure' }
 
       it 'updates the feedback status of the reference to email bounced' do
-        process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
+        process_notify_callback = described_class.new(notify_reference: notify_reference, status: status)
 
         process_notify_callback.call
 
@@ -40,7 +40,7 @@ RSpec.describe ProcessNotifyCallback do
       it 'sets not found to true if reference cannot be found' do
         allow(ApplicationReference).to receive(:find).with(reference.id.to_s).and_raise(ActiveRecord::RecordNotFound)
 
-        process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
+        process_notify_callback = described_class.new(notify_reference: notify_reference, status: status)
 
         process_notify_callback.call
 
@@ -62,7 +62,7 @@ RSpec.describe ProcessNotifyCallback do
       let(:status) { 'permanent-failure' }
 
       it 'updates sign up email bounced to true for candidate' do
-        process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
+        process_notify_callback = described_class.new(notify_reference: notify_reference, status: status)
 
         process_notify_callback.call
 
@@ -70,7 +70,7 @@ RSpec.describe ProcessNotifyCallback do
       end
 
       it 'updates hide in reporting to true for candidate' do
-        process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
+        process_notify_callback = described_class.new(notify_reference: notify_reference, status: status)
 
         process_notify_callback.call
 
@@ -80,7 +80,7 @@ RSpec.describe ProcessNotifyCallback do
       it 'sets not found to true if candidate cannot be found' do
         allow(Candidate).to receive(:find).with(candidate.id.to_s).and_raise(ActiveRecord::RecordNotFound)
 
-        process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
+        process_notify_callback = described_class.new(notify_reference: notify_reference, status: status)
 
         process_notify_callback.call
 
@@ -107,7 +107,7 @@ RSpec.describe ProcessNotifyCallback do
 
       it 'does not update sign up email bounced and hide in reporting to true for candidate' do
         notify_reference = "example_env-#{email_type}-#{candidate.id}"
-        process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
+        process_notify_callback = described_class.new(notify_reference: notify_reference, status: status)
 
         process_notify_callback.call
 

--- a/spec/services/process_state_spec.rb
+++ b/spec/services/process_state_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ProcessState do
   describe '#state' do
     it 'returns never_signed_in without an application' do
-      state = ProcessState.new(nil).state
+      state = described_class.new(nil).state
 
       expect(state).to be(:never_signed_in)
     end
@@ -11,14 +11,14 @@ RSpec.describe ProcessState do
     it 'returns unsubmitted without choices' do
       application_form = build_stubbed(:application_form)
 
-      state = ProcessState.new(application_form).state
+      state = described_class.new(application_form).state
 
       expect(state).to be(:unsubmitted_not_started_form)
     end
 
     it 'returns unsubmitted_not_started_form when unsubmitted choices exist but form has not been updated' do
       application_form = build_stubbed(:application_form, application_choices: build_list(:application_choice, 2, status: 'unsubmitted'))
-      state = ProcessState.new(application_form).state
+      state = described_class.new(application_form).state
 
       expect(state).to be(:unsubmitted_not_started_form)
     end
@@ -27,7 +27,7 @@ RSpec.describe ProcessState do
       application_form = build_stubbed(:application_form,
                                        application_choices: build_list(:application_choice, 2, status: 'unsubmitted'),
                                        updated_at: Time.zone.now + 1.day)
-      state = ProcessState.new(application_form).state
+      state = described_class.new(application_form).state
 
       expect(state).to be(:unsubmitted_in_progress)
     end
@@ -37,7 +37,7 @@ RSpec.describe ProcessState do
       create(:application_choice, application_form: application_form, status: 'awaiting_provider_decision')
       create(:application_choice, application_form: application_form, status: 'offer')
 
-      state = ProcessState.new(application_form).state
+      state = described_class.new(application_form).state
 
       expect(state).to be(:awaiting_provider_decisions)
     end
@@ -46,7 +46,7 @@ RSpec.describe ProcessState do
       application_form = create(:application_form)
       create(:application_choice, application_form: application_form, status: 'offer')
 
-      state = ProcessState.new(application_form).state
+      state = described_class.new(application_form).state
 
       expect(state).to be(:awaiting_candidate_response)
     end
@@ -55,7 +55,7 @@ RSpec.describe ProcessState do
       application_form = create(:application_form)
       create(:application_choice, application_form: application_form, status: 'pending_conditions')
 
-      state = ProcessState.new(application_form).state
+      state = described_class.new(application_form).state
 
       expect(state).to be(:pending_conditions)
     end
@@ -64,7 +64,7 @@ RSpec.describe ProcessState do
       application_form = create(:application_form)
       create(:application_choice, application_form: application_form, status: 'recruited')
 
-      state = ProcessState.new(application_form).state
+      state = described_class.new(application_form).state
 
       expect(state).to be(:recruited)
     end
@@ -75,7 +75,7 @@ RSpec.describe ProcessState do
       create(:application_choice, application_form: application_form, status: 'rejected')
       create(:application_choice, application_form: application_form, status: 'declined')
 
-      state = ProcessState.new(application_form).state
+      state = described_class.new(application_form).state
 
       expect(state).to be(:ended_without_success)
     end
@@ -84,7 +84,7 @@ RSpec.describe ProcessState do
       application_form = create(:application_form)
       create(:application_choice, application_form: application_form, status: 'declined')
 
-      state = ProcessState.new(application_form).state
+      state = described_class.new(application_form).state
 
       expect(state).to be(:ended_without_success)
     end

--- a/spec/services/provider_authorisation_analysis_spec.rb
+++ b/spec/services/provider_authorisation_analysis_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe ProviderAuthorisationAnalysis do
   let(:auth) { ProviderAuthorisation.new(actor: provider_user) }
 
   let(:analysis) do
-    ProviderAuthorisationAnalysis.new(permission: :make_decisions,
-                                      auth: auth,
-                                      application_choice: application_choice,
-                                      course_option_id: application_choice.course_option_id)
+    described_class.new(permission: :make_decisions,
+                        auth: auth,
+                        application_choice: application_choice,
+                        course_option_id: application_choice.course_option_id)
   end
 
   before do

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ProviderAuthorisation do
   include CourseOptionHelpers
 
   describe '#assert_can_set_up_interviews!' do
-    let(:auth_context) { ProviderAuthorisation.new(actor: nil) }
+    let(:auth_context) { described_class.new(actor: nil) }
 
     it 'raises a ValidationException if a course_option is not provided' do
       expect { auth_context.assert_can_set_up_interviews!(application_choice: nil) }.to raise_error(ValidationException, 'Please provide a course_option')
@@ -13,12 +13,12 @@ RSpec.describe ProviderAuthorisation do
     it 'raises an error if the actor cannot set up interviews' do
       allow(auth_context).to receive(:can_set_up_interviews?).and_return(false)
 
-      expect { auth_context.assert_can_set_up_interviews!(application_choice: nil, course_option: build_stubbed(:course_option)) }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
+      expect { auth_context.assert_can_set_up_interviews!(application_choice: nil, course_option: build_stubbed(:course_option)) }.to raise_error(described_class::NotAuthorisedError)
     end
   end
 
   describe '#assert_can_make_decisions!' do
-    let(:auth_context) { ProviderAuthorisation.new(actor: nil) }
+    let(:auth_context) { described_class.new(actor: nil) }
 
     it 'raises a ValidationException if neither a course_option or a course_option_id is provided' do
       expect { auth_context.assert_can_make_decisions!(application_choice: nil) }.to raise_error(ValidationException, 'Please provide a course_option or course_option_id')
@@ -27,7 +27,7 @@ RSpec.describe ProviderAuthorisation do
     it 'raises an error if the actor cannot make decisions' do
       allow(auth_context).to receive(:can_make_decisions?).and_return(false)
 
-      expect { auth_context.assert_can_make_decisions!(application_choice: nil, course_option_id: build_stubbed(:course_option).id) }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
+      expect { auth_context.assert_can_make_decisions!(application_choice: nil, course_option_id: build_stubbed(:course_option).id) }.to raise_error(described_class::NotAuthorisedError)
     end
   end
 
@@ -93,7 +93,7 @@ RSpec.describe ProviderAuthorisation do
     end
 
     def can_make_decisions?(actor:, choice: application_choice)
-      auth_context = ProviderAuthorisation.new(actor: actor)
+      auth_context = described_class.new(actor: actor)
       auth_context.can_make_decisions?(
         application_choice: choice,
         course_option_id: choice.course_option.id,
@@ -118,8 +118,8 @@ RSpec.describe ProviderAuthorisation do
       it 'bad data: relationship record is missing' do
         provider_relationship_permissions.destroy
 
-        expect { can_make_decisions?(actor: training_provider_user) }.to raise_error(ProviderAuthorisation::RelationshipNotPresent)
-        expect { can_make_decisions?(actor: ratifying_provider_user) }.to raise_error(ProviderAuthorisation::RelationshipNotPresent)
+        expect { can_make_decisions?(actor: training_provider_user) }.to raise_error(described_class::RelationshipNotPresent)
+        expect { can_make_decisions?(actor: ratifying_provider_user) }.to raise_error(described_class::RelationshipNotPresent)
       end
 
       it 'training_provider for self-ratified course can always decide' do
@@ -468,7 +468,7 @@ RSpec.describe ProviderAuthorisation do
     let(:course) { create(:course, :open_on_apply) }
 
     context 'for a support user' do
-      subject(:auth_context) { ProviderAuthorisation.new(actor: support_user) }
+      subject(:auth_context) { described_class.new(actor: support_user) }
 
       let(:support_user) { create(:support_user) }
 
@@ -479,7 +479,7 @@ RSpec.describe ProviderAuthorisation do
     end
 
     context 'for a provider user' do
-      subject(:auth_context) { ProviderAuthorisation.new(actor: provider_user) }
+      subject(:auth_context) { described_class.new(actor: provider_user) }
 
       let(:provider_user) { create(:provider_user, :with_provider) }
 
@@ -533,7 +533,7 @@ RSpec.describe ProviderAuthorisation do
     context 'for a support user' do
       let(:support_user) { create(:support_user) }
 
-      subject(:auth_context) { ProviderAuthorisation.new(actor: support_user) }
+      subject(:auth_context) { described_class.new(actor: support_user) }
 
       it 'is true' do
         expect(auth_context.can_manage_organisation?(provider: create(:provider))).to be true
@@ -543,7 +543,7 @@ RSpec.describe ProviderAuthorisation do
     context 'for a provider user with permission to manage an organisation' do
       let(:provider_user) { create(:provider_user, :with_provider) }
 
-      subject(:auth_context) { ProviderAuthorisation.new(actor: provider_user) }
+      subject(:auth_context) { described_class.new(actor: provider_user) }
 
       it 'is true' do
         provider = provider_user.providers.first
@@ -556,7 +556,7 @@ RSpec.describe ProviderAuthorisation do
     context 'for a provider user without permission to manage an organisation' do
       let(:provider_user) { create(:provider_user, :with_provider) }
 
-      subject(:auth_context) { ProviderAuthorisation.new(actor: provider_user) }
+      subject(:auth_context) { described_class.new(actor: provider_user) }
 
       it 'is false' do
         provider = provider_user.providers.first
@@ -597,7 +597,7 @@ RSpec.describe ProviderAuthorisation do
         manage_organisations: true,
       )
 
-      expect(ProviderAuthorisation.new(actor: provider_user).providers_that_actor_can_manage_organisations_for)
+      expect(described_class.new(actor: provider_user).providers_that_actor_can_manage_organisations_for)
         .to eq([training_provider])
     end
 
@@ -622,7 +622,7 @@ RSpec.describe ProviderAuthorisation do
           manage_organisations: true,
         )
 
-        expect(ProviderAuthorisation.new(actor: provider_user).providers_that_actor_can_manage_organisations_for(with_set_up_permissions: true))
+        expect(described_class.new(actor: provider_user).providers_that_actor_can_manage_organisations_for(with_set_up_permissions: true))
           .to eq([])
       end
 
@@ -641,7 +641,7 @@ RSpec.describe ProviderAuthorisation do
                ratifying_provider: ratifying_provider,
                setup_at: nil)
 
-        expect(ProviderAuthorisation.new(actor: provider_user).providers_that_actor_can_manage_organisations_for(with_set_up_permissions: true))
+        expect(described_class.new(actor: provider_user).providers_that_actor_can_manage_organisations_for(with_set_up_permissions: true))
           .to eq([])
       end
     end
@@ -649,7 +649,7 @@ RSpec.describe ProviderAuthorisation do
 
   describe '#provider_relationships_that_actor_can_manage_organisations_for' do
     let(:provider_relationship) { create(:provider_relationship_permissions) }
-    let(:auth) { ProviderAuthorisation.new(actor: provider_user) }
+    let(:auth) { described_class.new(actor: provider_user) }
 
     context 'when the user belongs to the training provider' do
       let(:provider_user) { create(:provider_user, :with_manage_organisations, providers: [provider_relationship.training_provider]) }

--- a/spec/services/reinstate_declined_offer_spec.rb
+++ b/spec/services/reinstate_declined_offer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ReinstateDeclinedOffer, with_audited: true do
         zendesk_ticket = 'www.becomingateacher.zendesk.com/agent/tickets/example'
 
         DeclineOffer.new(application_choice: course_choice).save!
-        ReinstateDeclinedOffer.new(course_choice: course_choice, zendesk_ticket: zendesk_ticket).save!
+        described_class.new(course_choice: course_choice, zendesk_ticket: zendesk_ticket).save!
 
         expect(course_choice).to eq original_course_choice
         expect(course_choice.audits.last.comment).to include(zendesk_ticket)
@@ -25,7 +25,7 @@ RSpec.describe ReinstateDeclinedOffer, with_audited: true do
         offered_course_choice = create(:application_choice, :with_offer, application_form: application_form)
         course_choice_awaiting_decision = create(:application_choice, status: :awaiting_provider_decision, application_form: application_form)
 
-        ReinstateDeclinedOffer.new(course_choice: declined_course_choice, zendesk_ticket: zendesk_ticket).save!
+        described_class.new(course_choice: declined_course_choice, zendesk_ticket: zendesk_ticket).save!
 
         expect(declined_course_choice).to have_attributes({
           status: 'offer',

--- a/spec/services/reject_by_default_feedback_spec.rb
+++ b/spec/services/reject_by_default_feedback_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe RejectByDefaultFeedback, sidekiq: true do
       candidate_behaviour_other: 'Bad language',
       candidate_behaviour_what_to_improve: 'Do not swear',
     }
-    service = RejectByDefaultFeedback.new(
+    service = described_class.new(
       actor: actor,
       application_choice: application_choice,
       structured_rejection_reasons: ReasonsForRejection.new(reasons_for_rejection_attrs),

--- a/spec/services/restructured_work_history_with_breaks_spec.rb
+++ b/spec/services/restructured_work_history_with_breaks_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe RestructuredWorkHistoryWithBreaks do
           submitted_at: submitted_at,
         )
 
-        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        get_work_history_with_breaks = described_class.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks).to eq([])
@@ -53,7 +53,7 @@ RSpec.describe RestructuredWorkHistoryWithBreaks do
           submitted_at: submitted_at,
         )
 
-        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        get_work_history_with_breaks = described_class.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(1)
@@ -71,7 +71,7 @@ RSpec.describe RestructuredWorkHistoryWithBreaks do
           submitted_at: submitted_at,
         )
 
-        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        get_work_history_with_breaks = described_class.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(1)
@@ -89,7 +89,7 @@ RSpec.describe RestructuredWorkHistoryWithBreaks do
           submitted_at: submitted_at,
         )
 
-        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        get_work_history_with_breaks = described_class.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(1)
@@ -107,7 +107,7 @@ RSpec.describe RestructuredWorkHistoryWithBreaks do
           submitted_at: submitted_at,
         )
 
-        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        get_work_history_with_breaks = described_class.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(2)
@@ -129,7 +129,7 @@ RSpec.describe RestructuredWorkHistoryWithBreaks do
           submitted_at: submitted_at,
         )
 
-        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        get_work_history_with_breaks = described_class.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(2)
@@ -151,7 +151,7 @@ RSpec.describe RestructuredWorkHistoryWithBreaks do
           submitted_at: submitted_at,
         )
 
-        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        get_work_history_with_breaks = described_class.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(3)
@@ -173,7 +173,7 @@ RSpec.describe RestructuredWorkHistoryWithBreaks do
           submitted_at: submitted_at,
         )
 
-        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        get_work_history_with_breaks = described_class.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(4)
@@ -197,7 +197,7 @@ RSpec.describe RestructuredWorkHistoryWithBreaks do
           submitted_at: submitted_at,
         )
 
-        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        get_work_history_with_breaks = described_class.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(3)
@@ -219,7 +219,7 @@ RSpec.describe RestructuredWorkHistoryWithBreaks do
           submitted_at: submitted_at,
         )
 
-        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        get_work_history_with_breaks = described_class.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(4)
@@ -243,7 +243,7 @@ RSpec.describe RestructuredWorkHistoryWithBreaks do
           submitted_at: submitted_at,
         )
 
-        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        get_work_history_with_breaks = described_class.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(3)
@@ -267,7 +267,7 @@ RSpec.describe RestructuredWorkHistoryWithBreaks do
           submitted_at: submitted_at,
         )
 
-        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        get_work_history_with_breaks = described_class.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(3)
@@ -292,7 +292,7 @@ RSpec.describe RestructuredWorkHistoryWithBreaks do
           submitted_at: submitted_at,
         )
 
-        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        get_work_history_with_breaks = described_class.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(1)
@@ -316,7 +316,7 @@ RSpec.describe RestructuredWorkHistoryWithBreaks do
           submitted_at: submitted_at,
         )
 
-        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        get_work_history_with_breaks = described_class.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(2)
@@ -344,7 +344,7 @@ RSpec.describe RestructuredWorkHistoryWithBreaks do
           submitted_at: submitted_at,
         )
 
-        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        get_work_history_with_breaks = described_class.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(2)

--- a/spec/services/safe_csv_spec.rb
+++ b/spec/services/safe_csv_spec.rb
@@ -4,25 +4,25 @@ RSpec.describe SafeCSV do
   describe '.sanitise' do
     it 'sanitises an array of values' do
       expect(
-        SafeCSV.sanitise([123, 'hello', '=(A1,A6)']),
+        described_class.sanitise([123, 'hello', '=(A1,A6)']),
       ).to eq(
         [123, 'hello', '.=(A1,A6)'],
       )
     end
 
     it 'sanitises a single value' do
-      expect(SafeCSV.sanitise('=(A1,A6)')).to eq('.=(A1,A6)')
+      expect(described_class.sanitise('=(A1,A6)')).to eq('.=(A1,A6)')
     end
   end
 
   describe '.generate' do
     it 'works with a header row' do
-      csv = SafeCSV.generate([[123, 'Bob'], [456, '=Alice()']], %w[id name])
+      csv = described_class.generate([[123, 'Bob'], [456, '=Alice()']], %w[id name])
       expect(csv).to eq "id,name\n123,Bob\n456,.=Alice()\n"
     end
 
     it 'works without a header row' do
-      csv = SafeCSV.generate([[123, 'Bob'], [456, '=Alice()']])
+      csv = described_class.generate([[123, 'Bob'], [456, '=Alice()']])
       expect(csv).to eq "123,Bob\n456,.=Alice()\n"
     end
   end

--- a/spec/services/send_application_to_provider_spec.rb
+++ b/spec/services/send_application_to_provider_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe SendApplicationToProvider do
   end
 
   it 'sets the status to `awaiting_provider_decision`' do
-    SendApplicationToProvider.new(application_choice: application_choice).call
+    described_class.new(application_choice: application_choice).call
 
     expect(application_choice.status).to eq 'awaiting_provider_decision'
   end
 
   it 'sets the `sent_to_provider` date' do
-    SendApplicationToProvider.new(application_choice: application_choice).call
+    described_class.new(application_choice: application_choice).call
 
     expect(application_choice.reload.sent_to_provider_at).not_to be_nil
   end
@@ -32,7 +32,7 @@ RSpec.describe SendApplicationToProvider do
     time_limit_calculator = instance_double(TimeLimitCalculator, call: { days: 20, time_in_future: reject_by_default_at })
     allow(TimeLimitCalculator).to receive(:new).and_return(time_limit_calculator)
 
-    SendApplicationToProvider.new(application_choice: application_choice).call
+    described_class.new(application_choice: application_choice).call
 
     expect(application_choice.reload.reject_by_default_at.round).to eq reject_by_default_at.round
     expect(application_choice.reject_by_default_days).to eq 20
@@ -44,7 +44,7 @@ RSpec.describe SendApplicationToProvider do
     application_choice.provider.provider_users = [user]
 
     expect {
-      SendApplicationToProvider.new(application_choice: application_choice).call
+      described_class.new(application_choice: application_choice).call
     }.to change { ActionMailer::Base.deliveries.count }.by(1)
 
     expect(ActionMailer::Base.deliveries.first.to.first).to eq(user.email_address)
@@ -52,7 +52,7 @@ RSpec.describe SendApplicationToProvider do
 
   it 'does not work for applications that are not sendable' do
     expect {
-      SendApplicationToProvider.new(application_choice: application_choice(status: 'awaiting_provider_decision')).call
-    }.to raise_error(SendApplicationToProvider::ApplicationNotReadyToSendError)
+      described_class.new(application_choice: application_choice(status: 'awaiting_provider_decision')).call
+    }.to raise_error(described_class::ApplicationNotReadyToSendError)
   end
 end

--- a/spec/services/set_decline_by_default_spec.rb
+++ b/spec/services/set_decline_by_default_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SetDeclineByDefault do
     let(:application_form) { create(:completed_application_form, application_choices_count: 3) }
     let(:choices) { application_form.application_choices }
     let(:now) { Time.zone.now }
-    let(:call_service) { SetDeclineByDefault.new(application_form: application_form).call }
+    let(:call_service) { described_class.new(application_form: application_form).call }
 
     around do |example|
       Timecop.freeze(now) do

--- a/spec/services/set_open_on_apply_for_new_course_spec.rb
+++ b/spec/services/set_open_on_apply_for_new_course_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SetOpenOnApplyForNewCourse do
   let(:course) { create(:course, open_on_apply: false) }
 
-  subject(:course_opener) { SetOpenOnApplyForNewCourse.new(course) }
+  subject(:course_opener) { described_class.new(course) }
 
   context 'in Sandbox', sandbox: true do
     it 'opens the course' do

--- a/spec/services/submit_reference_spec.rb
+++ b/spec/services/submit_reference_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe SubmitReference do
         reference_one = create(:reference, :feedback_requested)
         reference_two = create(:reference, :feedback_requested, application_form: reference_one.application_form)
 
-        SubmitReference.new(reference: reference_one).save!
-        SubmitReference.new(reference: reference_two).save!
+        described_class.new(reference: reference_one).save!
+        described_class.new(reference: reference_two).save!
 
         expect(reference_one).to be_feedback_provided
         expect(reference_one.feedback_provided_at).to eq Time.zone.now
@@ -30,8 +30,8 @@ RSpec.describe SubmitReference do
         reference3 = create(:reference, :feedback_refused, application_form: application_form)
         reference4 = create(:reference, :feedback_requested, application_form: application_form)
 
-        SubmitReference.new(reference: reference1).save!
-        SubmitReference.new(reference: reference2).save!
+        described_class.new(reference: reference1).save!
+        described_class.new(reference: reference2).save!
 
         expect(reference1).to be_feedback_provided
         expect(reference2).to be_feedback_provided

--- a/spec/services/support_interface/tad_provider_stats_export_spec.rb
+++ b/spec/services/support_interface/tad_provider_stats_export_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SupportInterface::TADProviderStatsExport do
     it_behaves_like 'a data export'
   end
 
-  subject(:exported_rows) { Bullet.profile { SupportInterface::TADProviderStatsExport.new.call } }
+  subject(:exported_rows) { Bullet.profile { described_class.new.call } }
 
   describe 'calculating offers and acceptances' do
     states_excluded_from_tad_export = [:offer_deferred]

--- a/spec/services/sync_provider_spec.rb
+++ b/spec/services/sync_provider_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SyncProvider, sidekiq: true do
   end
 
   it 'enables course syncing during sync' do
-    SyncProvider.new(provider: provider).call
+    described_class.new(provider: provider).call
 
     expect(provider.reload.sync_courses).to be true
   end
@@ -18,7 +18,7 @@ RSpec.describe SyncProvider, sidekiq: true do
   it 'syncs the provider' do
     expect(provider.courses.count).to be 0
 
-    SyncProvider.new(provider: provider).call
+    described_class.new(provider: provider).call
 
     expect(provider.courses.count).to be 1
   end

--- a/spec/services/time_limit_calculator_spec.rb
+++ b/spec/services/time_limit_calculator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TimeLimitCalculator do
         TimeLimitConfig::Rule.new(nil, nil, 20),
       ],
     )
-    calculator = TimeLimitCalculator.new(
+    calculator = described_class.new(
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     )
@@ -31,7 +31,7 @@ RSpec.describe TimeLimitCalculator do
         TimeLimitConfig::Rule.new(10.days.ago, nil, 10),
       ],
     )
-    calculator = TimeLimitCalculator.new(
+    calculator = described_class.new(
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     )
@@ -49,7 +49,7 @@ RSpec.describe TimeLimitCalculator do
         TimeLimitConfig::Rule.new(10.days.from_now, nil, 10),
       ],
     )
-    calculator = TimeLimitCalculator.new(
+    calculator = described_class.new(
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     )
@@ -68,7 +68,7 @@ RSpec.describe TimeLimitCalculator do
         TimeLimitConfig::Rule.new(5.days.ago, 5.days.from_now, 5),
       ],
     )
-    calculator = TimeLimitCalculator.new(
+    calculator = described_class.new(
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     )
@@ -81,7 +81,7 @@ RSpec.describe TimeLimitCalculator do
 
   it 'returns nil when there is no rule for the given effective date' do
     allow(TimeLimitConfig).to receive(:limits_for).and_return([])
-    calculator = TimeLimitCalculator.new(
+    calculator = described_class.new(
       rule: :reject_by_default,
       effective_date: 20.days.ago,
     )
@@ -93,7 +93,7 @@ RSpec.describe TimeLimitCalculator do
   describe 'configured reject_by_default limits' do
     context 'before 2020-07-01' do
       it 'applies the 40 day rule' do
-        calculator = TimeLimitCalculator.new(
+        calculator = described_class.new(
           rule: :reject_by_default,
           effective_date: Time.zone.local(2020, 6, 15),
         )
@@ -107,7 +107,7 @@ RSpec.describe TimeLimitCalculator do
 
     context 'after 2020-07-01' do
       it 'applies the 20 day rule' do
-        calculator = TimeLimitCalculator.new(
+        calculator = described_class.new(
           rule: :reject_by_default,
           effective_date: Time.zone.local(RecruitmentCycle.current_year, 7, 6),
         )
@@ -123,7 +123,7 @@ RSpec.describe TimeLimitCalculator do
   describe 'configured chase_provider_before_rbd limits' do
     context 'before 2020-07-01' do
       it 'applies the 40 day rule' do
-        calculator = TimeLimitCalculator.new(
+        calculator = described_class.new(
           rule: :chase_provider_before_rbd,
           effective_date: Time.zone.local(2020, 6, 15),
         )
@@ -137,7 +137,7 @@ RSpec.describe TimeLimitCalculator do
 
     context 'after 2020-07-01' do
       it 'applies the 20 day rule' do
-        calculator = TimeLimitCalculator.new(
+        calculator = described_class.new(
           rule: :chase_provider_before_rbd,
           effective_date: Time.zone.local(RecruitmentCycle.current_year, 7, 6),
         )

--- a/spec/services/ucas_matches/send_ucas_match_reminder_emails_spec.rb
+++ b/spec/services/ucas_matches/send_ucas_match_reminder_emails_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe UCASMatches::SendUCASMatchReminderEmails do
       ucas_match = create(:ucas_match, action_taken: 'reminder_emails_sent')
 
       expect {
-        UCASMatches::SendUCASMatchReminderEmails.new(ucas_match).call
+        described_class.new(ucas_match).call
       }.to raise_error("Reminder email for UCAS match ##{ucas_match.id} was already sent")
     end
 
@@ -18,7 +18,7 @@ RSpec.describe UCASMatches::SendUCASMatchReminderEmails do
       ucas_match = create(:ucas_match, action_taken: nil)
 
       expect {
-        UCASMatches::SendUCASMatchReminderEmails.new(ucas_match).call
+        described_class.new(ucas_match).call
       }.to raise_error("Cannot send reminder email before sending an initial one for UCAS match ##{ucas_match.id}")
     end
 

--- a/spec/services/ucas_matching/file_download_check_spec.rb
+++ b/spec/services/ucas_matching/file_download_check_spec.rb
@@ -4,30 +4,30 @@ RSpec.describe UCASMatching::FileDownloadCheck do
   describe '#check' do
     it 'succeeds if a download has taken before the weekend' do
       Timecop.freeze(2020, 12, 7, 0, 0) do # Monday
-        UCASMatching::FileDownloadCheck.set_last_sync(3.days.ago) # Friday
+        described_class.set_last_sync(3.days.ago) # Friday
 
-        expect(UCASMatching::FileDownloadCheck.new.check).to eql('There was a succesful UCAS file download that has taken place since the last weekday')
+        expect(described_class.new.check).to eql('There was a succesful UCAS file download that has taken place since the last weekday')
       end
     end
 
     it 'succeeds if a download has taken place on the previous weekday' do
       Timecop.freeze(2020, 12, 4, 0, 0) do # Friday
-        UCASMatching::FileDownloadCheck.set_last_sync(1.day.ago) # Thursday
+        described_class.set_last_sync(1.day.ago) # Thursday
 
-        expect(UCASMatching::FileDownloadCheck.new.check).to eql('There was a succesful UCAS file download that has taken place since the last weekday')
+        expect(described_class.new.check).to eql('There was a succesful UCAS file download that has taken place since the last weekday')
       end
     end
 
     it 'fails if the file has never been downloaded' do
-      UCASMatching::FileDownloadCheck.clear_last_sync
+      described_class.clear_last_sync
 
-      expect(UCASMatching::FileDownloadCheck.new.check).to eql('Cannot find the time when the last UCAS file download took place')
+      expect(described_class.new.check).to eql('Cannot find the time when the last UCAS file download took place')
     end
 
     it 'fails if the download has not happened since the last weekday' do
-      UCASMatching::FileDownloadCheck.set_last_sync(Time.zone.now.prev_weekday - 1.day)
+      described_class.set_last_sync(Time.zone.now.prev_weekday - 1.day)
 
-      expect(UCASMatching::FileDownloadCheck.new.check).to eql('There was no UCAS file download taking place yesterday')
+      expect(described_class.new.check).to eql('There was no UCAS file download taking place yesterday')
     end
   end
 end

--- a/spec/support/vendor_api/shared_examples.rb
+++ b/spec/support/vendor_api/shared_examples.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples 'an endpoint that requires metadata' do |action|
 
     post_api_request "/api/v1/applications/#{application_choice.id}/#{action}", params: { 'meta' => nil }
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
   end
 
@@ -15,7 +15,7 @@ RSpec.shared_examples 'an endpoint that requires metadata' do |action|
 
     post_api_request "/api/v1/applications/#{application_choice.id}/#{action}", params: { 'meta' => invalid_metadata }
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
 
     errors = parsed_response['errors']

--- a/spec/system/basic_auth_spec.rb
+++ b/spec/system/basic_auth_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Require basic authentication', type: :request do
         get candidate_interface_create_account_or_sign_in_url
       end
 
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'requests without basic auth get 401' do
@@ -17,7 +17,7 @@ RSpec.describe 'Require basic authentication', type: :request do
         get candidate_interface_create_account_or_sign_in_url
       end
 
-      expect(response).to have_http_status(401)
+      expect(response).to have_http_status(:unauthorized)
     end
 
     it 'requests with invalid basic auth get 401' do
@@ -25,7 +25,7 @@ RSpec.describe 'Require basic authentication', type: :request do
         get candidate_interface_create_account_or_sign_in_url, headers: basic_auth_headers('wrong', 'auth')
       end
 
-      expect(response).to have_http_status(401)
+      expect(response).to have_http_status(:unauthorized)
     end
 
     it 'requests with valid basic auth get 200' do
@@ -33,7 +33,7 @@ RSpec.describe 'Require basic authentication', type: :request do
         get candidate_interface_create_account_or_sign_in_url, headers: basic_auth_headers('foo', 'bar')
       end
 
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/workers/data_exporter_spec.rb
+++ b/spec/workers/data_exporter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DataExporter, with_audited: true do
       data_export = DataExport.create!
 
       expect {
-        DataExporter.new.perform('ExporterThatFails', data_export.id)
+        described_class.new.perform('ExporterThatFails', data_export.id)
       }.to raise_error('the level of debate in this country')
 
       expect(data_export.reload.audits.last.comment).to eql('Export generation failed: `the level of debate in this country`')

--- a/spec/workers/decline_offers_by_default_worker_spec.rb
+++ b/spec/workers/decline_offers_by_default_worker_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DeclineOffersByDefaultWorker do
       offer_expired = create(:application_choice, status: 'offer', decline_by_default_at: Time.zone.now - 1.day)
       rejected = create(:application_choice, status: 'rejected', decline_by_default_at: Time.zone.now - 1.day)
 
-      DeclineOffersByDefaultWorker.new.perform
+      described_class.new.perform
 
       expect(offer_not_expired.reload.status).to eq('offer')
       expect(offer_expired.reload.status).to eq('declined')

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe GenerateTestApplications do
     slack_request = stub_request(:post, 'https://example.com')
 
     ClimateControl.modify(STATE_CHANGE_SLACK_URL: 'https://example.com') do
-      GenerateTestApplications.new.perform
+      described_class.new.perform
     end
 
     expect(slack_request).not_to have_been_made

--- a/spec/workers/recalculate_dates_spec.rb
+++ b/spec/workers/recalculate_dates_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RecalculateDates do
   it 'recalculates reject_by_default_at for a submitted application choice' do
     application_choice = create(:submitted_application_choice, sent_to_provider_at: Time.zone.now)
 
-    RecalculateDates.new.perform
+    described_class.new.perform
 
     expect(application_choice.reload.reject_by_default_at).not_to be_nil
   end
@@ -24,7 +24,7 @@ RSpec.describe RecalculateDates do
       offered_at: Time.zone.now,
     )
 
-    RecalculateDates.new.perform
+    described_class.new.perform
 
     expect(application_choice.reload.decline_by_default_at).not_to be_nil
   end

--- a/spec/workers/ucas_integration_check_spec.rb
+++ b/spec/workers/ucas_integration_check_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe UCASIntegrationCheck do
       it 'detects a ucas match file upload failure' do
         UCASMatching::FileDownloadCheck.set_last_sync(3.days.ago)
 
-        UCASIntegrationCheck.new.perform
+        described_class.new.perform
 
         expect(Sentry).to have_received(:capture_exception).with(
           UCASIntegrationCheck::UCASMatchingFileDownloadFailure.new(
@@ -20,7 +20,7 @@ RSpec.describe UCASIntegrationCheck do
       it 'does not raise an error if the file wa uploaded successfully' do
         UCASMatching::FileDownloadCheck.set_last_sync(1.hour.ago)
 
-        UCASIntegrationCheck.new.perform
+        described_class.new.perform
 
         expect(Sentry).not_to have_received(:capture_exception)
       end


### PR DESCRIPTION
## Context
- Enable Rails/WhereNot, RSpec/DescribedClass, RSpec/FactoryBot/CreateList and RSpec/Rails/HttpStatus cops

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
