### PR TITLE
refine query for retrieving total numbers for active applications

### DIFF
--- a/app/queries/get_application_progress_data_by_course.rb
+++ b/app/queries/get_application_progress_data_by_course.rb
@@ -6,9 +6,13 @@ class GetApplicationProgressDataByCourse
   end
 
   def call
-    Course.joins(:application_choices).merge(provider_application_choices).left_joins(:accredited_provider)
-      .group('courses.id', 'courses.name', 'courses.code', 'application_choices.status', 'providers.name')
-      .select('courses.provider_id', 'courses.accredited_provider_id', 'providers.name as provider_name', 'courses.name', 'courses.code', "count('application_choices.status') as count", 'application_choices.status as status', 'courses.id')
+    Course.joins(:application_choices).merge(provider_application_choices)
+      .joins(:provider)
+      .left_joins(:accredited_provider)
+      .group('courses.id', 'courses.name', 'courses.code', 'application_choices.status', 'providers.name', 'accredited_providers_courses.name')
+      .select('courses.provider_id', 'courses.accredited_provider_id', 'providers.name as provider_name',
+              'accredited_providers_courses.name as accredited_provider_name', 'courses.name', 'courses.code',
+              "count('application_choices.status') as count", 'application_choices.status as status', 'courses.id')
   end
 
   def provider_application_choices

--- a/app/queries/get_application_progress_data_by_course.rb
+++ b/app/queries/get_application_progress_data_by_course.rb
@@ -1,0 +1,21 @@
+class GetApplicationProgressDataByCourse
+  attr_reader :provider
+
+  def initialize(provider:)
+    @provider = provider
+  end
+
+  def call
+    Course.joins(:application_choices).merge(provider_application_choices).left_joins(:accredited_provider)
+      .group('courses.id', 'courses.name', 'courses.code', 'application_choices.status', 'providers.name')
+      .select('providers.name as provider_name', 'courses.name', 'courses.code', "count('application_choices.status') as count", 'application_choices.status as status', 'courses.id')
+  end
+
+  def provider_application_choices
+    ApplicationChoice.joins(:course)
+      .where(status: %i[awaiting_provider_decision interviewing offer pending_conditions recruited])
+      .where(course: { provider_id: @provider.id })
+      .or(ApplicationChoice.joins(:course).where(course: { accredited_provider_id: @provider.id }))
+      .where(course: { recruitment_cycle_year: RecruitmentCycle.current_year })
+  end
+end

--- a/app/queries/get_application_progress_data_by_course.rb
+++ b/app/queries/get_application_progress_data_by_course.rb
@@ -8,14 +8,14 @@ class GetApplicationProgressDataByCourse
   def call
     Course.joins(:application_choices).merge(provider_application_choices).left_joins(:accredited_provider)
       .group('courses.id', 'courses.name', 'courses.code', 'application_choices.status', 'providers.name')
-      .select('providers.name as provider_name', 'courses.name', 'courses.code', "count('application_choices.status') as count", 'application_choices.status as status', 'courses.id')
+      .select('courses.provider_id', 'courses.accredited_provider_id', 'providers.name as provider_name', 'courses.name', 'courses.code', "count('application_choices.status') as count", 'application_choices.status as status', 'courses.id')
   end
 
   def provider_application_choices
     ApplicationChoice.joins(:course)
       .where(status: %i[awaiting_provider_decision interviewing offer pending_conditions recruited])
-      .where(course: { provider_id: @provider.id })
-      .or(ApplicationChoice.joins(:course).where(course: { accredited_provider_id: @provider.id }))
+      .where(course: { provider_id: provider.id })
+      .or(ApplicationChoice.joins(:course).where(course: { accredited_provider_id: provider.id }))
       .where(course: { recruitment_cycle_year: RecruitmentCycle.current_year })
   end
 end

--- a/app/services/provider_interface/active_application_statuses_by_provider.rb
+++ b/app/services/provider_interface/active_application_statuses_by_provider.rb
@@ -8,15 +8,15 @@ module ProviderInterface
 
     def call
       grouped_course_data.map do |course_data|
