### PR TITLE
Filter providers by unsigned DSA

### DIFF
--- a/app/models/support_interface/providers_filter.rb
+++ b/app/models/support_interface/providers_filter.rb
@@ -3,6 +3,7 @@ module SupportInterface
     attr_reader :applied_filters
     ONBOARDING_STAGES = {
       'synced_only' => 'With synced courses',
+      'dsa_unsigned_only' => 'With unsigned DSAs',
       'dsa_signed_only' => 'With signed DSAs',
     }.freeze
 
@@ -70,6 +71,10 @@ module SupportInterface
 
       if applied_filters[:onboarding_stages]&.include?('dsa_signed_only')
         providers = providers.joins(:provider_agreements)
+      end
+
+      if applied_filters[:onboarding_stages]&.include?('dsa_unsigned_only')
+        providers = providers.left_joins(:provider_agreements).where(provider_agreements: { id: nil })
       end
 
       if applied_filters[:provider_types].present?

--- a/spec/models/support_interface/providers_filter_spec.rb
+++ b/spec/models/support_interface/providers_filter_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe SupportInterface::ProvidersFilter do
       expect(filter.filter_records(providers)).to eq [provider_with_signed_dsa]
     end
 
+    it 'filters by DSA unsigned' do
+      provider_with_unsigned_dsa = create(:provider)
+      create_list(:provider, 2, :with_signed_agreement)
+
+      providers = Provider.all
+      filter = described_class.new(params: { onboarding_stages: %w[dsa_unsigned_only] })
+
+      expect(filter.filter_records(providers)).to eq [provider_with_unsigned_dsa]
+    end
+
     it 'filters by provider type' do
       lead_school = create(:provider, provider_type: 'lead_school')
       scitt = create(:provider, provider_type: 'scitt')


### PR DESCRIPTION
## Context

To enable support agents to know which providers have yet to sign their DSA, enable filtering by unsigned DSAs.

## Guidance to review

Look at ticket.

## Link to Trello card

https://trello.com/c/8D2IXlVg/4038-add-unsigned-dsa-filter-to-support-console-providers-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
