### PR TITLE
Add CacheKey class for standard cache key generation

### DIFF
--- a/app/lib/cache_key.rb
+++ b/app/lib/cache_key.rb
@@ -1,0 +1,8 @@
+class CacheKey
+  def self.generate(identifier)
+    sha = CODE_REVISION_FOR_CACHE
+    feature_flags_last_changed = Digest::SHA1.hexdigest(Feature.maximum(:updated_at).to_s).slice(0, 7)
+
+    "#{identifier}-#{sha}-#{feature_flags_last_changed}"
+  end
+end

--- a/config/initializers/code_revision_for_cache.rb
+++ b/config/initializers/code_revision_for_cache.rb
@@ -1,0 +1,10 @@
+revision = ENV.fetch('SHA') do
+  if HostingEnvironment.production?
+    raise 'Missing SHA environment value in production containing current git revision, required to support Rails caching'
+  else
+    Rails.logger.info('Falling back to app startup timestamp for cache keys in lieu of git revision')
+    Digest::SHA1.hexdigest(Time.zone.now.to_s)
+  end
+end
+
+CODE_REVISION_FOR_CACHE = revision.slice(0, 7).freeze

--- a/spec/lib/cache_key_spec.rb
+++ b/spec/lib/cache_key_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe CacheKey do
+  let(:identifier) { 'any old string' }
+
+  it 'differs by code revision' do
+    stub_const('CODE_REVISION_FOR_CACHE', 'sha-before')
+    old_key = described_class.generate(identifier)
+
+    stub_const('CODE_REVISION_FOR_CACHE', 'sha-after')
+    new_key = described_class.generate(identifier)
+
+    expect(old_key).not_to eq(new_key)
+  end
+
+  it 'differs by feature flag age' do
+    old_key = described_class.generate(identifier)
+
+    # when feature flags are enabled in advance
+    # this can result in the newly created flag having
+    # the same updated_at as an existing flag
+    Timecop.travel(1.second.from_now) { create(:feature) }
+
+    new_key = described_class.generate(identifier)
+
+    expect(old_key).not_to eq(new_key)
+  end
+
+  it 'differs by the passed identifier' do
+    old_key = described_class.generate(identifier)
+
+    new_key = described_class.generate('banana')
+
+    expect(old_key).not_to eq(new_key)
+  end
+end


### PR DESCRIPTION
## Context

We always want to consider code revision and feature flag state in our cache keys

## Changes proposed in this pull request

Make a method for generating the keys. Expected usage

`CacheKey.generate(model.cache_key_with_version)`

## Guidance to review

Could it have a better name?

## Link to Trello card

refactor for other caching branches

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
