### PR TITLE
Scope available providers to the current cycle

### DIFF
--- a/app/forms/candidate_interface/pick_provider_form.rb
+++ b/app/forms/candidate_interface/pick_provider_form.rb
@@ -6,7 +6,7 @@ module CandidateInterface
     validates :provider_id, presence: true
 
     def courses_available?
-      Course.exposed_in_find.where(provider_id: provider_id).present?
+      Course.current_cycle.exposed_in_find.where(provider_id: provider_id).present?
     end
 
     def available_providers

--- a/spec/forms/candidate_interface/pick_provider_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_provider_form_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe CandidateInterface::PickProviderForm do
   end
 
   describe '#courses_available?' do
-    it 'returns false if there are no exposed courses matched by provider id' do
+    it 'returns false if there are no exposed courses matched by provider id in the current cycle' do
       unexposed_course = create(:course, exposed_in_find: false)
       provider = unexposed_course.provider
+      create(:course, exposed_in_find: true, recruitment_cycle_year: RecruitmentCycle.previous_year, provider: unexposed_course.provider)
 
       form = described_class.new(provider_id: provider.id)
 


### PR DESCRIPTION
## Context

At the moment, the check to see if a provider has available courses isn't scoped to the current cycle. It should be.

## Changes proposed in this pull request

Scope the courses_available? method to the current cycle

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
