### PR TITLE
Fix redirects when updating the work experience section

### DIFF
--- a/app/components/shared/restructured_work_history/gap_component.html.erb
+++ b/app/components/shared/restructured_work_history/gap_component.html.erb
@@ -1,10 +1,10 @@
 <%= govuk_inset_text(classes: 'app-inset-text--important govuk-!-margin-top-0 govuk-!-margin-bottom-0') do %>
   You have a break in your work history (<%= format_months_to_years_and_months(@break_period.length) %>)
   <br>
-  <%= govuk_link_to candidate_interface_new_restructured_work_history_path do %>
+  <%= govuk_link_to(candidate_interface_new_restructured_work_history_path(return_to_params)) do %>
     Add another job<span class="govuk-visually-hidden"> <%= between_formatted_dates %></span><% end %>
     or
-  <%= govuk_link_to candidate_interface_new_restructured_work_history_break_path(start_date: @break_period.start_date, end_date: @break_period.end_date) do %>
+  <%= govuk_link_to(candidate_interface_new_restructured_work_history_break_path(add_a_reason_params)) do %>
     add a reason for this break<span class="govuk-visually-hidden"> <%= between_formatted_dates %></span>
   <% end %>
 <% end %>

--- a/app/components/shared/restructured_work_history/gap_component.rb
+++ b/app/components/shared/restructured_work_history/gap_component.rb
@@ -3,12 +3,27 @@ module RestructuredWorkHistory
   class GapComponent < ViewComponent::Base
     include ViewHelper
 
-    def initialize(break_period:)
+    def initialize(break_period:, return_to_application_review: false)
       @break_period = break_period
+      @return_to_application_review = return_to_application_review
     end
 
     def between_formatted_dates
       "between #{@break_period.start_date.to_s(:month_and_year)} and #{@break_period.end_date.to_s(:month_and_year)}"
+    end
+
+    def add_a_reason_params
+      params = { start_date: @break_period.start_date, end_date: @break_period.end_date }
+
+      if @return_to_application_review
+        params.merge(return_to_params)
+      else
+        params
+      end
+    end
+
+    def return_to_params
+      { 'return-to' => 'application-review' } if @return_to_application_review
     end
   end
 end

--- a/app/components/shared/restructured_work_history/job_component.html.erb
+++ b/app/components/shared/restructured_work_history/job_component.html.erb
@@ -8,7 +8,7 @@
       <p class="govuk-body govuk-!-margin-bottom-0"><%= @work_experience.role %></p>
     <% end %>
 
-    <p class="govuk-body">
+    <p class="govuk-body" data-qa="job-date">
       <%= formatted_start_date %> <%= formatted_end_date %>
     </p>
 
@@ -18,7 +18,7 @@
       <%= govuk_inset_text(classes: 'app-inset-text--error') do %>
         <%= govuk_link_to(
           'Select if this role used skills relevant to teaching',
-          candidate_interface_edit_restructured_work_history_path(@work_experience.id),
+          candidate_interface_edit_restructured_work_history_path(@work_experience.id, return_to_params),
         ) %>
       <% end %>
     <% end %>
@@ -26,11 +26,11 @@
 
   <% if @editable %>
     <div class="govuk-grid-column-one-third govuk-body app-grid-column-one-third--actions">
-      <%= govuk_link_to(candidate_interface_edit_restructured_work_history_path(@work_experience.id), class: 'govuk-!-margin-right-2') do %>
+      <%= govuk_link_to(candidate_interface_edit_restructured_work_history_path(@work_experience.id, return_to_params), class: 'govuk-!-margin-right-2') do %>
         Change <span class="govuk-visually-hidden">job <%= @work_experience.role %> for <%= @work_experience.organisation %></span>
       <% end %>
 
-      <%= govuk_link_to(candidate_interface_destroy_restructured_work_history_path(@work_experience.id)) do %>
+      <%= govuk_link_to(candidate_interface_destroy_restructured_work_history_path(@work_experience.id, return_to_params)) do %>
         Delete <span class="govuk-visually-hidden">job <%= @work_experience.role %> for <%= @work_experience.organisation %></span>
       <% end %>
     </div>

