### PR TITLE
Change organisation settings page

### DIFF
--- a/app/controllers/provider_interface/organisation_settings_controller.rb
+++ b/app/controllers/provider_interface/organisation_settings_controller.rb
@@ -7,7 +7,7 @@ module ProviderInterface
   private
 
     def require_manage_users_or_manage_organisations_permission
-      unless current_provider_user.authorisation.can_manage_users_or_organisations_for_at_least_one_setup_provider?
+      unless current_provider_user.authorisation.can_manage_users_or_organisations_for_at_least_one_setup_provider? || FeatureFlag.active?(:account_and_org_settings_changes)
         redirect_to(provider_interface_account_path)
       end
     end

--- a/app/controllers/provider_interface/organisation_settings_controller.rb
+++ b/app/controllers/provider_interface/organisation_settings_controller.rb
@@ -2,7 +2,11 @@ module ProviderInterface
   class OrganisationSettingsController < ProviderInterfaceController
     before_action :require_manage_users_or_manage_organisations_permission
 
-    def show; end
+    def show
+      if FeatureFlag.active?(:account_and_org_settings_changes)
+        @providers = current_user.providers.order(:name)
+      end
+    end
 
   private
 

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -72,7 +72,7 @@ class NavigationItems
       items = []
 
       unless performing_setup
-        if current_provider_user.authorisation.can_manage_users_or_organisations_for_at_least_one_setup_provider?
+        if current_provider_user.authorisation.can_manage_users_or_organisations_for_at_least_one_setup_provider? || FeatureFlag.active?(:account_and_org_settings_changes)
           items << NavigationItem.new(t('page_titles.provider.organisation_settings'), provider_interface_organisation_settings_path, active?(current_controller, %w[organisation_settings organisations provider_users provider_relationship_permissions]))
         end
 

--- a/app/models/provider_relationship_permissions.rb
+++ b/app/models/provider_relationship_permissions.rb
@@ -7,6 +7,15 @@ class ProviderRelationshipPermissions < ApplicationRecord
   validate :at_least_one_active_permission_in_pair, if: -> { setup_at.present? || validation_context == :setup }
   audited associated_with: :training_provider
 
+  scope :providers_have_open_course, lambda {
+    course_joins_sql = <<-SQL
+      JOIN courses
+      ON provider_relationship_permissions.training_provider_id = courses.provider_id
+      AND provider_relationship_permissions.ratifying_provider_id = courses.accredited_provider_id
+    SQL
+    joins(course_joins_sql).merge(Course.current_cycle.open_on_apply).distinct
+  }
+
   def self.all_relationships_for_providers(providers)
     provider_ids = providers.map(&:id)
     table = ProviderRelationshipPermissions.arel_table
@@ -34,6 +43,10 @@ class ProviderRelationshipPermissions < ApplicationRecord
     else
       send("ratifying_provider_can_#{permission}")
     end
+  end
+
+  def providers_have_open_course?
+    Course.current_cycle.open_on_apply.exists?(provider: training_provider, accredited_provider: ratifying_provider)
   end
 
 private

--- a/app/services/provider_setup.rb
+++ b/app/services/provider_setup.rb
@@ -28,7 +28,7 @@ class ProviderSetup
 
   def relationships_pending
     manageable_relationships.select do |relationship|
-      (relationship.setup_at.blank? || relationship.invalid?) && open_course_for_relationship?(relationship)
+      (relationship.setup_at.blank? || relationship.invalid?) && relationship.providers_have_open_course?
     end
   end
 
@@ -37,9 +37,5 @@ private
   def manageable_relationships
     auth = ProviderAuthorisation.new(actor: @provider_user)
     auth.provider_relationships_that_actor_can_manage_organisations_for
-  end
-
-  def open_course_for_relationship?(relationship)
-    Course.current_cycle.open_on_apply.exists?(provider: relationship.training_provider, accredited_provider: relationship.ratifying_provider)
   end
 end

--- a/app/views/provider_interface/organisation_settings/show.html.erb
+++ b/app/views/provider_interface/organisation_settings/show.html.erb
@@ -4,13 +4,13 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('page_titles.provider.organisation_settings') %></h1>
     <ul class="govuk-list govuk-list--spaced">
-      <% if current_provider_user.authorisation.can_manage_users_for_at_least_one_provider? %>
+      <% if current_provider_user.authorisation.can_manage_users_for_at_least_one_provider? || FeatureFlag.active?(:account_and_org_settings_changes) %>
         <li>
           <%= govuk_link_to t('page_titles.provider.users'), provider_interface_provider_users_path %>
         </li>
       <% end %>
 
