### PR TITLE
Add user permissions summary component

### DIFF
--- a/app/components/provider_interface/user_permission_summary_component.html.erb
+++ b/app/components/provider_interface/user_permission_summary_component.html.erb
@@ -1,0 +1,24 @@
+<%= tag.dl(class: 'govuk-summary-list') do %>
+  <% ProviderPermissions::VALID_PERMISSIONS.each do |permission| %>
+    <%= tag.div(class: 'govuk-summary-list__row') do %>
+      <dt class="govuk-summary-list__key">
+        <%= description_for(permission) %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= can_perform_permission_y_n?(permission) %>
+        <% if ProviderRelationshipPermissions::PERMISSIONS.include?(permission) && can_perform_permission?(permission) %>
+          <p>This user permission is affected by organisation permissions.</p>
+          <%= render ProviderInterface::ProviderPartnerPermissionBreakdownComponent.new(provider: provider, permission: permission) %>
+        <% end %>
+      </dd>
+      <% if can_change_permissions? %>
+        <dd class="govuk-summary-list__actions">
+          <%= govuk_link_to(provider_interface_provider_user_edit_permissions_path(provider_user, provider), class: 'govuk-!-display-none-print') do %>
+            Change
+            <span class="govuk-visually-hidden"><%= description_for(permission) %></span>
+          <% end %>
+        </dd>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/provider_interface/user_permission_summary_component.rb
+++ b/app/components/provider_interface/user_permission_summary_component.rb
@@ -1,0 +1,29 @@
+module ProviderInterface
+  class UserPermissionSummaryComponent < ViewComponent::Base
+    attr_reader :provider_user, :provider, :current_user
+
+    def initialize(provider_user:, provider:, current_user:)
+      @provider_user = provider_user
+      @current_user = current_user
+      @provider = provider
+    end
+
+  private
+
+    def can_perform_permission?(permission)
+      provider_user.provider_permissions.exists?(permission => true)
+    end
+
+    def can_perform_permission_y_n?(permission)
+      can_perform_permission?(permission) ? 'Yes' : 'No'
+    end
+
+    def can_change_permissions?
+      current_user.authorisation.can_manage_users_for?(provider: provider)
+    end
+
+    def description_for(permission)
+      I18n.t("user_permissions.#{permission}.description")
+    end
+  end
+end

--- a/app/models/provider_permissions.rb
+++ b/app/models/provider_permissions.rb
@@ -2,9 +2,9 @@ class ProviderPermissions < ApplicationRecord
   VALID_PERMISSIONS = %i[
     manage_users
     manage_organisations
-    view_safeguarding_information
     set_up_interviews
     make_decisions
+    view_safeguarding_information
     view_diversity_information
   ].freeze
 

--- a/config/locales/provider_interface/user_permisssions.yml
+++ b/config/locales/provider_interface/user_permisssions.yml
@@ -1,0 +1,14 @@
+en:
+  user_permissions:
+    make_decisions:
+      description: Make offers and reject applications
+    view_safeguarding_information:
+      description: View criminal convictions and professional misconduct
+    view_diversity_information:
+      description: View sex, disability and ethnicity information
+    manage_users:
+      description: Manage users
+    manage_organisations:
+      description: Manage organisation permissions
+    set_up_interviews:
+      description: Set up interviews

