### PR TITLE
Fix Apply 1 typo in the cycle timetable list

### DIFF
--- a/app/views/support_interface/settings/cycles.html.erb
+++ b/app/views/support_interface/settings/cycles.html.erb
@@ -34,7 +34,7 @@
 <p class="govuk-body">(Today is <%= Time.zone.today.to_s(:govuk_date) %>)</p>
 
 <%= render SummaryListComponent.new(rows: {
-  'Appy 1 deadline' => CycleTimetable.apply_1_deadline.to_s(:govuk_date),
+  'Apply 1 deadline' => CycleTimetable.apply_1_deadline.to_s(:govuk_date),
   'Apply 2 deadline' => CycleTimetable.apply_2_deadline.to_s(:govuk_date),
   'Find closes on' => CycleTimetable.find_closes.to_s(:govuk_date),
   'Find reopens on' => CycleTimetable.find_reopens.to_s(:govuk_date),

--- a/spec/system/support_interface/cycle_switching_spec.rb
+++ b/spec/system/support_interface/cycle_switching_spec.rb
@@ -32,6 +32,6 @@ RSpec.feature 'Cycle switching' do
   end
 
   def then_the_schedule_is_updated
-    expect(page).to have_content("Appy 1 deadline\n#{CycleTimetable.apply_1_deadline.to_s(:govuk_date)}")
+    expect(page).to have_content("Apply 1 deadline\n#{CycleTimetable.apply_1_deadline.to_s(:govuk_date)}")
   end
 end


### PR DESCRIPTION
## Context

Small typo on the cycle switcher page

## Changes proposed in this pull request

`appy 1` -> `apply 1`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
