### PR TITLE
Fix change links and backlinks for English as a foreign language section

### DIFF
--- a/app/components/candidate_interface/english_foreign_language/efl_review_helper.rb
+++ b/app/components/candidate_interface/english_foreign_language/efl_review_helper.rb
@@ -1,23 +1,27 @@
 module CandidateInterface
   module EnglishForeignLanguage
     module EflReviewHelper
-      def do_you_have_a_qualification_row(value:)
+      def do_you_have_a_qualification_row(value:, return_to_application_review: false)
         {
           key: 'Have you done an English as a foreign language assessment?',
           value: value,
           action: 'whether or not you have a qualification',
-          change_path: candidate_interface_english_foreign_language_edit_start_path,
+          change_path: candidate_interface_english_foreign_language_edit_start_path(return_to_params(return_to_application_review)),
           data_qa: 'english-as-a-foreign-language',
         }
       end
 
-      def type_of_qualification_row(name:)
+      def type_of_qualification_row(name:, return_to_application_review: false)
         {
           key: 'Type of assessment',
           value: name,
           action: 'type of assessment',
-          change_path: candidate_interface_english_foreign_language_type_path,
+          change_path: candidate_interface_english_foreign_language_type_path(return_to_params(return_to_application_review)),
         }
+      end
+
+      def return_to_params(return_to_application_review)
+        { 'return-to' => 'application-review' } if return_to_application_review
       end
     end
   end

--- a/app/components/candidate_interface/english_foreign_language/efl_review_helper.rb
+++ b/app/components/candidate_interface/english_foreign_language/efl_review_helper.rb
@@ -17,6 +17,7 @@ module CandidateInterface
           value: name,
           action: 'type of assessment',
           change_path: candidate_interface_english_foreign_language_type_path(return_to_params(return_to_application_review)),
+          data_qa: 'english-as-a-foreign-language-type',
         }
       end
 

--- a/app/components/candidate_interface/english_foreign_language/efl_review_helper.rb
+++ b/app/components/candidate_interface/english_foreign_language/efl_review_helper.rb
@@ -7,6 +7,7 @@ module CandidateInterface
           value: value,
           action: 'whether or not you have a qualification',
           change_path: candidate_interface_english_foreign_language_edit_start_path,
+          data_qa: 'english-as-a-foreign-language',
         }
       end
 

--- a/app/components/candidate_interface/english_foreign_language/ielts_review_component.rb
+++ b/app/components/candidate_interface/english_foreign_language/ielts_review_component.rb
@@ -18,19 +18,19 @@ module CandidateInterface
             key: 'Test report form (TRF) number',
             value: ielts_qualification.trf_number,
             action: 'Change TRF number',
-            change_path: candidate_interface_edit_ielts_path,
+            change_path: candidate_interface_edit_ielts_path(return_to_params(return_to_application_review)),
           },
           {
             key: 'Year completed',
             value: ielts_qualification.award_year,
             action: 'Change year completed',
-            change_path: candidate_interface_edit_ielts_path,
+            change_path: candidate_interface_edit_ielts_path(return_to_params(return_to_application_review)),
           },
           {
             key: 'Overall band score',
             value: ielts_qualification.band_score,
             action: 'Change overall band score',
-            change_path: candidate_interface_edit_ielts_path,
+            change_path: candidate_interface_edit_ielts_path(return_to_params(return_to_application_review)),
           },
         ]
       end

--- a/app/components/candidate_interface/english_foreign_language/ielts_review_component.rb
+++ b/app/components/candidate_interface/english_foreign_language/ielts_review_component.rb
@@ -3,16 +3,17 @@ module CandidateInterface
     class IeltsReviewComponent < ViewComponent::Base
       include EflReviewHelper
 
-      attr_reader :ielts_qualification
+      attr_reader :ielts_qualification, :return_to_application_review
 
-      def initialize(ielts_qualification)
+      def initialize(ielts_qualification, return_to_application_review: false)
         @ielts_qualification = ielts_qualification
+        @return_to_application_review = return_to_application_review
       end
 
       def ielts_rows
         [
-          do_you_have_a_qualification_row(value: 'Yes'),
-          type_of_qualification_row(name: 'IELTS'),
+          do_you_have_a_qualification_row(value: 'Yes', return_to_application_review: return_to_application_review),
+          type_of_qualification_row(name: 'IELTS', return_to_application_review: return_to_application_review),
           {
             key: 'Test report form (TRF) number',
             value: ielts_qualification.trf_number,

--- a/app/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component.rb
+++ b/app/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component.rb
@@ -12,7 +12,7 @@ module CandidateInterface
 
       def no_qualification_rows
         [
-          do_you_have_a_qualification_row(value: summary, return_to_application_review: return_to_application_review, return_to_application_review: return_to_application_review),
+          do_you_have_a_qualification_row(value: summary, return_to_application_review: return_to_application_review),
         ]
       end
 

--- a/app/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component.rb
+++ b/app/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component.rb
@@ -3,15 +3,16 @@ module CandidateInterface
     class NoEflQualificationReviewComponent < ViewComponent::Base
       include EflReviewHelper
 
-      attr_reader :english_proficiency
+      attr_reader :english_proficiency, :return_to_application_review
 
-      def initialize(english_proficiency)
+      def initialize(english_proficiency, return_to_application_review: false)
         @english_proficiency = english_proficiency
+        @return_to_application_review = return_to_application_review
       end
 
       def no_qualification_rows
         [
-          do_you_have_a_qualification_row(value: summary),
+          do_you_have_a_qualification_row(value: summary, return_to_application_review: return_to_application_review, return_to_application_review: return_to_application_review),
         ]
       end
 

--- a/app/components/candidate_interface/english_foreign_language/other_efl_qualification_review_component.rb
+++ b/app/components/candidate_interface/english_foreign_language/other_efl_qualification_review_component.rb
@@ -18,13 +18,13 @@ module CandidateInterface
             key: 'Score or grade',
             value: other_qualification.grade,
             action: 'Change score or grade',
-            change_path: candidate_interface_edit_other_efl_qualification_path,
+            change_path: candidate_interface_edit_other_efl_qualification_path(return_to_params(return_to_application_review)),
           },
           {
             key: 'Year completed',
             value: other_qualification.award_year,
             action: 'Change year completed',
-            change_path: candidate_interface_edit_other_efl_qualification_path,
+            change_path: candidate_interface_edit_other_efl_qualification_path(return_to_params(return_to_application_review)),
           },
         ]
       end

