### PR TITLE
Add placeholder links to your account page

### DIFF
--- a/app/views/provider_interface/account/show.html.erb
+++ b/app/views/provider_interface/account/show.html.erb
@@ -1,6 +1,20 @@
 <%= content_for :browser_title, t('page_titles.provider.account') %>
 
 <h1 class="govuk-heading-l"><%= t('page_titles.provider.account') %></h1>
+
+<% if FeatureFlag.active?(:account_and_org_settings_changes) %>
+<ul class="govuk-list govuk-list--spaced">
+  <li>
+    <%= govuk_link_to t('page_titles.provider.personal_details'), '#' %>
+  </li>
+  <li>
+    <%= govuk_link_to t('page_titles.provider.user_permissions'), '#' %>
+  </li>
+  <li>
+    <%= govuk_link_to t('page_titles.provider.email_notifications'), '#' %>
+  </li>
+</ul>
+<% else %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
 
@@ -24,3 +38,4 @@
 
   </div>
 </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -208,6 +208,9 @@ en:
       select_decision: Select decision
       account: Your account
       profile: Profile
+      personal_details: Your personal details
+      user_permissions: Your user permissions
+      email_notifications: Your email notifications
       organisation_settings: Organisation settings
       organisation_permissions: Organisation permissions
       change_organisation_permissions: Change permissions

--- a/spec/system/provider_interface/account_page_spec.rb
+++ b/spec/system/provider_interface/account_page_spec.rb
@@ -3,12 +3,14 @@ require 'rails_helper'
 RSpec.feature 'Viewing the provider user account page' do
   include DfESignInHelpers
 
-  scenario 'Provider user visits their account page with various permissions' do
+  before { FeatureFlag.activate(:account_and_org_settings_changes) }
+
+  scenario 'Provider user visits their account page' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_sign_in_to_the_provider_interface
 
     when_i_go_to_my_account
-    then_i_can_see_links_to_my_profile_and_notifications
+    then_i_can_see_links_to_my_settings_and_details
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -20,8 +22,9 @@ RSpec.feature 'Viewing the provider user account page' do
     click_on t('page_titles.provider.account')
   end
 
-  def then_i_can_see_links_to_my_profile_and_notifications
-    expect(page).to have_content(t('page_titles.provider.profile'))
-    expect(page).to have_content(t('page_titles.provider.notifications'))
+  def then_i_can_see_links_to_my_settings_and_details
+    expect(page).to have_content(t('page_titles.provider.personal_details'))
+    expect(page).to have_content(t('page_titles.provider.user_permissions'))
+    expect(page).to have_content(t('page_titles.provider.email_notifications'))
   end
 end

--- a/spec/system/provider_interface/manage_provider_user_notifications_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_notifications_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Managing notifications' do
   include DfESignInHelpers
 
+  before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
+
   scenario 'Provider can enable and disable individaul email notifications' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_sign_in_to_the_provider_interface

--- a/spec/system/provider_interface/provider_views_account_page_spec.rb
+++ b/spec/system/provider_interface/provider_views_account_page_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Provider views account page' do
   include DfESignInHelpers
 
+  before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
+
   scenario 'Provider views their account page' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_manage_applications_for_two_providers


### PR DESCRIPTION
## Context
We are improving the way providers view and edit their own settings.

## Changes proposed in this pull request
Update the layout of the "Your account" page behind the new feature flag.

Currently blocked by the removal of the other feature flag in #5253 

## Guidance to review
I've overwritten the old account page spec because it wasn't testing very much. We should extend the new spec as we add more functionality, and maybe test the personal details page in there.

## Link to Trello card
https://trello.com/c/7a1UfKKH/4044-change-your-account-page-to-show-new-layout

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
