### PR TITLE
Indicate for support if an application was submitted over 5 days ago

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -58,9 +58,15 @@ module SupportInterface
       if submitted?
         {
           key: 'Submitted',
-          value: submitted_at.to_s(:govuk_date_and_time),
+          value: "#{submitted_at.to_s(:govuk_date_and_time)} #{eligible_support_period}".html_safe,
         }
       end
+    end
+
+    def eligible_support_period
+      time_period = submitted_at.to_date.business_days_until(Time.zone.now)
+
+      time_period <= 5 ? govuk_tag(text: 'Less than 5 days ago', colour: 'green') : govuk_tag(text: 'Over 5 days ago', colour: 'red')
     end
 
     def support_reference_row

--- a/spec/components/support_interface/application_summary_component_spec.rb
+++ b/spec/components/support_interface/application_summary_component_spec.rb
@@ -22,5 +22,27 @@ RSpec.describe SupportInterface::ApplicationSummaryComponent do
       expect(result.css('.govuk-summary-list__key').text).to include('UCAS matching data')
       expect(result.css('.govuk-summary-list__value').text).to include('No matching data for this candidate')
     end
+
+    it 'indicates if the application was submitted less than 5 days ago' do
+      submitted_at = 3.business_days.ago
+      candidate = create(:candidate)
+      application_form = create(:completed_application_form, candidate: candidate, submitted_at: submitted_at)
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Submitted')
+      expect(result.css('.govuk-summary-list__value').text).to include('Less than 5 days ago')
+    end
+
+    it 'indicates if the application was submitted over 5 days ago' do
+      submitted_at = 6.business_days.ago
+      candidate = create(:candidate)
+      application_form = create(:completed_application_form, candidate: candidate, submitted_at: submitted_at)
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Submitted')
+      expect(result.css('.govuk-summary-list__value').text).to include('Over 5 days ago')
+    end
   end
 end


### PR DESCRIPTION
## Context

Candidates can request for amendments to be made to their application, however, support agents can only edit applications that have been submitted within the last 5 days. To make this a bit clearer the submitted row will now also indicate as to which side of the 5 day period an application is.

## Changes proposed in this pull request
Less than 5 days ago and is actionable:
![image](https://user-images.githubusercontent.com/47917431/129874077-d0f12b0e-bb94-4b6e-9943-5cda2970a187.png)

Over 5 days ago and is not actionable:
![image](https://user-images.githubusercontent.com/47917431/129874149-02b57dd0-ce78-4ab4-a356-2fd9fea86ecc.png)

## Guidance to review

Interested to hear content suggestions as to how we display the message

Also... is there a better name for `eligible_support_period`?

## Link to Trello card

https://trello.com/c/xJ4zvCzK

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