--- a/app/components/candidate_interface/english_foreign_language/other_efl_qualification_review_component.rb
+++ b/app/components/candidate_interface/english_foreign_language/other_efl_qualification_review_component.rb
@@ -3,16 +3,17 @@ module CandidateInterface
     class OtherEflQualificationReviewComponent < ViewComponent::Base
       include EflReviewHelper
 
-      attr_reader :other_qualification
+      attr_reader :other_qualification, :return_to_application_review
 
-      def initialize(other_qualification)
+      def initialize(other_qualification, return_to_application_review: false)
         @other_qualification = other_qualification
+        @return_to_application_review = return_to_application_review
       end
 
       def ielts_rows
         [
-          do_you_have_a_qualification_row(value: 'Yes'),
-          type_of_qualification_row(name: other_qualification.name),
+          do_you_have_a_qualification_row(value: 'Yes', return_to_application_review: return_to_application_review),
+          type_of_qualification_row(name: other_qualification.name, return_to_application_review: return_to_application_review),
           {
             key: 'Score or grade',
             value: other_qualification.grade,

--- a/app/components/candidate_interface/english_foreign_language/toefl_review_component.rb
+++ b/app/components/candidate_interface/english_foreign_language/toefl_review_component.rb
@@ -3,16 +3,17 @@ module CandidateInterface
     class ToeflReviewComponent < ViewComponent::Base
       include EflReviewHelper
 
-      attr_reader :toefl_qualification
+      attr_reader :toefl_qualification, :return_to_application_review
 
-      def initialize(toefl_qualification)
+      def initialize(toefl_qualification, return_to_application_review: false)
         @toefl_qualification = toefl_qualification
+        @return_to_application_review = return_to_application_review
       end
 
       def toefl_rows
         [
-          do_you_have_a_qualification_row(value: 'Yes'),
-          type_of_qualification_row(name: 'TOEFL'),
+          do_you_have_a_qualification_row(value: 'Yes', return_to_application_review: return_to_application_review),
+          type_of_qualification_row(name: 'TOEFL', return_to_application_review: return_to_application_review),
           {
             key: 'TOEFL registration number',
             value: toefl_qualification.registration_number,

--- a/app/components/candidate_interface/english_foreign_language/toefl_review_component.rb
+++ b/app/components/candidate_interface/english_foreign_language/toefl_review_component.rb
@@ -18,19 +18,22 @@ module CandidateInterface
             key: 'TOEFL registration number',
             value: toefl_qualification.registration_number,
             action: 'registration number',
-            change_path: candidate_interface_edit_toefl_path,
+            change_path: candidate_interface_edit_toefl_path(return_to_params(return_to_application_review)),
+            data_qa: 'english-as-a-foreign-language-registration-number',
           },
           {
             key: 'Year completed',
             value: toefl_qualification.award_year,
             action: 'year completed',
-            change_path: candidate_interface_edit_toefl_path,
+            change_path: candidate_interface_edit_toefl_path(return_to_params(return_to_application_review)),
+            data_qa: 'english-as-a-foreign-language-year-completed',
           },
           {
             key: 'Total score',
             value: toefl_qualification.total_score,
             action: 'total score',
-            change_path: candidate_interface_edit_toefl_path,
+            change_path: candidate_interface_edit_toefl_path(return_to_params(return_to_application_review)),
+            data_qa: 'english-as-a-foreign-language-total-score',
           },
         ]
       end

--- a/app/controllers/candidate_interface/english_foreign_language/ielts_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/ielts_controller.rb
@@ -5,13 +5,15 @@ module CandidateInterface
 
       def new
         @ielts_form = EnglishForeignLanguage::IeltsForm.new
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
       end
 
       def create
         @ielts_form = EnglishForeignLanguage::IeltsForm.new(ielts_params)
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
 
         if @ielts_form.save
-          redirect_to candidate_interface_english_foreign_language_review_path
+          redirect_to candidate_interface_english_foreign_language_review_path(@return_to[:params])
         else
           track_validation_error(@ielts_form)
           render :new
@@ -23,13 +25,15 @@ module CandidateInterface
         redirect_to_efl_root and return unless ielts
 
         @ielts_form = EnglishForeignLanguage::IeltsForm.new.fill(ielts: ielts)
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
       end
 
       def update
         @ielts_form = EnglishForeignLanguage::IeltsForm.new(ielts_params)
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
 
         if @ielts_form.save
-          redirect_to candidate_interface_english_foreign_language_review_path
+          redirect_to @return_to[:back_path]
         else
           track_validation_error(@ielts_form)
           render :edit

--- a/app/controllers/candidate_interface/english_foreign_language/other_efl_qualification_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/other_efl_qualification_controller.rb
@@ -5,13 +5,15 @@ module CandidateInterface
 
       def new
         @other_qualification_form = EnglishForeignLanguage::OtherEflQualificationForm.new
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
       end
 
       def create
         @other_qualification_form = EnglishForeignLanguage::OtherEflQualificationForm.new(other_params)
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
 
         if @other_qualification_form.save
-          redirect_to candidate_interface_english_foreign_language_review_path
+          redirect_to candidate_interface_english_foreign_language_review_path(@return_to[:params])
         else
           track_validation_error(@other_qualification_form)
           render :new
@@ -23,13 +25,15 @@ module CandidateInterface
         redirect_to_efl_root and return unless other_qualification
 
         @other_qualification_form = EnglishForeignLanguage::OtherEflQualificationForm.new.fill(qualification: other_qualification)
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
       end
 
       def update
         @other_qualification_form = EnglishForeignLanguage::OtherEflQualificationForm.new(other_params)
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
 
         if @other_qualification_form.save
-          redirect_to candidate_interface_english_foreign_language_review_path
+          redirect_to @return_to[:back_path]
         else
           track_validation_error(@other_qualification_form)
           render :edit

--- a/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
@@ -10,14 +10,16 @@ module CandidateInterface
         @section_complete_form = SectionCompleteForm.new(
           completed: current_application.efl_completed,
         )
+        @return_to = return_to_after_edit(default: candidate_interface_application_form_path)
       end
 
       def complete
         @component_instance = ChooseEflReviewComponent.call(english_proficiency)
         @section_complete_form = SectionCompleteForm.new(completion_params)
+        @return_to = return_to_after_edit(default: candidate_interface_application_form_path)
 
         if @section_complete_form.save(current_application, :efl_completed)
-          redirect_to candidate_interface_application_form_path
+          redirect_to @return_to[:back_path]
         else
           track_validation_error(@section_complete_form)
           render :show

--- a/app/controllers/candidate_interface/english_foreign_language/start_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/start_controller.rb
@@ -18,10 +18,12 @@ module CandidateInterface
 
       def edit
         @start_form = EnglishForeignLanguage::StartForm.new.fill(current_application.english_proficiency)
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
       end
 
       def update
         @start_form = EnglishForeignLanguage::StartForm.new(start_params)
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
 
         if @start_form.save
           redirect_to @start_form.next_path
@@ -38,6 +40,7 @@ module CandidateInterface
           .fetch(:candidate_interface_english_foreign_language_start_form, {})
           .permit(:qualification_status, :no_qualification_details)
           .merge(application_form: current_application)
+          .merge(return_to: params[:'return-to'])
       end
     end
   end

--- a/app/controllers/candidate_interface/english_foreign_language/toefl_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/toefl_controller.rb
@@ -4,14 +4,16 @@ module CandidateInterface
       include EflRootConcern
 
       def new
-        @toefl_form = EnglishForeignLanguage::ToeflForm.new
+        @toefl_form = EnglishForeignLanguage::ToeflForm.new(toefl_params)
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
       end
 
       def create
         @toefl_form = EnglishForeignLanguage::ToeflForm.new(toefl_params)
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
 
         if @toefl_form.save
-          redirect_to candidate_interface_english_foreign_language_review_path
+          redirect_to candidate_interface_english_foreign_language_review_path(@return_to[:params])
         else
           track_validation_error(@toefl_form)
           render :new
@@ -23,13 +25,15 @@ module CandidateInterface
         redirect_to_efl_root and return unless toefl
 
         @toefl_form = EnglishForeignLanguage::ToeflForm.new.fill(toefl: toefl)
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
       end
 
       def update
         @toefl_form = EnglishForeignLanguage::ToeflForm.new(toefl_params)
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
 
         if @toefl_form.save
-          redirect_to candidate_interface_english_foreign_language_review_path
+          redirect_to @return_to[:back_path]
         else
           track_validation_error(@toefl_form)
           render :edit

--- a/app/controllers/candidate_interface/english_foreign_language/type_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/type_controller.rb
@@ -2,11 +2,13 @@ module CandidateInterface
   module EnglishForeignLanguage
     class TypeController < CandidateInterfaceController
       def new
-        @type_form = EnglishForeignLanguage::TypeForm.new
+        @type_form = EnglishForeignLanguage::TypeForm.new(type_params)
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_start_path)
       end
 
       def create
         @type_form = EnglishForeignLanguage::TypeForm.new(type_params)
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_type_path)
 
         if @type_form.save
           redirect_to @type_form.next_form_path