--- a/spec/components/previews/provider_interface/user_permission_summary_component_preview.rb
+++ b/spec/components/previews/provider_interface/user_permission_summary_component_preview.rb
@@ -1,0 +1,60 @@
+module ProviderInterface
+  class UserPermissionSummaryComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
+    def user_permission_summary
+      provider = FactoryBot.create(:provider)
+      provider_user = FactoryBot.create(:provider_user)
+      current_provider_user = FactoryBot.create(:provider_user)
+
+      FactoryBot.create(:provider_permissions,
+                        provider: provider,
+                        provider_user: current_provider_user,
+                        manage_users: true)
+
+      FactoryBot.create(:provider_permissions,
+                        provider: provider,
+                        provider_user: provider_user,
+                        manage_users: Faker::Boolean.boolean(true_ratio: 0.5),
+                        manage_organisations: Faker::Boolean.boolean(true_ratio: 0.5),
+                        set_up_interviews: Faker::Boolean.boolean(true_ratio: 0.5),
+                        make_decisions: Faker::Boolean.boolean(true_ratio: 0.5),
+                        view_safeguarding_information: Faker::Boolean.boolean(true_ratio: 0.5),
+                        view_diversity_information: Faker::Boolean.boolean(true_ratio: 0.5))
+      providers = FactoryBot.build_list(:provider, 3)
+      other_providers = FactoryBot.build_list(:provider, 2)
+      random_boolean_value = Faker::Boolean.boolean(true_ratio: 0.5)
+      other_random_boolean_value = Faker::Boolean.boolean(true_ratio: 0.5)
+
+      providers.each do |training_provider|
+        FactoryBot.create(:provider_relationship_permissions,
+                          training_provider: training_provider,
+                          ratifying_provider: provider,
+                          training_provider_can_make_decisions: random_boolean_value,
+                          ratifying_provider_can_make_decisions: !random_boolean_value,
+                          training_provider_can_view_safeguarding_information: random_boolean_value,
+                          ratifying_provider_can_view_safeguarding_information: !random_boolean_value,
+                          training_provider_can_view_diversity_information: random_boolean_value,
+                          ratifying_provider_can_view_diversity_information: !random_boolean_value)
+      end
+
+      other_providers.each do |training_provider|
+        FactoryBot.create(:provider_relationship_permissions,
+                          training_provider: training_provider,
+                          ratifying_provider: provider,
+                          training_provider_can_make_decisions: !other_random_boolean_value,
+                          ratifying_provider_can_make_decisions: other_random_boolean_value,
+                          training_provider_can_view_safeguarding_information: !other_random_boolean_value,
+                          ratifying_provider_can_view_safeguarding_information: other_random_boolean_value,
+                          training_provider_can_view_diversity_information: !other_random_boolean_value,
+                          ratifying_provider_can_view_diversity_information: other_random_boolean_value)
+      end
+
+      render UserPermissionSummaryComponent.new(
+        provider_user: provider_user,
+        provider: provider,
+        current_user: current_provider_user,
+      )
+    end
+  end
+end

