### PR TITLE
Fix redirects when updating personal details

### DIFF
--- a/app/components/candidate_interface/contact_details_review_component.rb
+++ b/app/components/candidate_interface/contact_details_review_component.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class ContactDetailsReviewComponent < ViewComponent::Base
-    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
+    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false, return_to_application_review: false)
       @application_form = application_form
       @contact_details_form = CandidateInterface::ContactDetailsForm.build_from_application(
         @application_form,
@@ -8,6 +8,7 @@ module CandidateInterface
       @editable = editable
       @missing_error = missing_error
       @submitting_application = submitting_application
+      @return_to_application_review = return_to_application_review
     end
 
     def contact_details_form_rows
@@ -27,18 +28,20 @@ module CandidateInterface
         key: t('application_form.contact_details.phone_number.label'),
         value: @contact_details_form.phone_number,
         action: t('application_form.contact_details.phone_number.change_action'),
-        change_path: candidate_interface_edit_phone_number_path,
+        change_path: candidate_interface_edit_phone_number_path(return_to_params),
+        data_qa: 'contact-details-phone-number',
       }
     end
 
     def address_row
-      change_path = candidate_interface_edit_address_type_path
+      change_path = candidate_interface_edit_address_type_path(return_to_params)
 
       {
         key: t('application_form.contact_details.full_address.label'),
         value: full_address,
         action: t('application_form.contact_details.full_address.change_action'),
         change_path: change_path,
+        data_qa: 'contact-details-address',
       }
     end
 
@@ -58,6 +61,10 @@ module CandidateInterface
         @contact_details_form.address_line4,
         @contact_details_form.postcode,
       ]
+    end
+
+    def return_to_params
+      { 'return-to' => 'application-review' } if @return_to_application_review
     end
   end
 end

--- a/app/components/candidate_interface/personal_details_review_component.rb
+++ b/app/components/candidate_interface/personal_details_review_component.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class PersonalDetailsReviewComponent < ViewComponent::Base
-    def initialize(application_form:, editable: true, missing_error: false)
+    def initialize(application_form:, editable: true, missing_error: false, return_to_application_review: false)
       @application_form = application_form
       @personal_details_form = CandidateInterface::PersonalDetailsForm.build_from_application(
         application_form,
@@ -16,6 +16,7 @@ module CandidateInterface
       )
       @editable = editable
       @missing_error = missing_error
+      @return_to_application_review = return_to_application_review
     end
 
     def rows
@@ -25,6 +26,7 @@ module CandidateInterface
         languages_form: @languages_form,
         application_form: @application_form,
         right_to_work_form: @right_to_work_or_study_form,
+        return_to_application_review: @return_to_application_review,
       ).rows
     end
 

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -39,10 +39,14 @@ module CandidateInterface
 
     def return_to_after_edit(default:)
       if redirect_back_to_application_review_page?
-        { back_path: candidate_interface_application_review_path, params: { 'return-to' => 'application-review' } }
+        { back_path: candidate_interface_application_review_path, params: redirect_back_to_application_review_page_params }
       else
         { back_path: default, params: {} }
       end
+    end
+
+    def redirect_back_to_application_review_page_params
+      { 'return-to' => 'application-review' }
     end
 
     def redirect_back_to_application_review_page?

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -37,6 +37,22 @@ module CandidateInterface
       redirect_to candidate_interface_application_form_path if candidate_signed_in?
     end
 
+    def return_to_after_edit(default:)
+      if redirect_back_to_application_review_page?
+        { back_path: candidate_interface_application_review_path, params: { 'return-to' => 'application-review' } }
+      else
+        { back_path: default, params: {} }
+      end
+    end
+
+    def redirect_back_to_application_review_page?
+      params['return-to'] == 'application-review'
+    end
+
+    def application_review_path_and_params
+      { path: candidate_interface_application_review_path, params: { 'return-to' => 'application-review' } }
+    end
+
     def show_pilot_holding_page_if_not_open
       return if FeatureFlag.active?('pilot_open')
 

--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -15,7 +15,7 @@ module CandidateInterface
         redirect_to candidate_interface_contact_information_review_path
       else
         track_validation_error(@contact_details_form)
-        render :edit
+        render :new
       end
     end
 
