### PR TITLE
Add `feedback_requested` references to carry over

### DIFF
--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -46,7 +46,7 @@ class DuplicateApplication
       )
     end
 
-    original_application_form.application_references.where(feedback_status: %w[feedback_provided not_requested_yet cancelled_at_end_of_cycle]).reject(&:feedback_overdue?).each do |w|
+    original_application_form.application_references.where(feedback_status: %w[feedback_provided not_requested_yet cancelled_at_end_of_cycle feedback_requested]).reject(&:feedback_overdue?).each do |w|
       new_application_form.application_references.create!(
         w.attributes.except(*IGNORED_CHILD_ATTRIBUTES).merge!(duplicate: true),
       )
@@ -56,6 +56,10 @@ class DuplicateApplication
       if references_cancelled_at_eoc.present?
         references_cancelled_at_eoc.each(&:not_requested_yet!)
       end
+    end
+
+    original_application_form.application_references.feedback_requested.each do |reference|
+      reference.update_column(:hashed_sign_in_token, nil)
     end
 
     original_application_form.application_work_history_breaks.each do |w|

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -54,21 +54,22 @@ RSpec.describe CarryOverApplication do
 
     it 'sets the reference to the not_requested state' do
       create(:reference, feedback_status: :feedback_provided, application_form: application_form)
+      create(:reference, feedback_status: :feedback_requested, application_form: application_form)
       create(:reference, feedback_status: :cancelled_at_end_of_cycle, application_form: application_form)
       create(:reference, feedback_status: :feedback_refused, application_form: application_form)
 
       described_class.new(application_form).call
 
       expect(ApplicationForm.count).to eq 2
-      expect(ApplicationForm.last.application_references.count).to eq 2
-      expect(ApplicationForm.last.application_references.map(&:feedback_status)).to eq %w[feedback_provided not_requested_yet]
+      expect(ApplicationForm.last.application_references.count).to eq 3
+      expect(ApplicationForm.last.application_references.map(&:feedback_status)).to eq %w[feedback_provided feedback_requested not_requested_yet]
     end
 
     it 'does not carry over references whose feedback is overdue' do
       create(:reference, feedback_status: :cancelled_at_end_of_cycle, application_form: application_form, requested_at: 1.month.ago)
-      create(:reference, feedback_status: :cancelled_at_end_of_cycle, application_form: application_form, requested_at: 1.month.ago)
+      create(:reference, feedback_status: :feedback_requested, application_form: application_form, requested_at: 1.month.ago)
       create(:reference, feedback_status: :cancelled_at_end_of_cycle, application_form: application_form, requested_at: 2.days.ago, name: 'Carrie Over')
