### PR TITLE
Add JMETER_THREAD_COUNT to Apply plan

### DIFF
--- a/jmeter/plans/apply.rb
+++ b/jmeter/plans/apply.rb
@@ -2,6 +2,7 @@ require 'ruby-jmeter'
 
 BASEURL = ENV.fetch('JMETER_TARGET_BASEURL')
 WAIT_FACTOR = ENV.fetch('JMETER_WAIT_FACTOR', 1).to_f
+THREAD_COUNT = ENV.fetch('JMETER_THREAD_COUNT', 200).to_i
 
 def url(path)
   BASEURL + path
@@ -10,9 +11,8 @@ end
 test do
   cookies clear_each_iteration: true
   view_results_tree
-
-  random_timer 100, 900 * WAIT_FACTOR
-  thread_count = 975
+  thread_count = THREAD_COUNT
+  random_timer 1000, 2000 * WAIT_FACTOR
   csv_data_set_config filename: 'jmeter-courses.csv'
 
   threads count: thread_count, continue_forever: true, duration: 3600 do

--- a/jmeter/plans/find.rb
+++ b/jmeter/plans/find.rb
@@ -2,7 +2,7 @@ require 'ruby-jmeter'
 
 BASEURL = ENV.fetch('JMETER_TARGET_BASEURL', 'http://localhost:3002')
 WAIT_FACTOR = ENV.fetch('JMETER_WAIT_FACTOR', 1).to_f
-THREAD_COUNT = ENV.fetch('JMETER_THREAD_COUNT', 200)
+THREAD_COUNT = ENV.fetch('JMETER_THREAD_COUNT', 200).to_i
 
 def url(path)
   BASEURL + path


### PR DESCRIPTION
- Includes minor correction to Find plan as well, ensuring the thread
  count is handled as an integer rather than a string.
- random_timer values adjusted so that the Apply wait between actions is
  1-2 seconds.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
