### PR TITLE
Fix redirects for the references on the review unsubmitted application page

### DIFF
--- a/app/components/candidate_interface/selected_references_component.rb
+++ b/app/components/candidate_interface/selected_references_component.rb
@@ -3,12 +3,13 @@
 class CandidateInterface::SelectedReferencesComponent < ViewComponent::Base
   attr_reader :application_form, :selected_references, :editable, :show_incomplete, :is_errored
 
-  def initialize(application_form, editable: true, show_incomplete: false, is_errored: false)
+  def initialize(application_form, editable: true, show_incomplete: false, is_errored: false, return_to_application_review: false)
     @application_form = application_form
     @selected_references = application_form.selected_references
     @editable = editable
     @show_incomplete = show_incomplete
     @is_errored = is_errored
+    @return_to_application_review = return_to_application_review
   end
 
   def show_incomplete_banner?
@@ -22,7 +23,8 @@ class CandidateInterface::SelectedReferencesComponent < ViewComponent::Base
         value: reference_values,
         bulleted_format: true,
         action: 'Change selected references',
-        change_path: candidate_interface_select_references_path,
+        change_path: candidate_interface_select_references_path(return_to_params),
+        data_qa: 'selected-references',
       },
     ]
   end
@@ -55,5 +57,11 @@ class CandidateInterface::SelectedReferencesComponent < ViewComponent::Base
 
   def incomplete_message
     'References not marked as complete'
+  end
+
+private
+
+  def return_to_params
+    { 'return-to' => 'application-review' } if @return_to_application_review
   end
 end

--- a/app/controllers/candidate_interface/references/selection_controller.rb
+++ b/app/controllers/candidate_interface/references/selection_controller.rb
@@ -8,15 +8,18 @@ module CandidateInterface
           application_form: current_application,
           selected: current_application.application_references.selected.pluck(:id),
         )
+        @return_to = return_to_after_edit(default: candidate_interface_review_selected_references_path)
+
         @enough_references_provided = current_application.minimum_references_available_for_selection?
       end
 
       def create
         @selection_form = CandidateInterface::Reference::SelectionForm.new(selection_params)
         @enough_references_provided = current_application.minimum_references_available_for_selection?
+        @return_to = return_to_after_edit(default: candidate_interface_review_selected_references_path)
 
         if @selection_form.save!
-          redirect_to candidate_interface_review_selected_references_path
+          redirect_to @return_to[:back_path]
         elsif !@enough_references_provided
           flash.now[:warning] = I18n.t('application_form.references.review.need_two')
           render :new and return

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -25,7 +25,7 @@
 
 <section class="govuk-!-margin-bottom-8" id="references">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.references') %></h2>
-  <%= render(CandidateInterface::SelectedReferencesComponent.new(application_form, editable: editable, show_incomplete: true, is_errored: missing_error)) %>
+  <%= render(CandidateInterface::SelectedReferencesComponent.new(application_form, editable: editable, show_incomplete: true, is_errored: missing_error, return_to_application_review: true)) %>
 </section>
 
 <section class="govuk-!-margin-bottom-8">

--- a/app/views/candidate_interface/references/selection/new.html.erb
+++ b/app/views/candidate_interface/references/selection/new.html.erb
@@ -1,14 +1,13 @@
 <% content_for :title, t('page_titles.references') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path], 'Back to application') %>
 
 <% if @enough_references_provided %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <%= form_with(model: @selection_form, url: candidate_interface_select_references_path, method: :patch) do |f| %>
