### PR TITLE
Correctly order organisations in permissions views

### DIFF
--- a/app/components/provider_interface/organisation_permissions_form_component.rb
+++ b/app/components/provider_interface/organisation_permissions_form_component.rb
@@ -2,9 +2,13 @@ module ProviderInterface
   class OrganisationPermissionsFormComponent < ViewComponent::Base
     attr_reader :presenter, :permission_model, :mode, :form_url
 
-    def initialize(provider_user:, provider_relationship_permission:, mode:, form_url:)
+    def initialize(provider_user:, provider_relationship_permission:, mode:, form_url:, main_provider: nil)
       @permission_model = PermissionFormModel.new(provider_relationship_permission)
-      @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(relationship: provider_relationship_permission, provider_user: provider_user)
+      @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(
+        relationship: provider_relationship_permission,
+        provider_user: provider_user,
+        main_provider: main_provider,
+      )
       @mode = mode
       @form_url = form_url
     end

--- a/app/components/provider_interface/organisation_permissions_form_component.rb
+++ b/app/components/provider_interface/organisation_permissions_form_component.rb
@@ -4,7 +4,7 @@ module ProviderInterface
 
     def initialize(provider_user:, provider_relationship_permission:, mode:, form_url:)
       @permission_model = PermissionFormModel.new(provider_relationship_permission)
-      @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(provider_relationship_permission, provider_user)
+      @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(relationship: provider_relationship_permission, provider_user: provider_user)
       @mode = mode
       @form_url = form_url
     end

--- a/app/components/provider_interface/organisation_permissions_review_card_component.rb
+++ b/app/components/provider_interface/organisation_permissions_review_card_component.rb
@@ -4,7 +4,7 @@ module ProviderInterface
 
     def initialize(provider_user:, provider_relationship_permission:, summary_card_heading_level: 2, change_path: nil)
       @provider_relationship_permission = provider_relationship_permission
-      @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(provider_relationship_permission, provider_user)
+      @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(relationship: provider_relationship_permission, provider_user: provider_user)
       @summary_card_heading_level = summary_card_heading_level
       @change_path = change_path
     end

--- a/app/components/provider_interface/organisation_permissions_review_card_component.rb
+++ b/app/components/provider_interface/organisation_permissions_review_card_component.rb
@@ -2,9 +2,13 @@ module ProviderInterface
   class OrganisationPermissionsReviewCardComponent < ViewComponent::Base
     attr_reader :presenter, :provider_relationship_permission, :summary_card_heading_level, :change_path
 
-    def initialize(provider_user:, provider_relationship_permission:, summary_card_heading_level: 2, change_path: nil)
+    def initialize(provider_user:, provider_relationship_permission:, main_provider: nil, summary_card_heading_level: 2, change_path: nil)
       @provider_relationship_permission = provider_relationship_permission
-      @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(relationship: provider_relationship_permission, provider_user: provider_user)
+      @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(
+        relationship: provider_relationship_permission,
+        provider_user: provider_user,
+        main_provider: main_provider,
+      )
       @summary_card_heading_level = summary_card_heading_level
       @change_path = change_path
     end

--- a/app/controllers/provider_interface/organisation_permissions_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_controller.rb
@@ -60,7 +60,11 @@ module ProviderInterface
     def set_up_relationship_objects
       @relationship = ProviderRelationshipPermissions.find(params[:id])
       @provider = Provider.find(params[:organisation_id])
-      @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(relationship: @relationship, provider_user: current_provider_user)
+      @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(
+        relationship: @relationship,
+        provider_user: current_provider_user,
+        main_provider: @provider,
+      )
     rescue ActiveRecord::RecordNotFound
       render_404
     end

--- a/app/controllers/provider_interface/organisation_permissions_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_controller.rb
@@ -60,7 +60,7 @@ module ProviderInterface
     def set_up_relationship_objects
       @relationship = ProviderRelationshipPermissions.find(params[:id])
       @provider = Provider.find(params[:organisation_id])
-      @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(@relationship, current_provider_user)
+      @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(relationship: @relationship, provider_user: current_provider_user)
     rescue ActiveRecord::RecordNotFound
       render_404
     end

