### PR TITLE
Show per-interface status tags in docs

### DIFF
--- a/app/components/shared/state_explanation_component.html.erb
+++ b/app/components/shared/state_explanation_component.html.erb
@@ -8,6 +8,14 @@
       <dl class="govuk-list app-list--definition">
         <dt>Application status</dt>
         <dd><code><%= govuk_link_to state_name.inspect, api_docs_reference_path(anchor: 'applicationattributes-object') %></code></dd>
+        <% if ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.include?(state_name.to_sym) %>
+          <dt>Appears to candidate as</dd>
+          <% component = CandidateInterface::ApplicationStatusTagComponent.new(application_choice: Struct.new(:status).new(state_name)) %>
+          <dd><%= govuk_tag(text: component.text, colour: component.colour) %></dd>
+          <dt>Appears to provider as</dd>
+          <% component = ProviderInterface::ApplicationStatusTagComponent.new(application_choice: Struct.new(:status).new(state_name)) %>
+          <dd><%= govuk_tag(text: component.text, colour: component.colour) %></dd>
+        <% end %>
         <dt>Description</dd>
         <dd><%= state_description %></dd>
       <% if state.events.any? %>


### PR DESCRIPTION
These aren’t always the same across Apply and Manage, so include each rendition in the docs.

## Changes proposed in this pull request

Changing the shared component means that the Vendor API docs and the in-service documentation at `support/docs` can benefit from this change. Examples:

<img width="1051" alt="Screenshot 2021-08-18 at 14 40 11" src="https://user-images.githubusercontent.com/642279/129909131-af0443b8-e825-435c-93ff-a2a8c022ef9d.png">

<img width="1005" alt="Screenshot 2021-08-18 at 14 39 59" src="https://user-images.githubusercontent.com/642279/129909148-2faebd5e-f827-4a3b-87a9-0cd409e88a5a.png">

<img width="1069" alt="Screenshot 2021-08-18 at 14 40 05" src="https://user-images.githubusercontent.com/642279/129909142-12d9a2a0-0764-46e7-950c-a9679ca81a18.png">:

## Guidance to review

Visit `support/docs/candidate-flow`, `support/docs/provider-flow` or `api-docs/lifecycle`.

## Link to Trello card

N/A

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
