### PR TITLE
Update GiT links

### DIFF
--- a/app/components/candidate_interface/volunteering_review_component.html.erb
+++ b/app/components/candidate_interface/volunteering_review_component.html.erb
@@ -19,7 +19,12 @@
     <%= govuk_inset_text(classes: 'govuk-!-margin-top-0 govuk-!-width-two-thirds') do %>
       <p>The Department for Education have made it easier for teacher training applicants to gain experience in school.</p>
       <p>
-        <%= govuk_link_to t('application_form.volunteering.no_experience.get_experience'), 'https://schoolexperience.education.gov.uk', target: :_blank, rel: 'noopener' %>
+        <%= govuk_link_to(
+          t('application_form.volunteering.no_experience.get_experience'),
+          t('get_into_teaching.url_get_school_experience'),
+          target: :_blank,
+          rel: 'noopener',
+        ) %>
       </p>
     <% end %>
   <% end %>

--- a/app/views/candidate_interface/references/start/show.html.erb
+++ b/app/views/candidate_interface/references/start/show.html.erb
@@ -21,7 +21,7 @@
 
     <p class="govuk-body">
       <%= govuk_link_to(
-        'Talk to a teacher training advisor',
+        'Talk to a teacher training adviser',
         t('get_into_teaching.url_online_chat'),
       ) %>
       if you need help choosing a referee.

--- a/app/views/candidate_interface/references/start/show.html.erb
+++ b/app/views/candidate_interface/references/start/show.html.erb
@@ -19,6 +19,14 @@
 
     <p class="govuk-body">Training providers will only accept a character reference if there’s also an academic or professional reference.</p>
 
+    <p class="govuk-body">
+      <%= govuk_link_to(
+        'Talk to a teacher training advisor',
+        t('get_into_teaching.url_online_chat'),
+      ) %>
+      if you need help choosing a referee.
+    </p>
+
     <h2 class="govuk-heading-m">Contact your referees</h2>
 
     <p class="govuk-body">Your referees will receive a link to an online form to complete. References sent to providers by email will not be accepted.</p>

--- a/config/locales/candidate_interface/volunteering.yml
+++ b/config/locales/candidate_interface/volunteering.yml
@@ -6,7 +6,7 @@ en:
         change_action: Change
       no_experience:
         summary_card_title: 'Children and young people: no volunteering or experience in school roles entered'
-        get_experience: Learn more at Get school experience
+        get_experience: Learn about how to get school experience 
       role:
         label: Your role
         review_label: Role

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,7 @@ en:
     url_international_candidates: https://getintoteaching.education.gov.uk/international-candidates
     url_training_with_a_disability: https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#training-to-teach-if-you-have-a-disability
     url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
+    url_get_school_experience: https://getintoteaching.education.gov.uk/get-school-experience
   page_titles:
     application_form: Your application
     application_dashboard: Your application

--- a/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_and_school_experience_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_and_school_experience_spec.rb
@@ -249,7 +249,10 @@ RSpec.feature 'Entering volunteering and school experience' do
   end
 
   def then_i_can_see_a_link_to_get_school_experience
-    expect(page).to have_link(t('application_form.volunteering.no_experience.get_experience'), href: 'https://schoolexperience.education.gov.uk')
+    expect(page).to have_link(
+      t('application_form.volunteering.no_experience.get_experience'),
+      href: 'https://getintoteaching.education.gov.uk/get-school-experience',
+    )
   end
 
   def when_i_click_on_change


### PR DESCRIPTION
## Context

There are a couple of links to the _Get into teaching_ site that need to be updated.

This PR just covers the changes to Apply (others to follow in Find).

## Changes proposed in this pull request

- [x] Add link to the _Choose your referees_ page
<img width="1028" alt="image" src="https://user-images.githubusercontent.com/450843/129275996-baef74b6-d6fe-4427-84d3-b080ae6017eb.png">

- [x] Change link on the _Unpaid experience_ page
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/450843/129334025-bb516d41-d038-4e27-9d8d-a9ed003cfcd3.png">


## Guidance to review

- Is the copy as specified and do the links work?

## Link to Trello card

https://trello.com/c/EC0lo4u6/3728-add-git-links-to-apply-find

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
