### PR TITLE
Allow setting number of threads per load-test scenario for Manage

### DIFF
--- a/jmeter/README.md
+++ b/jmeter/README.md
@@ -1,3 +1,26 @@
+# JMeter docker app for load-testing Apply/Manage/Vendor API
+
+We are using `ruby-jmeter` to simplify the creation of JMeter test plans and a custom Dockerfile to satisfy all JMeter dependencies, run the tests within the gov.uk PaaS and collect jmeter metrics with Prometheus, so that we can examine our load tests in Grafana.
+
+## Testing the jmeter app locally
+
+You'll need docker installed.
+
+```
+cd jmeter && docker build . -t jmeter
+docker run --rm -ti --net=host -e JMETER_TARGET_BASEURL=http://localhost:3000 -e JMETER_TARGET_PLAN=test -e JMETER_WAIT_FACTOR=0.5 jmeter
+```
+
+The `docker run` command above will just run the `test.rb` plan against your local rails server. Here is an example of something more interesting:
+
+```
+docker run --rm -ti --net=host -e JMETER_TARGET_BASEURL=http://localhost:3000 -e JMETER_TARGET_PLAN=manage -e JMETER_WAIT_FACTOR=0.5 -e JMETER_THREAD_CONFIG=0,0,0,0,0,1 jmeter
+```
+
+Most of these calls will fail, though, because you probably don't have the required provider users in your database. You can edit `manage.rb` and carry on building your local docker images, however, to use provider user UIDs that you have.
+
+You can check jmeter prometheus metrics are being exported by visiting http://locahost:8080 in your browser.
+
 ## Deploying the app
 
 Make sure you are logged into the GitHub container register, this is required to publish the latest image to GHCR.

--- a/jmeter/plans/manage.rb
+++ b/jmeter/plans/manage.rb
@@ -13,6 +13,9 @@ def log_in(user_id)
     fill_in: { 'uid' => user_id }
 end
 
+THREAD_CONFIG = ENV.fetch('JMETER_THREAD_CONFIG', '1').split(',').map(&:to_i)
+THREADS_PER_SCENARIO = (0..5).map { |i| THREAD_CONFIG[i] || 1 }
+
 test do
   cookies clear_each_iteration: true
 
@@ -32,7 +35,7 @@ test do
     # The total number of sessions for each uid (below) should be 6
 
     # See interviewing application and interview information
-    threads count: 1, rampup: RAMPUP, continue_forever: true, duration: 3600 do
+    threads count: THREADS_PER_SCENARIO[0], rampup: RAMPUP, continue_forever: true, duration: 3600 do
       log_in uid
       visit name: 'Filter by interviewing', url: BASEURL + '/provider/applications?commit=Apply+filters&status%5B%5D=interviewing' do
         extract name: 'application_id', regex: 'href="/provider/applications/(\d+)"', match_number: 0
@@ -42,7 +45,7 @@ test do
     end
 
     # Start making an offer
-    threads count: 1, rampup: RAMPUP, continue_forever: true, duration: 3600 do
+    threads count: THREADS_PER_SCENARIO[1], rampup: RAMPUP, continue_forever: true, duration: 3600 do
       log_in uid
       visit name: 'Filter by awaiting_provider_decision', url: BASEURL + '/provider/applications?commit=Apply+filters&status%5B%5D=awaiting_provider_decision' do
         extract name: 'application_id', regex: 'href="/provider/applications/(\d+)"', match_number: 0
@@ -61,7 +64,7 @@ test do
     end
 
     # See rejected application
-    threads count: 1, rampup: RAMPUP, continue_forever: true, duration: 3600 do
+    threads count: THREADS_PER_SCENARIO[2], rampup: RAMPUP, continue_forever: true, duration: 3600 do
       log_in uid
       visit name: 'Filter by rejected', url: BASEURL + '/provider/applications?commit=Apply+filters&status%5B%5D=rejected' do
         extract name: 'application_id', regex: 'href="/provider/applications/(\d+)"', match_number: 0
@@ -72,20 +75,20 @@ test do
     end
 
     # See provider interview schedule
-    threads count: 1, rampup: RAMPUP, continue_forever: true, duration: 3600 do
+    threads count: THREADS_PER_SCENARIO[3], rampup: RAMPUP, continue_forever: true, duration: 3600 do
       log_in uid
       visit name: 'See interview schedule', url: BASEURL + '/provider/interview-schedule'
       visit name: 'See past interview schedule', url: BASEURL + '/provider/interview-schedule/past'
     end
 
     # See provider activity log
-    threads count: 1, rampup: RAMPUP, continue_forever: true, duration: 3600 do
+    threads count: THREADS_PER_SCENARIO[4], rampup: RAMPUP, continue_forever: true, duration: 3600 do
       log_in uid
       visit name: 'Load activity log', url: BASEURL + '/provider/activity'
     end
 
     # Data export
-     threads count: 1, rampup: RAMPUP, continue_forever: true, duration: 3600 do
+     threads count: THREADS_PER_SCENARIO[5], rampup: RAMPUP, continue_forever: true, duration: 3600 do
       log_in uid
       visit name: 'Load provider data export form', url: BASEURL + '/provider/applications/data-export/new'
       visit name: 'Download data export', url: BASEURL + '/provider/applications/data-export?provider_interface_application_data_export_form[recruitment_cycle_years][]=&provider_interface_application_data_export_form[recruitment_cycle_years][]=2021&provider_interface_application_data_export_form[recruitment_cycle_years][]=2020&provider_interface_application_data_export_form[application_status_choice]=all&provider_interface_application_data_export_form[statuses][]=' do


### PR DESCRIPTION
## Context

We are now focusing on improving specific actions, so it would be useful to be able to enable/disable individual scenaria at will when testing.

## Changes proposed in this pull request

Add `JMETER_THREAD_CONFIG` as an environment variable in `manage.rb`, expecting a comma-separated list of integers. For example, `JMETER_THREAD_CONFIG=0,0,1,1,1,0` will deactivate the first, second, and last scenaria.

## Guidance to review

You can use your local rails environment, assuming you have docker. I have added some instructions to the README.

## Link to Trello card

https://trello.com/c/1knVsJdh

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
