### PR TITLE
Revisit factories following reference selection feature going live

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -156,6 +156,7 @@ private
         phase: apply_again ? 'apply_2' : 'apply_1',
         work_history_completed: false,
         previous_application_form: previous_application_form,
+        references_count: 0,
       )
 
       @application_form.application_work_experiences.each { |experience| experience.update!(created_at: time) }

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -34,6 +34,8 @@ FactoryBot.define do
       support_reference { GenerateSupportReference.call }
       transient do
         references_state { :feedback_provided }
+        references_selected { true }
+        references_count { 2 }
       end
 
       references_completed { true }
@@ -163,7 +165,7 @@ FactoryBot.define do
         volunteering_experiences_count { 0 }
         references_count { 2 }
         references_state { :feedback_provided }
-        references_selected { true }
+        references_selected { false }
         full_work_history { false }
       end
 

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -161,15 +161,16 @@ FactoryBot.define do
         submitted_application_choices_count { 0 }
         work_experiences_count { 0 }
         volunteering_experiences_count { 0 }
-        references_count { 0 }
-        references_state { :feedback_requested }
+        references_count { 2 }
+        references_state { :feedback_provided }
+        references_selected { true }
         full_work_history { false }
       end
 
       after(:create) do |application_form, evaluator|
         application_form.application_choices << build_list(:application_choice, evaluator.application_choices_count, status: 'unsubmitted')
         application_form.application_choices << build_list(:submitted_application_choice, evaluator.submitted_application_choices_count, application_form: application_form)
-        application_form.application_references << build_list(:reference, evaluator.references_count, evaluator.references_state)
+        application_form.application_references << build_list(:reference, evaluator.references_count, evaluator.references_state, selected: evaluator.references_selected)
 
         if evaluator.full_work_history
           current_year = Time.zone.today.year

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -27,7 +27,12 @@ RSpec.describe ApplicationForm do
 
     context 'when the form belongs to a previous recruitment cycle' do
       it 'throws an exception rather than touch an application choice' do
-        application_form = create(:completed_application_form, recruitment_cycle_year: RecruitmentCycle.previous_year, application_choices_count: 1)
+        application_form = create(
+          :completed_application_form,
+          recruitment_cycle_year: RecruitmentCycle.previous_year,
+          application_choices_count: 1,
+          references_count: 0,
+        )
 
         expect { application_form.update(first_name: 'Maria') }
           .to raise_error('Tried to mark an application choice from a previous cycle as changed')
@@ -42,7 +47,12 @@ RSpec.describe ApplicationForm do
 
       context 'when we allow unsafe touches' do
         it 'does not throw an exception' do
-          application_form = create(:completed_application_form, recruitment_cycle_year: RecruitmentCycle.previous_year, application_choices_count: 1)
+          application_form = create(
+            :completed_application_form,
+            recruitment_cycle_year: RecruitmentCycle.previous_year,
+            application_choices_count: 1,
+            references_count: 0,
+          )
 
           described_class.with_unsafe_application_choice_touches do
             expect { application_form.update(first_name: 'Maria') }

--- a/spec/models/carry_over_feature_metrics_spec.rb
+++ b/spec/models/carry_over_feature_metrics_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe CarryOverFeatureMetrics, with_audited: true do
       :completed_application_form,
       application_choices_count: 3,
       recruitment_cycle_year: RecruitmentCycle.previous_year,
+      references_count: 0,
     )
   end
 

--- a/spec/services/apply_again_spec.rb
+++ b/spec/services/apply_again_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ApplyAgain do
         volunteering_experiences_count: 1,
         full_work_history: true,
         recruitment_cycle_year: RecruitmentCycle.current_year,
+        references_count: 0,
       )
       create_list(:reference, 2, feedback_status: :feedback_provided, application_form: @original_application_form)
       create(:reference, feedback_status: :feedback_refused, application_form: @original_application_form)

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe CarryOverApplication do
         application_choices_count: 1,
         volunteering_experiences_count: 1,
         full_work_history: true,
+        references_count: 0,
       )
       create(:reference, feedback_status: :feedback_provided, application_form: application_form)
       create(:reference, feedback_status: :not_requested_yet, application_form: application_form)
