### PR TITLE
Move Candidate Mailer out of transaction

### DIFF
--- a/app/services/reject_by_default_feedback.rb
+++ b/app/services/reject_by_default_feedback.rb
@@ -17,10 +17,9 @@ class RejectByDefaultFeedback
         application_choice.structured_rejection_reasons = structured_rejection_reasons
         application_choice.reject_by_default_feedback_sent_at = Time.zone.now
         application_choice.save!
-
-        CandidateMailer.feedback_received_for_application_rejected_by_default(application_choice).deliver_later
       end
 
+      CandidateMailer.feedback_received_for_application_rejected_by_default(application_choice).deliver_later
       notify_slack
     end
   end


### PR DESCRIPTION
## Context

Having the email inside a transaction is causing emails to be send without reasons for rejection as there is a race condition.

## Changes proposed in this pull request

Move mailer outside transaction block

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
