### PR TITLE
Fix course section back and change links to work with application review

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -112,7 +112,11 @@ module CandidateInterface
           href: course_change_path(application_choice),
           visually_hidden_text: "course choice for #{application_choice.current_course.name_and_code}",
         },
-        data_qa: 'course-choice',
+        html_attributes: {
+          data: {
+            qa: 'course-choice',
+          },
+        },
       }
     end
 
@@ -132,8 +136,11 @@ module CandidateInterface
           href: site_change_path(application_choice),
           visually_hidden_text: "location for #{application_choice.current_course.name_and_code}",
         },
-        action: "location for #{application_choice.current_course.name_and_code}",
-        data_qa: 'course-choice-location',
+        html_attributes: {
+          data: {
+            qa: 'course-choice-location',
+          },
+        },
       }
     end
 
@@ -153,7 +160,11 @@ module CandidateInterface
           href: change_path,
           visually_hidden_text: "study mode for #{application_choice.current_course.name_and_code}",
         },
-        data_qa: 'course-choice-study-mode',
+        html_attributes: {
+          data: {
+            qa: 'course-choice-study-mode',
+          },
+        },
       }
     end
 

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -11,8 +11,10 @@ module CandidateInterface
       missing_error: false,
       application_choice_error: false,
       render_link_to_find_when_rejected_on_qualifications: false,
-      display_accepted_application_choices: false
+      display_accepted_application_choices: false,
+      return_to_application_review: false
     )
+
       @application_form = application_form
       @editable = editable
       @heading_level = heading_level
@@ -22,6 +24,7 @@ module CandidateInterface
       @application_choice_error = application_choice_error
       @render_link_to_find_when_rejected_on_qualifications = render_link_to_find_when_rejected_on_qualifications
       @display_accepted_application_choices = display_accepted_application_choices
+      @return_to_application_review = return_to_application_review
     end
 
     def course_choice_rows(application_choice)
@@ -55,20 +58,20 @@ module CandidateInterface
 
     def course_change_path(application_choice)
       if multiple_courses?(application_choice)
-        candidate_interface_course_choices_course_path(
+        candidate_interface_edit_course_choices_course_path(
           application_choice.provider.id,
-          course_choice_id: application_choice.id,
+          change_path_params(application_choice),
         )
       end
     end
 
     def site_change_path(application_choice)
       if multiple_sites?(application_choice)
-        candidate_interface_course_choices_site_path(
+        candidate_interface_edit_course_choices_site_path(
           application_choice.provider.id,
           application_choice.current_course.id,
           application_choice.current_course_option.study_mode,
-          course_choice_id: application_choice.id,
+          change_path_params(application_choice),
         )
       end
     end
@@ -109,6 +112,7 @@ module CandidateInterface
           href: course_change_path(application_choice),
           visually_hidden_text: "course choice for #{application_choice.current_course.name_and_code}",
         },
+        data_qa: 'course-choice',
       }
     end
 
@@ -128,16 +132,18 @@ module CandidateInterface
           href: site_change_path(application_choice),
           visually_hidden_text: "location for #{application_choice.current_course.name_and_code}",
         },
+        action: "location for #{application_choice.current_course.name_and_code}",
+        data_qa: 'course-choice-location',
       }
     end
 
     def study_mode_row(application_choice)
       return unless application_choice.current_course.full_time_or_part_time?
 
-      change_path = candidate_interface_course_choices_study_mode_path(
+      change_path = candidate_interface_edit_course_choices_study_mode_path(
         application_choice.provider.id,
         application_choice.current_course.id,
-        course_choice_id: application_choice.id,
+        change_path_params(application_choice),
       )
 
       {
@@ -147,6 +153,7 @@ module CandidateInterface
           href: change_path,
           visually_hidden_text: "study mode for #{application_choice.current_course.name_and_code}",
         },
+        data_qa: 'course-choice-study-mode',
       }
     end
 
@@ -245,6 +252,23 @@ module CandidateInterface
 
     def application_choice_with_accepted_state_present?
       @application_form.application_choices.any? { |ac| ApplicationStateChange::ACCEPTED_STATES.include?(ac.status.to_sym) }