@@ -50,7 +51,7 @@ RSpec.describe CarryOverApplication do
       end
     end
 
-    let(:application_form) { create(:completed_application_form) }
+    let(:application_form) { create(:completed_application_form, references_count: 0) }
 
     it 'sets the reference to the not_requested state' do
       create(:reference, feedback_status: :feedback_provided, application_form: application_form)
@@ -85,7 +86,7 @@ RSpec.describe CarryOverApplication do
       end
     end
 
-    let(:application_form) { create(:completed_application_form) }
+    let(:application_form) { create(:completed_application_form, references_count: 0) }
     let(:reference) { create(:reference, feedback_status: :feedback_requested, application_form: application_form) }
 
     it 'moves reference tokens from the old to new references' do

--- a/spec/services/support_interface/candidate_journey_tracker_spec.rb
+++ b/spec/services/support_interface/candidate_journey_tracker_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe SupportInterface::CandidateJourneyTracker, with_audited: true do
 
   describe 'completed references' do
     let!(:application_form) do
-      create(:completed_application_form, application_choices_count: 1)
+      create(:completed_application_form, application_choices_count: 1, references_count: 0)
     end
     let(:application_choice) { application_form.application_choices.first }
     let(:reference_1) { build(:reference, :feedback_provided, requested_at: 4.days.ago - 1.hour, feedback_provided_at: 1.day.ago) }

--- a/spec/services/ucas_matching/matching_data_export_spec.rb
+++ b/spec/services/ucas_matching/matching_data_export_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe UCASMatching::MatchingDataExport do
   let(:unsubmitted_form) { create(:application_form) }
-  let(:previous_recruitment_cycle_form) { create(:completed_application_form, application_choices_count: 3, recruitment_cycle_year: RecruitmentCycle.previous_year) }
+  let(:previous_recruitment_cycle_form) { create(:completed_application_form, application_choices_count: 3, recruitment_cycle_year: RecruitmentCycle.previous_year, references_count: 0) }
   let(:submitted_current_recruitment_cycle_form) { create(:completed_application_form, application_choices_count: 3) }
 
   describe '#relevant_applications' do

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_and_needs_to_select_course_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_and_needs_to_select_course_spec.rb
@@ -41,6 +41,7 @@ RSpec.feature 'Carry over' do
       submitted_at: nil,
       candidate: @candidate,
       safeguarding_issues_status: :no_safeguarding_issues_to_declare,
