### PR TITLE
Display header links on all controller actions

### DIFF
--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -67,7 +67,7 @@ class NavigationItems
     end
 
     def for_provider_account_nav(current_provider_user, current_controller, performing_setup: false)
-      return [] if (active_action?(current_controller, 'new') && !active?(current_controller, 'application_data_export')) || active_action?(current_controller, 'sign_in_by_email')
+      return [] if (active_action?(current_controller, 'new') && active?(current_controller, 'sessions')) || active_action?(current_controller, 'sign_in_by_email')
 
       return [NavigationItem.new('Sign in', provider_interface_sign_in_path, false)] unless current_provider_user
 


### PR DESCRIPTION
## Context

Top bar links (Account, Sign out etc) should be displayed unless a provider user is on the Sign in page.

## Link to Trello card

https://trello.com/c/IojytPqY/4034-no-account-sign-out-links-when-making-offer-setting-up-interview

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