--- a/spec/components/provider_interface/user_permission_summary_component_spec.rb
+++ b/spec/components/provider_interface/user_permission_summary_component_spec.rb
@@ -1,0 +1,146 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::UserPermissionSummaryComponent, type: :controller do
+  let(:current_provider_user) { create(:provider_user) }
+  let(:provider_user) { create(:provider_user) }
+  let(:provider) { create(:provider) }
+  let!(:permissions) do
+    FactoryBot.create(:provider_permissions,
+                      provider: provider,
+                      provider_user: provider_user,
+                      manage_users: Faker::Boolean.boolean(true_ratio: 0.5),
+                      manage_organisations: Faker::Boolean.boolean(true_ratio: 0.5),
+                      set_up_interviews: Faker::Boolean.boolean(true_ratio: 0.5),
+                      make_decisions: Faker::Boolean.boolean(true_ratio: 0.5),
+                      view_safeguarding_information: Faker::Boolean.boolean(true_ratio: 0.5),
+                      view_diversity_information: Faker::Boolean.boolean(true_ratio: 0.5))
+  end
+
+  let(:allowed_providers) { create_list(:provider, 3) }
+  let(:prohibited_providers) { create_list(:provider, 2) }
+  let(:render) do
+    render_inline(described_class.new(provider_user: provider_user,
+                                      provider: provider,
+                                      current_user: current_provider_user))
+  end
+
+  before do
+    allowed_providers.each do |training_provider|
+      FactoryBot.create(:provider_relationship_permissions,
+                        training_provider: training_provider,
+                        ratifying_provider: provider,
+                        training_provider_can_make_decisions: true,
+                        training_provider_can_view_safeguarding_information: true,
+                        training_provider_can_view_diversity_information: true)
+    end
+
+    prohibited_providers.each do |training_provider|
+      FactoryBot.create(:provider_relationship_permissions,
+                        training_provider: training_provider,
+                        ratifying_provider: provider,
+                        training_provider_can_make_decisions: false,
+                        training_provider_can_view_safeguarding_information: false,
+                        training_provider_can_view_diversity_information: false,
+                        setup_at: nil)
+    end
+  end
+
+  def row_text_selector(row_name, render)
+    rows = {
+      manage_users: 0,
+      manage_permissions: 1,
+      set_up_interviews: 2,
+      make_decisions: 3,
+      view_safeguarding_information: 4,
+      view_diversity_information: 5,
+    }
+
+    render.css('.govuk-summary-list__row')[rows[row_name]].text
+  end
+
+  describe 'rendering details about each permission' do
+    it 'displays the correct details for Managing users' do
+      expect(row_text_selector(:manage_users, render)).to include('Manage users')
+      expect(row_text_selector(:manage_users, render)).to include(y_n(permissions.manage_users))
+    end
+
+    it 'displays the correct details for Managing organisations' do
+      expect(row_text_selector(:manage_permissions, render)).to include('Manage organisation permissions')
+      expect(row_text_selector(:manage_permissions, render)).to include(y_n(permissions.manage_organisations))
+    end
+
+    it 'displays the correct details for Set up interviews' do
+      expect(row_text_selector(:set_up_interviews, render)).to include('Set up interviews')
+      expect(row_text_selector(:set_up_interviews, render)).to include(y_n(permissions.set_up_interviews))
+    end
+
+    it 'displays the correct details for Make decisions' do
+      expect(row_text_selector(:make_decisions, render)).to include('Make offers and reject applications')
+      expect(row_text_selector(:make_decisions, render)).to include(y_n(permissions.make_decisions))
+    end
+
+    it 'displays the correct details for Viewing safeguarding information' do
+      expect(row_text_selector(:view_safeguarding_information, render)).to include('View criminal convictions and professional misconduct')
+      expect(row_text_selector(:view_safeguarding_information, render)).to include(y_n(permissions.view_safeguarding_information))
+    end
+
+    it 'displays the correct details for Viewing diversity information' do
+      expect(row_text_selector(:view_diversity_information, render)).to include('View sex, disability and ethnicity information')
+      expect(row_text_selector(:view_diversity_information, render)).to include(y_n(permissions.view_diversity_information))
+    end
+
+    context 'when user level permissions are false' do
+      before do
+        permissions.update!(view_diversity_information: false)
+      end
+
+      it 'does not display organisation level permissions' do
+        expect(row_text_selector(:view_diversity_information, render)).to include('View sex, disability and ethnicity information')
+        expect(row_text_selector(:view_diversity_information, render)).to include('No')
+        expect(row_text_selector(:view_diversity_information, render)).not_to include('This user permission is affected by organisation permissions.')
+      end
+    end
+
+    context 'when user level permissions are true' do
+      before do
+        permissions.update!(view_diversity_information: true)
+      end
+
+      it 'displays organisation level permissions' do
+        expect(row_text_selector(:view_diversity_information, render)).to include('View sex, disability and ethnicity information')
+        expect(row_text_selector(:view_diversity_information, render)).to include('Yes')
+        expect(row_text_selector(:view_diversity_information, render)).to include('This user permission is affected by organisation permissions.')
+      end
+    end
+
+    context 'when the user can manage users permissions' do
+      let!(:current_user_permissions) do
+        FactoryBot.create(:provider_permissions,
+                          provider: provider,
+                          provider_user: current_provider_user,
+                          manage_users: true)
+      end
+
+      it 'displays a change link' do
+        expect(row_text_selector(:view_diversity_information, render)).to include('Change')
+      end
+    end
+
+    context 'when the user cannot manage users permissions' do
+      let!(:current_user_permissions) do
+        FactoryBot.create(:provider_permissions,
+                          provider: provider,
+                          provider_user: current_provider_user,
+                          manage_users: false)
+      end
+
+      it 'does not display a change link' do
+        expect(row_text_selector(:view_diversity_information, render)).not_to include('Change')
+      end
+    end
+  end
+
+  def y_n(boolean)
+    boolean ? 'Yes' : 'No'
+  end
+end


### PR DESCRIPTION
## Context
Display a user's permissions based on a provider

## Link to Trello card

https://trello.com/c/cboW42Wr/4049-add-user-permissions-summary-component

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
