### PR TITLE
Edit provider user permissions

### DIFF
--- a/app/components/provider_interface/user_permission_summary_component.html.erb
+++ b/app/components/provider_interface/user_permission_summary_component.html.erb
@@ -5,7 +5,7 @@
         <%= description_for(permission) %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= can_perform_permission_y_n?(permission) %>
+        <p class="govuk-body"><%= can_perform_permission_y_n?(permission) %></p>
         <% if ProviderRelationshipPermissions::PERMISSIONS.include?(permission) && can_perform_permission?(permission) %>
           <p>This user permission is affected by organisation permissions.</p>
           <%= render ProviderInterface::ProviderPartnerPermissionBreakdownComponent.new(provider: provider, permission: permission) %>

--- a/app/components/provider_interface/user_permission_summary_component.html.erb
+++ b/app/components/provider_interface/user_permission_summary_component.html.erb
@@ -13,7 +13,10 @@
       </dd>
       <% if editable %>
         <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to(provider_interface_provider_user_edit_permissions_path(provider_user, provider), class: 'govuk-!-display-none-print') do %>
+          <%= govuk_link_to(
+            edit_provider_interface_organisation_settings_organisation_user_permissions_path(provider, provider_user),
+            class: 'govuk-!-display-none-print',
+          ) do %>
             Change
             <span class="govuk-visually-hidden"><%= description_for(permission) %></span>
           <% end %>

--- a/app/components/provider_interface/user_permission_summary_component.rb
+++ b/app/components/provider_interface/user_permission_summary_component.rb
@@ -11,7 +11,7 @@ module ProviderInterface
   private
 
     def can_perform_permission?(permission)
-      provider_user.provider_permissions.exists?(permission => true)
+      provider_user.provider_permissions.exists?(provider: provider, permission => true)
     end
 
     def can_perform_permission_y_n?(permission)

--- a/app/components/provider_interface/user_permissions_review_component.rb
+++ b/app/components/provider_interface/user_permissions_review_component.rb
@@ -1,0 +1,32 @@
+module ProviderInterface
+  class UserPermissionsReviewComponent < SummaryListComponent
+    def initialize(permissions:, change_path:)
+      @permissions = permissions
+      @change_path = change_path
+    end
+
+    def rows
+      ProviderPermissions::VALID_PERMISSIONS.map do |permission|
+        permission_description = t("user_permissions.#{permission}.description")
+        {
+          key: permission_description,
+          value: permission_value(permission),
+          action: permission_description,
+          change_path: change_path,
+        }
+      end
+    end
+
+  private
+
+    attr_accessor :permissions, :change_path
+
+    def permission_value(permission)
+      if permissions.include? permission.to_s
+        'Yes'
+      else
+        'No'
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/user_permissions_controller.rb
+++ b/app/controllers/provider_interface/user_permissions_controller.rb
@@ -1,0 +1,16 @@
+module ProviderInterface
+  class UserPermissionsController < UsersController
+    def edit
+      @previous_page_path = provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user)
+      provider_permissions = @provider_user.provider_permissions.find_by!(provider: @provider)
+      @wizard = EditUserPermissionsWizard.from_model(edit_user_permissions_store, provider_permissions)
+    end
+
+  private
+
+    def edit_user_permissions_store
+      key = "edit_user_permissions_wizard_store_#{current_provider_user.id}_#{@provider.id}_#{@provider_user.id}"
+      WizardStateStores::RedisStore.new(key: key)
+    end
+  end
+end

--- a/app/controllers/provider_interface/user_permissions_controller.rb
+++ b/app/controllers/provider_interface/user_permissions_controller.rb
@@ -1,7 +1,7 @@
 module ProviderInterface
   class UserPermissionsController < UsersController
     def edit
-      @previous_page_path = provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user)
+      @previous_page_path = previous_page_path
       provider_permissions = @provider_user.provider_permissions.find_by!(provider: @provider)
       @wizard = EditUserPermissionsWizard.from_model(edit_user_permissions_store, provider_permissions)
     end
@@ -26,6 +26,14 @@ module ProviderInterface
 
     def provider_permissions_params
       params.require(:provider_interface_edit_user_permissions_wizard).permit(permissions: [])
