### PR TITLE
Exclude candidates who have been excluded from performance data from the performance dashboard

### DIFF
--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -221,8 +221,9 @@ private
 
   def application_choices
     choices = ApplicationChoice
-      .joins(:application_form)
+      .joins(application_form: :candidate)
       .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+      .where('candidates.hide_in_reporting' => false)
 
     if year
       choices.where(application_forms: { recruitment_cycle_year: year })

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -268,6 +268,14 @@ RSpec.describe PerformanceStatistics, type: :model do
 
       expect(described_class.new(nil).total_application_choice_count).to eq 2
     end
+
+    it 'does not include candidates excluded from the performance data' do
+      candidate = create(:candidate, hide_in_reporting: true)
+      application_form = create(:completed_application_form, candidate: candidate)
+      create(:application_choice, :awaiting_provider_decision, application_form: application_form)
+
+      expect(described_class.new(nil).total_application_choice_count).to eq 0
+    end
   end
 
   describe '#application_choices_by_provider_type' do


### PR DESCRIPTION
## Context

We're not excluding candidates from the performance dashboard who should be excluded from the dashboard. This means that the application choice export and the performance dashboard are out of sync.

## Changes proposed in this pull request

- Exclude users who are from the DfE etc. from the dashboards

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
