### PR TITLE
Relax course option restrictions when making/changing an offer

### DIFF
--- a/app/queries/get_change_offer_options.rb
+++ b/app/queries/get_change_offer_options.rb
@@ -20,7 +20,6 @@ class GetChangeOfferOptions
 
   def available_study_modes(course:)
     CourseOption
-      .selectable
       .where(course: offerable_courses.find_by(id: course.id))
       .group('study_mode')
       .pluck(:study_mode)
@@ -28,7 +27,6 @@ class GetChangeOfferOptions
 
   def available_course_options(course:, study_mode:)
     CourseOption
-      .selectable
       .where(
         course: offerable_courses.find_by(id: course.id),
         study_mode: study_mode,

--- a/spec/queries/get_change_offer_options_spec.rb
+++ b/spec/queries/get_change_offer_options_spec.rb
@@ -156,14 +156,6 @@ RSpec.describe GetChangeOfferOptions do
           .to match_array(%w[full_time part_time])
       end
 
-      it 'only returns study modes related to a course option whose site is still valid' do
-        create(:course_option, :part_time, course: self_ratified_course)
-        create(:course_option, :full_time, course: self_ratified_course, site_still_valid: false)
-
-        expect(service.available_study_modes(course: self_ratified_course))
-            .to match_array(%w[part_time])
-      end
-
       it 'returns no study modes if there are no offerable courses' do
         create(:course_option, :part_time, course: self_ratified_course)
         allow(service).to receive(:offerable_courses).and_return(Course.none)
@@ -176,14 +168,6 @@ RSpec.describe GetChangeOfferOptions do
       it 'returns a collection of course options for a given course/study_mode' do
         expect(service.available_course_options(course: self_ratified_course, study_mode: 'part_time'))
           .to match_array([course_options.first, course_options.second])
-      end
-
-      it 'only returns course options whose sites are still valid' do
-        valid_course_option = create(:course_option, :part_time, course: self_ratified_course)
-        create(:course_option, :part_time, course: self_ratified_course, site_still_valid: false)
-
-        expect(service.available_course_options(course: self_ratified_course, study_mode: 'part_time'))
-            .to match_array([valid_course_option])
       end
 
       it 'returns no course options if there are no offerable courses' do


### PR DESCRIPTION
## Context

We no longer want to restrict making/changing an offer to selectable valid sites as we have removed all other
restrictions on courses/course options.

## Changes proposed in this pull request

Remove `selectable` restriction on course options.

## Guidance to review

This came out of the following PR: https://github.com/DFE-Digital/apply-for-teacher-training/pull/5180/files#r679798783

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
