### PR TITLE
Update analytics.yml to include offer_withdrawal_reason & rejection_r…

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -15,6 +15,7 @@ shared:
     - id
     - offer_changed_at
     - offer_deferred_at
+    - offer_withdrawal_reason
     - offer_withdrawn_at
     - offered_at
     - recruited_at
@@ -23,6 +24,7 @@ shared:
     - reject_by_default_feedback_sent_at
     - rejected_at
     - rejected_by_default
+    - rejection_reason
     - sent_to_provider_at
     - status
     - status_before_deferral


### PR DESCRIPTION
## Context
Making this change in order to stream the missing fields (offer_withdrawal_reason and rejection_reason are missing) into BQ so that all fields in the application_choices table in the database are streaming into BQ.

## Changes proposed in this pull request
Adding offer_withdrawal_reason and rejection_reason fields to the analytics.yml file


## Guidance to review
Please ensure both fields are present (and none have been removed) in the analytics.yml file.

## Link to Trello card
https://trello.com/c/wbvKXOZp


## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