-        course = course_data.last
+        courses = course_data.last
         {
-          header: course.first.name_and_code.to_s,
-          subheader: course.first.provider_name || provider.name,
-          values: [course.find { |c| c.status == 'awaiting_provider_decision' }&.count || 0,
-                   course.find { |c| c.status == 'interviewing' }&.count || 0,
-                   course.find { |c| c.status == 'offer' }&.count || 0,
-                   course.find { |c| c.status == 'pending_conditions' }&.count || 0,
-                   course.find { |c| c.status == 'recruited' }&.count || 0],
+          header: courses.first.name_and_code,
+          subheader: provider_name(courses.first),
+          values: [status_count(courses, :awaiting_provider_decision),
+                   status_count(courses, :interviewing),
+                   status_count(courses, :offer),
+                   status_count(courses, :pending_conditions),
+                   status_count(courses, :recruited)],
         }
       end
     end
@@ -25,6 +25,16 @@ module ProviderInterface
 
     def grouped_course_data
       @course_data ||= GetApplicationProgressDataByCourse.new(provider: provider).call.group_by(&:id)
+    end
+
+    def status_count(courses, status)
+      courses.find { |course| course.status == status.to_s }&.count || 0
+    end
+
+    def provider_name(course)
+      provider_name = course.provider_name || provider.name
+      provider_name = Provider.find(course.accredited_provider_id).name if course.provider_id != course.accredited_provider_id
+      provider_name
     end
   end
 end

--- a/app/services/provider_interface/active_application_statuses_by_provider.rb
+++ b/app/services/provider_interface/active_application_statuses_by_provider.rb
@@ -1,0 +1,30 @@
+module ProviderInterface
+  class ActiveApplicationStatusesByProvider
+    attr_reader :provider
+
+    def initialize(provider)
+      @provider = provider
+    end
+
+    def call
+      grouped_course_data.map do |course_data|
+        course = course_data.last
+        {
+          header: course.first.name_and_code.to_s,
+          subheader: course.first.provider_name || provider.name,
+          values: [course.find { |c| c.status == 'awaiting_provider_decision' }&.count || 0,
+                   course.find { |c| c.status == 'interviewing' }&.count || 0,
+                   course.find { |c| c.status == 'offer' }&.count || 0,
+                   course.find { |c| c.status == 'pending_conditions' }&.count || 0,
+                   course.find { |c| c.status == 'recruited' }&.count || 0],
+        }
+      end
+    end
+
+  private
+
+    def grouped_course_data
+      @course_data ||= GetApplicationProgressDataByCourse.new(provider: provider).call.group_by(&:id)
+    end
+  end
+end

--- a/app/services/provider_interface/active_application_statuses_by_provider.rb
+++ b/app/services/provider_interface/active_application_statuses_by_provider.rb
@@ -32,9 +32,11 @@ module ProviderInterface
     end
 
     def provider_name(course)
-      provider_name = course.provider_name || provider.name
-      provider_name = Provider.find(course.accredited_provider_id).name if course.provider_id != course.accredited_provider_id
-      provider_name
+      accredited_by_different_provider?(course) ? course.accredited_provider_name : course.provider_name
+    end
+
+    def accredited_by_different_provider?(course)
+      course.accredited_provider_id && provider.id == course.provider_id && course.provider_id != course.accredited_provider_id
     end
   end
 end

--- a/spec/queries/get_application_progress_data_by_course_spec.rb
+++ b/spec/queries/get_application_progress_data_by_course_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe GetApplicationProgressDataByCourse do
+  describe '#call' do
+    let(:provider) { create(:provider) }
+    let(:accredited_provider) { create(:provider) }
+    let(:course) { create(:course, provider: provider, accredited_provider: nil) }
+    let(:course_option) { create(:course_option, course: course) }
+    let(:accredited_course) { create(:course, accredited_provider: provider, provider: accredited_provider) }
+    let(:accredited_course_option) { create(:course_option, course: accredited_course) }
+
+    before do
+      create_list(:application_choice, 10, status: :interviewing, course_option: accredited_course_option)
+      create_list(:application_choice, 5, status: :pending_conditions, course_option: accredited_course_option)
+      create_list(:application_choice, 8, status: :interviewing, course_option: course_option)
+      create_list(:application_choice, 3, status: :pending_conditions, course_option: course_option)
+    end
+
+    it 'generates the correct count' do
+      expect(described_class.new(provider: provider).call.map(&:count).inject(:+)).to eq(26)
+    end
+
+    it 'can group the courses by id' do
+      courses = described_class.new(provider: provider).call.group_by(&:id)
+      provider_courses = courses[course.id]
+      accredited_provider_courses = courses[accredited_course.id]
+
+      expect(provider_courses.find { |c| c.status == 'interviewing' }.count).to eq(8)
+      expect(provider_courses.find { |c| c.status == 'pending_conditions' }.count).to eq(3)
+
+      expect(accredited_provider_courses.find { |c| c.status == 'interviewing' }.count).to eq(10)
+      expect(accredited_provider_courses.find { |c| c.status == 'pending_conditions' }.count).to eq(5)
+    end
+  end
+end

