### PR TITLE
Fix redirects when updating qualifications

### DIFF
--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -103,7 +103,7 @@ module CandidateInterface
         value: degree.enic_reference.present? ? 'Yes' : 'No',
         action: generate_action(degree: degree, attribute: t('application_form.degree.enic_statement.change_action')),
         change_path: candidate_interface_edit_degree_enic_path(degree.id, return_to_params),
-        data_qa: 'degree-enic-statement',
+        data_qa: 'degree-enic-comparability',
       }
     end
 

--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -2,13 +2,14 @@ module CandidateInterface
   class DegreesReviewComponent < ViewComponent::Base
     include ViewHelper
 
-    def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
+    def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false, return_to_application_review: false)
       @application_form = application_form
       @degrees = application_form.application_qualifications.degrees.order(id: :desc)
       @editable = editable
       @heading_level = heading_level
       @show_incomplete = show_incomplete
       @missing_error = missing_error
+      @return_to_application_review = return_to_application_review
     end
 
     def degree_rows(degree)
@@ -57,7 +58,8 @@ module CandidateInterface
         key: t('application_form.degree.qualification_type.review_label'),
         value: degree.qualification_type,
         action: generate_action(degree: degree, attribute: t('application_form.degree.qualification.change_action')),
-        change_path: candidate_interface_edit_degree_type_path(degree.id),
+        change_path: candidate_interface_edit_degree_type_path(degree.id, return_to_params),
+        data_qa: 'degree-type',
       }
     end
 
@@ -66,7 +68,8 @@ module CandidateInterface
         key: t('application_form.degree.subject.review_label'),
         value: degree.subject,
         action: generate_action(degree: degree, attribute: t('application_form.degree.subject.change_action')),
-        change_path: candidate_interface_edit_degree_subject_path(degree.id),
+        change_path: candidate_interface_edit_degree_subject_path(degree.id, return_to_params),
+        data_qa: 'degree-subject',
       }
     end
 
@@ -75,7 +78,8 @@ module CandidateInterface
         key: t('application_form.degree.institution_name.review_label'),
         value: institution_value(degree),
         action: generate_action(degree: degree, attribute: t('application_form.degree.institution_name.change_action')),
-        change_path: candidate_interface_edit_degree_institution_path(degree.id),
+        change_path: candidate_interface_edit_degree_institution_path(degree.id, return_to_params),
+        data_qa: 'degree-institution',
       }
     end
 
@@ -98,7 +102,8 @@ module CandidateInterface
         key: t('application_form.degree.enic_statement.review_label'),
         value: degree.enic_reference.present? ? 'Yes' : 'No',
         action: generate_action(degree: degree, attribute: t('application_form.degree.enic_statement.change_action')),
-        change_path: Rails.application.routes.url_helpers.candidate_interface_edit_degree_enic_path(degree.id),
+        change_path: candidate_interface_edit_degree_enic_path(degree.id, return_to_params),
+        data_qa: 'degree-enic-statement',
       }
     end
 
@@ -109,7 +114,8 @@ module CandidateInterface
         key: t('application_form.degree.enic_reference.review_label'),
         value: degree.enic_reference,
         action: generate_action(degree: degree, attribute: t('application_form.degree.enic_reference.change_action')),
-        change_path: Rails.application.routes.url_helpers.candidate_interface_edit_degree_enic_path(degree.id),
+        change_path: candidate_interface_edit_degree_enic_path(degree.id, return_to_params),
+        data_qa: 'degree-enic-reference',
       }
     end
 
@@ -120,7 +126,8 @@ module CandidateInterface
         key: t('application_form.degree.comparable_uk_degree.review_label'),
         value: t("application_form.degree.comparable_uk_degree.values.#{degree.comparable_uk_degree}", default: ''),
         action: generate_action(degree: degree, attribute: t('application_form.degree.comparable_uk_degree.change_action')),
-        change_path: candidate_interface_edit_degree_enic_path(degree.id),
+        change_path: candidate_interface_edit_degree_enic_path(degree.id, return_to_params),
+        data_qa: 'degree-comparable-uk-degree',
       }
     end
 
@@ -129,7 +136,8 @@ module CandidateInterface
         key: t('application_form.degree.start_year.review_label'),
         value: degree.start_year,
         action: generate_action(degree: degree, attribute: t('application_form.degree.start_year.change_action')),
-        change_path: candidate_interface_edit_degree_start_year_path(degree.id),
+        change_path: candidate_interface_edit_degree_year_path(degree.id, return_to_params),
+        data_qa: 'degree-start-year',
       }
     end
 
@@ -138,7 +146,8 @@ module CandidateInterface
         key: t('application_form.degree.award_year.review_label'),
         value: degree.award_year,
         action: generate_action(degree: degree, attribute: t('application_form.degree.award_year.change_action')),
-        change_path: candidate_interface_edit_degree_award_year_path(degree.id),
+        change_path: candidate_interface_edit_degree_year_path(degree.id, return_to_params),
+        data_qa: 'degree-award-year',
       }
     end
 
@@ -147,7 +156,8 @@ module CandidateInterface
         key: degree.completed? ? t('application_form.degree.grade.review_label') : t('application_form.degree.grade.review_label_predicted'),
         value: degree.grade,
         action: generate_action(degree: degree, attribute: t('application_form.degree.grade.change_action')),
-        change_path: candidate_interface_edit_degree_grade_path(degree.id),
+        change_path: candidate_interface_edit_degree_grade_path(degree.id, return_to_params),
+        data_qa: 'degree-grade',
       }
     end
 
@@ -156,7 +166,8 @@ module CandidateInterface
         key: t('application_form.degree.completion_status.review_label'),
         value: formatted_completion_status(degree),
         action: generate_action(degree: degree, attribute: t('application_form.degree.completion_status.change_action')),
-        change_path: candidate_interface_edit_degree_completion_status_path(degree.id),
+        change_path: candidate_interface_edit_degree_completion_status_path(degree.id, return_to_params),
+        data_qa: 'degree-completion-status',
       }
     end
 
@@ -168,6 +179,10 @@ module CandidateInterface
 
     def generate_action(degree:, attribute: '')
       "#{attribute.presence} for #{degree.qualification_type}, #{degree.subject}, #{degree.institution_name}, #{degree.award_year}"
+    end
+
+    def return_to_params
+      { 'return-to' => 'application-review' } if @return_to_application_review
     end
   end
 end

--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -136,7 +136,7 @@ module CandidateInterface
         key: t('application_form.degree.start_year.review_label'),
         value: degree.start_year,
         action: generate_action(degree: degree, attribute: t('application_form.degree.start_year.change_action')),
-        change_path: candidate_interface_edit_degree_year_path(degree.id, return_to_params),
+        change_path: candidate_interface_edit_degree_start_year_path(degree.id, return_to_params),
         data_qa: 'degree-start-year',
       }
     end
@@ -146,7 +146,7 @@ module CandidateInterface
         key: t('application_form.degree.award_year.review_label'),
         value: degree.award_year,
         action: generate_action(degree: degree, attribute: t('application_form.degree.award_year.change_action')),
-        change_path: candidate_interface_edit_degree_year_path(degree.id, return_to_params),
+        change_path: candidate_interface_edit_degree_award_year_path(degree.id, return_to_params),
         data_qa: 'degree-award-year',
       }
     end

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class GcseQualificationReviewComponent < ViewComponent::Base
-    def initialize(application_form:, application_qualification:, subject:, editable: true, heading_level: 2, missing_error: false, submitting_application: false)
+    def initialize(application_form:, application_qualification:, subject:, editable: true, heading_level: 2, missing_error: false, submitting_application: false, return_to_application_review: false)
       @application_form = application_form
       @application_qualification = application_qualification
       @subject = subject
@@ -8,6 +8,7 @@ module CandidateInterface
       @heading_level = heading_level
       @missing_error = missing_error
       @submitting_application = submitting_application
+      @return_to_application_review = return_to_application_review
     end
 
     def gcse_qualification_rows
@@ -54,7 +55,8 @@ module CandidateInterface
         key: t('application_form.gcse.qualification.label'),
         value: gcse_qualification_types[application_qualification.qualification_type.to_sym.downcase],
         action: "qualification for #{gcse_qualification_types[application_qualification.qualification_type.to_sym]}, #{subject}",
-        change_path: candidate_interface_gcse_details_edit_type_path(subject: subject),
+        change_path: candidate_interface_gcse_details_edit_type_path(change_path_params),
+        data_qa: "gcse-#{subject}-qualification",
       }
     end
 
