### PR TITLE
Add the option to filter applications by status in the support console

### DIFF
--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -38,11 +38,15 @@ module SupportInterface
         application_forms = application_forms.where(recruitment_cycle_year: applied_filters[:year])
       end
 
+      if applied_filters[:status]
+        application_forms = application_forms.joins(:application_choices).where(application_choices: { status: applied_filters[:status] })
+      end
+
       application_forms
     end
 
     def filters
-      @filters ||= [search_filter, search_by_application_choice_filter, year_filter, phase_filter, interviews_filter]
+      @filters ||= [search_filter, search_by_application_choice_filter, year_filter, phase_filter, interviews_filter, status_filter]
     end
 
   private
@@ -113,6 +117,76 @@ module SupportInterface
             value: 'has_interviews',
             label: 'Has interviews',
             checked: applied_filters[:interviews]&.include?('has_interviews'),
+          },
+        ],
+      }
+    end
+
+    def status_filter
+      {
+        type: :checkboxes,
+        heading: 'Status',
+        name: 'status',
+        options: [
+          {
+            value: 'unsubmitted',
+            label: 'Not submitted yet',
+            checked: applied_filters[:status]&.include?('unsubmitted'),
+          },
+          {
+            value: 'awaiting_provider_decision',
+            label: 'Awaiting provider decision',
+            checked: applied_filters[:status]&.include?('awaiting_provider_decision'),
+          },
+          {
+            value: 'interviewing',
+            label: 'Interviewing',
+            checked: applied_filters[:status]&.include?('interviewing'),
+          },
+          {
+            value: 'offer',
+            label: 'Offer made',
+            checked: applied_filters[:status]&.include?('offer'),
+          },
+          {
+            value: 'pending_conditions',
+            label: 'Pending conditions',
+            checked: applied_filters[:status]&.include?('pending_conditions'),
+          },
+          {
+            value: 'conditions_met',
+            label: 'Conditions met',
+            checked: applied_filters[:status]&.include?('conditions_met'),
+          },
+          {
+            value: 'rejected',
+            label: 'Rejected',
+            checked: applied_filters[:status]&.include?('rejected'),
+          },
+          {
+            value: 'declined',
+            label: 'Offer declined',
+            checked: applied_filters[:status]&.include?('declined'),
+          },
+          {
+            value: 'withdrawn',
+            label: 'Withdrawn',
+            checked: applied_filters[:status]&.include?('withdrawn'),
+          },
+          {
+            value: 'conditions_not_met',
+            label: 'Conditions not met',
+            checked: applied_filters[:status]&.include?('conditions_not_met'),
+          },
+          {
+            value: 'offer_withdrawn',
+            label: 'Offer withdrawn',
+            checked: applied_filters[:status]&.include?('offer_withdrawn'),
+          },
+          {
+            value: 'offer_deferred',
+            label: 'Offer deferred',
+            checked: applied_filters[:status]&.include?('offer_deferred'),
           },
         ],
       }

--- a/spec/models/support_interface/applications_filter_spec.rb
+++ b/spec/models/support_interface/applications_filter_spec.rb
@@ -65,5 +65,16 @@ RSpec.describe SupportInterface::ApplicationsFilter do
         },
       )
     end
+
+    it 'can filter by status' do
+      expected_form = application_choice_with_offer.application_form
+
+      verify_filtered_applications_for_params(
+        [expected_form],
+        params: {
+          status: %w[offer],
+        },
+      )
+    end
   end
 end


### PR DESCRIPTION
## Context

To assist the support agents in being able to better manage their incoming queries a new filter is being added to the applications tab that will allow them to also filter applications by status.

## Changes proposed in this pull request

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/47917431/128489681-06be3fc9-7b8e-46d9-95f1-93156d21604e.png)|![image](https://user-images.githubusercontent.com/47917431/128489580-29284ffd-8b53-42e4-b28b-1129079c899b.png)|

## Guidance to review

Under the support console select a provider and then got the 'Applications' tab

Or

View applications here: `/support/applications`

## Link to Trello card

https://trello.com/c/FVgdQC84
https://trello.com/c/Q0kOuCKE

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