--- a/spec/queries/get_application_progress_data_by_course_spec.rb
+++ b/spec/queries/get_application_progress_data_by_course_spec.rb
@@ -4,24 +4,42 @@ RSpec.describe GetApplicationProgressDataByCourse do
   describe '#call' do
     let(:provider) { create(:provider) }
     let(:accredited_provider) { create(:provider) }
-    let(:course) { create(:course, provider: provider, accredited_provider: nil) }
+    let(:course) { create(:course, name: 'Alpha Physics', code: '2AIC', provider: provider, accredited_provider: nil) }
     let(:course_option) { create(:course_option, course: course) }
-    let(:accredited_course) { create(:course, accredited_provider: provider, provider: accredited_provider) }
+    let(:accredited_course) { create(:course, name: 'Beta Physics', accredited_provider: provider, provider: accredited_provider) }
     let(:accredited_course_option) { create(:course_option, course: accredited_course) }
+    let(:third_course) { create(:course, name: 'Alpha Physics', code: '1ABX', provider: provider, accredited_provider: nil) }
+    let(:third_option) { create(:course_option, course: third_course) }
+    let!(:empty_course) { create(:course, name: 'Cappa', provider: provider) }
+    let!(:empty_course_option) { create(:course_option, course: empty_course) }
 
     before do
       create_list(:application_choice, 10, status: :interviewing, course_option: accredited_course_option)
       create_list(:application_choice, 5, status: :pending_conditions, course_option: accredited_course_option)
       create_list(:application_choice, 8, status: :interviewing, course_option: course_option)
       create_list(:application_choice, 3, status: :pending_conditions, course_option: course_option)
+      create_list(:application_choice, 6, status: :awaiting_provider_decision, course_option: third_option)
     end
 
+    subject(:progress_data) { described_class.new(provider: provider).call }
+
     it 'generates the correct count' do
-      expect(described_class.new(provider: provider).call.map(&:count).inject(:+)).to eq(26)
+      expect(progress_data.map(&:count).inject(:+)).to eq(33)
+    end
+
+    it 'retrieves courses with no applications' do
+      expect(progress_data.length).to eq(6)
+    end
+
+    it 'retrieves the courses in alphabetical order' do
+      expect(progress_data.first).to eq(third_course)
+      expect(progress_data.second).to eq(course)
+      expect(progress_data.fourth).to eq(accredited_course)
+      expect(progress_data.last).to eq(empty_course)
     end
 
     it 'can group the courses by id' do
-      courses = described_class.new(provider: provider).call.group_by(&:id)
+      courses = progress_data.group_by(&:id)
       provider_courses = courses[course.id]
       accredited_provider_courses = courses[accredited_course.id]
 

