### PR TITLE
Add rate limiting to the Vendor API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,9 @@ gem 'request_store-sidekiq'
 gem 'sidekiq'
 gem 'clockwork'
 
+# Rate limiting
+gem 'rack-attack'
+
 # For outgoing http requests
 gem 'http'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,6 +391,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-attack (6.5.0)
+      rack (>= 1.0, < 3)
     rack-mini-profiler (2.3.2)
       rack (>= 1.2.0)
     rack-oauth2 (1.16.0)
@@ -727,6 +729,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 5.4)
+  rack-attack
   rack-mini-profiler
   rails-erd
   rails_semantic_logger

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,7 @@
+VENDOR_API_MAX_REQS_PER_MINUTE = 120
+
+class Rack::Attack
+  throttle('vendor_api/ip', limit: VENDOR_API_MAX_REQS_PER_MINUTE, period: 1.minute) do |req|
+    req.ip if req.path.match(/api\/v1/)
+  end
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,7 +1,19 @@
 VENDOR_API_MAX_REQS_PER_MINUTE = 120
 
 class Rack::Attack
+  class Request < ::Rack::Request
+    def remote_ip
+      # This will always be present because the ActionDispatch::RemoteIp
+      # middleware runs long before this middleware. Use #fetch here
+      # so that we bail quickly if that middleware goes away or changes
+      # the field name. Have preferred this to instantiating a whole
+      # ActionDispatch::Request as that's a whole lot of work and this happens
+      # on every request
+      @remote_ip ||= env.fetch('action_dispatch.remote_ip')
+    end
+  end
+
   throttle('vendor_api/ip', limit: VENDOR_API_MAX_REQS_PER_MINUTE, period: 1.minute) do |req|
-    req.ip if req.path.match(/api\/v1/)
+    req.remote_ip if req.path.match(/api\/v1/)
   end
 end

--- a/spec/requests/vendor_api/throttling_spec.rb
+++ b/spec/requests/vendor_api/throttling_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API throttling', rack_attack: true do
+  include VendorAPISpecHelpers
+
+  it 'returns 429 responses when the rate limit is exceeded' do
+    VENDOR_API_MAX_REQS_PER_MINUTE.times do
+      get_api_request '/api/v1/applications?since=2021-01-01T12:00:00Z'
+    end
+
+    expect(response).to have_http_status(:success)
+
+    get_api_request '/api/v1/applications?since=2021-01-01T12:00:00Z'
+    expect(response).to have_http_status(:too_many_requests)
+
+    Timecop.travel(1.minute.from_now) do
+      get_api_request '/api/v1/applications?since=2021-01-01T12:00:00Z'
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  it 'does not apply to other paths' do
+    VENDOR_API_MAX_REQS_PER_MINUTE.times do
+      get_api_request '/provider'
+    end
+
+    get_api_request '/provider'
+    expect(response).to have_http_status(:success)
+  end
+end

--- a/spec/support/rack_attack.rb
+++ b/spec/support/rack_attack.rb
@@ -1,0 +1,17 @@
+Rack::Attack.enabled = false
+
+RSpec.configure do |config|
+  config.around do |example|
+    if example.metadata[:rack_attack] == true
+      begin
+        Rack::Attack.enabled = true
+        Rack::Attack.reset!
+        example.run
+      ensure
+        Rack::Attack.enabled = false
+      end
+    else
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to stop unruly clients making more than 2 requests per second to the vendor API.

## Changes proposed in this pull request

Add `Rack::Attack` gem, configure it, and test the integration.

**How it looks**

<img width="501" alt="Screenshot 2021-08-19 at 18 01 46" src="https://user-images.githubusercontent.com/642279/130115946-cdd8bb81-b98a-4f97-a1d0-92148e147089.png">

<img width="430" alt="Screenshot 2021-08-19 at 18 01 58" src="https://user-images.githubusercontent.com/642279/130116040-315a560b-ff6b-4cc8-ac80-f31b564a4dc6.png">

## Link to Trello card

https://trello.com/c/Rsidm7NZ/4068-%F0%9F%8F%88-implement-the-vendor-api-rate-limit-advertised-in-the-api-docs

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
