### PR TITLE
Update change and back links for unpaid experience

### DIFF
--- a/app/components/candidate_interface/volunteering_review_component.rb
+++ b/app/components/candidate_interface/volunteering_review_component.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     include ViewHelper
     include DateValidationHelper
 
-    def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false, show_experience_advice: false)
+    def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false, show_experience_advice: false, return_to_application_review: false)
       @application_form = application_form
       @volunteering_roles = CandidateInterface::VolunteeringRoleForm.build_all_from_application(
         @application_form,
@@ -13,6 +13,7 @@ module CandidateInterface
       @show_incomplete = show_incomplete
       @missing_error = missing_error
       @show_experience_advice = show_experience_advice
+      @return_to_application_review = return_to_application_review
     end
 
     def volunteering_role_rows(volunteering_role)
@@ -49,7 +50,8 @@ module CandidateInterface
         key: t('application_form.volunteering.role.review_label'),
         value: volunteering_role.role,
         action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.role.change_action')),
-        change_path: edit_path(volunteering_role),
+        change_path: edit_path(volunteering_role, return_to_params),
+        data_qa: 'volunteering-role',
       }
     end
 
@@ -58,7 +60,8 @@ module CandidateInterface
         key: t('application_form.volunteering.organisation.review_label'),
         value: volunteering_role.organisation,
         action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.organisation.change_action')),
-        change_path: edit_path(volunteering_role),
+        change_path: edit_path(volunteering_role, return_to_params),
+        data_qa: 'volunteering-organisation',
       }
     end
 
@@ -67,7 +70,8 @@ module CandidateInterface
         key: t('application_form.volunteering.working_with_children.review_label'),
         value: volunteering_role.working_with_children ? 'Yes' : 'No',
         action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.working_with_children.change_action')),
-        change_path: edit_path(volunteering_role),
+        change_path: edit_path(volunteering_role, return_to_params),
+        data_qa: 'volunteering-working-with-children',
       }
     end
 
@@ -76,7 +80,8 @@ module CandidateInterface
         key: t('application_form.volunteering.length.review_label'),
         value: formatted_length(volunteering_role),
         action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.length.change_action')),
-        change_path: edit_path(volunteering_role),
+        change_path: edit_path(volunteering_role, return_to_params),
+        data_qa: 'volunteering-length',
       }
     end
 
@@ -85,7 +90,8 @@ module CandidateInterface
         key: t('application_form.volunteering.details.review_label'),
         value: formatted_details(volunteering_role),
         action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.details.change_action')),
-        change_path: edit_path(volunteering_role),
+        change_path: edit_path(volunteering_role, return_to_params),
+        data_qa: 'volunteering-details',
       }
     end
 
@@ -107,8 +113,8 @@ module CandidateInterface
       volunteering_role.end_date.to_s(:month_and_year)
     end
 
-    def edit_path(volunteering_role)
-      candidate_interface_edit_volunteering_role_path(volunteering_role.id)
+    def edit_path(volunteering_role, return_to_params)
+      candidate_interface_edit_volunteering_role_path(volunteering_role.id, return_to_params)
     end
 
     def generate_action(volunteering_role:, attribute: '')
@@ -126,6 +132,10 @@ module CandidateInterface
         organisation: volunteering_role.organisation,
       )
       roles.many?
+    end
+
+    def return_to_params
+      { 'return-to' => 'application-review' } if @return_to_application_review
     end
   end
 end

--- a/app/controllers/candidate_interface/volunteering/role_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/role_controller.rb
@@ -20,12 +20,16 @@ module CandidateInterface
     def edit
       current_experience = current_application.application_volunteering_experiences.find(current_volunteering_role_id)
       @volunteering_role = VolunteeringRoleForm.build_from_experience(current_experience)
+      @return_to = return_to_after_edit(default: candidate_interface_complete_volunteering_path)
     end
 
     def update
       @volunteering_role = VolunteeringRoleForm.new(volunteering_role_params)
+      @return_to = return_to_after_edit(default: candidate_interface_complete_volunteering_path)
 
       if @volunteering_role.update(current_application)
+        return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
+
         redirect_to candidate_interface_review_volunteering_path
       else
         track_validation_error(@volunteering_role)

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -114,7 +114,7 @@
     <%= render(CandidateInterface::WorkHistoryReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, show_incomplete: !application_form.work_history_completed && editable, missing_error: missing_error)) %>
   <% end %>
   <h3 class="govuk-heading-m"><%= t('page_titles.volunteering.short') %></h3>
-  <%= render(CandidateInterface::VolunteeringReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, show_incomplete: true, missing_error: missing_error)) %>
+  <%= render(CandidateInterface::VolunteeringReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, show_incomplete: true, missing_error: missing_error, return_to_application_review: true)) %>
 </section>
 
 <section class="govuk-!-margin-bottom-8">

