### PR TITLE
Add the apply opens time value to the rejected application email

### DIFF
--- a/app/views/candidate_mailer/_still_interested_content.text.erb
+++ b/app/views/candidate_mailer/_still_interested_content.text.erb
@@ -2,7 +2,7 @@
 
 You can apply again for courses starting in the <%= "#{RecruitmentCycle.next_year} to #{RecruitmentCycle.next_year + 1}" %> academic year.
 
-Your last application has been saved. Make any changes and re-submit from <%= CycleTimetable.apply_opens.to_s(:govuk_date) %>.
+Your last application has been saved. Make any changes and re-submit from <%= CycleTimetable.apply_opens.to_s(:govuk_time) %> on <%= CycleTimetable.apply_opens.to_s(:govuk_date) %>.
 
 <% else %>
 

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -160,13 +160,13 @@ RSpec.describe CandidateMailer, type: :mailer do
       context 'when it is after the apply_2_deadline' do
         before do
           allow(CycleTimetable).to receive(:between_cycles_apply_2?).and_return(true)
-          allow(CycleTimetable).to receive(:apply_opens).and_return(Date.new(2021, 10, 13))
+          allow(CycleTimetable).to receive(:apply_opens).and_return(Time.zone.local(2021, 10, 12, 9))
           allow(RecruitmentCycle).to receive(:next_year).and_return(2022)
         end
 
         it 'informs the candidate they can apply again next year' do
           expect(email.body).to include('You can apply again for courses starting in the 2022 to 2023 academic year.')
-          expect(email.body).to include('Your last application has been saved. Make any changes and re-submit from 13 October 2021')
+          expect(email.body).to include('Your last application has been saved. Make any changes and re-submit from 9am on 12 October 2021')
         end
       end
     end


### PR DESCRIPTION
## Context

As part of the EoC work we now include the time, not just the date, for when apply opens. 

Adding it to this email copy for consistency.

## Changes proposed in this pull request

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/47917431/127483913-87411d0f-d7bc-49cd-b7c1-d78d5737d8ec.png)|![image](https://user-images.githubusercontent.com/47917431/127483965-d70e63e1-769f-42fb-b67d-6bd5feea40d1.png)|

## Guidance to review

## Link to Trello card

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
