### PR TITLE
Config redis cache instance for rails cache_store

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ ENV WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine \
     AUTHORISED_HOSTS=127.0.0.1 \
     SECRET_KEY_BASE=TestKey \
     BLAZER_DATABASE_URL=testURL \
-    GOVUK_NOTIFY_CALLBACK_API_KEY=TestKey
+    GOVUK_NOTIFY_CALLBACK_API_KEY=TestKey \
+    REDIS_CACHE_URL=redis://127.0.0.1:6379
 
 WORKDIR /app
 
@@ -51,7 +52,8 @@ ENV WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine \
     AUTHORISED_HOSTS=127.0.0.1 \
     SECRET_KEY_BASE=TestKey \
     GOVUK_NOTIFY_CALLBACK_API_KEY=TestKey \
-    SHA=${VERSION}
+    SHA=${VERSION} \
+    REDIS_CACHE_URL=redis://127.0.0.1:6379
 
 RUN apk -U upgrade && \
     apk add --update --no-cache tzdata libpq libxml2 libxslt graphviz && \

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,6 +21,8 @@ Rails.application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
+  config.cache_store = :redis_cache_store, { url: ENV.fetch('REDIS_CACHE_URL') }
+
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - DB_DATABASE=bat_apply_dev
       - DB_PORT=5432
       - REDIS_URL=redis://redis:6379/1
+      - REDIS_CACHE_URL=redis://redis:6379/0
     env_file:
       - .env
     command: /bin/sh -c "rm -f tmp/pids/server.pid && bundle exec rails server -b 0.0.0.0"
@@ -60,6 +61,6 @@ services:
       - REDIS_URL=redis://redis:6379/1
     env_file:
       - .env
-    command: /bin/sh -c "bundle exec clockwork config/clock.rb"    
+    command: /bin/sh -c "bundle exec clockwork config/clock.rb"
 volumes:
   db_data:

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -153,6 +153,11 @@ resource "cloudfoundry_service_key" "worker_redis_key" {
   service_instance = cloudfoundry_service_instance.redis.id
 }
 
+resource "cloudfoundry_service_key" "cache_redis_key" {
+  name             = "${local.cache_redis_service_name}-key"
+  service_instance = cloudfoundry_service_instance.redis_cache.id
+}
+
 resource "cloudfoundry_user_provided_service" "logging" {
   name             = local.logging_service_name
   space            = data.cloudfoundry_space.space.id

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -132,6 +132,17 @@ resource "cloudfoundry_service_instance" "redis" {
   }
 }
 
