### PR TITLE
Use contain exactly in flakey test as we don't care about order

### DIFF
--- a/spec/forms/candidate_interface/pick_course_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_course_form_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe CandidateInterface::PickCourseForm do
       end
 
       it 'returns both sites' do
-        expect(pick_course_form.available_course_options).to eq([course_option1, course_option2])
+        expect(pick_course_form.available_course_options).to contain_exactly(course_option1, course_option2)
       end
 
       context 'when one site is not longer valid' do


### PR DESCRIPTION
## Context

We are getting flakey failures due to ordering of course options returned. We don't seem to care about the order in this method

## Changes proposed in this pull request

Use `contains_exactly` instead of `eq` to avoid failures due to order

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
