### PR TITLE
4040 remove sync_courses from support exports

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -117,7 +117,7 @@ class DataExport < ApplicationRecord
     providers_export: {
       name: 'Providers',
       export_type: 'providers_export',
-      description: 'The list of providers that are being synced from the Find service, along with when they signed the data sharing agreement.',
+      description: 'The list of providers from the Find service, along with when they signed the data sharing agreement.',
       class: SupportInterface::ProvidersExport,
     },
     persona_export: {
@@ -141,7 +141,7 @@ class DataExport < ApplicationRecord
     sites_export: {
       name: 'Sites',
       export_type: 'sites_export',
-      description: 'A list of sites that are being synced from Find, along with distances to their respective providers.',
+      description: 'A list of sites from Find, along with distances to their respective providers.',
       class: SupportInterface::SitesExport,
     },
     structured_reasons_for_rejection: {

--- a/app/services/support_interface/provider_access_controls_export.rb
+++ b/app/services/support_interface/provider_access_controls_export.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class ProviderAccessControlsExport
     def data_for_export
-      providers = Provider.where(sync_courses: true)
+      providers = Provider.all
 
       providers.find_each(batch_size: 100).map do |provider|
         access_controls = ProviderAccessControlsStats.new(provider)

--- a/app/services/support_interface/providers_export.rb
+++ b/app/services/support_interface/providers_export.rb
@@ -23,7 +23,6 @@ module SupportInterface
           :provider_agreements,
           :sites,
         )
-        .where(sync_courses: true)
         .order(:name)
     end
 

--- a/app/services/support_interface/sites_export.rb
+++ b/app/services/support_interface/sites_export.rb
@@ -20,7 +20,6 @@ module SupportInterface
     def relevant_sites
       Site.joins(:course_options, :provider)
           .where(course_options: { site_still_valid: true })
-          .where(providers: { sync_courses: true })
           .order('providers.code ASC')
     end
   end

--- a/spec/services/support_interface/provider_access_controls_export_spec.rb
+++ b/spec/services/support_interface/provider_access_controls_export_spec.rb
@@ -2,19 +2,16 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::ProviderAccessControlsExport, with_audited: true do
   describe 'documentation' do
-    before { create(:provider, sync_courses: true) }
+    before { create(:provider) }
 
     it_behaves_like 'a data export'
   end
 
   describe '#data_for_export' do
-    it 'returns access control data for synced providers' do
+    it 'returns access control data for providers' do
       Timecop.freeze(2020, 5, 1, 12, 0, 0) do
-        training_provider = create(:provider, sync_courses: true)
-        ratifying_provider = create(:provider, sync_courses: true)
-
-        # Unsynced provider should not show up in the export
-        create(:provider)
+        training_provider = create(:provider)
+        ratifying_provider = create(:provider)
 
         provider_user1 = create(
           :provider_user,

--- a/spec/services/support_interface/providers_export_spec.rb
+++ b/spec/services/support_interface/providers_export_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportInterface::ProvidersExport, with_audited: true do
   describe 'documentation' do
     before do
-      provider = create(:provider, sync_courses: true, name: 'B', latitude: 51.498161, longitude: 0.129900)
+      provider = create(:provider, name: 'B', latitude: 51.498161, longitude: 0.129900)
       create(:site, latitude: 51.482578, longitude: -0.007659, provider: provider)
     end
 
@@ -11,9 +11,8 @@ RSpec.describe SupportInterface::ProvidersExport, with_audited: true do
   end
 
   describe '#providers' do
-    it 'returns synced providers and the date they signed the data sharing agreement' do
-      create(:provider, sync_courses: false)
-      provider_without_signed_dsa = create(:provider, sync_courses: true, name: 'B', latitude: 51.498161, longitude: 0.129900)
+    it 'returns providers and the date they signed the data sharing agreement' do
+      provider_without_signed_dsa = create(:provider, name: 'B', latitude: 51.498161, longitude: 0.129900)
       create(:site, latitude: 51.482578, longitude: -0.007659, provider: provider_without_signed_dsa)
       create(:site, latitude: 52.246868, longitude: 0.711190, provider: provider_without_signed_dsa)
 
@@ -22,7 +21,6 @@ RSpec.describe SupportInterface::ProvidersExport, with_audited: true do
         provider_with_signed_dsa = create(
           :provider,
           :with_signed_agreement,
-          sync_courses: true,
           name: 'A',
         )
       end

--- a/spec/services/support_interface/sites_export_spec.rb
+++ b/spec/services/support_interface/sites_export_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportInterface::SitesExport do
   describe 'documentation' do
     before do
-      provider = create(:provider, sync_courses: true)
+      provider = create(:provider)
       create(:course_option,
              site_still_valid: true,
              course: create(:course, provider: provider),
@@ -14,33 +14,39 @@ RSpec.describe SupportInterface::SitesExport do
   end
 
   describe '#sites' do
-    it 'returns synced sites and provider details' do
-      unsynced_provider = create(:provider, sync_courses: false, latitude: 20, longitude: 20)
-      synced_provider = create(:provider, sync_courses: true, latitude: 20, longitude: 20)
+    it 'returns sites and provider details' do
+      provider1 = create(:provider, latitude: 20, longitude: 20)
+      provider2 = create(:provider, latitude: 20, longitude: 20)
 
       create(:course_option,
              site_still_valid: true,
-             course: create(:course, provider: synced_provider),
-             site: create(:site, latitude: 20, longitude: 21, provider: synced_provider))
+             course: create(:course, provider: provider2),
+             site: create(:site, latitude: 20, longitude: 21, provider: provider2))
 
       create(:course_option,
              site_still_valid: true,
-             course: create(:course, provider: unsynced_provider),
-             site: create(:site, latitude: 20, longitude: 21, provider: unsynced_provider))
+             course: create(:course, provider: provider1),
+             site: create(:site, latitude: 20, longitude: 21, provider: provider1))
 
       create(:course_option,
              site_still_valid: false,
-             course: create(:course, provider: synced_provider),
-             site: create(:site, latitude: 20, longitude: 21, provider: synced_provider))
+             course: create(:course, provider: provider2),
+             site: create(:site, latitude: 20, longitude: 21, provider: provider2))
 
       sites = described_class.new.sites
-      expect(sites.size).to eq(1)
+      expect(sites.size).to eq(2)
 
       expect(sites).to contain_exactly(
         {
-          site_id: synced_provider.sites.first.id,
-          site_code: synced_provider.sites.first.code,
-          provider_code: synced_provider.code,
+          site_id: provider1.sites.first.id,
+          site_code: provider1.sites.first.code,
+          provider_code: provider1.code,
+          distance_from_provider: '64.9',
+        },
+        {
+          site_id: provider2.sites.first.id,
+          site_code: provider2.sites.first.code,
+          provider_code: provider2.code,
           distance_from_provider: '64.9',
         },
       )


### PR DESCRIPTION
## Context

As part of the epic to deprecate sync_courses we should remove them from the support data exports. 

## Link to Trello card

https://trello.com/c/RcBS6806/4040-remove-synccourses-from-support-exports

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
