### PR TITLE
Include filter styles in support css

### DIFF
--- a/app/frontend/styles/application-support.scss
+++ b/app/frontend/styles/application-support.scss
@@ -1,6 +1,7 @@
 @import "application";
 @import "support/all";
 @import "components/paginated_filter";
+@import "components/checkbox_search_filter";
 
 .app-data-set-documentation--datatype {
   color: $govuk-secondary-text-colour;


### PR DESCRIPTION
## Context
We use checkboxes in the support filter, but do not have the styles.
