### PR TITLE
Update course full feedback

### DIFF
--- a/app/components/shared/reasons_for_rejection_component.html.erb
+++ b/app/components/shared/reasons_for_rejection_component.html.erb
@@ -86,7 +86,7 @@
 <% if reasons_for_rejection.course_full_y_n == 'Yes' %>
   <div class="app-rejection">
     <%= content_tag(subheading_tag_name, 'Course full', class: 'govuk-heading-s') %>
-    <p>We're sorry to tell you the course you applied to was full</p>
+    <p><%= t('reasons_for_rejection.full_course.reason') %> </p>
 
     <% if editable? %>
       <p class="app-rejection__actions">

--- a/config/locales/provider_interface/reasons_for_rejection.yml
+++ b/config/locales/provider_interface/reasons_for_rejection.yml
@@ -20,7 +20,7 @@ en:
       what_to_improve_details: Performance at interview - what to improve
     full_course:
       title: 'Course full'
-      reason: "We're sorry to tell you the course you applied to was full"
+      reason: The course you applied to is full
     offered_on_another_course:
       title: 'They offered you a place on another course'
       other_details: Offered on another course - details

--- a/spec/presenters/rejected_application_choice_presenter_spec.rb
+++ b/spec/presenters/rejected_application_choice_presenter_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe RejectedApplicationChoicePresenter do
         rejected_application_choice = described_class.new(application_choice)
 
         expect(rejected_application_choice.rejection_reasons).to eq(
-          { 'Course full' => ["We're sorry to tell you the course you applied to was full"],
+          { 'Course full' => ['The course you applied to is full'],
             'They offered you a place on another course' => ['You have already been offered the Math course'],
             'Visa application sponsorship' => ['You misspelled visa as viza'] },
         )


### PR DESCRIPTION
## Context

Update the feedback sent to the candidate to "The course you applied to is full" when rejecting an application because the course is full.

## Changes proposed in this pull request

Feedback with updated text:

<img width="889" alt="Screenshot 2021-08-19 at 16 37 11" src="https://user-images.githubusercontent.com/159200/130099035-34fb7fe9-e338-4a40-9e68-e3a29d489f92.png">

## Guidance to review
Reject an application because the course is full and navigate to feedback tab.

## Link to Trello card
https://trello.com/c/n9XXij20/4088-update-copy-on-rejection-check-answers-screen

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
