### PR TITLE
Use Oj gem for faster JSON rendering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ gem 'discard'
 
 gem 'json-schema'
 gem 'json_api_client'
+# Oj is faster at rendering JSON than the default Rails JSON serializer
+gem 'oj'
 
 # We use a postgres sequence to generate public_ids for qualifications
 # See adr/0018-public-ids-for-qualifications.md for details on why this is necessary

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,6 +339,7 @@ GEM
       shellany (~> 0.0)
     notifications-ruby-client (5.3.0)
       jwt (>= 1.5, < 3)
+    oj (3.12.3)
     okcomputer (1.18.4)
     omniauth (1.9.1)
       hashie (>= 3.4.6)
@@ -710,6 +711,7 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.7)
   mail-notify
+  oj
   okcomputer
   omniauth
   omniauth-rails_csrf_protection

--- a/config/initializers/oj.rb
+++ b/config/initializers/oj.rb
@@ -1,0 +1,1 @@
+Oj.optimize_rails


### PR DESCRIPTION
## Context

`Oj` performs much better than the default Ruby/Rails JSON serializer.

https://www.koffeinfrei.org/2018/03/21/ruby-serialization-benchmark/

I ran some benchmarks calling `to_json` on 1675 application objects produced by `VendorAPI::SingleApplicationPresenter#as_json`, timings are average of 100 runs.

#### Default Rails serializer
```
[SingleApplicationPresenter#as_json]#to_json - 2662.184 ms
```

#### Oj
```
[SingleApplicationPresenter#as_json]#to_json - 913.974 ms
```

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds `oj` gem
- Adds initializer to optimize Oj for Rails.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/yzKDiTtI/4037-spike-investigate-performance-issues-with-get-applications-endpoint
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
