### PR TITLE
Introduce new Report table component

### DIFF
--- a/app/components/provider_interface/report_table_component.html.erb
+++ b/app/components/provider_interface/report_table_component.html.erb
@@ -1,0 +1,36 @@
+<table class='govuk-table'>
+  <thead class="govuk-table__head">
+    <tr class='govuk-table__row'>
+      <th class='govuk-table__header' scope='col'><%= headers[0] %></th>
+      <% headers[1..].each do |header| %>
+        <th class='govuk-table__row govuk-table__header govuk-table__header--numeric' scope='col' style='width: 12%'><%= header %></th>
+      <% end %>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% rows.each do |row| %>
+      <tr class='govuk-table__row'>
+        <th class='govuk-table__header' scope='row'>
+          <%= row[:header] %>
+          <span class='govuk-hint govuk-!-margin-bottom-0'><%= row[:subheader] %></span>
+        </th>
+
+        <% row[:values].each do |value| %>
+          <td class='govuk-table__cell govuk-table__cell--numeric'><%= value %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+
+  <% if show_footer %>
+    <tfoot>
+      <tr class='govuk-table__row'>
+        <th class='govuk-table__header' scope='row'>Total</th>
+        <% footer.each do |value| %>
+          <td class='govuk-table__header govuk-table__header--numeric'><%= value %></td>
+        <% end %>
+      </tr>
+    </tfoot>
+  <% end %>
+</table>

--- a/app/components/provider_interface/report_table_component.rb
+++ b/app/components/provider_interface/report_table_component.rb
@@ -1,0 +1,26 @@
+module ProviderInterface
+  class ReportTableComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :headers, :rows, :show_footer
+
+    def initialize(headers: [], rows: [], show_footer: true)
+      @headers = headers
+      @rows = rows
+      @show_footer = show_footer
+    end
+
+    def footer
+      [] unless show_footer
+
+      @footer = Array.new(rows.first[:values].length) { 0 }
+      rows.each do |row|
+        row[:values].each_with_index do |value, index|
+          @footer[index] += value
+        end
+      end
+
+      @footer
+    end
+  end
+end

--- a/spec/components/previews/provider_interface/report_table_component_preview.rb
+++ b/spec/components/previews/provider_interface/report_table_component_preview.rb
@@ -1,0 +1,36 @@
+module ProviderInterface
+  class ReportTableComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
+    def report
+      render ProviderInterface::ReportTableComponent.new(headers: headers,
+                                                         rows: row_data)
+    end
+
+    def report_without_footer
+      render ProviderInterface::ReportTableComponent.new(headers: headers,
+                                                         rows: row_data,
+                                                         show_footer: false)
+    end
+
+  private
+
+    def headers
+      ['Course', 'Received', 'Interviewing', 'Offered', 'Awaiting conditions', 'Ready to enrol']
+    end
+
+    def row_data
+      10.times.map do
+        {
+          header: "#{Faker::Educator.subject} (#{Faker::Alphanumeric.alphanumeric(number: 4, min_alpha: 1).upcase})",
+          subheader: Faker::University.name,
+          values: numbers_row,
+        }
+      end
+    end
+
+    def numbers_row
+      5.times.map { Faker::Number.non_zero_digit }
+    end
+  end
+end

--- a/spec/components/provider_interface/report_table_component_spec.rb
+++ b/spec/components/provider_interface/report_table_component_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ReportTableComponent do
+  let(:headers) { ['Course', 'Received', 'Interviewing', 'Offered', 'Awaiting conditions', 'Ready to enrol'] }
+  let(:data) do
+    {
+      headers: headers,
+      rows: [
+        {
+          header: 'Mathematics',
+          subheader: 'Hogwards University',
+          values: [1, 3, 2, 5, 4],
+        },
+        {
+          header: 'English',
+          subheader: 'University of Maximegalon',
+          values: [2, 3, 4, 5, 6],
+        },
+      ],
+    }
+  end
+  let(:render) { render_inline described_class.new(data) }
+
+  describe 'header rows' do
+    it 'correctly outputs header data' do
+      expect(render.css('thead th')[0].text).to eq(headers[0])
+      expect(render.css('thead th')[1].text).to eq(headers[1])
+      expect(render.css('thead th')[2].text).to eq(headers[2])
+      expect(render.css('thead th')[3].text).to eq(headers[3])
+      expect(render.css('thead th')[4].text).to eq(headers[4])
+    end
+  end
+
+  describe 'rows' do
+    it 'correctly outputs row data' do
+      expect(render.css('tbody th')[0].text).to include('Mathematics')
+      expect(render.css('tbody th span')[0].text).to eq('Hogwards University')
+      expect(render.css('tbody td')[0].text).to eq('1')
+      expect(render.css('tbody td')[1].text).to eq('3')
+      expect(render.css('tbody td')[2].text).to eq('2')
+      expect(render.css('tbody td')[3].text).to eq('5')
+      expect(render.css('tbody td')[4].text).to eq('4')
+
+      expect(render.css('tbody th')[1].text).to include('English')
+      expect(render.css('tbody th span')[1].text).to eq('University of Maximegalon')
+      expect(render.css('tbody td')[5].text).to eq('2')
+      expect(render.css('tbody td')[6].text).to eq('3')
+      expect(render.css('tbody td')[7].text).to eq('4')
+      expect(render.css('tbody td')[8].text).to eq('5')
+      expect(render.css('tbody td')[9].text).to eq('6')
+    end
+  end
+
+  describe 'footer' do
+    it 'calculates and outputs the totals of each row' do
+      expect(render.css('tfoot th')[0].text).to eq('Total')
+      expect(render.css('tfoot td')[0].text).to eq('3')
+      expect(render.css('tfoot td')[1].text).to eq('6')
+      expect(render.css('tfoot td')[2].text).to eq('6')
+      expect(render.css('tfoot td')[3].text).to eq('10')
+      expect(render.css('tfoot td')[4].text).to eq('10')
+    end
+  end
+
+  describe 'when show_footer is set to false' do
+    let(:render) { render_inline described_class.new(data.merge!(show_footer: false)) }
+
+    it 'does not render a footer' do
+      expect(render.css('tfoot')).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Context
Components to be used to render report table.

Accepts headers, rows and is able to optionally calculate the footer row totals.

## Changes proposed in this pull request

<img width="1321" alt="Screenshot 2021-08-10 at 12 44 41" src="https://user-images.githubusercontent.com/159200/128845566-3960acba-dbf2-4aeb-8f20-20d6c2642646.png">


## Link to Trello card

https://trello.com/c/uPqVDWWL/4107-new-reports-table-component

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
