### PR TITLE
New personal user permissions page

### DIFF
--- a/app/components/provider_interface/organisation_permissions_form_component.html.erb
+++ b/app/components/provider_interface/organisation_permissions_form_component.html.erb
@@ -10,7 +10,7 @@
     <%= page_heading %>
   </h1>
 
-  <p class="govuk-body"><%= t('.explanation') %></p>
+  <p class="govuk-body"><%= t('provider_relationship_permissions.view_applications_explanation') %></p>
 
   <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| %>
     <div class="govuk-form-group" data-qa="<%= permission_name.to_s.dasherize %>">

--- a/app/components/provider_interface/provider_partner_permission_breakdown_component.rb
+++ b/app/components/provider_interface/provider_partner_permission_breakdown_component.rb
@@ -10,11 +10,13 @@ module ProviderInterface
     def partners_for_which_permission_applies
       @partners_for_which_permission_applies ||= Provider.where(id: training_partners_for_which_permission_applies_ids)
                                                          .or(Provider.where(id: ratifying_partners_for_which_permission_applies_ids))
+                                                         .order(:name)
     end
 
     def partners_for_which_permission_does_not_apply
       @partners_for_which_permission_does_not_apply ||= Provider.where(id: training_partners_for_which_permission_does_not_apply_ids)
                                                                 .or(Provider.where(id: ratifying_partners_for_which_permission_does_not_apply_ids))
+                                                                .order(:name)
     end
 
     def partners_for_which_permission_applies_text

--- a/app/components/provider_interface/user_permission_summary_component.html.erb
+++ b/app/components/provider_interface/user_permission_summary_component.html.erb
@@ -11,7 +11,7 @@
           <%= render ProviderInterface::ProviderPartnerPermissionBreakdownComponent.new(provider: provider, permission: permission) %>
         <% end %>
       </dd>
-      <% if can_change_permissions? %>
+      <% if editable %>
         <dd class="govuk-summary-list__actions">
           <%= govuk_link_to(provider_interface_provider_user_edit_permissions_path(provider_user, provider), class: 'govuk-!-display-none-print') do %>
             Change

--- a/app/components/provider_interface/user_permission_summary_component.rb
+++ b/app/components/provider_interface/user_permission_summary_component.rb
@@ -1,10 +1,10 @@
 module ProviderInterface
   class UserPermissionSummaryComponent < ViewComponent::Base
-    attr_reader :provider_user, :provider, :current_user
+    attr_reader :provider_user, :provider, :editable
 
-    def initialize(provider_user:, provider:, current_user:)
+    def initialize(provider_user:, provider:, editable: false)
       @provider_user = provider_user
-      @current_user = current_user
+      @editable = editable
       @provider = provider
     end
 
@@ -16,10 +16,6 @@ module ProviderInterface
 
     def can_perform_permission_y_n?(permission)
       can_perform_permission?(permission) ? 'Yes' : 'No'
-    end
-
-    def can_change_permissions?
-      current_user.authorisation.can_manage_users_for?(provider: provider)
     end
 
     def description_for(permission)

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -10,6 +10,8 @@ class SummaryListComponent < ViewComponent::Base
     if row[:value].is_a?(Array)
       if row[:bulleted_format]
         format_list_with_bullets(row[:value])
+      elsif row[:paragraph_format]
+        format_list_as_paragraphs(row[:value])
       else
         row[:value].map { |s| ERB::Util.html_escape(s) }.join('<br>').html_safe
       end
@@ -64,5 +66,9 @@ private
       markup << '<li>'.html_safe << list_item << '</li>'.html_safe
     end
     markup + '</ul>'.html_safe
+  end
+
+  def format_list_as_paragraphs(list)
+    list.map { |s| "<p class=\"govuk-body\">#{ERB::Util.html_escape(s)}</p>" }.join.html_safe
   end
 end