@@ -23,14 +23,18 @@ module CandidateInterface
       @contact_details_form = ContactDetailsForm.build_from_application(
         current_application,
       )
+      @return_to = return_to_after_edit(default: candidate_interface_edit_address_type_path)
     end
 
     def update
       @contact_details_form = ContactDetailsForm.new(
         contact_details_params.merge(address_type: current_application.address_type),
       )
+      @return_to = return_to_after_edit(default: candidate_interface_edit_address_type_path)
 
       if @contact_details_form.save_address(current_application)
+        return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
+
         redirect_to candidate_interface_contact_information_review_path
       else
         track_validation_error(@contact_details_form)

--- a/app/controllers/candidate_interface/contact_details/address_type_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_type_controller.rb
@@ -21,13 +21,18 @@ module CandidateInterface
       @contact_details_form = ContactDetailsForm.build_from_application(
         current_application,
       )
+      @return_to = return_to_after_edit(default: candidate_interface_personal_details_complete_path)
     end
 
     def update
       @contact_details_form = ContactDetailsForm.new(address_type_params)
 
       if @contact_details_form.save_address_type(current_application)
-        redirect_to candidate_interface_edit_address_path
+        if redirect_back_to_application_review_page?
+          redirect_to candidate_interface_edit_address_path(redirect_back_to_application_review_page_params)
+        else
+          redirect_to candidate_interface_edit_address_path
+        end
       else
         track_validation_error(@contact_details_form)
         render :edit

--- a/app/controllers/candidate_interface/contact_details/phone_number_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/phone_number_controller.rb
@@ -20,12 +20,16 @@ module CandidateInterface
       @contact_details_form = ContactDetailsForm.build_from_application(
         current_application,
       )
+      @return_to = return_to_after_edit(default: candidate_interface_contact_information_review_path)
     end
 
     def update
       @contact_details_form = ContactDetailsForm.new(contact_details_params)
+      @return_to = return_to_after_edit(default: candidate_interface_contact_information_review_path)
 
       if @contact_details_form.save_base(current_application)
+        return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
+
         redirect_to candidate_interface_contact_information_review_path
       else
         track_validation_error(@contact_details_form)

--- a/app/controllers/candidate_interface/personal_details/languages_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/languages_controller.rb
@@ -21,13 +21,17 @@ module CandidateInterface
 
       def edit
         @languages_form = LanguagesForm.build_from_application(current_application)
+        @return_to = return_to_after_edit(default: candidate_interface_personal_details_complete_path)
       end
 
       def update
         @application_form = current_application
         @languages_form = LanguagesForm.new(languages_params)
+        @return_to = return_to_after_edit(default: candidate_interface_personal_details_complete_path)
 
         if @languages_form.save(current_application)
+          return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
+
           redirect_to candidate_interface_personal_details_show_path
         else
           track_validation_error(@languages_form)

--- a/app/controllers/candidate_interface/personal_details/name_and_dob_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/name_and_dob_controller.rb
@@ -21,13 +21,17 @@ module CandidateInterface
 
       def edit
         @personal_details_form = PersonalDetailsForm.build_from_application(current_application)
+        @return_to = return_to_after_edit(default: candidate_interface_personal_details_complete_path)
       end
 
       def update
         @application_form = current_application
         @personal_details_form = PersonalDetailsForm.new(personal_details_params)
+        @return_to = return_to_after_edit(default: candidate_interface_personal_details_complete_path)
 
         if @personal_details_form.save(current_application)
+          return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
+
           redirect_to candidate_interface_personal_details_show_path
         else
           track_validation_error(@personal_details_form)

--- a/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
@@ -27,13 +27,16 @@ module CandidateInterface
 
       def edit
         @nationalities_form = NationalitiesForm.build_from_application(current_application)
+        @return_to = return_to_after_edit(default: candidate_interface_personal_details_complete_path)
       end
 
       def update
         @application_form = current_application
         @nationalities_form = NationalitiesForm.new(prepare_nationalities_params)
+        @return_to = return_to_after_edit(default: candidate_interface_personal_details_complete_path)
 
         if @nationalities_form.save(current_application)
+          return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
           return redirect_to candidate_interface_edit_right_to_work_or_study_path if !british_or_irish?
 
           redirect_to candidate_interface_personal_details_show_path

