### PR TITLE
Fix success message on Organisation permissions update

### DIFF
--- a/app/controllers/provider_interface/organisation_permissions_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_controller.rb
@@ -26,7 +26,7 @@ module ProviderInterface
 
     def update
       if @relationship.update(new_relationship_permissions)
-        flash[:success] = 'Organisation permissions successfully updated'
+        flash[:success] = 'Organisation permissions updated'
         redirect_to provider_interface_organisation_settings_organisation_organisation_permissions_path(params[:organisation_id])
       else
         track_validation_error(@relationship)

--- a/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature 'Provider edits organisation permissions' do
   end
 
   def and_i_see_a_flash_message
-    expect(page).to have_content('Organisation permissions successfully updated')
+    expect(page).to have_content('Organisation permissions updated')
   end
 
   def and_my_organisation_is_listed_as_able_to_make_decisions


### PR DESCRIPTION
## Context

Content is incorrect when updating Organisation permissions

## Changes proposed in this pull request

Update flash success message to "Organisation permissions updated"

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
