### PR TITLE
Back link on interview page should take you to the right path

### DIFF
--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -38,7 +38,11 @@ module ProviderInterface
         @translation_prefix = '.update'
       end
 
-      @wizard = InterviewWizard.new(interview_store, interview_params.merge(current_step: 'check'))
+      if request.get?
+        @wizard = InterviewWizard.new(interview_store, interview_form_context_params.merge(current_step: 'check'))
+      elsif request.post?
+        @wizard = InterviewWizard.new(interview_store, interview_params.merge(current_step: 'check'))
+      end
       @wizard.save_state!
 
       unless @wizard.valid?

--- a/app/views/provider_interface/interviews/new.html.erb
+++ b/app/views/provider_interface/interviews/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_interviews_path(@application_choice)) %>
+<% content_for :before_content, govuk_back_link_to(request.referer) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -703,6 +703,7 @@ Rails.application.routes.draw do
 
       resources :interviews, only: %i[new edit index], as: :application_choice_interviews do
         collection do
+          get '/new/check', to: 'interviews#check'
           post '/new/check', to: 'interviews#check'
           post '/confirm', to: 'interviews#commit'
         end

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -22,7 +22,12 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
     when_i_visit_that_application_in_the_provider_interface
     and_i_click_set_up_an_interview
+    and_i_fill_out_the_interview_form(days_in_future: 1, time: '10pm')
+    then_i_can_check_the_interview_details(time: '10pm')
+
+    and_i_go_back
     and_i_fill_out_the_interview_form(days_in_future: 1, time: '12pm')
+    then_i_can_check_the_interview_details(time: '12pm')
     and_i_click_send_interview_details
     then_i_see_a_success_message
     and_an_interview_has_been_created(1.day.from_now.to_s(:govuk_date))
@@ -137,8 +142,18 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     click_on 'Continue'
   end
 
+  def then_i_can_check_the_interview_details(time:)
+    within all('.govuk-summary-list__row dd p')[1] do
+      expect(page).to have_content(time)
+    end
+  end
+
   def and_i_click_send_interview_details
     click_on 'Send interview details'
+  end
+
+  def and_i_go_back
+    click_on 'Back'
   end
 
   def then_i_see_a_success_message


### PR DESCRIPTION
## Context

When you are on the Check and Send Interview details page, if you click on any of the Change links to change some details and then, from the change details screen, use the backlink, the link takes you back to the applications page rather than back to the Check and Send interview details page.

## Changes proposed in this pull request

- Map back link to request.referer
- Add new route for `get /interview/check` as button issues a get request rather than a post
- Update controller action to not expect interfview params when accessed via get request
- Add spec to verify behavior

## Link to Trello card
https://trello.com/c/2lPlRb9c/4070-back-link-in-interview-workflow-takes-you-to-applications-page-rather-than-check-answers-page

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
