### PR TITLE
Fix redirects when updating the 'adjustments' section

### DIFF
--- a/app/components/candidate_interface/interview_preferences_review_component.rb
+++ b/app/components/candidate_interface/interview_preferences_review_component.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class InterviewPreferencesReviewComponent < ViewComponent::Base
-    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
+    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false, return_to_application_review: false)
       @application_form = application_form
       @interview_preferences_form = CandidateInterface::InterviewPreferencesForm.build_from_application(
         @application_form,
@@ -8,6 +8,7 @@ module CandidateInterface
       @editable = editable
       @missing_error = missing_error
       @submitting_application = submitting_application
+      @return_to_application_review = return_to_application_review
     end
 
     def interview_preferences_form_rows
@@ -29,8 +30,13 @@ module CandidateInterface
         key: t('application_form.personal_statement.interview_preferences.key'),
         value: preferences,
         action: t('application_form.personal_statement.interview_preferences.change_action'),
-        change_path: candidate_interface_edit_interview_preferences_path,
+        change_path: candidate_interface_edit_interview_preferences_path(return_to_params),
+        data_qa: 'adjustments-interview-preferences',
       }
+    end
+
+    def return_to_params
+      { 'return-to' => 'application-review' } if @return_to_application_review
     end
   end
 end

--- a/app/components/candidate_interface/training_with_a_disability_review_component.rb
+++ b/app/components/candidate_interface/training_with_a_disability_review_component.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class TrainingWithADisabilityReviewComponent < ViewComponent::Base
-    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
+    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false, return_to_application_review: false)
       @application_form = application_form
       @training_with_a_disability_form = CandidateInterface::TrainingWithADisabilityForm.build_from_application(
         @application_form,
@@ -8,6 +8,7 @@ module CandidateInterface
       @editable = editable
       @missing_error = missing_error
       @submitting_application = submitting_application
+      @return_to_application_review = return_to_application_review
     end
 
     def training_with_a_disability_form_rows
@@ -30,7 +31,8 @@ module CandidateInterface
         key: t('application_form.training_with_a_disability.disclose_disability.label'),
         value: boolean_display_value(@training_with_a_disability_form.disclose_disability),
         action: t('application_form.training_with_a_disability.disclose_disability.change_action'),
-        change_path: candidate_interface_edit_training_with_a_disability_path,
+        change_path: candidate_interface_edit_training_with_a_disability_path(return_to_params),
+        data_qa: 'adjustments-support-confirmation',
       }
     end
 
@@ -39,7 +41,8 @@ module CandidateInterface
         key: t('application_form.training_with_a_disability.disability_disclosure.review_label'),
         value: @training_with_a_disability_form.disability_disclosure,
         action: t('application_form.training_with_a_disability.disability_disclosure.change_action'),
-        change_path: candidate_interface_edit_training_with_a_disability_path,
+        change_path: candidate_interface_edit_training_with_a_disability_path(return_to_params),
+        data_qa: 'adjustments-support-details',
       }
     end
 
@@ -52,6 +55,10 @@ module CandidateInterface
               'no'
             end
       t(key, scope: %i[application_form training_with_a_disability disclose_disability])
+    end
+
+    def return_to_params
+      { 'return-to' => 'application-review' } if @return_to_application_review
     end
   end
 end

--- a/app/controllers/candidate_interface/interview_needs_controller.rb
+++ b/app/controllers/candidate_interface/interview_needs_controller.rb
@@ -21,13 +21,15 @@ module CandidateInterface
       @interview_preferences_form = InterviewPreferencesForm.build_from_application(
         current_application,
       )
+      @return_to = return_to_after_edit(default: candidate_interface_interview_preferences_show_path)
     end
 
     def update
       @interview_preferences_form = InterviewPreferencesForm.new(interview_preferences_params)
+      @return_to = return_to_after_edit(default: candidate_interface_interview_preferences_show_path)
 
       if @interview_preferences_form.save(current_application)
-        redirect_to candidate_interface_interview_preferences_show_path
+        redirect_to @return_to[:back_path]
       else
         track_validation_error(@interview_preferences_form)
         render :edit

--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -24,13 +24,15 @@ module CandidateInterface
 
     def edit
       @training_with_a_disability_form = TrainingWithADisabilityForm.build_from_application(current_application)
+      @return_to = return_to_after_edit(default: candidate_interface_training_with_a_disability_show_path)
     end
 
     def update
       @training_with_a_disability_form = TrainingWithADisabilityForm.new(training_with_a_disability_params)
+      @return_to = return_to_after_edit(default: candidate_interface_training_with_a_disability_show_path)
 
       if @training_with_a_disability_form.save(current_application)