@@ -22,6 +24,7 @@ module CandidateInterface
         strip_whitespace params
           .fetch(:candidate_interface_english_foreign_language_type_form, {})
           .permit(:type)
+          .merge(return_to: params[:'return-to'])
       end
     end
   end

--- a/app/forms/candidate_interface/english_foreign_language/start_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/start_form.rb
@@ -4,7 +4,7 @@ module CandidateInterface
       include ActiveModel::Model
       include Rails.application.routes.url_helpers
 
-      attr_accessor :qualification_status, :no_qualification_details, :application_form
+      attr_accessor :qualification_status, :no_qualification_details, :application_form, :return_to
 
       validates :qualification_status, presence: true
       validates :no_qualification_details, word_count: { maximum: 200 }
@@ -27,7 +27,9 @@ module CandidateInterface
 
       def next_path
         if qualification_status == 'has_qualification'
-          candidate_interface_english_foreign_language_type_path
+          candidate_interface_english_foreign_language_type_path(return_to_params)
+        elsif return_to == 'application-review'
+          candidate_interface_application_review_path
         else
           candidate_interface_english_foreign_language_review_path
         end
@@ -45,6 +47,10 @@ module CandidateInterface
         if application_form.blank?
           raise MissingApplicationFormError
         end
+      end
+
+      def return_to_params
+        return_to == 'application-review' ? { 'return-to' => 'application-review' } : {}
       end
     end
   end

