### PR TITLE
Fix redirects when updating the 'safeguarding' section

### DIFF
--- a/app/components/candidate_interface/safeguarding_review_component.rb
+++ b/app/components/candidate_interface/safeguarding_review_component.rb
@@ -1,11 +1,12 @@
 module CandidateInterface
   class SafeguardingReviewComponent < ViewComponent::Base
-    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
+    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false, return_to_application_review: false)
       @application_form = application_form
       @safeguarding = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
       @editable = editable
       @missing_error = missing_error
       @submitting_application = submitting_application
+      @return_to_application_review = return_to_application_review
     end
 
     def safeguarding_rows
@@ -23,7 +24,8 @@ module CandidateInterface
         key: 'Do you want to share any safeguarding issues?',
         value: @safeguarding.share_safeguarding_issues,
         action: 'if you want to share any safeguarding issues',
-        change_path: candidate_interface_edit_safeguarding_path,
+        change_path: candidate_interface_edit_safeguarding_path(return_to_params),
+        data_qa: 'safeguarding-issues',
       }
     end
 
@@ -34,8 +36,12 @@ module CandidateInterface
         key: 'Relevant information',
         value: @safeguarding.safeguarding_issues || 'Not entered',
         action: 'relevant information for safeguarding issues',
-        change_path: candidate_interface_edit_safeguarding_path,
+        change_path: candidate_interface_edit_safeguarding_path(return_to_params),
       }
+    end
+
+    def return_to_params
+      { 'return-to' => 'application-review' } if @return_to_application_review
     end
   end
 end

--- a/app/controllers/candidate_interface/safeguarding_controller.rb
+++ b/app/controllers/candidate_interface/safeguarding_controller.rb
@@ -24,13 +24,15 @@ module CandidateInterface
 
     def edit
       @safeguarding_form = SafeguardingIssuesDeclarationForm.build_from_application(current_application)
+      @return_to = return_to_after_edit(default: candidate_interface_review_safeguarding_path)
     end
 
     def update
       @safeguarding_form = SafeguardingIssuesDeclarationForm.new(safeguarding_params)
+      @return_to = return_to_after_edit(default: candidate_interface_review_safeguarding_path)
 
       if @safeguarding_form.save(current_application)
-        redirect_to candidate_interface_review_safeguarding_path
+        redirect_to @return_to[:back_path]
       else
         track_validation_error(@safeguarding_form)
         render :edit

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -103,5 +103,5 @@
 
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m"><%= t('section_groups.safeguarding') %></h2>
-  <%= render(CandidateInterface::SafeguardingReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
+  <%= render(CandidateInterface::SafeguardingReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submitting_application: true, return_to_application_review: true)) %>
 </section>

--- a/app/views/candidate_interface/safeguarding/edit.html.erb
+++ b/app/views/candidate_interface/safeguarding/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.suitability_to_work_with_children'), @safeguarding_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_review_safeguarding_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @safeguarding_form, url: candidate_interface_edit_safeguarding_path, method: :patch do |f| %>
+    <%= form_with model: @safeguarding_form, url: candidate_interface_edit_safeguarding_path(@return_to[:params]), method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_safeguarding_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_safeguarding_section_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate is redirected correctly' do
+  include CandidateHelper
+
+  scenario 'Candidate reviews completed application and updates adjustments section' do
+    given_i_am_signed_in
+    when_i_have_completed_my_application
+    and_i_review_my_application
+    then_i_should_see_all_sections_are_complete
+
+    when_i_click_safeguarding_issues
+    then_i_should_see_the_safeguarding_issues_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_safeguarding_issues
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_safeguarding_issues
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_have_completed_my_application
+    candidate_completes_application_form
+  end
+
+  def and_i_review_my_application
+    allow(LanguagesSectionPolicy).to receive(:hide?).and_return(false)
+    and_i_visit_the_application_form_page
+    when_i_click_on_check_your_answers
+  end
+
+  def then_i_should_see_all_sections_are_complete
+    application_form_sections.each do |section|
+      expect(page).not_to have_selector "[data-qa='incomplete-#{section}']"
+    end
+  end
+
+  def and_i_visit_the_application_form_page
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_check_your_answers
+    click_link 'Check and submit your application'
+  end
+
+  def when_i_click_safeguarding_issues
+    within('[data-qa="safeguarding-issues"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def then_i_should_be_redirected_to_the_application_review_page
+    expect(page).to have_current_path(candidate_interface_application_review_path)
+  end
+
+  def then_i_should_see_the_safeguarding_issues_form
+    expect(page).to have_current_path(candidate_interface_edit_safeguarding_path('return-to' => 'application-review'))
+  end
+
+  def when_i_update_safeguarding_issues
+    when_i_click_safeguarding_issues
+    choose 'No'
+    click_button t('continue')
+  end
+
+  def and_i_should_see_my_updated_safeguarding_issues
+    within('[data-qa="safeguarding-issues"]') do
+      expect(page).to have_content('No')
+    end
+  end
+end


### PR DESCRIPTION
## Context

If you visit the review unsubmitted application form page and click change on any of the links, then either:

- update the field and click save and continue
or
- click the backlink

You are redirected the review page for the section.

## Changes proposed in this pull request

Use params `(&return-to=application-review)` to redirect the candidate back to the application review path when required.

## Guidance to review

- Recommend manually testing this!
- This PR deals with the safeguarding section only. Other PRs to follow for remaining sections.

## Link to Trello card

https://trello.com/c/Af22b2i0/3772-change-links-and-backlinks-are-not-working-correctly-from-the-review-unsubmitted-page-safeguarding-section

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
