### PR TITLE
Use colons when displaying time of day

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,7 +25,7 @@ en:
     sandbox_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk/
   get_into_teaching:
     tel: 0800 389 2500
-    opening_times: "Monday to Friday, 8.30am to 5:30pm (except public\u00A0holidays)"
+    opening_times: "Monday to Friday, 8:30am to 5:30pm (except public\u00A0holidays)"
     url: https://getintoteaching.education.gov.uk
     url_applying: https://getintoteaching.education.gov.uk/steps-to-become-a-teacher#step-5
     url_get_an_advisor: https://adviser-getintoteaching.education.gov.uk


### PR DESCRIPTION
## Context

The formatting for time of day is incorrect in some places 

## Changes proposed in this pull request

- update locale with correct formatting

## Guidance to review

- This fixes the footer and sidebar. See Trello ticket for screenshots

## Link to Trello card

https://trello.com/c/OdmQ76yn/3861-dev-content-fix-use-colons-in-times-of-day

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