--- a/app/forms/candidate_interface/english_foreign_language/type_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/type_form.rb
@@ -4,7 +4,7 @@ module CandidateInterface
       include ActiveModel::Model
       include Rails.application.routes.url_helpers
 
-      attr_accessor :type
+      attr_accessor :type, :return_to
 
       validates :type, presence: true
 
@@ -17,12 +17,18 @@ module CandidateInterface
       def next_form_path
         case type
         when 'ielts'
-          candidate_interface_ielts_path
+          candidate_interface_ielts_path(return_to_params)
         when 'toefl'
-          candidate_interface_toefl_path
+          candidate_interface_toefl_path(return_to_params)
         when 'other'
-          candidate_interface_other_efl_qualification_path
+          candidate_interface_other_efl_qualification_path(return_to_params)
         end
+      end
+
+      private
+
+      def return_to_params
+        return_to == 'application-review' ? { 'return-to' => 'application-review' } : {}
       end
     end
   end

--- a/app/forms/candidate_interface/english_foreign_language/type_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/type_form.rb
@@ -25,7 +25,7 @@ module CandidateInterface
         end
       end
 
-      private
+    private
 
       def return_to_params
         return_to == 'application-review' ? { 'return-to' => 'application-review' } : {}

--- a/app/services/candidate_interface/choose_efl_review_component.rb
+++ b/app/services/candidate_interface/choose_efl_review_component.rb
@@ -1,29 +1,36 @@
 module CandidateInterface
   class ChooseEflReviewComponent
-    def self.call(english_proficiency)
-      new(english_proficiency).call
+    def self.call(english_proficiency, return_to_application_review: false)
+      new(english_proficiency, return_to_application_review: return_to_application_review).call
     end
 
     attr_reader :english_proficiency
 
-    def initialize(english_proficiency)
+    def initialize(english_proficiency, return_to_application_review: false)
       @english_proficiency = english_proficiency
+      @return_to_application_review = return_to_application_review
     end
 
     def call
       if !english_proficiency.has_qualification?
-        return EnglishForeignLanguage::NoEflQualificationReviewComponent.new(english_proficiency)
+        return EnglishForeignLanguage::NoEflQualificationReviewComponent.new(english_proficiency, component_params)
       end
 
       qualification = english_proficiency.efl_qualification
       case english_proficiency.efl_qualification_type
       when 'IeltsQualification'
-        EnglishForeignLanguage::IeltsReviewComponent.new(qualification)
+        EnglishForeignLanguage::IeltsReviewComponent.new(qualification, component_params)
       when 'ToeflQualification'
-        EnglishForeignLanguage::ToeflReviewComponent.new(qualification)
+        EnglishForeignLanguage::ToeflReviewComponent.new(qualification, component_params)
       when 'OtherEflQualification'
-        EnglishForeignLanguage::OtherEflQualificationReviewComponent.new(qualification)
+        EnglishForeignLanguage::OtherEflQualificationReviewComponent.new(qualification, component_params)
       end
+    end
+
+  private
+
+    def component_params
+      { return_to_application_review: @return_to_application_review }
     end
   end
 end

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -53,7 +53,7 @@
   <% if @application_form.international_applicant? %>
     <h3 class="govuk-heading-m"><%= t('page_titles.efl.start') %></h3>
     <% if @application_form.english_proficiency.present? %>
-      <%= render(CandidateInterface::ChooseEflReviewComponent.call(@application_form.english_proficiency)) %>
+      <%= render(CandidateInterface::ChooseEflReviewComponent.call(@application_form.english_proficiency, return_to_application_review: true)) %>
     <% else %>
       <%= render(CandidateInterface::IncompleteSectionComponent.new(section: 'efl', section_path: candidate_interface_english_foreign_language_start_path, error: missing_error)) %>
     <% end %>

--- a/app/views/candidate_interface/english_foreign_language/ielts/edit.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/ielts/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.ielts'), @ielts_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_english_foreign_language_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: @ielts_form, url: candidate_interface_edit_ielts_path, method: :patch) do |f| %>
+    <%= form_with(model: @ielts_form, url: candidate_interface_edit_ielts_path(@return_to[:params]), method: :patch) do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl">
         <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>

--- a/app/views/candidate_interface/english_foreign_language/ielts/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/ielts/new.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.ielts'), @ielts_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_english_foreign_language_type_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: @ielts_form, url: candidate_interface_ielts_path) do |f| %>
+    <%= form_with(model: @ielts_form, url: candidate_interface_ielts_path(@return_to[:params])) do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl">
         <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>

--- a/app/views/candidate_interface/english_foreign_language/other_efl_qualification/edit.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/other_efl_qualification/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.other'), @other_qualification_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_english_foreign_language_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: @other_qualification_form, url: candidate_interface_edit_other_efl_qualification_path, method: :patch) do |f| %>
+    <%= form_with(model: @other_qualification_form, url: candidate_interface_edit_other_efl_qualification_path(@return_to[:params]), method: :patch) do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class='govuk-heading-xl'>
         <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>