+    end
+
+    def change_path_params(application_choice)
+      params = { course_choice_id: application_choice.id }
+      if @return_to_application_review
+        params.merge(return_to_application_review_params)
+      else
+        params.merge(return_to_section_review_params)
+      end
+    end
+
+    def return_to_application_review_params
+      { 'return-to' => 'application-review' }
+    end
+
+    def return_to_section_review_params
+      { 'return-to' => 'section-review' }
     end
   end
 end

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -50,7 +50,7 @@ module CandidateInterface
     end
 
     def redirect_back_to_application_review_page?
-      params['return-to'] == 'application-review'
+      params['return-to'] == 'application-review' || params[:return_to] == 'application-review'
     end
 
     def show_pilot_holding_page_if_not_open

--- a/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
@@ -135,22 +135,6 @@ module CandidateInterface
           redirect_to candidate_interface_course_choices_review_path
         end
       end
-
-      def return_to_after_edit(default:)
-        if redirect_back_to_application_review_page?
-          { back_path: candidate_interface_application_review_path, params: redirect_back_to_application_review_page_params }
-        else
-          { back_path: default, params: {} }
-        end
-      end
-
-      def redirect_back_to_application_review_page_params
-        { 'return-to' => 'application-review' }
-      end
-
-      def redirect_back_to_application_review_page?
-        params['return-to'] == 'application-review' || params[:return_to] == 'application-review'
-      end
     end
   end
 end

--- a/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
@@ -2,21 +2,22 @@ module CandidateInterface
   module CourseChoices
     class CourseSelectionController < BaseController
       def new
-        if params[:course_choice_id]
-          @course_choice_id = params[:course_choice_id]
-          current_application_choice = current_application.application_choices.find(@course_choice_id)
+        @pick_course = PickCourseForm.new(
+          provider_id: params.fetch(:provider_id),
+          application_form: current_application,
+        )
+      end
 
-          @pick_course = PickCourseForm.new(
-            provider_id: params.fetch(:provider_id),
-            application_form: current_application,
-            course_id: current_application_choice.course.id,
-          )
-        else
-          @pick_course = PickCourseForm.new(
-            provider_id: params.fetch(:provider_id),
-            application_form: current_application,
-          )
-        end
+      def edit
+        @course_choice_id = params[:course_choice_id]
+        current_application_choice = current_application.application_choices.find(@course_choice_id)
+        @return_to = return_to_after_edit(default: candidate_interface_course_choices_review_path)
+
+        @pick_course = PickCourseForm.new(
+          provider_id: params.fetch(:provider_id),
+          application_form: current_application,
+          course_id: current_application_choice.course.id,
+        )
       end
 
       def create
@@ -63,8 +64,65 @@ module CandidateInterface
         end
       end
 
+      def update
+        course_id = params.dig(:candidate_interface_pick_course_form, :course_id)
+
+        @pick_course = PickCourseForm.new(
+          provider_id: params.fetch(:provider_id),
+          course_id: course_id,
+          application_form: current_application,
+        )
+        render :new and return unless @pick_course.valid?
+
+        redirect_to_review_page_if_course_already_added(current_application, course_id)
+        return if performed?
+
+        if !@pick_course.open_on_apply?
+          redirect_to candidate_interface_course_choices_ucas_with_course_path(@pick_course.provider_id, @pick_course.course_id)
+        elsif !@pick_course.available?
+          redirect_to candidate_interface_course_choices_full_path(
+            @pick_course.provider_id,
+            @pick_course.course_id,
+            return_to: params[:return_to],
+            previous_course_choice_id: params[:course_choice_id],
+          )
+        elsif @pick_course.currently_has_both_study_modes_available?
+          redirect_to candidate_interface_edit_course_choices_study_mode_path(
+            @pick_course.provider_id,
+            @pick_course.course_id,
+            course_choice_id: params[:course_choice_id],
+            return_to: params[:return_to],
+          )
+        elsif @pick_course.single_site?
+          course_option = @pick_course.available_course_options.first
+          AddOrUpdateCourseChoice.new(
+            course_option_id: course_option.id,
+            application_form: current_application,
+            controller: self,
+            id_of_course_choice_to_replace: params[:course_choice_id],
+          ).call
+        else
+          redirect_to candidate_interface_edit_course_choices_site_path(
+            @pick_course.provider_id,
+            @pick_course.course_id,
+            @pick_course.available_study_modes_with_vacancies.first,
+            course_choice_id: params[:course_choice_id],
+            return_to: params[:return_to],
+          )
+        end
+      end
+
       def full
         @course = Course.find(params[:course_id])
