### PR TITLE
Pre-fill application if you arrive from Find with course params and are a Sandbox candidate user

### DIFF
--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -30,12 +30,7 @@ module CandidateInterface
 
     def redirect_to_prefill_if_sandbox_user_has_blank_application
       if HostingEnvironment.sandbox_mode? && current_application.blank_application?
-        if course_from_find
-          key = "prefill_application_#{current_user.id}"
-          value = { course_id: course_from_find.id }
-
-          Rails.cache.write(key, value, expires_in: 5.minutes)
-        end
+        store_prefill_data if course_from_find
 
         redirect_to candidate_interface_prefill_path
       else
@@ -57,6 +52,12 @@ module CandidateInterface
 
     def course_from_find
       @course_from_find ||= current_candidate.course_from_find
+    end
+
+    def store_prefill_data
+      store = PrefillApplicationStateStore::RailsCache.new(current_user.id)
+      data = { course_id: course_from_find.id }
+      store.write(data)
     end
   end
 end

--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -1,25 +1,24 @@
 module CandidateInterface
   class AfterSignInController < CandidateInterfaceController
+    before_action :redirect_to_prefill_if_sandbox_user_has_blank_application
     before_action :redirect_to_path_if_path_params_are_present
     before_action :redirect_to_application_form_unless_course_from_find_is_present
 
     def interstitial
-      course = course_from_find
-
       current_candidate.update!(course_from_find_id: nil)
 
       if current_application.submitted?
         redirect_to candidate_interface_application_complete_path
-      elsif current_application.contains_course?(course)
-        flash[:warning] = "You have already selected #{course.name_and_code}."
+      elsif current_application.contains_course?(course_from_find)
+        flash[:warning] = "You have already selected #{course_from_find.name_and_code}."
         redirect_to candidate_interface_course_choices_review_path
       elsif current_application.maximum_number_of_course_choices?
         error_message_key = current_application.apply_1? ? 'errors.messages.too_many_course_choices' : 'errors.messages.apply_again_course_already_chosen'
-        flash[:warning] = I18n.t(error_message_key, course_name_and_code: course.name_and_code)
+        flash[:warning] = I18n.t(error_message_key, course_name_and_code: course_from_find.name_and_code)
 
         redirect_to candidate_interface_course_choices_review_path
       else
-        redirect_to candidate_interface_course_confirm_selection_path(course.id)
+        redirect_to candidate_interface_course_confirm_selection_path(course_from_find.id)
       end
     end
 
@@ -29,15 +28,26 @@ module CandidateInterface
       redirect_to params[:path] if params[:path].present?
     end
 
+    def redirect_to_prefill_if_sandbox_user_has_blank_application
+      if HostingEnvironment.sandbox_mode? && current_application.blank_application?
+        if course_from_find
+          key = "prefill_application_#{current_user.id}"
+          value = { course_id: course_from_find.id }
+
+          Rails.cache.write(key, value, expires_in: 5.minutes)
+        end
+
+        redirect_to candidate_interface_prefill_path
+      else
+        false
+      end
+    end
+
     def redirect_to_application_form_unless_course_from_find_is_present
       return false unless course_from_find.nil?
 
       if current_application.blank_application?
-        if HostingEnvironment.sandbox_mode?
-          redirect_to candidate_interface_prefill_path
-        else
-          redirect_to candidate_interface_before_you_start_path
-        end
+        redirect_to candidate_interface_before_you_start_path
       elsif current_application.submitted?
         redirect_to candidate_interface_application_complete_path
       else
@@ -46,7 +56,7 @@ module CandidateInterface
     end
 
     def course_from_find
-      current_candidate.course_from_find
+      @course_from_find ||= current_candidate.course_from_find
     end
   end
 end

--- a/app/controllers/candidate_interface/prefill_application_form_controller.rb
+++ b/app/controllers/candidate_interface/prefill_application_form_controller.rb
@@ -58,27 +58,16 @@ module CandidateInterface
         candidate: current_candidate,
       }
 
-      data = read_prefill_application_data
+      store = PrefillApplicationStateStore::RailsCache.new(current_candidate.id)
+      data = store.read
 
       if data
         course_from_find = Course.find(data[:course_id])
         test_application_options.merge!(courses_to_apply_to: [course_from_find])
-        clear_prefill_application_data
+        store.clear
       end
 
       test_application_options
-    end
-
-    def read_prefill_application_data
-      Rails.cache.read(key)
-    end
-
-    def clear_prefill_application_data
-      Rails.cache.clear(key)
-    end
-
-    def key
-      "prefill_application_#{current_candidate.id}"
     end
   end
 end

