### PR TITLE
Allow readonly viewing of org permissions

### DIFF
--- a/app/components/provider_interface/organisation_permissions_review_card_component.html.erb
+++ b/app/components/provider_interface/organisation_permissions_review_card_component.html.erb
@@ -1,6 +1,6 @@
 <%= render SummaryCardComponent.new(rows: permission_rows) do %>
   <%= render SummaryCardHeaderComponent.new(title: presenter.provider_relationship_description, heading_level: summary_card_heading_level) do %>
-    <% if change_path %>
+    <% if change_path && user_can_manage_relationship? %>
       <div class="app-summary-card__actions">
         <%= govuk_link_to change_path do %>
           Change

--- a/app/components/provider_interface/organisation_permissions_review_card_component.rb
+++ b/app/components/provider_interface/organisation_permissions_review_card_component.rb
@@ -17,27 +17,20 @@ module ProviderInterface
       ProviderRelationshipPermissions::PERMISSIONS.map do |permission_name|
         {
           key: label_for(permission_name),
-          value: providers_to_render_for(permission_name),
+          value: providers_with_permission(permission_name),
+          paragraph_format: true,
         }
       end
     end
 
   private
 
-    def label_for(permission_name)
-      t("provider_relationship_permissions.#{permission_name}.description")
+    def providers_with_permission(permission_name)
+      presenter.providers_with_permission(permission_name).presence || t('provider_relationship_permissions.no_provider_permitted')
     end
 
-    def providers_to_render_for(permission_name)
-      list_items = presenter.providers_with_permission(permission_name).map do |provider_name|
-        tag.li(provider_name)
-      end
-
-      provider_list = tag.ul(class: 'govuk-list') do
-        list_items.join.html_safe
-      end
-
-      provider_list.html_safe
+    def label_for(permission_name)
+      t("provider_relationship_permissions.#{permission_name}.description")
     end
   end
 end

--- a/app/components/provider_interface/organisation_permissions_review_card_component.rb
+++ b/app/components/provider_interface/organisation_permissions_review_card_component.rb
@@ -3,10 +3,11 @@ module ProviderInterface
     attr_reader :presenter, :provider_relationship_permission, :summary_card_heading_level, :change_path
 
     def initialize(provider_user:, provider_relationship_permission:, main_provider: nil, summary_card_heading_level: 2, change_path: nil)
+      @provider_user = provider_user
       @provider_relationship_permission = provider_relationship_permission
       @presenter = ProviderRelationshipPermissionAsProviderUserPresenter.new(
         relationship: provider_relationship_permission,
-        provider_user: provider_user,
+        provider_user: @provider_user,
         main_provider: main_provider,
       )
       @summary_card_heading_level = summary_card_heading_level
@@ -31,6 +32,12 @@ module ProviderInterface
 
     def label_for(permission_name)
       t("provider_relationship_permissions.#{permission_name}.description")
+    end
+
+    def user_can_manage_relationship?
+      relationship_providers = [provider_relationship_permission.training_provider, provider_relationship_permission.ratifying_provider]
+      auth = @provider_user.authorisation
+      relationship_providers.any? { |p| auth.can_manage_organisation?(provider: p) }
     end
   end
 end

--- a/app/controllers/provider_interface/organisation_permissions_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_controller.rb
@@ -84,7 +84,7 @@ module ProviderInterface
 
     def provider_relationships_to_display
       if FeatureFlag.active?(:account_and_org_settings_changes)
-        ProviderRelationshipPermissions.all_relationships_for_providers([provider]).providers_have_open_course
+        ProviderRelationshipPermissions.includes(:training_provider, :ratifying_provider).all_relationships_for_providers([provider]).providers_have_open_course
       else
         ProviderRelationshipPermissions.all_relationships_for_providers([provider]).where.not(setup_at: nil)
       end

