### PR TITLE
Test build improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,21 +117,21 @@ jobs:
         feature-flags: [on, off]
         include:
           - tests: unit_shared
-            include-pattern: spec/**/**/*_spec.rb
-            exclude-pattern: spec/**/{candidate_interface,support_interface,provider_interface,referee_interface,*api*}/**/*_spec.rb,spec/system/**/*_spec.rb
+            include-pattern: spec/.*/*_spec.rb
+            exclude-pattern: spec/.*(candidate_interface|provider_interface|support_interface|referee_interface|system|.*api.*).*/*_spec.rb
           - tests: unit_candidate-provider
-            include-pattern: spec/**/{candidate_interface,provider_interface}/**/*_spec.rb
-            exclude-pattern: spec/system/**/**/*_spec.rb
+            include-pattern: spec/.*(candidate_interface|provider_interface).*/*_spec.rb
+            exclude-pattern: spec/system/.*/*_spec.rb
           - tests: unit_support-referee-api
-            include-pattern: spec/**/{support_interface,referee_interface,*api*}/**/*_spec.rb
-            exclude-pattern: spec/system/**/*_spec.rb
+            include-pattern: spec/.*(support_interface|referee_interface|.*api.*).*/*_spec.rb
+            exclude-pattern: spec/system/.*/*_spec.rb
           - tests: integration_shared
-            include-pattern: spec/system/**/*_spec.rb
-            exclude-pattern: spec/system/{provider_interface,candidate_interface}/**/*_spec.rb
+            include-pattern: spec/system/.*/*_spec.rb
+            exclude-pattern: spec/system/.*(provider_interface|candidate_interface).*/*_spec.rb
           - tests: integration_provider
-            include-pattern: spec/system/provider_interface/**/*_spec.rb
+            include-pattern: spec/system/provider_interface/.*/*_spec.rb
           - tests: integration_candidate
-            include-pattern: spec/system/candidate_interface/**/*_spec.rb
+            include-pattern: spec/system/candidate_interface/.*/*_spec.rb
     services:
       redis:
         image: redis:alpine
@@ -162,17 +162,17 @@ jobs:
         REDIS_URL: redis://redis:6379/0
         DB_PORT: 5432
     steps:
-      - name: Setup Database
-        run: bundle exec rake db:setup
+      - name: Setup Parallel Database
+        run: bundle exec rake parallel:setup
 
       - name: Install chromedriver
         run: apk add chromium chromium-chromedriver
 
       - name: ${{ matrix.tests }} tests with feature flags ${{ matrix.feature-flags }}
-        run: bundle exec --verbose rspec --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}" --format progress
+        run: bundle exec --verbose parallel_rspec --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}"
         env:
           INCLUDE_PATTERN: ${{ matrix.include-pattern }}
-          EXCLUDE_PATTERN: ${{ matrix.exclude-pattern }}
+          EXCLUDE_PATTERN: ${{ matrix.exclude-pattern || ' ' }}
           DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
 
   trigger-deployment:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,22 @@ jobs:
     defaults:
       run:
         working-directory: /app
+    strategy:
+      fail-fast: false
+      matrix:
+        tests: [rubocop, erblint, brakeman, yarn_lint]
+        include:
+          - tests: rubocop
+            command: bundle exec rubocop --format clang --parallel
+          - tests: erblint
+            command: bundle exec rake erblint
+          - tests: brakeman
+            command: bundle exec rake brakeman
+          - tests: yarn_lint
+            command: |
+              yarn install
+              yarn run lint && yarn run stylelint app/frontend/styles && \
+              yarn run test
     container:
       image: ghcr.io/dfe-digital/apply-teacher-training-gems-node-modules:${{ needs.build.outputs.IMAGE_TAG }}
       options: -a STDOUT -a STDERR -t
@@ -86,21 +102,10 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GH_CONTAINER_REGISTRY_TOKEN }}
     steps:
-    - run:  bundle exec rubocop --format clang --parallel
-      name: Rubocop
-
-    - run:  bundle exec rake erblint
-      name: ERB Linter
-
-    - run:  bundle exec rake brakeman
-      name: Brakeman
-
-    - name: Yarn Lint
-      run: |
-        yarn install
-        yarn run lint && yarn run stylelint app/frontend/styles && \
-        yarn run test
-
+      - name: ${{ matrix.tests }}
+        run: ${{ env.COMMAND }}
+        env:
+          COMMAND: ${{ matrix.command }}
   test:
     name: Tests
     needs: [build]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -112,8 +112,9 @@ RSpec.configure do |config|
   # This allocates databases from 1 onwards, as it's assumed that 0 is the
   # development database.
   if ENV['TEST_ENV_NUMBER']
+    redis_url_without_database = ENV['REDIS_URL']&.gsub(/\/\d+$/, '') || 'redis://localhost:6379'
     config.around do |example|
-      ClimateControl.modify(REDIS_URL: "redis://localhost:6379/#{ENV['TEST_ENV_NUMBER'].to_i + 1}") do
+      ClimateControl.modify(REDIS_URL: "#{redis_url_without_database}/#{ENV['TEST_ENV_NUMBER'].to_i + 1}") do
         example.run
       end
     end


### PR DESCRIPTION
## Context

Splitting up the tests further has yielded a big improvement to the time it takes to run our test builds in: https://github.com/DFE-Digital/apply-for-teacher-training/pull/5337

To further speed up tests, we can utilise [parallel_tests](https://github.com/grosser/parallel_tests) which will parallelise the tests further past the matrix in Github actions.

We are defaulting to the maximum number of cores (2) to speed up the runs for each test step. This has yielded some improvement, and has shaved off around 1 to 2 minutes. Since this means we will run under 5 minutes, we also needed to split the linting steps into a matrix as well.

## Changes proposed in this pull request

- Split linting steps into a matrix to run in parallel
- Default to `REDIS_URL` in parallel tests setup, or localhost
- Use parallel test db setup and strategy to run tests. The regex seems to differ massively between rspec and parallel tests

## Guidance to review

Best go commit by commit to understand each step.

Also to ensure we aren't missing any specs I made sure to compare the count of examples for each step with the total count of examples and both equal 5629

## Link to Trello card

https://trello.com/c/iUbjoW38/4143-further-build-improvements

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
