### PR TITLE
Add text to org permissions for non-mananging users

### DIFF
--- a/app/controllers/provider_interface/organisation_permissions_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_controller.rb
@@ -14,7 +14,9 @@ module ProviderInterface
     end
 
     def index
-      unless FeatureFlag.active?(:account_and_org_settings_changes) || current_provider_user.authorisation.can_manage_organisation?(provider: provider)
+      @current_user_can_manage_organisation = current_provider_user.authorisation.can_manage_organisation?(provider: provider)
+
+      unless FeatureFlag.active?(:account_and_org_settings_changes) || @current_user_can_manage_organisation
         render_403 and return
       end
 
@@ -97,11 +99,7 @@ module ProviderInterface
     end
 
     def change_link_for_relationship(relationship)
-      relationship_providers = [relationship.training_provider, relationship.ratifying_provider]
-      auth = current_provider_user.authorisation
-      current_user_can_manage_relationship = relationship_providers.any? { |p| auth.can_manage_organisation?(provider: p) }
-
-      if current_user_can_manage_relationship
+      if @current_user_can_manage_organisation
         edit_provider_interface_organisation_settings_organisation_organisation_permission_path(relationship, organisation_id: provider.id)
       end
     end

--- a/app/views/provider_interface/organisation_permissions/index.html.erb
+++ b/app/views/provider_interface/organisation_permissions/index.html.erb
@@ -19,12 +19,14 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l"><%= @provider.name %></span>
     <h1 class="govuk-heading-l"><%= t('page_titles.provider.organisation_permissions') %></h1>
-
+    <% if FeatureFlag.active?(:account_and_org_settings_changes) && !@current_user_can_manage_organisation %>
+      <p class="govuk-body">You cannot change these permissions because you do not have permission to manage organisations.</p>
+    <% end %>
     <% @provider_relationships.each do |relationship| %>
       <%= render ProviderInterface::OrganisationPermissionsReviewCardComponent.new(
         provider_user: current_provider_user,
         provider_relationship_permission: relationship,
-        change_path: edit_provider_interface_organisation_settings_organisation_organisation_permission_path(relationship, organisation_id: @provider.id),
+        change_path: change_link_for_relationship(relationship),
         main_provider: @provider,
       ) %>
     <% end %>

--- a/spec/system/provider_interface/view_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/view_organisation_permissions_spec.rb
@@ -23,6 +23,7 @@ RSpec.feature 'Organisation permissions' do
     and_i_click_on_organisation_permissions_for_the_provider_i_cannot_manage
     then_i_can_see_the_permissions_that_have_been_set_up_without_change_links
     and_i_can_see_non_set_up_permissions
+    and_i_can_see_information_about_managing_the_organisation
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -99,5 +100,9 @@ RSpec.feature 'Organisation permissions' do
   def and_i_can_see_non_set_up_permissions
     expect(page).to have_selector('h2', text: "#{@read_only_provider.name} and #{@not_set_up_read_only_partner.name}")
     expect(page).to have_selector('.govuk-summary-list__value', text: 'Neither organisation can do this')
+  end
+
+  def and_i_can_see_information_about_managing_the_organisation
+    expect(page).to have_content('You cannot change these permissions because you do not have permission to manage organisations.')
   end
 end


### PR DESCRIPTION
## Context
https://trello.com/c/RdxGIL9Y/4146-show-explanation-text-on-org-settings-page-when-lacking-permission

We inform users when they're unable to make changes to permissions

## Changes proposed in this pull request

Users will see the text `You cannot change these permissions because you do not have permission to manage organisations.` when they cannot manage permissions in the Organisation permissions page. 

![image](https://user-images.githubusercontent.com/25597009/129593429-07c1fbec-8f24-48b3-8a8e-a38025c9da3e.png)