@@ -63,7 +65,8 @@ module CandidateInterface
         key: 'Year awarded',
         value: application_qualification.award_year || t('gcse_summary.not_specified'),
         action: "year awarded for #{gcse_qualification_types[application_qualification.qualification_type.to_sym]}, #{subject}",
-        change_path: candidate_interface_gcse_details_edit_year_path(subject: subject),
+        change_path: candidate_interface_gcse_details_edit_year_path(change_path_params),
+        data_qa: "gcse-#{subject}-award-year",
       }
     end
 
@@ -73,6 +76,7 @@ module CandidateInterface
         value: present_grades || t('gcse_summary.not_specified'),
         action: "grade for #{gcse_qualification_types[application_qualification.qualification_type.to_sym]}, #{subject}",
         change_path: grade_edit_path,
+        data_qa: "gcse-#{subject}-grade",
       }
     end
 
@@ -83,7 +87,8 @@ module CandidateInterface
         key: 'How I expect to gain this qualification',
         value: application_qualification.missing_explanation,
         action: 'if you are working towards this qualification at grade 4 (C) or above, give us details',
-        change_path: candidate_interface_gcse_details_edit_grade_explanation_path(subject: subject),
+        change_path: candidate_interface_gcse_details_edit_grade_explanation_path(change_path_params),
+        data_qa: 'gcse-failing-grade-explanation',
       }
     end
 
@@ -131,7 +136,8 @@ module CandidateInterface
         key: 'How I expect to gain this qualification',
         value: application_qualification.missing_explanation.presence || t('gcse_summary.not_specified'),
         action: 'how do you expect to gain this qualification',
-        change_path: candidate_interface_gcse_details_edit_type_path(subject: subject),
+        change_path: candidate_interface_gcse_details_edit_type_path(change_path_params),
+        data_qa: 'gcse-missing-qualification-explanation',
       }
     end
 
@@ -149,7 +155,8 @@ module CandidateInterface
         key: 'Country',
         value: COUNTRIES[application_qualification.institution_country],
         action: 'Change the country that you studied in',
-        change_path: candidate_interface_gcse_details_edit_institution_country_path(subject: subject),
+        change_path: candidate_interface_gcse_details_edit_institution_country_path(change_path_params),
+        data_qa: 'gcse-country',
       }
     end
 
@@ -160,7 +167,8 @@ module CandidateInterface
         key: t('application_form.gcse.enic_statement.review_label'),
         value: application_qualification.enic_reference ? 'Yes' : 'No',
         action: t('application_form.gcse.enic_statement.change_action'),
-        change_path: candidate_interface_gcse_details_edit_enic_path(subject: subject),
+        change_path: candidate_interface_gcse_details_edit_enic_path(change_path_params),
+        data_qa: 'gcse-enic-statement',
       }
     end
 
@@ -172,7 +180,8 @@ module CandidateInterface
         key: t('application_form.gcse.enic_reference.review_label'),
         value: application_qualification.enic_reference,
         action: t('application_form.gcse.enic_reference.change_action'),
-        change_path: candidate_interface_gcse_details_edit_enic_path(subject: subject),
+        change_path: candidate_interface_gcse_details_edit_enic_path(change_path_params),
+        data_qa: 'gcse-enic-reference',
       }
     end
 
@@ -184,18 +193,32 @@ module CandidateInterface
         key: t('application_form.gcse.comparable_uk_qualification.review_label'),
         value: application_qualification.comparable_uk_qualification,
         action: t('application_form.gcse.comparable_uk_qualification.change_action'),
-        change_path: candidate_interface_gcse_details_edit_enic_path(subject: subject),
+        change_path: candidate_interface_gcse_details_edit_enic_path(change_path_params),
+        data_qa: 'gcse-comparable-uk-qualification',
       }
+    end
+
+    def return_to_params
+      { 'return-to' => 'application-review' } if @return_to_application_review
+    end
+
+    def change_path_params
+      params = { subject: subject }
+      if @return_to_application_review
+        params.merge(return_to_params)
+      else
+        params
+      end
     end
 
     def grade_edit_path
       case subject
       when 'maths'
-        candidate_interface_edit_gcse_maths_grade_path
+        candidate_interface_edit_gcse_maths_grade_path(return_to_params)
       when 'science'
-        candidate_interface_edit_gcse_science_grade_path
+        candidate_interface_edit_gcse_science_grade_path(return_to_params)
       when 'english'
-        candidate_interface_edit_gcse_english_grade_path
+        candidate_interface_edit_gcse_english_grade_path(return_to_params)
       end
     end
   end

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   class OtherQualificationsReviewComponent < ViewComponent::Base
     include ViewHelper
 
-    def initialize(application_form:, editable: true, heading_level: 2, missing_error: false, submitting_application: false)
+    def initialize(application_form:, editable: true, heading_level: 2, missing_error: false, submitting_application: false, return_to_application_review: false)
       @application_form = application_form
       @qualifications =
         CandidateInterface::OtherQualificationDetailsForm.build_all(@application_form)
@@ -10,6 +10,7 @@ module CandidateInterface
       @heading_level = heading_level
       @missing_error = missing_error
       @submitting_application = submitting_application
+      @return_to_application_review = return_to_application_review
     end
 
     def other_qualifications_rows(qualification)
@@ -32,10 +33,11 @@ module CandidateInterface
     end
 
     def no_qualification_row
+      params = { change: true }.merge(return_to_params)
       [{
         key: 'Do you want to add any A levels and other qualifications',
         value: 'No',
-        change_path: candidate_interface_other_qualification_type_path(change: true),
+        change_path: candidate_interface_other_qualification_type_path(params),
       }]
     end
 
@@ -49,6 +51,7 @@ module CandidateInterface
         value: qualification_value(qualification),
         action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.qualification.change_action')),
         change_path: edit_other_qualification_type_path(qualification),
+        data_qa: 'other-qualifications-type',
       }
     end
 
@@ -68,6 +71,7 @@ module CandidateInterface
         value: rows_value(qualification.subject),
         action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.subject.change_action')),
         change_path: edit_other_qualification_details_path(qualification),
+        data_qa: 'other-qualifications-subject',
       }
     end
 
@@ -85,6 +89,7 @@ module CandidateInterface
         value: country_value(qualification),
         action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.country.change_action')),
         change_path: edit_other_qualification_details_path(qualification),
+        data_qa: 'other-qualifications-country',
       }
     end
 
@@ -106,6 +111,7 @@ module CandidateInterface
         value: rows_value(qualification.award_year),
         action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.award_year.change_action')),
         change_path: edit_other_qualification_details_path(qualification),
+        data_qa: 'other-qualifications-year-awarded',
       }
     end
 
@@ -115,6 +121,7 @@ module CandidateInterface
         value: rows_value(qualification.grade),
         action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.grade.change_action')),
         change_path: edit_other_qualification_details_path(qualification),
+        data_qa: 'other-qualifications-grade',
       }
     end
 
@@ -131,16 +138,24 @@ module CandidateInterface
     end
 
     def edit_other_qualification_details_path(qualification)
-      candidate_interface_edit_other_qualification_details_path(qualification.id)
+      candidate_interface_edit_other_qualification_details_path(qualification.id, return_to_params)
     end
 
     def edit_other_qualification_type_path(qualification)
-      candidate_interface_edit_other_qualification_type_path(qualification.id)
+      candidate_interface_edit_other_qualification_type_path(qualification.id, return_to_params)
     end
 
     def generate_action(qualification:, attribute: '')
       "#{attribute.presence} for #{qualification.qualification_type_name}, #{qualification.subject}, "\
         "#{qualification.award_year}"
+    end
+
+    def return_to_params
+      if @return_to_application_review
+        { 'return-to' => 'application-review' }
+      else
+        {}
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -23,19 +23,17 @@ module CandidateInterface
       @contact_details_form = ContactDetailsForm.build_from_application(
         current_application,
       )
-      @return_to = return_to_after_edit(default: candidate_interface_edit_address_type_path)
+      @return_to = return_to_after_edit(default: candidate_interface_contact_information_review_path)
     end
 
     def update
       @contact_details_form = ContactDetailsForm.new(
         contact_details_params.merge(address_type: current_application.address_type),
       )
-      @return_to = return_to_after_edit(default: candidate_interface_edit_address_type_path)
+      @return_to = return_to_after_edit(default: candidate_interface_contact_information_review_path)
 
       if @contact_details_form.save_address(current_application)
-        return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
-
-        redirect_to candidate_interface_contact_information_review_path
+        redirect_to @return_to[:back_path]
       else
         track_validation_error(@contact_details_form)
         render :edit

