### PR TITLE
Amendments to export data report page

### DIFF
--- a/app/views/provider_interface/application_data_export/new.html.erb
+++ b/app/views/provider_interface/application_data_export/new.html.erb
@@ -11,12 +11,6 @@
       <%= t('page_titles.provider.export_application_data') %>
     </h1>
 
-    <% if FeatureFlag.active?(:export_hesa_data) %>
-      <p class="govuk-body">
-        Choose which data to export or <%= govuk_link_to 'export only the data needed by the Higher Education Statistics Agency (HESA)', provider_interface_new_hesa_export_path %>.
-      </p>
-    <% end %>
-
     <%= form_with(
       model: @application_data_export_form,
       url: provider_interface_application_data_export_path,
@@ -45,7 +39,11 @@
         <%= f.govuk_collection_check_boxes :provider_ids, @application_data_export_form.providers_that_actor_belongs_to, ->(p) { p.id.to_s }, :name, legend: { text: 'Select applications for certain organisations', size: 'm' } %>
       <% end %>
 
-      <%= f.govuk_submit 'Export data (CSV)' %>
+      <div class="govuk-inset-text">
+        Sex, disability and ethnicity information will be marked as confidential if you do not have permission to view it, or if the candidate has not accepted your offer.
+      </div>
+
+      <%= f.govuk_submit 'Export application data (CSV)' %>
     <% end %>
   </div>
 </div>

--- a/spec/system/provider_interface/provider_reports_page_spec.rb
+++ b/spec/system/provider_interface/provider_reports_page_spec.rb
@@ -11,17 +11,18 @@ RSpec.feature 'Provider reports page' do
 
     when_i_visit_the_reports_page
     then_i_should_see_a_link_to_the_hesa_export_page
-    and_the_hesa_export_page_contains_breadcrumbs_including_the_reports_page
+    and_the_page_contains_breadcrumbs_including_the_reports_page
 
     given_the_hesa_export_feature_flag_is_off
 
     when_i_visit_the_reports_page
     then_i_should_not_see_a_link_to_the_hesa_export_page
 
-    given_the_hesa_export_feature_flag_is_on_and_the_application_data_export_feature_flag_is_off
+    given_the_data_export_feature_flag_is_on
 
     when_i_visit_the_reports_page_and_i_click_the_export_data_link
-    then_i_should_be_redirected_to_the_hesa_export_page
+    then_i_should_be_on_the_data_export_page
+    and_the_page_contains_breadcrumbs_including_the_reports_page
   end
 
   def given_the_hesa_and_application_data_export_feature_flags_are_on
@@ -36,11 +37,17 @@ RSpec.feature 'Provider reports page' do
 
   def when_i_visit_the_reports_page_and_i_click_the_export_data_link
     visit provider_interface_reports_path
-    click_on 'Export data'
+    click_on 'Export application data'
   end
 
   def when_i_visit_the_reports_page
     visit provider_interface_reports_path
+  end
+
+  def then_i_should_see_a_link_to_the_data_export_page
+    expect(page).to have_link('Export data for Higher Education Statistics Agency (HESA)')
+    click_on('Export data for Higher Education Statistics Agency (HESA)')
+    then_i_should_be_redirected_to_the_hesa_export_page
   end
 
   def then_i_should_see_a_link_to_the_hesa_export_page
@@ -49,7 +56,7 @@ RSpec.feature 'Provider reports page' do
     then_i_should_be_redirected_to_the_hesa_export_page
   end
 
-  def and_the_hesa_export_page_contains_breadcrumbs_including_the_reports_page
+  def and_the_page_contains_breadcrumbs_including_the_reports_page
     within '.govuk-breadcrumbs' do
       expect(page).to have_link('Reports')
     end
@@ -63,12 +70,17 @@ RSpec.feature 'Provider reports page' do
     expect(page).not_to have_content('Export data for Higher Education Statistics Agency (HESA)')
   end
 
-  def given_the_hesa_export_feature_flag_is_on_and_the_application_data_export_feature_flag_is_off
-    FeatureFlag.deactivate(:export_application_data)
-    FeatureFlag.activate(:export_hesa_data)
+  def given_the_data_export_feature_flag_is_on
+    FeatureFlag.activate(:export_application_data)
   end
 
   def then_i_should_be_redirected_to_the_hesa_export_page
     expect(page).to have_current_path(provider_interface_new_hesa_export_path)
+  end
+
+  def then_i_should_be_on_the_data_export_page
+    expect(page).to have_current_path(provider_interface_new_application_data_export_path)
+    expect(page).to have_content('Export application data (CSV)')
+    expect(page).to have_content('Sex, disability and ethnicity information will be marked as confidential')
   end
 end

--- a/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
+++ b/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature 'Provider user exports applications to a csv' do
   end
 
   def click_export_data
-    click_button 'Export data'
+    click_button 'Export application data (CSV)'
   end
 
   def and_i_fill_in_the_form_incorrectly


### PR DESCRIPTION
## Context
- Remove text with link to HESA export
- Add callout text with disability information


Latest design history version can be found here: 
https://bat-design-history.netlify.app/manage-teacher-training-applications/helping-users-check-how-quickly-courses-are-filling-up/

## Link to Trello card

https://trello.com/c/KS8Oe08D/4105-amendments-to-export-data-report-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
