### PR TITLE
Add new flow for deleting provider users

### DIFF
--- a/app/controllers/provider_interface/users_controller.rb
+++ b/app/controllers/provider_interface/users_controller.rb
@@ -2,13 +2,16 @@ module ProviderInterface
   class UsersController < ProviderInterfaceController
     before_action :redirect_unless_feature_flag_on
     before_action :set_provider
+    before_action :set_provider_user, except: :index
+    before_action :assert_can_manage_users!, only: %i[confirm_destroy]
 
     def index; end
 
     def show
-      @provider_user = @provider.provider_users.find(params[:id])
       @current_user_can_manage_users = current_user_can_manage_users
     end
+
+    def confirm_destroy; end
 
   private
 
@@ -20,6 +23,14 @@ module ProviderInterface
 
     def set_provider
       @provider = current_provider_user.providers.find(params[:organisation_id])
+    end
+
+    def set_provider_user
+      @provider_user = @provider.provider_users.find(params[:id])
+    end
+
+    def assert_can_manage_users!
+      render_403 unless current_user_can_manage_users
     end
 
     def current_user_can_manage_users

--- a/app/controllers/provider_interface/users_controller.rb
+++ b/app/controllers/provider_interface/users_controller.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     before_action :redirect_unless_feature_flag_on
     before_action :set_provider
     before_action :set_provider_user, except: :index
-    before_action :assert_can_manage_users!, only: %i[confirm_destroy]
+    before_action :assert_can_manage_users!, except: %i[index show]
 
     def index; end
 
@@ -12,6 +12,13 @@ module ProviderInterface
     end
 
     def confirm_destroy; end
+
+    def destroy
+      RemoveUserFromProvider.new(current_provider_user: current_provider_user, provider: @provider, user_to_remove: @provider_user).call!
+
+      flash[:success] = 'User deleted'
+      redirect_to provider_interface_organisation_settings_organisation_users_path(@provider)
+    end
 
   private
 

--- a/app/services/provider_interface/remove_user_from_provider.rb
+++ b/app/services/provider_interface/remove_user_from_provider.rb
@@ -1,0 +1,35 @@
+module ProviderInterface
+  class RemoveUserFromProvider
+    include ImpersonationAuditHelper
+
+    attr_reader :current_provider_user, :provider, :user_to_remove
+
+    def initialize(current_provider_user:, provider:, user_to_remove:)
+      @current_provider_user = current_provider_user
+      @provider = provider
+      @user_to_remove = user_to_remove
+    end
+
+    def call!
+      audit(current_provider_user) do
+        assert_current_user_can_manage_users!
+
+        provider_permission = user_to_remove.provider_permissions.find_by!(provider: provider)
+        provider_permission.audit_comment = 'User was deleted'
+        provider_permission.destroy!
+      end
+    end
+
+  private
+
+    def assert_current_user_can_manage_users!
+      return if current_provider_user.authorisation.can_manage_users_for?(provider: provider)
+
+      raise ProviderInterface::AccessDenied.new({
+        permission: 'manage_users',
+        training_provider: provider,
+        provider_user: current_provider_user,
+      }), 'manage_users required'
+    end
+  end
+end

--- a/app/views/provider_interface/organisation_permissions/index.html.erb
+++ b/app/views/provider_interface/organisation_permissions/index.html.erb
@@ -20,7 +20,7 @@
     <span class="govuk-caption-l"><%= @provider.name %></span>
     <h1 class="govuk-heading-l"><%= t('page_titles.provider.organisation_permissions') %></h1>
     <% if FeatureFlag.active?(:account_and_org_settings_changes) && !@current_user_can_manage_organisation %>
-      <p class="govuk-body">You cannot change these permissions because you do not have permission to manage organisations.</p>
+      <p class="govuk-body"><%= t('provider_relationship_permissions.no_permissions_explanation') %></p>
     <% end %>
     <% @provider_relationships.each do |relationship| %>
       <%= render ProviderInterface::OrganisationPermissionsReviewCardComponent.new(

--- a/app/views/provider_interface/users/confirm_destroy.html.erb
+++ b/app/views/provider_interface/users/confirm_destroy.html.erb
@@ -1,0 +1,16 @@
+<% content_for :browser_title, t('page_titles.provider.confirm_delete_user', provider_name: @provider.name) %>
+
+<% content_for :before_content, govuk_back_link_to(provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @provider_user.full_name %></span>
+    <h1 class="govuk-heading-l"><%= t('page_titles.provider.confirm_delete_user', provider_name: @provider.name) %></h1>
+
+    <%= govuk_button_to 'Delete user', provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user), method: :delete, class: 'govuk-button--warning' %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t('cancel'), provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user) %>
+    </p>
+  </div>
+</div>

--- a/app/views/provider_interface/users/show.html.erb
+++ b/app/views/provider_interface/users/show.html.erb
@@ -13,11 +13,13 @@
     <span class="govuk-caption-l"><%= @provider.name %></span>
     <h1 class="govuk-heading-l"><%= @provider_user.full_name %></h1>
 
