### PR TITLE
Rename existing apply-redis instance to apply-worker-redis

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -122,9 +122,14 @@ resource "cloudfoundry_service_instance" "postgres" {
 }
 
 resource "cloudfoundry_service_instance" "redis" {
-  name         = local.redis_service_name
+  name         = local.worker_redis_service_name
   space        = data.cloudfoundry_space.space.id
-  service_plan = data.cloudfoundry_service.redis.service_plans[var.redis_service_plan]
+  service_plan = data.cloudfoundry_service.redis.service_plans[var.worker_redis_service_plan]
+  json_params  = jsonencode(local.noeviction_maxmemory_policy)
+  timeouts {
+    create = "30m"
+    update = "30m"
+  }
 }
 
 resource "cloudfoundry_service_key" "postgres-readonly-key" {
@@ -132,8 +137,8 @@ resource "cloudfoundry_service_key" "postgres-readonly-key" {
   service_instance = cloudfoundry_service_instance.postgres.id
 }
 
-resource "cloudfoundry_service_key" "redis-key" {
-  name             = "${local.redis_service_name}-key"
+resource "cloudfoundry_service_key" "worker_redis_key" {
+  name             = "${local.worker_redis_service_name}-key"
   service_instance = cloudfoundry_service_instance.redis.id
 }
 

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -45,7 +45,7 @@ module "paas" {
   app_environment_variables = local.paas_app_environment_variables
   logstash_url              = local.infra_secrets.LOGSTASH_URL
   postgres_service_plan     = var.paas_postgres_service_plan
-  redis_service_plan        = var.paas_redis_service_plan
+  worker_redis_service_plan = var.paas_worker_redis_service_plan
   clock_app_memory          = var.paas_clock_app_memory
   worker_app_memory         = var.paas_worker_app_memory
   clock_app_instances       = var.paas_clock_app_instances

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,7 +13,7 @@ variable "paas_web_app_instances" {}
 
 variable "paas_postgres_service_plan" {}
 
-variable "paas_redis_service_plan" {}
+variable "paas_worker_redis_service_plan" {}
 
 variable "paas_clock_app_memory" { default = 512 }
 

--- a/terraform/workspace_variables/loadtest.tfvars
+++ b/terraform/workspace_variables/loadtest.tfvars
@@ -1,13 +1,13 @@
 # PaaS
-paas_app_environment       = "load-test"
-paas_cf_space              = "bat-prod"
-paas_web_app_memory        = 4096
-paas_worker_app_memory     = 4096
-paas_clock_app_memory      = 1024
-paas_web_app_instances     = 4
-paas_worker_app_instances  = 2
-paas_postgres_service_plan = "medium-ha-11"
-paas_redis_service_plan    = "micro-ha-5_x"
+paas_app_environment           = "load-test"
+paas_cf_space                  = "bat-prod"
+paas_web_app_memory            = 4096
+paas_worker_app_memory         = 4096
+paas_clock_app_memory          = 1024
+paas_web_app_instances         = 4
+paas_worker_app_instances      = 2
+paas_postgres_service_plan     = "medium-ha-11"
+paas_worker_redis_service_plan = "micro-ha-5_x"
 
 # KeyVault
 key_vault_resource_group    = "s121d01-shared-rg"

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -1,13 +1,13 @@
 # PaaS
-paas_app_environment       = "prod"
-paas_cf_space              = "bat-prod"
-paas_web_app_memory        = 6144
-paas_worker_app_memory     = 4096
-paas_clock_app_memory      = 1024
-paas_web_app_instances     = 8
-paas_worker_app_instances  = 2
-paas_postgres_service_plan = "medium-ha-11"
-paas_redis_service_plan    = "micro-ha-5_x"
+paas_app_environment           = "prod"
+paas_cf_space                  = "bat-prod"
+paas_web_app_memory            = 6144
+paas_worker_app_memory         = 4096
+paas_clock_app_memory          = 1024
+paas_web_app_instances         = 8
+paas_worker_app_instances      = 2
+paas_postgres_service_plan     = "medium-ha-11"
+paas_worker_redis_service_plan = "micro-ha-5_x"
 
 # KeyVault
 key_vault_resource_group    = "s121p01-shared-rg"

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -1,10 +1,10 @@
 # PaaS
-paas_app_environment       = "qa"
-paas_cf_space              = "bat-qa"
-paas_web_app_memory        = 1024
-paas_web_app_instances     = 2
-paas_postgres_service_plan = "small-11"
-paas_redis_service_plan    = "micro-5_x"
+paas_app_environment           = "qa"
+paas_cf_space                  = "bat-qa"
+paas_web_app_memory            = 1024
+paas_web_app_instances         = 2
+paas_postgres_service_plan     = "small-11"
+paas_worker_redis_service_plan = "micro-5_x"
 
 # KeyVault
 key_vault_resource_group    = "s121d01-shared-rg"

--- a/terraform/workspace_variables/research.tfvars
+++ b/terraform/workspace_variables/research.tfvars
@@ -1,10 +1,10 @@
 # PaaS
-paas_app_environment       = "research"
-paas_cf_space              = "bat-qa"
-paas_web_app_memory        = 1024
-paas_web_app_instances     = 2
-paas_postgres_service_plan = "small-11"
-paas_redis_service_plan    = "micro-5_x"
+paas_app_environment           = "research"
+paas_cf_space                  = "bat-qa"
+paas_web_app_memory            = 1024
+paas_web_app_instances         = 2
+paas_postgres_service_plan     = "small-11"
+paas_worker_redis_service_plan = "micro-5_x"
 
 # KeyVault
 key_vault_resource_group    = "s121d01-shared-rg"

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -1,12 +1,12 @@
 # PaaS
-paas_app_environment       = "sandbox"
-paas_cf_space              = "bat-prod"
-paas_web_app_memory        = 1024
-paas_worker_app_memory     = 1024
-paas_web_app_instances     = 4
-paas_worker_app_instances  = 2
-paas_postgres_service_plan = "medium-ha-11"
-paas_redis_service_plan    = "micro-5_x"
+paas_app_environment           = "sandbox"
+paas_cf_space                  = "bat-prod"
+paas_web_app_memory            = 1024
+paas_worker_app_memory         = 1024
+paas_web_app_instances         = 4
+paas_worker_app_instances      = 2
+paas_postgres_service_plan     = "medium-ha-11"
+paas_worker_redis_service_plan = "micro-5_x"
 
 # KeyVault
 key_vault_resource_group    = "s121p01-shared-rg"

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -1,10 +1,10 @@
 # PaaS
-paas_app_environment       = "staging"
-paas_cf_space              = "bat-staging"
-paas_web_app_memory        = 1024
-paas_web_app_instances     = 2
-paas_postgres_service_plan = "small-11"
-paas_redis_service_plan    = "micro-5_x"
+paas_app_environment           = "staging"
+paas_cf_space                  = "bat-staging"
+paas_web_app_memory            = 1024
+paas_web_app_instances         = 2
+paas_postgres_service_plan     = "small-11"
+paas_worker_redis_service_plan = "micro-5_x"
 
 # KeyVault
 key_vault_resource_group    = "s121t01-shared-rg"


### PR DESCRIPTION
## Context

Having separate redis instances for sidekiq and rails cache.
To be followed up with another PR for creating the cache redis instance.

## Changes proposed in this pull request

Rename existing apply-redis instance to apply-worker-redis

Not renaming the existing terraform redis element `cloudfoundry_service_instance.redis` to `cloudfoundry_service_instance.redis_worker` as doing so creates a plan where it deletes the existing instance and recreates it with the new name.
So just specifying a new name inside the element for the resource being altered.


## Link to Trello card

https://trello.com/c/8gESiDbF/488-implement-redis-caching-for-apply

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