--- a/app/views/candidate_interface/english_foreign_language/other_efl_qualification/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/other_efl_qualification/new.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.other'), @other_qualification_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_english_foreign_language_type_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: @other_qualification_form, url: candidate_interface_other_efl_qualification_path) do |f| %>
+    <%= form_with(model: @other_qualification_form, url: candidate_interface_other_efl_qualification_path(@return_to[:params])) do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class='govuk-heading-xl'>
         <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>

--- a/app/views/candidate_interface/english_foreign_language/review/show.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/review/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t('page_titles.efl.review') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
-<%= form_with model: @section_complete_form, url: candidate_interface_english_foreign_language_complete_path, method: :patch do |f| %>
+<%= form_with model: @section_complete_form, url: candidate_interface_english_foreign_language_complete_path(@return_to[:params]), method: :patch do |f| %>
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl"><%= t('page_titles.efl.review') %></h1>

--- a/app/views/candidate_interface/english_foreign_language/start/edit.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/start/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.start'), @start_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_english_foreign_language_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: @start_form, url: candidate_interface_english_foreign_language_edit_start_path, method: :patch) do |f| %>
+    <%= form_with(model: @start_form, url: candidate_interface_english_foreign_language_edit_start_path(@return_to[:params]), method: :patch) do |f| %>
       <%= render 'form_fields', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/english_foreign_language/toefl/edit.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/toefl/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.toefl'), @toefl_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_english_foreign_language_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: @toefl_form, url: candidate_interface_toefl_path) do |f| %>
+    <%= form_with(model: @toefl_form, url: candidate_interface_toefl_path(@return_to[:params])) do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl">
         <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>

--- a/app/views/candidate_interface/english_foreign_language/toefl/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/toefl/new.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.toefl'), @toefl_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_english_foreign_language_type_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: @toefl_form, url: candidate_interface_toefl_path) do |f| %>
+    <%= form_with(model: @toefl_form, url: candidate_interface_toefl_path(@return_to[:params])) do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class='govuk-heading-xl'>
         <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>

--- a/app/views/candidate_interface/english_foreign_language/type/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/type/new.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.type'), @type_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_english_foreign_language_start_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: @type_form, url: candidate_interface_english_foreign_language_type_path) do |f| %>
+    <%= form_with(model: @type_form, url: candidate_interface_english_foreign_language_type_path(@return_to[:params])) do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :type,

--- a/spec/components/candidate_interface/english_foreign_language/ielts_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/ielts_review_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::IeltsReviewComponent,
     result = render_inline(described_class.new(ielts_qualification))
 
     [
-      { position: 0, title: 'Have you done an English as a foreign language assessment?', value: 'Yes' },
+      { position: 0, title: 'Have you done an English as a foreign language assessment?', value: 'Yes', change: 'foo' },
       { position: 1, title: 'Type of assessment', value: 'IELTS' },
       { position: 2, title: 'Test report form (TRF) number', value: '111111' },
       { position: 3, title: 'Year completed', value: '2001' },
@@ -19,6 +19,25 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::IeltsReviewComponent,
     ].each do |row|
       expect(result.css('.govuk-summary-list__key')[row[:position]].text).to include(row[:title])
       expect(result.css('.govuk-summary-list__value')[row[:position]].text).to include(row[:value])
+
     end
+
+    expect(result.css('.govuk-summary-list__actions a')[0][:href]).to eq(
+      Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path,
+    )
+  end
+
+  it 'passes the `return-to` param to Change actions' do
+    ielts_qualification = build(
+      :ielts_qualification,
+      trf_number: '111111',
+      award_year: '2001',
+      band_score: '8',
+    )
+    result = render_inline(described_class.new(ielts_qualification, return_to_application_review: true))
+    
+    expect(result.css('.govuk-summary-list__actions a')[0][:href]).to eq(
+      Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path('return-to' => 'application-review'),
+    )
   end
 end

--- a/spec/components/candidate_interface/english_foreign_language/ielts_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/ielts_review_component_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::IeltsReviewComponent,
     ].each do |row|
       expect(result.css('.govuk-summary-list__key')[row[:position]].text).to include(row[:title])
       expect(result.css('.govuk-summary-list__value')[row[:position]].text).to include(row[:value])
-
     end
 
     expect(result.css('.govuk-summary-list__actions a')[0][:href]).to eq(
@@ -35,7 +34,7 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::IeltsReviewComponent,
       band_score: '8',
     )
     result = render_inline(described_class.new(ielts_qualification, return_to_application_review: true))
-    
+
     expect(result.css('.govuk-summary-list__actions a')[0][:href]).to eq(
       Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path('return-to' => 'application-review'),
     )

--- a/spec/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::NoEflQualificationRev
     expect(result.css('.govuk-summary-list__key')[row[:position]].text).to include(row[:title])
     expect(result.css('.govuk-summary-list__value')[row[:position]].text).to include(row[:answer])
     expect(result.css('.govuk-summary-list__value')[row[:position]].text).to include(row[:detail])
+    expect(result.css('.govuk-summary-list__actions a')[0][:href]).to eq(
+      Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path,
+    )
   end
 
   it 'renders a review summary for a "qualification not needed" statement of english proficiency' do
@@ -33,5 +36,14 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::NoEflQualificationRev
     }
     expect(result.css('.govuk-summary-list__key')[row[:position]].text).to include(row[:title])
     expect(result.css('.govuk-summary-list__value')[row[:position]].text).to include(row[:answer])
+  end
+
+  it 'passes the `return-to` param to Change actions' do
+    english_proficiency = build(:english_proficiency, :qualification_not_needed)
+    result = render_inline(described_class.new(english_proficiency, return_to_application_review: true))
+    
+    expect(result.css('.govuk-summary-list__actions a')[0][:href]).to eq(
+      Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path('return-to' => 'application-review'),
+    )
   end
 end

