### PR TITLE
Ensure ProviderAgreement records associated with duplicate providers are removed

### DIFF
--- a/app/services/data_migrations/remove_duplicate_provider.rb
+++ b/app/services/data_migrations/remove_duplicate_provider.rb
@@ -47,6 +47,7 @@ module DataMigrations
               Rails.logger.warn "Skipping deletion of #{permission.ratifying_provider.name}. This organisation has users which do not belong to any other provider."
             else
               permission.destroy!
+              permission.ratifying_provider.provider_agreements.map(&:destroy!)
               permission.ratifying_provider.destroy!
             end
           end

--- a/spec/services/data_migrations/remove_duplicate_provider_spec.rb
+++ b/spec/services/data_migrations/remove_duplicate_provider_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 
 RSpec.describe DataMigrations::RemoveDuplicateProvider do
   context 'with duplicate providers related via organisation permissions' do
-    let(:provider) { create(:provider, name: 'Test Provider 001') }
+    let(:provider) { create(:provider, :with_signed_agreement, name: 'Test Provider 001') }
     let(:duplicate_provider) { create(:provider, name: 'Test Provider 001') }
     let!(:provider_user) { create(:provider_user, providers: [provider, duplicate_provider]) }
     let!(:provider_relationship_permissions) { create(:provider_relationship_permissions, training_provider: provider, ratifying_provider: duplicate_provider) }
+    let!(:duplicate_provider_agreements) { create(:provider_agreement, provider: duplicate_provider, provider_user: provider_user) }
 
     let!(:self_ratified_course) { create(:course, provider: provider, accredited_provider: duplicate_provider) }
     let!(:other_course) { create(:course, provider: provider, accredited_provider: create(:provider)) }
@@ -23,6 +24,10 @@ RSpec.describe DataMigrations::RemoveDuplicateProvider do
 
     it 'destroys the duplicate provider' do
       expect { described_class.new.change }.to change(Provider, :count).by(-1)
+    end
+
+    it 'destroys the provider agreement for the duplicate provider' do
+      expect { described_class.new.change }.to change(ProviderAgreement, :count).by(-1)
     end
   end
 


### PR DESCRIPTION
## Context

See https://github.com/DFE-Digital/apply-for-teacher-training/pull/5245 for introduction of this manual data migration.
We need to ensure any data sharing agreements are also removed when deleting the duplicate ratifying providers.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Removes `ProviderAgreement` records associated with duplicate ratifying providers.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
