### PR TITLE
Create new scoped provider users pages

### DIFF
--- a/app/components/provider_interface/user_card_component.html.erb
+++ b/app/components/provider_interface/user_card_component.html.erb
@@ -1,0 +1,18 @@
+<div class="app-user-card">
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
+    <%= govuk_link_to provider_user.full_name, provider_interface_organisation_settings_organisation_user_path(provider, provider_user) %>
+    <span class="govuk-!-font-weight-regular"> - <%= provider_user.email_address %></span>
+  </h2>
+  <% if provider_user_permissions.any? %>
+    <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-0 govuk-!-font-size-16 govuk-hint">
+      <%= t('.permissions_list_preamble') %>
+    </p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1 govuk-!-margin-bottom-0 govuk-!-font-size-16 govuk-hint">
+      <% provider_user_permissions.each do |permission| %>
+        <li>
+          <%= t("user_permissions.#{permission}.description").downcase %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>

--- a/app/components/provider_interface/user_card_component.rb
+++ b/app/components/provider_interface/user_card_component.rb
@@ -1,0 +1,19 @@
+module ProviderInterface
+  class UserCardComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :provider_user, :provider
+
+    def initialize(provider_user:, provider:)
+      @provider_user = provider_user
+      @provider = provider
+    end
+
+    def provider_user_permissions
+      @provider_user_permissions ||= begin
+        provider_permission = provider_user.provider_permissions.find_by(provider: provider)
+        ProviderPermissions::VALID_PERMISSIONS.select { |permission| provider_permission.send(permission) }
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -1,5 +1,6 @@
 module ProviderInterface
   class ProviderUsersController < ProviderInterfaceController
+    before_action :redirect_if_feature_flag_on
     before_action :require_manage_users_permission!
     before_action :find_provider_user, except: %i[index]
 
@@ -80,6 +81,12 @@ module ProviderInterface
     end
 
   private
+
+    def redirect_if_feature_flag_on
+      return unless FeatureFlag.active?(:account_and_org_settings_changes)
+
+      redirect_to provider_interface_organisation_settings_path
+    end
 
     def provider_update_permissions_params
       params.require(:provider_interface_provider_user_edit_permissions_form)

--- a/app/controllers/provider_interface/users_controller.rb
+++ b/app/controllers/provider_interface/users_controller.rb
@@ -1,7 +1,22 @@
 module ProviderInterface
   class UsersController < ProviderInterfaceController
-    def index
+    before_action :set_provider
+
+    def index; end
+
+    def show
+      @provider_user = @provider.provider_users.find(params[:id])
+      @current_user_can_manage_users = current_user_can_manage_users
+    end
+
+  private
+
+    def set_provider
       @provider = current_provider_user.providers.find(params[:organisation_id])
+    end
+
+    def current_user_can_manage_users
+      current_provider_user.authorisation.can_manage_users_for?(provider: @provider)
     end
   end
 end

--- a/app/controllers/provider_interface/users_controller.rb
+++ b/app/controllers/provider_interface/users_controller.rb
@@ -1,0 +1,7 @@
+module ProviderInterface
+  class UsersController < ProviderInterfaceController
+    def index
+      @provider = current_provider_user.providers.find(params[:organisation_id])
+    end
+  end
+end

--- a/app/controllers/provider_interface/users_controller.rb
+++ b/app/controllers/provider_interface/users_controller.rb
@@ -1,5 +1,6 @@
 module ProviderInterface
   class UsersController < ProviderInterfaceController
+    before_action :redirect_unless_feature_flag_on
     before_action :set_provider
 
     def index; end
@@ -10,6 +11,12 @@ module ProviderInterface
     end
 
   private
+
+    def redirect_unless_feature_flag_on
+      return if FeatureFlag.active?(:account_and_org_settings_changes)
+
+      redirect_to provider_interface_organisation_settings_path
+    end
 
     def set_provider
       @provider = current_provider_user.providers.find(params[:organisation_id])

--- a/app/frontend/styles/provider/_all.scss
+++ b/app/frontend/styles/provider/_all.scss
@@ -13,3 +13,4 @@
 @import "offer-panel";
 @import "rejection";
 @import "timeline";