+      <%= form_with(model: @selection_form, url: candidate_interface_select_references_path(@return_to[:params]), method: :patch) do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl"><%= t('page_titles.references_select') %></h1>
-
         <%= f.govuk_check_boxes_fieldset :selected, multiple: true, legend: { text: '' } do %>
           <% @selection_form.available_references.each do |reference| %>
             <%= f.govuk_check_box(

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_adjustments_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_adjustments_section_spec.rb
@@ -38,9 +38,6 @@ RSpec.feature 'Candidate is redirected correctly' do
 
   def when_i_have_completed_my_application
     candidate_completes_application_form
-    @current_candidate.current_application.application_references.each do |reference|
-      reference.update!(feedback_status: :feedback_provided)
-    end
   end
 
   def and_i_review_my_application

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb
@@ -82,9 +82,6 @@ RSpec.feature 'Candidate is redirected correctly' do
 
   def when_i_have_completed_my_application
     candidate_completes_application_form
-    @current_candidate.current_application.application_references.each do |reference|
-      reference.update!(feedback_status: :feedback_provided)
-    end
   end
 
   def and_i_review_my_application

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_statement_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_statement_section_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Candidate is redirected correctly' do
   include CandidateHelper
 
-  scenario 'Candidate reviews completed application and updates personal details section' do
+  scenario 'Candidate reviews completed application and updates personal statement section' do
     given_i_am_signed_in
     when_i_have_completed_my_application
     and_i_review_my_application
@@ -36,9 +36,6 @@ RSpec.feature 'Candidate is redirected correctly' do
 
   def when_i_have_completed_my_application
     candidate_completes_application_form
-    @current_candidate.current_application.application_references.each do |reference|
-      reference.update!(feedback_status: :feedback_provided)
-    end
   end
 
   def and_i_review_my_application

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_their_selected_references_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_their_selected_references_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Candidate is redirected correctly' do
   include CandidateHelper
 
-  scenario 'Candidate reviews completed application and updates personal details section' do
+  scenario 'Candidate reviews completed application and updates references section' do
     given_i_am_signed_in
     when_i_have_completed_my_application_and_have_3_references
     and_i_review_my_application
@@ -27,9 +27,6 @@ RSpec.feature 'Candidate is redirected correctly' do
 
   def when_i_have_completed_my_application_and_have_3_references
     candidate_completes_application_form
-    @current_candidate.current_application.application_references.each do |reference|
-      reference.update!(feedback_status: :feedback_provided, selected: true)
-    end
     @first_reference = @current_candidate.current_application.application_references.selected.first
     @second_reference = @current_candidate.current_application.application_references.selected.second
     @third_reference = create(:reference, :feedback_provided, selected: false, application_form: @current_candidate.current_application)

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_their_selected_references_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_their_selected_references_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate is redirected correctly' do
+  include CandidateHelper
+
+  scenario 'Candidate reviews completed application and updates personal details section' do
+    given_i_am_signed_in
+    when_i_have_completed_my_application_and_have_3_references
+    and_i_review_my_application
+    then_i_should_see_all_sections_are_complete
+    and_i_should_see_my_two_selected_references
+
+    when_i_click_change_references
+    then_i_should_see_the_select_references_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_my_selected_references
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_references
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_have_completed_my_application_and_have_3_references
+    candidate_completes_application_form
+    @current_candidate.current_application.application_references.each do |reference|
+      reference.update!(feedback_status: :feedback_provided, selected: true)
+    end
+    @first_reference = @current_candidate.current_application.application_references.selected.first
+    @second_reference = @current_candidate.current_application.application_references.selected.second
+    @third_reference = create(:reference, :feedback_provided, selected: false, application_form: @current_candidate.current_application)
+  end
+
+  def and_i_review_my_application
+    and_i_visit_the_application_form_page
+    when_i_click_on_check_your_answers
+  end
+
+  def then_i_should_see_all_sections_are_complete
+    application_form_sections.each do |section|
+      expect(page).not_to have_selector "[data-qa='incomplete-#{section}']"
+    end
+  end
+
+  def and_i_should_see_my_two_selected_references
+    within('[data-qa="selected-references"]') do
+      expect(page).to have_content @first_reference.name
+      expect(page).to have_content @second_reference.name
+      expect(page).not_to have_content @third_reference.name
+    end
+  end
+
+  def and_i_visit_the_application_form_page
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_check_your_answers
+    click_link 'Check and submit your application'
+  end
+
+  def when_i_click_change_references
+    within('[data-qa="selected-references"]') do
+      click_link 'Change'
+    end
+  end
+
+  def then_i_should_see_the_select_references_form
+    expect(page).to have_current_path(candidate_interface_select_references_path('return-to' => 'application-review'))
+  end
+
+  def when_i_click_back
+    click_link 'Back to application'
+  end
+
+  def then_i_should_be_redirected_to_the_application_review_page
+    expect(page).to have_current_path(candidate_interface_application_review_path)
+  end
+
+  def when_i_update_my_selected_references
+    when_i_click_change_references
+    uncheck @second_reference.name
+    check @third_reference.name
+    click_button 'Save and continue'
+  end
+
+  def and_i_should_see_my_updated_references
+    within('[data-qa="selected-references"]') do
+      expect(page).to have_content @first_reference.name
+      expect(page).to have_content @third_reference.name
+      expect(page).not_to have_content @second_reference.name
+    end
+  end
+end


### PR DESCRIPTION
## Context

The *fifth* PR in possibly, a large-ish number of PRs_

If you visit the review unsubmitted application form page and click change on any of the links in the references section, then either:

1. update the selected references and click save and continue 
or
2. click the backlink

You are redirected the review page for the section.

In both of these cases you should be redirected to the review unsubmitted page 

## Changes proposed in this pull request

Use params (`&return-to=application-review`) to redirect the candidate back to the application review path when required.

## Guidance to review

- This PR deals with the references section only. Other PRs to follow for remaining sections.

## Link to Trello card

https://trello.com/c/FCOvEcex/3767-change-links-and-backlinks-are-not-working-correctly-from-the-review-unsubmitted-page-references-section

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
