### PR TITLE
Reorder application page tabs so that offer comes before interviews

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -13,8 +13,8 @@ module ProviderInterface
     def sub_navigation_items
       sub_navigation_items = [application_navigation_item]
 
-      sub_navigation_items.push(interviews_navigation_item) if interviews_present?
       sub_navigation_items.push(offer_navigation_item) if offer_present?
+      sub_navigation_items.push(interviews_navigation_item) if interviews_present?
       sub_navigation_items.push(notes_navigation_item)
       sub_navigation_items.push(timeline_navigation_item)
       sub_navigation_items.push(feedback_navigation_item) if application_choice.display_provider_feedback?

--- a/spec/components/provider_interface/application_choice_header_component_spec.rb
+++ b/spec/components/provider_interface/application_choice_header_component_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
         let(:interviews) { class_double(Interview, kept: [build_stubbed(:interview)]) }
 
         it 'shows the interview tab' do
-          expect(result.css('.app-tab-navigation li:nth-child(2) a').text).to include(
+          expect(result.css('.app-tab-navigation li a').text).to include(
             'Interviews',
           )
         end


### PR DESCRIPTION
## Context
Offer is more immediately relevant, so should come first

Here's what it looks like now:
<img width="715" alt="Screenshot 2021-08-19 at 15 39 36" src="https://user-images.githubusercontent.com/30071178/130088862-4fa09e04-45cc-4d56-8a22-33ee0f3811d1.png">



## Link to Trello card
https://trello.com/c/ZFKIBMq9/4163-change-the-ordering-of-the-application-tabs-so-that-the-offer-tab-is-second-when-an-application-choice-has-interviews-associated
