### PR TITLE
Fix inset text spacing around rejection reasons display

### DIFF
--- a/app/frontend/styles/provider/_rejection.scss
+++ b/app/frontend/styles/provider/_rejection.scss
@@ -3,6 +3,22 @@
   padding-right: 70px;
   position: relative;
 
+  p {
+    margin-bottom: 0;
+  }
+
+  li:last-of-type {
+    margin-bottom: 0;
+  }
+
+  ul:last-of-type {
+    margin-bottom: 0;
+  }
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+
   .app-rejection__actions {
     margin: 0;
     position: absolute;


### PR DESCRIPTION

## Context

Bad:

<img width="615" alt="Screenshot 2021-08-19 at 16 26 57" src="https://user-images.githubusercontent.com/30071178/130096607-6b01f70c-cbb8-4426-aaa2-5ca8263e42a5.png">


Good:

<img width="554" alt="Screenshot 2021-08-19 at 16 26 13" src="https://user-images.githubusercontent.com/30071178/130096475-96dfbcbf-4fd0-4d11-b839-c218d78f7374.png">


## Changes proposed in this pull request
Set some bottom margins to 0 to keep the inset text close to the end of the content.

Generally, things that appeared at the end of the rejection reasons block had a margin set. Those elements seem to be `<p>` or a `<ul>` full of `<li>`s.

## Guidance to review
Not sure if this is the most robust fix, but it should only affect this component.

Test in the review app: Reject an application and give it some feedback. The check answers page in that flow also uses the component, so pay attention there too!

## Link to Trello card
https://trello.com/c/Ed7wnjPy/4087-remove-whitespace-on-feedback-inset-text-on-reasons-for-rejection-check-your-answers-page