--- a/app/controllers/provider_interface/organisation_permissions_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_controller.rb
@@ -14,7 +14,9 @@ module ProviderInterface
     end
 
     def index
-      render_403 unless current_provider_user.authorisation.can_manage_organisation?(provider: provider)
+      unless FeatureFlag.active?(:account_and_org_settings_changes) || current_provider_user.authorisation.can_manage_organisation?(provider: provider)
+        render_403 and return
+      end
 
       unsorted_provider_relationships = provider_relationships_to_display
       @provider_relationships = sort_relationships_by_provider_name(unsorted_provider_relationships, provider)

--- a/app/controllers/provider_interface/organisation_permissions_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_controller.rb
@@ -93,5 +93,17 @@ module ProviderInterface
         relationship.training_provider == provider ? relationship.ratifying_provider.name : relationship.training_provider.name
       end
     end
+
+    def change_link_for_relationship(relationship)
+      relationship_providers = [relationship.training_provider, relationship.ratifying_provider]
+      auth = current_provider_user.authorisation
+      current_user_can_manage_relationship = relationship_providers.any? { |p| auth.can_manage_organisation?(provider: p) }
+
+      if current_user_can_manage_relationship
+        edit_provider_interface_organisation_settings_organisation_organisation_permission_path(relationship, organisation_id: provider.id)
+      end
+    end
+
+    helper_method :change_link_for_relationship
   end
 end

--- a/app/controllers/provider_interface/organisation_permissions_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_controller.rb
@@ -8,6 +8,8 @@ module ProviderInterface
     # This action and the relevant route will be removed once Organisation Settings
     # is broken down into provider sections.
     def organisations
+      redirect_to provider_interface_organisation_settings_path if FeatureFlag.active?(:account_and_org_settings_changes)
+
       @manageable_providers = manageable_providers
     end
 

--- a/app/views/provider_interface/organisation_permissions/index.html.erb
+++ b/app/views/provider_interface/organisation_permissions/index.html.erb
@@ -1,11 +1,18 @@
 <%= content_for :browser_title, t('page_titles.provider.organisation_permissions') %>
 
 <% content_for :before_content do %>
-  <%= breadcrumbs({
-    t('page_titles.provider.organisation_settings') => provider_interface_organisation_settings_path,
-    t('page_titles.provider.organisation_permissions') => provider_interface_organisation_settings_organisations_path,
-    @provider.name => nil,
-  }) %>
+  <% if FeatureFlag.active?(:account_and_org_settings_changes) %>
+    <%= breadcrumbs({
+      t('page_titles.provider.organisation_settings') => provider_interface_organisation_settings_path,
+      t('page_titles.provider.organisation_permissions') => nil,
+    }) %>
+  <% else %>
+    <%= breadcrumbs({
+      t('page_titles.provider.organisation_settings') => provider_interface_organisation_settings_path,
+      t('page_titles.provider.organisation_permissions') => provider_interface_organisation_settings_organisations_path,
+      @provider.name => nil,
+    }) %>
+  <% end %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -8,6 +8,7 @@ en:
       description: View criminal convictions and professional misconduct
     view_diversity_information:
       description: View sex, disability and ethnicity information
+    no_provider_permitted: Neither organisation can do this
   provider_interface:
     organisation_permissions_form_component:
       setup:

--- a/spec/components/provider_interface/organisation_permissions_review_card_component_spec.rb
+++ b/spec/components/provider_interface/organisation_permissions_review_card_component_spec.rb
@@ -77,10 +77,20 @@ RSpec.describe ProviderInterface::OrganisationPermissionsReviewCardComponent do
     context 'when the change path is provided' do
       let(:change_path) { '/path-to-change' }
 