+
+        @return_to_path = if params[:return_to].nil?
+                            candidate_interface_course_choices_course_path(@course.provider)
+                          else
+                            candidate_interface_edit_course_choices_course_path(
+                              course_choice_id: params[:previous_course_choice_id],
+                              return_to: params[:return_to],
+                            )
+                          end
       end
 
     private
@@ -76,6 +134,22 @@ module CandidateInterface
           flash[:info] = I18n.t!('errors.application_choices.already_added', course_name_and_code: course.name_and_code)
           redirect_to candidate_interface_course_choices_review_path
         end
+      end
+
+      def return_to_after_edit(default:)
+        if redirect_back_to_application_review_page?
+          { back_path: candidate_interface_application_review_path, params: redirect_back_to_application_review_page_params }
+        else
+          { back_path: default, params: {} }
+        end
+      end
+
+      def redirect_back_to_application_review_page_params
+        { 'return-to' => 'application-review' }
+      end
+
+      def redirect_back_to_application_review_page?
+        params['return-to'] == 'application-review' || params[:return_to] == 'application-review'
       end
     end
   end

--- a/app/controllers/candidate_interface/course_choices/site_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/site_selection_controller.rb
@@ -2,18 +2,26 @@ module CandidateInterface
   module CourseChoices
     class SiteSelectionController < BaseController
       def new
-        candidate_is_updating_a_choice = params[:course_choice_id]
+        @pick_site = PickSiteForm.new
+      end
 
-        if candidate_is_updating_a_choice
-          @course_choice_id = params[:course_choice_id]
-          current_application_choice = current_application.application_choices.find(@course_choice_id)
+      def edit
+        @course_choice_id = params[:course_choice_id]
+        current_application_choice = current_application.application_choices.find(@course_choice_id)
+        new_course_choice = Course.find(params[:course_id])
 
-          @pick_site = PickSiteForm.new(
-            course_option_id: current_application_choice.course_option_id.to_s,
-          )
-        else
-          @pick_site = PickSiteForm.new
-        end
+        @pick_site = PickSiteForm.new(
+          course_option_id: current_application_choice.course_option_id.to_s,
+        )
+
+        @return_to = return_to_after_edit(default: candidate_interface_course_choices_review_path)
+        @application_review = params['return-to'] || params[:return_to]
+
+        @return_to_path = if new_course_choice.currently_has_both_study_modes_available?
+                            candidate_interface_edit_course_choices_study_mode_path(course_choice_id: @course_choice_id, return_to: @application_review, start_edit: params[:start_edit])
+                          else
+                            candidate_interface_edit_course_choices_course_path(course_choice_id: @course_choice_id, return_to: @application_review)
+                          end
       end
 
       def create
@@ -32,6 +40,26 @@ module CandidateInterface
             application_form: current_application,
             controller: self,
             id_of_course_choice_to_replace: params[:course_choice_id],
+          )
+          .call
+      end
+
+      def update
+        course_option_id = params.dig(:candidate_interface_pick_site_form, :course_option_id)
+        @pick_site = PickSiteForm.new(
+          application_form: current_application,
+          course_option_id: course_option_id,
+        )
+
+        render :new and return unless @pick_site.valid?
+
+        AddOrUpdateCourseChoice
+          .new(
+            course_option_id: course_option_id,
+            application_form: current_application,
+            controller: self,
+            id_of_course_choice_to_replace: params[:course_choice_id],
+            return_to: params[:return_to],
           )
           .call
       end