--- a/spec/services/provider_interface/active_application_statuses_by_provider_spec.rb
+++ b/spec/services/provider_interface/active_application_statuses_by_provider_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ActiveApplicationStatusesByProvider do
+  describe '#call' do
+    let(:provider) { create(:provider) }
+    let(:other_provider) { create(:provider) }
+    let(:course_without_accredited_provider) { create(:course, provider: provider, accredited_provider: nil) }
+    let(:course_option_without_accredited_provider) { create(:course_option, course: course_without_accredited_provider) }
+    let(:course_with_other_accredited_provider) { create(:course, provider: provider, accredited_provider: other_provider) }
+    let(:course_option_with_other_accredited_provider) { create(:course_option, course: course_with_other_accredited_provider) }
+    let(:course_provider_accredits) { create(:course, provider: other_provider, accredited_provider: provider) }
+    let(:course_option_provider_accredits) { create(:course_option, course: course_provider_accredits) }
+
+    before do
+      create_list(:application_choice, 10, status: :interviewing, course_option: course_option_with_other_accredited_provider)
+      create_list(:application_choice, 5, status: :pending_conditions, course_option: course_option_with_other_accredited_provider)
+      create_list(:application_choice, 8, status: :interviewing, course_option: course_option_without_accredited_provider)
+      create_list(:application_choice, 3, status: :pending_conditions, course_option: course_option_without_accredited_provider)
+      create_list(:application_choice, 4, status: :recruited, course_option: course_option_provider_accredits)
+      create_list(:application_choice, 6, status: :offer, course_option: course_option_provider_accredits)
+    end
+
+    it 'outputs the correct course names' do
+      output = described_class.new(provider).call
+      expect(output[0][:header]).to eq(course_with_other_accredited_provider.name_and_code)
+      expect(output[1][:header]).to eq(course_without_accredited_provider.name_and_code)
+      expect(output[2][:header]).to eq(course_provider_accredits.name_and_code)
+    end
+
+    it 'outputs the correct provider names' do
+      output = described_class.new(provider).call
+      expect(output[0][:subheader]).to eq(course_with_other_accredited_provider.accredited_provider.name)
+      expect(output[1][:subheader]).to eq(course_without_accredited_provider.provider.name)
+      expect(output[2][:subheader]).to eq(course_provider_accredits.provider.name)
+    end
+
+    it 'outputs the correct status count values' do
+      output = described_class.new(provider).call
+      expect(output[0][:values]).to eq([0, 10, 0, 5, 0])
+      expect(output[1][:values]).to eq([0, 8, 0, 3, 0])
+      expect(output[2][:values]).to eq([0, 0, 6, 0, 4])
+    end
+  end
+end

--- a/spec/services/provider_interface/active_application_statuses_by_provider_spec.rb
+++ b/spec/services/provider_interface/active_application_statuses_by_provider_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe ProviderInterface::ActiveApplicationStatusesByProvider do
   describe '#call' do
     let(:provider) { create(:provider) }
     let(:other_provider) { create(:provider) }
-    let(:course_without_accredited_provider) { create(:course, provider: provider, accredited_provider: nil) }
+    let(:course_without_accredited_provider) { create(:course, name: 'Beekeeping', provider: provider, accredited_provider: nil) }
     let(:course_option_without_accredited_provider) { create(:course_option, course: course_without_accredited_provider) }
-    let(:course_with_other_accredited_provider) { create(:course, provider: provider, accredited_provider: other_provider) }
+    let(:course_with_other_accredited_provider) { create(:course, name: 'Archaeology', provider: provider, accredited_provider: other_provider) }
     let(:course_option_with_other_accredited_provider) { create(:course_option, course: course_with_other_accredited_provider) }
-    let(:course_provider_accredits) { create(:course, provider: other_provider, accredited_provider: provider) }
+    let(:course_provider_accredits) { create(:course, name: 'Criminology', provider: other_provider, accredited_provider: provider) }
     let(:course_option_provider_accredits) { create(:course_option, course: course_provider_accredits) }
 
     before do


### PR DESCRIPTION
## Context

Added a service to generate data for use in a progress report to display application statuses by course for a given provider.


## Changes proposed in this pull request

Introduce new query + service that retrieves and generate data in the correct format.

## Guidance to review

```ruby
 render ProviderInterface::ReportTableComponent.new(headers: headers,
                                                   rows: ActiveApplicationStatusesByProvider.new(provider).call,
                                                   show_footer: false)
```

apply-for-teacher-training/spec/components/previews/provider_interface/report_table_component_preview.rb
^ place above code snippet in this file, and load the preview component in rails/view_component to test that the information is pulling correctly. 

## Link to Trello card

https://trello.com/c/QcbaDXJd/4136-refine-query-for-retrieving-total-numbers-for-active-applications
## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
