### PR TITLE
Change filter label and label on application details to "Year received"

### DIFF
--- a/app/components/provider_interface/application_summary_component.rb
+++ b/app/components/provider_interface/application_summary_component.rb
@@ -31,7 +31,7 @@ module ProviderInterface
 
     def recruitment_cycle_year
       {
-        key: 'Cycle',
+        key: 'Year received',
         value: recruitment_cycle_year_name,
       }
     end

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -73,7 +73,7 @@ module ProviderInterface
 
       {
         type: :checkboxes,
-        heading: 'Cycle',
+        heading: 'Year received',
         name: 'recruitment_cycle_year',
         options: cycle_options,
       }


### PR DESCRIPTION
## Context
Feedback from providers suggested that `Cycle` is an ambiguous and potentially confusing term since some providers understand cycle to be the  "recruitment cycle", whilst others refer to the "academic cycle". We think "Year received" is clearer.

## Link to Trello card

https://trello.com/c/1pmk2yob/4052-change-filter-label-and-label-on-application-details-to-year-received

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
