### PR TITLE
add organisation_type column to provider data export

### DIFF
--- a/app/exports/providers_export.yml
+++ b/app/exports/providers_export.yml
@@ -3,6 +3,12 @@ common_columns:
   - provider_code
 
 custom_columns:
+  organisation_type:
+    type: string
+    format: string
+    description: The type of provider. Possible values include `lead_school`, `scitt`, and `university`
+    example: lead_school
+
   agreement_accepted_at:
     type: string
     format: date-time

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -117,7 +117,7 @@ class DataExport < ApplicationRecord
     providers_export: {
       name: 'Providers',
       export_type: 'providers_export',
-      description: 'The list of providers from the Find service, along with when they signed the data sharing agreement.',
+      description: 'The list of providers that are being synced from the Find service, along with when they signed the data sharing agreement.',
       class: SupportInterface::ProvidersExport,
     },
     persona_export: {
@@ -141,7 +141,7 @@ class DataExport < ApplicationRecord
     sites_export: {
       name: 'Sites',
       export_type: 'sites_export',
-      description: 'A list of sites from Find, along with distances to their respective providers.',
+      description: 'A list of sites that are being synced from Find, along with distances to their respective providers.',
       class: SupportInterface::SitesExport,
     },
     structured_reasons_for_rejection: {

--- a/app/services/support_interface/providers_export.rb
+++ b/app/services/support_interface/providers_export.rb
@@ -9,6 +9,7 @@ module SupportInterface
           provider_code: provider.code,
           agreement_accepted_at: provider.provider_agreements.where.not(accepted_at: nil).first&.accepted_at,
           average_distance_to_site: average_distance_to_site(provider),
+          organisation_type: provider.provider_type,
         }
       end
     end

--- a/spec/services/support_interface/providers_export_spec.rb
+++ b/spec/services/support_interface/providers_export_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SupportInterface::ProvidersExport, with_audited: true do
 
   describe '#providers' do
     it 'returns providers and the date they signed the data sharing agreement' do
-      provider_without_signed_dsa = create(:provider, name: 'B', latitude: 51.498161, longitude: 0.129900)
+      provider_without_signed_dsa = create(:provider, name: 'B', latitude: 51.498161, longitude: 0.129900, provider_type: 'lead_school')
       create(:site, latitude: 51.482578, longitude: -0.007659, provider: provider_without_signed_dsa)
       create(:site, latitude: 52.246868, longitude: 0.711190, provider: provider_without_signed_dsa)
 
@@ -22,6 +22,7 @@ RSpec.describe SupportInterface::ProvidersExport, with_audited: true do
           :provider,
           :with_signed_agreement,
           name: 'A',
+          provider_type: 'lead_school',
         )
       end
 
@@ -34,12 +35,14 @@ RSpec.describe SupportInterface::ProvidersExport, with_audited: true do
           provider_code: provider_with_signed_dsa.code,
           agreement_accepted_at: Time.zone.local(2019, 10, 1, 12, 0, 0),
           average_distance_to_site: '',
+          organisation_type: provider_with_signed_dsa.provider_type,
         },
         {
           provider_name: provider_without_signed_dsa.name,
           provider_code: provider_without_signed_dsa.code,
           agreement_accepted_at: nil,
           average_distance_to_site: '31.7',
+          organisation_type: provider_without_signed_dsa.provider_type,
         },
       )
     end


### PR DESCRIPTION
## Context

Add a new field to the providers export in order to render provider type (with the field name organisation type). 

## Link to Trello card

https://trello.com/c/SJvETVRD/4098-add-providertype-column-to-provider-export

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
