### PR TITLE
Implement worker to open all courses on Apply

### DIFF
--- a/app/controllers/support_interface/tasks_controller.rb
+++ b/app/controllers/support_interface/tasks_controller.rb
@@ -28,6 +28,10 @@ module SupportInterface
         CancelUnsubmittedApplicationsWorker.perform_async
         flash[:success] = 'Scheduled job to cancel unsubmitted applications that reached end-of-cycle'
         redirect_to support_interface_tasks_path
+      when 'open_all_courses_on_apply'
+        OpenAllCoursesOnApplyWorker.perform_async
+        flash[:success] = 'Scheduled job to make all courses open on Apply'
+        redirect_to support_interface_tasks_path
       else
         render_404
       end

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -89,4 +89,16 @@
       </div>
     </div>
   </section>
+
+    <section class="app-section app-section--with-top-border">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m">Open all courses on Apply</h2>
+        <p class="govuk-body">This task will open all courses on Apply at the start of a new cycle.</p>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <%= govuk_button_to 'Open all courses on Apply', support_interface_run_task_path('open_all_courses_on_apply'), class: 'govuk-button--secondary' %>
+      </div>
+    </div>
+  </section>
 <% end %>

--- a/app/workers/open_all_courses_on_apply_worker.rb
+++ b/app/workers/open_all_courses_on_apply_worker.rb
@@ -1,0 +1,17 @@
+class OpenAllCoursesOnApplyWorker
+  include Sidekiq::Worker
+
+  def perform
+    return unless RecruitmentCycle.current_year == 2022
+
+    closed_courses.find_each { |course| course.update!(open_on_apply: true, opened_on_apply_at: Time.zone.now) }
+  end
+
+private
+
+  def closed_courses
+    Course
+      .current_cycle
+      .where(open_on_apply: false)
+  end
+end

--- a/spec/workers/open_all_courses_on_apply_worker_spec.rb
+++ b/spec/workers/open_all_courses_on_apply_worker_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe OpenAllCoursesOnApplyWorker do
+  it 'opens courses that are closed on Apply and in the current cycle' do
+    Timecop.freeze(CycleTimetable.apply_reopens) do
+      open_course = create(:course, open_on_apply: true)
+      closed_course = create(:course, open_on_apply: false)
+      course_in_the_previous_cycle = create(:course, open_on_apply: false, recruitment_cycle_year: RecruitmentCycle.previous_year)
+
+      described_class.new.perform
+
+      expect(open_course.reload.open_on_apply).to eq true
+      expect(course_in_the_previous_cycle.reload.open_on_apply).to eq false
+      expect(closed_course.reload.open_on_apply).to eq true
+    end
+  end
+
+  it 'sets the opened on apply timestamp' do
+    opened_on_apply = CycleTimetable.apply_reopens + 2.days
+
+    Timecop.freeze(opened_on_apply) do
+      course = create(:course, open_on_apply: false)
+      described_class.new.perform
+
+      expect(course.reload.opened_on_apply_at).to eq(opened_on_apply)
+    end
+  end
+
+  it 'wont open courses if Apply is not in the new cycle' do
+    course = create(:course, open_on_apply: false)
+
+    Timecop.freeze(CycleTimetable.apply_reopens - 1.day) do
+      described_class.new.perform
+      expect(course.reload.open_on_apply).to eq false
+    end
+  end
+end


### PR DESCRIPTION
## Context

With the next cycle all courses will be on Apply so there is no longer the concept of open on Apply or/and UCAS. Previously courses had to be opened manually on Apply, this adds a new worker that, once run, will open all the courses for the current cycle.

## Changes proposed in this pull request

New task at `/support/settings/tasks`:

![image](https://user-images.githubusercontent.com/47917431/128890127-aa7ba411-5d9d-4f3f-9ba1-7ecace74cb46.png)

It runs a worker that will grab all courses that are not open on apply for the current cycle and update these to open.

## Guidance to review

Ensure some courses are closed for the 2021 cycle. Run the task and then check them again

## Link to Trello card

https://trello.com/c/wWfIpWiJ

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
