### PR TITLE
Add rack-mini-profiler to development and QA

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,6 +122,9 @@ gem 'strong_migrations'
 # Rails console colours
 gem 'colorize'
 
+# Performance profiling - keep this below 'pg' gem
+gem 'rack-mini-profiler', require: false
+
 group :production do
   gem 'rails_semantic_logger'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,6 +391,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-mini-profiler (2.3.2)
+      rack (>= 1.2.0)
     rack-oauth2 (1.16.0)
       activesupport
       attr_required
@@ -520,7 +522,7 @@ GEM
     ruby-next-core (0.12.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    rubyzip (2.3.0)
+    rubyzip (2.3.2)
     safely_block (0.3.0)
       errbase (>= 0.1.1)
     selenium-webdriver (3.142.7)
@@ -725,6 +727,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 5.4)
+  rack-mini-profiler
   rails-erd
   rails_semantic_logger
   railties (~> 6.1)

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+if HostingEnvironment.test_environment? && HostingEnvironment.environment_name != 'test'
+  require 'rack-mini-profiler'
+
+  # initialization is skipped so trigger it
+  Rack::MiniProfilerRails.initialize!(Rails.application)
+end


### PR DESCRIPTION
## Context
We're doing some performance tuning of certain endpoints. This is a useful tool for quickly getting data on queries, render time, and several other metrics on any given page.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Add the gem
- Configure it to run in dev and QA
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/TzqiS7Jg
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
