### PR TITLE
Fix placement of inset text for predicted degree grade

### DIFF
--- a/app/views/candidate_interface/degrees/grade/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/grade/_form_fields.html.erb
@@ -1,8 +1,6 @@
 <% if @degree_grade_form.international? %>
 
-  <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: @page_title, size: 'xl', tag: 'h1' } do %>
-    <p class="govuk-body"><%= t('application_form.degree.grade.international.grade_examples') %></p>
-
+  <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: @page_title, size: 'xl', tag: 'h1' }, hint: { text: t('application_form.degree.grade.international.grade_examples') } do %>
     <%= f.govuk_radio_button :grade, 'other', label: { text: 'Yes' }, link_errors: true do %>
       <% if degree.predicted_grade? %>
         <% text_field_options = { label: nil, hint: { text: t('application_form.degree.grade.international.hint_text') } } %>
@@ -19,11 +17,11 @@
 
 <% else %>
 
-  <% if degree.predicted_grade? %>
-    <%= govuk_inset_text(text: 'You must give an academic referee who can agree that you’re aiming for this grade.') %>
-  <% end %>
-
   <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: @page_title, size: 'xl', tag: 'h1' } do %>
+    <% if degree.predicted_grade? %>
+      <%= govuk_inset_text(text: t('application_form.degree.grade.inset_text')) %>
+    <% end %>
+
     <% @main_grades.each_with_index do |grade, i| %>
       <%= f.govuk_radio_button :grade, grade, label: { text: grade }, link_errors: i.zero? %>
     <% end %>

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -37,6 +37,7 @@ en:
         review_label: Grade
         review_label_predicted: Predicted grade
         change_action: grade
+        inset_text: You must give an academic referee who can agree that you’re aiming for this grade.
         international:
           grade_examples: For example, ‘A’, ‘4.5’, ‘94%’, ‘Distinction’
           hint_text: Enter the grade that you think you’ll get. You must give an academic referee who can agree that you’re aiming for this grade.


### PR DESCRIPTION
## Context

The inset text shown when entering a predicted grade should appear below the page heading, not above it.

## Changes proposed in this pull request

* Move inset text below page heading
* Localise inset text string
* Use hint text styling for example grades for international degree grade

<!-- If there are UI changes, please include Before and After screenshots. -->

| Before | After |
| - | - |
| <img width="660" alt="Screenshot 2021-07-30 at 11 49 43" src="https://user-images.githubusercontent.com/813383/127643025-71e26092-5228-419b-ad82-3a67c628b61f.png"> | <img width="640" alt="Screenshot 2021-07-30 at 11 50 05" src="https://user-images.githubusercontent.com/813383/127643027-0d2f75b7-55f2-4b0f-b791-7e4251175fa7.png"> |
| <img width="515" alt="Screenshot 2021-07-30 at 11 49 12" src="https://user-images.githubusercontent.com/813383/127643022-e9de3e2b-eded-4bfd-822c-9726b7ad7cb8.png"> | <img width="515" alt="Screenshot 2021-07-30 at 11 48 43" src="https://user-images.githubusercontent.com/813383/127643017-c05a6169-2646-4d48-b8d9-d997636c177c.png"> |
