### PR TITLE
Remove `reference_selection` feature flag

### DIFF
--- a/app/components/candidate_interface/add_reference_component.html.erb
+++ b/app/components/candidate_interface/add_reference_component.html.erb
@@ -6,13 +6,10 @@
     <p class="govuk-body">You need to get 2 references back before you can submit your application.</p>
     <%= govuk_link_to 'Add a second referee', candidate_interface_references_start_path, button: true %>
   <% else %>
-    <% if FeatureFlag.active?(:reference_selection) && @application_form.minimum_references_available_for_selection? %>
+    <% if @application_form.minimum_references_available_for_selection? %>
       <p class="govuk-body">You can add as many referees as you like but you can only submit 2 with your application.</p>
-    <% elsif FeatureFlag.active?(:reference_selection) %>
-      <p class="govuk-body">You can add more referees to increase the chances of getting 2 references quickly.</p>
     <% else %>
       <p class="govuk-body">You can add more referees to increase the chances of getting 2 references quickly.</p>
-      <p class="govuk-body">We’ll cancel any remaining requests when you’ve received 2 references.</p>
     <% end %>
     <%= govuk_link_to 'Add another referee', candidate_interface_references_start_path, button: true, class: 'govuk-button--secondary' %>
   <% end %>

--- a/app/components/candidate_interface/add_reference_component.rb
+++ b/app/components/candidate_interface/add_reference_component.rb
@@ -16,10 +16,6 @@ module CandidateInterface
       viable_references.one?
     end
 
-    def render?
-      !application_form.enough_references_have_been_provided?
-    end
-
   private
 
     def viable_references

