### PR TITLE
Update 'Find closes' calendar event in CycleTimetable

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -7,7 +7,7 @@ class CycleTimetable
       apply_opens: Time.zone.local(2018, 10, 13, 9),
       apply_1_deadline: Time.zone.local(2019, 8, 24, 18),
       apply_2_deadline: Time.zone.local(2019, 9, 18, 18),
-      find_closes: Time.zone.local(2019, 10, 3),
+      find_closes: Time.zone.local(2019, 10, 3, 23, 59, 59),
     },
     2020 => {
       find_opens: Time.zone.local(2019, 10, 6, 9),
@@ -15,7 +15,7 @@ class CycleTimetable
       show_deadline_banner: Time.zone.local(2020, 8, 1, 9),
       apply_1_deadline: Time.zone.local(2020, 8, 24, 18),
       apply_2_deadline: Time.zone.local(2020, 9, 18, 18),
-      find_closes: Time.zone.local(2020, 10, 3),
+      find_closes: Time.zone.local(2020, 10, 3, 23, 59, 59),
     },
     2021 => {
       find_opens: Time.zone.local(2020, 10, 6, 9),
@@ -23,7 +23,7 @@ class CycleTimetable
       show_deadline_banner: Time.zone.local(2021, 8, 1, 9),
       apply_1_deadline: Time.zone.local(2021, 9, 7, 18),
       apply_2_deadline: Time.zone.local(2021, 9, 21, 18),
-      find_closes: Time.zone.local(2021, 10, 3),
+      find_closes: Time.zone.local(2021, 10, 4, 23, 59, 59),
     },
     2022 => {
       find_opens: Time.zone.local(2021, 10, 5, 9),

--- a/app/services/set_reject_by_default.rb
+++ b/app/services/set_reject_by_default.rb
@@ -33,6 +33,6 @@ private
   end
 
   def eoc_rbd_date
-    0.business_days.before(CycleTimetable.find_closes).end_of_day
+    1.business_days.before(CycleTimetable.find_closes).end_of_day
   end
 end

--- a/spec/services/set_reject_by_default_spec.rb
+++ b/spec/services/set_reject_by_default_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe SetRejectByDefault do
       ['7 Sept 2021 0:00:00 AM BST', '1 Oct 2021 23:59:59 PM BST', 'beyond the 2021 EoC deadline'],
       ['20 Sept 2021 0:00:00 AM BST', '1 Oct 2021 23:59:59 PM BST', 'beyond the 2021 EoC deadline'],
       ['29 Sept 2021 0:00:00 AM BST', '1 Oct 2021 23:59:59 PM BST', 'beyond the 2021 EoC deadline'],
-      ['28 Sept 2020 0:00:00 AM BST', '2 Oct 2020 23:59:59 PM BST', 'beyond the 2020 EoC deadline'],
     ].freeze
 
     submitted_vs_rbd_dates.each do |submitted, correct_rbd, test_case|


### PR DESCRIPTION
## Context

Find closes at the end of the day (11:59pm) on 4th October in the 2021 cycle

## Changes proposed in this pull request

Make it so.

## Guidance to review

It should just work ™️ 

Please also review similar change for Find - https://github.com/DFE-Digital/find-teacher-training/pull/886

## Link to Trello card

https://trello.com/c/y2CZ1eMw/3856-eoc-dev-update-find-closed-date-in-timeline-across-find-apply

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