+    end
+
+    def previous_page_path
+      if params[:checking_answers] == 'true'
+        check_provider_interface_organisation_settings_organisation_user_permissions_path(@provider, @provider_user)
+      else
+        provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user)
+      end
     end
   end
 end

--- a/app/controllers/provider_interface/user_permissions_controller.rb
+++ b/app/controllers/provider_interface/user_permissions_controller.rb
@@ -6,11 +6,26 @@ module ProviderInterface
       @wizard = EditUserPermissionsWizard.from_model(edit_user_permissions_store, provider_permissions)
     end
 
+    def update
+      @wizard = EditUserPermissionsWizard.new(edit_user_permissions_store, provider_permissions_params)
+      @wizard.save_state!
+
+      redirect_to check_provider_interface_organisation_settings_organisation_user_permissions_path(@provider, @provider_user)
+    end
+
+    def check
+      @wizard = EditUserPermissionsWizard.new(edit_user_permissions_store)
+    end
+
   private
 
     def edit_user_permissions_store
       key = "edit_user_permissions_wizard_store_#{current_provider_user.id}_#{@provider.id}_#{@provider_user.id}"
       WizardStateStores::RedisStore.new(key: key)
+    end
+
+    def provider_permissions_params
+      params.require(:provider_interface_edit_user_permissions_wizard).permit(permissions: [])
     end
   end
 end

--- a/app/controllers/provider_interface/user_permissions_controller.rb
+++ b/app/controllers/provider_interface/user_permissions_controller.rb
@@ -17,6 +17,19 @@ module ProviderInterface
       @wizard = EditUserPermissionsWizard.new(edit_user_permissions_store)
     end
 
+    def commit
+      wizard = EditUserPermissionsWizard.new(edit_user_permissions_store)
+      provider_permissions = @provider_user.provider_permissions.find_by!(provider: @provider)
+
+      update_provider_permissions(provider_permissions, wizard)
+
+      if provider_permissions.save
+        wizard.clear_state!
+        flash[:success] = 'User permissions updated'
+        redirect_to provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user)
+      end
+    end
+
   private
 
     def edit_user_permissions_store
@@ -33,6 +46,12 @@ module ProviderInterface
         check_provider_interface_organisation_settings_organisation_user_permissions_path(@provider, @provider_user)
       else
         provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user)
+      end
+    end
+
+    def update_provider_permissions(provider_permissions, wizard)
+      ProviderPermissions::VALID_PERMISSIONS.each do |permission|
+        provider_permissions.send("#{permission}=", wizard.permissions.include?(permission.to_s))
       end
     end
   end

--- a/app/forms/provider_interface/edit_user_permissions_wizard.rb
+++ b/app/forms/provider_interface/edit_user_permissions_wizard.rb
@@ -1,0 +1,42 @@
+module ProviderInterface
+  class EditUserPermissionsWizard
+    include ActiveModel::Model
+
+    attr_accessor :permissions
+
+    def initialize(state_store, attrs = {})
+      @state_store = state_store
+
+      super(last_saved_state.deep_merge(attrs))
+    end
+
+    def self.from_model(store, provider_permissions)
+      wizard = new(store)
+
+      wizard.permissions ||= ProviderPermissions::VALID_PERMISSIONS.map(&:to_s).select do |permission|
+        provider_permissions.send(permission)
+      end
+
+      wizard
+    end
+
+    def save_state!
+      @state_store.write(state)
+    end
+
+    def clear_state!
+      @state_store.delete
+    end
+
+  private
+
+    def last_saved_state
+      saved_state = @state_store.read
+      saved_state ? JSON.parse(saved_state) : {}
+    end
+
+    def state
+      as_json(except: %w[state_store errors validation_context]).to_json
+    end
+  end
+end

