### PR TITLE
Update `reject_by_default` date and add to CycleTimetable

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -7,6 +7,7 @@ class CycleTimetable
       apply_opens: Time.zone.local(2018, 10, 13, 9),
       apply_1_deadline: Time.zone.local(2019, 8, 24, 18),
       apply_2_deadline: Time.zone.local(2019, 9, 18, 18),
+      reject_by_default: Time.zone.local(2021, 9, 29, 23, 59, 59),
       find_closes: Time.zone.local(2019, 10, 3, 23, 59, 59),
     },
     2020 => {
@@ -15,6 +16,7 @@ class CycleTimetable
       show_deadline_banner: Time.zone.local(2020, 8, 1, 9),
       apply_1_deadline: Time.zone.local(2020, 8, 24, 18),
       apply_2_deadline: Time.zone.local(2020, 9, 18, 18),
+      reject_by_default: Time.zone.local(2021, 9, 29, 23, 59, 59),
       find_closes: Time.zone.local(2020, 10, 3, 23, 59, 59),
     },
     2021 => {
@@ -23,6 +25,7 @@ class CycleTimetable
       show_deadline_banner: Time.zone.local(2021, 8, 1, 9),
       apply_1_deadline: Time.zone.local(2021, 9, 7, 18),
       apply_2_deadline: Time.zone.local(2021, 9, 21, 18),
+      reject_by_default: Time.zone.local(2021, 9, 29, 23, 59, 59),
       find_closes: Time.zone.local(2021, 10, 4, 23, 59, 59),
     },
     2022 => {
@@ -66,6 +69,10 @@ class CycleTimetable
 
   def self.apply_2_deadline(year = current_year)
     date(:apply_2_deadline, year)
+  end
+
+  def self.reject_by_default(year = current_year)
+    date(:reject_by_default, year)
   end
 
   def self.find_closes(year = current_year)
@@ -152,7 +159,8 @@ class CycleTimetable
           show_deadline_banner: 1.day.ago,
           apply_1_deadline: 1.day.from_now,
           apply_2_deadline: 2.days.from_now,
-          find_closes: 3.days.from_now,
+          reject_by_default: 3.days.from_now,
+          find_closes: 4.days.from_now,
         },
         next_year => {
           find_opens: 6.days.from_now,
@@ -166,7 +174,8 @@ class CycleTimetable
           show_deadline_banner: 3.days.ago,
           apply_1_deadline: 1.day.ago,
           apply_2_deadline: 2.days.from_now,
-          find_closes: 3.days.from_now,
+          reject_by_default: 3.days.from_now,
+          find_closes: 4.days.from_now,
         },
         next_year => {
           find_opens: 6.days.from_now,
@@ -180,7 +189,8 @@ class CycleTimetable
           show_deadline_banner: 4.days.ago,
           apply_1_deadline: 3.days.ago,
           apply_2_deadline: 1.day.ago,
-          find_closes: 1.day.from_now,
+          reject_by_default: 1.day.from_now,
+          find_closes: 2.days.from_now,
         },
         next_year => {
           find_opens: 6.days.from_now,
@@ -194,7 +204,8 @@ class CycleTimetable
           apply_opens: 6.days.ago,
           show_deadline_banner: 5.days.ago,
           apply_1_deadline: 4.days.ago,
-          apply_2_deadline: 2.days.ago,
+          apply_2_deadline: 3.days.ago,
+          reject_by_default: 2.days.ago,
           find_closes: 1.day.ago,
         },
         next_year => {
@@ -210,7 +221,8 @@ class CycleTimetable
           show_deadline_banner: 7.days.ago,
           apply_1_deadline: 6.days.ago,
           apply_2_deadline: 5.days.ago,
-          find_closes: 4.days.ago,
+          reject_by_default: 4.days.ago,
+          find_closes: 3.days.ago,
         },
         next_year => {
           find_opens: 1.day.ago,
@@ -225,7 +237,8 @@ class CycleTimetable
           show_deadline_banner: 7.days.ago,
           apply_1_deadline: 6.days.ago,
           apply_2_deadline: 5.days.ago,
-          find_closes: 4.days.ago,
+          reject_by_default: 4.days.ago,
+          find_closes: 3.days.ago,
         },
         next_year => {
           find_opens: 2.days.ago,

--- a/app/services/set_reject_by_default.rb
+++ b/app/services/set_reject_by_default.rb
@@ -18,7 +18,7 @@ class SetRejectByDefault
     return if application_choice.reject_by_default_at.to_s == time.in_time_zone.to_s &&
               application_choice.reject_by_default_days == days
 
-    rbd_date = beyond_eoc?(time) ? eoc_rbd_date : time
+    rbd_date = beyond_end_of_cycle_reject_by_default_deadline?(time) ? reject_by_default_date : time
 
     application_choice.update!(
       reject_by_default_at: rbd_date,
@@ -28,11 +28,11 @@ class SetRejectByDefault
 
 private
 
-  def beyond_eoc?(date)
-    date >= CycleTimetable.find_closes
+  def beyond_end_of_cycle_reject_by_default_deadline?(date)
+    date >= reject_by_default_date
   end
 
-  def eoc_rbd_date
-    1.business_days.before(CycleTimetable.find_closes).end_of_day
+  def reject_by_default_date
+    0.business_days.before(CycleTimetable.reject_by_default).end_of_day
   end
 end

--- a/spec/services/set_reject_by_default_spec.rb
+++ b/spec/services/set_reject_by_default_spec.rb
@@ -17,10 +17,9 @@ RSpec.describe SetRejectByDefault do
       ['4 Jan 2019 11:00:00 PM GMT', '2 Mar 2019 0:00:00 AM GMT',  'safely within GMT'],
       ['1 Jul 2020 11:00:00 PM BST', '30 Jul 2020 0:00:00 AM BST', 'during the 20-day summer period'],
       ['21 Nov 2020 12:00:00 PM GMT', '2 Feb 2021 0:00:00 AM GMT', 'near the UCAS winter break'],
-      ['1 Sept 2021 0:00:00 AM BST', '29 Sept 2021 23:59:59 PM BST', 'not beyond the 2021 EoC deadline'],
-      ['7 Sept 2021 0:00:00 AM BST', '1 Oct 2021 23:59:59 PM BST', 'beyond the 2021 EoC deadline'],
-      ['20 Sept 2021 0:00:00 AM BST', '1 Oct 2021 23:59:59 PM BST', 'beyond the 2021 EoC deadline'],
-      ['29 Sept 2021 0:00:00 AM BST', '1 Oct 2021 23:59:59 PM BST', 'beyond the 2021 EoC deadline'],
+      ['1 Sept 2021 0:00:00 AM BST', '29 Sept 2021 23:59:59 PM BST', '7 days before the apply 1 deadline'],
+      ['7 Sept 2021 0:00:00 AM BST', '29 Sept 2021 23:59:59 PM BST', '1 day before apply 1 deadline'],
+      ['20 Sept 2021 0:00:00 AM BST', '29 Sep 2021 23:59:59 PM BST', '1 day before apply 2 deadline'],
     ].freeze
 
     submitted_vs_rbd_dates.each do |submitted, correct_rbd, test_case|


### PR DESCRIPTION
## Context

This year UCAS's cycle’s final deadline for reject by default (i.e. any applications without a decision from providers) is 29 September 2021 (end of day) – so this is in effect the last date for provider decisions

See Slack discussion - https://ukgovernmentdfe.slack.com/archives/CP18YJXPY/p1629283704211300?thread_ts=1629283346.210900&cid=CP18YJXPY

## Changes proposed in this pull request

- Add 'reject_by_default' date as as a new event in the CycleTimetable
- Wire up `SetRejectByDefault` to use the 'reject_by_default' event in the CycleTimetable
- Fix specs and update descriptions

## Guidance to review

Make sense?

## Link to Trello card

https://trello.com/c/MsIJ5rbx/3871-update-rejectbydefault-date-and-add-to-cycletimetable

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
