### PR TITLE
Fix RBD service spec

### DIFF
--- a/spec/services/set_reject_by_default_spec.rb
+++ b/spec/services/set_reject_by_default_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe SetRejectByDefault do
     it 'does not update dates when nothing changes', with_audited: true do
       application_choice = create(:application_choice, sent_to_provider_at: Time.zone.now)
 
-      expect { call_service(application_choice) }.to change { Audited::Audit.count }.by(1)
-      expect { call_service(application_choice) }.to change { Audited::Audit.count }.by(0)
+      expect { call_service(application_choice) }.to change { Audited::Audit.where(auditable_type: 'ApplicationChoice').count }.by(1)
+      expect { call_service(application_choice) }.to change { Audited::Audit.where(auditable_type: 'ApplicationChoice').count }.by(0)
     end
   end
 


### PR DESCRIPTION
## Context

Locally `spec/services/set_reject_by_default_spec.rb:4` is now failing (but didn't at time of the original PR: [#5350](https://github.com/DFE-Digital/apply-for-teacher-training/pull/5350)).

This is because the RBD service is now calling the `CycleTimetable` class, which uses the audited class `SiteSetting` and as a result is adding a second record to the audit, whereas the test is only expecting an increase of 1:
```
 #<Audited::Audit:0x00007ff59a8aa9e8
  id: 415,
  auditable_id: 69,
  auditable_type: "SiteSetting",
  associated_id: nil,
  associated_type: nil,
  user_id: nil,
  user_type: nil,
  username: nil,
  action: "create",
  audited_changes: {"name"=>"cycle_schedule", "value"=>nil},
  version: 1,
  comment: nil,
  remote_address: nil,
  request_uuid: "1ea96d73-c42d-4ade-9c81-d4b18c0faa4b",
  created_at: Mon, 16 Aug 2021 18:06:32.359367000 BST +01:00>,
 #<Audited::Audit:0x00007ff59a8aa268
  id: 416,
  auditable_id: 186,
  auditable_type: "ApplicationChoice",
  associated_id: 248,
  associated_type: "ApplicationForm",
  user_id: nil,
  user_type: nil,
  username: nil,
  action: "update",
  audited_changes: {"reject_by_default_at"=>[nil, "2021-09-14T23:59:59.999+01:00"], "reject_by_default_days"=>[nil, 20]},
  version: 2,
  comment: nil,
  remote_address: nil,
  request_uuid: "33ba28c9-5f94-4edb-8592-1c519d262962",
  created_at: Mon, 16 Aug 2021 18:06:32.365022000 BST +01:00>]
```

## Changes proposed in this pull request

Rather than check for a generic count increase, this PR will now check to make sure an ApplicationChoice record has been added.

change:
 ```
expect { call_service(application_choice) }.to change { Audited::Audit.count }.by(1)
expect { call_service(application_choice) }.to change { Audited::Audit.count }.by(0)
```
to
```
expect { call_service(application_choice) }.to change { Audited::Audit.where(auditable_type: 'ApplicationChoice').count }.by(1)
expect { call_service(application_choice) }.to change { Audited::Audit.where(auditable_type: 'ApplicationChoice').count }.by(0)
```

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