+@import "user-card";

--- a/app/frontend/styles/provider/_user-card.scss
+++ b/app/frontend/styles/provider/_user-card.scss
@@ -1,0 +1,10 @@
+.app-user-card {
+  border-bottom: 1px solid govuk-colour('mid-grey');
+  margin-bottom: 10px;
+  padding-bottom: 10px;
+}
+
+.app-user-card:first-of-type {
+  border-top: 1px solid govuk-colour('mid-grey');
+  padding-top: 10px;
+}

--- a/app/views/provider_interface/organisation_settings/show.html.erb
+++ b/app/views/provider_interface/organisation_settings/show.html.erb
@@ -10,7 +10,7 @@
         <% end %>
         <ul class="govuk-list govuk-list--spaced">
           <li>
-            <%= govuk_link_to provider_interface_provider_users_path do %>
+            <%= govuk_link_to provider_interface_organisation_settings_organisation_users_path(provider) do %>
               <%= t('page_titles.provider.users') %><span class="govuk-visually-hidden"> <%= provider.name %></span>
             <% end %>
           </li>

--- a/app/views/provider_interface/users/index.html.erb
+++ b/app/views/provider_interface/users/index.html.erb
@@ -1,0 +1,19 @@
+<% content_for :browser_title, t('page_titles.provider.users') %>
+
+<% content_for :before_content do %>
+  <%= breadcrumbs({
+    t('page_titles.provider.organisation_settings') => provider_interface_organisation_settings_path,
+    t('page_titles.provider.users') => nil,
+  }) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @provider.name %></span>
+    <h1 class="govuk-heading-l"><%= t('page_titles.provider.users') %></h1>
+
+    <% @provider.provider_users.order(:first_name, :last_name).each do |user| %>
+      <%= render ProviderInterface::UserCardComponent.new(provider: @provider, provider_user: user) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/users/show.html.erb
+++ b/app/views/provider_interface/users/show.html.erb
@@ -1,0 +1,27 @@
+<% content_for :browser_title, t('page_titles.provider.users') %>
+
+<% content_for :before_content do %>
+  <%= breadcrumbs({
+    t('page_titles.provider.organisation_settings') => provider_interface_organisation_settings_path,
+    t('page_titles.provider.users') => provider_interface_organisation_settings_organisation_users_path(@provider),
+    @provider_user.full_name => nil,
+  }) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @provider.name %></span>
+    <h1 class="govuk-heading-l"><%= @provider_user.full_name %></h1>
+    <h2 class="govuk-heading-m">Personal details</h2>
+    <%= render SummaryListComponent.new(
+      rows: [
+        { key: 'First name', value: @provider_user.first_name },
+        { key: 'Last name', value: @provider_user.last_name },
+        { key: 'Email address', value: @provider_user.email_address },
+      ],
+    ) %>
+    <h2 class="govuk-heading-m">User permissions</h2>
+    <p class="govuk-body"><%= t('provider_relationship_permissions.view_applications_explanation') %></p>
+    <%= render ProviderInterface::UserPermissionSummaryComponent.new(provider_user: @provider_user, provider: @provider, editable: @current_user_can_manage_users) %>
+  </div>
+</div>

--- a/config/locales/provider_interface/user_permisssions.yml
+++ b/config/locales/provider_interface/user_permisssions.yml
@@ -19,3 +19,5 @@ en:
         access_to_orgs:
           heading: Access to organisations
           key: Organisations you have access to
+    user_card_component:
+      permissions_list_preamble: 'This user has permission to:'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -777,6 +777,7 @@ Rails.application.routes.draw do
       resources :organisations, only: [] do
         get '/' => 'organisation_permissions#organisations', on: :collection
         resources :organisation_permissions, path: '/organisation-permissions', only: %i[index edit update]
+        resources :users, path: '/users', only: %i[index]
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -777,7 +777,7 @@ Rails.application.routes.draw do
       resources :organisations, only: [] do
         get '/' => 'organisation_permissions#organisations', on: :collection
         resources :organisation_permissions, path: '/organisation-permissions', only: %i[index edit update]
