### PR TITLE
Check user has access to requested providers during exports

### DIFF
--- a/app/controllers/provider_interface/application_data_export_controller.rb
+++ b/app/controllers/provider_interface/application_data_export_controller.rb
@@ -16,7 +16,7 @@ module ProviderInterface
 
         application_choices = GetApplicationChoicesForProviders
           .call(
-            providers: providers,
+            providers: current_provider_user.providers & providers,
             includes: [
               :provider,
               :accredited_provider,


### PR DESCRIPTION
## Context

It is currently possible to construct a data export url to request data for providers you shouldn't have access to. 

## Changes proposed in this pull request

Check the current provider user has access to the requested providers.

## Guidance to review

This could do with a request spec, which may follow in another PR.

## Link to Trello card

No Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