--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -104,7 +104,7 @@ module ProviderInterface
     end
 
     def current_relationship_description
-      ProviderRelationshipPermissionAsProviderUserPresenter.new(@current_relationship, current_provider_user).provider_relationship_description
+      ProviderRelationshipPermissionAsProviderUserPresenter.new(relationship: @current_relationship, provider_user: current_provider_user).provider_relationship_description
     end
 
     helper_method :current_relationship_description

--- a/app/presenters/provider_interface/provider_relationship_permission_setup_presenter.rb
+++ b/app/presenters/provider_interface/provider_relationship_permission_setup_presenter.rb
@@ -38,7 +38,7 @@ module ProviderInterface
 
     def grouped_provider_names_with_relationships
       provider_relationship_permissions_list.each_with_object({}) do |prp, h|
-        presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(prp, provider_user)
+        presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(relationship: prp, provider_user: provider_user)
         main_provider = presenter.ordered_providers.first
         other_provider = presenter.ordered_providers.second
         h[main_provider.name] ||= []

--- a/app/views/provider_interface/organisation_permissions/edit.html.erb
+++ b/app/views/provider_interface/organisation_permissions/edit.html.erb
@@ -6,6 +6,7 @@
     <%= render ProviderInterface::OrganisationPermissionsFormComponent.new(
       provider_user: current_provider_user,
       provider_relationship_permission: @relationship,
+      main_provider: @provider,
       mode: :edit,
       form_url: provider_interface_organisation_settings_organisation_organisation_permission_path(@relationship, organisation_id: @provider.id),
     ) %>

--- a/app/views/provider_interface/organisation_permissions/index.html.erb
+++ b/app/views/provider_interface/organisation_permissions/index.html.erb
@@ -18,6 +18,7 @@
         provider_user: current_provider_user,
         provider_relationship_permission: relationship,
         change_path: edit_provider_interface_organisation_settings_organisation_organisation_permission_path(relationship, organisation_id: @provider.id),
+        main_provider: @provider,
       ) %>
     <% end %>
   </div>

--- a/spec/components/provider_interface/organisation_permissions_form_component_spec.rb
+++ b/spec/components/provider_interface/organisation_permissions_form_component_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ProviderInterface::OrganisationPermissionsFormComponent do
   let(:provider_relationship_permission) { build_stubbed(:provider_relationship_permissions) }
   let(:training_provider) { provider_relationship_permission.training_provider }
   let(:ratifying_provider) { provider_relationship_permission.ratifying_provider }
+  let(:main_provider) { nil }
   let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider]) }
   let(:mode) { :setup }
 
@@ -12,6 +13,7 @@ RSpec.describe ProviderInterface::OrganisationPermissionsFormComponent do
       described_class.new(
         provider_user: provider_user,
         provider_relationship_permission: provider_relationship_permission,
+        main_provider: main_provider,
         mode: mode,
         form_url: '',
       ),
@@ -87,6 +89,24 @@ RSpec.describe ProviderInterface::OrganisationPermissionsFormComponent do
         expected_heading = "#{training_provider.name} and #{ratifying_provider.name}"
         expect(render.css('.govuk-caption-l').text.squish).to eq(expected_heading)
       end
+    end
+  end
+
+  context 'when the main_provider is given' do
+    let(:main_provider) { training_provider }
+
+    before do
+      expected_params = {
+        relationship: provider_relationship_permission,
+        provider_user: provider_user,
+        main_provider: training_provider,
+      }
+      allow(ProviderInterface::ProviderRelationshipPermissionAsProviderUserPresenter).to receive(:new).with(expected_params).and_call_original
+    end
+
+    it 'initialises a the presenter with the correct parameters' do
+      render
+      expect(ProviderInterface::ProviderRelationshipPermissionAsProviderUserPresenter).to have_received(:new)
     end
   end
 

--- a/spec/components/provider_interface/organisation_permissions_review_card_component_spec.rb
+++ b/spec/components/provider_interface/organisation_permissions_review_card_component_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ProviderInterface::OrganisationPermissionsReviewCardComponent do
   let(:provider_relationship_permission) { build_stubbed(:provider_relationship_permissions) }
   let(:training_provider) { provider_relationship_permission.training_provider }
   let(:ratifying_provider) { provider_relationship_permission.ratifying_provider }
