### PR TITLE
Add new provider user personal details page

### DIFF
--- a/app/controllers/provider_interface/personal_details_controller.rb
+++ b/app/controllers/provider_interface/personal_details_controller.rb
@@ -1,0 +1,15 @@
+module ProviderInterface
+  class PersonalDetailsController < ProviderInterfaceController
+    before_action :redirect_to_profile_unless_feature_flag_on
+
+    def show; end
+
+  private
+
+    def redirect_to_profile_unless_feature_flag_on
+      unless FeatureFlag.active?(:account_and_org_settings_changes)
+        redirect_to provider_interface_profile_path
+      end
+    end
+  end
+end

--- a/app/views/provider_interface/account/show.html.erb
+++ b/app/views/provider_interface/account/show.html.erb
@@ -5,7 +5,7 @@
 <% if FeatureFlag.active?(:account_and_org_settings_changes) %>
 <ul class="govuk-list govuk-list--spaced">
   <li>
-    <%= govuk_link_to t('page_titles.provider.personal_details'), '#' %>
+    <%= govuk_link_to t('page_titles.provider.personal_details'), provider_interface_personal_details_path %>
   </li>
   <li>
     <%= govuk_link_to t('page_titles.provider.user_permissions'), '#' %>

--- a/app/views/provider_interface/personal_details/show.html.erb
+++ b/app/views/provider_interface/personal_details/show.html.erb
@@ -1,0 +1,21 @@
+<%= content_for :browser_title, t('page_titles.provider.personal_details') %>
+
+<% content_for :before_content do %>
+  <%= breadcrumbs({
+    t('page_titles.provider.account') => provider_interface_account_path,
+    t('page_titles.provider.personal_details') => nil,
+  }) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('page_titles.provider.personal_details') %></h1>
+    <%= render SummaryListComponent.new(
+      rows: [
+        { key: 'First name', value: current_provider_user.first_name },
+        { key: 'Last name', value: current_provider_user.last_name },
+        { key: 'Email address', value: current_provider_user.email_address },
+      ],
+    ) %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -729,6 +729,8 @@ Rails.application.routes.draw do
     scope path: '/account' do
       get '/profile' => 'profile#show'
 
+      resource :personal_details, only: :show, path: 'personal-details'
+
       scope path: '/users' do
         get '/' => 'provider_users#index', as: :provider_users
 

--- a/spec/system/provider_interface/provider_user_personal_details_spec.rb
+++ b/spec/system/provider_interface/provider_user_personal_details_spec.rb
@@ -1,16 +1,19 @@
 require 'rails_helper'
 
-RSpec.feature 'Viewing the provider user account page' do
+RSpec.feature 'Personal details page' do
   include DfESignInHelpers
 
   before { FeatureFlag.activate(:account_and_org_settings_changes) }
 
-  scenario 'Provider user visits their account page' do
+  scenario 'Provider user views their personal details' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_sign_in_to_the_provider_interface
 
     when_i_go_to_my_account
     then_i_can_see_links_to_my_settings_and_details
+
+    when_i_click_on_personal_details
+    then_i_can_see_all_my_details
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -26,5 +29,16 @@ RSpec.feature 'Viewing the provider user account page' do
     expect(page).to have_content(t('page_titles.provider.personal_details'))
     expect(page).to have_content(t('page_titles.provider.user_permissions'))
     expect(page).to have_content(t('page_titles.provider.email_notifications'))
+  end
+
+  def when_i_click_on_personal_details
+    click_on t('page_titles.provider.personal_details')
+  end
+
+  def then_i_can_see_all_my_details
+    provider_user = ProviderUser.last
+    expect(page).to have_content(provider_user.first_name)
+    expect(page).to have_content(provider_user.last_name)
+    expect(page).to have_content(provider_user.email_address)
   end
 end


### PR DESCRIPTION
## Context
As part of the new layout of settings, the personal details page has been simplified and renamed

## Changes proposed in this pull request
Link to the new personal details page from the new "Your account" page

## Guidance to review
Hopefully simple

## Link to Trello card
https://trello.com/c/jUGl3UZE/4046-add-your-personal-details-page-to-your-account

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
