### PR TITLE
Remove duplicate accrediting providers

### DIFF
--- a/app/services/data_migrations/remove_duplicate_provider.rb
+++ b/app/services/data_migrations/remove_duplicate_provider.rb
@@ -12,16 +12,23 @@ module DataMigrations
       if permissions.any?
         permissions.each do |permission|
           ActiveRecord::Base.transaction do
-            courses = permission.training_provider.courses.where(accredited_provider: permission.ratifying_provider)
-
             next if permission.ratifying_provider.courses.any?
+
+            courses = permission.training_provider.courses.where(accredited_provider: permission.ratifying_provider)
 
             courses.each do |course|
               course.update!(accredited_provider: nil, audit_comment: 'Deduplicating accredited provider, this course is self-ratified')
             end
 
             permission.destroy!
-            permission.ratifying_provider.destroy!
+
+            # Ensure we don't orphan any users who were only associated with the duplicate provider
+            if permission.ratifying_provider.provider_users.select { |user| user.providers.size == 1 }.any?
+              Rails.logger.warn "Skipping deletion of #{permission.ratifying_provider.name}. This organisation has users which do not belong to any other provider."
+            else
+              permission.destroy!
+              permission.ratifying_provider.destroy!
+            end
           end
         end
       end

--- a/app/services/data_migrations/remove_duplicate_provider.rb
+++ b/app/services/data_migrations/remove_duplicate_provider.rb
@@ -10,10 +10,11 @@ module DataMigrations
         .where('tp.name = rp.name')
 
       if permissions.any?
-        ActiveRecord::Base.transaction do
-          permissions.each do |permission|
+        permissions.each do |permission|
+          ActiveRecord::Base.transaction do
             courses = permission.training_provider.courses.where(accredited_provider: permission.ratifying_provider)
-            next if courses.empty?
+
+            next if permission.ratifying_provider.courses.any?
 
             courses.each do |course|
               course.update!(accredited_provider: nil, audit_comment: 'Deduplicating accredited provider, this course is self-ratified')

--- a/app/services/data_migrations/remove_duplicate_provider.rb
+++ b/app/services/data_migrations/remove_duplicate_provider.rb
@@ -1,0 +1,29 @@
+module DataMigrations
+  class RemoveDuplicateProvider
+    TIMESTAMP = 20210505095417
+    MANUAL_RUN = false
+
+    def change
+      permissions = ProviderRelationshipPermissions
+        .joins('INNER JOIN providers tp ON training_provider_id = tp.id')
+        .joins('INNER JOIN providers rp ON ratifying_provider_id = rp.id')
+        .where('tp.name = rp.name')
+
+      if permissions.any?
+        ActiveRecord::Base.transaction do
+          permissions.each do |permission|
+            courses = permission.training_provider.courses.where(accredited_provider: permission.ratifying_provider)
+            next if courses.empty?
+
+            courses.each do |course|
+              course.update!(accredited_provider: nil, audit_comment: 'Deduplicating accredited provider, this course is self-ratified')
+            end
+
+            permission.destroy!
+            permission.ratifying_provider.destroy!
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveDuplicateProvider',
   'DataMigrations::BackfillReferencesCompleted',
   'DataMigrations::CleanseEocChasersSentData',
   'DataMigrations::BackfillSetupInterviewsPermission',

--- a/spec/services/data_migrations/remove_duplicate_provider_spec.rb
+++ b/spec/services/data_migrations/remove_duplicate_provider_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe DataMigrations::RemoveDuplicateProvider do
   let(:provider) { create(:provider, name: 'Test Provider 001') }
   let(:duplicate_provider) { create(:provider, name: 'Test Provider 001') }
+  let!(:provider_user) { create(:provider_user, providers: [provider, duplicate_provider]) }
   let!(:provider_relationship_permissions) { create(:provider_relationship_permissions, training_provider: provider, ratifying_provider: duplicate_provider) }
   let!(:self_ratified_course) { create(:course, provider: provider, accredited_provider: duplicate_provider) }
   let!(:other_course) { create(:course, provider: provider, accredited_provider: create(:provider)) }