--- a/app/views/provider_interface/user_permissions/check.html.erb
+++ b/app/views/provider_interface/user_permissions/check.html.erb
@@ -1,0 +1,24 @@
+<% content_for :browser_title, t('page_titles.provider.check_user_permissions') %>
+<% content_for :before_content, govuk_back_link_to(edit_provider_interface_organisation_settings_organisation_user_permissions_path(@provider, @provider_user)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= "#{@provider_user.full_name} - #{@provider.name}" %></span>
+      <%= t('page_titles.provider.check_user_permissions') %>
+    </h1>
+
+    <p class="govuk-body"><%= t('provider_relationship_permissions.view_applications_explanation') %></p>
+
+    <%= render ProviderInterface::UserPermissionsReviewComponent.new(
+      permissions: @wizard.permissions,
+      change_path: edit_provider_interface_organisation_settings_organisation_user_permissions_path(@provider, @provider_user, checking_answers: true),
+    ) %>
+
+    <%= govuk_button_to('Save user permissions', commit_provider_interface_organisation_settings_organisation_user_permissions_path(@provider, @provider_user), method: :put) %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t('cancel'), provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user) %>
+    </p>
+  </div>
+</div>

--- a/app/views/provider_interface/user_permissions/edit.html.erb
+++ b/app/views/provider_interface/user_permissions/edit.html.erb
@@ -1,0 +1,16 @@
+<% content_for :browser_title, t('page_titles.provider.edit_user_permissions') %>
+<% content_for :before_content, govuk_back_link_to(@previous_page_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render ProviderInterface::ProviderUserPermissionsFormComponent.new(
+      form_model: @wizard,
+      form_path: provider_interface_organisation_settings_organisation_user_permissions_path(@provider, @provider_user),
+      provider: @provider,
+      user_name: @provider_user.full_name,
+    ) %>
+    <p class="govuk-body">
+      <%= govuk_link_to t('cancel'), provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user) %>
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -212,6 +212,7 @@ en:
       personal_details: Your personal details
       user_permissions: Your user permissions
       edit_user_permissions: User permissions
+      check_user_permissions: Check and save user permissions
       email_notifications: Your email notifications
       organisation_settings: Organisation settings
       organisation_permissions: Organisation permissions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -790,7 +790,12 @@ Rails.application.routes.draw do
           member do
             get :confirm_destroy, path: 'delete'
 
-            resource :user_permissions, path: 'permissions', only: %i[edit]
+            resource :user_permissions, path: 'permissions', only: %i[edit update] do
+              member do
+                get :check
+                put :commit
+              end
+            end
           end
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -789,6 +789,8 @@ Rails.application.routes.draw do
         resources :users, path: '/users', only: %i[index show destroy] do
           member do
             get :confirm_destroy, path: 'delete'
+
+            resource :user_permissions, path: 'permissions', only: %i[edit]
           end
         end
       end

--- a/spec/components/provider_interface/user_permissions_review_component_spec.rb
+++ b/spec/components/provider_interface/user_permissions_review_component_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::UserPermissionsReviewComponent do
+  let(:permissions) { %w[make_decisions] }
+  let(:change_path) { '/path' }
+  let(:render) { render_inline(described_class.new(permissions: permissions, change_path: change_path)) }
+
+  describe 'change link' do
+    it 'links to the given path' do
+      expect(render.css('a').first.attributes['href'].value).to eq(change_path)
+    end
+
+    it 'contains the correct text' do
+      expect(render.css('a').first.text).to eq('Change Manage users')
+    end
+  end
+
+  describe 'permission values' do
+    it 'renders No in the row for a permission that is not in the array' do
+      manage_users_row = render.css('.govuk-summary-list__row').find { |row| row.text.include? 'Manage users' }
+      expect(manage_users_row.css('.govuk-summary-list__value').text.squish).to eq('No')
+    end
+
+    it 'renders Yes in the row for a permission that is in the array' do
+      make_decisions_row = render.css('.govuk-summary-list__row').find { |row| row.text.include? 'Make offers and reject applications' }
+      expect(make_decisions_row.css('.govuk-summary-list__value').text.squish).to eq('Yes')
+    end
+  end
+end

