### PR TITLE
Start setting git sha ENV again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN bundle exec rake assets:precompile && \
 # If a existing base image name is specified Stage 1 & 2 will not be built and gems and dev packages will be used from the supplied image.
 FROM ${BASE_RUBY_IMAGE} AS production
 
+ARG VERSION
 ENV WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine \
     RAILS_ENV=production \
     GOVUK_NOTIFY_API_KEY=TestKey \
@@ -68,7 +69,6 @@ ENV ENV="/root/.ashrc"
 COPY --from=gems-node-modules /app /app
 COPY --from=gems-node-modules /usr/local/bundle/ /usr/local/bundle/
 
-ARG VERSION
 RUN echo ${VERSION} > public/check
 
 # Use this for development testing


### PR DESCRIPTION
## Context

We would like to use the git SHA in our cache keys, start setting the ENV variable again

## Changes proposed in this pull request

Move the variable above setting the ENV SHA to populate it

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
