### PR TITLE
Amendments to HESA report page

### DIFF
--- a/app/views/provider_interface/hesa_export/new.html.erb
+++ b/app/views/provider_interface/hesa_export/new.html.erb
@@ -1,20 +1,20 @@
-<%= content_for :title, t('page_titles.provider.export_hesa_data', timeframe: '') %>
+<%= content_for :title, t('page_titles.provider.export_hesa_data') %>
 
 <%= breadcrumbs({
   t('page_titles.provider.reports') => provider_interface_reports_path,
-  t('page_titles.provider.export_hesa_data', timeframe: '') => nil,
+  t('page_titles.provider.export_hesa_data') => nil,
 }) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <%= t('page_titles.provider.export_hesa_data', timeframe: "since #{CycleTimetable.apply_opens.to_s(:govuk_date)}") %>
+      <%= t('page_titles.provider.export_hesa_data') %>
     </h1>
     <p class="govuk-body">
-      The data will include all candidates who have accepted an offer from any of your organisations.
+      The data will include all candidates who have accepted an offer since <%= CycleTimetable.apply_opens.to_s(:govuk_date) %>.
     </p>
     <p class="govuk-body">
-      Diversity information will be marked confidential if you do not have permission to view it.
+      Sex, disability and ethnicity information will be marked as confidential if you do not have permission to view it.
     </p>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -215,7 +215,7 @@ en:
       organisation_permissions: Organisation permissions
       change_organisation_permissions: Change permissions
       users: Users
-      export_hesa_data: Export data %{timeframe} for Higher Education Statistics Agency (HESA)
+      export_hesa_data: Export data for Higher Education Statistics Agency (HESA)
       export_application_data: Export application data
       notifications: Email notifications
       reports: Reports

--- a/spec/system/provider_interface/export_applications_in_hesa_format_spec.rb
+++ b/spec/system/provider_interface/export_applications_in_hesa_format_spec.rb
@@ -40,8 +40,8 @@ RSpec.feature 'Export applications in HESA format' do
   end
 
   def and_i_click_export_data
-    expect(page).to have_content('The data will include all candidates who have accepted an offer from any of your organisations.')
-    expect(page).to have_content('Diversity information will be marked confidential if you do not have permission to view it.')
+    expect(page).to have_content("The data will include all candidates who have accepted an offer since #{CycleTimetable.apply_opens.to_s(:govuk_date)}.")
+    expect(page).to have_content('Sex, disability and ethnicity information will be marked as confidential if you do not have permission to view it.')
 
     click_button 'Export data'
   end


### PR DESCRIPTION
## Context

Latest design history version can be found here: 
https://bat-design-history.netlify.app/manage-teacher-training-applications/helping-users-check-how-quickly-courses-are-filling-up/

Update the header and content text of the HESA report page
_Breadcrumb updated as part of #5320_

<img width="1287" alt="Screenshot 2021-08-10 at 16 17 43" src="https://user-images.githubusercontent.com/159200/128873848-472c11e5-3ac9-4fd2-a812-89c1a3253b35.png">


## Link to Trello card

https://trello.com/c/16KWAhg3/4106-amendments-to-hesa-report-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