-      <% if current_provider_user.authorisation.can_manage_organisations_for_at_least_one_setup_provider? %>
+      <% if current_provider_user.authorisation.can_manage_organisations_for_at_least_one_setup_provider? || FeatureFlag.active?(:account_and_org_settings_changes) %>
         <li>
           <%= govuk_link_to t('page_titles.provider.organisation_permissions'), provider_interface_organisation_settings_organisations_path %>
         </li>

--- a/app/views/provider_interface/organisation_settings/show.html.erb
+++ b/app/views/provider_interface/organisation_settings/show.html.erb
@@ -3,18 +3,40 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('page_titles.provider.organisation_settings') %></h1>
-    <ul class="govuk-list govuk-list--spaced">
-      <% if current_provider_user.authorisation.can_manage_users_for_at_least_one_provider? || FeatureFlag.active?(:account_and_org_settings_changes) %>
-        <li>
-          <%= govuk_link_to t('page_titles.provider.users'), provider_interface_provider_users_path %>
-        </li>
+    <% if FeatureFlag.active?(:account_and_org_settings_changes) %>
+      <% @providers.each do |provider| %>
+        <% if @providers.count > 1 %>
+          <h2 class="govuk-heading-m"><%= provider.name %></h2>
+        <% end %>
+        <ul class="govuk-list govuk-list--spaced">
+          <li>
+            <%= govuk_link_to provider_interface_provider_users_path do %>
+              <%= t('page_titles.provider.users') %><span class="govuk-visually-hidden"> <%= provider.name %></span>
+            <% end %>
+          </li>
+          <% if ProviderRelationshipPermissions.all_relationships_for_providers([provider]).providers_have_open_course.any? %>
+            <li>
+              <%= govuk_link_to provider_interface_organisation_settings_organisation_organisation_permissions_path(provider) do %>
+                <%= t('page_titles.provider.organisation_permissions') %><span class="govuk-visually-hidden"> <%= provider.name %></span>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
       <% end %>
+    <% else %>
+      <ul class="govuk-list govuk-list--spaced">
+        <% if current_provider_user.authorisation.can_manage_users_for_at_least_one_provider? %>
+          <li>
+            <%= govuk_link_to t('page_titles.provider.users'), provider_interface_provider_users_path %>
+          </li>
+        <% end %>
 
-      <% if current_provider_user.authorisation.can_manage_organisations_for_at_least_one_setup_provider? || FeatureFlag.active?(:account_and_org_settings_changes) %>
-        <li>
-          <%= govuk_link_to t('page_titles.provider.organisation_permissions'), provider_interface_organisation_settings_organisations_path %>
-        </li>
-      <% end %>
-    </ul>
+        <% if current_provider_user.authorisation.can_manage_organisations_for_at_least_one_setup_provider? %>
+          <li>
+            <%= govuk_link_to t('page_titles.provider.organisation_permissions'), provider_interface_organisation_settings_organisations_path %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
   </div>
 </div>

--- a/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Managing provider user permissions' do
   include DfESignInHelpers
 
+  before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
+
   scenario 'Provider manages permissions for users' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_manage_applications_for_two_providers

--- a/spec/system/provider_interface/manage_provider_user_providers_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_providers_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Managing providers a user has access to' do
   include DfESignInHelpers
 
+  before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
+
   scenario 'Provider adds and removes providers from a user' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_manage_users_for_two_providers

--- a/spec/system/provider_interface/manage_provider_user_providers_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_providers_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Managing providers a user has access to' do
   include DfESignInHelpers
 
+  # We are removing this behaviour
   before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
 
   scenario 'Provider adds and removes providers from a user' do

--- a/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 RSpec.feature 'Provider edits organisation permissions' do
   include DfESignInHelpers
 
-  before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
-
   scenario 'Provider edits organisation permissions' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_view_applications_for_some_providers
@@ -13,8 +11,12 @@ RSpec.feature 'Provider edits organisation permissions' do
     and_i_sign_in_to_the_provider_interface
 
     when_i_click_on_the_organisation_settings_link
-    and_i_click_on_organisation_permissions
-    and_i_click_on_an_organisation_i_can_manage
+    if FeatureFlag.active?(:account_and_org_settings_changes)
+      and_i_click_on_a_particular_organisation_permissions_link
+    else
+      and_i_click_on_organisation_permissions
+      and_i_click_on_an_organisation_i_can_manage
+    end
     and_i_click_to_change_one_of_its_relationships
     and_i_give_my_organisation_permission_to_make_decisions
     then_i_am_redirected_to_the_organisation_relationships_page
