### PR TITLE
Rename heading to "Personal details"

### DIFF
--- a/app/components/provider_interface/personal_details_component.html.erb
+++ b/app/components/provider_interface/personal_details_component.html.erb
@@ -1,5 +1,5 @@
 <section class="app-section govuk-!-width-two-thirds" data-qa="personal-details">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="personal-details">Applicant details</h2>
+  <h2 class="govuk-heading-m govuk-!-font-size-27" id="personal-details">Personal details</h2>
 
   <%= render SummaryListComponent.new(rows: rows) %>
 </section>


### PR DESCRIPTION
## Context

Rename the "Applicant details" heading on the application details page to "Personal details" 

## Link to Trello card

https://trello.com/c/bMfFUCTc/4051-rename-heading-on-application-details-page-from-applicant-details-to-personal-details

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