--- a/app/components/shared/restructured_work_history/job_component.rb
+++ b/app/components/shared/restructured_work_history/job_component.rb
@@ -3,9 +3,14 @@ module RestructuredWorkHistory
   class JobComponent < ViewComponent::Base
     include ViewHelper
 
-    def initialize(work_experience:, editable: true)
+    def initialize(work_experience:, editable: true, return_to_application_review: false)
       @work_experience = work_experience
       @editable = editable
+      @return_to_application_review = return_to_application_review
+    end
+
+    def return_to_params
+      { 'return-to' => 'application-review' } if @return_to_application_review
     end
 
   private

--- a/app/components/shared/restructured_work_history/review_component.html.erb
+++ b/app/components/shared/restructured_work_history/review_component.html.erb
@@ -6,11 +6,11 @@
       <section>
         <% @work_history_with_breaks.each do |entry| %>
           <% if entry.is_a?(ApplicationWorkExperience) %>
-            <%= render(RestructuredWorkHistory::JobComponent.new(work_experience: entry, editable: @editable)) %>
+            <%= render(RestructuredWorkHistory::JobComponent.new(work_experience: entry, editable: @editable, return_to_application_review: return_to_application_review)) %>
           <% elsif @editable && entry.is_a?(RestructuredWorkHistoryWithBreaks::BreakPlaceholder) %>
-            <%= render(RestructuredWorkHistory::GapComponent.new(break_period: entry)) %>
+            <%= render(RestructuredWorkHistory::GapComponent.new(break_period: entry, return_to_application_review: return_to_application_review)) %>
           <% elsif entry.is_a?(ApplicationWorkHistoryBreak) %>
-            <%= render(RestructuredWorkHistory::WorkBreakComponent.new(work_break: entry, editable: @editable)) %>
+            <%= render(RestructuredWorkHistory::WorkBreakComponent.new(work_break: entry, editable: @editable, return_to_application_review: return_to_application_review)) %>
           <% end %>
 
           <% if @work_history_with_breaks.last != entry %>

--- a/app/components/shared/restructured_work_history/review_component.rb
+++ b/app/components/shared/restructured_work_history/review_component.rb
@@ -1,13 +1,14 @@
 # NOTE: This component is used by both provider and support UIs
 module RestructuredWorkHistory
   class ReviewComponent < ViewComponent::Base
-    def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
+    def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false, return_to_application_review: false)
       @application_form = application_form
       @editable = editable
       @heading_level = heading_level
       @show_incomplete = show_incomplete
       @missing_error = missing_error
       @work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(@application_form).timeline
+      @return_to_application_review = return_to_application_review
     end
 
     def show_missing_banner?
@@ -38,7 +39,7 @@ module RestructuredWorkHistory
 
   private
 
-    attr_reader :application_form
+    attr_reader :application_form, :return_to_application_review
 
     def no_work_experience_value
       application_form.full_time_education? ? t('application_form.work_history.full_time_education.label') : application_form.work_history_explanation

--- a/app/components/shared/restructured_work_history/work_break_component.html.erb
+++ b/app/components/shared/restructured_work_history/work_break_component.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-s govuk-!-margin-bottom-0">Break in work history</h2>
-    <p class="govuk-body govuk-!-margin-bottom-0"><%= @work_break.reason %></p>
+    <p class="govuk-body govuk-!-margin-bottom-0" data-qa="work-break-reason"><%= @work_break.reason %></p>
     <p class="govuk-body">
       <%= formatted_start_date %> to <%= formatted_end_date %>
     </p>
@@ -9,11 +9,11 @@
 
   <% if @editable %>
     <div class="govuk-grid-column-one-third govuk-body app-grid-column-one-third--actions">
-      <%= govuk_link_to(candidate_interface_edit_restructured_work_history_break_path(@work_break.id), class: 'govuk-!-margin-right-2') do %>
+      <%= govuk_link_to(candidate_interface_edit_restructured_work_history_break_path(@work_break.id, return_to_params), class: 'govuk-!-margin-right-2') do %>
         Change <span class="govuk-visually-hidden">entry for break between <%= formatted_start_date %> and <%= formatted_end_date %></span>
       <% end %>
 