--- a/app/controllers/provider_interface/personal_permissions_controller.rb
+++ b/app/controllers/provider_interface/personal_permissions_controller.rb
@@ -1,0 +1,17 @@
+module ProviderInterface
+  class PersonalPermissionsController < ProviderInterfaceController
+    before_action :redirect_to_account_unless_feature_flag_on
+
+    def show
+      @providers = current_provider_user.providers.order(:name)
+    end
+
+  private
+
+    def redirect_to_account_unless_feature_flag_on
+      unless FeatureFlag.active?(:account_and_org_settings_changes)
+        redirect_to provider_interface_account_path
+      end
+    end
+  end
+end

--- a/app/views/provider_interface/account/show.html.erb
+++ b/app/views/provider_interface/account/show.html.erb
@@ -8,7 +8,7 @@
     <%= govuk_link_to t('page_titles.provider.personal_details'), '#' %>
   </li>
   <li>
-    <%= govuk_link_to t('page_titles.provider.user_permissions'), '#' %>
+    <%= govuk_link_to t('page_titles.provider.user_permissions'), provider_interface_personal_permissions_path %>
   </li>
   <li>
     <%= govuk_link_to t('page_titles.provider.email_notifications'), '#' %>

--- a/app/views/provider_interface/personal_permissions/show.html.erb
+++ b/app/views/provider_interface/personal_permissions/show.html.erb
@@ -23,7 +23,7 @@
 
     <% @providers.each do |provider| %>
       <h2 class="govuk-heading-m"><%= t('.permissions_for', provider_name: provider.name) %></h2>