--- a/app/components/candidate_interface/references_review_component.html.erb
+++ b/app/components/candidate_interface/references_review_component.html.erb
@@ -1,9 +1,4 @@
-<div class="<%= container_class %>">
-  <% if too_many_complete_references? %>
-    <p class="app-inset-text__title"><%= t('application_form.references.review.more_than_two') %></p>
-    <p class="govuk-body"><%= too_many_references_error %></p>
-  <% end %>
-
+<div>
   <% references.each do |reference| %>
     <%= render(SummaryCardComponent.new(
       rows: reference_rows(reference),

--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -54,20 +54,6 @@ module CandidateInterface
       %w[History]
     end
 
-    def too_many_complete_references?
-      if FeatureFlag.active?(:reference_selection)
-        false
-      else
-        references.select(&:feedback_provided?).size > ApplicationForm::MINIMUM_COMPLETE_REFERENCES
-      end
-    end
-
-    def container_class
-      if too_many_complete_references?
-        "govuk-inset-text app-inset-text--narrow-border app-inset-text--#{is_errored ? 'error' : 'important'}"
-      end
-    end
-
     def too_many_references_error
       return if references.blank?
 

--- a/app/components/task_list_item_references_component.html.erb
+++ b/app/components/task_list_item_references_component.html.erb
@@ -1,13 +1,11 @@
 <div class="app-task-list__content">
-  <% if FeatureFlag.active?(:reference_selection) %>
-    <p class="govuk-body">
-      <% if references.count > 1 %>
-        <%= govuk_link_to t('page_titles.references_review'), references_path, 'aria-describedby': "#{t('page_titles.references_review').parameterize}-badge-id" %>
-      <% else %>
-        <%= govuk_link_to t('page_titles.references_request'), references_path, 'aria-describedby': "#{t('page_titles.references_review').parameterize}-badge-id" %>
-      <% end %>
-    </p>
-  <% end %>
+  <p class="govuk-body">
+    <% if references.count > 1 %>
+      <%= govuk_link_to t('page_titles.references_review'), references_path, 'aria-describedby': "#{t('page_titles.references_review').parameterize}-badge-id" %>
+    <% else %>
+      <%= govuk_link_to t('page_titles.references_request'), references_path, 'aria-describedby': "#{t('page_titles.references_review').parameterize}-badge-id" %>
+    <% end %>
+  </p>
   <ul class="govuk-list">
     <% references.each do |reference| %>
       <li class="govuk-body-s">

--- a/app/controllers/candidate_interface/references/retry_request_controller.rb
+++ b/app/controllers/candidate_interface/references/retry_request_controller.rb
@@ -25,7 +25,6 @@ module CandidateInterface
 
       def can_retry?
         @reference.email_bounced? &&
-          !@reference.application_form.enough_references_have_been_provided? &&
           CandidateInterface::Reference::SubmitRefereeForm.new(
             submit: 'yes',
             reference_id: @reference.id,

--- a/app/controllers/candidate_interface/references/review_controller.rb
+++ b/app/controllers/candidate_interface/references/review_controller.rb
@@ -5,7 +5,6 @@ module CandidateInterface
 
       def show
         set_references
-        @too_many_references = current_application.too_many_complete_references?
       end
 
       def unsubmitted

--- a/app/controllers/candidate_interface/references/review_controller.rb
+++ b/app/controllers/candidate_interface/references/review_controller.rb
@@ -103,10 +103,7 @@ module CandidateInterface
       end
 
       def set_references
-        if FeatureFlag.active?(:reference_selection)
-          @references_selected = current_application.application_references.includes(:application_form).selected
-        end
-
+        @references_selected = current_application.application_references.includes(:application_form).selected
         @references_given = current_application.application_references.includes(:application_form).feedback_provided
         @references_waiting_to_be_sent = current_application.application_references.includes(:application_form).not_requested_yet
         @references_sent = current_application.application_references.includes(:application_form).pending_feedback_or_failed

--- a/app/controllers/candidate_interface/references/selection_controller.rb
+++ b/app/controllers/candidate_interface/references/selection_controller.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   module References
     class SelectionController < BaseController
-      before_action :render_404_unless_feature_enabled
       before_action :redirect_to_select_references_unless_enough_selected, only: %i[review complete]
 
       def new
@@ -63,10 +62,6 @@ module CandidateInterface
 
       def section_complete_params
         strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
-      end
-
-      def render_404_unless_feature_enabled
-        render_404 unless FeatureFlag.active?(:reference_selection)
       end
     end
   end

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -211,24 +211,15 @@ private
       # The first reference is declined by the referee
       @application_form.application_references.feedback_requested.first.update!(feedback_status: 'feedback_refused')
 
-      if FeatureFlag.active?(:reference_selection)
-        # Cancel 1 reference manually and receive feedback on the remaining 2.
-        # Select the two references with feedback.
-        @application_form.application_references.feedback_requested.first.cancelled!
-        @application_form.application_references.feedback_requested.each do |reference|
-          submit_reference!(reference.reload)
-          reference.update(selected: true)
-          fast_forward
-        end
-        @application_form.update!(references_completed: true)
-      else
-        # The 2 other of the outstanding references come in. However, only the
-        # first two are actually submitted, the last one is automatically cancelled.
-        @application_form.application_references.feedback_requested.each do |reference|
-          submit_reference!(reference.reload)
-          fast_forward
-        end
+      # Cancel 1 reference manually and receive feedback on the remaining 2.
+      # Select the two references with feedback.
+      @application_form.application_references.feedback_requested.first.cancelled!
+      @application_form.application_references.feedback_requested.each do |reference|
+        submit_reference!(reference.reload)
+        reference.update(selected: true)
+        fast_forward
       end
+      @application_form.update!(references_completed: true)
 
       if states.include?(:unsubmitted_with_completed_references)
         return application_choices

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -250,14 +250,6 @@ class ApplicationForm < ApplicationRecord
       application_choices.map(&:status).map(&:to_sym).all? { |status| (ApplicationStateChange::SUCCESSFUL_STATES + ApplicationStateChange::UNSUCCESSFUL_END_STATES).include?(status) }
   end
 
-  def too_many_complete_references?
-    if FeatureFlag.active?(:reference_selection)
-      false
-    else
-      application_references.feedback_provided.size > MINIMUM_COMPLETE_REFERENCES
-    end
-  end
-
   def surplus_references_available_for_selection?
     application_references.select(&:feedback_provided?).count >= 3
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -356,11 +356,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def enough_references_have_been_provided?
-    if FeatureFlag.active?(:reference_selection)
-      false
-    else
-      application_references.feedback_provided.count >= MINIMUM_COMPLETE_REFERENCES
-    end
+    false
   end
 
   def selected_enough_references?

--- a/app/models/reference_feature_metrics.rb
+++ b/app/models/reference_feature_metrics.rb
@@ -43,11 +43,7 @@ private
   end
 
   def time_to_get_for(application, end_time)
-    if FeatureFlag.active?(:reference_selection)
-      return nil unless application.minimum_references_available_for_selection?
-    else
-      return nil unless application.enough_references_have_been_provided?
-    end
+    return nil unless application.minimum_references_available_for_selection?
 
     times = application.application_references.feedback_provided.where(duplicate: false).map do |reference|
       [reference.requested_at, reference.feedback_provided_at]

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -111,13 +111,9 @@ module CandidateInterface
 
     def reference_section_errors
       [].tap do |errors|
-        if FeatureFlag.active?(:reference_selection)
-          # A defensive check, in case the candidate somehow ends up in this state
-          if @application_form.references_completed? && @application_form.selected_incorrect_number_of_references?
-            errors << OpenStruct.new(message: I18n.t('application_form.references.review.incorrect_number_selected'), anchor: '#references')
-          end
-        elsif @application_form.too_many_complete_references?
-          errors << OpenStruct.new(message: I18n.t('application_form.references.review.more_than_two'), anchor: '#references')
+        # A defensive check, in case the candidate somehow ends up in this state
+        if @application_form.references_completed? && @application_form.selected_incorrect_number_of_references?
+          errors << OpenStruct.new(message: I18n.t('application_form.references.review.incorrect_number_selected'), anchor: '#references')
         end
       end
     end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -40,11 +40,7 @@ module CandidateInterface
     end
 
     def references_section_definition
-      if FeatureFlag.active?(:reference_selection)
-        [:references_selected, references_completed?]
-      else
-        [:references_provided, references_completed?]
-      end
+      [:references_selected, references_completed?]
     end
 
     def incomplete_sections
@@ -152,15 +148,6 @@ module CandidateInterface
         I18n.t('section_items.manage_references')
       else
         I18n.t('section_items.add_references')
-      end
-    end
-
-    # TODO: remove this method when deleting the reference_selection feature flag
-    def references_path
-      if @application_form.application_references.present?
-        Rails.application.routes.url_helpers.candidate_interface_references_review_path
-      else
-        Rails.application.routes.url_helpers.candidate_interface_references_start_path
       end
     end
 
@@ -331,19 +318,7 @@ module CandidateInterface
     end
 
     def references_completed?
-      if FeatureFlag.active?(:reference_selection)
-        @application_form.references_completed
-      else
-        @application_form.enough_references_have_been_provided?
-      end
-    end
-
-    def references_in_progress?
-      if FeatureFlag.active?(:reference_selection)
-        false # Irrelevant to the reference_selection flow
-      else
-        !references_completed? && @application_form.application_references.present?
-      end
+      @application_form.references_completed
     end
 
     def safeguarding_completed?

--- a/app/services/reference_actions_policy.rb
+++ b/app/services/reference_actions_policy.rb
@@ -46,11 +46,7 @@ private
   attr_reader :reference
 
   def needs_more_references?
-    if FeatureFlag.active?(:reference_selection)
-      true
-    else
-      !reference.application_form.enough_references_have_been_provided?
-    end
+    true
   end
 
   def valid_reference?

--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -12,7 +12,6 @@ class SubmitReference
       @reference.update!(feedback_status: :feedback_provided, feedback_provided_at: Time.zone.now, selected: false)
     else
       @reference.update!(feedback_status: :feedback_provided, feedback_provided_at: Time.zone.now, selected: true)
-      cancel_feedback_requested_references if enough_references_have_been_provided?
     end
 
     if @send_emails

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -82,7 +82,6 @@
               text: @application_form_presenter.references_link_text,
               completed: @application_form_presenter.references_completed?,
               path: @application_form_presenter.references_path,
-              custom_status: @application_form_presenter.references_in_progress? ? 'In progress' : nil,
             )) %>
             <% if @application_form_presenter.references.present? %>
               <%= render(TaskListItemReferencesComponent.new(

--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -1,23 +1,17 @@
 # You have a reference from <%= @reference.name %>
 
-<% if FeatureFlag.active?(:reference_selection) && @selected_references.count >= ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
+<% if @selected_references.count >= ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
 You’ve selected 2 references to submit with your application already, but you can change your selection if you want.
 
 Sign in to complete your application:
-<% elsif FeatureFlag.active?(:reference_selection) && @provided_references.count > ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
+<% elsif @provided_references.count > ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
 You have more than enough references to send your application to training providers.
 
 Sign in and select 2 references to submit with your application:
-<% elsif FeatureFlag.active?(:reference_selection) && @provided_references.count == ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
+<% elsif @provided_references.count == ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
 You have enough references to send your application to training providers.
 
 Sign in and select 2 references to submit with your application:
-<% elsif @application_form.enough_references_have_been_provided? %>
-You’ve got 2 references back now.
-
-When you’re ready, you can send your application to training providers.
-
-Sign in to continue your application:
 <% else %>
 You need to get another reference back before you can send your application to training providers.
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -277,38 +277,6 @@ RSpec.describe ApplicationForm do
     end
   end
 
-  describe '#too_many_complete_references?' do
-    context 'when reference_selection feature is on' do
-      before { FeatureFlag.activate(:reference_selection) }
-
-      it 'returns false' do
-        application_form = create :application_form
-        create_list(:reference, 3, :feedback_provided, application_form: application_form)
-        expect(application_form.too_many_complete_references?).to be false
-      end
-    end
-
-    context 'when reference_selection feature is off' do
-      before { FeatureFlag.deactivate(:reference_selection) }
-
-      it 'returns true if there are more than 2 references' do
-        application_form = create :application_form
-        create_list(:reference, 3, :feedback_provided, application_form: application_form)
-
-        expect(application_form.too_many_complete_references?).to be true
-      end
-
-      it 'returns false if there are 2 or fewer references' do
-        application_form = create :application_form
-        expect(application_form.too_many_complete_references?).to be false
-        application_form.application_references << create(:reference)
-        expect(application_form.too_many_complete_references?).to be false
-        application_form.application_references << create(:reference)
-        expect(application_form.too_many_complete_references?).to be false
-      end
-    end
-  end
-
   describe '#selected_incorrect_number_of_references?' do
     it 'is true when < 2 selections' do
       application_form = create(:application_form)

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -679,26 +679,6 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
         expect(presenter.reference_section_errors).to eq []
       end
     end
-
-    context 'with reference_selection feature off' do
-      before { FeatureFlag.deactivate(:reference_selection) }
-
-      it 'returns an error if the application form has too many references' do
-        application_form = instance_double(ApplicationForm, too_many_complete_references?: true)
-        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
-
-        expect(presenter.reference_section_errors).to eq(
-          [OpenStruct.new(message: 'More than 2 references have been given', anchor: '#references')],
-        )
-      end
-
-      it 'returns an empty array if the application form does not have too many references' do
-        application_form = instance_double(ApplicationForm, too_many_complete_references?: false)
-        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
-
-        expect(presenter.reference_section_errors).to eq []
-      end
-    end
   end
 
   describe '#becoming_a_teacher_completed?' do


### PR DESCRIPTION
## Context

This feature flag has recently been switched on and is pretty much a one way journey. It won't be all that practical to switch it back off. Removing it gives us a few opportunities to simplify and tidy up some code.

## Changes proposed in this pull request

- [x] Remove tests that deactivate the feature flag.
- [x] Remove any test setup code that activates the feature flag.
- [x] Fix the tests by removing all the conditional logic driven by the flag.
- [x] Remove the feature flag itself
- [ ] Remove any newly redundant methods
- [ ] Refactoring

## Guidance to review

Draft - not quite ready yet

## Link to Trello card

https://trello.com/c/UT52kbRQ/3518-delete-referenceselection-feature-flag

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