-        redirect_to candidate_interface_training_with_a_disability_show_path
+        redirect_to @return_to[:back_path]
       else
         track_validation_error(@training_with_a_disability_form)
         render :edit

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -85,8 +85,8 @@
 
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.adjustments') %></h2>
-  <%= render(CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
-  <%= render(CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
+  <%= render(CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submitting_application: true, return_to_application_review: true)) %>
+  <%= render(CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true, return_to_application_review: true)) %>
 </section>
 
 <section class="govuk-!-margin-bottom-8">

--- a/app/views/candidate_interface/interview_needs/edit.html.erb
+++ b/app/views/candidate_interface/interview_needs/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.interview_preferences'), @interview_preferences_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_interview_preferences_show_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @interview_preferences_form, url: candidate_interface_edit_interview_preferences_path, method: :patch do |f| %>
+    <%= form_with model: @interview_preferences_form, url: candidate_interface_edit_interview_preferences_path(@return_to[:params]), method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/training_with_a_disability/edit.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.training_with_a_disability'), @training_with_a_disability_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_training_with_a_disability_show_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @training_with_a_disability_form, url: candidate_interface_edit_training_with_a_disability_path, method: :patch do |f| %>
+    <%= form_with model: @training_with_a_disability_form, url: candidate_interface_edit_training_with_a_disability_path(@return_to[:params]), method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_adjustments_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_adjustments_section_spec.rb
@@ -1,0 +1,117 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate is redirected correctly' do
+  include CandidateHelper
+
+  scenario 'Candidate reviews completed application and updates adjustments section' do
+    given_i_am_signed_in
+    when_i_have_completed_my_application
+    and_i_review_my_application
+    then_i_should_see_all_sections_are_complete
+
+    # asking for support
+    when_i_click_ask_for_support
+    then_i_should_see_the_ask_for_support_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_ask_for_support_status
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_ask_for_support_status
+
+    # interview needs
+    when_i_click_interview_needs
+    then_i_should_see_the_interview_needs_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_interview_needs
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_interview_needs
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_have_completed_my_application
+    candidate_completes_application_form
+    @current_candidate.current_application.application_references.each do |reference|
+      reference.update!(feedback_status: :feedback_provided)
+    end
+  end
+
+  def and_i_review_my_application
+    allow(LanguagesSectionPolicy).to receive(:hide?).and_return(false)
+    and_i_visit_the_application_form_page
+    when_i_click_on_check_your_answers
+  end
+
+  def then_i_should_see_all_sections_are_complete
+    application_form_sections.each do |section|
+      expect(page).not_to have_selector "[data-qa='incomplete-#{section}']"
+    end
+  end
+
+  def and_i_visit_the_application_form_page
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_check_your_answers
+    click_link 'Check and submit your application'
+  end
+
+  def when_i_click_ask_for_support
+    within('[data-qa="adjustments-support-confirmation"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_interview_needs
+    within('[data-qa="adjustments-interview-preferences"]') do
+      click_link 'Change'
+    end
+  end
+
+  def then_i_should_see_the_ask_for_support_form
+    expect(page).to have_content('Ask for support if you’re disabled')
+  end
+
+  def then_i_should_see_the_interview_needs_form
+    expect(page).to have_content('Interview needs')
+  end
+
+  def then_i_should_be_redirected_to_the_application_review_page
+    expect(page).to have_current_path(candidate_interface_application_review_path)
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def when_i_update_ask_for_support_status
+    when_i_click_ask_for_support
+    choose 'No'
+    click_button t('continue')
+  end
+
+  def when_i_update_interview_needs
+    when_i_click_interview_needs
+    choose 'No'
+    click_button t('save_and_continue')
+  end
+
+  def and_i_should_see_my_updated_ask_for_support_status
+    within('[data-qa="adjustments-support-confirmation"]') do
+      expect(page).to have_content('No')
+    end
+  end
+
+  def and_i_should_see_my_updated_interview_needs
+    within('[data-qa="adjustments-interview-preferences"]') do
+      expect(page).to have_content('No')
+    end
+  end
+end


### PR DESCRIPTION
## Context

If you visit the review unsubmitted application form page and click change on any of the links, then either:

- update the field and click save and continue
or
- click the backlink

You are redirected the review page for the section.

In both of these cases you should be redirected to the review submitted page

### Changes proposed in this pull request
Use params (&return-to=application-review) to redirect the candidate back to the application review path when required.

### Guidance to review
- Recommend manually testing this!
- This PR deals with the adjustments section only. Other PRs to follow for remaining sections.

## Link to Trello card

https://trello.com/c/0RwRe8eT/3771-change-links-and-backlinks-are-not-working-correctly-from-the-review-unsubmitted-page-adjustments-section

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