-      it 'renders an action link with hidden text set to the relationship description' do
-        expect(render.css('a').text).to include('Change')
-        expect(render.css('a .govuk-visually-hidden').text).to eq(" #{training_provider.name} and #{ratifying_provider.name}")
-        expect(render.css('a').first.attributes['href'].value).to eq(change_path)
+      context 'when the user can manage the relationship' do
+        let(:provider_user) { create(:provider_user, :with_manage_organisations, providers: [training_provider]) }
+
+        it 'renders an action link with hidden text set to the relationship description' do
+          expect(render.css('a').text).to include('Change')
+          expect(render.css('a .govuk-visually-hidden').text).to eq(" #{training_provider.name} and #{ratifying_provider.name}")
+          expect(render.css('a').first.attributes['href'].value).to eq(change_path)
+        end
+      end
+
+      context 'when the user cannot manage the relationship' do
+        it 'does not render an action link' do
+          expect(render.css('a')).to be_empty
+        end
       end
     end
   end

--- a/spec/components/provider_interface/organisation_permissions_review_card_component_spec.rb
+++ b/spec/components/provider_interface/organisation_permissions_review_card_component_spec.rb
@@ -138,13 +138,26 @@ RSpec.describe ProviderInterface::OrganisationPermissionsReviewCardComponent do
       end
     end
 
+    context 'when the permissions have not been set up' do
+      let(:provider_relationship_permission) { build_stubbed(:provider_relationship_permissions, :not_set_up_yet) }
+
+      it 'displays not set up yet text' do
+        make_decision_row = row_with_key('Make offers and reject applications')
+        safeguarding_row = row_with_key('View criminal convictions and professional misconduct')
+        diversity_row = row_with_key('View sex, disability and ethnicity information')
+        expect(entries_in_row(make_decision_row)).to contain_exactly('Neither organisation can do this')
+        expect(entries_in_row(safeguarding_row)).to contain_exactly('Neither organisation can do this')
+        expect(entries_in_row(diversity_row)).to contain_exactly('Neither organisation can do this')
+      end
+    end
+
     def row_with_key(key)
       rows = render.css('.govuk-summary-list__row')
       rows.find { |row| row.css('.govuk-summary-list__key').text.squish == key }
     end
 
     def entries_in_row(row)
-      row.css('.govuk-summary-list__value > ul > li').map(&:text)
+      row.css('.govuk-summary-list__value > p').map(&:text)
     end
   end
 end

--- a/spec/requests/provider_interface/organisation_permissions_spec.rb
+++ b/spec/requests/provider_interface/organisation_permissions_spec.rb
@@ -18,6 +18,27 @@ RSpec.describe 'Viewing organisation permissions', type: :request do
       )
   end
 
