### PR TITLE
Fix redirects when updating personal statement and subject knowledge

### DIFF
--- a/app/components/candidate_interface/becoming_a_teacher_review_component.rb
+++ b/app/components/candidate_interface/becoming_a_teacher_review_component.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class BecomingATeacherReviewComponent < ViewComponent::Base
-    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
+    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false, return_to_application_review: false)
       @application_form = application_form
       @becoming_a_teacher_form = CandidateInterface::BecomingATeacherForm.build_from_application(
         @application_form,
@@ -8,6 +8,7 @@ module CandidateInterface
       @editable = editable
       @missing_error = missing_error
       @submitting_application = submitting_application
+      @return_to_application_review = return_to_application_review
     end
 
     def becoming_a_teacher_form_rows
@@ -31,8 +32,13 @@ module CandidateInterface
         key: t('application_form.personal_statement.becoming_a_teacher.label'),
         value: @becoming_a_teacher_form.becoming_a_teacher,
         action: t('application_form.personal_statement.becoming_a_teacher.change_action'),
-        change_path: candidate_interface_edit_becoming_a_teacher_path,
+        change_path: candidate_interface_edit_becoming_a_teacher_path(return_to_params),
+        data_qa: 'becoming-a-teacher',
       }
+    end
+
+    def return_to_params
+      { 'return-to' => 'application-review' } if @return_to_application_review
     end
   end
 end

--- a/app/components/candidate_interface/subject_knowledge_review_component.rb
+++ b/app/components/candidate_interface/subject_knowledge_review_component.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class SubjectKnowledgeReviewComponent < ViewComponent::Base
-    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
+    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false, return_to_application_review: false)
       @application_form = application_form
       @subject_knowledge_form = CandidateInterface::SubjectKnowledgeForm.build_from_application(
         @application_form,
@@ -8,6 +8,7 @@ module CandidateInterface
       @editable = editable
       @missing_error = missing_error
       @submitting_application = submitting_application
+      @return_to_application_review = return_to_application_review
     end
 
     def subject_knowledge_form_rows
@@ -31,8 +32,13 @@ module CandidateInterface
         key: t('application_form.personal_statement.subject_knowledge.key'),
         value: @subject_knowledge_form.subject_knowledge,
         action: t('application_form.personal_statement.subject_knowledge.change_action'),
-        change_path: candidate_interface_edit_subject_knowledge_path,
+        change_path: candidate_interface_edit_subject_knowledge_path(return_to_params),
+        data_qa: 'subject-knowledge',
       }
+    end
+
+    def return_to_params
+      { 'return-to' => 'application-review' } if @return_to_application_review
     end
   end
 end

--- a/app/controllers/candidate_interface/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement_controller.rb
@@ -21,13 +21,15 @@ module CandidateInterface
       @becoming_a_teacher_form = BecomingATeacherForm.build_from_application(
         current_application,
       )
+      @return_to = return_to_after_edit(default: candidate_interface_becoming_a_teacher_show_path)
     end
 
     def update
       @becoming_a_teacher_form = BecomingATeacherForm.new(becoming_a_teacher_params)
+      @return_to = return_to_after_edit(default: candidate_interface_becoming_a_teacher_show_path)
 
       if @becoming_a_teacher_form.save(current_application)
-        redirect_to candidate_interface_becoming_a_teacher_show_path
+        redirect_to @return_to[:back_path]
       else
         track_validation_error(@becoming_a_teacher_form)
         render :edit

--- a/app/controllers/candidate_interface/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/subject_knowledge_controller.rb
@@ -24,13 +24,15 @@ module CandidateInterface
         current_application,
       )
       @course_names = chosen_course_names
+      @return_to = return_to_after_edit(default: candidate_interface_subject_knowledge_show_path)
     end
 
     def update
       @subject_knowledge_form = SubjectKnowledgeForm.new(subject_knowledge_params)
+      @return_to = return_to_after_edit(default: candidate_interface_subject_knowledge_show_path)
 
       if @subject_knowledge_form.save(current_application)
-        redirect_to candidate_interface_subject_knowledge_show_path
+        redirect_to @return_to[:back_path]
       else
         track_validation_error(@subject_knowledge_form)
         @course_names = chosen_course_names

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -84,9 +84,15 @@
     editable: editable,
     missing_error: missing_error,
     submitting_application: true,
-    return_to_application_review: true
+    return_to_application_review: true,
   )) %>
-  <%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
+  <%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(
+    application_form: application_form,
+    editable: editable,
+    missing_error: missing_error,
+    submitting_application: true,
+    return_to_application_review: true,
+  )) %>
 </section>
 
 <section class="govuk-!-margin-bottom-8">

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -79,7 +79,13 @@
 
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.personal_statement') %></h2>
-  <%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
+  <%= render(CandidateInterface::BecomingATeacherReviewComponent.new(
+    application_form: application_form,
+    editable: editable,
+    missing_error: missing_error,
+    submitting_application: true,
+    return_to_application_review: true
+  )) %>
   <%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 </section>
 

