### PR TITLE
Modify organisation permissions change message

### DIFF
--- a/app/controllers/provider_interface/organisation_permissions_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_controller.rb
@@ -26,7 +26,7 @@ module ProviderInterface
 
     def update
       if @relationship.update(new_relationship_permissions)
-        flash[:success] = 'Organisation permissions successfully updated'
+        flash[:success] = 'Organisation permissions updated'
         redirect_to provider_interface_organisation_settings_organisation_organisation_permissions_path(params[:organisation_id])
       else
         track_validation_error(@relationship)

--- a/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature 'Provider edits organisation permissions' do
   end
 
   def and_i_see_a_flash_message
-    expect(page).to have_content('Organisation permissions successfully updated')
+    expect(page).to have_content('Organisation permissions updated')
   end
 
   def and_my_organisation_is_listed_as_able_to_make_decisions


### PR DESCRIPTION
## Context

The success message displayed when a user changes their orgnisation's ProviderRelationshipPermissions needs to say "Organisation permissions updated"

## Changes proposed in this pull request

Change the flash message from "Organisation permissions successfully updated" to "Organisation permissions updated"

