### PR TITLE
 Add new Redis cache instance in Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,7 +23,17 @@
       "size": "hobby"
     }
   },
-  "addons": ["heroku-postgresql:hobby-basic", "heroku-redis:hobby-dev"],
+  "addons": [
+    "heroku-postgresql:hobby-basic",
+    "heroku-redis:hobby-dev",
+    {
+      "plan": "heroku-redis:hobby-dev",
+      "as": "REDIS_CACHE",
+      "options": {
+        "maxmemory-policy": "allkeys-lru"
+      }
+    }
+  ],
   "buildpacks": [
     {
       "url": "heroku/nodejs"


### PR DESCRIPTION
## Context

We have added a new instance of Redis for memory cache. To replicate this in our Heroku review apps we need to expose a new `REDIS_CACHE_URL` instance with the same eviction policy

## Changes proposed in this pull request

- Add a new Redis add on, set as `redis_cache` to generate a `REDIS_CACHE_URL` in the review apps config vars
- Set the eviction similar to instance in production

## Guidance to review

I attempted to use the same Redis instance already defined, however couldn't fin a clean way to copy the ENV vars. This is a free tier so won't affect us.

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