--- a/app/controllers/candidate_interface/course_choices/study_mode_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/study_mode_selection_controller.rb
@@ -2,21 +2,24 @@ module CandidateInterface
   module CourseChoices
     class StudyModeSelectionController < BaseController
       def new
-        if params[:course_choice_id]
-          @course_choice_id = params[:course_choice_id]
-          current_application_choice = current_application.application_choices.find(@course_choice_id)
+        @pick_study_mode = PickStudyModeForm.new(
+          provider_id: params.fetch(:provider_id),
+          course_id: params.fetch(:course_id),
+        )
+      end
 
-          @pick_study_mode = PickStudyModeForm.new(
-            provider_id: params.fetch(:provider_id),
-            course_id: params.fetch(:course_id),
-            study_mode: current_application_choice.current_course_option.study_mode,
-          )
-        else
-          @pick_study_mode = PickStudyModeForm.new(
-            provider_id: params.fetch(:provider_id),
-            course_id: params.fetch(:course_id),
-          )
-        end
+      def edit
+        @course_choice_id = params[:course_choice_id]
+        current_application_choice = current_application.application_choices.find(@course_choice_id)
+        @return_to = return_to_after_edit(default: candidate_interface_course_choices_review_path)
+
+        @application_review = params['return-to'] || params[:return_to]
+
+        @pick_study_mode = PickStudyModeForm.new(
+          provider_id: params.fetch(:provider_id),
+          course_id: params.fetch(:course_id),
+          study_mode: current_application_choice.current_course_option.study_mode,
+        )
       end
 
       def create
@@ -43,6 +46,36 @@ module CandidateInterface
             @pick_study_mode.course_id,
             @pick_study_mode.study_mode,
             course_choice_id: params[:course_choice_id],
+          )
+        end
+      end
+
+      def update
+        @pick_study_mode = PickStudyModeForm.new(
+          provider_id: params.fetch(:provider_id),
+          course_id: params.fetch(:course_id),
+          study_mode: params.dig(
+            :candidate_interface_pick_study_mode_form,
+            :study_mode,
+          ),
+        )
+        render :new and return unless @pick_study_mode.valid?
+
+        if @pick_study_mode.single_site_course?
+          AddOrUpdateCourseChoice.new(
+            course_option_id: @pick_study_mode.first_site_id,
+            application_form: current_application,
+            controller: self,
+            id_of_course_choice_to_replace: params[:course_choice_id],
+            return_to: params[:return_to],
+          ).call
+        else
+          redirect_to candidate_interface_edit_course_choices_site_path(
+            @pick_study_mode.provider_id,
+            @pick_study_mode.course_id,
+            @pick_study_mode.study_mode,
+            course_choice_id: params[:course_choice_id],
+            return_to: params[:return_to],
           )
         end
       end

--- a/app/controllers/candidate_interface/course_choices/ucas_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/ucas_controller.rb
@@ -8,6 +8,15 @@ module CandidateInterface
       def with_course
         @provider = Provider.find(params[:provider_id])
         @course = Course.find(params[:course_id])
+
+        @return_to_path = if params[:return_to].nil?
+                            candidate_interface_course_choices_course_path(@provider.id)
+                          else
+                            candidate_interface_edit_course_choices_course_path(
+                              course_choice_id: params[:previous_course_choice_id],
+                              return_to: params[:return_to],
+                            )
+                          end
       end
     end
   end

--- a/app/services/candidate_interface/add_or_update_course_choice.rb
+++ b/app/services/candidate_interface/add_or_update_course_choice.rb
@@ -2,11 +2,12 @@ module CandidateInterface
   class AddOrUpdateCourseChoice
     attr_reader :course_option_id, :application_form, :controller, :id_of_course_choice_to_replace
 
-    def initialize(course_option_id:, application_form:, controller:, id_of_course_choice_to_replace: nil)
+    def initialize(course_option_id:, application_form:, controller:, return_to: nil, id_of_course_choice_to_replace: nil)
       @course_option_id = course_option_id
       @application_form = application_form
       @controller = controller
       @id_of_course_choice_to_replace = id_of_course_choice_to_replace