-      <%= govuk_link_to(candidate_interface_destroy_restructured_work_history_break_path(@work_break.id)) do %>
+      <%= govuk_link_to(candidate_interface_destroy_restructured_work_history_break_path(@work_break.id, return_to_params)) do %>
         Delete <span class="govuk-visually-hidden">entry for break between <%= formatted_start_date %> and <%= formatted_end_date %></span>
       <% end %>
     </div>

--- a/app/components/shared/restructured_work_history/work_break_component.rb
+++ b/app/components/shared/restructured_work_history/work_break_component.rb
@@ -3,9 +3,14 @@ module RestructuredWorkHistory
   class WorkBreakComponent < ViewComponent::Base
     include ViewHelper
 
-    def initialize(work_break:, editable: true)
+    def initialize(work_break:, editable: true, return_to_application_review: false)
       @work_break = work_break
       @editable = editable
+      @return_to_application_review = return_to_application_review
+    end
+
+    def return_to_params
+      { 'return-to' => 'application-review' } if @return_to_application_review
     end
 
   private

--- a/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
@@ -3,14 +3,16 @@ module CandidateInterface
     def show
       @application_form = current_application
       @section_complete_form = SectionCompleteForm.new(completed: current_application.work_history_completed)
+      @return_to = return_to_after_edit(default: candidate_interface_application_form_path)
     end
 
     def complete
       @application_form = current_application
       @section_complete_form = SectionCompleteForm.new(form_params)
+      @return_to = return_to_after_edit(default: candidate_interface_application_form_path)
 
       if @section_complete_form.save(current_application, :work_history_completed)
-        redirect_to candidate_interface_application_form_path
+        redirect_to @return_to[:back_path]
       else
         track_validation_error(@section_complete_form)
         render :show

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -160,7 +160,7 @@ module CandidateInterface
     def work_experience_path
       if @application_form.feature_restructured_work_history && FeatureFlag.active?(:restructured_work_history)
         if @application_form.application_work_experiences.any? || @application_form.work_history_explanation.present?
-          Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_review_path
+          Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_review_path('return-to' => 'application-review')
         else
           Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_path
         end

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -108,7 +108,14 @@
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.work_experience') %></h2>
   <% if FeatureFlag.active?(:restructured_work_history) && @application_form.feature_restructured_work_history %>
-    <%= render(RestructuredWorkHistory::ReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, show_incomplete: !application_form.work_history_completed && editable, missing_error: missing_error)) %>
+    <%= render(RestructuredWorkHistory::ReviewComponent.new(
+      application_form: application_form,
+      editable: editable,
+      heading_level: 4,
+      show_incomplete: !application_form.work_history_completed && editable,
+      missing_error: missing_error,
+      return_to_application_review: true,
+    )) %>
   <% else %>
     <h3 class="govuk-heading-m"><%= t('page_titles.work_history') %></h3>
     <%= render(CandidateInterface::WorkHistoryReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, show_incomplete: !application_form.work_history_completed && editable, missing_error: missing_error)) %>

--- a/app/views/candidate_interface/restructured_work_history/break/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/break/confirm_destroy.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, t('page_titles.destroy_work_history_break') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_restructured_work_history_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @work_break, url: candidate_interface_destroy_restructured_work_history_break_path(@work_break), method: :delete do |f| %>
+    <%= form_with model: @work_break, url: candidate_interface_destroy_restructured_work_history_break_path(@work_break, @return_to[:params]), method: :delete do |f| %>
       <h1 class="govuk-heading-xl">
         <span class="govuk-caption-xl">Work history</span>
         <%= t('page_titles.destroy_work_history_break') %>

