### PR TITLE
Display breakdown of user’s relationship permission based on provider…

### DIFF
--- a/app/components/provider_interface/provider_partner_permission_breakdown_component.html.erb
+++ b/app/components/provider_interface/provider_partner_permission_breakdown_component.html.erb
@@ -1,0 +1,21 @@
+<% if partners_for_which_permission_applies.any? %>
+  <p class="govuk-body">
+    <%= partners_for_which_permission_applies_text %>
+  </p>
+  <ul id='partners-for-which-permission-applies' class="govuk-list govuk-list--bullet">
+    <% partners_for_which_permission_applies.each do |provider| %>
+      <li><%= provider.name %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<% if partners_for_which_permission_does_not_apply.any? %>
+  <p class="govuk-body">
+    <%= partners_for_which_permission_does_not_apply_text %>
+  </p>
+  <ul id='partners-for-which-permission-does-not-apply' class="govuk-list govuk-list--bullet">
+    <% partners_for_which_permission_does_not_apply.each do |provider| %>
+      <li><%= provider.name %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/components/provider_interface/provider_partner_permission_breakdown_component.rb
+++ b/app/components/provider_interface/provider_partner_permission_breakdown_component.rb
@@ -1,0 +1,66 @@
+module ProviderInterface
+  class ProviderPartnerPermissionBreakdownComponent < ViewComponent::Base
+    attr_reader :provider, :permission
+
+    def initialize(provider:, permission:)
+      @provider = provider
+      @permission = permission
+    end
+
+    def partners_for_which_permission_applies
+      @partners_for_which_permission_applies ||= Provider.where(id: training_partners_for_which_permission_applies_ids)
+                                                         .or(Provider.where(id: ratifying_partners_for_which_permission_applies_ids))
+    end
+
+    def partners_for_which_permission_does_not_apply
+      @partners_for_which_permission_does_not_apply ||= Provider.where(id: training_partners_for_which_permission_does_not_apply_ids)
+                                                                .or(Provider.where(id: ratifying_partners_for_which_permission_does_not_apply_ids))
+    end
+
+    def partners_for_which_permission_applies_text
+      if partners_for_which_permission_does_not_apply.any?
+        'It currently applies to courses you work on with:'
+      else
+        'It currently applies to courses you work on with all of your partner organisations:'
+      end
+    end
+
+    def partners_for_which_permission_does_not_apply_text
+      if partners_for_which_permission_applies.any?
+        'It currently does not apply to courses you work on with:'
+      else
+        'It currently does not apply to courses you work on with any of your partner organisations:'
+      end
+    end
+
+  private
+
+    def training_partners_for_which_permission_applies_ids
+      Provider.joins(:training_provider_permissions)
+              .where(provider_relationship_permissions: { ratifying_provider: provider,
+                                                          "ratifying_provider_can_#{permission}" => true })
+              .pluck(:id)
+    end
+
+    def ratifying_partners_for_which_permission_applies_ids
+      Provider.joins(:ratifying_provider_permissions)
+              .where(provider_relationship_permissions: { training_provider: provider,
+                                                          "training_provider_can_#{permission}" => true })
+              .pluck(:id)
+    end
+
+    def training_partners_for_which_permission_does_not_apply_ids
+      Provider.joins(:training_provider_permissions)
+              .where(provider_relationship_permissions: { ratifying_provider: provider,
+                                                          "ratifying_provider_can_#{permission}" => false })
+              .pluck(:id)
+    end
+
+    def ratifying_partners_for_which_permission_does_not_apply_ids
+      Provider.joins(:ratifying_provider_permissions)
+              .where(provider_relationship_permissions: { training_provider: provider,
+                                                          "training_provider_can_#{permission}" => false })
+              .pluck(:id)
+    end
+  end
+end

