### PR TITLE
Small fixes to personal details page

### DIFF
--- a/app/controllers/provider_interface/personal_details_controller.rb
+++ b/app/controllers/provider_interface/personal_details_controller.rb
@@ -2,7 +2,9 @@ module ProviderInterface
   class PersonalDetailsController < ProviderInterfaceController
     before_action :redirect_to_profile_unless_feature_flag_on
 
-    def show; end
+    def show
+      @dsi_profile_url = dsi_profile_url
+    end
 
   private
 
@@ -10,6 +12,12 @@ module ProviderInterface
       unless FeatureFlag.active?(:account_and_org_settings_changes)
         redirect_to provider_interface_profile_path
       end
+    end
+
+    def dsi_profile_url
+      return 'https://test-profile.signin.education.gov.uk' if HostingEnvironment.qa?
+
+      'https://profile.signin.education.gov.uk'
     end
   end
 end

--- a/app/controllers/provider_interface/profile_controller.rb
+++ b/app/controllers/provider_interface/profile_controller.rb
@@ -1,5 +1,15 @@
 module ProviderInterface
   class ProfileController < ProviderInterfaceController
+    before_action :redirect_to_personal_details_if_feature_flag_on
+
     def show; end
+
+  private
+
+    def redirect_to_personal_details_if_feature_flag_on
+      if FeatureFlag.active?(:account_and_org_settings_changes)
+        redirect_to provider_interface_personal_details_path
+      end
+    end
   end
 end

--- a/app/views/provider_interface/personal_details/show.html.erb
+++ b/app/views/provider_interface/personal_details/show.html.erb
@@ -17,5 +17,9 @@
         { key: 'Email address', value: current_provider_user.email_address },
       ],
     ) %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to 'Change your details or password in DfE Sign-in', @dsi_profile_url %>
+    </p>
   </div>
 </div>

--- a/spec/system/provider_interface/provider_user_personal_details_spec.rb
+++ b/spec/system/provider_interface/provider_user_personal_details_spec.rb
@@ -14,6 +14,7 @@ RSpec.feature 'Personal details page' do
 
     when_i_click_on_personal_details
     then_i_can_see_all_my_details
+    and_i_see_a_link_to_change_dsi_details
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -40,5 +41,9 @@ RSpec.feature 'Personal details page' do
     expect(page).to have_content(provider_user.first_name)
     expect(page).to have_content(provider_user.last_name)
     expect(page).to have_content(provider_user.email_address)
+  end
+
+  def and_i_see_a_link_to_change_dsi_details
+    expect(page).to have_link('Change your details or password in DfE Sign-in', href: 'https://profile.signin.education.gov.uk')
   end
 end


### PR DESCRIPTION
## Changes proposed in this pull request
We missed a couple of things:
- DSI profile URL in the personal details page
- Need to redirect away from the old page when the feature flag is on

