### PR TITLE
add organisation_type column to provider data export

### DIFF
--- a/app/exports/providers_export.yml
+++ b/app/exports/providers_export.yml
@@ -3,6 +3,12 @@ common_columns:
   - provider_code
 
 custom_columns:
+  organisation_type:
+    tpye: string
+    format: string
+    description: The type of provider. Possible values, lead_school, scitt, university
+    example: lead_school
+
   agreement_accepted_at:
     type: string
     format: date-time

--- a/app/services/support_interface/providers_export.rb
+++ b/app/services/support_interface/providers_export.rb
@@ -9,6 +9,7 @@ module SupportInterface
           provider_code: provider.code,
           agreement_accepted_at: provider.provider_agreements.where.not(accepted_at: nil).first&.accepted_at,
           average_distance_to_site: average_distance_to_site(provider),
+          organisation_type: provider.provider_type,
         }
       end
     end
@@ -23,7 +24,6 @@ module SupportInterface
           :provider_agreements,
           :sites,
         )
-        .where(sync_courses: true)
         .order(:name)
     end
 

--- a/db/migrate/20210714120419_add_index_to_emails_notify_reference.rb
+++ b/db/migrate/20210714120419_add_index_to_emails_notify_reference.rb
@@ -2,6 +2,6 @@ class AddIndexToEmailsNotifyReference < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 
   def change
-    add_index :emails, :notify_reference, algorithm: :concurrently
+    add_index :emails, :notify_reference, unique: true, algorithm: :concurrently
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -450,7 +450,7 @@ ActiveRecord::Schema.define(version: 2021_07_14_120419) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "delivery_status", default: "unknown", null: false
     t.index ["application_form_id"], name: "index_emails_on_application_form_id"
-    t.index ["notify_reference"], name: "index_emails_on_notify_reference"
+    t.index ["notify_reference"], name: "index_emails_on_notify_reference", unique: true
   end
 
   create_table "english_proficiencies", force: :cascade do |t|

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -230,14 +230,12 @@ RSpec.describe PerformanceStatistics, type: :model do
     let!(:withdrawn_audit) { create(:withdrawn_at_candidates_request_audit, application_choice: withdrawn_choice) }
 
     it '#withdrawn_at_candidates_request_count returns a count of applications which have been declined or withdrawn at the candidates request' do
-      stats = described_class.new(2021)
-
+      stats = PerformanceStatistics.new(2021)
       expect(stats.withdrawn_at_candidates_request_count).to eq(2)
     end
 
     it '#withdrawn_by_candidate_count returns a count of applications which have been declined or withdrawn by the candidate' do
-      stats = described_class.new(2021)
-
+      stats = PerformanceStatistics.new(2021)
       expect(stats.withdrawn_by_candidate_count).to eq(1)
     end
   end

--- a/spec/services/support_interface/providers_export_spec.rb
+++ b/spec/services/support_interface/providers_export_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportInterface::ProvidersExport, with_audited: true do
   describe 'documentation' do
     before do
-      provider = create(:provider, sync_courses: true, name: 'B', latitude: 51.498161, longitude: 0.129900)
+      provider = create(:provider, name: 'B', latitude: 51.498161, longitude: 0.129900)
       create(:site, latitude: 51.482578, longitude: -0.007659, provider: provider)
     end
 
@@ -11,9 +11,9 @@ RSpec.describe SupportInterface::ProvidersExport, with_audited: true do
   end
 
   describe '#providers' do
-    it 'returns synced providers and the date they signed the data sharing agreement' do
-      create(:provider, sync_courses: false)
-      provider_without_signed_dsa = create(:provider, sync_courses: true, name: 'B', latitude: 51.498161, longitude: 0.129900)
+    it 'returns providers and the date they signed the data sharing agreement' do
+      first_provider = create(:provider)
+      provider_without_signed_dsa = create(:provider, name: 'B', latitude: 51.498161, longitude: 0.129900, provider_type: 'string')
       create(:site, latitude: 51.482578, longitude: -0.007659, provider: provider_without_signed_dsa)
       create(:site, latitude: 52.246868, longitude: 0.711190, provider: provider_without_signed_dsa)
 
@@ -22,13 +22,13 @@ RSpec.describe SupportInterface::ProvidersExport, with_audited: true do
         provider_with_signed_dsa = create(
           :provider,
           :with_signed_agreement,
-          sync_courses: true,
           name: 'A',
+          provider_type: 'string',
         )
       end
 
       providers = described_class.new.providers
-      expect(providers.size).to eq(2)
+      expect(providers.size).to eq(3)
 
       expect(providers).to contain_exactly(
         {
@@ -36,12 +36,21 @@ RSpec.describe SupportInterface::ProvidersExport, with_audited: true do
           provider_code: provider_with_signed_dsa.code,
           agreement_accepted_at: Time.zone.local(2019, 10, 1, 12, 0, 0),
           average_distance_to_site: '',
+          organisation_type: provider_with_signed_dsa.provider_type,
         },
         {
           provider_name: provider_without_signed_dsa.name,
           provider_code: provider_without_signed_dsa.code,
           agreement_accepted_at: nil,
           average_distance_to_site: '31.7',
+          organisation_type: provider_without_signed_dsa.provider_type,
+        },
+        {
+          provider_name: first_provider.name,
+          provider_code: first_provider.code,
+          agreement_accepted_at: nil,
+          average_distance_to_site: '',
+          organisation_type: first_provider.provider_type,
         },
       )
     end


### PR DESCRIPTION
## Context

Add a column to provider data export to reflect the organisation type. 

## Link to Trello card

https://trello.com/c/SJvETVRD/4098-add-providertype-column-to-provider-export
## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
