### PR TITLE
Add type to features

### DIFF
--- a/app/controllers/integrations/feature_flags_controller.rb
+++ b/app/controllers/integrations/feature_flags_controller.rb
@@ -5,7 +5,7 @@ module Integrations
         {
           name: feature_name.humanize,
           active: FeatureFlag.active?(feature_name),
-          type: FeatureFlag::FEATURES[feature_name].type.humanize,
+          type: FeatureFlag::FEATURES[feature_name].type,
         }
       end
 

--- a/app/controllers/integrations/feature_flags_controller.rb
+++ b/app/controllers/integrations/feature_flags_controller.rb
@@ -5,6 +5,7 @@ module Integrations
         {
           name: feature_name.humanize,
           active: FeatureFlag.active?(feature_name),
+          type: FeatureFlag::FEATURES[feature_name].type.humanize,
         }
       end
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,10 +1,11 @@
 class FeatureFlag
-  attr_accessor :name, :description, :owner
+  attr_accessor :name, :description, :owner, :type
 
   def initialize(name:, description:, owner:)
     self.name = name
     self.description = description
     self.owner = owner
+    self.type =  FEATURE_TYPES[name].presence || 'temporary'
   end
 
   def feature
@@ -38,6 +39,10 @@ class FeatureFlag
     [:summer_recruitment_banner, 'Show a banner to indicate a shorter recruitment timeframe during summer', 'Richard Pattinson'],
     [:account_and_org_settings_changes, 'Allows new account and org setting changes', 'Despo Pentara'],
   ].freeze
+
+  FEATURE_TYPES = {
+    send_request_data_to_bigquery: 'permanent',
+  }.with_indifferent_access.freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map do |name, description, owner|
     [name, FeatureFlag.new(name: name, description: description, owner: owner)]

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -5,7 +5,7 @@ class FeatureFlag
     self.name = name
     self.description = description
     self.owner = owner
-    self.type =  FEATURE_TYPES[name].presence || 'temporary'
+    self.type =  FEATURE_TYPES[name].presence || 'invariant'
   end
 
   def feature
@@ -40,8 +40,12 @@ class FeatureFlag
     [:account_and_org_settings_changes, 'Allows new account and org setting changes', 'Despo Pentara'],
   ].freeze
 
+  # Mark features as `variant` i.e. can be inconsistently marked as active/inactive
+  # across environments and we won't be notified if inconsistent. All other features
+  # will default to `invariant` which means they will need to be consistently marked
+  # as active/inactive across all our environments, and we will be notified about otherwise.
   FEATURE_TYPES = {
-    send_request_data_to_bigquery: 'permanent',
+    send_request_data_to_bigquery: 'variant',
   }.with_indifferent_access.freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map do |name, description, owner|

--- a/app/views/support_interface/settings/feature_flags.html.erb
+++ b/app/views/support_interface/settings/feature_flags.html.erb
@@ -18,6 +18,10 @@
       value: feature_flag.owner,
     },
     {
+      key: 'Type',
+      value: feature_flag.type.humanize,
+    },
+    {
       key: 'History',
       value: render(
         SupportInterface::FeatureAuditTrailComponent.new(feature: feature_flag.feature),

--- a/spec/requests/integrations/feature_flags_spec.rb
+++ b/spec/requests/integrations/feature_flags_spec.rb
@@ -8,7 +8,14 @@ RSpec.describe 'GET /integrations/feature-flags', type: :request do
 
     expect(parsed_response['feature_flags']['pilot_open']['name']).to eql('Pilot open')
     expect(parsed_response['feature_flags']['pilot_open']['active']).to be(true)
-    expect(parsed_response['feature_flags']['pilot_open']['type']).to eq('Temporary')
+    expect(parsed_response['feature_flags']['pilot_open']['type']).to eq('Invariant')
+  end
+
+  it 'returns variant feature flags' do
+    get '/integrations/feature-flags'
+
+    expect(parsed_response['feature_flags']['send_request_data_to_bigquery']['active']).to be(false)
+    expect(parsed_response['feature_flags']['send_request_data_to_bigquery']['type']).to eq('Variant')
   end
 
   it 'tells us when Sandbox mode is on', sandbox: true do

--- a/spec/requests/integrations/feature_flags_spec.rb
+++ b/spec/requests/integrations/feature_flags_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'GET /integrations/feature-flags', type: :request do
 
     expect(parsed_response['feature_flags']['pilot_open']['name']).to eql('Pilot open')
     expect(parsed_response['feature_flags']['pilot_open']['active']).to be(true)
+    expect(parsed_response['feature_flags']['pilot_open']['type']).to eq('Temporary')
   end
 
   it 'tells us when Sandbox mode is on', sandbox: true do

--- a/spec/requests/integrations/feature_flags_spec.rb
+++ b/spec/requests/integrations/feature_flags_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe 'GET /integrations/feature-flags', type: :request do
 
     expect(parsed_response['feature_flags']['pilot_open']['name']).to eql('Pilot open')
     expect(parsed_response['feature_flags']['pilot_open']['active']).to be(true)
-    expect(parsed_response['feature_flags']['pilot_open']['type']).to eq('Invariant')
+    expect(parsed_response['feature_flags']['pilot_open']['type']).to eq('invariant')
   end
 
   it 'returns variant feature flags' do
     get '/integrations/feature-flags'
 
     expect(parsed_response['feature_flags']['send_request_data_to_bigquery']['active']).to be(false)
-    expect(parsed_response['feature_flags']['send_request_data_to_bigquery']['type']).to eq('Variant')
+    expect(parsed_response['feature_flags']['send_request_data_to_bigquery']['type']).to eq('variant')
   end
 
   it 'tells us when Sandbox mode is on', sandbox: true do

--- a/spec/system/support_interface/feature_flags_spec.rb
+++ b/spec/system/support_interface/feature_flags_spec.rb
@@ -34,9 +34,12 @@ RSpec.feature 'Feature flags', with_audited: true do
   end
 
   def then_i_should_see_the_existing_feature_flags
-    expect(page).to have_content('Pilot open')
-    expect(page).to have_content(pilot_open_feature.owner)
-    expect(page).to have_content(pilot_open_feature.description)
+    within('.app-summary-card', text: 'Pilot open') do
+      expect(page).to have_content('Pilot open')
+      expect(page).to have_content(pilot_open_feature.owner)
+      expect(page).to have_content(pilot_open_feature.description)
+      expect(page).to have_content('Temporary')
+    end
   end
 
   def when_i_activate_the_feature

--- a/spec/system/support_interface/feature_flags_spec.rb
+++ b/spec/system/support_interface/feature_flags_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'Feature flags', with_audited: true do
       expect(page).to have_content('Pilot open')
       expect(page).to have_content(pilot_open_feature.owner)
       expect(page).to have_content(pilot_open_feature.description)
-      expect(page).to have_content('Temporary')
+      expect(page).to have_content('Invariant')
     end
   end
 


### PR DESCRIPTION
## Context

We are currently sending slack alerts when we have inconsistent flags between environments. However some feature flags are permanent and will always be different between environments. We need a concept of a feature type which will allow us to distinguish between those

## Changes proposed in this pull request

Add a type to the feature flag which defaults to temporary, unless explicitly set in `FEATURE_TYPES`. Surface this value on the feature flag settings page and integrations endpoint which will be read by the ops dashboard.

## Guidance to review

PR to amend ops dashboard to follow shortly

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
