### PR TITLE
Avoid saving a `ProviderRelationshipPermissions` in course sync

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -103,16 +103,13 @@ module TeacherTrainingPublicAPI
     end
 
     def add_provider_relationship(course)
-      provider_relationship_permission = ProviderRelationshipPermissions.find_or_initialize_by(
+      ProviderRelationshipPermissions.find_or_create_by(
         training_provider: provider,
         ratifying_provider: course.accredited_provider,
-      )
-
-      permission_changed = provider_relationship_permission.new_record?
-      provider_relationship_permission.save!
-
-      if !@incremental_sync && permission_changed
-        @updates.merge!(provider_relationship_permission: true)
+      ) do |provider_relationship_permission|
+        if !@incremental_sync && provider_relationship_permission.new_record?
+          @updates.merge!(provider_relationship_permission: true)
+        end
       end
     end
 


### PR DESCRIPTION
## Context

There are invalid set up `ProviderRelationshipPermissions` in the production environment. Those will cause validation errors when we attempt to sync courses and retrieve those permissions. We need to fix those records to ensure they are valid, but in the meantime avoid triggering validation errors by avoiding an explicit `save!`.
## Changes proposed in this pull request

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
