### PR TITLE
Drop word count validation to 100 for other_advice_or_feedback_details field

### DIFF
--- a/app/forms/provider_interface/reasons_for_rejection_wizard.rb
+++ b/app/forms/provider_interface/reasons_for_rejection_wizard.rb
@@ -172,8 +172,12 @@ module ProviderInterface
                 presence: true,
                 if: :reason_not_captured_by_initial_questions?
 
-      validates_each(:other_advice_or_feedback_details, :why_are_you_rejecting_this_application) do |record, attr, value|
-        record.errors.add(attr, :too_long) if record.excessive_word_count?(value, 200)
+      validates_each(:why_are_you_rejecting_this_application) do |record, attr, value|
+        record.errors.add(attr, :too_long, count: 200) if record.excessive_word_count?(value, 200)
+      end
+
+      validates_each(:other_advice_or_feedback_details) do |record, attr, value|
+        record.errors.add(attr, :too_long, count: 100) if record.excessive_word_count?(value, 100)
       end
     end
 

--- a/config/locales/provider_interface/reasons_for_rejection.yml
+++ b/config/locales/provider_interface/reasons_for_rejection.yml
@@ -159,4 +159,4 @@ en:
               blank: Select yes if there is any other advice or feedback you‘d like to give
             other_advice_or_feedback_details:
               blank: Enter any other advice or feedback
-              too_long: The other advice or feedback must be 200 words or fewer
+              too_long: The other advice or feedback must be %{count} words or fewer


### PR DESCRIPTION

## Context

When providing additional reasons for rejection, the user is able to submit more than the word count in the free text box due to an error in the field validation.

## Guidance to review
1. Find a received application and navigate to the Make decisions page.
2. Select reject application 
3. Select No on all questions and click Continue
4. Fill in a reason you are rejecting this application
4. Select Yes on the 'Is there any other advice or feedback you’d like to give ...' field
5. Add more than 100 words
6. Click Continue

You should now not be able to proceed to the next page.

## Link to Trello card
https://trello.com/c/8Neaiyb8/4072-rejected-candidate-additional-advice-allowed-to-submit-more-than-the-word-count-in-the-free-text-box

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