--- a/spec/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::NoEflQualificationRev
   it 'passes the `return-to` param to Change actions' do
     english_proficiency = build(:english_proficiency, :qualification_not_needed)
     result = render_inline(described_class.new(english_proficiency, return_to_application_review: true))
-    
+
     expect(result.css('.govuk-summary-list__actions a')[0][:href]).to eq(
       Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path('return-to' => 'application-review'),
     )

--- a/spec/components/candidate_interface/english_foreign_language/other_efl_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/other_efl_qualification_review_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::OtherEflQualification
   it 'passes the `return-to` param to Change actions' do
     other_qualification = build :other_efl_qualification
     result = render_inline(described_class.new(other_qualification, return_to_application_review: true))
-    
+
     expect(result.css('.govuk-summary-list__actions a')[0][:href]).to eq(
       Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path('return-to' => 'application-review'),
     )

--- a/spec/components/candidate_interface/english_foreign_language/other_efl_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/other_efl_qualification_review_component_spec.rb
@@ -19,5 +19,18 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::OtherEflQualification
       expect(result.css('.govuk-summary-list__key')[row[:position]].text).to include(row[:title])
       expect(result.css('.govuk-summary-list__value')[row[:position]].text).to include(row[:value])
     end
+
+    expect(result.css('.govuk-summary-list__actions a')[0][:href]).to eq(
+      Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path,
+    )
+  end
+
+  it 'passes the `return-to` param to Change actions' do
+    other_qualification = build :other_efl_qualification
+    result = render_inline(described_class.new(other_qualification, return_to_application_review: true))
+    
+    expect(result.css('.govuk-summary-list__actions a')[0][:href]).to eq(
+      Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path('return-to' => 'application-review'),
+    )
   end
 end

--- a/spec/components/candidate_interface/english_foreign_language/toefl_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/toefl_review_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::ToeflReviewComponent,
   it 'passes the `return-to` param to Change actions' do
     toefl_qualification = build(:toefl_qualification)
     result = render_inline(described_class.new(toefl_qualification, return_to_application_review: true))
-    
+
     expect(result.css('.govuk-summary-list__actions a')[0][:href]).to eq(
       Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path('return-to' => 'application-review'),
     )

--- a/spec/components/candidate_interface/english_foreign_language/toefl_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/toefl_review_component_spec.rb
@@ -20,5 +20,18 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::ToeflReviewComponent,
       expect(result.css('.govuk-summary-list__key')[row[:position]].text).to include(row[:title])
       expect(result.css('.govuk-summary-list__value')[row[:position]].text).to include(row[:value])
     end
+
+    expect(result.css('.govuk-summary-list__actions a')[0][:href]).to eq(
+      Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path,
+    )
+  end
+
+  it 'passes the `return-to` param to Change actions' do
+    toefl_qualification = build(:toefl_qualification)
+    result = render_inline(described_class.new(toefl_qualification, return_to_application_review: true))
+    
+    expect(result.css('.govuk-summary-list__actions a')[0][:href]).to eq(
+      Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path('return-to' => 'application-review'),
+    )
   end
 end

--- a/spec/forms/candidate_interface/english_foreign_language/start_form_spec.rb
+++ b/spec/forms/candidate_interface/english_foreign_language/start_form_spec.rb
@@ -63,6 +63,14 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::StartForm, type: :mod
       it 'returns path for selecting qualification type' do
         expect(form.next_path).to eq '/candidate/application/english-as-a-foreign-language/type'
       end
+
+      context 'when `return_to` is set' do
+        let(:form) { described_class.new(qualification_status: 'has_qualification', return_to: 'application-review') }
+
+        it 'returns path for selecting qualification type with `return-to` parameter' do
+          expect(form.next_path).to eq '/candidate/application/english-as-a-foreign-language/type?return-to=application-review'
+        end
+      end
     end
 
     context 'when qualification_status is "no_qualification"' do

--- a/spec/services/candidate_interface/choose_efl_review_component_spec.rb
+++ b/spec/services/candidate_interface/choose_efl_review_component_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe CandidateInterface::ChooseEflReviewComponent do
 
         expect(component).to be_instance_of(CandidateInterface::EnglishForeignLanguage::IeltsReviewComponent)
         expect(component.ielts_qualification).to eq english_proficiency.efl_qualification
+        expect(component.return_to_application_review).to be false
+      end
+
+      it 'returns an instance of IeltsReviewComponent with `return_to_application_review` set to true' do
+        component = described_class.call(english_proficiency, return_to_application_review: true)
+
+        expect(component).to be_instance_of(CandidateInterface::EnglishForeignLanguage::IeltsReviewComponent)
+        expect(component.ielts_qualification).to eq english_proficiency.efl_qualification
+        expect(component.return_to_application_review).to be true
       end
     end
 
@@ -21,6 +30,15 @@ RSpec.describe CandidateInterface::ChooseEflReviewComponent do
 
         expect(component).to be_instance_of(CandidateInterface::EnglishForeignLanguage::ToeflReviewComponent)
         expect(component.toefl_qualification).to eq english_proficiency.efl_qualification
+        expect(component.return_to_application_review).to be false
+      end
+
+      it 'returns an instance of ToeflReviewComponent with `return_to_application_review` set to true' do
+        component = described_class.call(english_proficiency, return_to_application_review: true)
+
+        expect(component).to be_instance_of(CandidateInterface::EnglishForeignLanguage::ToeflReviewComponent)
+        expect(component.toefl_qualification).to eq english_proficiency.efl_qualification
+        expect(component.return_to_application_review).to be true
       end
     end
 
