### PR TITLE
Disable slack notifications for next cycle courses

### DIFF
--- a/app/services/set_open_on_apply_for_new_course.rb
+++ b/app/services/set_open_on_apply_for_new_course.rb
@@ -20,6 +20,9 @@ class SetOpenOnApplyForNewCourse
 private
 
   def notify_of_new_course!(provider, accredited_provider, auto_open)
+    # TODO: remove after syncing all courses for next cycle
+    return if @course.recruitment_cycle_year == RecruitmentCycle.next_year
+
     notification = [":seedling: #{provider.name}, which has courses open on Apply, added #{@course.name_and_code}"]
     notification << auto_open_message(auto_open)
     notification << accredited_body_message(accredited_provider)

--- a/spec/services/set_open_on_apply_for_new_course_spec.rb
+++ b/spec/services/set_open_on_apply_for_new_course_spec.rb
@@ -110,6 +110,23 @@ RSpec.describe SetOpenOnApplyForNewCourse do
       expect_slack_message_with_text('We didn’t automatically open it')
     end
 
+    context 'when the course is in the next cycle' do
+      let(:course) { create(:course, open_on_apply: false, recruitment_cycle_year: RecruitmentCycle.next_year) }
+
+      before do
+        create(:course, :open_on_apply, provider: course.provider, code: course.code)
+        course_opener.call
+      end
+
+      it 'opens the course' do
+        expect(course).to be_open_on_apply
+      end
+
+      it 'does not notify Slack' do
+        expect_no_slack_message
+      end
+    end
+
     context 'when the course has an accredited provider' do
       let(:accredited_provider) { create(:provider, name: 'Canterbury') }
       let(:course) { create(:course, open_on_apply: false, accredited_provider: accredited_provider) }


### PR DESCRIPTION
## Context

Caused slack-megadon when syncing courses on Sandbox for 2022. We want to avoid this for production.

## Changes proposed in this pull request

Disable the slack notifier temporarily on production for courses in the next cycle until we run the full sync

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