--- a/app/controllers/candidate_interface/personal_details/right_to_work_or_study_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/right_to_work_or_study_controller.rb
@@ -24,12 +24,16 @@ module CandidateInterface
 
       def edit
         @right_to_work_or_study_form = RightToWorkOrStudyForm.build_from_application(current_application)
+        @return_to = return_to_after_edit(default: candidate_interface_personal_details_complete_path)
       end
 
       def update
         @right_to_work_or_study_form = RightToWorkOrStudyForm.new(right_to_work_params)
+        @return_to = return_to_after_edit(default: candidate_interface_personal_details_complete_path)
 
         if @right_to_work_or_study_form.save(current_application)
+          return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
+
           redirect_to candidate_interface_personal_details_show_path
         else
           track_validation_error(@right_to_work_or_study_form)

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -3,13 +3,14 @@ module CandidateInterface
     include ActionView::Helpers::TagHelper
     include Rails.application.routes.url_helpers
 
-    def initialize(personal_details_form:, nationalities_form:, languages_form:, right_to_work_form:, application_form:, editable: true)
+    def initialize(personal_details_form:, nationalities_form:, languages_form:, right_to_work_form:, application_form:, editable: true, return_to_application_review: false)
       @personal_details_form = personal_details_form
       @nationalities_form = nationalities_form
       @languages_form = languages_form
       @right_to_work_or_study_form = right_to_work_form
       @application_form = application_form
       @editable = editable
+      @return_to_application_review = return_to_application_review
     end
 
     def rows
@@ -36,7 +37,8 @@ module CandidateInterface
         key: I18n.t('application_form.personal_details.name.label'),
         value: @personal_details_form.name,
         action: ('name' if @editable),
-        change_path: candidate_interface_edit_name_and_dob_path,
+        change_path: candidate_interface_edit_name_and_dob_path(return_to_params),
+        data_qa: 'personal-details-name',
       }
     end
 
@@ -45,7 +47,8 @@ module CandidateInterface
         key: I18n.t('application_form.personal_details.date_of_birth.label'),
         value: @personal_details_form.date_of_birth.to_s(:govuk_date),
         action: ('date of birth' if @editable),
-        change_path: candidate_interface_edit_name_and_dob_path,
+        change_path: candidate_interface_edit_name_and_dob_path(return_to_params),
+        data_qa: 'personal-details-dob',
       }
     end
 
@@ -54,7 +57,8 @@ module CandidateInterface
         key: I18n.t('application_form.personal_details.nationality.label'),
         value: formatted_nationalities,
         action: ('nationality' if @editable),
-        change_path: candidate_interface_edit_nationalities_path,
+        change_path: candidate_interface_edit_nationalities_path(return_to_params),
+        data_qa: 'personal-details-nationality',
       }
     end
 
@@ -63,7 +67,8 @@ module CandidateInterface
         key: I18n.t('application_form.personal_details.english_main_language.label'),
         value: @languages_form.english_main_language&.titleize,
         action: ('if English is your main language' if @editable),
-        change_path: candidate_interface_edit_languages_path,
+        change_path: candidate_interface_edit_languages_path(return_to_params),
+        data_qa: 'personal-details-english-main-language',
       }
     end
 
@@ -80,7 +85,8 @@ module CandidateInterface
         key: I18n.t('application_form.personal_details.other_language_details.label'),
         value: @languages_form.other_language_details,
         action: ('other languages' if @editable),
-        change_path: candidate_interface_edit_languages_path,
+        change_path: candidate_interface_edit_languages_path(return_to_params),
+        data_qa: 'personal-details-other-language',
       }
     end
 
@@ -89,7 +95,8 @@ module CandidateInterface
         key: I18n.t('application_form.personal_details.english_language_details.label'),
         value: @languages_form.english_language_details,
         action: ('English language qualifications' if @editable),
-        change_path: candidate_interface_edit_languages_path,
+        change_path: candidate_interface_edit_languages_path(return_to_params),
+        data_qa: 'personal-details-english-details',
       }
     end
 
@@ -100,7 +107,8 @@ module CandidateInterface
         key: 'Immigration status',
         value: formatted_right_to_work_or_study,
         action: ('Right to work or study' if @editable),
