### PR TITLE
Reduce SQL queries in SignUpController#create

### DIFF
--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -2,7 +2,6 @@ module CandidateInterface
   class SignUpController < CandidateInterfaceController
     skip_before_action :authenticate_candidate!
     before_action :redirect_to_application_if_signed_in, except: :external_sign_up_forbidden
-    before_action :show_pilot_holding_page_if_not_open
 
     def new
       @sign_up_form = CandidateInterface::SignUpForm.new
@@ -14,7 +13,7 @@ module CandidateInterface
       if @sign_up_form.existing_candidate?
         CandidateInterface::RequestMagicLink.for_sign_in(candidate: @sign_up_form.candidate)
         set_user_context @sign_up_form.candidate.id
-        candidate = Candidate.find(@sign_up_form.candidate.id)
+        candidate = @sign_up_form.candidate
         candidate.update!(course_from_find_id: @sign_up_form.course_from_find_id)
         redirect_to candidate_interface_check_email_sign_up_path
       elsif @sign_up_form.save
@@ -44,6 +43,8 @@ module CandidateInterface
     end
 
     def course_id
+      return unless params[:providerCode]
+
       @provider = Provider.find_by(code: params[:providerCode])
       @course = @provider.courses.current_cycle.find_by(code: params[:courseCode]) if @provider.present?
       @course.id if @course.present?

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -7,10 +7,7 @@ class Candidate < ApplicationRecord
   audited last_signed_in_at: true
 
   before_validation :downcase_email
-  validates :email_address, presence: true,
-                            uniqueness: { case_sensitive: false },
-                            length: { maximum: 100 },
-                            valid_for_notify: true
+  validates :email_address, presence: true, length: { maximum: 100 }, valid_for_notify: true
 
   has_one :ucas_match
   has_many :application_forms

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Candidate, type: :model do
 
     it { is_expected.to validate_presence_of :email_address }
     it { is_expected.to validate_length_of(:email_address).is_at_most(100) }
-    it { is_expected.to validate_uniqueness_of(:email_address).case_insensitive }
     it { is_expected.to allow_value('user@example.com').for(:email_address) }
     it { is_expected.not_to allow_value('foo').for(:email_address) }
     it { is_expected.not_to allow_value(Faker::Lorem.characters(number: 251)).for(:email_address) }

--- a/spec/system/candidate_interface/pilot_spec.rb
+++ b/spec/system/candidate_interface/pilot_spec.rb
@@ -6,9 +6,6 @@ RSpec.feature 'Pilot' do
 
     when_i_visit_the_start_page
     then_i_see_a_page_saying_were_not_open
-
-    when_i_visit_the_sign_up_page
-    then_i_see_a_page_saying_were_not_open
   end
 
   def given_the_pilot_is_not_open


### PR DESCRIPTION

## Context
Noticed while reviewing performance of slow endpoints, as identified
from a recent load test. 
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
This action makes several unnecessary queries
which can be removed/avoided.

This includes a change to email validation in the Candidate model. We
don't need to evaluate uniqueness here:

- There's already a unique index on emails in the table
- From a user perspective we don't need a validation message because the
  sign up form gracefully handles both new and existing candidates

## Guidance to review
- A review of the diff and an expectation that the tests still pass should be sufficient, but a manual test would be to check that you can still sign up/sign in with the review app.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/TzqiS7Jg
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