-        resources :users, path: '/users', only: %i[index]
+        resources :users, path: '/users', only: %i[index show]
       end
     end
 

--- a/spec/components/previews/provider_interface/user_card_component_preview.rb
+++ b/spec/components/previews/provider_interface/user_card_component_preview.rb
@@ -1,0 +1,37 @@
+module ProviderInterface
+  class UserCardComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
+    def user_with_permissions
+      provider_user = example_provider_user
+      render UserCardComponent.new(
+        provider_user: provider_user,
+        provider: provider_user.providers.first,
+      )
+    end
+
+    def user_without_permissions
+      provider_user = FactoryBot.create(:provider_user, :with_provider)
+      render UserCardComponent.new(
+        provider_user: provider_user,
+        provider: provider_user.providers.first,
+      )
+    end
+
+  private
+
+    def example_provider_user
+      permissions = FactoryBot.create(
+        :provider_permissions,
+        manage_users: Faker::Boolean.boolean(true_ratio: 0.5),
+        manage_organisations: Faker::Boolean.boolean(true_ratio: 0.5),
+        set_up_interviews: Faker::Boolean.boolean(true_ratio: 0.5),
+        make_decisions: Faker::Boolean.boolean(true_ratio: 0.5),
+        view_safeguarding_information: Faker::Boolean.boolean(true_ratio: 0.5),
+        view_diversity_information: Faker::Boolean.boolean(true_ratio: 0.5),
+      )
+
+      permissions.provider_user
+    end
+  end
+end

--- a/spec/components/provider_interface/user_card_component_spec.rb
+++ b/spec/components/provider_interface/user_card_component_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::UserCardComponent do
+  let(:provider_user) { create(:provider_user, :with_provider) }
+  let(:provider) { provider_user.providers.first }
+  let!(:render) do
+    render_inline(
+      described_class.new(
+        provider_user: provider_user,
+        provider: provider,
+      ),
+    )
+  end
+
+  describe 'heading' do
+    it 'renders the user full name as a link' do
+      expect(render.css('h2 > a').text).to eq(provider_user.full_name)
+    end
+
+    it 'renders the user email address' do
+      expect(render.css('h2 > span').text).to eq(" - #{provider_user.email_address}")
+    end
+  end
+
+  context 'when the user has no extra permissions' do
+    it 'does not render any permissions' do
+      expect(page).not_to have_content(t('provider_interface.user_card_component.permissions_list_preamble'))
+      expect(page).not_to have_selector('ul')
+    end
+  end
+
+  context 'when the user has extra permissions' do
+    let(:provider_user) do
+      provider_traits = ProviderPermissions::VALID_PERMISSIONS.map { |permission| "with_#{permission}".to_sym }
+      create(:provider_user, :with_provider, *provider_traits.shuffle)
+    end
+
+    it 'renders a list of the user’s permissions' do
+      expect(render.css('p.govuk-hint').text.squish).to eq(t('provider_interface.user_card_component.permissions_list_preamble'))
+      expect(render.css('li').map(&:text).map(&:squish)).to eq([
+        'manage users',
+        'manage organisation permissions',
+        'set up interviews',
+        'make offers and reject applications',
+        'view criminal convictions and professional misconduct',
+        'view sex, disability and ethnicity information',
+      ])
+    end
+  end
+end

--- a/spec/requests/provider_interface/managing_provider_users_spec.rb
+++ b/spec/requests/provider_interface/managing_provider_users_spec.rb
@@ -16,25 +16,29 @@ RSpec.describe 'ProviderUserController actions' do
       )
   end
 
-  context 'when the user is not permitted to manage users' do
-    it 'redirects GET requests to index' do
-      get provider_interface_provider_users_path
+  context 'when the account_and_org_settings_changes feature flag is off' do
+    before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
 
-      expect(response).to be_forbidden
-    end
+    context 'when the user is not permitted to manage users' do
+      it 'redirects GET requests to index' do
+        get provider_interface_provider_users_path
 
-    it 'redirects GET requests to show' do
-      another_user = create(:provider_user, providers: [provider])
-      get provider_interface_provider_user_path(another_user)
+        expect(response).to be_forbidden
+      end
 
