### PR TITLE
Cache return value of `VendorAPI::SingleApplicationPresenter#as_json`

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -2,6 +2,8 @@ module VendorAPI
   class SingleApplicationPresenter
     include Rails.application.routes.url_helpers
 
+    CACHE_EXPIRES_IN = 30.minutes
+
     UCAS_FEE_PAYER_CODES = {
       'SLC,SAAS,NIBd,EU,Chl,IoM' => '02',
       'Not Known' => '99',
@@ -13,52 +15,54 @@ module VendorAPI
     end
 
     def as_json
-      {
-        id: application_choice.id.to_s,
-        type: 'application',
-        attributes: {
-          support_reference: application_form.support_reference,
-          status: status,
-          phase: application_form.phase,
-          updated_at: application_choice.updated_at.iso8601,
-          submitted_at: application_form.submitted_at.iso8601,
-          personal_statement: personal_statement,
-          interview_preferences: application_form.interview_preferences,
-          reject_by_default_at: application_choice.reject_by_default_at&.iso8601,
-          recruited_at: application_choice.recruited_at,
-          hesa_itt_data: hesa_itt_data,
-          candidate: {
-            id: application_form.candidate.public_id,
-            first_name: application_form.first_name,
-            last_name: application_form.last_name,
-            date_of_birth: application_form.date_of_birth,
-            nationality: application_choice.nationalities,
-            domicile: application_form.domicile,
-            uk_residency_status: uk_residency_status,
-            uk_residency_status_code: uk_residency_status_code,
-            fee_payer: provisional_fee_payer_status,
-            english_main_language: application_form.english_main_language,
-            english_language_qualifications: application_form.english_language_qualification_details,
-            other_languages: application_form.other_language_details,
-            disability_disclosure: application_form.disability_disclosure,
+      Rails.cache.fetch(cache_key(application_choice), expires_in: CACHE_EXPIRES_IN) do
+        {
+          id: application_choice.id.to_s,
+          type: 'application',
+          attributes: {
+            support_reference: application_form.support_reference,
+            status: status,
+            phase: application_form.phase,
+            updated_at: application_choice.updated_at.iso8601,
+            submitted_at: application_form.submitted_at.iso8601,
+            personal_statement: personal_statement,
+            interview_preferences: application_form.interview_preferences,
+            reject_by_default_at: application_choice.reject_by_default_at&.iso8601,
+            recruited_at: application_choice.recruited_at,
+            hesa_itt_data: hesa_itt_data,
+            candidate: {
+              id: application_form.candidate.public_id,
+              first_name: application_form.first_name,
+              last_name: application_form.last_name,
+              date_of_birth: application_form.date_of_birth,
+              nationality: application_choice.nationalities,
+              domicile: application_form.domicile,
+              uk_residency_status: uk_residency_status,
+              uk_residency_status_code: uk_residency_status_code,
+              fee_payer: provisional_fee_payer_status,
+              english_main_language: application_form.english_main_language,
+              english_language_qualifications: application_form.english_language_qualification_details,
+              other_languages: application_form.other_language_details,
+              disability_disclosure: application_form.disability_disclosure,
+            },
+            contact_details: contact_details,
+            course: course_info_for(application_choice.course_option),
+            references: references,
+            qualifications: qualifications,
+            work_experience: {
+              jobs: work_experience_jobs,
+              volunteering: work_experience_volunteering,
+              work_history_break_explanation: work_history_breaks,
+            },
+            offer: offer,
+            rejection: rejection,
+            withdrawal: withdrawal,
+            further_information: application_form.further_information,
+            safeguarding_issues_status: application_form.safeguarding_issues_status,
+            safeguarding_issues_details_url: safeguarding_issues_details_url,
           },
-          contact_details: contact_details,
-          course: course_info_for(application_choice.course_option),
-          references: references,
-          qualifications: qualifications,
-          work_experience: {
-            jobs: work_experience_jobs,
-            volunteering: work_experience_volunteering,
-            work_history_break_explanation: work_history_breaks,
-          },
-          offer: offer,
-          rejection: rejection,
-          withdrawal: withdrawal,
-          further_information: application_form.further_information,
-          safeguarding_issues_status: application_form.safeguarding_issues_status,
-          safeguarding_issues_details_url: safeguarding_issues_details_url,
-        },
-      }
+        }
+      end
     end
 
   private
@@ -406,6 +410,10 @@ module VendorAPI
 
     def safeguarding_issues_details_url
       application_form.has_safeguarding_issues_to_declare? ? provider_interface_application_choice_url(application_choice, anchor: 'criminal-convictions-and-professional-misconduct') : nil
+    end
+
+    def cache_key(model)
+      "#{model.model_name.param_key}-#{model.id}-#{model.updated_at.iso8601}"
     end
   end
 end

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -413,7 +413,7 @@ module VendorAPI
     end
 
     def cache_key(model)
-      "#{model.cache_key_with_version}-#{ENV['SHA']}"
+      "#{model.cache_key_with_version}-#{ENV.fetch('SHA', Digest::SHA1.hexdigest(Time.zone.now.to_s))}"
     end
   end
 end

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -417,7 +417,7 @@ module VendorAPI
     end
 
     def cache_key(model)
-      "#{model.cache_key_with_version}-#{ENV.fetch('SHA', Digest::SHA1.hexdigest(Time.zone.now.to_s))}"
+      CacheKey.generate(model.cache_key_with_version)
     end
   end
 end

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -2,7 +2,7 @@ module VendorAPI
   class SingleApplicationPresenter
     include Rails.application.routes.url_helpers
 
-    CACHE_EXPIRES_IN = 30.minutes
+    CACHE_EXPIRES_IN = 1.day
 
     UCAS_FEE_PAYER_CODES = {
       'SLC,SAAS,NIBd,EU,Chl,IoM' => '02',
@@ -413,7 +413,7 @@ module VendorAPI
     end
 
     def cache_key(model)
-      "#{model.model_name.param_key}-#{model.id}-#{model.updated_at.iso8601}"
+      "#{model.cache_key_with_version}-#{ENV['SHA']}"
     end
   end
 end

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -16,58 +16,62 @@ module VendorAPI
 
     def as_json
       Rails.cache.fetch(cache_key(application_choice), expires_in: CACHE_EXPIRES_IN) do
-        {
-          id: application_choice.id.to_s,
-          type: 'application',
-          attributes: {
-            support_reference: application_form.support_reference,
-            status: status,
-            phase: application_form.phase,
-            updated_at: application_choice.updated_at.iso8601,
-            submitted_at: application_form.submitted_at.iso8601,
-            personal_statement: personal_statement,
-            interview_preferences: application_form.interview_preferences,
-            reject_by_default_at: application_choice.reject_by_default_at&.iso8601,
-            recruited_at: application_choice.recruited_at,
-            hesa_itt_data: hesa_itt_data,
-            candidate: {
-              id: application_form.candidate.public_id,
-              first_name: application_form.first_name,
-              last_name: application_form.last_name,
-              date_of_birth: application_form.date_of_birth,
-              nationality: application_choice.nationalities,
-              domicile: application_form.domicile,
-              uk_residency_status: uk_residency_status,
-              uk_residency_status_code: uk_residency_status_code,
-              fee_payer: provisional_fee_payer_status,
-              english_main_language: application_form.english_main_language,
-              english_language_qualifications: application_form.english_language_qualification_details,
-              other_languages: application_form.other_language_details,
-              disability_disclosure: application_form.disability_disclosure,
-            },
-            contact_details: contact_details,
-            course: course_info_for(application_choice.course_option),
-            references: references,
-            qualifications: qualifications,
-            work_experience: {
-              jobs: work_experience_jobs,
-              volunteering: work_experience_volunteering,
-              work_history_break_explanation: work_history_breaks,
-            },
-            offer: offer,
-            rejection: rejection,
-            withdrawal: withdrawal,
-            further_information: application_form.further_information,
-            safeguarding_issues_status: application_form.safeguarding_issues_status,
-            safeguarding_issues_details_url: safeguarding_issues_details_url,
-          },
-        }
+        application_as_json
       end
     end
 
   private
 
     attr_reader :application_choice, :application_form
+
+    def application_as_json
+      {
+        id: application_choice.id.to_s,
+        type: 'application',
+        attributes: {
+          support_reference: application_form.support_reference,
+          status: status,
+          phase: application_form.phase,
+          updated_at: application_choice.updated_at.iso8601,
+          submitted_at: application_form.submitted_at.iso8601,
+          personal_statement: personal_statement,
+          interview_preferences: application_form.interview_preferences,
+          reject_by_default_at: application_choice.reject_by_default_at&.iso8601,
+          recruited_at: application_choice.recruited_at,
+          hesa_itt_data: hesa_itt_data,
+          candidate: {
+            id: application_form.candidate.public_id,
+            first_name: application_form.first_name,
+            last_name: application_form.last_name,
+            date_of_birth: application_form.date_of_birth,
+            nationality: application_choice.nationalities,
+            domicile: application_form.domicile,
+            uk_residency_status: uk_residency_status,
+            uk_residency_status_code: uk_residency_status_code,
+            fee_payer: provisional_fee_payer_status,
+            english_main_language: application_form.english_main_language,
+            english_language_qualifications: application_form.english_language_qualification_details,
+            other_languages: application_form.other_language_details,
+            disability_disclosure: application_form.disability_disclosure,
+          },
+          contact_details: contact_details,
+          course: course_info_for(application_choice.course_option),
+          references: references,
+          qualifications: qualifications,
+          work_experience: {
+            jobs: work_experience_jobs,
+            volunteering: work_experience_volunteering,
+            work_history_break_explanation: work_history_breaks,
+          },
+          offer: offer,
+          rejection: rejection,
+          withdrawal: withdrawal,
+          further_information: application_form.further_information,
+          safeguarding_issues_status: application_form.safeguarding_issues_status,
+          safeguarding_issues_details_url: safeguarding_issues_details_url,
+        },
+      }
+    end
 
     # V2: handles backwards compatibility (`offer_withdrawn` state is displayed as `rejected`) and
     #     converting statuses that cannot be handles by Vendor.

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -1128,17 +1128,4 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       end
     end
   end
-
-  describe 'Caching output of #as_json' do
-    it 'caches the output of #as_json using a compound key' do
-      allow(Rails.cache).to receive(:fetch)
-
-      choice = create(:application_choice, :with_completed_application_form, :with_recruited)
-      expected_cache_key = "application_choice-#{choice.id}-#{choice.updated_at.iso8601}"
-
-      described_class.new(choice).as_json
-
-      expect(Rails.cache).to have_received(:fetch).with(expected_cache_key, { expires_in: 30.minutes })
-    end
-  end
 end

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -1128,4 +1128,17 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       end
     end
   end
+
+  describe 'Caching output of #as_json' do
+    it 'caches the output of #as_json using a compound key' do
+      allow(Rails.cache).to receive(:fetch)
+
+      choice = create(:application_choice, :with_completed_application_form, :with_recruited)
+      expected_cache_key = "application_choice-#{choice.id}-#{choice.updated_at.iso8601}"
+
+      described_class.new(choice).as_json
+
+      expect(Rails.cache).to have_received(:fetch).with(expected_cache_key, { expires_in: 30.minutes })
+    end
+  end
 end

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -296,6 +296,8 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
         },
       }
 
+      Timecop.travel(1.minute.from_now)
+
       post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: request_body
 
       expect(parsed_response['data']['attributes']['offer']).to eq(
@@ -305,7 +307,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
           'Completion of professional skills test',
         ],
         'course' => course_option_to_course_payload(new_course_option),
-        'offer_made_at' => Time.zone.now.iso8601(3),
+        'offer_made_at' => application_choice.reload.offered_at.iso8601(3),
         'offer_accepted_at' => nil,
         'offer_declined_at' => nil,
       )

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
   include VendorAPISpecHelpers
   include CourseOptionHelpers
 
