### PR TITLE
Correction to GiT opening hours

### DIFF
--- a/app/views/candidate_mailer/application_withdrawn_on_request_all_applications_withdrawn.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_all_applications_withdrawn.text.erb
@@ -8,7 +8,7 @@ If you did not ask them to withdraw the application, contact a Get Into Teaching
 
 https://getintoteaching.education.gov.uk/#talk-to-us
 
-You can also call for free on 0800 389 2500, Monday to Friday, 8.30am to 5pm (except public holidays).
+You can also call for free on 0800 389 2500, <%= t('get_into_teaching.opening_times') %>.
 
 # You can apply again
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_awaiting_decision_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_awaiting_decision_only.text.erb
@@ -8,7 +8,7 @@ If you did not ask them to withdraw the application, contact a Get Into Teaching
 
 https://getintoteaching.education.gov.uk/#talk-to-us
 
-You can also call for free on 0800 389 2500, Monday to Friday, 8.30am to 5pm (except public holidays).
+You can also call for free on 0800 389 2500, <%= t('get_into_teaching.opening_times') %>.
 
 <% if @awaiting_decision.length == 1 %>
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
@@ -8,7 +8,7 @@ If you did not ask them to withdraw the application, contact a Get Into Teaching
 
 https://getintoteaching.education.gov.uk/#talk-to-us
 
-You can also call for free on 0800 389 2500, Monday to Friday, 8.30am to 5pm (except public holidays).
+You can also call for free on 0800 389 2500, <%= t('get_into_teaching.opening_times') %>.
 
 # Respond to your <%= 'offer'.pluralize(@offers.length) %> by <%= @respond_by_date %>
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
@@ -8,7 +8,7 @@ If you did not ask them to withdraw the application, contact a Get Into Teaching
 
 https://getintoteaching.education.gov.uk/#talk-to-us
 
-You can also call for free on 0800 389 2500, Monday to Friday, 8.30am to 5pm (except public holidays).
+You can also call for free on 0800 389 2500, <%= t('get_into_teaching.opening_times') %>.
 
 # You have an offer and are waiting for a decision about another course
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,7 +25,7 @@ en:
     sandbox_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk/
   get_into_teaching:
     tel: 0800 389 2500
-    opening_times: "Monday to Friday, 8.30am to 5pm (except public\u00A0holidays)"
+    opening_times: "Monday to Friday, 8.30am to 5:30pm (except public\u00A0holidays)"
     url: https://getintoteaching.education.gov.uk
     url_applying: https://getintoteaching.education.gov.uk/steps-to-become-a-teacher#step-5
     url_get_an_advisor: https://adviser-getintoteaching.education.gov.uk


### PR DESCRIPTION
## Context

We need to change the the 'Get help' opening hours to '8:30am to 5:30pm'.

## Changes proposed in this pull request

- [x] Update string that displays GiT opening hours
- [x] Also remove duplication by using the existing i18n string in mail templates as well as elsewhere.

Before:

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/450843/128704101-c33fdfe7-d9c8-4aac-a332-6dfd636522f8.png">

After:

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/450843/128704141-3b7e8411-f213-4b3a-85ea-36256353823e.png">


## Guidance to review

Have I missed anything?

## Link to Trello card

https://trello.com/c/B4jhNPiq/3754-fix-opening-hours-for-git-support-on-apply

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