+  describe 'GET organisations' do
+    context 'with the account_and_org_settings_changes feature flag on' do
+      before { FeatureFlag.activate(:account_and_org_settings_changes) }
+
+      it 'redirects to the organisation settings page' do
+        get provider_interface_organisation_settings_organisations_path
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(provider_interface_organisation_settings_url)
+      end
+    end
+
+    context 'with the account_and_org_settings_changes feature flag off' do
+      before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
+
+      it 'responds with 200' do
+        get provider_interface_organisation_settings_organisations_path
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+
   describe 'without manage organisations' do
     let(:provider_user) { create(:provider_user, providers: [training_provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
 

--- a/spec/requests/provider_interface/organisation_permissions_spec.rb
+++ b/spec/requests/provider_interface/organisation_permissions_spec.rb
@@ -42,19 +42,42 @@ RSpec.describe 'Viewing organisation permissions', type: :request do
   describe 'without manage organisations' do
     let(:provider_user) { create(:provider_user, providers: [training_provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
 
-    it 'GET index responds with 403' do
-      get provider_interface_organisation_settings_organisation_organisation_permissions_path(training_provider)
-      expect(response.status).to eq(403)
+    context 'with the account_and_org_settings_changes feature flag on' do
+      before { FeatureFlag.activate(:account_and_org_settings_changes) }
+
+      it 'GET index responds with 200' do
+        get provider_interface_organisation_settings_organisation_organisation_permissions_path(training_provider)
+        expect(response.status).to eq(200)
+      end
+
+      it 'GET edit responds with 403' do
+        get edit_provider_interface_organisation_settings_organisation_organisation_permission_path(relationship, organisation_id: training_provider.id)
+        expect(response.status).to eq(403)
+      end
+
+      it 'PATCH update responds with 403' do
+        patch provider_interface_organisation_settings_organisation_organisation_permission_path(relationship, organisation_id: training_provider)
+        expect(response.status).to eq(403)
+      end
     end
 
-    it 'GET edit responds with 403' do
-      get edit_provider_interface_organisation_settings_organisation_organisation_permission_path(relationship, organisation_id: training_provider.id)
-      expect(response.status).to eq(403)
-    end
+    context 'with the account_and_org_settings_changes feature flag off' do
+      before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
 
-    it 'PATCH update responds with 403' do
-      patch provider_interface_organisation_settings_organisation_organisation_permission_path(relationship, organisation_id: training_provider)
-      expect(response.status).to eq(403)
+      it 'GET index responds with 403' do
+        get provider_interface_organisation_settings_organisation_organisation_permissions_path(training_provider)
+        expect(response.status).to eq(403)
+      end
+
+      it 'GET edit responds with 403' do
+        get edit_provider_interface_organisation_settings_organisation_organisation_permission_path(relationship, organisation_id: training_provider.id)
+        expect(response.status).to eq(403)
+      end
+
+      it 'PATCH update responds with 403' do
+        patch provider_interface_organisation_settings_organisation_organisation_permission_path(relationship, organisation_id: training_provider)
+        expect(response.status).to eq(403)
+      end
     end
   end
 

--- a/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
@@ -101,7 +101,7 @@ RSpec.feature 'Provider edits organisation permissions' do
   end
 
   def and_my_organisation_is_listed_as_able_to_make_decisions
-    expect(page).to have_content("Make offers and reject applications\n#{@ratifying_provider.name}#{@training_provider.name}")
+    expect(page).to have_content("Make offers and reject applications\n#{@ratifying_provider.name}\n#{@training_provider.name}")
   end
 
   def and_my_organisation_is_able_to_make_decisions

--- a/spec/system/provider_interface/provider_views_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_views_organisation_permissions_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Viewing organisation permissions' do
   include DfESignInHelpers
 
+  # Behaviour tested here has moved to spec/system/provider_interface/view_organisation_permissions_spec.rb
   before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
 
   scenario 'Provider user views their organisation permissions page with various permissions' do

--- a/spec/system/provider_interface/view_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/view_organisation_permissions_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.feature 'Organisation permissions' do
+  include DfESignInHelpers
+
+  before { FeatureFlag.activate(:account_and_org_settings_changes) }
+
+  scenario 'Provider user views their organisation permissions page with various permissions' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_can_manage_orgs_for_one_provider
+    and_i_cannot_manage_orgs_for_another_provider
+    and_i_belong_to_a_provider_with_no_open_courses
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_go_to_organisation_settings
+    then_i_can_see_the_correct_organisation_permissions_links
+
+    when_i_go_to_organisation_settings
+    and_i_click_on_organisation_permissions_for_the_provider_i_can_manage
+    then_i_can_see_the_permissions_with_change_links
+
+    when_i_go_to_organisation_settings
+    and_i_click_on_organisation_permissions_for_the_provider_i_cannot_manage
+    then_i_can_see_the_permissions_that_have_been_set_up_without_change_links
+    and_i_can_see_non_set_up_permissions
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_can_manage_orgs_for_one_provider
+    @manage_orgs_provider = create(:provider, :with_signed_agreement, code: 'ABC')
+    @provider_user = create(
+      :provider_user,
+      :with_manage_organisations,
+      providers: [@manage_orgs_provider],
+      dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
+      email_address: 'email@provider.ac.uk',
+    )
+
+    relationship = create(:provider_relationship_permissions, training_provider: @manage_orgs_provider)
+    @manage_orgs_partner = relationship.ratifying_provider
+    create_open_course_for_relationship(relationship)
+  end
+
+  def and_i_cannot_manage_orgs_for_another_provider
+    @read_only_provider = create(:provider, :with_signed_agreement, code: 'DEF')
+    create(:provider_permissions, provider_user: @provider_user, provider: @read_only_provider)
+
+    set_up_relationship = create(:provider_relationship_permissions, ratifying_provider: @read_only_provider)
+    create_open_course_for_relationship(set_up_relationship)
+    @set_up_read_only_partner = set_up_relationship.training_provider
+
+    not_set_up_relationship = create(:provider_relationship_permissions, :not_set_up_yet, ratifying_provider: @read_only_provider)
+    create_open_course_for_relationship(not_set_up_relationship)
+    @not_set_up_read_only_partner = not_set_up_relationship.training_provider
+  end
+
+  def create_open_course_for_relationship(relationship)
+    create(:course, :open_on_apply, provider: relationship.training_provider, accredited_provider: relationship.ratifying_provider)
+  end
+
+  def and_i_belong_to_a_provider_with_no_open_courses
+    @no_open_courses_provider = create(:provider, :with_signed_agreement, code: 'GHI')
+    create(:provider_permissions, provider_user: @provider_user, provider: @no_open_courses_provider)
+
+    create(:provider_relationship_permissions, training_provider: @no_open_courses_provider)
+  end
+
+  def when_i_go_to_organisation_settings
+    click_on t('page_titles.provider.organisation_settings'), match: :first
+  end
+
+  def then_i_can_see_the_correct_organisation_permissions_links
+    expect(page).to have_link("Organisation permissions #{@manage_orgs_provider.name}")
+    expect(page).to have_link("Organisation permissions #{@read_only_provider.name}")
+    expect(page).not_to have_link("Organisation permissions #{@no_open_courses_provider.name}")
+  end
+
+  def and_i_click_on_organisation_permissions_for_the_provider_i_can_manage
+    click_on "Organisation permissions #{@manage_orgs_provider.name}"
+  end
+
+  def then_i_can_see_the_permissions_with_change_links
+    expect(page).to have_selector('h2', text: "#{@manage_orgs_provider.name} and #{@manage_orgs_partner.name}")
+    expect(page).to have_selector('a', text: "Change #{@manage_orgs_provider.name} and #{@manage_orgs_partner.name}")
+  end
+
+  def and_i_click_on_organisation_permissions_for_the_provider_i_cannot_manage
+    click_on "Organisation permissions #{@read_only_provider.name}"
+  end
+
+  def then_i_can_see_the_permissions_that_have_been_set_up_without_change_links
+    expect(page).to have_selector('h2', text: "#{@read_only_provider.name} and #{@set_up_read_only_partner.name}")
+    expect(page).not_to have_selector('.app-summary-card__actions > a')
+  end
+
+  def and_i_can_see_non_set_up_permissions
+    expect(page).to have_selector('h2', text: "#{@read_only_provider.name} and #{@not_set_up_read_only_partner.name}")
+    expect(page).to have_selector('.govuk-summary-list__value', text: 'Neither organisation can do this')
+  end
+end


### PR DESCRIPTION
## Context
We are relaxing the rules around viewing organisation permissions to help demystify them.

## Changes proposed in this pull request
Behind the feature flag:
- Redirect away from the organisations list page under 'Org permissions'
- Show all permissions that have an open course associated (including non-setup ones)
- Do not 403 on permissions index page for a provider

Also more generally:
- Update the permissions display component to handle rendering non-setup permissions

## Guidance to review
Per commit

## Link to Trello card
https://trello.com/c/z3EDakZA/4082-changes-to-organisation-permissions

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
