### PR TITLE
Add training and accredited provider type to Register API

### DIFF
--- a/app/presenters/register_api/single_application_presenter.rb
+++ b/app/presenters/register_api/single_application_presenter.rb
@@ -92,6 +92,8 @@ module RegisterAPI
         recruitment_cycle_year: course_option.course.recruitment_cycle_year,
         course_code: course_option.course.code,
         training_provider_code: course_option.course.provider.code,
+        training_provider_type: course_option.course.provider.provider_type,
+        accredited_provider_type: course_option.course.accredited_provider&.provider_type,
         site_code: course_option.site.code,
         study_mode: course_option.study_mode,
       }

--- a/config/register-api.yml
+++ b/config/register-api.yml
@@ -373,6 +373,8 @@ components:
       - recruitment_cycle_year
       - course_code
       - training_provider_code
+      - training_provider_type
+      - accredited_provider_type
       - site_code
       - study_mode
       properties:
@@ -385,6 +387,28 @@ components:
           description: The training provider’s code
           example: 2FR
           maxLength: 3
+        training_provider_type:
+          type: string
+          nullable: true
+          description: |
+            The training provider’s type
+          enum:
+            - scitt
+            - lead_school
+            - university
+          example: scitt
+          maxLength: 25
+        accredited_provider_type:
+          type: string
+          nullable: true
+          description: |
+            The accredited provider’s type
+          enum:
+            - scitt
+            - lead_school
+            - university
+          example: university
+          maxLength: 25
         course_code:
           type: string
           description: The course’s code

--- a/spec/presenters/register_api/single_application_presenter_spec.rb
+++ b/spec/presenters/register_api/single_application_presenter_spec.rb
@@ -389,6 +389,30 @@ RSpec.describe RegisterAPI::SingleApplicationPresenter do
     end
   end
 
+  describe 'attributes.course' do
+    let(:application_choice) { create(:application_choice, :with_completed_application_form, :with_offer, :with_recruited, course: course) }
+    let(:training_provider) { create(:provider, provider_type: 'scitt') }
+    let(:accredited_provider) { create(:provider, provider_type: 'university') }
+    let(:course) { create(:course, provider: training_provider, accredited_provider: accredited_provider) }
+    let(:presenter) { described_class.new(application_choice).as_json }
+
+    it 'returns the course training provider type' do
+      expect(presenter.dig(:attributes, :course, :training_provider_type)).to eq('scitt')
+    end
+
+    it 'returns the course accredited provider type' do
+      expect(presenter.dig(:attributes, :course, :accredited_provider_type)).to eq('university')
+    end
+
+    context 'with a self ratified course' do
+      let(:accredited_provider) { nil }
+
+      it 'returns no accredited provider type' do
+        expect(presenter.dig(:attributes, :course, :accredited_provider_type)).to be_nil
+      end
+    end
+  end
+
   describe 'attributes.qualifications' do
     let(:application_choice) { create(:application_choice, :with_completed_application_form, :with_offer, :with_recruited) }
     let(:presenter) { described_class.new(application_choice) }

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -138,7 +138,7 @@ module CandidateHelper
   end
 
   def given_courses_exist
-    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
+    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1', provider_type: 'scitt')
     site = create(:site, name: 'Main site', code: '-', provider: @provider)
     course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Primary', code: '2XT2', provider: @provider, start_date: Date.new(2020, 9, 1))
     course2 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Drama', code: '2397', provider: @provider, start_date: Date.new(2020, 9, 1))

--- a/spec/system/register_api/register_receives_application_spec.rb
+++ b/spec/system/register_api/register_receives_application_spec.rb
@@ -85,6 +85,8 @@ RSpec.feature 'Register receives an application data' do
           recruitment_cycle_year: RecruitmentCycle.current_year,
           course_code: '2XT2',
           training_provider_code: '1N1',
+          training_provider_type: 'scitt',
+          accredited_provider_type: nil,
           site_code: '-',
           study_mode: 'full_time',
         },


### PR DESCRIPTION
## Context

The register team have requested surfacing the course provider types to help with further integration referencing.

## Changes proposed in this pull request

- Add new training and accredited provider type fields to Register API
- Allow `nil` values for accredited provider type if the course is self ratified
 
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
