### PR TITLE
Remove assets precompile stage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build gems-node-modules Docker Image
         uses: docker/build-push-action@v2
         with:
-          target: apply-for-teacher-training-gems-node-modules
+          target: gems-node-modules
           tags: |
             ${{ env.GEMS_NODE_MODULES_IMAGE }}:${{ env.BRANCH_TAG }}
           push: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           target: gems-node-modules
           tags: |
+            ${{ env.GEMS_NODE_MODULES_IMAGE }}:${{ env.IMAGE_TAG }}
             ${{ env.GEMS_NODE_MODULES_IMAGE }}:${{ env.BRANCH_TAG }}
           push: true
           cache-to: type=inline
@@ -67,9 +68,9 @@ jobs:
             type=registry,ref=${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
             type=registry,ref=${{ env.DOCKER_IMAGE }}:${{ env.BRANCH_TAG }}
             type=registry,ref=${{ env.GEMS_NODE_MODULES_IMAGE }}:${{ env.BRANCH_TAG }}
+            type=register,ref=${{ env.GEMS_NODE_MODULES_IMAGE }}:main
           build-args: |
             VERSION=${{ env.IMAGE_TAG }}
-            BASE_RUBY_IMAGE_WITH_GEMS_AND_NODE_MODULES=${{ env.GEMS_NODE_MODULES_IMAGE }}:${{ env.BRANCH_TAG }}
 
   lint:
     name: Lint
@@ -79,7 +80,7 @@ jobs:
       run:
         working-directory: /app
     container:
-      image: ghcr.io/dfe-digital/apply-teacher-training:${{ needs.build.outputs.IMAGE_TAG }}
+      image: ghcr.io/dfe-digital/apply-teacher-training-gems-node-modules:${{ needs.build.outputs.IMAGE_TAG }}
       options: -a STDOUT -a STDERR -t
       credentials:
         username: ${{ github.actor }}
@@ -93,6 +94,12 @@ jobs:
 
     - run:  bundle exec rake brakeman
       name: Brakeman
+
+    - name: Yarn Lint
+      run: |
+        yarn install
+        yarn run lint && yarn run stylelint app/frontend/styles && \
+        yarn run test
 
   test:
     name: Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,13 +54,8 @@ COPY --from=install-gems-node-modules /usr/local/bundle/ /usr/local/bundle/
 WORKDIR /app
 COPY . .
 
-RUN yarn run lint && \
-    yarn run test && \
-    yarn run stylelint app/frontend/styles && \
-    bundle exec rake assets:precompile && \
-    apk del nodejs yarn && \
-    rm -rf yarn.lock && \
-    rm -rf tmp/* log/* node_modules /usr/local/share/.cache /tmp/*
+RUN bundle exec rake assets:precompile && \
+    rm -rf tmp/* log/* node_modules /tmp/*
 
 # Stage 3: production, copy application code and compiled assets to base ruby image.
 # Depends on assets-precompile stage which can be cached from a pre-built image


### PR DESCRIPTION
## Context

Simplify the different stages in the Dockerfile

## Changes proposed in this pull request

Remove separate stage for assets precompile and move it inside a different layer in the gems-node-modules stage.

## Guidance to review


## Link to Trello card
https://trello.com/c/6vdVY6PL/481-refactor-apply-docker-image

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