@@ -18,7 +19,29 @@ RSpec.describe DataMigrations::RemoveDuplicateProvider do
     expect { DataMigrations::RemoveDuplicateProvider.new.change }.to change(ProviderRelationshipPermissions, :count).by(-1)
   end
 
-  it 'destroys the duplicate provider' do
-    expect { DataMigrations::RemoveDuplicateProvider.new.change }.to change(Provider, :count).by(-1)
+  context 'with unrelated courses ratified by the ratifying provider' do
+    it 'does nothing' do
+      provider = create(:provider, name: 'Test Provider 002')
+      another_provider = create(:provider, name: 'Another Test Provider')
+      duplicate_provider = create(:provider, name: 'Test Provider 002')
+      create(:course, provider: provider, accredited_provider: duplicate_provider)
+      ratified_course = create(:course, provider: another_provider, accredited_provider: duplicate_provider)
+      create(:provider_relationship_permissions, training_provider: provider, ratifying_provider: duplicate_provider)
+      create(:provider_relationship_permissions, training_provider: another_provider, ratifying_provider: duplicate_provider)
+
+      expect { described_class.new.change }.not_to change(ProviderRelationshipPermissions, :count)
+      expect(ratified_course.reload.accredited_provider).not_to be_nil
+    end
+  end
+
+  context 'with users who only belong to the duplicate provider' do
+    it 'does not remove the provider' do
+      provider = create(:provider, name: 'Test Provider 002')
+      duplicate_provider = create(:provider, name: 'Test Provider 002')
+      create(:provider_user, providers: [duplicate_provider])
+      create(:provider_relationship_permissions, training_provider: provider, ratifying_provider: duplicate_provider)
+
+      expect { described_class.new.change }.not_to change(Provider, :count)
+    end
   end
 end

--- a/spec/services/data_migrations/remove_duplicate_provider_spec.rb
+++ b/spec/services/data_migrations/remove_duplicate_provider_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveDuplicateProvider do
+  let(:provider) { create(:provider, name: 'Test Provider 001') }
+  let(:duplicate_provider) { create(:provider, name: 'Test Provider 001') }
+  let!(:provider_relationship_permissions) { create(:provider_relationship_permissions, training_provider: provider, ratifying_provider: duplicate_provider) }
+  let!(:self_ratified_course) { create(:course, provider: provider, accredited_provider: duplicate_provider) }
+  let!(:other_course) { create(:course, provider: provider, accredited_provider: create(:provider)) }
+
+  it 'makes courses accredited by the duplicate provider self-ratified by the training provider' do
+    DataMigrations::RemoveDuplicateProvider.new.change
+
+    expect(self_ratified_course.reload.accredited_provider).to be_nil
+    expect(other_course.reload.accredited_provider).not_to be_nil
+  end
+
+  it 'destroys the relationship between the training provider and the duplicate' do
+    expect { DataMigrations::RemoveDuplicateProvider.new.change }.to change(ProviderRelationshipPermissions, :count).by(-1)
+  end
+
+  it 'destroys the duplicate provider' do
+    expect { DataMigrations::RemoveDuplicateProvider.new.change }.to change(Provider, :count).by(-1)
+  end
+end


### PR DESCRIPTION
## Context

There are 10 provider relationships in production where the training and ratifying provider have the same name.
There are 278 courses for these providers which are provided/ratified by the two sides of the seemingly unnecessary relationships.
This seems to be bad data as a self-ratified course should have a nil accredited provider and the duplication of provider records and relationship records are undesirable.

## Changes proposed in this pull request

This data migration finds these relationships and iterates over courses concerned nillifying the accredited_provider thus making them self-ratified.
The relationship and duplicate provider records are then destroyed.

## Guidance to review

## Link to Trello card

From support query https://trello.com/c/IEHp1BE0/446-united-teaching-national-scitt-codes

https://trello.com/c/Lb5uFkix/4036-remove-9-duplicate-providers
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