--- a/app/controllers/candidate_interface/contact_details/address_type_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_type_controller.rb
@@ -26,13 +26,12 @@ module CandidateInterface
 
     def update
       @contact_details_form = ContactDetailsForm.new(address_type_params)
+      @return_to = return_to_after_edit(default: candidate_interface_personal_details_complete_path)
 
       if @contact_details_form.save_address_type(current_application)
-        if redirect_back_to_application_review_page?
-          redirect_to candidate_interface_edit_address_path(redirect_back_to_application_review_page_params)
-        else
-          redirect_to candidate_interface_edit_address_path
-        end
+        return redirect_to candidate_interface_edit_address_path(redirect_back_to_application_review_page_params) if redirect_back_to_application_review_page?
+
+        redirect_to candidate_interface_edit_address_path
       else
         track_validation_error(@contact_details_form)
         render :edit

--- a/app/controllers/candidate_interface/contact_details/phone_number_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/phone_number_controller.rb
@@ -28,9 +28,7 @@ module CandidateInterface
       @return_to = return_to_after_edit(default: candidate_interface_contact_information_review_path)
 
       if @contact_details_form.save_base(current_application)
-        return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
-
-        redirect_to candidate_interface_contact_information_review_path
+        redirect_to @return_to[:back_path]
       else
         track_validation_error(@contact_details_form)
         render :edit

--- a/app/controllers/candidate_interface/degrees/completion_status_controller.rb
+++ b/app/controllers/candidate_interface/degrees/completion_status_controller.rb
@@ -19,13 +19,15 @@ module CandidateInterface
 
       def edit
         @completion_status_form = DegreeCompletionStatusForm.new(completion_status_params).assign_form_values(current_degree)
+        @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
       end
 
       def update
         @completion_status_form = DegreeCompletionStatusForm.new(completion_status_params)
+        @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
 
         if @completion_status_form.save(current_degree)
-          redirect_to candidate_interface_degrees_review_path
+          redirect_to @return_to[:back_path]
         else
           track_validation_error(@completion_status_form)
           render :edit

--- a/app/controllers/candidate_interface/degrees/enic_controller.rb
+++ b/app/controllers/candidate_interface/degrees/enic_controller.rb
@@ -18,12 +18,15 @@ module CandidateInterface
 
       def edit
         @degree_enic_form = DegreeEnicForm.new(degree: current_degree).assign_form_values
+        @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
       end
 
       def update
         @degree_enic_form = DegreeEnicForm.new(enic_params)
+        @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
+
         if @degree_enic_form.save
-          redirect_to candidate_interface_degrees_review_path
+          redirect_to @return_to[:back_path]
         else
           track_validation_error(@degree_enic_form)
           render :edit

--- a/app/controllers/candidate_interface/degrees/grade_controller.rb
+++ b/app/controllers/candidate_interface/degrees/grade_controller.rb
@@ -23,13 +23,15 @@ module CandidateInterface
 
       def edit
         @degree_grade_form = DegreeGradeForm.new(degree: current_degree).assign_form_values
+        @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
       end
 
       def update
         @degree_grade_form = DegreeGradeForm.new(grade_params)
+        @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
 
         if @degree_grade_form.save
-          redirect_to candidate_interface_degrees_review_path
+          redirect_to @return_to[:back_path]
         else
           track_validation_error(@degree_grade_form)
           render :edit

--- a/app/controllers/candidate_interface/degrees/institution_controller.rb
+++ b/app/controllers/candidate_interface/degrees/institution_controller.rb
@@ -24,12 +24,15 @@ module CandidateInterface
 
       def edit
         @degree_institution_form = DegreeInstitutionForm.new(degree: current_degree).assign_form_values
+        @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
       end
 
       def update
         @degree_institution_form = DegreeInstitutionForm.new(institution_params)
+        @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
+
         if @degree_institution_form.save
-          redirect_to candidate_interface_degrees_review_path
+          redirect_to @return_to[:back_path]
         else
           track_validation_error(@degree_institution_form)
           render :edit

--- a/app/controllers/candidate_interface/degrees/start_year_controller.rb
+++ b/app/controllers/candidate_interface/degrees/start_year_controller.rb
@@ -18,13 +18,15 @@ module CandidateInterface
 
       def edit
         @degree_start_year_form = DegreeStartYearForm.new(degree: current_degree).assign_form_values
+        @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
       end
 
       def update
         @degree_start_year_form = DegreeStartYearForm.new(degree_start_year_params)
+        @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
 
         if @degree_start_year_form.save
-          redirect_to candidate_interface_degrees_review_path
+          redirect_to @return_to[:back_path]
         else
           track_validation_error(@degree_start_year_form)
           render :edit

--- a/app/controllers/candidate_interface/degrees/subject_controller.rb
+++ b/app/controllers/candidate_interface/degrees/subject_controller.rb
@@ -19,12 +19,15 @@ module CandidateInterface
 
       def edit
         @degree_subject_form = DegreeSubjectForm.new(degree: current_degree).assign_form_values
+        @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
       end
 
       def update
         @degree_subject_form = DegreeSubjectForm.new(subject_params)
+        @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
+
         if @degree_subject_form.save
-          redirect_to candidate_interface_degrees_review_path
+          redirect_to @return_to[:back_path]
         else
           track_validation_error(@degree_subject_form)
           render :edit

--- a/app/controllers/candidate_interface/degrees/type_controller.rb
+++ b/app/controllers/candidate_interface/degrees/type_controller.rb
@@ -25,12 +25,15 @@ module CandidateInterface
 
       def edit
         @degree_type_form = DegreeTypeForm.new(degree: current_degree).assign_form_values
+        @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
       end
 
       def update
         @degree_type_form = DegreeTypeForm.new(update_params)
+        @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
+
         if @degree_type_form.update
-          redirect_to candidate_interface_degrees_review_path
+          redirect_to @return_to[:back_path]
         else
           track_validation_error(@degree_type_form)
           render :edit

--- a/app/controllers/candidate_interface/degrees/year_controller.rb
+++ b/app/controllers/candidate_interface/degrees/year_controller.rb
@@ -1,0 +1,45 @@
+module CandidateInterface
+  module Degrees
+    class YearController < BaseController
+      def new
+        @degree_year_form = DegreeYearForm.new(degree: current_degree).assign_form_values
+      end
+
+      def create
+        @degree_year_form = DegreeYearForm.new(degree_year_params)
+
+        if @degree_year_form.save
+          redirect_to candidate_interface_degrees_review_path
+        else
+          track_validation_error(@degree_year_form)
+          render :new
+        end
+      end
+
+      def edit
+        @degree_year_form = DegreeAwardYearForm.new(degree: current_degree).assign_form_values
+        @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
+      end
+
+      def update
+        @degree_year_form = DegreeAwardYearForm.new(degree_year_params)
+        @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
+
+        if @degree_year_form.save
+          redirect_to @return_to[:back_path]
+        else
+          track_validation_error(@degree_year_form)
+          render :edit
+        end
+      end
+
+    private
+
+      def degree_year_params
+        strip_whitespace(
+          params.require(:candidate_interface_degree_year_form).permit(:start_year, :award_year),
+        ).merge(degree: current_degree)
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/gcse/english/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/english/grade_controller.rb
@@ -28,6 +28,7 @@ module CandidateInterface
     def edit
       @gcse_grade_form = english_gcse_grade_form
       @qualification_type = gcse_english_qualification.qualification_type
+      @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path(@subject))
 
       render view_path
     end
@@ -35,8 +36,11 @@ module CandidateInterface
     def update
       @qualification_type = gcse_english_qualification.qualification_type
       @gcse_grade_form = english_gcse_grade_form.assign_values(english_details_params)
+      @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path(@subject))
 
       if @gcse_grade_form.save
+        return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
+
         if current_qualification.failed_required_gcse?
           redirect_to candidate_interface_gcse_details_edit_grade_explanation_path(@subject)
         else

--- a/app/controllers/candidate_interface/gcse/enic_controller.rb
+++ b/app/controllers/candidate_interface/gcse/enic_controller.rb
@@ -19,13 +19,15 @@ module CandidateInterface
 
     def edit
       @enic_form = GcseEnicForm.build_from_qualification(current_qualification)
+      @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path)
     end
 
     def update
       @enic_form = GcseEnicForm.new(enic_params)
+      @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path)
 
       if @enic_form.save(current_qualification)
-        redirect_to candidate_interface_gcse_review_path
+        redirect_to @return_to[:back_path]
       else
         track_validation_error(@enic_form)
         render :edit

