### PR TITLE
Always clear authentication details between RSpec scenarios

### DIFF
--- a/spec/support/warden.rb
+++ b/spec/support/warden.rb
@@ -1,6 +1,9 @@
 RSpec.configure do |config|
   config.include Warden::Test::Helpers
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.after do
+    Warden.test_reset!
+  end
 end
 
 # The Devise test helpers rely on an ApplicationController being present


### PR DESCRIPTION
## Context

We have been seeing a common flakey test in candidate specs. An example to replicate locally is to run:
```
be rspec ./spec/system/candidate_interface/carry_over/candidate_carries_over_application_with_references_to_new_cycle_and_referee_provides_reference_spec.rb[1:1] ./spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb[1:1] --seed 24253
```
which yields the following failure:
```
ActiveRecord::InvalidForeignKey:
       PG::ForeignKeyViolation: ERROR:  insert or update on table "application_forms" violates foreign key constraint "fk_rails_a3a5a8cae7"
       DETAIL:  Key (candidate_id)=(10484) is not present in table "candidates".
     # ./app/models/candidate.rb:31:in `current_application'
     # ./app/controllers/candidate_interface/candidate_interface_controller.rb:67:in `current_application'
     # ./app/controllers/candidate_interface/candidate_interface_controller.rb:16:in `set_user_context'
```

This shows we are getting errors when accessing the `current_candidate` value. This value is being maintained across scenarios, even after clearing the database. It tries to access this value and thus errors as it no longer exists in the database. This value is set by devise authentication, which indicates that we are not clearing authentication sessions between scenarios

## Changes proposed in this pull request

Reset devise session between scenarios to avoid leaking authenticated users between sessions to avoid flakey tests

## Guidance to review

Try replicating locally with the above details

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