+      references_count: 0,
     )
     @application_choice = create(
       :application_choice,

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -53,6 +53,7 @@ RSpec.feature 'Carry over' do
       submitted_at: nil,
       candidate: @candidate,
       safeguarding_issues_status: :no_safeguarding_issues_to_declare,
+      references_count: 0,
     )
     @application_choice = create(
       :application_choice,

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
@@ -48,6 +48,7 @@ RSpec.feature 'Carry over' do
       submitted_at: nil,
       candidate: @candidate,
       safeguarding_issues_status: :no_safeguarding_issues_to_declare,
+      references_count: 0,
     )
     @first_reference = create(
       :reference,

--- a/spec/system/candidate_interface/references/candidate_replaces_reference_after_applying_again_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_replaces_reference_after_applying_again_spec.rb
@@ -39,9 +39,14 @@ RSpec.feature 'Candidate applying again' do
   end
 
   def when_i_have_an_unsuccessful_application_with_references
-    @application_form = create(:completed_application_form, :with_gcses, candidate: @candidate, safeguarding_issues_status: :no_safeguarding_issues_to_declare)
+    @application_form = create(
+      :completed_application_form,
+      :with_gcses,
+      candidate: @candidate,
+      safeguarding_issues_status: :no_safeguarding_issues_to_declare,
+    )
     create(:application_choice, status: :rejected, application_form: @application_form)
-    @completed_references = create_list(:reference, 2, feedback_status: :feedback_provided, application_form: @application_form)
+    @completed_references = @application_form.application_references
     @refused_reference = create(:reference, feedback_status: :feedback_refused, application_form: @application_form)
   end
 

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -67,7 +67,12 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
 
   def given_i_am_a_referee_of_an_application
     @reference = create(:reference, :feedback_requested, email_address: 'terri@example.com', name: 'Terri Tudor')
-    @application = create(:completed_application_form, application_references: [@reference], candidate: current_candidate)
+    @application = create(
+      :completed_application_form,
+      references_count: 0,
+      application_references: [@reference],
+      candidate: current_candidate,
+    )
   end
 
   def and_i_received_the_initial_reference_request_email

--- a/spec/system/referee_interface/referee_tries_to_submit_incomplete_reference_spec.rb
+++ b/spec/system/referee_interface/referee_tries_to_submit_incomplete_reference_spec.rb
@@ -14,7 +14,11 @@ RSpec.feature 'Stop submission of incomplete references', with_audited: true do
 
   def given_i_am_a_referee_of_an_application
     @reference = create(:reference, :feedback_requested)
-    @application = create(:completed_application_form, application_references: [@reference])
+    @application = create(
+      :completed_application_form,
+      references_count: 0,
+      application_references: [@reference],
+    )
   end
 
   def and_i_received_the_initial_reference_request_email

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -30,10 +30,20 @@ RSpec.feature 'See an application' do
   end
 
   def and_there_are_applications_in_the_system
-    @completed_application = create(:completed_application_form, :with_gcses, references_count: 2)
+    @completed_application = create(
+      :completed_application_form,
+      :with_gcses,
+      references_count: 2,
+      references_state: :feedback_requested,
+    )
     SubmitApplication.new(@completed_application).call
     @unsubmitted_application = create(:application_form)
-    @application_with_reference = create(:completed_application_form, :with_gcses, references_count: 2)
+    @application_with_reference = create(
+      :completed_application_form,
+      :with_gcses,
+      references_count: 2,
+      references_state: :feedback_requested,
+    )
   end
 
   def and_an_application_has_received_a_reference

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -33,7 +33,6 @@ RSpec.feature 'See an application' do
     @completed_application = create(
       :completed_application_form,
       :with_gcses,
-      references_count: 2,
       references_state: :feedback_requested,
     )
     SubmitApplication.new(@completed_application).call
@@ -41,7 +40,6 @@ RSpec.feature 'See an application' do
     @application_with_reference = create(
       :completed_application_form,
       :with_gcses,
-      references_count: 2,
       references_state: :feedback_requested,
     )
   end

--- a/spec/workers/detect_invariants_daily_check_spec.rb
+++ b/spec/workers/detect_invariants_daily_check_spec.rb
@@ -93,13 +93,9 @@ RSpec.describe DetectInvariantsDailyCheck do
       application_form_with_three_selected_references = create(:completed_application_form, :with_completed_references)
       create(:submitted_application_choice, application_form: application_form_with_three_selected_references)
       create(:reference, :feedback_provided, selected: true, application_form: application_form_with_three_selected_references)
-      create(:reference, :feedback_provided, selected: true, application_form: application_form_with_three_selected_references)
-      create(:reference, :feedback_provided, selected: true, application_form: application_form_with_three_selected_references)
 
       valid_application_form = create(:completed_application_form, :with_completed_references)
       create(:submitted_application_choice, application_form: valid_application_form)
-      create(:reference, :feedback_provided, selected: true, application_form: valid_application_form)
-      create(:reference, :feedback_provided, selected: true, application_form: valid_application_form)
 
       described_class.new.perform
 


### PR DESCRIPTION
## Context

Now that reference selection has been deployed to production we should review our factories. In the past, it made sense for a completed_application_form to not have any references on it by default (because references would be received after app submission). This is no longer the case, so maybe this factory should create an application form with two selected, feedback_provided references. Also, the with_completed_references trait should be updated so that it does the same thing for any application form.

## Changes proposed in this pull request

Investigate whether `completed_application_form` trait should create selected references.

## Guidance to review

- Does this change make sense?
- Are there any knock-on effects that I've not thought of (other than the various spec regressions that I've fixed)?

## Link to Trello card

https://trello.com/c/UT52kbRQ/3518-delete-referenceselection-feature-flag

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
