### PR TITLE
4039 change with synced courses filter to with courses filter

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -76,7 +76,7 @@ class Provider < ApplicationRecord
   end
 
   def lacks_admin_users?
-    sync_courses &&
+    courses.any? &&
       !(provider_permissions.exists?(manage_users: true) &&
         provider_permissions.exists?(manage_organisations: true))
   end

--- a/app/models/support_interface/providers_filter.rb
+++ b/app/models/support_interface/providers_filter.rb
@@ -66,7 +66,7 @@ module SupportInterface
       end
 
       if applied_filters[:onboarding_stages]&.include?('with_courses')
-        providers = providers.joins(:courses).where.not(courses: { id: nil })
+        providers = providers.includes(:courses).where.not(courses: { id: nil })
       end
 
       if applied_filters[:onboarding_stages]&.include?('dsa_signed_only')

--- a/app/models/support_interface/providers_filter.rb
+++ b/app/models/support_interface/providers_filter.rb
@@ -2,7 +2,7 @@ module SupportInterface
   class ProvidersFilter
     attr_reader :applied_filters
     ONBOARDING_STAGES = {
-      'synced_only' => 'With synced courses',
+      'with_courses' => 'With courses',
       'dsa_unsigned_only' => 'With unsigned DSAs',
       'dsa_signed_only' => 'With signed DSAs',
     }.freeze
@@ -65,8 +65,8 @@ module SupportInterface
         @search_count = 0
       end
 
-      if applied_filters[:onboarding_stages]&.include?('synced_only')
-        providers = providers.where(sync_courses: true)
+      if applied_filters[:onboarding_stages]&.include?('with_courses')
+        providers = providers.joins(:courses).where.not(courses: { id: nil })
       end
 
       if applied_filters[:onboarding_stages]&.include?('dsa_signed_only')

--- a/app/views/support_interface/providers/index.html.erb
+++ b/app/views/support_interface/providers/index.html.erb
@@ -33,7 +33,7 @@
               <%= provider.courses.current_cycle.open_on_apply.size %> out of
               <%= provider.courses.current_cycle.size %>
             <% else %>
-              No courses synced
+              No courses available
             <% end %>
           </td>
           <td class="govuk-table__cell">

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -86,4 +86,29 @@ RSpec.describe Provider, type: :model do
       end
     end
   end
+
+  describe '#lacks_admin_users?' do
+    let(:provider) { create(:provider) }
+
+    it 'is true if there are no admin users and the provider has one course' do
+      create(:course, provider: provider)
+      expect(provider.lacks_admin_users?).to be true
+    end
+
+    it 'is true if there are no users with both manage users and manage organisations and the provider has one course' do
+      create(:course, provider: provider)
+      create(:provider_user, :with_manage_users, providers: [provider])
+      expect(provider.lacks_admin_users?).to be true
+    end
+
+    it 'is false if the provider has no courses' do
+      expect(provider.lacks_admin_users?).to be false
+    end
+
+    it 'is false if there is at least one admin user and the provider has one course' do
+      create(:course, provider: provider)
+      create(:provider_user, :with_manage_users, :with_manage_organisations, providers: [provider])
+      expect(provider.lacks_admin_users?).to be false
+    end
+  end
 end

--- a/spec/models/support_interface/providers_filter_spec.rb
+++ b/spec/models/support_interface/providers_filter_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::ProvidersFilter do
   describe '#filter_records' do
-    it 'filters by having one or more courses open on apply' do
+    it 'filters by having one or more courses' do
       provider_with_course = create(:provider)
       create(:course, :open_on_apply, provider: provider_with_course)
       create(:provider)

--- a/spec/models/support_interface/providers_filter_spec.rb
+++ b/spec/models/support_interface/providers_filter_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::ProvidersFilter do
   describe '#filter_records' do