--- a/app/views/candidate_interface/restructured_work_history/break/edit.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/break/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.work_history_break'), @work_break.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_restructured_work_history_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @work_break, url: candidate_interface_edit_restructured_work_history_break_path, method: :patch do |f| %>
+    <%= form_with model: @work_break, url: candidate_interface_edit_restructured_work_history_break_path(@return_to[:params]), method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/restructured_work_history/break/new.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/break/new.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.work_history_break'), @work_break.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_restructured_work_history_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @work_break, url: candidate_interface_new_restructured_work_history_break_path do |f| %>
+    <%= form_with model: @work_break, url: candidate_interface_new_restructured_work_history_break_path(@return_to[:params]) do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/restructured_work_history/job/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/job/confirm_destroy.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, t('page_titles.restructured_work_history_destroy') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_restructured_work_history_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @job, url: candidate_interface_destroy_restructured_work_history_path(@job.id), method: :delete do |f| %>
+    <%= form_with model: @job, url: candidate_interface_destroy_restructured_work_history_path(@job.id, @return_to[:params]), method: :delete do |f| %>
       <h1 class="govuk-heading-xl">
         <span class="govuk-caption-xl"><%= @job.role %></span>
         <%= t('page_titles.restructured_work_history_destroy') %>

--- a/app/views/candidate_interface/restructured_work_history/job/edit.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/job/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.edit_job'), @job_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_restructured_work_history_review_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @job_form, url: candidate_interface_edit_restructured_work_history_path, method: :patch do |f| %>
+    <%= form_with model: @job_form, url: candidate_interface_edit_restructured_work_history_path(@return_to[:params]), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/restructured_work_history/job/new.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/job/new.html.erb
@@ -1,13 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.add_job'), @job_form.errors.any?) %>
-<% if current_application.application_work_experiences.present? %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_restructured_work_history_review_path) %>
-<% else %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_restructured_work_history_path) %>
-<% end %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @job_form, url: candidate_interface_new_restructured_work_history_path do |f| %>
+    <%= form_with model: @job_form, url: candidate_interface_new_restructured_work_history_path(@return_to[:params]) do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t('page_titles.work_history') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
-<%= form_with model: @section_complete_form, url: candidate_interface_restructured_work_history_complete_path, method: :patch do |f| %>
+<%= form_with model: @section_complete_form, url: candidate_interface_restructured_work_history_complete_path(@return_to[:params]), method: :patch do |f| %>
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl"><%= t('page_titles.work_history') %></h1>

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -439,7 +439,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
         presenter = described_class.new(application_form)
 
         expect(presenter.work_experience_path).to eq(
-          Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_review_path,
+          Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_review_path('return-to' => 'application-review'),
         )
       end
     end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -26,8 +26,13 @@ module CandidateHelper
     APPLICATION_FORM_SECTIONS
   end
 
-  def candidate_completes_application_form(with_referees: true)
-    FeatureFlag.deactivate(:restructured_work_history)
+  def candidate_completes_application_form(with_referees: true, with_restructured_work_history: false)
+    if with_restructured_work_history
+      FeatureFlag.activate(:restructured_work_history)
+    else
+      FeatureFlag.deactivate(:restructured_work_history)
+    end
+
     given_courses_exist
     create_and_sign_in_candidate
     visit candidate_interface_application_form_path
@@ -42,10 +47,21 @@ module CandidateHelper
     candidate_fills_in_contact_details
 
     click_link t('page_titles.work_history')
-    candidate_fills_in_work_experience
+
+    if with_restructured_work_history
+      candidate_fills_in_restructured_work_experience
+      candidate_fills_in_restructured_work_experience_break
+    else
+      candidate_fills_in_work_experience
+    end
 
     click_link t('page_titles.volunteering.short')
-    candidate_fills_in_volunteering_role
+
+    if with_restructured_work_history
+      candidate_fills_in_restructured_volunteering_role
+    else
+      candidate_fills_in_volunteering_role
+    end
 
     click_link t('page_titles.training_with_a_disability')
     candidate_fills_in_disability_info
@@ -303,6 +319,49 @@ module CandidateHelper
     click_button t('continue')
   end
 