-      create(:reference, feedback_status: :cancelled_at_end_of_cycle, application_form: application_form, requested_at: 1.day.ago, name: 'Nixt Cycle')
+      create(:reference, feedback_status: :feedback_requested, application_form: application_form, requested_at: 1.day.ago, name: 'Nixt Cycle')
 
       described_class.new(application_form).call
 

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_application_with_references_to_new_cycle_and_referee_provides_reference_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_application_with_references_to_new_cycle_and_referee_provides_reference_spec.rb
@@ -1,0 +1,128 @@
+require 'rails_helper'
+
+RSpec.feature 'Carry over' do
+  include CandidateHelper
+  include CycleTimetableHelper
+
+  around do |example|
+    Timecop.freeze(mid_cycle) do
+      example.run
+    end
+  end
+
+  scenario 'Candidate carries over application with reference to new cycle and referees provide references' do
+    given_i_am_signed_in_as_a_candidate
+    when_i_have_an_unsubmitted_application
+    and_reference_is_sent_to_referee
+    and_the_recruitment_cycle_ends
+    and_the_cancel_unsubmitted_applications_worker_runs
+
+    when_i_sign_in_again
+    and_i_visit_the_application_dashboard
+    then_i_am_redirected_to_the_carry_over_interstitial
+
+    when_i_click_on_continue
+    then_i_see_a_copy_of_my_application
+    and_i_can_see_the_referee_i_previously_added
+
+    when_i_sign_out_as_the_candidate
+    and_i_sign_in_as_the_referee
+    then_i_am_asked_to_provide_a_reference_for_the_candidate
+
+    when_i_submit_the_outstanding_reference
+    and_sign_back_in_as_the_candidate
+    then_i_see_the_reference_completed
+  end
+
+  def given_i_am_signed_in_as_a_candidate
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def when_i_have_an_unsubmitted_application
+    @application_form = create(
+      :completed_application_form,
+      :with_gcses,
+      submitted_at: nil,
+      candidate: @candidate,
+      safeguarding_issues_status: :no_safeguarding_issues_to_declare,
+    )
+    @reference = create(
+      :reference,
+      feedback_status: :feedback_requested,
+      application_form: @application_form,
+    )
+  end
+
+  def and_reference_is_sent_to_referee
+    RefereeMailer.reference_request_email(@reference).deliver_now
+  end
+
+  def and_the_recruitment_cycle_ends
+    Timecop.safe_mode = false
+    Timecop.travel(after_apply_reopens)
+  ensure
+    Timecop.safe_mode = true
+  end
+
+  def and_the_cancel_unsubmitted_applications_worker_runs
+    CancelUnsubmittedApplicationsWorker.new.perform
+  end
+
+  def when_i_sign_in_again
+    logout
+    login_as(@candidate)
+  end
+
+  def and_i_visit_the_application_dashboard
+    visit candidate_interface_application_complete_path
+  end
+
+  def then_i_am_redirected_to_the_carry_over_interstitial
+    expect(page).to have_current_path candidate_interface_start_carry_over_path
+  end
+
+  def when_i_click_on_continue
+    click_button 'Continue'
+  end
+
+  def then_i_see_a_copy_of_my_application
+    expect(page).to have_title('Your application')
+  end
+
+  def and_i_can_see_the_referee_i_previously_added
+    expect(page).to have_content("#{@reference.name}: Awaiting response")
+  end
+
+  def when_i_sign_out_as_the_candidate
+    logout
+  end
+
+  def and_i_sign_in_as_the_referee
+    open_email(@reference.email_address)
+    click_sign_in_link(current_email)
+  end
+
+  def then_i_am_asked_to_provide_a_reference_for_the_candidate
+    expect(page).to have_content("Confirm how you know #{@application_form.full_name}")
+  end
+
+  def when_i_submit_the_outstanding_reference
+    choose 'Yes'
+    click_button t('continue')
+    choose 'No'
+    click_button t('continue')
+    fill_in 'Your reference', with: 'This is a reference for the candidate.'
+    click_button t('continue')
+    click_button t('referee.review.submit')
+  end
+
+  def and_sign_back_in_as_the_candidate
+    visit candidate_interface_application_complete_path
+    login_as(@candidate)
+  end
+
+  def then_i_see_the_reference_completed
+    expect(page).to have_content("#{@reference.name}: Reference received")
+  end
+end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_and_needs_to_select_course_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_and_needs_to_select_course_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature 'Carry over' do
     )
     @second_reference = create(
       :reference,
-      feedback_status: :not_requested_yet,
+      feedback_status: :feedback_requested,
       application_form: @application_form,
     )
   end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'Carry over' do
     )
     @second_reference = create(
       :reference,
-      feedback_status: :not_requested_yet,
+      feedback_status: :feedback_requested,
       application_form: @application_form,
     )
   end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature 'Carry over' do
     )
     @second_reference = create(
       :reference,
-      feedback_status: :not_requested_yet,
+      feedback_status: :feedback_requested,
       application_form: @application_form,
     )
   end

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
     then_i_can_review_the_amended_safeguarding_concerns
 
     and_i_click_the_submit_reference_button
-    then_i_see_am_told_i_submittted_my_refernce
+    then_i_see_am_told_i_submitted_my_reference
     then_i_see_the_confirmation_page
     and_i_receive_an_email_confirmation
     and_the_candidate_receives_a_notification
@@ -185,7 +185,7 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
     click_button t('referee.questionnaire.submit')
   end
 
-  def then_i_see_am_told_i_submittted_my_refernce
+  def then_i_see_am_told_i_submitted_my_reference
     expect(page).to have_content("Your reference for #{@application.full_name}")
   end
 


### PR DESCRIPTION
## Context

In order to facilitate applicants carrying over applications to the next cycle we need to ensure they can retain any references 'awaiting response' from the referee from unsubmitted applications.

## Changes proposed in this pull request
By tweaking the existing `duplicate` in the DuplicateApplication it 
should allow references in this state to be carried over with the 
application form. This should be naturally be excluded from apply again 
by virtue of the fact that that these references won't be in this state.

## Guidance to review

In the review app go to the support UI and put it in 'apply has re-opened' state then sign in as a candidate with an unsubmitted application and 'awaiting response' references. Carry the application over and check that references are also carried over.

Having a minor issue with a Runtime error on a system spec regarding hitting the `touch_choices` method when setting previous references `hashed_sign_in` token to `nil`. Is there a whitelist I can add this to or is this a bug of implementation?

## Link to Trello card

https://trello.com/c/YHa8gIEQ/3706-%F0%9F%94%81-eoc-not-cancelling-referees-tech-spike

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