@@ -32,6 +50,15 @@ RSpec.describe CandidateInterface::ChooseEflReviewComponent do
 
         expect(component).to be_instance_of(CandidateInterface::EnglishForeignLanguage::OtherEflQualificationReviewComponent)
         expect(component.other_qualification).to eq english_proficiency.efl_qualification
+        expect(component.return_to_application_review).to be false
+      end
+
+      it 'returns an instance of OtherEflQualificationReviewComponent with `return_to_application_review` set to true' do
+        component = described_class.call(english_proficiency, return_to_application_review: true)
+
+        expect(component).to be_instance_of(CandidateInterface::EnglishForeignLanguage::OtherEflQualificationReviewComponent)
+        expect(component.other_qualification).to eq english_proficiency.efl_qualification
+        expect(component.return_to_application_review).to be true
       end
     end
 
@@ -43,6 +70,15 @@ RSpec.describe CandidateInterface::ChooseEflReviewComponent do
 
         expect(component).to be_instance_of(CandidateInterface::EnglishForeignLanguage::NoEflQualificationReviewComponent)
         expect(component.english_proficiency).to eq english_proficiency
+        expect(component.return_to_application_review).to be false
+      end
+
+      it 'returns an instance of NoEflQualificationReviewComponent with `return_to_application_review` set to true' do
+        component = described_class.call(english_proficiency, return_to_application_review: true)
+
+        expect(component).to be_instance_of(CandidateInterface::EnglishForeignLanguage::NoEflQualificationReviewComponent)
+        expect(component.english_proficiency).to eq english_proficiency
+        expect(component.return_to_application_review).to be true
       end
     end
   end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -26,7 +26,7 @@ module CandidateHelper
     APPLICATION_FORM_SECTIONS
   end
 
-  def candidate_completes_application_form(with_referees: true, with_restructured_work_history: false)
+  def candidate_completes_application_form(with_referees: true, with_restructured_work_history: false, international: false)
     if with_restructured_work_history
       FeatureFlag.activate(:restructured_work_history)
     else
@@ -41,7 +41,7 @@ module CandidateHelper
     candidate_fills_in_course_choices
 
     click_link t('page_titles.personal_information')
-    candidate_fills_in_personal_details
+    candidate_fills_in_personal_details(international: international)
 
     click_link t('page_titles.contact_information')
     candidate_fills_in_contact_details
@@ -81,7 +81,7 @@ module CandidateHelper
     click_link 'Science GCSE or equivalent'
     candidate_explains_a_missing_gcse
 
-    click_link 'A levels and other qualifications'
+    click_link(international ? 'Other qualifications' : 'A levels and other qualifications')
     candidate_fills_in_their_other_qualifications
 
     click_link 'Why do you want to teach'
@@ -92,6 +92,14 @@ module CandidateHelper
 
     click_link t('page_titles.interview_preferences')
     candidate_fills_in_interview_preferences
+
+    if international
+      click_link t('page_titles.efl.review')
+      choose 'No, English is not a foreign language to me'
+      click_button 'Continue'
+      choose 'Yes, I have completed this section'
+      click_button 'Continue'
+    end
 
     if with_referees
       candidate_provides_two_referees

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_english_as_foreign_language_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_english_as_foreign_language_section_spec.rb
@@ -15,6 +15,9 @@ RSpec.feature 'Candidate is redirected correctly' do
 
     when_i_click_back
     then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_change_efl_response_and_enter_toefl_details
+    then_i_should_be_redirected_to_the_application_review_page
   end
 
   def given_i_am_signed_in
@@ -66,45 +69,17 @@ RSpec.feature 'Candidate is redirected correctly' do
     expect(page).to have_current_path(candidate_interface_application_review_path)
   end
 