-      <p class="govuk-body">All users can view applications</p>
+      <p class="govuk-body"><%= t('provider_relationship_permissions.view_applications_explanation') %></p>
 
       <%= render ProviderInterface::UserPermissionSummaryComponent.new(
         provider_user: current_provider_user,

--- a/app/views/provider_interface/personal_permissions/show.html.erb
+++ b/app/views/provider_interface/personal_permissions/show.html.erb
@@ -1,0 +1,34 @@
+<%= content_for :browser_title, t('page_titles.provider.user_permissions') %>
+<% content_for :before_content do %>
+  <%= breadcrumbs({
+    t('page_titles.provider.account') => provider_interface_account_path,
+    t('page_titles.provider.user_permissions') => nil,
+  }) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('page_titles.provider.user_permissions') %></h1>
+
+    <h2 class="govuk-heading-m"><%= t('.access_to_orgs.heading') %></h2>
+    <%= render SummaryListComponent.new(
+      rows: [
+        {
+          key: t('.access_to_orgs.key'),
+          value: @providers.map(&:name),
+          paragraph_format: true,
+        },
+      ],
+    ) %>
+
+    <% @providers.each do |provider| %>
+      <h2 class="govuk-heading-m"><%= t('.permissions_for', provider_name: provider.name) %></h2>
+      <p class="govuk-body">All users can view applications</p>
+
+      <%= render ProviderInterface::UserPermissionSummaryComponent.new(
+        provider_user: current_provider_user,
+        provider: provider,
+      ) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/personal_permissions/show.html.erb
+++ b/app/views/provider_interface/personal_permissions/show.html.erb
@@ -10,19 +10,24 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('page_titles.provider.user_permissions') %></h1>
 
-    <h2 class="govuk-heading-m"><%= t('.access_to_orgs.heading') %></h2>
-    <%= render SummaryListComponent.new(
-      rows: [
-        {
-          key: t('.access_to_orgs.key'),
-          value: @providers.map(&:name),
-          paragraph_format: true,
-        },
-      ],
-    ) %>
+    <% if @providers.length > 1 %>
+      <h2 class="govuk-heading-m"><%= t('.access_to_orgs.heading') %></h2>
+      <%= render SummaryListComponent.new(
+        rows: [
+          {
+            key: t('.access_to_orgs.key'),
+            value: @providers.map(&:name),
+            paragraph_format: true,
+          },
+        ],
+      ) %>
+    <% end %>
 
     <% @providers.each do |provider| %>
-      <h2 class="govuk-heading-m"><%= t('.permissions_for', provider_name: provider.name) %></h2>
+      <% if @providers.length > 1 %>
+        <h2 class="govuk-heading-m"><%= t('.permissions_for', provider_name: provider.name) %></h2>
+      <% end %>
+
       <p class="govuk-body"><%= t('provider_relationship_permissions.view_applications_explanation') %></p>
 
       <%= render ProviderInterface::UserPermissionSummaryComponent.new(

--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -1,18 +1,15 @@
 en:
   provider_relationship_permissions:
+    view_applications_explanation: All users can view applications.
     question: Who can %{permission_description}?
     make_decisions:
       description: Make offers and reject applications
-      hint: This includes making offers, amending offers and rejecting applications
     view_safeguarding_information:
       description: View criminal convictions and professional misconduct
-      hint: This information is in the ‘criminal convictions and professional misconduct’ section of the application
     view_diversity_information:
       description: View sex, disability and ethnicity information
-      hint: This information is in the ‘equality and diversity’ section of the application – it includes sex, ethnicity and disability status
   provider_interface:
     organisation_permissions_form_component:
-      explanation: All users can view applications.
       setup:
         caption: Set up organisation permissions
         submit_button: Continue

--- a/config/locales/provider_interface/user_permisssions.yml
+++ b/config/locales/provider_interface/user_permisssions.yml
@@ -12,3 +12,10 @@ en:
       description: Manage organisation permissions
     set_up_interviews:
       description: Set up interviews
+  provider_interface:
+    personal_permissions:
+      show:
+        permissions_for: Permissions for %{provider_name}
+        access_to_orgs:
+          heading: Access to organisations
+          key: Organisations you have access to

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -755,6 +755,8 @@ Rails.application.routes.draw do
         end
       end
 
+      resource :personal_permissions, only: %i[show], path: 'permissions'
+
       # TODO: Revisit whether these redirects are still needed after 1st November 2021
       get '/organisational-permissions', to: redirect('/provider/organisation-settings/organisations')
       get '/organisational-permissions/:id', to: redirect { |params, _| "/provider/organisation-settings/organisations/#{params[:id]}/organisation-permissions" }

--- a/spec/components/previews/provider_interface/user_permission_summary_component_preview.rb
+++ b/spec/components/previews/provider_interface/user_permission_summary_component_preview.rb
@@ -2,15 +2,28 @@ module ProviderInterface
   class UserPermissionSummaryComponentPreview < ViewComponent::Preview
     layout 'previews/provider'
 
-    def user_permission_summary
+    def editable_permission_summary
+      provider_user = example_provider_user
+      render UserPermissionSummaryComponent.new(
+        provider_user: provider_user,
+        provider: provider_user.providers.first,
+        editable: true,
+      )
+    end
+
+    def uneditable_permission_summary
+      provider_user = example_provider_user
+      render UserPermissionSummaryComponent.new(
+        provider_user: provider_user,
+        provider: provider_user.providers.first,
+      )
+    end
+
+  private
+
+    def example_provider_user
       provider = FactoryBot.create(:provider)
       provider_user = FactoryBot.create(:provider_user)
-      current_provider_user = FactoryBot.create(:provider_user)
-
-      FactoryBot.create(:provider_permissions,
-                        provider: provider,
-                        provider_user: current_provider_user,
-                        manage_users: true)
 
       FactoryBot.create(:provider_permissions,
                         provider: provider,
@@ -50,11 +63,7 @@ module ProviderInterface
                           ratifying_provider_can_view_diversity_information: other_random_boolean_value)
       end
 
-      render UserPermissionSummaryComponent.new(
-        provider_user: provider_user,
-        provider: provider,
-        current_user: current_provider_user,
-      )
+      provider_user
     end
   end
 end

--- a/spec/components/provider_interface/provider_partner_permission_breakdown_component_spec.rb
+++ b/spec/components/provider_interface/provider_partner_permission_breakdown_component_spec.rb
@@ -31,9 +31,8 @@ RSpec.describe ProviderInterface::ProviderPartnerPermissionBreakdownComponent do
     end
 
     it 'returns a list of all providers that allow the specified provider to make decisions on their behalf' do
-      (allowed_training_providers + allowed_ratifying_providers).each do |provider|
-        expect(render.css('#partners-for-which-permission-applies').text).to include(provider.name)
-      end
+      expected_provider_names = (allowed_training_providers + allowed_ratifying_providers).map(&:name).sort
+      expect(render.css('#partners-for-which-permission-applies li').map(&:text)).to eq(expected_provider_names)
     end
   end
 
@@ -64,9 +63,8 @@ RSpec.describe ProviderInterface::ProviderPartnerPermissionBreakdownComponent do
     end
 
     it 'returns a list of all providers that allow the specified provider to make decisions on their behalf' do
-      (prohibited_training_providers + prohibited_ratifying_providers + non_configured_providers).each do |provider|
-        expect(render.css('#partners-for-which-permission-does-not-apply').text).to include(provider.name)
-      end
+      expected_provider_names = (prohibited_training_providers + prohibited_ratifying_providers + non_configured_providers).map(&:name).sort
+      expect(render.css('#partners-for-which-permission-does-not-apply li').map(&:text)).to eq(expected_provider_names)
     end
   end
 

--- a/spec/components/provider_interface/user_permission_summary_component_spec.rb
+++ b/spec/components/provider_interface/user_permission_summary_component_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::UserPermissionSummaryComponent, type: :controller do
-  let(:current_provider_user) { create(:provider_user) }
+  let(:editable) { false }
   let(:provider_user) { create(:provider_user) }
   let(:provider) { create(:provider) }
   let!(:permissions) do
@@ -21,7 +21,7 @@ RSpec.describe ProviderInterface::UserPermissionSummaryComponent, type: :control
   let(:render) do
     render_inline(described_class.new(provider_user: provider_user,
                                       provider: provider,
-                                      current_user: current_provider_user))
+                                      editable: editable))
   end
 
   before do
