### PR TITLE
New notification settings page in Manage

### DIFF
--- a/app/controllers/provider_interface/notifications_controller.rb
+++ b/app/controllers/provider_interface/notifications_controller.rb
@@ -1,5 +1,13 @@
 module ProviderInterface
   class NotificationsController < ProviderInterfaceController
+    def show
+      @page_title = if FeatureFlag.active?(:account_and_org_settings_changes)
+                      t('page_titles.provider.email_notifications')
+                    else
+                      t('page_titles.provider.notifications')
+                    end
+    end
+
     def update
       provider_user_notifications_service = SaveProviderUserNotificationPreferences.new(provider_user: current_provider_user)
 

--- a/app/views/provider_interface/account/show.html.erb
+++ b/app/views/provider_interface/account/show.html.erb
@@ -11,7 +11,7 @@
     <%= govuk_link_to t('page_titles.provider.user_permissions'), '#' %>
   </li>
   <li>
-    <%= govuk_link_to t('page_titles.provider.email_notifications'), '#' %>
+    <%= govuk_link_to t('page_titles.provider.email_notifications'), provider_interface_notifications_path %>
   </li>
 </ul>
 <% else %>

--- a/app/views/provider_interface/notifications/show.html.erb
+++ b/app/views/provider_interface/notifications/show.html.erb
@@ -1,17 +1,19 @@
-<%= content_for :browser_title, t('page_titles.provider.notifications') %>
+<%= content_for :browser_title, @page_title %>
 
 <% content_for :before_content do %>
   <%= breadcrumbs({
     t('page_titles.provider.account') => provider_interface_account_path,
-    t('page_titles.provider.notifications') => nil,
+    @page_title => nil,
   }) %>
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
-      <%= t('page_titles.provider.notifications') %>
-      <span class="govuk-caption-m govuk-!-margin-top-1">Choose which email notifications you want to receive.</span>
+  <div class="govuk-grid-column-two-thirds<%= ' govuk-!-margin-bottom-2' unless FeatureFlag.active?(:account_and_org_settings_changes) %>">
+    <h1 class="govuk-heading-l">
+      <%= @page_title %>
+      <% unless FeatureFlag.active?(:account_and_org_settings_changes) %>
+        <span class="govuk-caption-m govuk-!-margin-top-1">Choose which email notifications you want to receive.</span>
+      <% end %>
     </h1>
     <%= render ProviderUserNotificationPreferencesComponent.new(current_provider_user.notification_preferences, form_path: provider_interface_notifications_path) %>
   </div>

--- a/spec/system/provider_interface/manage_provider_user_notifications_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_notifications_spec.rb
@@ -3,9 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Managing notifications' do
   include DfESignInHelpers
 
-  before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
-
-  scenario 'Provider can enable and disable individaul email notifications' do
+  scenario 'Provider can enable and disable individual email notifications' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_sign_in_to_the_provider_interface
 
@@ -27,7 +25,12 @@ RSpec.feature 'Managing notifications' do
   end
 
   def and_i_click_on_the_notification_settings_link
-    click_on(t('page_titles.provider.notifications'))
+    link_text = if FeatureFlag.active?(:account_and_org_settings_changes)
+                  t('page_titles.provider.email_notifications')
+                else
+                  t('page_titles.provider.notifications')
+                end
+    click_on(link_text)
   end
 
   def then_i_can_see_all_notifications_are_on_by_default


### PR DESCRIPTION
## Context
As part of a new design, we have simplified the notification settings page

## Changes proposed in this pull request
Link to the existing notification settings page from the new "Your account" page

Update the content on the page behind the feature flag

## Guidance to review
I didn't add a new route here because it didn't seem necessary.

## Link to Trello card
https://trello.com/c/PDNnOsg9/4047-add-your-email-notifications-page-to-your-account
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
