### PR TITLE
Render the LIVE phase banner content in QA

### DIFF
--- a/app/components/utility/phase_banner_component.rb
+++ b/app/components/utility/phase_banner_component.rb
@@ -12,10 +12,8 @@ class PhaseBannerComponent < ViewComponent::Base
     end
 
     case HostingEnvironment.environment_name
-    when 'production'
+    when 'production', 'qa'
       "This is a new service – #{govuk_link_to('give feedback or report a problem', @feedback_link, class: 'govuk-link--no-visited-state')}".html_safe
-    when 'qa'
-      'This is the QA version of the Apply service'
     when 'staging'
       'This is an internal environment used by DfE to test deploys'
     when 'development'

--- a/spec/components/utility/phase_banner_component_spec.rb
+++ b/spec/components/utility/phase_banner_component_spec.rb
@@ -18,4 +18,16 @@ RSpec.describe PhaseBannerComponent do
       expect(result.css('.govuk-link').attribute('href').value).to eq('http://geocities.com')
     end
   end
+
+  describe 'in QA' do
+    around do |ex|
+      ClimateControl.modify(HOSTING_ENVIRONMENT_NAME: 'qa') { ex.run }
+    end
+
+    it 'renders a feedback link' do
+      result = render_inline(described_class.new)
+
+      expect(result.css('.govuk-link').attribute('href').value).to eq('mailto:becomingateacher@digital.education.gov.uk?subject=Feedback%20about%20Apply%20for%20teacher%20training')
+    end
+  end
 end


### PR DESCRIPTION
## Context
In QA, add the LIVE phase banner content including the feedback link.

## Link to Trello card
https://trello.com/c/W92iM8w4/4162-qa-proto-show-the-right-phase-banner-but-with-a-different-label

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
