### PR TITLE
Make some changes to the v1.1 api

### DIFF
--- a/app/controllers/candidate_api/candidates_controller.rb
+++ b/app/controllers/candidate_api/candidates_controller.rb
@@ -42,16 +42,16 @@ module CandidateAPI
             email_address: candidate.email_address,
             created_at: candidate.created_at,
             updated_at: candidate.candidate_api_updated_at,
-            application_forms: {
-              data: [candidate.application_forms.map do |application|
+            application_forms:
+              candidate.application_forms.map do |application|
                 {
                   id: application.id,
                   created_at: application.created_at,
+                  updated_at: application.updated_at,
                   application_status: ProcessState.new(application).state,
                   application_phase: application.phase,
                 }
-              end],
-            },
+              end,
           },
         }
       end

--- a/app/controllers/candidate_api/candidates_controller.rb
+++ b/app/controllers/candidate_api/candidates_controller.rb
@@ -35,21 +35,23 @@ module CandidateAPI
                             .order('application_forms.created_at DESC')
 
       candidates.map do |candidate|
+        current_application = candidate.application_forms.order(:created_at).last
+
         {
           id: candidate.public_id,
           type: 'candidate',
           attributes: {
-            email_address: candidate.email_address,
             created_at: candidate.created_at,
             updated_at: candidate.candidate_api_updated_at,
+            email_address: candidate.email_address,
+            application_status: ProcessState.new(current_application).state,
+            application_phase: current_application&.phase,
             application_forms:
               candidate.application_forms.map do |application|
                 {
                   id: application.id,
                   created_at: application.created_at,
                   updated_at: application.updated_at,
-                  application_status: ProcessState.new(application).state,
-                  application_phase: application.phase,
                 }
               end,
           },

--- a/config/candidate-api.yml
+++ b/config/candidate-api.yml
@@ -89,10 +89,6 @@ components:
         - updated_at
         - application_forms
       properties:
-        email_address:
-         type: string
-         description: Candidate email address
-         example: email@example.com
         created_at:
          type: string
          format: date-time
@@ -103,14 +99,37 @@ components:
          format: date-time
          description: Time of last change
          example: 2021-05-20T12:34:00Z
+        email_address:
+         type: string
+         description: Candidate email address
+         example: email@example.com
+        application_status:
+         type: string
+         description: The status of the candidates current application form
+         enum:
+          - never_signed_in
+          - unsubmitted_not_started_form
+          - unsubmitted_in_progress
+          - awaiting_provider_decisions
+          - awaiting_candidate_response
+          - recruited
+          - pending_conditions
+          - offer_deferred
+          - ended_without_success
+          - unknown_state
+         example: awaiting_provider_decisions
+        application_phase:
+         type: string
+         nullable: true
+         description: The phase of the candidates current application. In the first phase, "Apply 1", the
+            candidate can choose up to 3 courses. If all of those choices are rejected,
+            declined, or withdrawn, the user can go into "Apply 2". This means
+            they can choose 1 course at a time.
+         enum:
+          - apply_1
+          - apply_2
+         example: apply_1
         application_forms:
-         "$ref": "#/components/schemas/ApplicationForms"
-    ApplicationForms:
-      type: object
-      required:
-        - data
-      properties:
-        data:
          type: array
          items:
           "$ref": "#/components/schemas/ApplicationForm"
@@ -131,31 +150,11 @@ components:
          format: date-time
          description: The date an application was created
          example: 2021-05-20T12:34:00Z
-        application_status:
+        updated_at:
          type: string
-         description: The status of the candidates application form
-         enum:
-          - never_signed_in
-          - unsubmitted_not_started_form
-          - unsubmitted_in_progress
-          - awaiting_provider_decisions
-          - awaiting_candidate_response
-          - recruited
-          - pending_conditions
-          - offer_deferred
-          - ended_without_success
-          - unknown_state
-         example: awaiting_provider_decisions
-        application_phase:
-         type: string
-         description: The phase of this application. In the first phase, "Apply 1", the
-            candidate can choose up to 3 courses. If all of those choices are rejected,
-            declined, or withdrawn, the user can go into "Apply 2". This means
-            they can choose 1 course at a time.
-         enum:
-          - apply_1
-          - apply_2
-         example: apply_1
+         format: date-time
+         description: Time of last change
+         example: 2021-05-20T12:34:00Z
     UnauthorizedResponse:
       type: object
       required:

--- a/spec/requests/candidate_api/get_candidates_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_spec.rb
@@ -64,7 +64,8 @@ RSpec.describe 'GET /candidate-api/candidates', type: :request do
 
     get_api_request "/candidate-api/candidates?updated_since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}", token: candidate_api_token
 
-    response_data = parsed_response.dig('data', 0, 'attributes', 'application_forms', 'data', 0)
+    response_data = parsed_response.dig('data', 0, 'attributes', 'application_forms')
+
     expect(response_data.size).to eq(2)
 
     expect(response_data.first['id']).to eq(application_forms.second.id)
@@ -74,7 +75,7 @@ RSpec.describe 'GET /candidate-api/candidates', type: :request do
 
     get_api_request "/candidate-api/candidates?updated_since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}", token: candidate_api_token
 
-    response_data = parsed_response.dig('data', 0, 'attributes', 'application_forms', 'data', 0)
+    response_data = parsed_response.dig('data', 0, 'attributes', 'application_forms')
 
     expect(response_data.first['id']).to eq(application_forms.first.id)
     expect(response_data.second['id']).to eq(application_forms.second.id)


### PR DESCRIPTION
## Context

Some changes are required to the Candidates V1.1 API. We've been asked to move application status and phase to the top level (an attr on the candidate).

We've also been asked to add updated_at to application forms

## Changes proposed in this pull request

- Move application_status and application_status to attrs on the candidate
- Add updated_at to application forms
- Update the YAML file 
- Update the tests

## Link to Trello card

https://trello.com/c/bMh9QWYM/3773-update-v11-candidates-api-with-requested-changes

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