--- a/app/controllers/candidate_interface/gcse/institution_country_controller.rb
+++ b/app/controllers/candidate_interface/gcse/institution_country_controller.rb
@@ -17,13 +17,15 @@ module CandidateInterface
 
     def edit
       @institution_country = GcseInstitutionCountryForm.build_from_qualification(current_qualification)
+      @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path)
     end
 
     def update
       @institution_country = GcseInstitutionCountryForm.new(institution_country_params)
+      @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path)
 
       if @institution_country.save(current_qualification)
-        redirect_to candidate_interface_gcse_review_path
+        redirect_to @return_to[:back_path]
       else
         track_validation_error(@institution_country)
         render :edit

--- a/app/controllers/candidate_interface/gcse/maths/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/maths/grade_controller.rb
@@ -27,12 +27,16 @@ module CandidateInterface
     def edit
       @gcse_grade_form = MathsGcseGradeForm.build_from_qualification(current_qualification)
       @qualification_type = @gcse_grade_form.qualification_type
+      @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path(@subject))
     end
 
     def update
       @gcse_grade_form = MathsGcseGradeForm.new(maths_params)
+      @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path(@subject))
 
       if @gcse_grade_form.save(current_qualification)
+        return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
+
         if current_qualification.failed_required_gcse?
           redirect_to candidate_interface_gcse_details_edit_grade_explanation_path(subject: @subject)
         else

--- a/app/controllers/candidate_interface/gcse/science/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/science/grade_controller.rb
@@ -27,14 +27,18 @@ module CandidateInterface
     def edit
       @gcse_grade_form = science_gcse_grade_form
       @qualification_type = current_qualification.qualification_type
+      @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path(@subject))
 
       render view_path
     end
 
     def update
       @gcse_grade_form = science_gcse_grade_form.assign_values(science_details_params)
+      @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path(@subject))
 
       if @gcse_grade_form.save
+        return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
+
         if current_qualification.failed_required_gcse?
           candidate_interface_gcse_details_edit_grade_explanation_path(@subject)
         else

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -35,9 +35,7 @@ module CandidateInterface
       @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path)
 
       if @type_form.update(current_qualification)
-        return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
-
-        redirect_to candidate_interface_gcse_review_path
+        redirect_to @return_to[:back_path]
       else
         track_validation_error(@type_form)
         render :edit

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -27,12 +27,16 @@ module CandidateInterface
 
     def edit
       @type_form = GcseQualificationTypeForm.build_from_qualification(current_qualification)
+      @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path)
     end
 
     def update
       @type_form = GcseQualificationTypeForm.new(qualification_params)
+      @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path)
 
       if @type_form.update(current_qualification)
+        return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
+
         redirect_to candidate_interface_gcse_review_path
       else
         track_validation_error(@type_form)

--- a/app/controllers/candidate_interface/gcse/year_controller.rb
+++ b/app/controllers/candidate_interface/gcse/year_controller.rb
@@ -20,12 +20,16 @@ module CandidateInterface
 
     def edit
       @year_form = CandidateInterface::GcseYearForm.build_from_qualification(current_qualification)
+      @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path)
     end
 
     def update
       @year_form = CandidateInterface::GcseYearForm.new(year_params)
+      @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path)
 
       if @year_form.save(current_qualification)
+        return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
+
         redirect_to candidate_interface_gcse_review_path
       else
         track_validation_error(@year_form)

--- a/app/controllers/candidate_interface/gcse/year_controller.rb
+++ b/app/controllers/candidate_interface/gcse/year_controller.rb
@@ -28,9 +28,7 @@ module CandidateInterface
       @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path)
 
       if @year_form.save(current_qualification)
-        return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
-
-        redirect_to candidate_interface_gcse_review_path
+        redirect_to @return_to[:back_path]
       else
         track_validation_error(@year_form)
 

--- a/app/controllers/candidate_interface/other_qualifications/details_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/details_controller.rb
@@ -49,6 +49,7 @@ module CandidateInterface
         current_step: :details,
         editing: true,
       )
+      @return_to = return_to_after_edit(default: candidate_interface_review_other_qualifications_path)
     end
 
     def update
@@ -61,9 +62,10 @@ module CandidateInterface
           editing: true,
         ),
       )
+      @return_to = return_to_after_edit(default: candidate_interface_review_other_qualifications_path)
 
       if @form.save
-        redirect_to candidate_interface_review_other_qualifications_path
+        redirect_to @return_to[:back_path]
       else
         track_validation_error(@form)
         render :edit

--- a/app/controllers/candidate_interface/other_qualifications/type_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/type_controller.rb
@@ -44,6 +44,7 @@ module CandidateInterface
         }.merge!(type_attributes(current_qualification)),
       )
       @form.save_intermediate!
+      @return_to = return_to_after_edit(default: candidate_interface_review_other_qualifications_path)
     end
 
     def update
@@ -56,6 +57,7 @@ module CandidateInterface
           id: current_qualification.id,
         ),
       )
+      @return_to = return_to_after_edit(default: candidate_interface_review_other_qualifications_path)
 
       if @form.valid?
         @form.save_intermediate!
@@ -63,7 +65,7 @@ module CandidateInterface
         next_step = @form.next_step
 
         if next_step == :details
-          redirect_to candidate_interface_edit_other_qualification_details_path(current_qualification.id)
+          redirect_to candidate_interface_edit_other_qualification_details_path(current_qualification.id, @return_to[:params])
         elsif next_step == :check
           @form.save!
           redirect_to candidate_interface_review_other_qualifications_path

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -39,7 +39,15 @@
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.qualifications') %></h2>
   <h3 class="govuk-heading-m"><%= t('page_titles.english_gcse') %></h3>
-  <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.english_gcse, subject: 'english', editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
+  <%= render(CandidateInterface::GcseQualificationReviewComponent.new(
+    application_form: @application_form,
+    application_qualification: @application_form.english_gcse,
+    subject: 'english',
+    editable: editable,
+    heading_level: 4,
+    missing_error: missing_error,
+    submitting_application: true,
+    return_to_application_review: true)) %>
 
   <% if @application_form.international_applicant? %>
     <h3 class="govuk-heading-m"><%= t('page_titles.efl.start') %></h3>
@@ -51,11 +59,29 @@
   <% end %>
 
   <h3 class="govuk-heading-m"><%= t('page_titles.maths_gcse') %></h3>
-  <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.maths_gcse, subject: 'maths', editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
+  <%= render(CandidateInterface::GcseQualificationReviewComponent.new(
+    application_form: @application_form,
+    application_qualification: @application_form.maths_gcse,
+    subject: 'maths',
+    editable: editable,
+    heading_level: 4,
+    missing_error: missing_error,
+    submitting_application: true,
+    return_to_application_review: true,
+  )) %>
 
   <% if @application_form.science_gcse_needed? %>
     <h3 class="govuk-heading-m"><%= t('page_titles.science_gcse') %></h3>
-    <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
+    <%= render(CandidateInterface::GcseQualificationReviewComponent.new(
+      application_form: @application_form,
+      application_qualification: @application_form.science_gcse,
+      subject: 'science',
+      editable: editable,
+      heading_level: 4,
+      missing_error: missing_error,
+      submitting_application: true,
+      return_to_application_review: true
+    )) %>
   <% end %>
 
   <h3 class="govuk-heading-m"><%= other_qualifications_title(@application_form) %></h3>

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -85,7 +85,14 @@
   <% end %>
 
   <h3 class="govuk-heading-m"><%= other_qualifications_title(@application_form) %></h3>
-  <%= render(CandidateInterface::OtherQualificationsReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
+  <%= render(CandidateInterface::OtherQualificationsReviewComponent.new(
+    application_form: application_form,
+    editable: editable,
+    heading_level: 4,
+    missing_error: missing_error,
+    submitting_application: true,
+    return_to_application_review: true
+  )) %>
 
   <h3 class="govuk-heading-m"><%= t('page_titles.degree') %></h3>
   <%= render(CandidateInterface::DegreesReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, show_incomplete: true, missing_error: missing_error)) %>

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -47,7 +47,8 @@
     heading_level: 4,
     missing_error: missing_error,
     submitting_application: true,
-    return_to_application_review: true)) %>
+    return_to_application_review: true,
+  )) %>
 
   <% if @application_form.international_applicant? %>
     <h3 class="govuk-heading-m"><%= t('page_titles.efl.start') %></h3>
@@ -80,7 +81,7 @@
       heading_level: 4,
       missing_error: missing_error,
       submitting_application: true,
-      return_to_application_review: true
+      return_to_application_review: true,
     )) %>
   <% end %>
 
