### PR TITLE
Org permissions cleanup

### DIFF
--- a/app/components/provider_interface/organisation_permissions_review_card_component.html.erb
+++ b/app/components/provider_interface/organisation_permissions_review_card_component.html.erb
@@ -2,7 +2,10 @@
   <%= render SummaryCardHeaderComponent.new(title: presenter.provider_relationship_description, heading_level: summary_card_heading_level) do %>
     <% if change_path %>
       <div class="app-summary-card__actions">
-        <%= govuk_link_to 'Change', change_path %>
+        <%= govuk_link_to change_path do %>
+          Change
+          <span class="govuk-visually-hidden"> <%= presenter.provider_relationship_description %></span>
+        <% end %>
       </div>
     <% end %>
   <% end %>

--- a/app/components/provider_interface/safeguarding_declaration_component.html.erb
+++ b/app/components/provider_interface/safeguarding_declaration_component.html.erb
@@ -43,12 +43,7 @@
         The candidate has disclosed information related to safeguarding but you cannot see it.
       </p>
 
-      <% if @analysis.provider_user_can_manage_organisations? && @analysis.provider_user_associated_with_training_provider? %>
-        <p class="govuk-body">
-          This is because you have not set up organisational permissions.
-          <%= govuk_link_to 'Set organisational permissions', @analysis.fix_org_permissions_path %>
-        </p>
-      <% elsif @analysis.training_provider_users_who_can_manage_organisations.present? %>
+      <% if @analysis.training_provider_users_who_can_manage_organisations.present? %>
         <% others = @analysis.training_provider_users_who_can_manage_organisations %>
         <p class="govuk-body">
           This is because organisational permissions have not been set up. Contact

--- a/app/services/provider_authorisation_analysis.rb
+++ b/app/services/provider_authorisation_analysis.rb
@@ -71,56 +71,8 @@ class ProviderAuthorisationAnalysis
     end
   end
 
-  def other_provider_users_who_can_manage_users
-    @_alt_manage_users ||= if provider_user_associated_with_training_provider?
-                             training_provider.provider_permissions.manage_users.where.not(
-                               provider_user: provider_user,
-                             ).map(&:provider_user)
-                           else
-                             ratifying_provider.provider_permissions.manage_users.where.not(
-                               provider_user: provider_user,
-                             ).map(&:provider_user)
-                           end
-  end
-
-  def other_provider_users_who_can_manage_organisations
-    @_alt_manage_orgs ||= if provider_user_associated_with_training_provider?
-                            training_provider.provider_permissions.manage_organisations.where.not(
-                              provider_user: provider_user,
-                            ).map(&:provider_user)
-                          else
-                            ratifying_provider.provider_permissions.manage_organisations.where.not(
-                              provider_user: provider_user,
-                            ).map(&:provider_user)
-                          end
-  end
-
   def training_provider_users_who_can_manage_organisations
     @_training_provider_users_manage_orgs ||=
       training_provider.provider_permissions.manage_organisations.map(&:provider_user)
-  end
-
-  def fix_user_permissions_path
-    if provider_user_associated_with_training_provider?
-      url_helpers.provider_interface_provider_user_edit_permissions_path(
-        provider_id: training_provider.id,
-        provider_user_id: provider_user.id,
-      )
-    else
-      url_helpers.provider_interface_provider_user_edit_permissions_path(
-        provider_id: ratifying_provider.id,
-        provider_user_id: provider_user.id,
-      )
-    end
-  end
-
-  def fix_org_permissions_path
-    url_helpers.provider_interface_edit_provider_relationship_permissions_path(id: relationship.id) if relationship
-  end
-
-private
-
-  def url_helpers
-    Rails.application.routes.url_helpers
   end
 end

--- a/app/views/provider_interface/organisation_permissions/edit.html.erb
+++ b/app/views/provider_interface/organisation_permissions/edit.html.erb
@@ -1,5 +1,13 @@
 <%= content_for :browser_title, "#{t('page_titles.provider.change_organisation_permissions')} - #{@presenter.provider_relationship_description}" %>
-
 <% content_for :before_content, govuk_back_link_to(provider_interface_organisation_settings_organisation_organisation_permissions_path(@provider)) %>
 
