### PR TITLE
Update summer recruitment banner content

### DIFF
--- a/config/locales/summer_recruitment_banner.yml
+++ b/config/locales/summer_recruitment_banner.yml
@@ -1,5 +1,5 @@
 en:
   summer_recruitment_banner:
     title: Important
-    header: Applications will be automatically rejected if you do not make a decision within 20 working days
-    body: This reduced time to make a decision will last until the recruitment cycle ends on 4 October.
+    header: The deadline for candidates to apply for the first time in this recruitment cycle is 6pm on 7 September
+    body: Candidates who apply before the deadline will be able to apply again until 6pm on 21 September.

--- a/spec/components/provider_interface/summer_recruitment_banner_spec.rb
+++ b/spec/components/provider_interface/summer_recruitment_banner_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe ProviderInterface::SummerRecruitmentBanner do
     end
 
     it 'renders the banner header' do
-      expect(result.text).to include('Applications will be automatically rejected if you do not make a decision within 20 working days')
+      expect(result.text).to include('The deadline for candidates to apply for the first time in this recruitment cycle is 6pm on 7 September')
     end
 
     it 'renders the banner content' do
-      expect(result.text).to include('This reduced time to make a decision will last until the recruitment cycle ends on 4 October.')
+      expect(result.text).to include('Candidates who apply before the deadline will be able to apply again until 6pm on 21 September.')
     end
   end
 


### PR DESCRIPTION
The message has now changed to highlight key dates for when candidates must apply

Here's what the new content looks like:
<img width="1010" alt="Screenshot 2021-08-19 at 15 44 23" src="https://user-images.githubusercontent.com/30071178/130089638-da2de01c-83ce-43fd-8a20-a89e4e7d9dad.png">


## Guidance to review
Have a look in the review app.

## Link to Trello card
https://trello.com/c/ikznDTt8/4161-update-provider-banner-content
