### PR TITLE
Move sidekiq latency check out of health monitor into invariant check

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -15,9 +15,6 @@ OkComputer.mount_at = 'integrations/monitoring'
 
 OkComputer::Registry.register 'postgres', OkComputer::ActiveRecordCheck.new
 OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ENV['REDIS_URL'])
-OkComputer::Registry.register 'sidekiq_low_priority_queue', OkComputer::SidekiqLatencyCheck.new('low_priority', 100) # threshold in seconds
-OkComputer::Registry.register 'sidekiq_default_queue', OkComputer::SidekiqLatencyCheck.new('default', 100) # threshold in seconds
-OkComputer::Registry.register 'sidekiq_mailers_queue', OkComputer::SidekiqLatencyCheck.new('mailers', 100) # threshold in seconds
 OkComputer::Registry.register 'simulated_failure', SimulatedFailureCheck.new
 OkComputer::Registry.register 'version', OkComputer::AppVersionCheck.new
 


### PR DESCRIPTION
## Context

When the Sidekiq is high, since we have the checks in the integrations health monitor, we are reporting the website is down if we get a high number of jobs to process. 

## Changes proposed in this pull request

Move latency Sidekiq checks out of the health check into an invariant check to still alert us hourly, however not report that the app is down through status cake.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
