### PR TITLE
Add random hex generator to email factories

### DIFF
--- a/spec/factories/dfe_sign_in_user.rb
+++ b/spec/factories/dfe_sign_in_user.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :dfe_sign_in_user do
     dfe_sign_in_uid { SecureRandom.uuid }
-    email_address { "#{Faker::Name.first_name.downcase}@example.com" }
+    email_address { "#{Faker::Name.first_name.downcase}-#{SecureRandom.hex}@example.com" }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
 

--- a/spec/factories/support_user.rb
+++ b/spec/factories/support_user.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :support_user do
     dfe_sign_in_uid { SecureRandom.uuid }
-    email_address { "#{Faker::Name.first_name.downcase}@example.com" }
+    email_address { "#{Faker::Name.first_name.downcase}-#{SecureRandom.hex}@example.com" }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
   end


### PR DESCRIPTION
## Context

We seem to be getting flakey failures in tests due to duplicate emails being generated in factories for users

## Changes proposed in this pull request
Add `SecureRandom.hex` to generate a random string to append to generated emails.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
