### PR TITLE
Use batch size 100 for the apply again perform dashboard

### DIFF
--- a/app/models/apply_again_feature_metrics.rb
+++ b/app/models/apply_again_feature_metrics.rb
@@ -7,7 +7,7 @@ class ApplyAgainFeatureMetrics
   )
     success_count = 0.0
     fail_count = 0.0
-    application_forms(start_time, end_time).find_each do |application_form|
+    application_forms(start_time, end_time).find_each(batch_size: 100) do |application_form|
       if application_form.successful?
         success_count += 1
       elsif application_form.ended_without_success?


### PR DESCRIPTION
## Context

The feature metric dashboard  worker is timing out on this request.

Just checking that smaller batch sizing will not fix the issue before diving into rethinking how we populate this field.

## Changes proposed in this pull request

- Use a smaller batch size for the request

## Link to Trello card

https://trello.com/c/BUgLV77S/3733-feature-metric-dashboard-is-timing-out

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