--- a/app/views/candidate_interface/personal_statement/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.becoming_a_teacher'), @becoming_a_teacher_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_becoming_a_teacher_show_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @becoming_a_teacher_form, url: candidate_interface_edit_becoming_a_teacher_path, method: :patch do |f| %>
+    <%= form_with model: @becoming_a_teacher_form, url: candidate_interface_edit_becoming_a_teacher_path(@return_to[:params]), method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/subject_knowledge/edit.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.subject_knowledge'), @subject_knowledge_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_subject_knowledge_show_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @subject_knowledge_form, url: candidate_interface_edit_subject_knowledge_path, method: :patch do |f| %>
+    <%= form_with model: @subject_knowledge_form, url: candidate_interface_edit_subject_knowledge_path(@return_to[:params]), method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_statement_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_statement_section_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate is redirected correctly' do
+  include CandidateHelper
+
+  scenario 'Candidate reviews completed application and updates personal details section' do
+    given_i_am_signed_in
+    when_i_have_completed_my_application
+    and_i_review_my_application
+    then_i_should_see_all_sections_are_complete
+
+    when_i_click_change_on_why_i_want_to_become_a_teacher
+    then_i_should_see_the_becoming_a_teacher_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_why_i_want_to_become_a_teacher
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_becoming_a_teacher_response
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_have_completed_my_application
+    candidate_completes_application_form
+    @current_candidate.current_application.application_references.each do |reference|
+      reference.update!(feedback_status: :feedback_provided)
+    end
+  end
+
+  def and_i_review_my_application
+    and_i_visit_the_application_form_page
+    when_i_click_on_check_your_answers
+  end
+
+  def then_i_should_see_all_sections_are_complete
+    application_form_sections.each do |section|
+      expect(page).not_to have_selector "[data-qa='incomplete-#{section}']"
+    end
+  end
+
+  def and_i_visit_the_application_form_page
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_check_your_answers
+    click_link 'Check and submit your application'
+  end
+
+  def when_i_click_change_on_why_i_want_to_become_a_teacher
+    within('[data-qa="becoming-a-teacher"]') do
+      click_link 'Change'
+    end
+  end
+
+  def then_i_should_see_the_becoming_a_teacher_form
+    expect(page).to have_current_path(candidate_interface_edit_becoming_a_teacher_path('return-to' => 'application-review'))
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def then_i_should_be_redirected_to_the_application_review_page
+    expect(page).to have_current_path(candidate_interface_application_review_path)
+  end
+
+  def when_i_update_why_i_want_to_become_a_teacher
+    when_i_click_change_on_why_i_want_to_become_a_teacher
+    fill_in 'Why do you want to be a teacher?', with: 'All the dev jobs were taken.'
+    click_button 'Continue'
+  end
+
+  def and_i_should_see_my_updated_becoming_a_teacher_response
+    within('[data-qa="becoming-a-teacher"]') do
+      expect(page).to have_content('All the dev jobs were taken.')
+    end
+  end
+end

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_statement_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_statement_section_spec.rb
@@ -18,6 +18,16 @@ RSpec.feature 'Candidate is redirected correctly' do
     when_i_update_why_i_want_to_become_a_teacher
     then_i_should_be_redirected_to_the_application_review_page
     and_i_should_see_my_updated_becoming_a_teacher_response
+
+    when_i_click_change_on_subject_knowledge
+    then_i_should_see_the_subject_knowledge_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_my_subject_knowledge
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_subject_knowledge
   end
 
   def given_i_am_signed_in
@@ -77,6 +87,36 @@ RSpec.feature 'Candidate is redirected correctly' do
   def and_i_should_see_my_updated_becoming_a_teacher_response
     within('[data-qa="becoming-a-teacher"]') do
       expect(page).to have_content('All the dev jobs were taken.')
+    end
+  end
+
+  def when_i_click_change_on_subject_knowledge
+    within('[data-qa="subject-knowledge"]') do
+      click_link 'Change'
+    end
+  end
+
+  def then_i_should_see_the_subject_knowledge_form
+    expect(page).to have_current_path(candidate_interface_edit_subject_knowledge_path('return-to' => 'application-review'))
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def then_i_should_be_redirected_to_the_application_review_page
+    expect(page).to have_current_path(candidate_interface_application_review_path)
+  end
+
+  def when_i_update_my_subject_knowledge
+    when_i_click_change_on_subject_knowledge
+    fill_in 'Tell us what you know about the subject you want to teach', with: 'I have a very particular set of skills.'
+    click_button 'Continue'
+  end
+
+  def and_i_should_see_my_updated_subject_knowledge
+    within('[data-qa="subject-knowledge"]') do
+      expect(page).to have_content('I have a very particular set of skills.')
     end
   end
 end


### PR DESCRIPTION
## Context

The *third* PR in possibly, a large-ish number of PRs_

If you visit the review unsubmitted application form page and click change on any of the links in the personal statement section, then either:

1. update the field and click save and continue 
or
2. click the backlink

You are redirected the review page for the section.

In both of these cases you should be redirected to the review submitted page 

## Changes proposed in this pull request

Use params (`&return-to=application-review`) to redirect the candidate back to the application review path when required.

## Guidance to review

- This PR deals with the personal statment section only. Other PRs to follow for remaining sections.

## Link to Trello card

https://trello.com/c/oFukRCNe/3770-change-links-and-backlinks-are-not-working-correctly-from-the-review-unsubmitted-page-personal-statement-section

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