+      @return_to = return_to
     end
 
     delegate(
@@ -84,7 +85,11 @@ module CandidateInterface
         flash[:warning] = pick_site_form.errors.full_messages.first
       end
 
-      redirect_to candidate_interface_course_choices_index_path
+      if @return_to == 'application-review'
+        redirect_to '/candidate/application/review'
+      else
+        redirect_to candidate_interface_course_choices_index_path
+      end
     end
   end
 end

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -26,6 +26,7 @@
         show_status: @application_form.submitted?,
         missing_error: missing_error,
         application_choice_error: application_choice_error,
+        return_to_application_review: true,
       ),
     ) %>
   <% end %>

--- a/app/views/candidate_interface/course_choices/course_selection/_form_fields.html.erb
+++ b/app/views/candidate_interface/course_choices/course_selection/_form_fields.html.erb
@@ -1,0 +1,24 @@
+<% if @pick_course.radio_available_courses.count > 20 %>
+  <%= f.govuk_collection_select(
+    :course_id,
+    select_course_options(@pick_course.dropdown_available_courses),
+    :id,
+    :name,
+    label: { text: t('page_titles.which_course'), size: 'xl', tag: 'h1' },
+    options: { selected: nil },
+  ) %>
+<% else %>
+  <%= f.govuk_radio_buttons_fieldset :course_id, legend: { size: 'xl', text: t('page_titles.which_course'), tag: 'h1' } do %>
+    <% @pick_course.radio_available_courses.each_with_index do |course, i| %>
+      <% if !course.open_on_apply? %>
+        <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code}) – Only on UCAS" }, hint: { text: course.description }, link_errors: i.zero? %>
+      <% elsif course.course_options.available.blank? %>
+        <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code}) – No vacancies" }, hint: { text: course.description }, link_errors: i.zero? %>
+      <% else %>
+        <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code})" }, hint: { text: course.description }, link_errors: i.zero? %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= f.govuk_submit t('continue') %>

--- a/app/views/candidate_interface/course_choices/course_selection/edit.html.erb
+++ b/app/views/candidate_interface/course_choices/course_selection/edit.html.erb
@@ -1,12 +1,13 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.which_course'), @pick_course.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_provider_path) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @pick_course,
-      url: candidate_interface_course_choices_course_path(provider_id: params[:provider_id], course_choice_id: @course_choice_id),
+      url: candidate_interface_edit_course_choices_course_path(provider_id: params[:provider_id], course_choice_id: @course_choice_id, return_to: params['return-to']),
       id: 'pick-course-form',
+      method: :patch,
     ) do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/candidate_interface/course_choices/course_selection/full.html.erb
+++ b/app/views/candidate_interface/course_choices/course_selection/full.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.full_course') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_course_path(@course.provider)) %>
+<% content_for :before_content, govuk_back_link_to(@return_to_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/course_choices/site_selection/_form_fields.html.erb
+++ b/app/views/candidate_interface/course_choices/site_selection/_form_fields.html.erb
@@ -1,0 +1,7 @@
+<%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: t('page_titles.which_location'), size: 'xl', tag: 'h1' } do %>
+  <% available_sites.each_with_index do |option, i| %>
+    <%= f.govuk_radio_button :course_option_id, option.id, label: { text: option.site.name }, hint: { text: option.site.full_address }, link_errors: i.zero? %>
+  <% end %>
+<% end %>
+
+<%= f.govuk_submit t('continue') %>

--- a/app/views/candidate_interface/course_choices/site_selection/edit.html.erb
+++ b/app/views/candidate_interface/course_choices/site_selection/edit.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.which_location'), @pick_site.errors.any?) %>
+<% if params['return-to'].nil? %>
+  <% content_for :before_content, govuk_back_link_to(@return_to_path) %>
+<% else %>
+  <% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+          model: @pick_site,
+          url: candidate_interface_edit_course_choices_site_path(
+            params[:provider_id], params[:course_id], params[:study_mode], course_choice_id: @course_choice_id, return_to: @application_review
+          ),
+          method: :patch,
+        ) do |f| %>
+          <%= f.govuk_error_summary %>
+
+          <%= render 'form_fields', f: f %>
+        <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/course_choices/site_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/site_selection/new.html.erb
@@ -9,15 +9,9 @@
             params[:provider_id], params[:course_id], params[:study_mode], course_choice_id: @course_choice_id
           ),
         ) do |f| %>