-        change_path: candidate_interface_edit_right_to_work_or_study_path,
+        change_path: candidate_interface_edit_right_to_work_or_study_path(return_to_params),
+        data_qa: 'personal_details_right_to_work_or_study',
       }
     end
 
@@ -129,6 +137,10 @@ module CandidateInterface
       else
         'I do not know'
       end
+    end
+
+    def return_to_params
+      { 'return-to' => 'application-review' } if @return_to_application_review
     end
   end
 end

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -31,7 +31,7 @@
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.personal_details') %></h2>
   <h3 class="govuk-heading-m"><%= t('page_titles.personal_information') %></h3>
-  <%= render(CandidateInterface::PersonalDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
+  <%= render(CandidateInterface::PersonalDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, return_to_application_review: true)) %>
   <h3 class="govuk-heading-m"><%= t('page_titles.contact_information') %></h3>
   <%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 </section>

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -33,7 +33,7 @@
   <h3 class="govuk-heading-m"><%= t('page_titles.personal_information') %></h3>
   <%= render(CandidateInterface::PersonalDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, return_to_application_review: true)) %>
   <h3 class="govuk-heading-m"><%= t('page_titles.contact_information') %></h3>
-  <%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
+  <%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true, return_to_application_review: true)) %>
 </section>
 
 <section class="govuk-!-margin-bottom-8">

--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.address'), @contact_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_edit_address_type_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_edit_address_path, method: :patch do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_edit_address_path(@return_to[:params]), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= render 'form', f: f %>

--- a/app/views/candidate_interface/contact_details/address_type/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address_type/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.where_do_you_live'), @contact_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_contact_information_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_edit_address_type_path, method: :patch do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_edit_address_type_path(@return_to[:params]), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= render 'form', f: f %>

--- a/app/views/candidate_interface/contact_details/phone_number/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/phone_number/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.contact_details'), @contact_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_contact_information_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_edit_phone_number_path, method: :patch do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_edit_phone_number_path(@return_to[:params]), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/personal_details/languages/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/languages/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.languages'), @languages_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_personal_details_complete_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
-<%= form_with model: @languages_form, url: candidate_interface_edit_languages_path, method: :patch do |f| %>
+<%= form_with model: @languages_form, url: candidate_interface_edit_languages_path(@return_to[:params]), method: :patch do |f| %>
   <%= render partial: 'shared_form', locals: { f: f } %>
 <% end %>

--- a/app/views/candidate_interface/personal_details/name_and_dob/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/name_and_dob/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.personal_information'), @personal_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_personal_details_complete_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @personal_details_form, url: candidate_interface_edit_name_and_dob_path, method: :patch do |f| %>
+    <%= form_with model: @personal_details_form, url: candidate_interface_edit_name_and_dob_path(@return_to[:params]), method: :patch do |f| %>
     <%= render partial: 'shared_form', locals: { f: f } %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_details/nationalities/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.nationalities'), @nationalities_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_personal_details_complete_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @nationalities_form, url: candidate_interface_edit_nationalities_path, class: 'app-nationality', method: :patch do |f| %>
+    <%= form_with model: @nationalities_form, url: candidate_interface_edit_nationalities_path(@return_to[:params]), class: 'app-nationality', method: :patch do |f| %>
       <%= render partial: 'shared_form', locals: { f: f } %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.right_to_work'), @right_to_work_or_study_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_personal_details_complete_path) %>
+<% content_for :before_content, govuk_back_link_to(govuk_back_link_to(@return_to[:back_path])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @right_to_work_or_study_form, url: candidate_interface_edit_right_to_work_or_study_path, method: :patch do |f| %>
+    <%= form_with model: @right_to_work_or_study_form, url: candidate_interface_edit_right_to_work_or_study_path(@return_to[:params]), method: :patch do |f| %>
       <%= render partial: 'shared_form', locals: { f: f } %>
     <% end %>
   </div>

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       languages_form: languages_form,
       right_to_work_form: right_to_work_form,
       application_form: application_form,
+      return_to_application_review: true,
     ).rows
   end
 