--- a/spec/forms/provider_interface/edit_user_permissions_wizard_spec.rb
+++ b/spec/forms/provider_interface/edit_user_permissions_wizard_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+RSpec.describe ProviderInterface::EditUserPermissionsWizard do
+  describe '.from_model' do
+    let(:provider_permissions) { build_stubbed(:provider_permissions, make_decisions: true, view_safeguarding_information: true) }
+    let(:store_value) { {} }
+    let(:store) { instance_double(WizardStateStores::RedisStore, read: store_value) }
+    let(:wizard) { described_class.from_model(store, provider_permissions) }
+
+    context 'when there is nothing saved in the state store' do
+      it 'initializes a wizard from the given model' do
+        expect(wizard.permissions).to contain_exactly('make_decisions', 'view_safeguarding_information')
+      end
+    end
+
+    context 'when there is data saved in the state store' do
+      let(:store_value) { { permissions: ['manage_users'] }.to_json }
+
+      it 'initializes a wizard from the stored data' do
+        expect(wizard.permissions).to contain_exactly('manage_users')
+      end
+    end
+  end
+end

--- a/spec/requests/provider_interface/user_permissions_controller_spec.rb
+++ b/spec/requests/provider_interface/user_permissions_controller_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::UserPermissionsController do
+  include DfESignInHelpers
+
+  let(:managing_user) { create(:provider_user, :with_manage_organisations, :with_manage_users, providers: [provider]) }
+  let(:provider) { create(:provider, :with_signed_agreement) }
+
+  before do
+    allow(DfESignInUser).to receive(:load_from_session).and_return(managing_user)
+
+    user_exists_in_dfe_sign_in(email_address: managing_user.email_address)
+  end
+
+  context 'when the account_and_org_settings_changes feature flag is on' do
+    before { FeatureFlag.activate(:account_and_org_settings_changes) }
+
+    it 'returns a success response for GET index' do
+      get provider_interface_organisation_settings_organisation_users_path(provider)
+
+      expect(response.status).to eq(200)
+    end
+
+    context 'when a user does not have manage orgs permissions' do
+      let(:managing_user) { create(:provider_user, :with_manage_organisations, providers: [provider]) }
+      let(:provider_user) { create(:provider_user, providers: [provider]) }
+
+      it 'responds with a 403 on GET edit' do
+        get edit_provider_interface_organisation_settings_organisation_user_permissions_path(provider, provider_user)
+
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+
+  context 'when the account_and_org_settings_changes feature flag is off' do
+    before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
+
+    it 'redirects to the org settings page' do
+      get provider_interface_organisation_settings_organisation_users_path(provider)
+
+      expect(response.status).to eq(302)
+      expect(response.redirect_url).to eq(provider_interface_organisation_settings_url)
+    end
+  end
+end

--- a/spec/requests/provider_interface/user_permissions_controller_spec.rb
+++ b/spec/requests/provider_interface/user_permissions_controller_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe ProviderInterface::UserPermissionsController do
 
         expect(response.status).to eq(403)
       end
+
+      it 'responds with a 403 on PUT' do
+        put provider_interface_organisation_settings_organisation_user_permissions_path(provider, provider_user)
+
+        expect(response.status).to eq(403)
+      end
+
+      it 'responds with a 403 on GET check' do
+        get check_provider_interface_organisation_settings_organisation_user_permissions_path(provider, provider_user)
+
+        expect(response.status).to eq(403)
+      end
     end
   end
 

--- a/spec/requests/provider_interface/user_permissions_controller_spec.rb
+++ b/spec/requests/provider_interface/user_permissions_controller_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe ProviderInterface::UserPermissionsController do
 
         expect(response.status).to eq(403)
       end
+
+      it 'responds with a 403 on PUT commit' do
+        put commit_provider_interface_organisation_settings_organisation_user_permissions_path(provider, provider_user)
+
+        expect(response.status).to eq(403)
+      end
     end
   end
 

--- a/spec/system/provider_interface/edit_user_permissions_spec.rb
+++ b/spec/system/provider_interface/edit_user_permissions_spec.rb
@@ -15,6 +15,15 @@ RSpec.feature 'User permissions' do
     and_i_click_on_a_user
     and_i_click_on_the_change_link
     then_i_see_a_permissions_form_page
+
+    when_i_edit_the_permissions
+    and_i_click_continue
+    then_i_see_the_check_page
+
+    when_i_click_change
+    and_i_modify_the_selected_permissions
+    and_i_click_continue
+    then_i_see_the_modified_permissions
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -30,7 +39,13 @@ RSpec.feature 'User permissions' do
       dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
     )
 
