### PR TITLE
Stop syncing TTAPI when in Heroku review apps

### DIFF
--- a/app/workers/teacher_training_public_api/sync_all_providers_and_courses_worker.rb
+++ b/app/workers/teacher_training_public_api/sync_all_providers_and_courses_worker.rb
@@ -4,6 +4,8 @@ module TeacherTrainingPublicAPI
     sidekiq_options retry: 3, queue: :low_priority
 
     def perform(incremental = true, year = ::RecruitmentCycle.current_year, suppress_sync_update_errors = false)
+      return if HostingEnvironment.review?
+
       SyncSubjects.new.perform
       SyncAllProvidersAndCourses.call(recruitment_cycle_year: year, incremental_sync: incremental, suppress_sync_update_errors: suppress_sync_update_errors)
     end

--- a/spec/workers/teacher_training_public_api/sync_all_providers_and_courses_worker_spec.rb
+++ b/spec/workers/teacher_training_public_api/sync_all_providers_and_courses_worker_spec.rb
@@ -26,5 +26,21 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker do
       described_class.new.perform(false)
       expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCourses).to have_received(:call).with(incremental_sync: false, recruitment_cycle_year: RecruitmentCycle.current_year, suppress_sync_update_errors: false)
     end
+
+    context 'when the hosting environment is review' do
+      around do |example|
+        ClimateControl.modify(HOSTING_ENVIRONMENT_NAME: 'review') { example.run }
+      end
+
+      it 'does not call the SyncSubjects service' do
+        described_class.new.perform
+        expect(stubbed_sync_subjects_service).not_to have_received(:perform)
+      end
+
+      it 'does not call the SyncAllProvidersAndCourses' do
+        described_class.new.perform
+        expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCourses).not_to have_received(:call)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

This is causing spikes on the TTAPI, and sycing every night. Since a sync isn't required and can be done manually, skip the sync if on a review app.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