@@ -41,6 +43,7 @@ RSpec.feature 'Provider edits organisation permissions' do
       training_provider: @training_provider,
       ratifying_provider: @ratifying_provider,
     )
+    create(:course, :open_on_apply, provider: @training_provider, accredited_provider: @ratifying_provider)
 
     @training_provider_users = create_list(:provider_user, 2, providers: [@training_provider])
     @training_provider_users.each { |user| user.provider_permissions.where(provider: @training_provider).update_all(manage_organisations: true) }
@@ -57,6 +60,10 @@ RSpec.feature 'Provider edits organisation permissions' do
 
   def when_i_click_on_the_organisation_settings_link
     click_on 'Organisation settings'
+  end
+
+  def and_i_click_on_a_particular_organisation_permissions_link
+    click_on "Organisation permissions #{@ratifying_provider.name}"
   end
 
   def and_i_click_on_organisation_permissions

--- a/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Provider edits organisation permissions' do
   include DfESignInHelpers
 
+  before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
+
   scenario 'Provider edits organisation permissions' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_view_applications_for_some_providers

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
   include DfESignInHelpers
   include DsiAPIHelper
 
+  before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
+
   scenario 'Provider sends invite to user' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_manage_applications_for_two_providers

--- a/spec/system/provider_interface/provider_views_account_page_spec.rb
+++ b/spec/system/provider_interface/provider_views_account_page_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Provider views account page' do
   include DfESignInHelpers
 
+  # Behaviour tested here has moved to spec/system/provider_interface/provider_user_personal_details_spec.rb
   before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
 
   scenario 'Provider views their account page' do

--- a/spec/system/provider_interface/provider_views_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_views_organisation_permissions_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Viewing organisation permissions' do
   include DfESignInHelpers
 
+  before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
+
   scenario 'Provider user views their organisation permissions page with various permissions' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_manage_multiple_organisations_that_do_not_have_permissions_set_up

--- a/spec/system/provider_interface/provider_views_organisation_settings_spec.rb
+++ b/spec/system/provider_interface/provider_views_organisation_settings_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Provider views organisation settings' do
   include DfESignInHelpers
 
+  # Behaviour tested here has moved to spec/system/provider_interface/view_organisation_settings_spec.rb
   before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
 
   scenario 'Provider views organisation settings' do

--- a/spec/system/provider_interface/provider_views_organisation_settings_spec.rb
+++ b/spec/system/provider_interface/provider_views_organisation_settings_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Provider views organisation settings' do
   include DfESignInHelpers
 
+  before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
+
   scenario 'Provider views organisation settings' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_view_applications_for_some_providers

--- a/spec/system/provider_interface/providers_can_view_managed_users_spec.rb
+++ b/spec/system/provider_interface/providers_can_view_managed_users_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature 'Providers can view managed users' do
   include DfESignInHelpers
   include DsiAPIHelper
 
+  before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
+
   scenario 'Provider use can see their individual users permissions' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_manage_applications_for_two_providers

--- a/spec/system/provider_interface/removing_provider_user_spec.rb
+++ b/spec/system/provider_interface/removing_provider_user_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Removing a provider user' do
   include DfESignInHelpers
 
+  before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
+
   scenario 'removing a user from all providers', with_audited: true do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_manage_applications_for_two_providers

--- a/spec/system/provider_interface/view_organisation_settings_spec.rb
+++ b/spec/system/provider_interface/view_organisation_settings_spec.rb
@@ -7,22 +7,41 @@ RSpec.feature 'Organisation settings' do
 
   scenario 'Provider user views organisation settings' do
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_i_can_view_applications_for_some_providers
+    and_i_belong_to_a_single_provider
+    and_its_relationship_permissions_have_already_been_set_up
     and_i_sign_in_to_the_provider_interface
-    then_i_can_see_the_organisation_settings_link
+
+    when_i_click_on_the_organisation_settings_link
+    then_i_see_the_organisation_settings_page
+    and_i_see_a_link_to_manage_users_for_my_provider
+    and_i_see_a_link_to_manage_organisation_permissions_for_my_provider
+
+    given_i_belong_to_a_second_provider
+    and_i_click_on_the_organisation_settings_link
+    then_i_see_both_of_my_providers
+    and_i_cannot_see_a_link_to_manage_organisation_permissions_for_the_second_provider
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
   end
 
-  def and_i_can_view_applications_for_some_providers
+  def and_i_belong_to_a_single_provider
     provider_user_exists_in_apply_database
-    @user = ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    @provider_user = ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    @first_provider = Provider.find_by(code: 'ABC')
+    @second_provider = Provider.find_by(code: 'DEF')
+    @provider_user.update(providers: [@first_provider])
+    ProviderPermissions.find_by(provider: @first_provider, provider_user: @provider_user).update(manage_organisations: true)
   end
 