@@ -113,26 +113,16 @@ RSpec.describe ProviderInterface::UserPermissionSummaryComponent, type: :control
       end
     end
 
-    context 'when the user can manage users permissions' do
-      let!(:current_user_permissions) do
-        FactoryBot.create(:provider_permissions,
-                          provider: provider,
-                          provider_user: current_provider_user,
-                          manage_users: true)
-      end
+    context 'when editable is true' do
+      let(:editable) { true }
 
       it 'displays a change link' do
         expect(row_text_selector(:view_diversity_information, render)).to include('Change')
       end
     end
 
-    context 'when the user cannot manage users permissions' do
-      let!(:current_user_permissions) do
-        FactoryBot.create(:provider_permissions,
-                          provider: provider,
-                          provider_user: current_provider_user,
-                          manage_users: false)
-      end
+    context 'when editable is false' do
+      let(:editable) { false }
 
       it 'does not display a change link' do
         expect(row_text_selector(:view_diversity_information, render)).not_to include('Change')

--- a/spec/components/summary_list_component_spec.rb
+++ b/spec/components/summary_list_component_spec.rb
@@ -29,6 +29,36 @@ RSpec.describe SummaryListComponent do
       expect(result.css('.govuk-summary-list__value').to_html).to include('Whoa Drive<br>Wewvile<br>London')
     end
 