-<%= render ProviderInterface::OrganisationPermissionsFormComponent.new(provider_user: current_provider_user, provider_relationship_permission: @relationship, mode: :edit, form_url: provider_interface_organisation_settings_organisation_organisation_permission_path(@relationship, organisation_id: @provider.id)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render ProviderInterface::OrganisationPermissionsFormComponent.new(
+      provider_user: current_provider_user,
+      provider_relationship_permission: @relationship,
+      mode: :edit,
+      form_url: provider_interface_organisation_settings_organisation_organisation_permission_path(@relationship, organisation_id: @provider.id),
+    ) %>
+  </div>
+</div>

--- a/app/views/provider_interface/organisation_permissions/edit.html.erb
+++ b/app/views/provider_interface/organisation_permissions/edit.html.erb
@@ -9,5 +9,9 @@
       mode: :edit,
       form_url: provider_interface_organisation_settings_organisation_organisation_permission_path(@relationship, organisation_id: @provider.id),
     ) %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t('cancel'), provider_interface_organisation_settings_organisation_organisation_permissions_path(@provider), class: 'govuk-link--no-visited-state' %>
+    </p>
   </div>
 </div>

--- a/spec/components/provider_interface/organisation_permissions_review_card_component_spec.rb
+++ b/spec/components/provider_interface/organisation_permissions_review_card_component_spec.rb
@@ -57,8 +57,9 @@ RSpec.describe ProviderInterface::OrganisationPermissionsReviewCardComponent do
     context 'when the change path is provided' do
       let(:change_path) { '/path-to-change' }
 
-      it 'renders an action link' do
-        expect(render.css('a').text).to eq('Change')
+      it 'renders an action link with hidden text set to the relationship description' do
+        expect(render.css('a').text).to include('Change')
+        expect(render.css('a .govuk-visually-hidden').text).to eq(" #{training_provider.name} and #{ratifying_provider.name}")
         expect(render.css('a').first.attributes['href'].value).to eq(change_path)
       end
     end

--- a/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
+++ b/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
@@ -170,19 +170,7 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
         user_has_view_safeguarding_information(true)
       end
 
-      it 'when provider user has manage_organisations' do
-        user_has_manage_organisations(true)
-        result = render_component(
-          user: provider_user,
-          safeguarding_issues: 'I have a criminal conviction.',
-          safeguarding_issues_status: 'has_safeguarding_issues_to_declare',
-        )
-        expect_user_cannot_see_safeguarding_information(result)
-        fix_it_link = Rails.application.routes.url_helpers.provider_interface_edit_provider_relationship_permissions_path(id: @relationship.id)
-        expect(result.to_html).to include(fix_it_link)
-      end
-
-      it 'when provider user does not have manage_organisations' do
+      it 'shows a list of users to contact' do
         user_has_manage_organisations(false)
         result = render_component(
           user: provider_user,

--- a/spec/services/provider_authorisation_analysis_spec.rb
+++ b/spec/services/provider_authorisation_analysis_spec.rb
@@ -60,13 +60,6 @@ RSpec.describe ProviderAuthorisationAnalysis do
     expect(analysis.provider_user_can_manage_organisations?).to be_falsy
   end
 
-  it '#other_provider_users_who_can_manage_users' do
-    expected = other_users.second
-
-    expect(analysis.other_provider_users_who_can_manage_users.count).to eq(1)
-    expect(analysis.other_provider_users_who_can_manage_users.first.id).to eq(expected.id)
-  end
-
   it '#training_provider_users_who_can_manage_organisations' do
     expected = other_users.first
 


### PR DESCRIPTION
## Context
A few things we spotted in the Dev/Design review

## Changes proposed in this pull request
- Remove legacy permission denied hint from safeguarding component – this would never have been rendered anyway
- Wrap org permission edit form in 2/3 container
- Add cancel link to org permission edit form
- Add hidden text to org permission change link

## Guidance to review
The latter 3 changes live behind the existing feature flag. The first one does not. I don't think that's a real issue since not many users would be seeing the content anyway.

## Link to Trello card
https://trello.com/c/D0QfG9Rz/4045-new-org-permissions-cleanup-issues-from-dev-design
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