--- a/spec/components/previews/provider_interface/provider_partner_permission_breakdown_component_preview.rb
+++ b/spec/components/previews/provider_interface/provider_partner_permission_breakdown_component_preview.rb
@@ -1,0 +1,104 @@
+module ProviderInterface
+  class ProviderPartnerPermissionBreakdownComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
+    def both_partners_for_which_permission_applies_and_partners_for_which_permission_does_not_apply
+      provider = FactoryBot.create(:provider)
+      allowed_training_providers = FactoryBot.build_list(:provider, 3)
+      allowed_ratifying_providers = FactoryBot.build_list(:provider, 2)
+      prohibited_training_providers = FactoryBot.build_list(:provider, 1)
+      prohibited_ratifying_providers = FactoryBot.build_list(:provider, 1)
+
+      allowed_training_providers.each do |training_provider|
+        FactoryBot.create(:provider_relationship_permissions,
+                          training_provider: training_provider,
+                          training_provider_can_make_decisions: false,
+                          ratifying_provider: provider,
+                          ratifying_provider_can_make_decisions: true)
+      end
+
+      allowed_ratifying_providers.each do |training_provider|
+        FactoryBot.create(:provider_relationship_permissions,
+                          ratifying_provider: training_provider,
+                          ratifying_provider_can_make_decisions: false,
+                          training_provider: provider,
+                          training_provider_can_make_decisions: true)
+      end
+
+      prohibited_training_providers.each do |training_provider|
+        FactoryBot.create(:provider_relationship_permissions,
+                          ratifying_provider: provider,
+                          training_provider: training_provider,
+                          training_provider_can_make_decisions: true,
+                          ratifying_provider_can_make_decisions: false)
+      end
+
+      prohibited_ratifying_providers.each do |training_provider|
+        FactoryBot.create(:provider_relationship_permissions,
+                          ratifying_provider: training_provider,
+                          training_provider: provider,
+                          training_provider_can_make_decisions: false,
+                          ratifying_provider_can_make_decisions: true)
+      end
+
+      render ProviderPartnerPermissionBreakdownComponent.new(
+        provider: provider,
+        permission: :make_decisions,
+      )
+    end
+
+    def only_partners_for_which_permission_applies
+      provider = FactoryBot.create(:provider)
+      allowed_training_providers = FactoryBot.build_list(:provider, 3)
+      allowed_ratifying_providers = FactoryBot.build_list(:provider, 2)
+
+      allowed_training_providers.each do |training_provider|
+        FactoryBot.create(:provider_relationship_permissions,
+                          training_provider: training_provider,
+                          training_provider_can_make_decisions: false,
+                          ratifying_provider: provider,
+                          ratifying_provider_can_make_decisions: true)
+      end
+
+      allowed_ratifying_providers.each do |training_provider|
+        FactoryBot.create(:provider_relationship_permissions,
+                          ratifying_provider: training_provider,
+                          ratifying_provider_can_make_decisions: false,
+                          training_provider: provider,
+                          training_provider_can_make_decisions: true)
+      end
+
+      render ProviderPartnerPermissionBreakdownComponent.new(
+        provider: provider,
+        permission: :make_decisions,
+      )
+    end
+
+    def only_partners_for_which_permission_does_not_apply
+      provider = FactoryBot.create(:provider)
+      prohibited_training_providers = FactoryBot.build_list(:provider, 1)
+      prohibited_ratifying_providers = FactoryBot.build_list(:provider, 1)
+
+      prohibited_training_providers.each do |training_provider|
+        FactoryBot.create(:provider_relationship_permissions,
+                          ratifying_provider: provider,
+                          training_provider: training_provider,
+                          training_provider_can_make_decisions: true,
+                          ratifying_provider_can_make_decisions: false)
+      end
+
+      prohibited_ratifying_providers.each do |training_provider|
+        FactoryBot.create(:provider_relationship_permissions,
+                          ratifying_provider: training_provider,
+                          training_provider: provider,
+                          training_provider_can_make_decisions: false,
+                          ratifying_provider_can_make_decisions: true)
+      end
+
+      render ProviderPartnerPermissionBreakdownComponent.new(
+        provider: provider,
+        permission: :make_decisions,
+      )
+    end
+  end
+end