+  def candidate_fills_in_restructured_work_experience
+    choose 'Yes'
+    click_button t('continue')
+
+    click_link 'Add a job'
+
+    with_options scope: 'application_form.restructured_work_history' do |locale|
+      fill_in locale.t('employer.label'), with: 'Weyland-Yutani'
+      fill_in locale.t('role.label'), with: 'Chief Terraforming Officer'
+
+      choose 'Part time'
+
+      within('[data-qa="start-date"]') do
+        fill_in 'Month', with: '5'
+        fill_in 'Year', with: '2014'
+      end
+
+      within('[data-qa="currently-working"]') do
+        choose 'No'
+      end
+
+      within('[data-qa="end-date"]') do
+        fill_in 'Month', with: '1'
+        fill_in 'Year', with: '2019'
+      end
+
+      within('[data-qa="relevant-skills"]') do
+        choose 'Yes'
+      end
+
+      click_button t('save_and_continue')
+    end
+  end
+
+  def candidate_fills_in_restructured_work_experience_break
+    click_link 'add a reason for this break', match: :first
+    fill_in 'Enter reasons for break in work history', with: 'Terraforming is tiring.'
+    click_button t('continue')
+
+    choose t('application_form.completed_radio')
+    click_button t('continue')
+  end
+
   def candidate_fills_in_work_experience
     choose t('application_form.work_history.complete.label')
     click_button t('continue')
@@ -326,6 +385,40 @@ module CandidateHelper
     end
 
     click_button t('save_and_continue')
+    choose t('application_form.completed_radio')
+    click_button t('continue')
+  end
+
+  def candidate_fills_in_restructured_volunteering_role
+    choose 'Yes' # "Do you have any relevant unpaid experience?"
+    click_button t('save_and_continue')
+
+    with_options scope: 'application_form.volunteering' do |locale|
+      fill_in locale.t('organisation.label'), with: 'National Trust'
+      fill_in locale.t('role.label'), with: 'Tour guide'
+
+      within('[data-qa="working-with-children"]') do
+        choose 'Yes'
+      end
+
+      within('[data-qa="start-date"]') do
+        fill_in 'Month', with: '5'
+        fill_in 'Year', with: '2014'
+      end
+
+      within('[data-qa="currently-working"]') do
+        choose 'No'
+      end
+
+      within('[data-qa="end-date"]') do
+        fill_in 'Month', with: '1'
+        fill_in 'Year', with: '2019'
+      end
+
+      fill_in t('application_form.volunteering.details.label'), with: 'I volunteered.'
+      click_button t('save_and_continue')
+    end
+
     choose t('application_form.completed_radio')
     click_button t('continue')
   end

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_work_experience_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_work_experience_section_spec.rb
@@ -20,6 +20,17 @@ RSpec.feature 'Candidate is redirected correctly' do
     then_i_should_be_redirected_to_the_application_review_page
     and_i_should_see_my_updated_job
 
+    # section complete
+    when_i_mark_the_work_experience_section_as_incomplete
+    and_i_review_my_application
+    and_i_click_link_complete_your_work_history
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_work_history_completed
+    then_i_should_be_redirected_to_the_application_review_page
+
     # delete job
     when_i_click_delete_job
     then_i_should_see_the_delete_job_form
@@ -60,9 +71,20 @@ RSpec.feature 'Candidate is redirected correctly' do
     candidate_completes_application_form(with_restructured_work_history: true)
   end
 
+  def when_i_mark_the_work_experience_section_as_incomplete
+    visit candidate_interface_application_form_path
+    click_link 'Work history'
+    choose t('application_form.incomplete_radio')
+    click_button t('continue')
+  end
+
   def and_i_review_my_application
     and_i_visit_the_application_form_page
     when_i_click_on_check_your_answers
+  end
+
+  def and_i_click_link_complete_your_work_history
+    click_link 'Complete your work history'
   end
 
   def then_i_should_see_all_sections_are_complete
@@ -124,6 +146,13 @@ RSpec.feature 'Candidate is redirected correctly' do
   def when_i_update_work_break
     when_i_click_change_work_break
     fill_in 'Enter reasons for break in work history', with: 'The Nostromo blew up'