+resource "cloudfoundry_service_instance" "redis_cache" {
+  name         = local.cache_redis_service_name
+  space        = data.cloudfoundry_space.space.id
+  service_plan = data.cloudfoundry_service.redis.service_plans[var.cache_redis_service_plan]
+  json_params  = jsonencode(local.allkeys_lru_maxmemory_policy)
+  timeouts {
+    create = "30m"
+    update = "30m"
+  }
+}
+
 resource "cloudfoundry_service_key" "postgres-readonly-key" {
   name             = "${local.postgres_service_name}-readonly-key"
   service_instance = cloudfoundry_service_instance.postgres.id

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -44,6 +44,7 @@ locals {
   worker_app_name           = "apply-worker-${var.app_environment}"
   postgres_service_name     = "apply-postgres-${var.app_environment}"
   worker_redis_service_name = "apply-worker-redis-${var.app_environment}"
+  cache_redis_service_name  = "apply-cache-redis-${var.app_environment}"
   logging_service_name      = "apply-logit-${var.app_environment}"
   postgres_params = {
     enable_extensions = ["pg_buffercache", "pg_stat_statements", "pgcrypto"]
@@ -51,7 +52,11 @@ locals {
   noeviction_maxmemory_policy = {
     maxmemory_policy = "noeviction"
   }
-  app_service_bindings = [cloudfoundry_service_instance.postgres, cloudfoundry_service_instance.redis, cloudfoundry_user_provided_service.logging]
+  allkeys_lru_maxmemory_policy = {
+    maxmemory_policy = "allkeys-lru"
+  }
+  app_service_bindings = [cloudfoundry_service_instance.postgres, cloudfoundry_service_instance.redis,
+  cloudfoundry_service_instance.redis_cache, cloudfoundry_user_provided_service.logging]
   service_gov_uk_host_names = {
     qa        = "qa"
     staging   = "staging"

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -79,6 +79,7 @@ locals {
     {
       BLAZER_DATABASE_URL = cloudfoundry_service_key.postgres-readonly-key.credentials.uri
       REDIS_URL           = cloudfoundry_service_key.worker_redis_key.credentials.uri
+      REDIS_CACHE_URL     = cloudfoundry_service_key.cache_redis_key.credentials.uri
   })
   web_app_env_variables    = merge(local.app_environment_variables, { SERVICE_TYPE = "web" })
   clock_app_env_variables  = merge(local.app_environment_variables, { SERVICE_TYPE = "clock" })

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -24,6 +24,8 @@ variable "postgres_service_plan" {}
 
 variable "worker_redis_service_plan" {}
 
+variable "cache_redis_service_plan" {}
+
 variable "clock_app_memory" {}
 
 variable "worker_app_memory" {}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -46,6 +46,7 @@ module "paas" {
   logstash_url              = local.infra_secrets.LOGSTASH_URL
   postgres_service_plan     = var.paas_postgres_service_plan
   worker_redis_service_plan = var.paas_worker_redis_service_plan
+  cache_redis_service_plan  = var.paas_cache_redis_service_plan
   clock_app_memory          = var.paas_clock_app_memory
   worker_app_memory         = var.paas_worker_app_memory
   clock_app_instances       = var.paas_clock_app_instances

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,6 +15,8 @@ variable "paas_postgres_service_plan" {}
 
 variable "paas_worker_redis_service_plan" {}
 
+variable "paas_cache_redis_service_plan" {}
+
 variable "paas_clock_app_memory" { default = 512 }
 
 variable "paas_worker_app_memory" { default = 512 }

--- a/terraform/workspace_variables/loadtest.tfvars
+++ b/terraform/workspace_variables/loadtest.tfvars
@@ -8,6 +8,7 @@ paas_web_app_instances         = 4
 paas_worker_app_instances      = 2
 paas_postgres_service_plan     = "medium-ha-11"
 paas_worker_redis_service_plan = "micro-ha-5_x"
+paas_cache_redis_service_plan  = "micro-ha-5_x"
 
 # KeyVault
 key_vault_resource_group    = "s121d01-shared-rg"

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -8,6 +8,7 @@ paas_web_app_instances         = 8
 paas_worker_app_instances      = 2
 paas_postgres_service_plan     = "medium-ha-11"
 paas_worker_redis_service_plan = "micro-ha-5_x"
+paas_cache_redis_service_plan  = "micro-ha-5_x"
 
 # KeyVault
 key_vault_resource_group    = "s121p01-shared-rg"

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -5,6 +5,7 @@ paas_web_app_memory            = 1024
 paas_web_app_instances         = 2
 paas_postgres_service_plan     = "small-11"
 paas_worker_redis_service_plan = "micro-5_x"
+paas_cache_redis_service_plan  = "micro-5_x"
 
 # KeyVault
 key_vault_resource_group    = "s121d01-shared-rg"

--- a/terraform/workspace_variables/research.tfvars
+++ b/terraform/workspace_variables/research.tfvars
@@ -5,6 +5,7 @@ paas_web_app_memory            = 1024
 paas_web_app_instances         = 2
 paas_postgres_service_plan     = "small-11"
 paas_worker_redis_service_plan = "micro-5_x"
+paas_cache_redis_service_plan  = "micro-5_x"
 
 # KeyVault
 key_vault_resource_group    = "s121d01-shared-rg"

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -7,6 +7,7 @@ paas_web_app_instances         = 4
 paas_worker_app_instances      = 2
 paas_postgres_service_plan     = "medium-ha-11"
 paas_worker_redis_service_plan = "micro-5_x"
+paas_cache_redis_service_plan  = "micro-5_x"
 
 # KeyVault
 key_vault_resource_group    = "s121p01-shared-rg"

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -5,6 +5,7 @@ paas_web_app_memory            = 1024
 paas_web_app_instances         = 2
 paas_postgres_service_plan     = "small-11"
 paas_worker_redis_service_plan = "micro-5_x"
+paas_cache_redis_service_plan  = "micro-5_x"
 
 # KeyVault
 key_vault_resource_group    = "s121t01-shared-rg"


### PR DESCRIPTION
## Context

Create a separate redis instance for application cache.

## Changes proposed in this pull request

Create a new redis instance with LRU policy for use as a rails cache store.
Set `:memory_store` as `cache_store` for non production environments
Set `:redis_store` as `cache_store` for production

## Link to Trello card

https://trello.com/c/8gESiDbF/488-implement-redis-caching-for-apply

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
