### PR TITLE
Reduce Application heading size to `l`

### DIFF
--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -3,7 +3,7 @@
 <%= render ServiceInformationBanner.new(namespace: :provider) %>
 <%= render ProviderInterface::SummerRecruitmentBanner.new %>
 
-<h1 class="govuk-heading-xl">Applications (<%= @application_choices.total_count %>)</h1>
+<h1 class="govuk-heading-l">Applications (<%= @application_choices.total_count %>)</h1>
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @application_choices) do %>
   <% if @application_choices.size > 0 %>

--- a/spec/system/provider_interface/setup_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/setup_provider_relationship_permissions_spec.rb
@@ -223,6 +223,6 @@ RSpec.feature 'Setting up provider relationship permissions' do
   end
 
   def then_i_can_see_candidate_applications
-    expect(page).to have_css('h1.govuk-heading-xl', text: 'Applications')
+    expect(page).to have_css('h1.govuk-heading-l', text: 'Applications')
   end
 end


### PR DESCRIPTION
## Context

Reduce Application heading size to `l`

## Link to Trello card

https://trello.com/c/cVpqZtnl/4053-application-heading-size-throughout-manage-should-be-l-not-xl

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