+    it 'renders values surrounded by <p> tags if specified for the row' do
+      rows = [
+        key: 'Address:',
+        value: %w[A list of items],
+        paragraph_format: true,
+      ]
+      result = render_inline(described_class.new(rows: rows))
+
+      expect(result.to_html).to include(<<~HTML)
+        <p class="govuk-body">A</p>
+        <p class="govuk-body">list</p>
+        <p class="govuk-body">of</p>
+        <p class="govuk-body">items</p>
+      HTML
+    end
+
+    it 'safely escapes markup when rendering values as <p> tags' do
+      rows = [
+        key: 'Address:',
+        value: ['<script></script>', '<br>'],
+        paragraph_format: true,
+      ]
+      result = render_inline(described_class.new(rows: rows))
+
+      expect(result.to_html).to include(<<~HTML)
+        <p class="govuk-body">&lt;script&gt;&lt;/script&gt;</p>
+        <p class="govuk-body">&lt;br&gt;</p>
+      HTML
+    end
+
     it 'renders values as bullets if specified for the row' do
       rows = [
         key: 'Address:',

--- a/spec/system/provider_interface/provider_views_their_own_user_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_views_their_own_user_permissions_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.feature 'User permissions page' do
+  include DfESignInHelpers
+
+  before { FeatureFlag.activate(:account_and_org_settings_changes) }
+
+  scenario 'Provider views their own user permissions' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_belong_to_two_providers
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_click_on_the_account_profile_link
+    then_i_see_the_user_permissions_page_with_my_providers
+    and_i_see_my_permissions_for_the_alphabetically_first_provider
+    and_i_see_my_permissions_for_the_alphabetically_second_provider
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_belong_to_two_providers
+    provider_user_exists_in_apply_database
+    @provider_user = ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    @first_provider = Provider.find_by(code: 'ABC')
+    @second_provider = Provider.find_by(code: 'DEF')
+    ProviderPermissions.find_by(provider: @second_provider, provider_user: @provider_user).update(view_diversity_information: true)
+  end
+
+  def when_i_click_on_the_account_profile_link
+    click_on('Your account')
+    click_on('Your user permissions')
+  end
+
+  def then_i_see_the_user_permissions_page_with_my_providers
+    expect(element_text(selector: 'h2', index: 1)).to eq('Access to organisations')
+    within(element(selector: '.govuk-summary-list__value', index: 0)) do
+      expect(page).to have_selector('p', text: @first_provider.name)
+      expect(page).to have_selector('p', text: @second_provider.name)
+    end
+  end
+
+  def and_i_see_my_permissions_for_the_alphabetically_first_provider
+    expect(element_text(selector: 'h2', index: 2)).to eq("Permissions for #{@second_provider.name}")
+    within(element(selector: '.govuk-summary-list', index: 1)) do
+      expect(element_text(selector: '.govuk-summary-list__key', index: 0)).to eq('Manage users')
+      expect(element_text(selector: '.govuk-summary-list__key', index: 1)).to eq('Manage organisation permissions')
+      expect(element_text(selector: '.govuk-summary-list__key', index: 2)).to eq('Set up interviews')
+      expect(element_text(selector: '.govuk-summary-list__key', index: 3)).to eq('Make offers and reject applications')
+      expect(element_text(selector: '.govuk-summary-list__key', index: 4)).to eq('View criminal convictions and professional misconduct')
+      expect(element_text(selector: '.govuk-summary-list__key', index: 5)).to eq('View sex, disability and ethnicity information')
+      expect(element_text(selector: '.govuk-summary-list__value', index: 5)).to include('This user permission is affected by organisation permissions.')
+    end
+  end
+
+  def and_i_see_my_permissions_for_the_alphabetically_second_provider
+    expect(element_text(selector: 'h2', index: 3)).to eq("Permissions for #{@first_provider.name}")
+    within(element(selector: '.govuk-summary-list', index: 2)) do
+      expect(element_text(selector: '.govuk-summary-list__key', index: 0)).to eq('Manage users')
+      expect(element_text(selector: '.govuk-summary-list__key', index: 1)).to eq('Manage organisation permissions')
+      expect(element_text(selector: '.govuk-summary-list__key', index: 2)).to eq('Set up interviews')
+      expect(element_text(selector: '.govuk-summary-list__key', index: 3)).to eq('Make offers and reject applications')
+      expect(element_text(selector: '.govuk-summary-list__key', index: 4)).to eq('View criminal convictions and professional misconduct')
+      expect(element_text(selector: '.govuk-summary-list__key', index: 5)).to eq('View sex, disability and ethnicity information')
+    end
+  end
+
+  def element_text(selector:, index:)
+    element(selector: selector, index: index).text.squish
+  end
+
+  def element(selector:, index:)
+    all(selector)[index]
+  end
+end


### PR DESCRIPTION
## Context
We have added a separate page for provider users to view their own user permissions. This should make permissions more obvious

## Changes proposed in this pull request
Add a new permissions page, which uses the new breakdown components

Tweak the new component to conditionally render change links

Tweak the summary list component to allow `<p>` tags to be rendered rather than `<br>`

## Guidance to review
Per commit

## Link to Trello card
https://trello.com/c/7a1UfKKH/4044-change-your-account-page-to-show-new-layout

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
