### PR TITLE
Add user permissions component form

### DIFF
--- a/app/components/provider_interface/provider_user_permissions_form_component.html.erb
+++ b/app/components/provider_interface/provider_user_permissions_form_component.html.erb
@@ -1,0 +1,41 @@
+<%= form_with(
+  model: form_model,
+  url: form_path,
+  method: :patch,
+) do |f| %>
+  <% unless provider_has_no_relationships? %>
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= caption_text %></span>
+      <%= t('page_titles.provider.edit_user_permissions') %>
+    </h1>
+
+    <p class="govuk-body">User permissions for courses you work on with partner organisations are affected by organisation permissions.</p>
+    <p class="govuk-body">This means that the permissions you give to users may only apply to courses you work on with certain partner organisations.</p>
+
+    <%= govuk_details(
+      summary: 'Check how user permissions are affected by organisation permissions',
+    ) do %>
+      <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission| %>
+        <h2 class="govuk-heading-s"><%= t("provider_relationship_permissions.#{permission}.description") %></h2>
+        <%= render ProviderInterface::ProviderPartnerPermissionBreakdownComponent.new(provider: provider, permission: permission) %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_check_boxes_fieldset(
+    :permissions,
+    caption: form_caption,
+    legend: form_legend,
+    hint: { text: t('provider_relationship_permissions.view_applications_explanation') },
+  ) do %>
+    <% ProviderPermissions::VALID_PERMISSIONS.each do |permission| %>
+      <%= f.govuk_check_box(
+        :permissions,
+        permission.to_s,
+        label: { text: t("user_permissions.#{permission}.description") },
+      ) %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit t('continue') %>
+<% end %>

--- a/app/components/provider_interface/provider_user_permissions_form_component.rb
+++ b/app/components/provider_interface/provider_user_permissions_form_component.rb
@@ -1,0 +1,35 @@
+module ProviderInterface
+  class ProviderUserPermissionsFormComponent < ViewComponent::Base
+    attr_reader :form_model, :provider, :form_path, :user_name
+
+    def initialize(form_model:, form_path:, provider:, user_name: nil)
+      @form_model = form_model
+      @provider = provider
+      @form_path = form_path
+      @user_name = user_name
+    end
+
+  private
+
+    def provider_has_no_relationships?
+      ProviderRelationshipPermissions.all_relationships_for_providers([provider]).providers_have_open_course.none?
+    end
+
+    def form_legend
+      if provider_has_no_relationships?
+        { text: t('page_titles.provider.edit_user_permissions'), size: 'l', tag: 'h1' }
+      else
+        { text: 'Choose user permissions', size: 'm' }
+      end
+    end
+
+    def caption_text
+      prefix = user_name || 'Invite user'
+      "#{prefix} - #{provider.name}"
+    end
+
+    def form_caption
+      { text: caption_text, size: 'l' } if provider_has_no_relationships?
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,6 +211,7 @@ en:
       profile: Profile
       personal_details: Your personal details
       user_permissions: Your user permissions
+      edit_user_permissions: User permissions
       email_notifications: Your email notifications
       organisation_settings: Organisation settings
       organisation_permissions: Organisation permissions

--- a/spec/components/previews/provider_interface/provider_user_permissions_form_component_preview.rb
+++ b/spec/components/previews/provider_interface/provider_user_permissions_form_component_preview.rb
@@ -1,0 +1,62 @@
+module ProviderInterface
+  class ProviderUserPermissionsFormComponentPreview < ViewComponent::Preview
+    layout 'previews/provider'
+
+    def provider_with_partner_organisation
+      provider = FactoryBot.create(:provider)
+      setup_relationship_for(provider)
+      render ProviderUserPermissionsFormComponent.new(
+        form_model: form_model_for(provider),
+        form_path: '',
+        provider: provider,
+        user_name: user_name,
+      )
+    end
+
+    def self_ratifying_provider
+      provider = FactoryBot.create(:provider)
+      render ProviderUserPermissionsFormComponent.new(
+        form_model: form_model_for(provider),
+        form_path: '',
+        provider: provider,
+        user_name: user_name,
+      )
+    end
+
+  private
+
+    def setup_relationship_for(provider)
+      relationship = FactoryBot.create(:provider_relationship_permissions, training_provider: provider)
+      FactoryBot.create(:course, :open_on_apply, provider: provider, accredited_provider: relationship.ratifying_provider)
+    end
+
+    def form_model_for(provider)
+      provider_permissions = provider_permissions_for(provider)
+      enabled_permissions = ProviderPermissions::VALID_PERMISSIONS.map(&:to_s).select { |p| provider_permissions.send(p) }
+      PermissionsFormModel.new(permissions: enabled_permissions)
+    end
+
+    def provider_permissions_for(provider)
+      FactoryBot.create(
+        :provider_permissions,
+        manage_users: rand > 0.5,
+        manage_organisations: rand > 0.5,
+        make_decisions: rand > 0.5,
+        view_safeguarding_information: rand > 0.5,
+        view_diversity_information: rand > 0.5,
+        set_up_interviews: rand > 0.5,
+        provider: provider,
+      )
+    end
+
+    def user_name
+      rand > 0.5 ? Faker::Name.name : nil
+    end
+
+    class PermissionsFormModel
+      include ActiveModel::Model
+
+      attr_accessor :permissions
+    end
+  end
+end