+  let(:main_provider) { nil }
   let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider]) }
   let(:change_path) { nil }
 
@@ -12,9 +13,28 @@ RSpec.describe ProviderInterface::OrganisationPermissionsReviewCardComponent do
       described_class.new(
         provider_user: provider_user,
         provider_relationship_permission: provider_relationship_permission,
+        main_provider: main_provider,
         change_path: change_path,
       ),
     )
+  end
+
+  context 'when the main_provider is given' do
+    let(:main_provider) { training_provider }
+
+    before do
+      expected_params = {
+        relationship: provider_relationship_permission,
+        provider_user: provider_user,
+        main_provider: training_provider,
+      }
+      allow(ProviderInterface::ProviderRelationshipPermissionAsProviderUserPresenter).to receive(:new).with(expected_params).and_call_original
+    end
+
+    it 'initialises a the presenter with the correct parameters' do
+      render
+      expect(ProviderInterface::ProviderRelationshipPermissionAsProviderUserPresenter).to have_received(:new)
+    end
   end
 
   describe 'heading levels' do

--- a/spec/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter_spec.rb
+++ b/spec/presenters/provider_interface/provider_relationship_permission_as_provider_user_presenter_spec.rb
@@ -14,8 +14,15 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionAsProviderUserPr
   end
   let(:training_provider) { provider_relationship_permission.training_provider }
   let(:ratifying_provider) { provider_relationship_permission.ratifying_provider }
+  let(:main_provider) { nil }
 
-  let(:presenter) { described_class.new(provider_relationship_permission, provider_user) }
+  let(:presenter) do
+    described_class.new(
+      relationship: provider_relationship_permission,
+      provider_user: provider_user,
+      main_provider: main_provider,
+    )
+  end
 
   describe '#ordered_providers' do
     context 'when the user belongs to the training provider' do
@@ -28,6 +35,24 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionAsProviderUserPr
 
     context 'when the user belongs to the ratifying provider' do
       let(:provider_user) { build_stubbed(:provider_user, providers: [ratifying_provider]) }
+
+      it 'returns the ratifying provider followed by the training provider' do
+        expect(presenter.ordered_providers).to eq([ratifying_provider, training_provider])
+      end
+    end
+
+    context 'when the main_provider is given as the training provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [ratifying_provider]) }
+      let(:main_provider) { training_provider }
+
+      it 'returns the training provider followed by the ratifying provider' do
+        expect(presenter.ordered_providers).to eq([training_provider, ratifying_provider])
+      end
+    end
+
+    context 'when the main_provider is given as the ratifying provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider]) }
+      let(:main_provider) { ratifying_provider }
 
       it 'returns the ratifying provider followed by the training provider' do
         expect(presenter.ordered_providers).to eq([ratifying_provider, training_provider])
@@ -62,6 +87,26 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionAsProviderUserPr
         expect(presenter.provider_relationship_description).to eq(expected_string)
       end
     end
+
+    context 'when the main_provider is given as the training provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [ratifying_provider]) }
+      let(:main_provider) { training_provider }
+
+      it 'returns the training provider name first' do
+        expected_string = "#{training_provider.name} and #{ratifying_provider.name}"
+        expect(presenter.provider_relationship_description).to eq(expected_string)
+      end
+    end
+
+    context 'when the main_provider is given as the ratifying provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider]) }
+      let(:main_provider) { ratifying_provider }
+
+      it 'returns the ratifying provider name first' do
+        expected_string = "#{ratifying_provider.name} and #{training_provider.name}"
+        expect(presenter.provider_relationship_description).to eq(expected_string)
+      end
+    end
   end
 
   describe '#checkbox_details_for_providers' do
@@ -86,6 +131,24 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionAsProviderUserPr
 
       it 'returns the training provider checkbox first' do
         expect(presenter.checkbox_details_for_providers.first[:type]).to eq('training')
