### PR TITLE
Update copy on the rejection check your answers screen

### DIFF
--- a/app/components/shared/reasons_for_rejection_component.html.erb
+++ b/app/components/shared/reasons_for_rejection_component.html.erb
@@ -197,7 +197,7 @@
 
 <% if reasons_for_rejection.other_advice_or_feedback_y_n == 'Yes' %>
   <div class="app-rejection">
-    <%= content_tag(subheading_tag_name, 'Additional advice', class: 'govuk-heading-s') %>
+    <%= content_tag(subheading_tag_name, 'Additional feedback', class: 'govuk-heading-s') %>
     <p class="govuk-body"><%= reasons_for_rejection.other_advice_or_feedback_details %></p>
     <% if editable? %>
       <p class="app-rejection__actions">

--- a/app/views/provider_interface/reasons_for_rejection/check.html.erb
+++ b/app/views/provider_interface/reasons_for_rejection/check.html.erb
@@ -27,7 +27,7 @@
       <% if @application_choice.rejected_by_default? %>
         <%= f.govuk_submit 'Send feedback' %>
       <% else %>
-        <%= f.govuk_submit 'Reject application' %>
+        <%= f.govuk_submit 'Send feedback and reject application' %>
       <% end %>
     <% end %>
 

--- a/spec/components/provider_interface/reasons_for_rejection_component_spec.rb
+++ b/spec/components/provider_interface/reasons_for_rejection_component_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ReasonsForRejectionComponent do
       expect(result.css('h3.govuk-heading-s').text).to include('Performance at interview')
       expect(html).to include('There was no need to do all those pressups')
 
-      expect(result.css('h3.govuk-heading-s').text).to include('Additional advice')
+      expect(result.css('h3.govuk-heading-s').text).to include('Additional feedback')
       expect(html).to include('That zoom background...')
 
       expect(result.css('h3.govuk-heading-s').text).to include('Future applications')
@@ -72,7 +72,7 @@ RSpec.describe ReasonsForRejectionComponent do
       expect(result.css('h2.govuk-heading-s').text).to include('Quality of application')
       expect(result.css('h2.govuk-heading-s').text).to include('Qualifications')
       expect(result.css('h2.govuk-heading-s').text).to include('Performance at interview')
-      expect(result.css('h2.govuk-heading-s').text).to include('Additional advice')
+      expect(result.css('h2.govuk-heading-s').text).to include('Additional feedback')
       expect(result.css('h2.govuk-heading-s').text).to include('Future applications')
     end
   end

--- a/spec/components/utility/reasons_for_rejection_component_spec.rb
+++ b/spec/components/utility/reasons_for_rejection_component_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe ReasonsForRejectionComponent do
       expect(result.css('h3.govuk-heading-s').text).to include('They offered you a place on another course')
       expect(html).to include('We felt you would be better suited to Mathematics')
 
-      expect(result.css('h3.govuk-heading-s').text).to include('Additional advice')
+      expect(result.css('h3.govuk-heading-s').text).to include('Additional feedback')
       expect(html).to include('That zoom background...')
 
       expect(result.css('h3.govuk-heading-s').text).to include('Future applications')
@@ -94,7 +94,7 @@ RSpec.describe ReasonsForRejectionComponent do
       expect(result.css('h2.govuk-heading-s').text).to include('Quality of application')
       expect(result.css('h2.govuk-heading-s').text).to include('Qualifications')
       expect(result.css('h2.govuk-heading-s').text).to include('Performance at interview')
-      expect(result.css('h2.govuk-heading-s').text).to include('Additional advice')
+      expect(result.css('h2.govuk-heading-s').text).to include('Additional feedback')
       expect(result.css('h2.govuk-heading-s').text).to include('Future applications')
     end
 

--- a/spec/system/provider_interface/provider_gives_feedback_for_rejected_by_default_spec.rb
+++ b/spec/system/provider_interface/provider_gives_feedback_for_rejected_by_default_spec.rb
@@ -152,7 +152,7 @@ RSpec.feature 'Provider gives feedback for application rejected by default', wit
     expect(page).not_to have_content('Honesty and professionalism')
     expect(page).not_to have_content('Safeguarding issues')
 
-    expect(page).to have_content('Additional advice')
+    expect(page).to have_content('Additional feedback')
     expect(page).to have_content('While impressive, your parkour skills are not relevant')
 
     expect(page).not_to have_content('Future applications')

--- a/spec/system/provider_interface/reject_an_application_spec.rb
+++ b/spec/system/provider_interface/reject_an_application_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe 'Reject an application' do
     expect(page).not_to have_content('Honesty and professionalism')
     expect(page).not_to have_content('Safeguarding issues')
 
-    expect(page).to have_content('Additional advice')
+    expect(page).to have_content('Additional feedback')
     expect(page).to have_content('While impressive, your parkour skills are not relevant')
 
     expect(page).not_to have_content('Future applications')
@@ -198,7 +198,7 @@ RSpec.describe 'Reject an application' do
   end
 
   def and_i_submit_the_reasons_for_rejection
-    click_on 'Reject application'
+    click_on 'Send feedback and reject application'
   end
 
   def then_i_can_see_the_reasons_why_the_application_was_rejected


### PR DESCRIPTION
## Context

Update the copy on the rejection check your answers screen to align with prototype. Change:  
 -  ‘Additional advice’ to ‘Additional feedback’
-   ‘Reject application’ to  ‘Send feedback and reject application’

## Link to Trello card

https://trello.com/c/OyWxBBzJ/4089-update-course-full-copy-on-rejection-check-answers-screen

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