--- a/spec/components/provider_interface/provider_user_permissions_form_component_spec.rb
+++ b/spec/components/provider_interface/provider_user_permissions_form_component_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ProviderUserPermissionsFormComponent do
+  let(:provider_user) { create(:provider_user, :with_provider) }
+  let(:form_model) { double }
+  let(:provider) { provider_user.providers.first }
+  let(:path) { '/path' }
+  let(:user_name) { nil }
+  let(:render) { render_inline(described_class.new(form_model: form_model, form_path: path, provider: provider, user_name: user_name)) }
+
+  before do
+    provider_permissions = provider_user.provider_permissions.first
+    enabled_permissions = ProviderPermissions::VALID_PERMISSIONS.select { |p| provider_permissions.send(p) }
+    allow(form_model).to receive(:permissions).and_return(enabled_permissions)
+    allow(form_model).to receive(:model_name).and_return(ActiveModel::Name.new(Object))
+  end
+
+  it 'renders checkboxes for each of the user level permissions' do
+    expected_permission_text = ProviderPermissions::VALID_PERMISSIONS.map { |permission| I18n.t("user_permissions.#{permission}.description") }
+    expect(render.css('.govuk-checkboxes__item').map(&:text)).to eq(expected_permission_text)
+  end
+
+  it 'uses the given path for the form' do
+    expect(render.css('form').first.attributes['action'].value).to eq(path)
+  end
+
+  context 'when the provider has no partner organisations' do
+    before { allow(ProviderInterface::ProviderPartnerPermissionBreakdownComponent).to receive(:new).and_call_original }
+
+    it 'does not render the organisation permissions explanation text' do
+      expect(render.css('p').text).not_to include('User permissions for courses you work on with partner organisations are affected by organisation permissions')
+      expect(render.css('p').text).not_to include('This means that the permissions you give to users may only apply to courses you work on with certain partner organisations.')
+    end
+
+    it 'does not render the details component' do
+      expect(render.css('details')).to be_empty
+      expect(ProviderInterface::ProviderPartnerPermissionBreakdownComponent).not_to have_received(:new)
+    end
+
+    it 'renders the correct legend as an h1 for the form' do
+      expect(render.css('legend > h1').text).to include('User permissions')
+      expect(render.text).not_to include('Choose user permissions')
+    end
+
+    it 'renders the correct caption as a span within a legend for the form' do
+      expect(render.css('legend > h1 > span').text).to include("Invite user - #{provider.name}")
+    end
+  end
+
+  context 'when the provider has partner organisations' do
+    before do
+      relationship = create(:provider_relationship_permissions, training_provider: provider)
+      create(:course, :open_on_apply, provider: provider, accredited_provider: relationship.ratifying_provider)
+
+      allow(ProviderInterface::ProviderPartnerPermissionBreakdownComponent).to receive(:new).with(provider: provider, permission: anything).and_call_original
+    end
+
+    it 'renders the organisation permissions explanation text' do
+      expect(render.css('p').text).to include('User permissions for courses you work on with partner organisations are affected by organisation permissions')
+      expect(render.css('p').text).to include('This means that the permissions you give to users may only apply to courses you work on with certain partner organisations.')
+    end
+
+    it 'renders the details component' do
+      expect(render.css('details > summary').text.squish).to eq('Check how user permissions are affected by organisation permissions')
+      expect(render.css('details h2').map(&:text)).to contain_exactly(
+        'Make offers and reject applications',
+        'View criminal convictions and professional misconduct',
+        'View sex, disability and ethnicity information',
+      )
+
+      expect(ProviderInterface::ProviderPartnerPermissionBreakdownComponent).to have_received(:new).thrice
+    end
+
+    it 'renders the correct legend for the form' do
+      expect(render.css('legend').text).to include('Choose user permissions')
+    end
+
+    it 'renders the correct caption as a span for the form' do
+      expect(render.css('h1 > span').text).to include("Invite user - #{provider.name}")
+    end
+  end
+
+  context 'when a username is passed in' do
+    let(:user_name) { Faker::Name.name }
+
+    it 'shows the user name in the caption' do
+      expect(render.css('h1 > span').text).to include(user_name)
+    end
+  end
+end


### PR DESCRIPTION
## Context
We are updating the invite and edit user flows. They will share a new componentized form.

## Changes proposed in this pull request
Add a component to wrap up the permissions form from the invite and edit user flows

## Guidance to review
Per commit
You can test the component in the previews here: https://apply-for-te-user-permi-zyvhuc.herokuapp.com/rails/view_components/provider_interface/provider_user_permissions_form_component

## Link to Trello card
https://trello.com/c/hciw82AV/4144-edit-provider-user-permissions

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