--- a/spec/components/provider_interface/provider_partner_permission_breakdown_component_spec.rb
+++ b/spec/components/provider_interface/provider_partner_permission_breakdown_component_spec.rb
@@ -1,0 +1,160 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ProviderPartnerPermissionBreakdownComponent do
+  let(:provider) { create(:provider) }
+  let(:allowed_training_providers) { create_list(:provider, 3) }
+  let(:allowed_ratifying_providers) { create_list(:provider, 3) }
+  let(:prohibited_training_providers) { create_list(:provider, 2) }
+  let(:prohibited_ratifying_providers) { create_list(:provider, 2) }
+  let(:non_configured_providers) { create_list(:provider, 2) }
+  let(:render) do
+    render_inline(described_class.new(provider: provider, permission: :make_decisions))
+  end
+
+  describe '#partners_for_which_permission_applies' do
+    before do
+      allowed_training_providers.each do |training_provider|
+        create(:provider_relationship_permissions,
+               training_provider: training_provider,
+               ratifying_provider: provider,
+               ratifying_provider_can_make_decisions: true,
+               training_provider_can_make_decisions: false)
+      end
+
+      allowed_ratifying_providers.each do |training_provider|
+        create(:provider_relationship_permissions,
+               training_provider: provider,
+               ratifying_provider: training_provider,
+               training_provider_can_make_decisions: true,
+               ratifying_provider_can_make_decisions: false)
+      end
+    end
+
+    it 'returns a list of all providers that allow the specified provider to make decisions on their behalf' do
+      (allowed_training_providers + allowed_ratifying_providers).each do |provider|
+        expect(render.css('#partners-for-which-permission-applies').text).to include(provider.name)
+      end
+    end
+  end
+
+  describe '#partners_for_which_permission_does_not_apply' do
+    before do
+      prohibited_training_providers.each do |training_provider|
+        create(:provider_relationship_permissions,
+               training_provider: training_provider,
+               ratifying_provider: provider,
+               training_provider_can_make_decisions: true,
+               ratifying_provider_can_make_decisions: false)
+      end
+
+      prohibited_ratifying_providers.each do |training_provider|
+        create(:provider_relationship_permissions,
+               training_provider: provider,
+               ratifying_provider: training_provider,
+               training_provider_can_make_decisions: false,
+               ratifying_provider_can_make_decisions: true)
+      end
+
+      non_configured_providers.each do |training_provider|
+        create(:provider_relationship_permissions,
+               :not_set_up_yet,
+               training_provider: training_provider,
+               ratifying_provider: provider)
+      end
+    end
+
+    it 'returns a list of all providers that allow the specified provider to make decisions on their behalf' do
+      (prohibited_training_providers + prohibited_ratifying_providers + non_configured_providers).each do |provider|
+        expect(render.css('#partners-for-which-permission-does-not-apply').text).to include(provider.name)
+      end
+    end
+  end
+
+  describe '#partners_for_which_permission_applies_text' do
+    context 'when there are only partners where permission applies' do
+      before do
+        allowed_training_providers.each do |training_provider|
+          create(:provider_relationship_permissions,
+                 training_provider: training_provider,
+                 ratifying_provider: provider,
+                 ratifying_provider_can_make_decisions: true,
+                 training_provider_can_make_decisions: false)
+        end
+      end
+
+      it 'indicates that the permission applies to all partners' do
+        expect(render.css('.govuk-body')[0].text)
+          .to include('It currently applies to courses you work on with all of your partner organisations:')
+      end
+    end
+
+    context 'when there are both partners where permission applies and partners where it does not apply' do
+      before do
+        allowed_training_providers.each do |training_provider|
+          create(:provider_relationship_permissions,
+                 training_provider: training_provider,
+                 ratifying_provider: provider,
+                 ratifying_provider_can_make_decisions: true,
+                 training_provider_can_make_decisions: false)
+        end
+
+        prohibited_ratifying_providers.each do |training_provider|
+          create(:provider_relationship_permissions,
+                 training_provider: provider,
+                 ratifying_provider: training_provider,
+                 training_provider_can_make_decisions: false,
+                 ratifying_provider_can_make_decisions: true)
+        end
+      end
+
+      it 'does not indicate that the permission applies to all partners' do
+        expect(render.css('.govuk-body')[0].text)
+          .to include('It currently applies to courses you work on with:')
+      end
+    end
+  end
+
+  describe '#partners_for_which_permission_does_not_apply_text' do
+    context 'when there are only partners where permission does not apply' do
+      before do
+        prohibited_ratifying_providers.each do |training_provider|
+          create(:provider_relationship_permissions,
+                 training_provider: provider,
+                 ratifying_provider: training_provider,
+                 training_provider_can_make_decisions: false,
+                 ratifying_provider_can_make_decisions: true)
+        end
+      end
+
+      it 'indicates that the permission applies to all partners' do
+        expect(render.css('.govuk-body')[0].text)
+          .to include('It currently does not apply to courses you work on with any of your partner organisations:')
+      end
+    end
+
+    context 'when there are both partners where permission applies and partners where it does not apply' do
+      before do
+        allowed_training_providers.each do |training_provider|
+          create(:provider_relationship_permissions,
+                 training_provider: training_provider,
+                 ratifying_provider: provider,
+                 ratifying_provider_can_make_decisions: true,
+                 training_provider_can_make_decisions: false)
+        end
+
+        prohibited_ratifying_providers.each do |training_provider|
+          create(:provider_relationship_permissions,
+                 training_provider: provider,
+                 ratifying_provider: training_provider,
+                 training_provider_can_make_decisions: false,
+                 ratifying_provider_can_make_decisions: true)
+        end
+      end
+
+      it 'does not indicate that the permission applies to all partners' do
+        expect(render.css('.govuk-body')[1].text)
+          .to include('It currently does not apply to courses you work on with:')
+      end
+    end
+  end
+end


### PR DESCRIPTION
…, and how that permission interacts with related providers

## Context
Display relationship permission interaction with all providers

- Accepts a provider and specific permissions type (i.e. Make decisions, View safeguarding, View Diversity)
- Display a list of other Providers that have set-up relationships with the provider. 
- Splits list into ones where permissions are `true` and into ones where permissions are `false`  set to `false`
- If a relationship is not yet set up then the corresponding provider is shown in the "Does not apply" section (this is captured via the `false` check as the `ProviderRelationshipPermission` is always created via the TTAPI sync but with all permissions set to false)

Component can be reviewed via preview: 
e.g. http://localhost:3000/rails/view_components/provider_interface/user_org_permission_breakdown_component/view_safeguarding_information

## Screenshot

<img width="658" alt="Screenshot 2021-07-30 at 12 43 02" src="https://user-images.githubusercontent.com/159200/127634803-fa3e87c8-db21-4ae3-938e-3d7bcf316a50.png">



## Link to Trello card

https://trello.com/c/qqgyvXbD/4059-add-user-relationship-permissions-breakdown-component
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