-  around do |ex|
-    Timecop.freeze { ex.run }
-  end
-
   it_behaves_like 'an endpoint that requires metadata', '/offer'
 
   describe 'making an offer with specified conditions' do
@@ -36,7 +32,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
           'Completion of professional skills test',
         ],
         'course' => course_option_to_course_payload(course_option),
-        'offer_made_at' => Time.zone.now.iso8601(3),
+        'offer_made_at' => application_choice.reload.offered_at.iso8601(3),
         'offer_accepted_at' => nil,
         'offer_declined_at' => nil,
       )
@@ -91,7 +87,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
           'Completion of professional skills test',
         ],
         'course' => course_option_to_course_payload(course_option),
-        'offer_made_at' => Time.zone.now.iso8601(3),
+        'offer_made_at' => application_choice.reload.offered_at.iso8601(3),
         'offer_accepted_at' => nil,
         'offer_declined_at' => nil,
       )
@@ -117,7 +113,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       expect(parsed_response['data']['attributes']['offer']).to eq(
         'conditions' => [],
         'course' => course_option_to_course_payload(other_course_option),
-        'offer_made_at' => Time.zone.now.iso8601(3),
+        'offer_made_at' => application_choice.reload.offered_at.iso8601(3),
         'offer_accepted_at' => nil,
         'offer_declined_at' => nil,
       )