-    <% if @current_user_can_manage_users %>
-      <p class="govuk-body">
+    <p class="govuk-body">
+      <% if @current_user_can_manage_users %>
         <%= govuk_link_to 'Delete user', confirm_destroy_provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user) %>
-      </p>
-    <% end %>
+      <% else %>
+        You cannot change these details because you do not have permission to manage users.
+      <% end %>
+    </p>
 
     <h2 class="govuk-heading-m">Personal details</h2>
     <%= render SummaryListComponent.new(

--- a/app/views/provider_interface/users/show.html.erb
+++ b/app/views/provider_interface/users/show.html.erb
@@ -17,7 +17,7 @@
       <% if @current_user_can_manage_users %>
         <%= govuk_link_to 'Delete user', confirm_destroy_provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user) %>
       <% else %>
-        You cannot change these details because you do not have permission to manage users.
+        <%= t('user_permissions.no_permissions_explanation') %>
       <% end %>
     </p>
 

--- a/app/views/provider_interface/users/show.html.erb
+++ b/app/views/provider_interface/users/show.html.erb
@@ -12,6 +12,13 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l"><%= @provider.name %></span>
     <h1 class="govuk-heading-l"><%= @provider_user.full_name %></h1>
+
+    <% if @current_user_can_manage_users %>
+      <p class="govuk-body">
+        <%= govuk_link_to 'Delete user', confirm_destroy_provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user) %>
+      </p>
+    <% end %>
+
     <h2 class="govuk-heading-m">Personal details</h2>
     <%= render SummaryListComponent.new(
       rows: [

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -216,6 +216,7 @@ en:
       organisation_permissions: Organisation permissions
       change_organisation_permissions: Change permissions
       users: Users
+      confirm_delete_user: Confirm that you want to delete this user from %{provider_name}
       export_hesa_data: Export data for Higher Education Statistics Agency (HESA)
       export_application_data: Export application data
       notifications: Email notifications

--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -1,6 +1,7 @@
 en:
   provider_relationship_permissions:
     view_applications_explanation: All users can view applications.
+    no_permissions_explanation: You cannot change these permissions because you do not have permission to manage organisations.
     question: Who can %{permission_description}?
     make_decisions:
       description: Make offers and reject applications

--- a/config/locales/provider_interface/user_permisssions.yml
+++ b/config/locales/provider_interface/user_permisssions.yml
@@ -1,5 +1,6 @@
 en:
   user_permissions:
+    no_permissions_explanation: You cannot change these details because you do not have permission to manage users.
     make_decisions:
       description: Make offers and reject applications
     view_safeguarding_information:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -777,7 +777,11 @@ Rails.application.routes.draw do
       resources :organisations, only: [] do
         get '/' => 'organisation_permissions#organisations', on: :collection
         resources :organisation_permissions, path: '/organisation-permissions', only: %i[index edit update]
-        resources :users, path: '/users', only: %i[index show]
+        resources :users, path: '/users', only: %i[index show destroy] do
+          member do
+            get :confirm_destroy, path: 'delete'
+          end
+        end
       end
     end
 

--- a/spec/requests/provider_interface/users_controller_spec.rb
+++ b/spec/requests/provider_interface/users_controller_spec.rb
@@ -15,10 +15,27 @@ RSpec.describe ProviderInterface::UsersController do
   context 'when the account_and_org_settings_changes feature flag is on' do
     before { FeatureFlag.activate(:account_and_org_settings_changes) }
 
-    it 'returns a success response' do
+    it 'returns a success response for GET index' do
       get provider_interface_organisation_settings_organisation_users_path(provider)
 
       expect(response.status).to eq(200)
+    end
+
+    context 'when a user does not have manage orgs permissions' do
+      let(:managing_user) { create(:provider_user, :with_manage_organisations, providers: [provider]) }
+      let(:provider_user) { create(:provider_user, providers: [provider]) }
+
+      it 'responds with a 403 on GET confirm_destroy' do
+        get confirm_destroy_provider_interface_organisation_settings_organisation_user_path(provider, provider_user)
+
+        expect(response.status).to eq(403)
+      end
+
+      it 'responds with a 403 on DELETE' do
+        delete provider_interface_organisation_settings_organisation_user_path(provider, provider_user)
+
+        expect(response.status).to eq(403)
+      end
     end
   end
 

--- a/spec/services/provider_interface/remove_user_from_provider_spec.rb
+++ b/spec/services/provider_interface/remove_user_from_provider_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::RemoveUserFromProvider do
+  let(:user_to_remove) { create(:provider_user, :with_provider) }
+  let(:provider) { user_to_remove.providers.first }
+  let(:current_provider_user) { create(:provider_user) }
+  let(:service) do
+    described_class.new(
+      current_provider_user: current_provider_user,
+      provider: provider,
+      user_to_remove: user_to_remove,
+    )
+  end
+
+  describe '#call!' do
+    context 'when the current user does not have the manage users permission' do
+      it 'raises an access denied error' do
+        expect { service.call! }.to raise_error(ProviderInterface::AccessDenied)
+      end
+    end
+
+    context 'when the current user can manage users for the given provider' do
+      let(:current_provider_user) { create(:provider_user, :with_manage_users, providers: [provider]) }
+
+      context 'when the user_to_remove does not belong to the given provider' do
+        let(:provider) { create(:provider) }
+
+        it 'raises a not found error' do
+          expect { service.call! }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      it 'deletes the relationship between user and provider' do
+        expect { service.call! }.to change(user_to_remove.providers, :count).by(-1)
+        expect(user_to_remove.providers).not_to include(provider)
+      end
+
+      it 'audits the change', with_audited: true do
+        expect { service.call! }.to change(user_to_remove.associated_audits, :count).by(1)
+        expect(user_to_remove.associated_audits.last.comment).to eq('User was deleted')
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/remove_provider_user_spec.rb
+++ b/spec/system/provider_interface/remove_provider_user_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe 'Organisation users' do
+  include DfESignInHelpers
+
+  before { FeatureFlag.activate(:account_and_org_settings_changes) }
+
+  scenario 'Provider user removes another user from one of their organisations' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_can_manage_users_for_one_provider
+    and_i_cannot_manage_users_for_another_provider
+    and_a_provider_user_belonging_to_both_providers_exists
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_click_on_the_users_link_for(@manage_users_provider)
+    and_i_click_on_the_user_to_remove
+    and_i_click_delete_user
+    and_i_confirm_i_want_to_delete_this_user
+    then_i_see_the_success_message
+    and_the_user_no_longer_belongs_to_the_provider
+
+    when_i_click_on_the_users_link_for(@read_only_provider)
+    and_i_click_on_the_user_to_remove
+    then_i_cannot_see_a_link_to_delete_the_user
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_can_manage_users_for_one_provider
+    @manage_users_provider = create(:provider, :with_signed_agreement, code: 'ABC')
+    @provider_user = create(
+      :provider_user,
+      :with_manage_users,
+      providers: [@manage_users_provider],
+      dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
+      email_address: 'email@provider.ac.uk',
+    )
+  end
+
+  def and_i_cannot_manage_users_for_another_provider
+    @read_only_provider = create(:provider, :with_signed_agreement, code: 'DEF')
+    create(:provider_permissions, provider_user: @provider_user, provider: @read_only_provider)
+  end
+
+  def and_a_provider_user_belonging_to_both_providers_exists
+    @user_to_remove = create(:provider_user, providers: [@manage_users_provider, @read_only_provider])
+  end
+
+  def when_i_click_on_the_users_link_for(provider)
+    click_on 'Organisation settings', match: :first
+    click_on("Users #{provider.name}")
+  end
+
+  def and_i_click_on_the_user_to_remove
+    click_on @user_to_remove.full_name
+  end
+
+  def and_i_click_delete_user
+    click_on 'Delete user'
+  end
+
+  def and_i_confirm_i_want_to_delete_this_user
+    and_i_click_delete_user
+  end
+
+  def then_i_see_the_success_message
+    expect(page).to have_content('User deleted')
+  end
+
+  def and_the_user_no_longer_belongs_to_the_provider
+    expect(page).not_to have_content(@user_to_remove.full_name)
+    expect(@user_to_remove.reload.providers).to contain_exactly(@read_only_provider)
+  end
+
+  def then_i_cannot_see_a_link_to_delete_the_user
+    expect(page).not_to have_link('Delete user')
+  end
+end

--- a/spec/system/provider_interface/remove_provider_user_spec.rb
+++ b/spec/system/provider_interface/remove_provider_user_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe 'Organisation users' do
     when_i_click_on_the_users_link_for(@read_only_provider)
     and_i_click_on_the_user_to_remove
     then_i_cannot_see_a_link_to_delete_the_user
+    and_i_can_see_text_about_not_having_permissions
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -76,5 +77,9 @@ RSpec.describe 'Organisation users' do
 
   def then_i_cannot_see_a_link_to_delete_the_user
     expect(page).not_to have_link('Delete user')
+  end
+
+  def and_i_can_see_text_about_not_having_permissions
+    expect(page).to have_content('You cannot change these details because you do not have permission to manage users.')
   end
 end

--- a/spec/system/provider_interface/removing_provider_user_spec.rb
+++ b/spec/system/provider_interface/removing_provider_user_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Removing a provider user' do
   include DfESignInHelpers
 
+  # Behaviour tested here has moved to spec/system/provider_interface/remove_provider_user_spec.rb
   before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
 
   scenario 'removing a user from all providers', with_audited: true do


### PR DESCRIPTION
## Context
With the new scoped-to-provider users page, we need a new flow for removing provider users

## Changes proposed in this pull request
- Add new routes for deleting provider users
- Add new service for removing a user from a specified org

## Guidance to review
Per commit, test in the review app

## Link to Trello card
https://trello.com/c/IMbZ8zrQ/4091-delete-provider-user

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