@@ -71,8 +72,18 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(personal_details_form: personal_details_form)).to include(
-        row_for(:name, 'Max Caulfield', candidate_interface_edit_name_and_dob_path),
-        row_for(:date_of_birth, '21 September 1995', candidate_interface_edit_name_and_dob_path),
+        row_for(
+          :name,
+          'Max Caulfield',
+          candidate_interface_edit_name_and_dob_path('return-to' => 'application-review'),
+          'personal-details-name',
+        ),
+        row_for(
+          :date_of_birth,
+          '21 September 1995',
+          candidate_interface_edit_name_and_dob_path('return-to' => 'application-review'),
+          'personal-details-dob',
+        ),
       )
     end
   end
@@ -86,7 +97,12 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(nationalities_form: nationalities_form)).to include(
-        row_for(:nationality, 'British', candidate_interface_edit_nationalities_path),
+        row_for(
+          :nationality,
+          'British',
+          candidate_interface_edit_nationalities_path('return-to' => 'application-review'),
+          'personal-details-nationality',
+        ),
       )
     end
 
@@ -99,7 +115,12 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(nationalities_form: nationalities_form)).to include(
-        row_for(:nationality, 'British and Spanish', candidate_interface_edit_nationalities_path),
+        row_for(
+          :nationality,
+          'British and Spanish',
+          candidate_interface_edit_nationalities_path('return-to' => 'application-review'),
+          'personal-details-nationality',
+        ),
       )
     end
 
@@ -114,7 +135,12 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(nationalities_form: nationalities_form)).to include(
-        row_for(:nationality, 'British, French, German, and Spanish', candidate_interface_edit_nationalities_path),
+        row_for(
+          :nationality,
+          'British, French, German, and Spanish',
+          candidate_interface_edit_nationalities_path('return-to' => 'application-review'),
+          'personal-details-nationality',
+        ),
       )
     end
   end
@@ -149,7 +175,12 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(nationalities_form: nationalities_form, right_to_work_form: right_to_work_form)).to include(
-        row_for(:right_to_work, 'I have the right to work or study in the UK<br> <p>I have the right.</p>', candidate_interface_edit_right_to_work_or_study_path),
+        row_for(
+          :right_to_work,
+          'I have the right to work or study in the UK<br> <p>I have the right.</p>',
+          candidate_interface_edit_right_to_work_or_study_path('return-to' => 'application-review'),
+          'personal_details_right_to_work_or_study',
+        ),
       )
     end
   end
@@ -173,17 +204,23 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(application_form: application_form, nationalities_form: nationalities_form, right_to_work_form: right_to_work_form)).not_to include(
-        row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", candidate_interface_edit_right_to_work_or_study_path),
+        row_for(
+          :right_to_work,
+          "I have the right to work or study in the UK \b<br> <p>I have the right.</p>",
+          candidate_interface_edit_right_to_work_or_study_path('return-to' => 'applicaton-review'),
+          'personal_details_right_to_work_or_study',
+        ),
       )
     end
   end
 
