### PR TITLE
Sleep batch email workers for 0.03 seconds to avoid hitting rate limiting

### DIFF
--- a/app/workers/send_eoc_deadline_reminder_email_to_candidates_worker.rb
+++ b/app/workers/send_eoc_deadline_reminder_email_to_candidates_worker.rb
@@ -6,6 +6,7 @@ class SendEocDeadlineReminderEmailToCandidatesWorker
 
     applications_to_send_reminders_to.find_each(batch_size: 100) do |application|
       SendEocDeadlineReminderEmailToCandidate.call(application_form: application)
+      sleep 0.03
     end
   end
 

--- a/app/workers/send_new_cycle_has_started_email_to_candidates_worker.rb
+++ b/app/workers/send_new_cycle_has_started_email_to_candidates_worker.rb
@@ -5,7 +5,10 @@ class SendNewCycleHasStartedEmailToCandidatesWorker
     if CycleTimetable.send_new_cycle_has_started_email?
       GetUnsuccessfulAndUnsubmittedApplicationsFromPreviousCycle
         .call
-        .find_each(batch_size: 100) { |application| SendNewCycleHasStartedEmailToCandidate.call(application_form: application) }
+        .find_each(batch_size: 100) do |application|
+          SendNewCycleHasStartedEmailToCandidate.call(application_form: application)
+          sleep 0.03
+        end
     end
   end
 end


### PR DESCRIPTION
## Context

We're hitting  a rate limit with our batch emails as over 3000 requests in a minute are generated.

We can have 3000 requests per second

60 sec/3000 = 0.02 seconds

setting it to 0.03 sleep should avoid this

## Changes proposed in this pull request

- sleep the batch email workers for 0.03 seconds

## Guidance to review

- Another PR will follow which will send the emails out to candidates who have not already received one


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
