### PR TITLE
Correctly use except to ignore keys in a hash

### DIFF
--- a/spec/presenters/hesa_qualification_fields_presenter_spec.rb
+++ b/spec/presenters/hesa_qualification_fields_presenter_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe HesaQualificationFieldsPresenter do
 
     context 'when iso3166 institution country code matches HESA degctry code' do
       it 'returns the institution country code' do
-        iso3166_code = COUNTRIES.except(described_class::HESA_DEGCTRY_MAPPING.keys).keys.sample
+        iso3166_code = COUNTRIES.except(*described_class::HESA_DEGCTRY_MAPPING.keys).keys.sample
         presenter = described_class.new(build(:degree_qualification, institution_country: iso3166_code))
         expect(presenter.to_hash[:hesa_degctry]).to eq(iso3166_code)
       end


### PR DESCRIPTION
## Context

We're getting flakey tests as we map `COUNTRIES` keys further in the HESA qualifications presenter. In the spec we had a workaround to ignore those keys however we weren't using it correctly:

```
[11] pry(#<RSpec::ExampleGroups::HesaQualificationFieldsPresenter::ToHash::WhenIso3166InstitutionCountryCodeMatchesHESADegctryCode>)> {"CY" => "1", "GB" => "2", "XK" => "3"}.except(HesaQualificationFieldsPresenter::HESA_DEGCTRY_MAPPING.keys)
=> {"CY"=>"1", "GB"=>"2", "XK"=>"3"}
[12] pry(#<RSpec::ExampleGroups::HesaQualificationFieldsPresenter::ToHash::WhenIso3166InstitutionCountryCodeMatchesHESADegctryCode>)> {"CY" => "1", "GB" => "2", "XK" => "3"}.except(*HesaQualificationFieldsPresenter::HESA_DEGCTRY_MAPPING.keys)
=> {}
```
## Changes proposed in this pull request

Splat the keys in the `except` method to correctly reject the keys we want to avoid flakey specs

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