--- a/app/views/candidate_interface/volunteering/role/edit.html.erb
+++ b/app/views/candidate_interface/volunteering/role/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.edit_volunteering_role'), @volunteering_role.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_review_volunteering_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @volunteering_role, url: candidate_interface_edit_volunteering_role_path, method: :patch do |f| %>
+    <%= form_with model: @volunteering_role, url: candidate_interface_edit_volunteering_role_path(@return_to[:params]), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_unpaid_experience_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_unpaid_experience_section_spec.rb
@@ -129,9 +129,9 @@ RSpec.feature 'Candidate is redirected correctly' do
   def then_i_should_see_the_edit_role_form
     expect(page).to have_current_path(
       candidate_interface_edit_volunteering_role_path(
-      current_candidate.application_forms.first.application_volunteering_experiences.first.id,
-      'return-to' => 'application-review'
-      )
+        current_candidate.application_forms.first.application_volunteering_experiences.first.id,
+        'return-to' => 'application-review',
+      ),
     )
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_unpaid_experience_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_unpaid_experience_section_spec.rb
@@ -1,0 +1,229 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate is redirected correctly' do
+  include CandidateHelper
+
+  scenario 'Candidate reviews completed application and updates unpaid experience section' do
+    given_i_am_signed_in
+    when_i_have_completed_my_application
+    and_i_review_my_application
+    then_i_should_see_all_sections_are_complete
+
+    # each attribute is edited via the same form but have written system spec to
+    # be scalable should they be separated
+
+    # role
+    when_i_click_change_role
+    then_i_should_see_the_edit_role_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_the_role
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_the_updated_role
+
+    # organisation
+    when_i_click_change_organisation
+    then_i_should_see_the_edit_role_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_the_organisation
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_the_updated_organisation
+
+    # working with children
+    when_i_click_change_working_with_children
+    then_i_should_see_the_edit_role_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_working_with_children
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_updated_working_with_children
+
+    # length
+    when_i_click_change_length
+    then_i_should_see_the_edit_role_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_the_length
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_the_updated_length
+
+    # details
+    when_i_click_change_details
+    then_i_should_see_the_edit_role_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_the_details
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_the_updated_details
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_have_completed_my_application
+    candidate_completes_application_form
+  end
+
+  def and_i_review_my_application
+    allow(LanguagesSectionPolicy).to receive(:hide?).and_return(false)
+    and_i_visit_the_application_form_page
+    when_i_click_on_check_your_answers
+  end
+
+  def then_i_should_see_all_sections_are_complete
+    application_form_sections.each do |section|
+      expect(page).not_to have_selector "[data-qa='incomplete-#{section}']"
+    end
+  end
+
+  def and_i_visit_the_application_form_page
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_check_your_answers
+    click_link 'Check and submit your application'
+  end
+
+  def when_i_click_change_role
+    within('[data-qa="volunteering-role"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_organisation
+    within('[data-qa="volunteering-organisation"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_working_with_children
+    within('[data-qa="volunteering-working-with-children"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_length
+    within('[data-qa="volunteering-length"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_details
+    within('[data-qa="volunteering-details"]') do
+      click_link 'Change'
+    end
+  end
+
+  def then_i_should_see_the_edit_role_form
+    expect(page).to have_current_path(
+      candidate_interface_edit_volunteering_role_path(
+      current_candidate.application_forms.first.application_volunteering_experiences.first.id,
+      'return-to' => 'application-review'
+      )
+    )
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def then_i_should_be_redirected_to_the_application_review_page
+    expect(page).to have_current_path(candidate_interface_application_review_path)
+  end
+
+  def when_i_update_the_role
+    when_i_click_change_role
+    fill_in 'Your role', with: 'School Assistant'
+    click_button 'Save and continue'
+  end
+
+  def when_i_update_the_organisation
+    when_i_click_change_organisation
+    fill_in 'Organisation where you gained experience or volunteered', with: 'Reigate Priory'
+    click_button 'Save and continue'
+  end
+
+  def when_i_update_working_with_children
+    when_i_click_change_working_with_children
+
+    choose 'No'
+    click_button 'Save and continue'
+  end
+
+  def when_i_update_the_length
+    when_i_click_change_length
+
+    within('[data-qa="start-date"]') do
+      fill_in 'Month', with: '11'
+    end
+
+    click_button 'Save and continue'
+  end
+
+  def when_i_update_the_details
+    when_i_click_change_details
+
+    fill_in 'Enter details of your time commitment and responsibilities', with: 'Part time trainee'
+    click_button 'Save and continue'
+  end
+
+  def and_i_should_see_the_updated_role
+    within('[data-qa="volunteering-role"]') do
+      expect(page).to have_content('School Assistant')
+    end
+  end
+
+  def when_i_click_change_working_with_children
+    within('[data-qa="volunteering-working-with-children"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_length
+    within('[data-qa="volunteering-length"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_details
+    within('[data-qa="volunteering-details"]') do
+      click_link 'Change'
+    end
+  end
+
+  def and_i_should_see_the_updated_organisation
+    within('[data-qa="volunteering-organisation"]') do
+      expect(page).to have_content('Reigate Priory')
+    end
+  end
+
+  def and_i_should_see_updated_working_with_children
+    within('[data-qa="volunteering-working-with-children"]') do
+      expect(page).to have_content('No')
+    end
+  end
+
+  def and_i_should_see_the_updated_length
+    within('[data-qa="volunteering-length"]') do
+      expect(page).to have_content('November')
+    end
+  end
+
+  def and_i_should_see_the_updated_details
+    within('[data-qa="volunteering-details"]') do
+      expect(page).to have_content('Part time trainee')
+    end
+  end
+end


### PR DESCRIPTION
## Context

In line with chaqnges to back links across the application. following on from Toby's initial #5273 

## Changes proposed in this pull request

back link on edit form now directs contextually depending on the screen user came from.

## Guidance to review

Test functionality in review app.

## Link to Trello card

https://trello.com/c/xjnzXLcY/3769-change-links-and-backlinks-are-not-working-correctly-from-the-review-unsubmitted-page-unpaid-experience-section

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
