### PR TITLE
Check that RBD does not go beyond the EoC deadline

### DIFF
--- a/app/services/set_reject_by_default.rb
+++ b/app/services/set_reject_by_default.rb
@@ -1,14 +1,15 @@
 class SetRejectByDefault
-  attr_reader :application_choice
+  attr_reader :application_choice, :effective_date
 
   def initialize(application_choice)
     @application_choice = application_choice
+    @effective_date = application_choice.sent_to_provider_at
   end
 
   def call
     time_limit = TimeLimitCalculator.new(
       rule: :reject_by_default,
-      effective_date: application_choice.sent_to_provider_at,
+      effective_date: effective_date,
     ).call
 
     days = time_limit[:days]
@@ -17,9 +18,21 @@ class SetRejectByDefault
     return if application_choice.reject_by_default_at.to_s == time.in_time_zone.to_s &&
               application_choice.reject_by_default_days == days
 
+    rbd_date = beyond_eoc?(time) ? eoc_rbd_date : time
+
     application_choice.update!(
-      reject_by_default_at: time,
+      reject_by_default_at: rbd_date,
       reject_by_default_days: days,
     )
+  end
+
+private
+
+  def beyond_eoc?(date)
+    date >= CycleTimetable.find_closes
+  end
+
+  def eoc_rbd_date
+    0.business_days.before(CycleTimetable.find_closes).end_of_day
   end
 end

--- a/app/services/time_limit_calculator.rb
+++ b/app/services/time_limit_calculator.rb
@@ -8,6 +8,7 @@ class TimeLimitCalculator
 
   def call
     days = calculate_days
+
     {
       days: days,
       time_in_future: calculate_time_in_future(days),

--- a/spec/services/set_reject_by_default_spec.rb
+++ b/spec/services/set_reject_by_default_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe SetRejectByDefault do
       ['4 Jan 2019 11:00:00 PM GMT', '2 Mar 2019 0:00:00 AM GMT',  'safely within GMT'],
       ['1 Jul 2020 11:00:00 PM BST', '30 Jul 2020 0:00:00 AM BST', 'during the 20-day summer period'],
       ['21 Nov 2020 12:00:00 PM GMT', '2 Feb 2021 0:00:00 AM GMT', 'near the UCAS winter break'],
+      ['1 Sept 2021 0:00:00 AM BST', '29 Sept 2021 23:59:59 PM BST', 'not beyond the 2021 EoC deadline'],
+      ['7 Sept 2021 0:00:00 AM BST', '1 Oct 2021 23:59:59 PM BST', 'beyond the 2021 EoC deadline'],
+      ['20 Sept 2021 0:00:00 AM BST', '1 Oct 2021 23:59:59 PM BST', 'beyond the 2021 EoC deadline'],
+      ['29 Sept 2021 0:00:00 AM BST', '1 Oct 2021 23:59:59 PM BST', 'beyond the 2021 EoC deadline'],
+      ['28 Sept 2020 0:00:00 AM BST', '2 Oct 2020 23:59:59 PM BST', 'beyond the 2020 EoC deadline'],
     ].freeze
 
     submitted_vs_rbd_dates.each do |submitted, correct_rbd, test_case|


### PR DESCRIPTION
## Context

The reject by default value defaults to 20 days for all applications awaiting decisions. However if there are applications submitted towards the end of cycle the RBD might fall after the cycle deadline. We need to ensure that does not happen.

## Changes proposed in this pull request

Two new methods added to the `SetRejectByDefault` class

`beyond_eoc?` checks to see if the standard RBD date will go beyond the EoC deadline.

if this returns true then `calculate_eoc_rbd` will return the RBD date as the business day before the EoC deadline.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/CnHqjKjp

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
