### PR TITLE
Refactor how bulleted lists work in SelectedReferencesComponent

### DIFF
--- a/app/components/selected_references_component.rb
+++ b/app/components/selected_references_component.rb
@@ -20,20 +20,17 @@ class SelectedReferencesComponent < ViewComponent::Base
       {
         key: 'Selected references',
         value: reference_values,
+        bulleted_format: true,
         action: 'Change selected references',
         change_path: candidate_interface_select_references_path,
       },
     ]
   end
 
-  # TODO: refactor the following, possibly by enhancing SummaryCardComponent to
-  # support rendering of bulleted lists
   def reference_values
-    list = '<ul class="govuk-list govuk-list--bullet">'.html_safe
     selected_references.map do |reference|
-      list << '<li>'.html_safe << "#{reference.referee_type.capitalize.dasherize} reference from #{reference.name}" << '</li>'.html_safe
+      "#{reference.referee_type.capitalize.dasherize} reference from #{reference.name}"
     end
-    list + '</ul>'.html_safe
   end
 
   def incomplete_path

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -8,7 +8,11 @@ class SummaryListComponent < ViewComponent::Base
 
   def value(row)
     if row[:value].is_a?(Array)
-      row[:value].map { |s| ERB::Util.html_escape(s) }.join('<br>').html_safe
+      if row[:bulleted_format]
+        format_list_with_bullets(row[:value])
+      else
+        row[:value].map { |s| ERB::Util.html_escape(s) }.join('<br>').html_safe
+      end
     elsif row[:value].html_safe?
       row[:value]
     else
@@ -52,5 +56,13 @@ private
         value: value,
       }
     end
+  end
+
+  def format_list_with_bullets(list)
+    markup = '<ul class="govuk-list govuk-list--bullet">'.html_safe
+    list.map do |list_item|
+      markup << '<li>'.html_safe << list_item << '</li>'.html_safe
+    end
+    markup + '</ul>'.html_safe
   end
 end

--- a/spec/components/summary_list_component_spec.rb
+++ b/spec/components/summary_list_component_spec.rb
@@ -16,16 +16,52 @@ RSpec.describe SummaryListComponent do
     expect(result.css('.govuk-summary-list__actions').text).to include('Change Name')
   end
 
-  it 'renders arrays content when passed in' do
-    rows = [
-      key: 'Address:',
-      value: ['Whoa Drive', 'Wewvile', 'London'],
-      action: 'Name',
-      change_path: '/some/url',
-    ]
-    result = render_inline(SummaryListComponent.new(rows: rows))
+  describe 'array content' do
+    it 'renders array content when passed in' do
+      rows = [
+        key: 'Address:',
+        value: ['Whoa Drive', 'Wewvile', 'London'],
+        action: 'Name',
+        change_path: '/some/url',
+      ]
+      result = render_inline(SummaryListComponent.new(rows: rows))
 
-    expect(result.css('.govuk-summary-list__value').to_html).to include('Whoa Drive<br>Wewvile<br>London')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Whoa Drive<br>Wewvile<br>London')
+    end
+
+    it 'renders values as bullets if specified for the row' do
+      rows = [
+        key: 'Address:',
+        value: %w[A list of items],
+        bulleted_format: true,
+      ]
+      result = render_inline(SummaryListComponent.new(rows: rows))
+
+      expect(result.to_html).to include(<<~HTML)
+        <ul class="govuk-list govuk-list--bullet">
+        <li>A</li>
+        <li>list</li>
+        <li>of</li>
+        <li>items</li>
+        </ul>
+      HTML
+    end
+
+    it 'safely escapes markup when rendering values as bullets' do
+      rows = [
+        key: 'Address:',
+        value: ['<script></script>', '<br>'],
+        bulleted_format: true,
+      ]
+      result = render_inline(SummaryListComponent.new(rows: rows))
+
+      expect(result.to_html).to include(<<~HTML)
+        <ul class="govuk-list govuk-list--bullet">
+        <li>&lt;script&gt;&lt;/script&gt;</li>
+        <li>&lt;br&gt;</li>
+        </ul>
+      HTML
+    end
   end
 
   it 'renders component with correct struture using action_path' do


### PR DESCRIPTION

## Context
Tidying up a short-term solution that we implemented to render selected references in an unordered list.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Make rendering of bulleted lists a properly tested option in the
  SummaryListComponent
- Refactor SelectedReferencesComponent to use this option
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Should be able to confirm selected references still render correctly in the review app.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/fg69LAwP
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