-    it 'filters by synced courses' do
-      provider_with_synced_courses = create(:provider, sync_courses: true)
-      create(:provider, sync_courses: false)
-
+    it 'filters by having one or more courses open on apply' do
+      provider_with_course = create(:provider)
+      create(:course, :open_on_apply, provider: provider_with_course)
+      create(:provider)
       providers = Provider.all
-      filter = described_class.new(params: { onboarding_stages: %w[synced_only] })
+      filter = described_class.new(params: { onboarding_stages: %w[with_courses] })
 
-      expect(filter.filter_records(providers)).to eq [provider_with_synced_courses]
+      expect(filter.filter_records(providers)).to eq [provider_with_course]
     end
 
     it 'filters by DSA signed' do

--- a/spec/system/support_interface/adding_a_new_provider_user_spec.rb
+++ b/spec/system/support_interface/adding_a_new_provider_user_spec.rb
@@ -11,10 +11,10 @@ RSpec.feature 'Managing provider users v2' do
 
     when_i_visit_the_support_console
     and_i_navigate_to_provider_users_page
-    and_i_filter_providers_by_synced_courses
-    then_i_see_synced_providers
+    and_i_filter_providers_by_having_courses
+    then_i_see_providers_with_courses
 
-    when_i_click_on_a_synced_provider
+    when_i_click_on_a_provider
     and_i_click_on_users
     and_i_click_add_user
     then_i_should_see_the_add_user_form
@@ -43,14 +43,14 @@ RSpec.feature 'Managing provider users v2' do
   end
 
   def and_providers_exist
-    @provider = create(:provider, name: 'Example provider', code: 'ABC', sync_courses: true)
+    @provider = create(:provider, name: 'Example provider', code: 'ABC')
     create(:course, :open_on_apply, provider: @provider)
     @provider2 = create(:provider, name: 'Another provider', code: 'DEF')
     create(:course, :open_on_apply, provider: @provider2)
     create(:provider, name: 'Not shown provider', code: 'GHI')
   end
 
-  def then_i_see_synced_providers
+  def then_i_see_providers_with_courses
     expect(page).to have_content 'Example provider'
     expect(page).to have_content 'Another provider'
     expect(page).not_to have_content 'Not shown provider'
@@ -64,7 +64,7 @@ RSpec.feature 'Managing provider users v2' do
     click_link 'Providers'
   end
 
-  def and_i_filter_providers_by_synced_courses
+  def and_i_filter_providers_by_having_courses
     check 'With courses'
     click_on 'Apply filters'
   end
@@ -73,7 +73,7 @@ RSpec.feature 'Managing provider users v2' do
     click_on 'Add user'
   end
 
-  def when_i_click_on_a_synced_provider
+  def when_i_click_on_a_provider
     click_on 'Example provider (ABC)'
   end
 

--- a/spec/system/support_interface/adding_a_new_provider_user_spec.rb
+++ b/spec/system/support_interface/adding_a_new_provider_user_spec.rb
@@ -45,7 +45,8 @@ RSpec.feature 'Managing provider users v2' do
   def and_providers_exist
     @provider = create(:provider, name: 'Example provider', code: 'ABC', sync_courses: true)
     create(:course, :open_on_apply, provider: @provider)
-    create(:provider, name: 'Another provider', code: 'DEF', sync_courses: true)
+    @provider2 = create(:provider, name: 'Another provider', code: 'DEF')
+    create(:course, :open_on_apply, provider: @provider2)
     create(:provider, name: 'Not shown provider', code: 'GHI')
   end
 
@@ -64,7 +65,7 @@ RSpec.feature 'Managing provider users v2' do
   end
 
   def and_i_filter_providers_by_synced_courses
-    check 'With synced courses'
+    check 'With courses'
     click_on 'Apply filters'
   end
 


### PR DESCRIPTION
## Context

Remove references to sync courses and have the old 'sync courses filter' key off available courses instead. 

## Link to Trello card

https://trello.com/c/CJY1j6Uk/4039-change-with-synced-courses-filter-to-with-courses-filter
## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