@@ -91,11 +92,17 @@
     heading_level: 4,
     missing_error: missing_error,
     submitting_application: true,
-    return_to_application_review: true
+    return_to_application_review: true,
   )) %>
 
   <h3 class="govuk-heading-m"><%= t('page_titles.degree') %></h3>
-  <%= render(CandidateInterface::DegreesReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, show_incomplete: true, missing_error: missing_error)) %>
+  <%= render(CandidateInterface::DegreesReviewComponent.new(
+    application_form: application_form,
+    editable: editable, heading_level: 4,
+    show_incomplete: true,
+    missing_error: missing_error,
+    return_to_application_review: true
+  )) %>
 </section>
 
 <section class="govuk-!-margin-bottom-8">

--- a/app/views/candidate_interface/degrees/completion_status/edit.html.erb
+++ b/app/views/candidate_interface/degrees/completion_status/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.degree_completion_status'), @completion_status_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_degrees_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @completion_status_form, url: candidate_interface_edit_degree_completion_status_path(current_degree), method: :patch do |f| %>
+    <%= form_with model: @completion_status_form, url: candidate_interface_edit_degree_completion_status_path(current_degree, @return_to[:params]), method: :patch do |f| %>
       <%= render 'form_fields', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/degrees/enic/edit.html.erb
+++ b/app/views/candidate_interface/degrees/enic/edit.html.erb
@@ -1,11 +1,11 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.degree_enic'), @degree_enic_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_degrees_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @degree_enic_form,
-      url: candidate_interface_edit_degree_enic_path(@degree_enic_form.degree),
+      url: candidate_interface_edit_degree_enic_path(@degree_enic_form.degree, @return_to[:params]),
       method: :patch,
     ) do |f| %>
       <%= render 'form_fields', f: f %>

--- a/app/views/candidate_interface/degrees/grade/edit.html.erb
+++ b/app/views/candidate_interface/degrees/grade/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(@page_title, @degree_grade_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_degrees_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @degree_grade_form, url: candidate_interface_edit_degree_grade_path(@degree_grade_form.degree), method: :patch do |f| %>
+    <%= form_with model: @degree_grade_form, url: candidate_interface_edit_degree_grade_path(@degree_grade_form.degree, @return_to[:params]), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= render 'form_fields', f: f, degree: @degree_grade_form.degree %>

--- a/app/views/candidate_interface/degrees/institution/edit.html.erb
+++ b/app/views/candidate_interface/degrees/institution/edit.html.erb
@@ -1,11 +1,11 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.degree_institution'), @degree_institution_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_degrees_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @degree_institution_form,
-      url: candidate_interface_edit_degree_institution_path(@degree_institution_form.degree),
+      url: candidate_interface_edit_degree_institution_path(@degree_institution_form.degree, @return_to[:params]),
       method: :patch,
     ) do |f| %>
       <%= render 'form_fields', f: f %>

--- a/app/views/candidate_interface/degrees/start_year/edit.html.erb
+++ b/app/views/candidate_interface/degrees/start_year/edit.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.what_year_did_you_start_your_degree'), @degree_start_year_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_degrees_review_path) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.when_did_you_study_for_your_degree'), @degree_start_year_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @degree_start_year_form, url: candidate_interface_edit_degree_start_year_path, method: :patch do |f| %>
+    <%= form_with model: @degree_start_year_form, url: candidate_interface_edit_degree_year_path(@return_to[:params]), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= render 'form_fields', f: f %>

--- a/app/views/candidate_interface/degrees/start_year/edit.html.erb
+++ b/app/views/candidate_interface/degrees/start_year/edit.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.when_did_you_study_for_your_degree'), @degree_start_year_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.what_year_did_you_start_your_degree'), @degree_start_year_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @degree_start_year_form, url: candidate_interface_edit_degree_year_path(@return_to[:params]), method: :patch do |f| %>
+    <%= form_with model: @degree_start_year_form, url: candidate_interface_edit_degree_start_year_path(@return_to[:params]), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= render 'form_fields', f: f %>

--- a/app/views/candidate_interface/degrees/subject/edit.html.erb
+++ b/app/views/candidate_interface/degrees/subject/edit.html.erb
@@ -1,11 +1,11 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.degree_subject'), @degree_subject_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_degrees_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @degree_subject_form,
-      url: candidate_interface_edit_degree_subject_path(@degree_subject_form.degree),
+      url: candidate_interface_edit_degree_subject_path(@degree_subject_form.degree, @return_to[:params]),
       method: :patch,
     ) do |f| %>
 

--- a/app/views/candidate_interface/degrees/type/edit.html.erb
+++ b/app/views/candidate_interface/degrees/type/edit.html.erb
@@ -1,11 +1,11 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.edit_degree_type'), @degree_type_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_degrees_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @degree_type_form,
-      url: candidate_interface_edit_degree_type_path(@degree_type_form.degree),
+      url: candidate_interface_edit_degree_type_path(@degree_type_form.degree, @return_to[:params]),
       method: :patch,
     ) do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/gcse/english/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/english/grade/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(grade_step_title(@subject, @qualification_type), @gcse_grade_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_gcse_review_path(@subject)) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @gcse_grade_form, url: candidate_interface_edit_gcse_english_grade_path, method: :patch do |f| %>
+    <%= form_with model: @gcse_grade_form, url: candidate_interface_edit_gcse_english_grade_path(@return_to[:params]), method: :patch do |f| %>
       <%= render 'single_grade_form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/gcse/enic/edit.html.erb
