### PR TITLE
Skip first run for jobs with no specific schedule

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -9,8 +9,8 @@ class Clock
   error_handler { |error| Sentry.capture_exception(error) if defined? Sentry }
 
   # More-than-hourly jobs
-  every(10.minutes, 'IncrementalSyncAllFromTeacherTrainingPublicAPI') { TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async }
-  every(11.minutes, 'IncrementalSyncNextCycleFromTeacherTrainingPublicAPI') do
+  every(10.minutes, 'IncrementalSyncAllFromTeacherTrainingPublicAPI', skip_first_run: true) { TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async }
+  every(11.minutes, 'IncrementalSyncNextCycleFromTeacherTrainingPublicAPI', skip_first_run: true) do
     if FeatureFlag.active?(:sync_next_cycle)
       TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(true, RecruitmentCycle.next_year)
     end


### PR DESCRIPTION
Avoid running immediately after startup

## Context

Check if this helps ease clock deployment issues

## Changes proposed in this pull request

Set `:skip_first_run => true` for jobs that run every x mins

## Guidance to review


## Link to Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
