### PR TITLE
Fix a small performance issue with `GET /api/v1/applications` endpoint

### DIFF
--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -24,8 +24,8 @@ module VendorAPI
           providers: current_provider,
           vendor_api: true,
           includes: [
-            :offer,
-            application_form: %i[candidate application_qualifications application_work_experiences application_work_history_breaks application_volunteering_experiences english_proficiency],
+            offer: %i[conditions],
+            application_form: %i[candidate application_qualifications application_references application_work_experiences application_work_history_breaks application_volunteering_experiences english_proficiency],
             course_option: [{ course: %i[provider] }, :site],
             current_course_option: [{ course: %i[provider] }, :site],
           ],

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -180,7 +180,8 @@ module VendorAPI
     end
 
     def references
-      application_form.application_references.selected.map do |reference|
+      # Filter selected references programmatically to avoid n+1 queries caused by using the .selected scope.
+      application_form.application_references.select { |r| r.selected && r.feedback_status == 'feedback_provided' }.map do |reference|
         reference_to_hash(reference)
       end
     end


### PR DESCRIPTION
## Context

We've not included a couple of associated models as includes in the query the `GET /applications` endpoint uses to fetch applications. This was causing _many_ n+1 queries like

```
ApplicationReference Load (0.6ms)  SELECT "references".* FROM "references" WHERE "references"."application_form_id" = $1 AND "references"."feedback_status" = $2 AND "references"."selected" = $3 ORDER BY id ASC  [["application_form_id", 186], ["feedback_status", "feedback_provided"], ["selected", true]]       
↳ app/presenters/vendor_api/single_application_presenter.rb:183:in `map'                              
ApplicationReference Load (0.6ms)  SELECT "references".* FROM "references" WHERE "references"."application_form_id" = $1 AND "references"."feedback_status" = $2 AND "references"."selected" = $3 ORDER BY id ASC  [["application_form_id", 184], ["feedback_status", "feedback_provided"], ["selected", true]]
↳ app/presenters/vendor_api/single_application_presenter.rb:183:in `map'
```

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds `application_form: [:application_references]` and `offer: [:conditions]` includes the the API version of the query.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

Noticed this when investigating:
https://trello.com/c/yzKDiTtI/4037-spike-investigate-performance-issues-with-get-applications-endpoint
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