+    click_button t('continue')
+  end
+
+  def when_i_update_work_history_completed
+    and_i_click_link_complete_your_work_history
+
+    choose t('application_form.completed_radio')
     click_button t('continue')
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_work_experience_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_work_experience_section_spec.rb
@@ -1,0 +1,160 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate is redirected correctly' do
+  include CandidateHelper
+
+  scenario 'Candidate reviews completed application and updates restructured work experience section' do
+    given_i_am_signed_in
+    when_i_have_completed_my_application
+    and_i_review_my_application
+    then_i_should_see_all_sections_are_complete
+
+    # update job
+    when_i_click_change_job
+    then_i_should_see_the_job_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_job
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_job
+
+    # delete job
+    when_i_click_delete_job
+    then_i_should_see_the_delete_job_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_delete_job
+    then_i_should_be_redirected_to_the_application_review_page
+
+    # update work break
+    when_i_click_change_work_break
+    then_i_should_see_the_work_break_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_work_break
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_my_updated_work_break
+
+    # delete work break
+    when_i_click_delete_work_break
+    then_i_should_see_the_delete_work_break_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_delete_work_break
+    then_i_should_be_redirected_to_the_application_review_page
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_have_completed_my_application
+    candidate_completes_application_form(with_restructured_work_history: true)
+  end
+
+  def and_i_review_my_application
+    and_i_visit_the_application_form_page
+    when_i_click_on_check_your_answers
+  end
+
+  def then_i_should_see_all_sections_are_complete
+    application_form_sections.each do |section|
+      expect(page).not_to have_selector "[data-qa='incomplete-#{section}']"
+    end
+  end
+
+  def and_i_visit_the_application_form_page
+    visit candidate_interface_application_form_path
+  end
+
+  def then_i_should_see_the_work_break_form
+    expect(page).to have_content('Please tell us what you were doing over this period')
+  end
+
+  def then_i_should_see_the_delete_job_form
+    expect(page).to have_content('Are you sure you want to delete this job?')
+  end
+
+  def when_i_click_on_check_your_answers
+    click_link 'Check and submit your application'
+  end
+
+  def then_i_should_be_redirected_to_the_application_review_page
+    expect(page).to have_current_path(candidate_interface_application_review_path)
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def when_i_click_change_job
+    click_link 'Change job'
+  end
+
+  def when_i_click_delete_job
+    click_link 'Delete job'
+  end
+
+  def when_i_click_change_work_break
+    click_link 'Change entry for break'
+  end
+
+  def when_i_click_delete_work_break
+    click_link 'Delete entry for break'
+  end
+
+  def when_i_update_job
+    when_i_click_change_job
+
+    within('[data-qa="start-date"]') do
+      fill_in 'Month', with: '3'
+    end
+
+    click_button t('save_and_continue')
+  end
+
+  def when_i_update_work_break
+    when_i_click_change_work_break
+    fill_in 'Enter reasons for break in work history', with: 'The Nostromo blew up'
+    click_button t('continue')
+  end
+
+  def when_i_delete_job
+    when_i_click_delete_job
+    click_button t('application_form.restructured_work_history.delete_job.confirm')
+  end
+
+  def when_i_delete_work_break
+    when_i_click_delete_work_break
+
+    click_button 'Yes I’m sure - delete this entry'
+  end
+
+  def then_i_should_see_the_job_form
+    expect(page).to have_content('Edit job')
+  end
+
+  def then_i_should_see_the_delete_work_break_form
+    expect(page).to have_content('Are you sure you want to delete this entry?')
+  end
+
+  def and_i_should_see_my_updated_job
+    within('[data-qa="job-date"]') do
+      expect(page).to have_content('Mar 2014')
+    end
+  end
+
+  def and_i_should_see_my_updated_work_break
+    within('[data-qa="work-break-reason"]') do
+      expect(page).to have_content('The Nostromo blew up')
+    end
+  end
+end


### PR DESCRIPTION
## Context

If you visit the review unsubmitted application form page and click change on any of the links, then either:

- update the field and click save and continue
or
- click the backlink

You are redirected the review page for the section.

## Changes proposed in this pull request

Use params `(&return-to=application-review)` to redirect the candidate back to the application review path when required.

## Guidance to review

- Recommend manually testing this!
- This PR deals with the safeguarding section only. Other PRs to follow for remaining sections.

## Link to Trello card

https://trello.com/c/Hnr0hxZI/3768-change-links-and-backlinks-are-not-working-correctly-from-the-review-unsubmitted-page-work-experience-section

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
