### PR TITLE
Fragment cache the provider select box

### DIFF
--- a/app/controllers/candidate_interface/course_choices/provider_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/provider_selection_controller.rb
@@ -3,6 +3,7 @@ module CandidateInterface
     class ProviderSelectionController < BaseController
       def new
         @pick_provider = PickProviderForm.new
+        @provider_cache_key = "provider-list-#{Provider.maximum(:updated_at)}"
       end
 
       def create

--- a/app/views/candidate_interface/course_choices/provider_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/provider_selection/new.html.erb
@@ -10,14 +10,16 @@
     ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_collection_select(
-        :provider_id,
-        select_provider_options(@pick_provider.available_providers),
-        :id,
-        :name,
-        label: { text: t('page_titles.which_provider'), size: 'xl', tag: 'h1' },
-      ) do %>
-        <p class="govuk-body">You can <%= govuk_link_to 'see a list of training providers and courses', candidate_interface_providers_path %> currently available on <%= service_name %>.</p>
+      <% cache @provider_cache_key do %>
+        <%= f.govuk_collection_select(
+          :provider_id,
+          select_provider_options(@pick_provider.available_providers),
+          :id,
+          :name,
+          label: { text: t('page_titles.which_provider'), size: 'xl', tag: 'h1' },
+        ) do %>
+          <p class="govuk-body">You can <%= govuk_link_to 'see a list of training providers and courses', candidate_interface_providers_path %> currently available on <%= service_name %>.</p>
+        <% end %>
       <% end %>
 
       <%= f.govuk_submit t('continue') %>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,6 +106,7 @@ RSpec.configure do |config|
   end
 
   config.before { Redis.new.flushdb }
+  config.before { Rails.cache.clear }
 
   # If running tests in parallel, use a unique Redis database per test process.
   # This allocates databases from 1 onwards, as it's assumed that 0 is the


### PR DESCRIPTION
## Context
The provider screen in the course choice flow has a high object
allocation according to Skylight.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Cache the select box with a cache key that's dependent on the most
recent updated_at in the providers table. This will retrieve that part
of the view from the cache instead of holding all providers in memory to
render it.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
~Raising this as a draft PR initially, for visibility. This work is dependent on getting Redis caching sorted out for Apply.~
The Redis cache infrastructure work is progressing, so I've marked this PR ready for review.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/J0zr2qE6
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