-  # def when_i_update_why_i_want_to_become_a_teacher
-  #   when_i_click_change_on_why_i_want_to_become_a_teacher
-  #   fill_in 'Why do you want to be a teacher?', with: 'All the dev jobs were taken.'
-  #   click_button 'Continue'
-  # end
-
-  # def and_i_should_see_my_updated_becoming_a_teacher_response
-  #   within('[data-qa="becoming-a-teacher"]') do
-  #     expect(page).to have_content('All the dev jobs were taken.')
-  #   end
-  # end
-
-  # def when_i_click_change_on_subject_knowledge
-  #   within('[data-qa="subject-knowledge"]') do
-  #     click_link 'Change'
-  #   end
-  # end
-
-  # def then_i_should_see_the_subject_knowledge_form
-  #   expect(page).to have_current_path(candidate_interface_edit_subject_knowledge_path('return-to' => 'application-review'))
-  # end
-
-  # def when_i_click_back
-  #   click_link 'Back'
-  # end
-
-  # def then_i_should_be_redirected_to_the_application_review_page
-  #   expect(page).to have_current_path(candidate_interface_application_review_path)
-  # end
-
-  # def when_i_update_my_subject_knowledge
-  #   when_i_click_change_on_subject_knowledge
-  #   fill_in 'Tell us what you know about the subject you want to teach', with: 'I have a very particular set of skills.'
-  #   click_button 'Continue'
-  # end
-
-  # def and_i_should_see_my_updated_subject_knowledge
-  #   within('[data-qa="subject-knowledge"]') do
-  #     expect(page).to have_content('I have a very particular set of skills.')
-  #   end
-  # end
+  def when_i_change_efl_response_and_enter_toefl_details
+    when_i_click_change_on_efl
+    choose 'Yes'
+    click_button 'Continue'
+    choose 'Test of English as a Foreign Language'
+    click_button 'Continue'
+    fill_in 'Total score', with: '95'
+    fill_in 'TOEFL registration number', with: '0000 0000 1234 5678'
+    fill_in 'When did you complete the assessment?', with: '2010'
+    click_button 'Save and continue'
+    choose 'Yes, I have completed this section'
+    click_button 'Continue'
+  end
 end

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_english_as_foreign_language_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_english_as_foreign_language_section_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate is redirected correctly' do
+  include CandidateHelper
+  include EFLHelper
+
+  scenario 'Candidate reviews completed application and updates English as a foreign language section' do
+    given_i_am_signed_in
+    when_i_have_completed_my_application
+    and_i_review_my_application
+    then_i_should_see_all_sections_are_complete
+
+    when_i_click_change_on_efl
+    then_i_should_see_the_efl_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_have_completed_my_application
+    candidate_completes_application_form(international: true)
+
+    @current_candidate.current_application.application_references.each do |reference|
+      reference.update!(feedback_status: :feedback_provided)
+    end
+  end
+
+  def and_i_review_my_application
+    and_i_visit_the_application_form_page
+    when_i_click_on_check_your_answers
+  end
+
+  def then_i_should_see_all_sections_are_complete
+    application_form_sections.each do |section|
+      expect(page).not_to have_selector "[data-qa='incomplete-#{section}']"
+    end
+  end
+
+  def and_i_visit_the_application_form_page
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_check_your_answers
+    click_link 'Check and submit your application'
+  end
+
+  def when_i_click_change_on_efl
+    within('[data-qa="english-as-a-foreign-language"]') do
+      click_link 'Change'
+    end
+  end
+
+  def then_i_should_see_the_efl_form
+    expect(page).to have_current_path(candidate_interface_english_foreign_language_edit_start_path('return-to' => 'application-review'))
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def then_i_should_be_redirected_to_the_application_review_page
+    expect(page).to have_current_path(candidate_interface_application_review_path)
+  end
+
+  # def when_i_update_why_i_want_to_become_a_teacher
+  #   when_i_click_change_on_why_i_want_to_become_a_teacher
+  #   fill_in 'Why do you want to be a teacher?', with: 'All the dev jobs were taken.'
+  #   click_button 'Continue'
+  # end
+
+  # def and_i_should_see_my_updated_becoming_a_teacher_response
+  #   within('[data-qa="becoming-a-teacher"]') do
+  #     expect(page).to have_content('All the dev jobs were taken.')
+  #   end
+  # end
+
+  # def when_i_click_change_on_subject_knowledge
+  #   within('[data-qa="subject-knowledge"]') do
+  #     click_link 'Change'
+  #   end
+  # end
+
+  # def then_i_should_see_the_subject_knowledge_form
+  #   expect(page).to have_current_path(candidate_interface_edit_subject_knowledge_path('return-to' => 'application-review'))
+  # end
+
+  # def when_i_click_back
+  #   click_link 'Back'
+  # end
+
+  # def then_i_should_be_redirected_to_the_application_review_page
+  #   expect(page).to have_current_path(candidate_interface_application_review_path)
+  # end
+
+  # def when_i_update_my_subject_knowledge
+  #   when_i_click_change_on_subject_knowledge
+  #   fill_in 'Tell us what you know about the subject you want to teach', with: 'I have a very particular set of skills.'
+  #   click_button 'Continue'
+  # end
+
+  # def and_i_should_see_my_updated_subject_knowledge
+  #   within('[data-qa="subject-knowledge"]') do
+  #     expect(page).to have_content('I have a very particular set of skills.')
+  #   end
+  # end
+end

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_english_as_foreign_language_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_english_as_foreign_language_section_spec.rb
@@ -18,6 +18,9 @@ RSpec.feature 'Candidate is redirected correctly' do
 
     when_i_change_efl_response_and_enter_toefl_details
     then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_change_toefl_score
+    then_i_should_be_redirected_to_the_application_review_page
   end
 
   def given_i_am_signed_in
@@ -81,5 +84,19 @@ RSpec.feature 'Candidate is redirected correctly' do
     click_button 'Save and continue'
     choose 'Yes, I have completed this section'
     click_button 'Continue'
+  end
+
+  def when_i_change_toefl_score
+    when_i_click_change_on_efl_score
+    fill_in 'Total score', with: '85'
+    click_button 'Save and continue'
+    choose 'Yes, I have completed this section'
+    click_button 'Continue'
+  end
+
+  def when_i_click_change_on_efl_score
+    within('[data-qa="english-as-a-foreign-language-total-score"]') do
+      click_link 'Change'
+    end
   end
 end


### PR DESCRIPTION
## Context

If you visit the review unsubmitted application form page and click change on any of the links, then either, update the field and click save and continue or click the backlink, then you are redirected the review page for the section. You should be redirected to the review submitted page.

This PR is one of several that addresses this issue. This one is for the English as a foreign language section.

## Changes proposed in this pull request

- Using the patterns established in earlier changes add a `return-to` param to URLs that are part of this flow and use this at the point where we need to navigate back or redirect at the end of the flow to work out what the correct 'return destination' should be.

## Guidance to review

- Per commit is probably sensible.
- The functionality covered by this PR should be testable by creating an un-submitted application with an overseas address.

## Link to Trello card

https://trello.com/c/N3MfgAdY/3779-change-links-and-backlinks-are-not-working-correctly-from-the-review-unsubmitted-page-english-as-a-foreign-language-section

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