-            <%= f.govuk_error_summary %>
+          <%= f.govuk_error_summary %>
 
-            <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: t('page_titles.which_location'), size: 'xl', tag: 'h1' } do %>
-              <% available_sites.each_with_index do |option, i| %>
-                <%= f.govuk_radio_button :course_option_id, option.id, label: { text: option.site.name }, hint: { text: option.site.full_address }, link_errors: i.zero? %>
-              <% end %>
-            <% end %>
-
-          <%= f.govuk_submit t('continue') %>
+          <%= render 'form_fields', f: f %>
         <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/study_mode_selection/_form_fields.html.erb
+++ b/app/views/candidate_interface/course_choices/study_mode_selection/_form_fields.html.erb
@@ -1,0 +1,6 @@
+<%= f.govuk_radio_buttons_fieldset :study_mode, legend: { text: t('page_titles.which_study_mode'), size: 'xl', tag: 'h1' } do %>
+  <%= f.govuk_radio_button :study_mode, :full_time, label: { text: 'Full time' }, link_errors: true %>
+  <%= f.govuk_radio_button :study_mode, :part_time, label: { text: 'Part time' } %>
+<% end %>
+
+<%= f.govuk_submit t('continue') %>

--- a/app/views/candidate_interface/course_choices/study_mode_selection/edit.html.erb
+++ b/app/views/candidate_interface/course_choices/study_mode_selection/edit.html.erb
@@ -1,15 +1,21 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.which_study_mode'), @pick_study_mode.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_course_path(@pick_study_mode.provider_id)) %>
+<% if params['return-to'].nil? %>
+  <% content_for :before_content, govuk_back_link_to(candidate_interface_edit_course_choices_course_path(course_choice_id: @course_choice_id, return_to: params[:return_to])) %>
+<% else %>
+  <% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
           model: @pick_study_mode,
-          url: candidate_interface_course_choices_study_mode_path(
+          url: candidate_interface_edit_course_choices_study_mode_path(
             provider_id: @pick_study_mode.provider_id,
             course_id: @pick_study_mode.course_id,
             course_choice_id: @course_choice_id,
+            return_to: @application_review,
           ),
+          method: :patch,
         ) do |f| %>
           <%= f.govuk_error_summary %>
 

