### PR TITLE
Suppress sync update errors for full syncs

### DIFF
--- a/app/workers/teacher_training_public_api/sync_all_providers_and_courses_worker.rb
+++ b/app/workers/teacher_training_public_api/sync_all_providers_and_courses_worker.rb
@@ -3,9 +3,9 @@ module TeacherTrainingPublicAPI
     include Sidekiq::Worker
     sidekiq_options retry: 3, queue: :low_priority
 
-    def perform(incremental = true, year = ::RecruitmentCycle.current_year)
+    def perform(incremental = true, year = ::RecruitmentCycle.current_year, suppress_sync_update_errors = false)
       SyncSubjects.new.perform
-      SyncAllProvidersAndCourses.call(recruitment_cycle_year: year, incremental_sync: incremental)
+      SyncAllProvidersAndCourses.call(recruitment_cycle_year: year, incremental_sync: incremental, suppress_sync_update_errors: suppress_sync_update_errors)
     end
   end
 end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -56,12 +56,12 @@ class Clock
   every(1.day, 'SendNewCycleStartedEmailToCandidatesWorker', at: '12:00') { SendNewCycleHasStartedEmailToCandidatesWorker.new.perform }
 
   every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: '00:59') do
-    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false)
+    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false, RecruitmentCycle.current_year, true)
   end
 
   every(7.days, 'FullSyncNextCycleFromTeacherTrainingPublicAPI', at: '03:59') do
     if FeatureFlag.active?(:sync_next_cycle)
-      TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false, RecruitmentCycle.next_year)
+      TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false, RecruitmentCycle.next_year, true)
     end
   end
 end

--- a/spec/workers/teacher_training_public_api/sync_all_providers_and_courses_worker_spec.rb
+++ b/spec/workers/teacher_training_public_api/sync_all_providers_and_courses_worker_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker do
 
     it 'calls the SyncAllProvidersAndCourses service with the correct args for an incremental sync' do
       described_class.new.perform
-      expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCourses).to have_received(:call).with(incremental_sync: true, recruitment_cycle_year: RecruitmentCycle.current_year)
+      expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCourses).to have_received(:call).with(incremental_sync: true, recruitment_cycle_year: RecruitmentCycle.current_year, suppress_sync_update_errors: false)
     end
 
     it 'calls the SyncAllProvidersAndCourses service with the correct args for a full sync' do
       described_class.new.perform(false)
-      expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCourses).to have_received(:call).with(incremental_sync: false, recruitment_cycle_year: RecruitmentCycle.current_year)
+      expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCourses).to have_received(:call).with(incremental_sync: false, recruitment_cycle_year: RecruitmentCycle.current_year, suppress_sync_update_errors: false)
     end
   end
 end


### PR DESCRIPTION
## Context

Running a full sync has surfaced many change errors. To give us the time to investigate those errors, suppress the full sync update errors for now

## Changes proposed in this pull request

Set the suppress errors flag as true on all scheduled full syncs

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