+      end
+    end
+
+    context 'when the main_provider is given as the training provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [ratifying_provider]) }
+      let(:main_provider) { training_provider }
+
+      it 'returns the training provider checkbox first' do
+        expect(presenter.checkbox_details_for_providers.first[:type]).to eq('training')
+      end
+    end
+
+    context 'when the main_provider is given as the ratifying provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider]) }
+      let(:main_provider) { ratifying_provider }
+
+      it 'returns the training provider checkbox first' do
+        expect(presenter.checkbox_details_for_providers.first[:type]).to eq('ratifying')
       end
     end
   end
@@ -114,6 +177,24 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionAsProviderUserPr
 
       it 'returns the names providers that have the specified permission with the ratifying provider firs' do
         expect(presenter.providers_with_permission(:make_decisions)).to eq([training_provider.name, ratifying_provider.name])
+      end
+    end
+
+    context 'when the main_provider is given as the training provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [ratifying_provider]) }
+      let(:main_provider) { training_provider }
+
+      it 'returns the names providers that have the specified permission with the ratifying provider firs' do
+        expect(presenter.providers_with_permission(:make_decisions)).to eq([training_provider.name, ratifying_provider.name])
+      end
+    end
+
+    context 'when the main_provider is given as the ratifying provider' do
+      let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider]) }
+      let(:main_provider) { ratifying_provider }
+
+      it 'returns the names providers that have the specified permission with the ratifying provider firs' do
+        expect(presenter.providers_with_permission(:make_decisions)).to eq([ratifying_provider.name, training_provider.name])
       end
     end
   end

--- a/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature 'Provider edits organisation permissions' do
   end
 
   def and_my_organisation_is_listed_as_able_to_make_decisions
-    expect(page).to have_content("Make offers and reject applications\n#{@training_provider.name}#{@ratifying_provider.name}")
+    expect(page).to have_content("Make offers and reject applications\n#{@ratifying_provider.name}#{@training_provider.name}")
   end
 
   def and_my_organisation_is_able_to_make_decisions

--- a/spec/system/provider_interface/provider_views_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_views_organisation_permissions_spec.rb
@@ -17,11 +17,11 @@ RSpec.feature 'Viewing organisation permissions' do
     then_i_can_see_organisations_with_setup_permissions
 
     when_i_go_to_the_training_provider_permissions
-    then_i_can_only_see_permissions_that_have_been_set_up
+    then_i_can_only_see_permissions_that_have_been_set_up_for_the_training_provider
 
     when_i_click_organisation_permissions
     then_i_go_to_the_ratifying_provider_permissions
-    then_i_can_only_see_permissions_that_have_been_set_up
+    then_i_can_see_permissions_that_have_been_set_up_for_the_ratifying_provider
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -95,8 +95,12 @@ RSpec.feature 'Viewing organisation permissions' do
     click_on @ratifying_provider.name.to_s
   end
 
-  def then_i_can_only_see_permissions_that_have_been_set_up
+  def then_i_can_only_see_permissions_that_have_been_set_up_for_the_training_provider
     expect(page).to have_content("#{@training_provider.name} and #{@ratifying_provider.name}")
     expect(page).not_to have_content("#{@training_provider.name} and #{@another_ratifying_provider.name}")
+  end
+
+  def then_i_can_see_permissions_that_have_been_set_up_for_the_ratifying_provider
+    expect(page).to have_content("#{@ratifying_provider.name} and #{@training_provider.name}")
   end
 end

--- a/spec/system/provider_interface/provider_views_organisation_settings_spec.rb
+++ b/spec/system/provider_interface/provider_views_organisation_settings_spec.rb
@@ -120,6 +120,6 @@ RSpec.feature 'Provider views organisation settings' do
   end
 
   def then_i_see_the_organisations_permissions
-    expect(page).to have_content("#{@example_provider.name} and #{@another_provider.name}")
+    expect(page).to have_content("#{@another_provider.name} and #{@example_provider.name}")
   end
 end


### PR DESCRIPTION
## Context
We didn't do this initially, but promised to do it in this iteration of work.

## Changes proposed in this pull request
- Allow the "main" provider to be configured in the form and review card components


## Link to Trello card
https://trello.com/c/q5TX1EMb/4058-org-permissions-review-card-title-should-be-ordered-correctly