-      expect(response).to be_forbidden
-    end
+      it 'redirects GET requests to show' do
+        another_user = create(:provider_user, providers: [provider])
+        get provider_interface_provider_user_path(another_user)
 
-    it 'redirects GET requests to edit-providers' do
-      another_user = create(:provider_user, providers: [provider])
-      get provider_interface_provider_user_edit_providers_path(another_user)
+        expect(response).to be_forbidden
+      end
 
-      expect(response).to be_forbidden
+      it 'redirects GET requests to edit-providers' do
+        another_user = create(:provider_user, providers: [provider])
+        get provider_interface_provider_user_edit_providers_path(another_user)
+
+        expect(response).to be_forbidden
+      end
     end
   end
 end

--- a/spec/requests/provider_interface/provider_users_controller_spec.rb
+++ b/spec/requests/provider_interface/provider_users_controller_spec.rb
@@ -4,40 +4,56 @@ RSpec.describe ProviderInterface::ProviderUsersController, type: :request do
   include DfESignInHelpers
   include ModelWithErrorsStubHelper
 
-  describe 'validation errors' do
-    let(:managing_user) { create(:provider_user, :with_manage_organisations, :with_manage_users, providers: [provider]) }
+  let(:managing_user) { create(:provider_user, :with_manage_organisations, :with_manage_users, providers: [provider]) }
+  let(:provider) { create(:provider, :with_signed_agreement) }
+
+  before do
+    allow(DfESignInUser).to receive(:load_from_session).and_return(managing_user)
+
+    user_exists_in_dfe_sign_in(email_address: managing_user.email_address)
+  end
+
+  context 'when the account_and_org_settings_changes feature flag is on' do
+    before { FeatureFlag.activate(:account_and_org_settings_changes) }
+
+    it 'redirects to the org settings page' do
+      get provider_interface_provider_users_path
+
+      expect(response.status).to eq(302)
+      expect(response.redirect_url).to eq(provider_interface_organisation_settings_url)
+    end
+  end
+
+  context 'when the account_and_org_settings_changes feature flag is off' do
     let(:provider_user) { create(:provider_user, providers: [provider]) }
-    let(:provider) { create(:provider, :with_signed_agreement) }
 
-    before do
-      allow(DfESignInUser).to receive(:load_from_session).and_return(managing_user)
+    before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
 
-      user_exists_in_dfe_sign_in(email_address: managing_user.email_address)
-    end
+    describe 'validation errors' do
+      it 'tracks validation errors for GET to edit_permissions' do
+        stub_model_instance_with_errors(ProviderInterface::ProviderUserEditPermissionsForm, invalid?: true, :provider_permissions= => nil)
 
-    it 'tracks validation errors for GET to edit_permissions' do
-      stub_model_instance_with_errors(ProviderInterface::ProviderUserEditPermissionsForm, invalid?: true, :provider_permissions= => nil)
+        expect { get provider_interface_provider_user_edit_permissions_path(provider_user, provider) }.to change(ValidationError, :count).by(1)
+      end
 