-    @manageable_user = create(:provider_user, providers: [@manage_users_provider])
+    @manageable_user = create(
+      :provider_user,
+      :with_manage_users,
+      :with_view_safeguarding_information,
+      :with_make_decisions,
+      providers: [@manage_users_provider],
+    )
   end
 
   def when_i_go_to_organisation_settings
@@ -52,5 +67,50 @@ RSpec.feature 'User permissions' do
   def then_i_see_a_permissions_form_page
     expect(page).to have_content("#{@manageable_user.full_name} - #{@manage_users_provider.name}")
     expect(page).to have_content('User permissions')
+    expect(page).to have_field('Manage users', checked: true)
+    expect(page).to have_field('Manage organisation permissions', checked: false)
+    expect(page).to have_field('Set up interviews', checked: false)
+    expect(page).to have_field('Make offers and reject applications', checked: true)
+    expect(page).to have_field('View criminal convictions and professional misconduct', checked: true)
+    expect(page).to have_field('View sex, disability and ethnicity information', checked: false)
+  end
+
+  def when_i_edit_the_permissions
+    uncheck 'Manage users'
+    check 'Set up interviews'
+  end
+
+  def and_i_click_continue
+    click_on 'Continue'
+  end
+
+  def then_i_see_the_check_page
+    expect(page).to have_content('Check and save user permissions')
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Manage users\nNo")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Manage organisation permissions\nNo")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Set up interviews\nYes")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Make offers and reject applications\nYes")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "View criminal convictions and professional misconduct\nYes")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "View sex, disability and ethnicity information\nNo")
+  end
+
+  def when_i_click_change
+    click_on 'Change Manage users'
+  end
+
+  def and_i_modify_the_selected_permissions
+    check 'Manage users'
+    uncheck 'Set up interviews'
+    check 'View sex, disability and ethnicity information'
+  end
+
+  def then_i_see_the_modified_permissions
+    expect(page).to have_content('Check and save user permissions')
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Manage users\nYes")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Manage organisation permissions\nNo")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Set up interviews\nNo")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Make offers and reject applications\nYes")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "View criminal convictions and professional misconduct\nYes")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "View sex, disability and ethnicity information\nYes")
   end
 end

--- a/spec/system/provider_interface/edit_user_permissions_spec.rb
+++ b/spec/system/provider_interface/edit_user_permissions_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.feature 'User permissions' do
+  include DfESignInHelpers
+
+  before { FeatureFlag.activate(:account_and_org_settings_changes) }
+
+  scenario 'Provider user edits another user’s permissions' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_can_manage_users_for_one_provider
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_go_to_organisation_settings
+    and_i_view_users_for_my_provider
+    and_i_click_on_a_user
+    and_i_click_on_the_change_link
+    then_i_see_a_permissions_form_page
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_can_manage_users_for_one_provider
+    @manage_users_provider = create(:provider, :with_signed_agreement, code: 'ABC')
+    @provider_user = create(
+      :provider_user,
+      :with_manage_users,
+      providers: [@manage_users_provider],
+      dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
+    )
+
+    @manageable_user = create(:provider_user, providers: [@manage_users_provider])
+  end
+
+  def when_i_go_to_organisation_settings
+    click_on 'Organisation settings', match: :first
+  end
+
+  def and_i_view_users_for_my_provider
+    click_on "Users #{@manage_users_provider.name}"
+  end
+
+  def and_i_click_on_a_user
+    click_on @manageable_user.full_name
+  end
+
+  def and_i_click_on_the_change_link
+    click_on 'Change Manage users'
+  end
+
+  def then_i_see_a_permissions_form_page
+    expect(page).to have_content("#{@manageable_user.full_name} - #{@manage_users_provider.name}")
+    expect(page).to have_content('User permissions')
+  end
+end

--- a/spec/system/provider_interface/edit_user_permissions_spec.rb
+++ b/spec/system/provider_interface/edit_user_permissions_spec.rb
@@ -23,7 +23,12 @@ RSpec.feature 'User permissions' do
     when_i_click_change
     and_i_modify_the_selected_permissions
     and_i_click_continue