+++ b/app/views/candidate_interface/gcse/enic/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('gcse_edit_enic.page_title', subject: @subject.capitalize), @enic_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_gcse_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @enic_form, url: candidate_interface_gcse_details_edit_enic_path, method: :patch do |f| %>
+    <%= form_with model: @enic_form, url: candidate_interface_gcse_details_edit_enic_path(@return_to[:params]), method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/gcse/institution_country/edit.html.erb
+++ b/app/views/candidate_interface/gcse/institution_country/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('gcse_edit_institution_country.page_title', subject: @subject.capitalize), @institution_country.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_gcse_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @institution_country, url: candidate_interface_gcse_details_edit_institution_country_path, method: :patch do |f| %>
+    <%= form_with model: @institution_country, url: candidate_interface_gcse_details_edit_institution_country_path(@return_to[:params]), method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/gcse/maths/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/maths/grade/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(grade_step_title(@subject, @qualification_type), @gcse_grade_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_gcse_review_path(@subject)) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @gcse_grade_form, url: candidate_interface_edit_gcse_maths_grade_path, method: :patch do |f| %>
+    <%= form_with model: @gcse_grade_form, url: candidate_interface_edit_gcse_maths_grade_path(@return_to[:params]), method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/gcse/science/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/science/grade/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(grade_step_title(@subject, @qualification_type), @gcse_grade_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_gcse_review_path(@subject)) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_link]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @gcse_grade_form, url: candidate_interface_edit_gcse_science_grade_path, method: :patch do |f| %>
+    <%= form_with model: @gcse_grade_form, url: candidate_interface_edit_gcse_science_grade_path(@return_to[:params]), method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t("gcse_edit_type.page_titles.#{@subject}"), @type_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_gcse_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @type_form, url: candidate_interface_gcse_details_edit_type_path, method: :patch do |f| %>
+    <%= form_with model: @type_form, url: candidate_interface_gcse_details_edit_type_path(@return_to[:params]), method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/gcse/year/edit.html.erb
+++ b/app/views/candidate_interface/gcse/year/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(year_step_title(@subject, @year_form.qualification_type), @year_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_gcse_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @year_form, url: candidate_interface_gcse_details_edit_year_path, method: :patch do |f| %>
+    <%= form_with model: @year_form, url: candidate_interface_gcse_details_edit_year_path(@return_to[:params]), method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/other_qualifications/details/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.qualification_details'), @form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_review_other_qualifications_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: candidate_interface_edit_other_qualification_details_path, method: :patch do |f| %>
+    <%= form_with model: @form, url: candidate_interface_edit_other_qualification_details_path(@return_to[:params]), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/other_qualifications/type/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(other_qualifications_title(current_application), @form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_review_other_qualifications_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: candidate_interface_edit_other_qualification_type_path, method: :patch do |f| %>
+    <%= form_with model: @form, url: candidate_interface_edit_other_qualification_type_path(@return_to[:params]), method: :patch do |f| %>
       <%= render partial: 'shared_form', locals: { f: f } %>
     <% end %>
   </div>

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_applicatiion_and_updates_qualifications_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_applicatiion_and_updates_qualifications_spec.rb
@@ -41,6 +41,28 @@ RSpec.feature 'Candidate is redirected correctly' do
     when_i_update_english_gcse_year
     then_i_should_be_redirected_to_the_application_review_page
     and_i_should_see_my_updated_gcse_year
+
+    # Other qualifications type
+    when_i_click_change_other_qualification_type
+    then_i_should_see_the_other_qualification_type_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_the_other_qualification_type
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_qualification_type
+
+    # Other qualifications grade
+    when_i_click_change_other_qualification_grade
+    then_i_should_see_the_other_qualification_details_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_the_other_qualification_grade
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_qualification_grade
   end
 
   def given_i_am_signed_in
@@ -100,6 +122,18 @@ RSpec.feature 'Candidate is redirected correctly' do
     end
   end
 
+  def when_i_click_change_other_qualification_type
+    within('[data-qa="other-qualifications-type"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_other_qualification_grade
+    within('[data-qa="other-qualifications-grade"]') do
+      click_link 'Change'
+    end
+  end
+
   def then_i_should_see_the_gcse_type_form
     expect(page).to have_current_path(candidate_interface_gcse_details_edit_type_path(subject: 'english', 'return-to' => 'application-review'))
   end
@@ -112,6 +146,14 @@ RSpec.feature 'Candidate is redirected correctly' do
     expect(page).to have_current_path(candidate_interface_gcse_details_edit_year_path(subject: 'english', 'return-to' => 'application-review'))
   end
 
+  def then_i_should_see_the_other_qualification_type_form
+    expect(page).to have_content('A levels and other qualifications')
+  end
+
+  def then_i_should_see_the_other_qualification_details_form
+    expect(page).to have_content('Edit AS level qualification')
+  end
+
   def when_i_update_english_gcse_qualification
     when_i_click_change_english_gcse_qualification
 
@@ -122,7 +164,6 @@ RSpec.feature 'Candidate is redirected correctly' do
   def when_i_update_english_gcse_grade
     when_i_click_change_english_gcse_grade
     fill_in 'Please specify your grade', with: 'C'
-
     click_button t('save_and_continue')
   end
 
@@ -133,21 +174,48 @@ RSpec.feature 'Candidate is redirected correctly' do
     click_button t('save_and_continue')
   end
 
+  def when_i_update_the_other_qualification_type
+    when_i_click_change_other_qualification_type
+
+    choose 'AS level'
+    click_button t('continue')
+    click_button t('save_and_continue')
+  end
+
+  def when_i_update_the_other_qualification_grade
+    when_i_click_change_other_qualification_grade
+
+    fill_in 'Grade', with: 'C'
+    click_button t('save_and_continue')
+  end
+
   def and_i_should_see_my_updated_gcse_qualification
-    within('[data-qa="gcse-english-grade"]') do
+    within('[data-qa="gcse-english-qualification"]') do
       expect(page).to have_content('O level')
     end
   end
 
   def and_i_should_see_my_updated_gcse_grade
-    within('[data-qa="gcse-english-qualification"]') do
-      expect(page).to have_content('O level')
+    within('[data-qa="gcse-english-grade"]') do
+      expect(page).to have_content('C')
     end
   end
 
   def and_i_should_see_my_updated_gcse_year
     within('[data-qa="gcse-english-award-year"]') do
       expect(page).to have_content('1980')
+    end
+  end
+
+  def and_i_should_see_my_updated_qualification_type
+    within('[data-qa="other-qualifications-type"]') do
+      expect(page).to have_content('AS level')
+    end
+  end
+
+  def and_i_should_see_my_updated_qualification_grade
+    within('[data-qa="other-qualifications-grade"]') do
+      expect(page).to have_content('C')
     end
   end
 end

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_applicatiion_and_updates_qualifications_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_applicatiion_and_updates_qualifications_spec.rb
@@ -1,0 +1,153 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate is redirected correctly' do
+  include CandidateHelper
+
+  scenario 'Candidate reviews completed application and updates qualification details section' do
+    given_i_am_signed_in
+    when_i_have_completed_my_application
+    and_i_review_my_application
+    then_i_should_see_all_sections_are_complete
+
+    # GCSE English qualification
+    when_i_click_change_english_gcse_qualification
+    then_i_should_see_the_gcse_type_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_english_gcse_qualification
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_gcse_qualification
+
+    # GCSE English grade
+    when_i_click_change_english_gcse_grade
+    then_i_should_see_the_gcse_grade_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_english_gcse_grade
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_gcse_grade
+
+    # GCSE English year awarded
+    when_i_click_change_english_gcse_year
+    then_i_should_see_the_gcse_year_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_english_gcse_year
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_gcse_year
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_have_completed_my_application
+    candidate_completes_application_form
+    @current_candidate.current_application.application_references.each do |reference|
+      reference.update!(feedback_status: :feedback_provided)
+    end
+  end
+
+  def and_i_visit_the_application_form_page
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_check_your_answers
+    click_link 'Check and submit your application'
+  end
+
+  def and_i_review_my_application
+    allow(LanguagesSectionPolicy).to receive(:hide?).and_return(false)
+    and_i_visit_the_application_form_page
+    when_i_click_on_check_your_answers
+  end
+
+  def then_i_should_see_all_sections_are_complete
+    application_form_sections.each do |section|
+      expect(page).not_to have_selector "[data-qa='incomplete-#{section}']"
+    end
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def then_i_should_be_redirected_to_the_application_review_page
+    expect(page).to have_current_path(candidate_interface_application_review_path)
+  end
+
+  def when_i_click_change_english_gcse_qualification
+    within('[data-qa="gcse-english-qualification"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_english_gcse_grade
+    within('[data-qa="gcse-english-grade"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_english_gcse_year
+    within('[data-qa="gcse-english-award-year"]') do
+      click_link 'Change'
+    end
+  end
+
+  def then_i_should_see_the_gcse_type_form
+    expect(page).to have_current_path(candidate_interface_gcse_details_edit_type_path(subject: 'english', 'return-to' => 'application-review'))
+  end
+
+  def then_i_should_see_the_gcse_grade_form
+    expect(page).to have_current_path(candidate_interface_edit_gcse_english_grade_path('return-to' => 'application-review'))
+  end
+
+  def then_i_should_see_the_gcse_year_form
+    expect(page).to have_current_path(candidate_interface_gcse_details_edit_year_path(subject: 'english', 'return-to' => 'application-review'))
+  end
+
+  def when_i_update_english_gcse_qualification
+    when_i_click_change_english_gcse_qualification
+
+    choose 'O level'
+    click_button t('save_and_continue')
+  end
+
+  def when_i_update_english_gcse_grade
+    when_i_click_change_english_gcse_grade
+    fill_in 'Please specify your grade', with: 'C'
+
+    click_button t('save_and_continue')
+  end
+
+  def when_i_update_english_gcse_year
+    when_i_click_change_english_gcse_year
+    fill_in 'Enter year', with: '1980j'
+
+    click_button t('save_and_continue')
+  end
+
+  def and_i_should_see_my_updated_gcse_qualification
+    within('[data-qa="gcse-english-grade"]') do
+      expect(page).to have_content('O level')
+    end
+  end
+
+  def and_i_should_see_my_updated_gcse_grade
+    within('[data-qa="gcse-english-qualification"]') do
+      expect(page).to have_content('O level')
+    end
+  end
+
+  def and_i_should_see_my_updated_gcse_year
+    within('[data-qa="gcse-english-award-year"]') do
+      expect(page).to have_content('1980')
+    end
+  end
+end

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_adjustments_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_adjustments_section_spec.rb
@@ -38,9 +38,6 @@ RSpec.feature 'Candidate is redirected correctly' do
 
   def when_i_have_completed_my_application
     candidate_completes_application_form
-    @current_candidate.current_application.application_references.each do |reference|
-      reference.update!(feedback_status: :feedback_provided)
-    end
   end
 
   def and_i_review_my_application

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb
@@ -82,9 +82,6 @@ RSpec.feature 'Candidate is redirected correctly' do
 
   def when_i_have_completed_my_application
     candidate_completes_application_form
-    @current_candidate.current_application.application_references.each do |reference|
-      reference.update!(feedback_status: :feedback_provided)
-    end
   end
 
   def and_i_review_my_application

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_statement_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_statement_section_spec.rb
@@ -36,9 +36,6 @@ RSpec.feature 'Candidate is redirected correctly' do
 
   def when_i_have_completed_my_application
     candidate_completes_application_form
-    @current_candidate.current_application.application_references.each do |reference|
-      reference.update!(feedback_status: :feedback_provided)
-    end
   end
 
   def and_i_review_my_application

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
@@ -63,6 +63,72 @@ RSpec.feature 'Candidate is redirected correctly' do
     when_i_update_the_other_qualification_grade
     then_i_should_be_redirected_to_the_application_review_page
     and_i_should_see_my_updated_qualification_grade
+
+    # Degree type
+    when_i_click_change_degree_type
+    then_i_should_see_the_degree_type_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_the_degree_type
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_degree_type
+
+    # Degree subject
+    when_i_click_change_degree_subject
+    then_i_should_see_the_degree_subject_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_the_degree_subject
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_degree_subject
+
+    # Degree institution
+    when_i_click_change_degree_institution
+    then_i_should_see_the_degree_institution_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_the_degree_institution
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_degree_institution
+
+    # Degree completion status
+    when_i_click_change_degree_completion_status
+    then_i_should_see_the_degree_completion_status_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_degree_completion_status
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_degree_completion_status
+
+    # Degree grade
+    when_i_click_change_degree_grade
+    then_i_should_see_the_degree_grade_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_degree_grade
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_degree_grade
+
+    # Degree start year
+    when_i_click_change_degree_start_year
+    then_i_should_see_the_degree_start_year_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_degree_start_year
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_degree_start_year
   end
 
   def given_i_am_signed_in
@@ -71,9 +137,6 @@ RSpec.feature 'Candidate is redirected correctly' do
 
   def when_i_have_completed_my_application
     candidate_completes_application_form
-    @current_candidate.current_application.application_references.each do |reference|
-      reference.update!(feedback_status: :feedback_provided)
-    end
   end
 
   def and_i_visit_the_application_form_page
@@ -134,6 +197,42 @@ RSpec.feature 'Candidate is redirected correctly' do
     end
   end
 
+  def when_i_click_change_degree_type
+    within('[data-qa="degree-type"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_degree_subject
+    within('[data-qa="degree-subject"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_degree_institution
+    within('[data-qa="degree-institution"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_degree_completion_status
+    within('[data-qa="degree-completion-status"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_degree_grade
+    within('[data-qa="degree-grade"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_degree_start_year
+    within('[data-qa="degree-start-year"]') do
+      click_link 'Change'
+    end
+  end
+
   def then_i_should_see_the_gcse_type_form
     expect(page).to have_current_path(candidate_interface_gcse_details_edit_type_path(subject: 'english', 'return-to' => 'application-review'))
   end
@@ -152,6 +251,30 @@ RSpec.feature 'Candidate is redirected correctly' do
 
   def then_i_should_see_the_other_qualification_details_form
     expect(page).to have_content('Edit AS level qualification')
+  end
+
+  def then_i_should_see_the_degree_type_form
+    expect(page).to have_content('Edit degree type')
+  end
+
+  def then_i_should_see_the_degree_subject_form
+    expect(page).to have_content('What subject is your degree?')
+  end
+
+  def then_i_should_see_the_degree_institution_form
+    expect(page).to have_content('Which institution did you study at?')
+  end
+
+  def then_i_should_see_the_degree_completion_status_form
+    expect(page).to have_content('Have you completed your degree?')
+  end
+
+  def then_i_should_see_the_degree_grade_form
+    expect(page).to have_content('Did your degree give a grade?')
+  end
+
+  def then_i_should_see_the_degree_start_year_form
+    expect(page).to have_content('When did you study for your degree?')
   end
 
   def when_i_update_english_gcse_qualification
@@ -174,6 +297,14 @@ RSpec.feature 'Candidate is redirected correctly' do
     click_button t('save_and_continue')
   end
 
+  def when_i_update_the_degree_type
+    when_i_click_change_degree_type
+    choose 'Non-UK degree'
+    fill_in 'Type of qualification', with: 'Diploma in New Zealand Studies'
+
+    click_button t('save_and_continue')
+  end
+
   def when_i_update_the_other_qualification_type
     when_i_click_change_other_qualification_type
 
@@ -186,6 +317,43 @@ RSpec.feature 'Candidate is redirected correctly' do
     when_i_click_change_other_qualification_grade
 
     fill_in 'Grade', with: 'C'
+    click_button t('save_and_continue')
+  end
+
+  def when_i_update_the_degree_subject
+    when_i_click_change_degree_subject
+
+    fill_in 'What subject is your degree?', with: 'Computer Science'
+    click_button t('save_and_continue')
+  end
+
+  def when_i_update_the_degree_institution
+    when_i_click_change_degree_institution
+
+    fill_in 'Institution name', with: 'Otago University'
+    select('New Zealand', from: 'In which country is this institution based?')
+    click_button t('save_and_continue')
+  end
+
+  def when_i_update_degree_completion_status
+    when_i_click_change_degree_completion_status
+
+    choose 'Yes'
+    click_button t('save_and_continue')
+  end
+
+  def when_i_update_degree_grade
+    when_i_click_change_degree_grade
+
+    choose 'Yes'
+    fill_in 'Enter your degree grade', with: 'First class honours'
+    click_button t('save_and_continue')
+  end
+
+  def when_i_update_degree_start_year
+    when_i_click_change_degree_start_year
+
+    fill_in 'Year started course', with: '2000'
     click_button t('save_and_continue')
   end
 
@@ -216,6 +384,42 @@ RSpec.feature 'Candidate is redirected correctly' do
   def and_i_should_see_my_updated_qualification_grade
     within('[data-qa="other-qualifications-grade"]') do
       expect(page).to have_content('C')
+    end
+  end
+
+  def and_i_should_see_my_updated_degree_type
+    within('[data-qa="degree-type"]') do
+      expect(page).to have_content('Diploma in New Zealand Studies')
+    end
+  end
+
+  def and_i_should_see_my_updated_degree_subject
+    within('[data-qa="degree-subject"]') do
+      expect(page).to have_content('Computer Science')
+    end
+  end
+
+  def and_i_should_see_my_updated_degree_institution
+    within('[data-qa="degree-institution"]') do
+      expect(page).to have_content('Otago University')
+    end
+  end
+
+  def and_i_should_see_my_updated_degree_completion_status
+    within('[data-qa="degree-completion-status"]') do
+      expect(page).to have_content('Yes')
+    end
+  end
+
+  def and_i_should_see_my_updated_degree_grade
+    within('[data-qa="degree-grade"]') do
+      expect(page).to have_content('First class honours')
+    end
+  end
+
+  def and_i_should_see_my_updated_degree_start_year
+    within('[data-qa="degree-start-year"]') do
+      expect(page).to have_content('2000')
     end
   end
 end

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
@@ -305,7 +305,7 @@ RSpec.feature 'Candidate is redirected correctly' do
   end
 
   def then_i_should_see_the_other_qualification_type_form
-    expect(page).to have_content('A levels and other qualifications')
+    expect(page).to have_content(t('page_titles.other_qualifications'))
   end
 
   def then_i_should_see_the_other_qualification_details_form
@@ -313,23 +313,23 @@ RSpec.feature 'Candidate is redirected correctly' do
   end
 
   def then_i_should_see_the_degree_type_form
-    expect(page).to have_content('Edit degree type')
+    expect(page).to have_content(t('page_titles.edit_degree_type'))
   end
 
   def then_i_should_see_the_degree_subject_form
-    expect(page).to have_content('What subject is your degree?')
+    expect(page).to have_content(t('page_titles.degree_subject'))
   end
 
   def then_i_should_see_the_degree_institution_form
-    expect(page).to have_content('Which institution did you study at?')
+    expect(page).to have_content(t('page_titles.degree_institution'))
   end
 
   def then_i_should_see_the_degree_completion_status_form
-    expect(page).to have_content('Have you completed your degree?')
+    expect(page).to have_content(t('page_titles.degree_completion_status'))
   end
 
   def then_i_should_see_the_degree_grade_form
-    expect(page).to have_content('Did your degree give a grade?')
+    expect(page).to have_content(t('page_titles.degree_grade_international'))
   end
 
   def then_i_should_see_the_degree_start_year_form

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Candidate is redirected correctly' do
     and_i_review_my_application
     then_i_should_see_all_sections_are_complete
 
-    # GCSE English qualification
+    # GCSE English equivalent qualification
     when_i_click_change_english_gcse_qualification
     then_i_should_see_the_gcse_type_form
 
@@ -20,7 +20,29 @@ RSpec.feature 'Candidate is redirected correctly' do
     then_i_should_be_redirected_to_the_application_review_page
     and_i_should_see_my_updated_gcse_qualification
 
-    # GCSE English grade
+    # GCSE English equivalent country
+    when_i_click_change_english_gcse_country
+    then_i_should_see_the_gcse_country_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_english_gcse_country
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_gcse_country
+
+    # GCSE English equivalent ENIC statement
+    when_i_click_change_enic_statement
+    then_i_should_see_the_gcse_enic_statement_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_enic_statement
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_enic_statement
+
+    # GCSE English equivalent grade
     when_i_click_change_english_gcse_grade
     then_i_should_see_the_gcse_grade_form
 
@@ -31,7 +53,7 @@ RSpec.feature 'Candidate is redirected correctly' do
     then_i_should_be_redirected_to_the_application_review_page
     and_i_should_see_my_updated_gcse_grade
 
-    # GCSE English year awarded
+    # GCSE English equivalent year awarded
     when_i_click_change_english_gcse_year
     then_i_should_see_the_gcse_year_form
 
@@ -74,6 +96,17 @@ RSpec.feature 'Candidate is redirected correctly' do
     when_i_update_the_degree_type
     then_i_should_be_redirected_to_the_application_review_page
     and_i_should_see_my_updated_degree_type
+
+    # Degree ENIC comparability
+    when_i_click_change_degree_enic_comparability
+    then_i_should_see_the_degree_enic_comparability_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_the_degree_enic_comparability
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_degree_enic_comparability
 
     # Degree subject
     when_i_click_change_degree_subject
@@ -173,6 +206,18 @@ RSpec.feature 'Candidate is redirected correctly' do
     end
   end
 
+  def when_i_click_change_english_gcse_country
+    within('[data-qa="gcse-country"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_enic_statement
+    within('[data-qa="gcse-enic-statement"]') do
+      click_link 'Change'
+    end
+  end
+
   def when_i_click_change_english_gcse_grade
     within('[data-qa="gcse-english-grade"]') do
       click_link 'Change'
@@ -233,8 +278,22 @@ RSpec.feature 'Candidate is redirected correctly' do
     end
   end
 
+  def when_i_click_change_degree_enic_comparability
+    within('[data-qa="degree-enic-comparability"]') do
+      click_link 'Change'
+    end
+  end
+
   def then_i_should_see_the_gcse_type_form
     expect(page).to have_current_path(candidate_interface_gcse_details_edit_type_path(subject: 'english', 'return-to' => 'application-review'))
+  end
+
+  def then_i_should_see_the_gcse_country_form
+    expect(page).to have_current_path(candidate_interface_gcse_details_edit_institution_country_path(subject: 'english', 'return-to' => 'application-review'))
+  end
+
+  def then_i_should_see_the_gcse_enic_statement_form
+    expect(page).to have_current_path(candidate_interface_gcse_details_edit_enic_path(subject: 'english', 'return-to' => 'application-review'))
   end
 
   def then_i_should_see_the_gcse_grade_form
@@ -250,7 +309,7 @@ RSpec.feature 'Candidate is redirected correctly' do
   end
 
   def then_i_should_see_the_other_qualification_details_form
-    expect(page).to have_content('Edit AS level qualification')
+    expect(page).to have_content('Edit First Aid Certificate qualification')
   end
 
   def then_i_should_see_the_degree_type_form
@@ -277,22 +336,46 @@ RSpec.feature 'Candidate is redirected correctly' do
     expect(page).to have_content('When did you study for your degree?')
   end
 
+  def then_i_should_see_the_degree_enic_comparability_form
+    expect(page).to have_content('How your degree compares to a UK degree')
+  end
+
   def when_i_update_english_gcse_qualification
     when_i_click_change_english_gcse_qualification
 
-    choose 'O level'
+    choose 'Non-UK qualification'
+
+    within '#candidate-interface-gcse-qualification-type-form-qualification-type-non-uk-conditional' do
+      fill_in 'Qualification name', with: 'School Certificate English'
+    end
+
+    click_button t('save_and_continue')
+  end
+
+  def when_i_update_english_gcse_country
+    when_i_click_change_english_gcse_country
+
+    select 'New Zealand'
+    click_button t('save_and_continue')
+  end
+
+  def when_i_update_enic_statement
+    when_i_click_change_enic_statement
+
+    choose 'No'
     click_button t('save_and_continue')
   end
 
   def when_i_update_english_gcse_grade
     when_i_click_change_english_gcse_grade
-    fill_in 'Please specify your grade', with: 'C'
+    choose 'Other'
+    fill_in 'Grade', with: 'C'
     click_button t('save_and_continue')
   end
 
   def when_i_update_english_gcse_year
     when_i_click_change_english_gcse_year
-    fill_in 'Enter year', with: '1980j'
+    fill_in 'Enter year', with: '1980'
 
     click_button t('save_and_continue')
   end
@@ -308,8 +391,12 @@ RSpec.feature 'Candidate is redirected correctly' do
   def when_i_update_the_other_qualification_type
     when_i_click_change_other_qualification_type
 
-    choose 'AS level'
+    choose 'Non-UK qualification'
+    within '#candidate-interface-other-qualification-type-form-qualification-type-non-uk-conditional' do
+      fill_in 'Qualification name', with: 'First Aid Certificate'
+    end
     click_button t('continue')
+    select 'New Zealand'
     click_button t('save_and_continue')
   end
 
@@ -342,6 +429,13 @@ RSpec.feature 'Candidate is redirected correctly' do
     click_button t('save_and_continue')
   end
 
+  def when_i_update_the_degree_enic_comparability
+    when_i_click_change_degree_enic_comparability
+
+    choose 'No'
+    click_button t('save_and_continue')
+  end
+
   def when_i_update_degree_grade
     when_i_click_change_degree_grade
 
@@ -359,7 +453,19 @@ RSpec.feature 'Candidate is redirected correctly' do
 
   def and_i_should_see_my_updated_gcse_qualification
     within('[data-qa="gcse-english-qualification"]') do
-      expect(page).to have_content('O level')
+      expect(page).to have_content('School Certificate English')
+    end
+  end
+
+  def and_i_should_see_my_updated_gcse_country
+    within('[data-qa="gcse-country"]') do
+      expect(page).to have_content('New Zealand')
+    end
+  end
+
+  def and_i_should_see_my_updated_enic_statement
+    within('[data-qa="gcse-enic-statement"]') do
+      expect(page).to have_content('No')
     end
   end
 
@@ -377,7 +483,7 @@ RSpec.feature 'Candidate is redirected correctly' do
 
   def and_i_should_see_my_updated_qualification_type
     within('[data-qa="other-qualifications-type"]') do
-      expect(page).to have_content('AS level')
+      expect(page).to have_content('First Aid Certificate')
     end
   end
 
@@ -420,6 +526,12 @@ RSpec.feature 'Candidate is redirected correctly' do
   def and_i_should_see_my_updated_degree_start_year
     within('[data-qa="degree-start-year"]') do
       expect(page).to have_content('2000')
+    end
+  end
+
+  def and_i_should_see_my_updated_degree_enic_comparability
+    within('[data-qa="degree-enic-comparability"]') do
+      expect(page).to have_content('No')
     end
   end
 end

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
@@ -333,11 +333,11 @@ RSpec.feature 'Candidate is redirected correctly' do
   end
 
   def then_i_should_see_the_degree_start_year_form
-    expect(page).to have_content('When did you study for your degree?')
+    expect(page).to have_content(t('page_titles.what_year_did_you_start_your_degree'))
   end
 
   def then_i_should_see_the_degree_enic_comparability_form
-    expect(page).to have_content('How your degree compares to a UK degree')
+    expect(page).to have_content(t('page_titles.degree_enic'))
   end
 
   def when_i_update_english_gcse_qualification
@@ -447,7 +447,7 @@ RSpec.feature 'Candidate is redirected correctly' do
   def when_i_update_degree_start_year
     when_i_click_change_degree_start_year
 
-    fill_in 'Year started course', with: '2000'
+    fill_in t('page_titles.what_year_did_you_start_your_degree'), with: '2000'
     click_button t('save_and_continue')
   end
 


### PR DESCRIPTION
## Context

_The *second* PR in possibly, a large-ish number of PRs_

If you visit the review unsubmitted application form page and click change on any of the links in the qualifications section, then either:

1. update the field and click save and continue 
or
2. click the backlink

You are redirected the review page for the section.

In both of these cases you should be redirected to the review submitted page 

## Changes proposed in this pull request

Use params (`&return-to=application-review`) to redirect the candidate back to the application review path when required.

## Guidance to review

- This PR deals with the qualifications section only. Other PRs to follow for remaining sections.

## Link to Trello card

https://trello.com/c/S41ihgH5/3765-change-links-and-backlinks-are-not-working-correctly-from-the-review-unsubmitted-page-qualifications

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