-  def then_i_can_see_the_organisation_settings_link
-    expect(page).to have_link('Organisation settings', href: provider_interface_organisation_settings_path)
+  def and_its_relationship_permissions_have_already_been_set_up
+    course = create(:course, :open_on_apply, :with_accredited_provider, provider: @first_provider)
+    create(
+      :provider_relationship_permissions,
+      training_provider: @first_provider,
+      ratifying_provider: course.accredited_provider,
+    )
   end
 
   def when_i_click_on_the_organisation_settings_link
@@ -31,15 +50,34 @@ RSpec.feature 'Organisation settings' do
     end
   end
 
+  alias_method(
+    :and_i_click_on_the_organisation_settings_link,
+    :when_i_click_on_the_organisation_settings_link,
+  )
+
   def then_i_see_the_organisation_settings_page
     expect(page).to have_current_path(provider_interface_organisation_settings_path)
   end
 
-  def and_i_see_a_link_to_manage_users
-    expect(page).to have_link('Users', href: provider_interface_provider_users_path)
+  def and_i_see_a_link_to_manage_users_for_my_provider
+    expect(page).to have_link("Users #{@first_provider.name}", href: provider_interface_provider_users_path)
   end
 
-  def and_i_see_a_link_to_manage_organisations
-    expect(page).to have_link('Organisation permissions', href: provider_interface_organisation_settings_organisations_path)
+  def and_i_see_a_link_to_manage_organisation_permissions_for_my_provider
+    expected_org_permissions_path = provider_interface_organisation_settings_organisation_organisation_permissions_path(@first_provider)
+    expect(page).to have_link("Organisation permissions #{@first_provider.name}", href: expected_org_permissions_path)
+  end
+
+  def given_i_belong_to_a_second_provider
+    @provider_user.update(providers: [@first_provider, @second_provider])
+  end
+
+  def then_i_see_both_of_my_providers
+    expect(page).to have_selector('h2', text: @first_provider.name)
+    expect(page).to have_selector('h2', text: @second_provider.name)
+  end
+
+  def and_i_cannot_see_a_link_to_manage_organisation_permissions_for_the_second_provider
+    expect(page).not_to have_content("Organisation permissions #{@second_provider.name}")
   end
 end

--- a/spec/system/provider_interface/view_organisation_settings_spec.rb
+++ b/spec/system/provider_interface/view_organisation_settings_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.feature 'Organisation settings' do
+  include DfESignInHelpers
+
+  before { FeatureFlag.activate(:account_and_org_settings_changes) }
+
+  scenario 'Provider user views organisation settings' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_can_view_applications_for_some_providers
+    and_i_sign_in_to_the_provider_interface
+    then_i_can_see_the_organisation_settings_link
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_can_view_applications_for_some_providers
+    provider_user_exists_in_apply_database
+    @user = ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+  end
+
+  def then_i_can_see_the_organisation_settings_link
+    expect(page).to have_link('Organisation settings', href: provider_interface_organisation_settings_path)
+  end
+
+  def when_i_click_on_the_organisation_settings_link
+    within('#navigation') do
+      click_on('Organisation settings')
+    end
+  end
+
+  def then_i_see_the_organisation_settings_page
+    expect(page).to have_current_path(provider_interface_organisation_settings_path)
+  end
+
+  def and_i_see_a_link_to_manage_users
+    expect(page).to have_link('Users', href: provider_interface_provider_users_path)
+  end
+
+  def and_i_see_a_link_to_manage_organisations
+    expect(page).to have_link('Organisation permissions', href: provider_interface_organisation_settings_organisations_path)
+  end
+end


### PR DESCRIPTION
## Context
https://trello.com/c/ls5z2eFr/4083-changes-to-organisation-settings

This change takes place behind the `:account_and_org_settings_changes` feature flag. 

* We're showing the "Organisation settings" navbar option unconditionally for every user
* If a user is associated with more than one provider, each one is listed out in the org settings page, with its own Users and Organisation permissions links
* The users links appear unconditionally 
* The org permissions links appear based on whether the user can manage orgs (this is changing in a subsequent ticket)

## Changes proposed in this pull request
Multiple orgs listed out separately

![image](https://user-images.githubusercontent.com/25597009/128344863-61165dc4-6c88-43b5-91d4-c29f6d93f068.png)

## Guidance to review

You'll need a user that's associated with multiple providers (Susan Upport worked for me), and to click on Organisation Settings. 

You can also be a user who doesn't have any special permissions for their provider, and you'll still be able to see the Organisation Settings page
