### PR TITLE
Fix validation on GCSE qualification type form

### DIFF
--- a/app/forms/candidate_interface/gcse_qualification_type_form.rb
+++ b/app/forms/candidate_interface/gcse_qualification_type_form.rb
@@ -12,7 +12,8 @@ module CandidateInterface
     validates :other_uk_qualification_type, presence: true, if: -> { qualification_type == OTHER_UK_QUALIFICATION_TYPE }
     validates :non_uk_qualification_type, presence: true, if: -> { qualification_type == NON_UK_QUALIFICATION_TYPE }
     validates :qualification_type, length: { maximum: 255 }
-    validates :other_uk_qualification_type, :non_uk_qualification_type, length: { maximum: 255 }
+    validates :non_uk_qualification_type, length: { maximum: 255 }
+    validates :other_uk_qualification_type, length: { maximum: 100 }
 
     validates :missing_explanation, word_count: { maximum: 200 }
 

--- a/spec/forms/candidate_interface/gcse_qualification_type_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_qualification_type_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
     it { is_expected.to validate_presence_of(:subject) }
     it { is_expected.to validate_presence_of(:qualification_type) }
 
-    it { is_expected.to validate_length_of(:other_uk_qualification_type).is_at_most(255) }
+    it { is_expected.to validate_length_of(:other_uk_qualification_type).is_at_most(100) }
     it { is_expected.to validate_length_of(:qualification_type).is_at_most(255) }
     it { is_expected.to validate_length_of(:subject).is_at_most(255) }
   end


### PR DESCRIPTION
## Context

Validation length  for `:other_uk_qualification_type` on `GcseQualificationTypeForm` is for
255 when it is specified as 100 in the db. 

Error message: https://sentry.io/organizations/dfe-bat/issues/2481163853/?project=1765973&referrer=slack

## Changes proposed in this pull request

This PR adjusts the form to bring it in line.

## Guidance to review

## Link to Trello card

https://trello.com/c/q1C6G0UG/3734-validate-otherukqualificationtype-length

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
