### PR TITLE
Revert "Disable slack notifications for next cycle courses"

### DIFF
--- a/app/services/set_open_on_apply_for_new_course.rb
+++ b/app/services/set_open_on_apply_for_new_course.rb
@@ -20,9 +20,6 @@ class SetOpenOnApplyForNewCourse
 private
 
   def notify_of_new_course!(provider, accredited_provider, auto_open)
-    # TODO: remove after syncing all courses for next cycle
-    return if @course.recruitment_cycle_year == RecruitmentCycle.next_year
-
     notification = [":seedling: #{provider.name}, which has courses open on Apply, added #{@course.name_and_code}"]
     notification << auto_open_message(auto_open)
     notification << accredited_body_message(accredited_provider)

--- a/spec/services/set_open_on_apply_for_new_course_spec.rb
+++ b/spec/services/set_open_on_apply_for_new_course_spec.rb
@@ -110,23 +110,6 @@ RSpec.describe SetOpenOnApplyForNewCourse do
       expect_slack_message_with_text('We didn’t automatically open it')
     end
 
-    context 'when the course is in the next cycle' do
-      let(:course) { create(:course, open_on_apply: false, recruitment_cycle_year: RecruitmentCycle.next_year) }
-
-      before do
-        create(:course, :open_on_apply, provider: course.provider, code: course.code)
-        course_opener.call
-      end
-
-      it 'opens the course' do
-        expect(course).to be_open_on_apply
-      end
-
-      it 'does not notify Slack' do
-        expect_no_slack_message
-      end
-    end
-
     context 'when the course has an accredited provider' do
       let(:accredited_provider) { create(:provider, name: 'Canterbury') }
       let(:course) { create(:course, open_on_apply: false, accredited_provider: accredited_provider) }


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-teacher-training#5280

We can now start alerting on any new courses as we have completed the full sync for year 2022