-    then_i_see_the_modified_permissions
+    then_i_see_the_check_page
+    and_i_see_the_modified_permissions
+
+    when_i_submit_the_modified_permissions
+    then_i_see_the_user_page
+    and_i_see_the_modified_permissions
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -104,13 +109,25 @@ RSpec.feature 'User permissions' do
     check 'View sex, disability and ethnicity information'
   end
 
-  def then_i_see_the_modified_permissions
+  def then_i_see_the_check_page
     expect(page).to have_content('Check and save user permissions')
+  end
+
+  def and_i_see_the_modified_permissions
     expect(page).to have_selector('.govuk-summary-list__row', text: "Manage users\nYes")
     expect(page).to have_selector('.govuk-summary-list__row', text: "Manage organisation permissions\nNo")
     expect(page).to have_selector('.govuk-summary-list__row', text: "Set up interviews\nNo")
     expect(page).to have_selector('.govuk-summary-list__row', text: "Make offers and reject applications\nYes")
     expect(page).to have_selector('.govuk-summary-list__row', text: "View criminal convictions and professional misconduct\nYes")
     expect(page).to have_selector('.govuk-summary-list__row', text: "View sex, disability and ethnicity information\nYes")
+  end
+
+  def when_i_submit_the_modified_permissions
+    click_on 'Save user permissions'
+  end
+
+  def then_i_see_the_user_page
+    expect(page).to have_content('User permissions updated')
+    expect(page).to have_selector('h1', text: @manageable_user.full_name)
   end
 end

--- a/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Managing provider user permissions' do
   include DfESignInHelpers
 
+  # Behaviour tested here has moved to spec/system/provider_interface/edit_organisation_user_permissions_spec.rb
   before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
 
   scenario 'Provider manages permissions for users' do

--- a/spec/system/provider_interface/view_organisation_users_spec.rb
+++ b/spec/system/provider_interface/view_organisation_users_spec.rb
@@ -96,12 +96,12 @@ RSpec.feature 'Organisation users' do
 
   def and_i_can_see_their_user_permissions
     expect(page).to have_selector('h2', text: 'User permissions')
-    expect(page).to have_selector('.govuk-summary-list__row', text: 'Manage users No')
-    expect(page).to have_selector('.govuk-summary-list__row', text: 'Manage organisation permissions No')
-    expect(page).to have_selector('.govuk-summary-list__row', text: 'Set up interviews No')
-    expect(page).to have_selector('.govuk-summary-list__row', text: 'Make offers and reject applications No')
-    expect(page).to have_selector('.govuk-summary-list__row', text: 'View criminal convictions and professional misconduct No')
-    expect(page).to have_selector('.govuk-summary-list__row', text: 'View sex, disability and ethnicity information No')
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Manage users\nNo")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Manage organisation permissions\nNo")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Set up interviews\nNo")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Make offers and reject applications\nNo")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "View criminal convictions and professional misconduct\nNo")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "View sex, disability and ethnicity information\nNo")
   end
 
   def and_i_can_see_change_links


### PR DESCRIPTION
## Context
https://trello.com/c/hciw82AV/4144-edit-provider-user-permissions

## Changes proposed in this pull request

Added an edit user permissions flow in the Users section of organisations settings

* Permissions can only be edited by a user who has `manage_users` for that organisation
* All permissions can be toggled on and off in the flow, which is reflected in the summary page
* Provider permissions are updated when submitting the check page, and a flash message is shown 

## Guidance to review

Navigate to org settings for a provider user, and click on users for a provider. There, select one of the users in the list, and click on on a change link on their permissions summary. You'll need to be able to manage users for that provider to see the change link

![image](https://user-images.githubusercontent.com/25597009/130058800-a6d8b277-4626-42f2-8c2c-76a73832017a.png)

You can then select which permissions you want to modify for that user

![image](https://user-images.githubusercontent.com/25597009/130058907-bc3e8db3-dcf6-4933-b4d7-a398395f9815.png)

And clicking continue, you'll see a summary of those changed permissions

![image](https://user-images.githubusercontent.com/25597009/130058963-2c25b610-9c2e-4bdd-acc7-3211ce2acc31.png)

Submitting this brings you back to the user summary page, with a flash message 

![image](https://user-images.githubusercontent.com/25597009/130059061-a5f522bf-770a-4dc7-b706-289f1327c320.png)