--- a/app/lib/prefill_application_state_store/rails_cache.rb
+++ b/app/lib/prefill_application_state_store/rails_cache.rb
@@ -1,0 +1,25 @@
+module PrefillApplicationStateStore
+  class RailsCache
+    def initialize(current_candidate_id)
+      @current_candidate_id = current_candidate_id
+    end
+
+    def write(data)
+      Rails.cache.write(key, data, expires_in: 5.minutes.to_i)
+    end
+
+    def read
+      Rails.cache.read(key)
+    end
+
+    def clear
+      Rails.cache.clear(key)
+    end
+
+  private
+
+    def key
+      "prefill_application_#{@current_candidate_id}"
+    end
+  end
+end

--- a/spec/lib/prefill_application_state_store/rails_cache_spec.rb
+++ b/spec/lib/prefill_application_state_store/rails_cache_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe PrefillApplicationStateStore::RailsCache do
+  it 'expires the key after 5 minutes' do
+    current_candidate_id = '12345'
+    data = { value: 'value' }
+    store = described_class.new(current_candidate_id)
+
+    store.write(data)
+
+    expect(store.read).to eq(data)
+
+    Timecop.travel(5.minutes) do
+      expect(store.read).to be_nil
+    end
+  end
+end

--- a/spec/system/candidate_interface/course_selection/sandbox_user_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/course_selection/sandbox_user_apply_from_find_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe 'A sandbox user arriving from Find with a course and provider code', sandbox: true do
+  include SignInHelper
+
+  scenario 'can prefill their application with their chosen course' do
+    given_the_pilot_is_open
+    and_i_do_not_have_an_account
+    and_a_course_and_course_option_exists
+    and_i_am_on_the_apply_from_find_page_with_a_course_and_provider_code
+
+    when_i_choose_to_apply_through_apply
+    and_i_confirm_i_am_not_already_signed_up
+    then_i_see_the_sign_up_page
+
+    when_i_sign_up
+    then_i_am_signed_in
+    and_i_see_the_prefill_application_form
+
+    when_i_select_prefill_application
+    then_i_see_the_course_choice_has_been_added_to_my_application
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def and_i_do_not_have_an_account
+    @email = "#{SecureRandom.hex}@example.com"
+  end
+
+  def and_a_course_and_course_option_exists
+    @provider = create(:provider, code: 'DEF')
+    @course_on_apply = create(:course, exposed_in_find: true, open_on_apply: true, code: 'DEF1', name: 'Potions', provider: @provider)
+    @course_options_on_apply = create_list(:course_option, 3, course: @course_on_apply)
+  end
+
+  def and_i_am_on_the_apply_from_find_page_with_a_course_and_provider_code
+    visit candidate_interface_apply_from_find_path providerCode: @course_on_apply.provider.code, courseCode: @course_on_apply.code
+  end
+
+  def when_i_choose_to_apply_through_apply
+    choose 'Yes, I want to apply using the new service'
+
+    click_button t('continue')
+  end
+
+  def and_i_confirm_i_am_not_already_signed_up
+    choose 'No, I need to create an account'
+    click_button t('continue')
+  end
+
+  def then_i_see_the_sign_up_page
+    expect(page).to have_content 'Create an Apply for teacher training account'
+  end
+
+  def when_i_sign_up
+    check t('authentication.sign_up.accept_terms_checkbox')
+    fill_in t('authentication.sign_up.email_address.label'), with: @email
+    click_on t('continue')
+
+    open_email(@email)
+    expect(current_email.subject).to have_content t('authentication.sign_up.email.subject')
+
+    click_magic_link_in_email
+    confirm_sign_in
+  end
+
+  def then_i_am_signed_in
+    within 'header' do
+      expect(page).to have_content @email
+    end
+  end
+
+  def and_i_see_the_prefill_application_form
+    expect(page).to have_content('What do you want to do?')
+  end
+
+  def when_i_select_prefill_application
+    choose 'Start with the form filled in automatically'
+    click_button t('continue')
+  end
+
+  def then_i_see_the_course_choice_has_been_added_to_my_application
+    click_link 'Choose your courses'
+    expect(page).to have_content(@course_on_apply.name_and_code)
+  end
+end


### PR DESCRIPTION
## Context

#### Current behaviour on Sandbox

`Find -> Apply with course params -> sign up -> don't get asked to prefill application`

#### Desired journey on Sandbox

`Find -> Apply with course params -> sign up -> don't get asked to prefill application -> add chosen course to application`

## Changes proposed in this pull request

- Use Redis to store information about the Sandbox user's chosen course. When pre-filling the application we can then add the chosen course to the application

## Guidance to review

- Make sense?
- I chose to use Redis as I felt it would not have been appropriate to pass around params in order to mutate an application. Seem reasonable?
- Should `WizardStateStores` be renamed to something more generic?

## Link to Trello card
https://trello.com/c/YNIVreWw/3726-bug-you-are-not-asked-if-you-want-your-application-form-pre-filled-if-you-arrive-from-find-with-course-params

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