-      expect { get provider_interface_provider_user_edit_permissions_path(provider_user, provider) }.to change(ValidationError, :count).by(1)
-    end
-
-    it 'tracks validation errors for PATCH to update_permissions' do
-      stub_model_instance_with_errors(
-        ProviderInterface::ProviderUserEditPermissionsForm,
-        save: false, update_from_params: nil, provider: provider, provider_user: provider_user, :provider_permissions= => nil,
-        permissions_form: instance_double(
-          ProviderInterface::FieldsForProviderUserPermissionsForm, id: '1', provider_id: provider.id, view_applications_only: nil, permissions: {}
+      it 'tracks validation errors for PATCH to update_permissions' do
+        stub_model_instance_with_errors(
+          ProviderInterface::ProviderUserEditPermissionsForm,
+          save: false, update_from_params: nil, provider: provider, provider_user: provider_user, :provider_permissions= => nil,
+          permissions_form: instance_double(
+            ProviderInterface::FieldsForProviderUserPermissionsForm, id: '1', provider_id: provider.id, view_applications_only: nil, permissions: {}
+          )
         )
-      )
 
-      expect {
-        patch provider_interface_provider_user_edit_permissions_path(provider_user, provider),
-              params: { provider_interface_provider_user_edit_permissions_form: { provider_id: provider.id } }
-      }.to change(ValidationError, :count).by(1)
-    end
+        expect {
+          patch provider_interface_provider_user_edit_permissions_path(provider_user, provider),
+                params: { provider_interface_provider_user_edit_permissions_form: { provider_id: provider.id } }
+        }.to change(ValidationError, :count).by(1)
+      end
 
-    it 'tracks validation errors for PUT to update_providers' do
-      expect { patch provider_interface_provider_user_edit_providers_path(provider_user) }.to change(ValidationError, :count).by(1)
+      it 'tracks validation errors for PUT to update_providers' do
+        expect { patch provider_interface_provider_user_edit_providers_path(provider_user) }.to change(ValidationError, :count).by(1)
+      end
     end
   end
 end

--- a/spec/requests/provider_interface/users_controller_spec.rb
+++ b/spec/requests/provider_interface/users_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::UsersController do
+  include DfESignInHelpers
+
+  let(:managing_user) { create(:provider_user, :with_manage_organisations, :with_manage_users, providers: [provider]) }
+  let(:provider) { create(:provider, :with_signed_agreement) }
+
+  before do
+    allow(DfESignInUser).to receive(:load_from_session).and_return(managing_user)
+
+    user_exists_in_dfe_sign_in(email_address: managing_user.email_address)
+  end
+
+  context 'when the account_and_org_settings_changes feature flag is on' do
+    before { FeatureFlag.activate(:account_and_org_settings_changes) }
+
+    it 'returns a success response' do
+      get provider_interface_organisation_settings_organisation_users_path(provider)
+
+      expect(response.status).to eq(200)
+    end
+  end
+
+  context 'when the account_and_org_settings_changes feature flag is off' do
+    before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
+
+    it 'redirects to the org settings page' do
+      get provider_interface_organisation_settings_organisation_users_path(provider)
+
+      expect(response.status).to eq(302)
+      expect(response.redirect_url).to eq(provider_interface_organisation_settings_url)
+    end
+  end
+end

--- a/spec/system/provider_interface/providers_can_view_managed_users_spec.rb
+++ b/spec/system/provider_interface/providers_can_view_managed_users_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature 'Providers can view managed users' do
   include DfESignInHelpers
   include DsiAPIHelper
 
+  # Behaviour tested here has moved to spec/system/provider_interface/view_organisation_users_spec.rb
   before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
 
   scenario 'Provider use can see their individual users permissions' do

--- a/spec/system/provider_interface/view_organisation_settings_spec.rb
+++ b/spec/system/provider_interface/view_organisation_settings_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'Organisation settings' do
   end
 
   def and_i_see_a_link_to_manage_users_for_my_provider
-    expect(page).to have_link("Users #{@first_provider.name}", href: provider_interface_provider_users_path)
+    expect(page).to have_link("Users #{@first_provider.name}", href: provider_interface_organisation_settings_organisation_users_path(@first_provider))
   end
 
   def and_i_see_a_link_to_manage_organisation_permissions_for_my_provider

--- a/spec/system/provider_interface/view_organisation_users_spec.rb
+++ b/spec/system/provider_interface/view_organisation_users_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.feature 'Organisation users' do
+  include DfESignInHelpers
+
+  before { FeatureFlag.activate(:account_and_org_settings_changes) }
+
+  scenario 'Provider user views their organisation’s users' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_can_manage_users_for_one_provider
+    and_i_cannot_manage_users_for_another_provider
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_go_to_organisation_settings
+    then_i_see_users_links_for_both_providers
+
+    when_i_view_users_for(@manage_users_provider)
+    then_i_see_a_list_of_users_for(@manage_users_provider)
+
+    when_i_click_on_the(@first_manageable_user)
+    then_i_see_personal_details_for(@first_manageable_user)
+    and_i_can_see_their_user_permissions
+    and_i_can_see_change_links
+
+    when_i_go_to_organisation_settings
+    and_i_view_users_for(@read_only_provider)
+    then_i_see_a_list_of_users_for(@read_only_provider)
+
+    when_i_click_on_the(@first_unmanageable_user)
+    then_i_see_personal_details_for(@first_unmanageable_user)
+    and_i_can_see_their_user_permissions
+    and_i_cannot_see_change_links
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_can_manage_users_for_one_provider
+    @manage_users_provider = create(:provider, :with_signed_agreement, code: 'ABC')
+    @provider_user = create(
+      :provider_user,
+      :with_manage_users,
+      providers: [@manage_users_provider],
+      dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
+      email_address: 'email@provider.ac.uk',
+    )
+
+    create_list(:provider_user, 3, providers: [@manage_users_provider])
+    @first_manageable_user = @manage_users_provider.provider_users.where.not(id: @provider_user.id).order(:first_name, :last_name).first
+  end
+
+  def and_i_cannot_manage_users_for_another_provider
+    @read_only_provider = create(:provider, :with_signed_agreement, code: 'DEF')
+    create(:provider_permissions, provider_user: @provider_user, provider: @read_only_provider)
+
+    create_list(:provider_user, 3, providers: [@read_only_provider])
+    @first_unmanageable_user = @read_only_provider.provider_users.where.not(id: @provider_user.id).order(:first_name, :last_name).first
+  end
+
+  def when_i_go_to_organisation_settings
+    click_on 'Organisation settings', match: :first
+  end
+
+  def then_i_see_users_links_for_both_providers
+    expect(page).to have_link("Users #{@manage_users_provider.name}")
+    expect(page).to have_link("Users #{@read_only_provider.name}")
+  end
+
+  def when_i_view_users_for(provider)
+    click_on "Users #{provider.name}"
+  end
+
+  alias_method :and_i_view_users_for, :when_i_view_users_for
+
+  def then_i_see_a_list_of_users_for(provider)
+    expect(page).to have_selector('span', text: provider.name)
+    expect(page).to have_selector('h1', text: 'Users')
+    users = provider.provider_users
+    users.each do |user|
+      expect(page).to have_selector('h2 > a', text: user.full_name)
+    end
+  end
+
+  def when_i_click_on_the(user)
+    click_on user.full_name
+  end
+
+  def then_i_see_personal_details_for(user)
+    expect(page).to have_selector('h1', text: user.full_name)
+    expect(page).to have_selector('h2', text: 'Personal details')
+    expect(page).to have_selector('.govuk-summary-list__value', text: user.first_name)
+    expect(page).to have_selector('.govuk-summary-list__value', text: user.last_name)
+    expect(page).to have_selector('.govuk-summary-list__value', text: user.email_address)
+  end
+
+  def and_i_can_see_their_user_permissions
+    expect(page).to have_selector('h2', text: 'User permissions')
+    expect(page).to have_selector('.govuk-summary-list__row', text: 'Manage users No')
+    expect(page).to have_selector('.govuk-summary-list__row', text: 'Manage organisation permissions No')
+    expect(page).to have_selector('.govuk-summary-list__row', text: 'Set up interviews No')
+    expect(page).to have_selector('.govuk-summary-list__row', text: 'Make offers and reject applications No')
+    expect(page).to have_selector('.govuk-summary-list__row', text: 'View criminal convictions and professional misconduct No')
+    expect(page).to have_selector('.govuk-summary-list__row', text: 'View sex, disability and ethnicity information No')
+  end
+
+  def and_i_can_see_change_links
+    expect(page).to have_link('Change Set up interviews')
+  end
+
+  def and_i_cannot_see_change_links
+    expect(page).not_to have_link('Change Set up interviews')
+  end
+end


### PR DESCRIPTION
## Context
Users are now going to be viewed and edited from within the scope of a single organisation

## Changes proposed in this pull request
Add a new scoped-to-provider users index page and a show page

## Guidance to review
Per commit

## Link to Trello card
https://trello.com/c/xG728hDB/4084-create-new-users-org-settings-pages

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