--- a/app/views/candidate_interface/course_choices/ucas/with_course.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas/with_course.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.apply_to_course_on_ucas') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_course_path(@provider.id)) %>
+<% content_for :before_content, govuk_back_link_to(@return_to_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -376,11 +376,21 @@ Rails.application.routes.draw do
 
         get '/provider/:provider_id/courses' => 'course_choices/course_selection#new', as: :course_choices_course
         post '/provider/:provider_id/courses' => 'course_choices/course_selection#create'
+        get '/provider/:provider_id/courses/edit' => 'course_choices/course_selection#edit', as: :edit_course_choices_course
+        patch '/provider/:provider_id/courses/edit' => 'course_choices/course_selection#update'
+
         get '/provider/:provider_id/courses/:course_id' => 'course_choices/study_mode_selection#new', as: :course_choices_study_mode
         post '/provider/:provider_id/courses/:course_id' => 'course_choices/study_mode_selection#create'
+        get '/provider/:provider_id/courses/:course_id/edit' => 'course_choices/study_mode_selection#edit', as: :edit_course_choices_study_mode
+        patch '/provider/:provider_id/courses/:course_id/edit' => 'course_choices/study_mode_selection#update'
+
         get '/provider/:provider_id/courses/:course_id/full' => 'course_choices/course_selection#full', as: :course_choices_full
+
         get '/provider/:provider_id/courses/:course_id/:study_mode' => 'course_choices/site_selection#new', as: :course_choices_site
         post '/provider/:provider_id/courses/:course_id/:study_mode' => 'course_choices/site_selection#create'
+        get '/provider/:provider_id/courses/:course_id/:study_mode/edit' => 'course_choices/site_selection#edit', as: :edit_course_choices_site
+        patch '/provider/:provider_id/courses/:course_id/:study_mode/edit' => 'course_choices/site_selection#update'
+
         get '/another' => 'course_choices/add_another_course#ask', as: :course_choices_add_another_course
         post '/another' => 'course_choices/add_another_course#decide', as: :course_choices_add_another_course_selection
 

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_course_selection_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_course_selection_section_spec.rb
@@ -1,0 +1,242 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate is redirected correctly' do
+  include CandidateHelper
+  include CourseOptionHelpers
+
+  scenario 'Candidate reviews completed application and updates course selection section' do
+    given_i_am_signed_in
+    and_two_courses_are_available
+    when_i_add_a_course_choice
+    and_i_review_my_application
+    then_i_should_see_my_course_choice
+
+    # course_choice
+    when_i_click_change_course_choice
+    then_i_should_see_the_edit_select_course_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_click_change_the_course_choice_again
+    and_i_choose_a_course
+    and_i_click_back
+    and_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_the_course_to_a_course_with_two_available_study_modes
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_the_updated_course_choice
+
+    # study_mode
+    when_i_click_change_study_mode
+    then_i_should_see_the_edit_study_mode_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_click_change_study_mode_again
+    and_i_choose_part_time_study_mode
+    and_i_click_back
+    and_i_click_back
+    and_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_the_study_mode_and_site
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_the_updated_study_mode_and_site
+
+    # site
+    when_i_click_change_site
+    then_i_should_see_the_edit_site_form
+
+    when_i_click_back
+    then_i_should_be_redirected_to_the_application_review_page
+
+    when_i_update_the_site
+    then_i_should_be_redirected_to_the_application_review_page
+    and_i_should_see_the_updated_course_site
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_two_courses_are_available
+    @provider = create(:provider)
+    site1 = create(:site, provider: @provider)
+    site2 = create(:site, provider: @provider)
+
+    create(:course, name: 'English', provider: @provider, exposed_in_find: true, open_on_apply: true, study_mode: :full_time)
+    course_option_for_provider(provider: @provider, course: @provider.courses.first, site: site1)
+    course_option_for_provider(provider: @provider, course: @provider.courses.first, site: site2)
+
+    create(:course, name: 'Primary', provider: @provider, exposed_in_find: true, open_on_apply: true, study_mode: :full_time)
+    course_option_for_provider(provider: @provider, course: @provider.courses.second, site: site1)
+    course_option_for_provider(provider: @provider, course: @provider.courses.second, site: site2)
+
+    create(:course, :with_both_study_modes, name: 'Maths', provider: @provider, exposed_in_find: true, open_on_apply: true)
+    course_option_for_provider(provider: @provider, course: @provider.courses.third, site: site1, study_mode: 'full_time')
+    course_option_for_provider(provider: @provider, course: @provider.courses.third, site: site2, study_mode: 'full_time')
+    course_option_for_provider(provider: @provider, course: @provider.courses.third, site: site1, study_mode: 'part_time')
+    course_option_for_provider(provider: @provider, course: @provider.courses.third, site: site2, study_mode: 'part_time')
+  end
+
+  def when_i_add_a_course_choice
+    visit candidate_interface_application_form_path
+    click_link 'Choose your courses'
+    click_link t('continue')
+    choose 'Yes, I know where I want to apply'
+    click_button t('continue')
+    select @provider.name_and_code
+    click_button t('continue')
+    choose @provider.courses.first.name_and_code
+    click_button t('continue')
+    choose @provider.courses.second.course_options.first.site.name
+    click_button t('continue')
+  end
+
+  def when_i_click_on_check_your_answers
+    click_link 'Check and submit your application'
+  end
+
+  def and_i_review_my_application
+    visit candidate_interface_application_form_path
+    when_i_click_on_check_your_answers
+  end
+
+  def then_i_should_see_my_course_choice
+    expect(page).to have_content @provider.courses.first.name.to_s
+  end
+
+  def when_i_click_change_course_choice
+    within('[data-qa="course-choice"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_the_course_choice_again
+    when_i_click_change_course_choice
+  end
+
+  def when_i_click_change_study_mode
+    within('[data-qa="course-choice-study-mode"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_study_mode_again
+    when_i_click_change_study_mode
+  end
+
+  def when_i_click_change_site
+    within('[data-qa="course-choice-location"]') do
+      click_link 'Change'
+    end
+  end
+
+  def when_i_click_change_site_again
+    when_i_click_change_site
+  end
+
+  def then_i_should_see_the_edit_select_course_form
+    expect(page).to have_current_path(
+      candidate_interface_edit_course_choices_course_path(
+        @provider.id,
+        course_choice_id: current_candidate.application_choices.first.id,
+        'return-to' => 'application-review',
+      ),
+    )
+  end
+
+  def then_i_should_see_the_edit_study_mode_form
+    expect(page).to have_current_path(
+      candidate_interface_edit_course_choices_study_mode_path(
+        @provider.id,
+        @provider.courses.third.id,
+        course_choice_id: current_candidate.application_choices.first.id,
+        'return-to' => 'application-review',
+      ),
+    )
+  end
+
+  def then_i_should_see_the_edit_site_form
+    expect(page).to have_current_path(
+      candidate_interface_edit_course_choices_site_path(
+        @provider.id,
+        @provider.courses.third.id,
+        @provider.courses.third.course_options.third.study_mode,
+        course_choice_id: current_candidate.application_choices.first.id,
+        'return-to' => 'application-review',
+      ),
+    )
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def and_i_click_back
+    when_i_click_back
+  end
+
+  def then_i_should_be_redirected_to_the_application_review_page
+    expect(page).to have_current_path(candidate_interface_application_review_path)
+  end
+
+  def and_i_choose_a_course
+    choose @provider.courses.second.name_and_code
+    click_button t('continue')
+  end
+
+  def and_i_choose_part_time_study_mode
+    choose 'Part time'
+    click_button t('continue')
+  end
+
+  def when_i_update_the_course_to_a_course_with_two_available_study_modes
+    when_i_click_change_course_choice
+    choose @provider.courses.third.name_and_code
+    click_button t('continue')
+    choose 'Full time'
+    click_button t('continue')
+    choose @provider.courses.third.course_options.first.site.name
+    click_button t('continue')
+  end
+
+  def when_i_update_the_study_mode_and_site
+    when_i_click_change_study_mode
+    choose 'Part time'
+    click_button t('continue')
+    choose @provider.courses.third.course_options.third.site.name
+    click_button t('continue')
+  end
+
+  def when_i_update_the_site
+    when_i_click_change_site
+    choose @provider.courses.third.course_options.second.site.name
+    click_button t('continue')
+  end
+
+  def and_i_should_see_the_updated_course_choice
+    within('[data-qa="course-choice"]') do
+      expect(page).to have_content @provider.courses.third.name.to_s
+    end
+  end
+
+  def and_i_should_see_the_updated_study_mode_and_site
+    within('[data-qa="course-choice-study-mode"]') do
+      expect(page).to have_content 'Part time'
+    end
+
+    within('[data-qa="course-choice-location"]') do
+      expect(page).to have_content @provider.courses.third.course_options.third.site.name.to_s
+    end
+  end
+
+  def and_i_should_see_the_updated_course_site
+    within('[data-qa="course-choice-location"]') do
+      expect(page).to have_content @provider.courses.third.course_options.fourth.site.name.to_s
+    end
+  end
+end


### PR DESCRIPTION
## Context

Courses section needs to follow the same back link pattern implements across the application.

## Changes proposed in this pull request

I've had to split out each view in the course section into 'new' and 'edit' views to make things clearer. I've left the new flow in tact and created a new edit flow. 

I've expanded on the back link solution across the app in a couple of ways to handle the multiple user journeys possible in this section.

## Guidance to review

test in review app and let me know any possible refactors

## Link to Trello card

https://trello.com/c/734ow7WB/3766-change-links-and-backlinks-are-not-working-correctly-from-the-review-unsubmitted-page-courses-section

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