@@ -235,7 +231,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       expect(parsed_response['data']['attributes']['offer']).to eq(
         'conditions' => [],
         'course' => course_option_to_course_payload(other_course_option),
-        'offer_made_at' => Time.zone.now.iso8601(3),
+        'offer_made_at' => application_choice.reload.offered_at.iso8601(3),
         'offer_accepted_at' => nil,
         'offer_declined_at' => nil,
       )
@@ -259,7 +255,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       expect(parsed_response['data']['attributes']['offer']).to eq(
         'conditions' => [],
         'course' => course_option_to_course_payload(other_course_option),
-        'offer_made_at' => Time.zone.now.iso8601(3),
+        'offer_made_at' => application_choice.reload.offered_at.iso8601(3),
         'offer_accepted_at' => nil,
         'offer_declined_at' => nil,
       )
@@ -295,8 +291,6 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
           course: course_option_to_course_payload(new_course_option),
         },
       }
-
-      Timecop.travel(1.minute.from_now)
 
       post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: request_body
 
@@ -344,7 +338,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       expect(parsed_response['data']['attributes']['offer']).to eq(
         'conditions' => [],
         'course' => course_option_to_course_payload(course_option),
-        'offer_made_at' => Time.zone.now.iso8601(3),
+        'offer_made_at' => application_choice.reload.offered_at.iso8601(3),
         'offer_accepted_at' => nil,
         'offer_declined_at' => nil,
       )
@@ -375,7 +369,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
           'Wash your clothes',
         ],
         'course' => course_option_to_course_payload(choice.course_option),
-        'offer_made_at' => Time.zone.now.iso8601(3),
+        'offer_made_at' => choice.reload.offered_at.iso8601(3),
         'offer_accepted_at' => nil,
         'offer_declined_at' => nil,
       )


### PR DESCRIPTION
## Context

Multiple requests to `GET /api/v1/applications` will typically return JSON objects which haven't change much over time. This endpoint could be more performant with the use of some basic caching.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

We can rely on `ApplicationChoice#updated_at` as an indication of change to an application so cache the output of `SingleApplicationPresenter#as_json` calls using a compound key containing this timestamp.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

I've arbitrarily passed `expires_in: 30.minutes` as a caching arg, should we make this longer?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/yzKDiTtI/4037-spike-investigate-performance-issues-with-get-applications-endpoint
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