-  def row_for(key, value, path)
+  def row_for(key, value, path, data_qa)
     {
       key: t("application_form.personal_details.#{key}.label"),
       value: value,
       action: t("application_form.personal_details.#{key}.change_action"),
       change_path: path,
+      data_qa: data_qa,
     }
   end
 end

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_fields_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_fields_spec.rb
@@ -1,0 +1,185 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate is redirected correctly' do
+  include CandidateHelper
+
+  scenario 'Candidate reviews completed application and updates personal details fields' do
+    given_i_am_signed_in
+    when_i_have_completed_my_application
+    and_i_have_received_2_references
+    and_i_review_my_application
+    then_i_should_see_all_sections_are_complete
+
+    # name and contact details form
+    when_i_click_change_name
+    then_i_should_see_the_personal_details_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_my_name
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_name
+
+    # date of birth form
+    when_i_click_change_date_of_birth
+    then_i_should_see_the_personal_details_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_my_date_of_birth
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_date_of_birth
+
+    # nationality form
+    when_i_click_change_nationality
+    then_i_should_see_the_nationality_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_my_nationality
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_nationality
+
+    # languages form
+    when_i_click_change_language
+    then_i_should_see_the_language_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_my_language
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_language
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_have_completed_my_application
+    candidate_completes_application_form
+  end
+
+  def and_i_have_received_2_references
+    @current_candidate.current_application.application_references.each do |reference|
+      reference.update!(feedback_status: :feedback_provided)
+    end
+  end
+
+  def and_i_review_my_application
+    allow(LanguagesSectionPolicy).to receive(:hide?).and_return(false)
+    and_i_visit_the_application_form_page
+    when_i_click_on_check_your_answers
+  end
+
+  def then_i_should_see_all_sections_are_complete
+    application_form_sections.each do |section|
+      expect(page).not_to have_selector "[data-qa='incomplete-#{section}']"
+    end
+  end
+
+  def and_i_visit_the_application_form_page
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_check_your_answers
+    click_link 'Check and submit your application'
+  end
+
+  def when_i_click_change_name
+    within('[data-qa="personal-details-name"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_date_of_birth
+    within('[data-qa="personal-details-dob"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_nationality
+    within('[data-qa="personal-details-nationality"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_language
+    within('[data-qa="personal-details-english-main-language"]') do
+      click_link 'Change'
+    end
+  end
+
+  def then_i_should_see_the_personal_details_form
+    expect(page).to have_current_path(candidate_interface_edit_name_and_dob_path('return-to' => 'application-review'))
+  end
+
+  def then_i_should_see_the_nationality_form
+    expect(page).to have_current_path(candidate_interface_edit_nationalities_path('return-to' => 'application-review'))
+  end
+
+  def then_i_should_see_the_language_form
+    expect(page).to have_current_path(candidate_interface_edit_languages_path('return-to' => 'application-review'))
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def then_i_should_be_redirected_to_the_application_review_page
+    expect(page).to have_current_path(candidate_interface_application_review_path)
+  end
+
+  def when_i_update_my_name
+    when_i_click_change_name
+    fill_in 'First name', with: 'Ruddeger'
+    click_button 'Save and continue'
+  end
+
+  def when_i_update_my_date_of_birth
+    when_i_click_change_date_of_birth
+    fill_in 'Day', with: '2'
+    click_button 'Save and continue'
+  end
+
+  def when_i_update_my_nationality
+    when_i_click_change_nationality
+
+    check 'Irish'
+    click_button 'Save and continue'
+  end
+
+  def when_i_update_my_language
+    when_i_click_change_language
+
+    choose 'No'
+    click_button 'Save and continue'
+  end
+
+  def and_i_should_see_my_updated_name
+    within('[data-qa="personal-details-name"]') do
+      expect(page).to have_content('Ruddeger')
+    end
+  end
+
+  def and_i_should_see_my_updated_date_of_birth
+    within('[data-qa="personal-details-dob"]') do
+      expect(page).to have_content('2')
+    end
+  end
+
+  def and_i_should_see_my_updated_nationality
+    within('[data-qa="personal-details-nationality"]') do
+      expect(page).to have_content('Irish')
+    end
+  end
+
+  def and_i_should_see_my_updated_language
+    within('[data-qa="personal-details-english-main-language"]') do
+      expect(page).to have_content('No')
+    end
+  end
+end

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb
@@ -3,14 +3,13 @@ require 'rails_helper'
 RSpec.feature 'Candidate is redirected correctly' do
   include CandidateHelper
 
-  scenario 'Candidate reviews completed application and updates personal details fields' do
+  scenario 'Candidate reviews completed application and updates personal details section' do
     given_i_am_signed_in
     when_i_have_completed_my_application
-    and_i_have_received_2_references
     and_i_review_my_application
     then_i_should_see_all_sections_are_complete
 
-    # name and contact details form
+    # name
     when_i_click_change_name
     then_i_should_see_the_personal_details_form
 
@@ -21,7 +20,7 @@ RSpec.feature 'Candidate is redirected correctly' do
     then_i_should_be_redirected_to_the_application_review_page
     and_i_should_see_my_updated_name
 
-    # date of birth form
+    # date of birth
     when_i_click_change_date_of_birth
     then_i_should_see_the_personal_details_form
 
@@ -32,7 +31,7 @@ RSpec.feature 'Candidate is redirected correctly' do
     then_i_should_be_redirected_to_the_application_review_page
     and_i_should_see_my_updated_date_of_birth
 
-    # nationality form
+    # nationality
     when_i_click_change_nationality
     then_i_should_see_the_nationality_form
 
@@ -43,7 +42,7 @@ RSpec.feature 'Candidate is redirected correctly' do
     then_i_should_be_redirected_to_the_application_review_page
     and_i_should_see_my_updated_nationality
 
-    # languages form
+    # languages
     when_i_click_change_language
     then_i_should_see_the_language_form
 
@@ -53,6 +52,28 @@ RSpec.feature 'Candidate is redirected correctly' do
     when_i_update_my_language
     then_i_should_be_redirected_to_the_application_review_page
     and_i_should_see_my_updated_language
+
+    # phone number
+    when_i_click_change_phone_number
+    then_i_should_see_the_phone_number_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_my_phone_number
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_phone_number
+
+    # address
+    when_i_click_change_address
+    then_i_should_see_the_address_type_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_my_address
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_address
   end
 
   def given_i_am_signed_in
@@ -61,9 +82,6 @@ RSpec.feature 'Candidate is redirected correctly' do
 
   def when_i_have_completed_my_application
     candidate_completes_application_form
-  end
-
-  def and_i_have_received_2_references
     @current_candidate.current_application.application_references.each do |reference|
       reference.update!(feedback_status: :feedback_provided)
     end
@@ -113,6 +131,18 @@ RSpec.feature 'Candidate is redirected correctly' do
     end
   end
 
+  def when_i_click_change_phone_number
+    within('[data-qa="contact-details-phone-number"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_address
+    within('[data-qa="contact-details-address"]') do
+      click_link 'Change'
+    end
+  end
+
   def then_i_should_see_the_personal_details_form
     expect(page).to have_current_path(candidate_interface_edit_name_and_dob_path('return-to' => 'application-review'))
   end
@@ -123,6 +153,14 @@ RSpec.feature 'Candidate is redirected correctly' do
 
   def then_i_should_see_the_language_form
     expect(page).to have_current_path(candidate_interface_edit_languages_path('return-to' => 'application-review'))
+  end
+
+  def then_i_should_see_the_phone_number_form
+    expect(page).to have_current_path(candidate_interface_edit_phone_number_path('return-to' => 'application-review'))
+  end
+
+  def then_i_should_see_the_address_type_form
+    expect(page).to have_current_path(candidate_interface_edit_address_type_path('return-to' => 'application-review'))
   end
 
   def when_i_click_back
@@ -159,6 +197,21 @@ RSpec.feature 'Candidate is redirected correctly' do
     click_button 'Save and continue'
   end
 
+  def when_i_update_my_phone_number
+    when_i_click_change_phone_number
+
+    fill_in 'Phone number', with: '0736519012'
+    click_button 'Save and continue'
+  end
+
+  def when_i_update_my_address
+    when_i_click_change_address
+
+    click_button 'Save and continue'
+    fill_in 'Town or city', with: 'Auckland'
+    click_button 'Save and continue'
+  end
+
   def and_i_should_see_my_updated_name
     within('[data-qa="personal-details-name"]') do
       expect(page).to have_content('Ruddeger')
@@ -180,6 +233,18 @@ RSpec.feature 'Candidate is redirected correctly' do
   def and_i_should_see_my_updated_language
     within('[data-qa="personal-details-english-main-language"]') do
       expect(page).to have_content('No')
+    end
+  end
+
+  def and_i_should_see_my_updated_phone_number
+    within('[data-qa="contact-details-phone-number"]') do
+      expect(page).to have_content('0736519012')
+    end
+  end
+
+  def and_i_should_see_my_updated_address
+    within('[data-qa="contact-details-address"]') do
+      expect(page).to have_content('Auckland')
     end
   end
 end


### PR DESCRIPTION
## Context

_The first in possibly, a large-ish number of PRs_

If you visit the review unsubmitted application form page and click change on any of the links, then either:

1. update the field and click save and continue 
or
2. click the backlink

You are redirected the review page for the section.

In both of these cases you should be redirected to the review submitted page 

## Changes proposed in this pull request

Use params (`&return-to=application-review`) to redirect the candidate back to the application review path when required.

## Guidance to review

- This PR deals with the personal details section only. Other PRs to follow for remaining sections.

## Link to Trello card

https://trello.com/c/0MxsfCi5/3720-bug-change-links-and-backlinks-are-not-working-correctly-from-the-review-unsubmitted-page


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
