### PR TITLE
Update analytics.yml file to incl more fields

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,6 +1,14 @@
 shared:
   candidates:
+    - candidate_api_updated_at
+    - course_from_find_id
     - created_at
+    - hide_in_reporting
+    - id
+    - last_signed_in_at
+    - magic_link_token_sent_at
+    - sign_up_email_bounced
+    - updated_at
   application_choices:
     - created_at
     - accepted_at
@@ -32,3 +40,380 @@ shared:
     - updated_at
     - withdrawal_feedback
     - withdrawn_at
+  application_experiences:
+    - application_form_id
+    - commitment
+    - created_at
+    - currently_working
+    - details
+    - end_date
+    - end_date_unknown
+    - id
+    - organisation
+    - relevant_skills
+    - role
+    - start_date
+    - start_date_unknown
+    - type
+    - updated_at
+    - working_pattern
+    - working_with_children
+  application_feedback:
+    - application_form_id
+    - consent_to_be_contacted
+    - created_at
+    - feedback
+    - id
+    - page_title
+    - path
+    - updated_at
+  application_forms:
+    - becoming_a_teacher
+    - becoming_a_teacher_completed
+    - candidate_id
+    - contact_details_completed
+    - country
+    - course_choices_completed
+    - created_at
+    - date_of_birth
+    - degrees_completed
+    - disability_disclosure
+    - disclose_disability
+    - edit_by
+    - efl_completed
+    - english_gcse_completed
+    - english_language_details
+    - english_main_language
+    - equality_and_diversity
+    - feature_restructured_work_history
+    - feedback_satisfaction_level
+    - feedback_suggestions
+    - fifth_nationality
+    - first_nationality
+    - fourth_nationality
+    - further_information
+    - id
+    - international_address
+    - interview_preferences
+    - interview_preferences_completed
+    - maths_gcse_completed
+    - no_other_qualifications
+    - other_language_details
+    - other_qualifications_completed
+    - personal_details_completed
+    - phase
+    - postcode
+    - previous_application_form_id
+    - recruitment_cycle_year
+    - references_completed
+    - right_to_work_or_study
+    - right_to_work_or_study_details
+    - safeguarding_issues_completed
+    - safeguarding_issues_status
+    - science_gcse_completed
+    - second_nationality
+    - subject_knowledge
+    - subject_knowledge_completed
+    - submitted_at
+    - support_reference
+    - third_nationality
+    - training_with_a_disability_completed
+    - uk_residency_status
+    - updated_at
+    - volunteering_completed
+    - volunteering_experience
+    - work_history_breaks
+    - work_history_completed
+    - work_history_explanation
+    - work_history_status
+  application_qualifications:
+    - application_form_id
+    - award_year
+    - comparable_uk_degree
+    - comparable_uk_qualification
+    - constituent_grades
+    - created_at
+    - enic_reference
+    - equivalency_details
+    - grade
+    - grade_hesa_code
+    - id
+    - institution_country
+    - institution_hesa_code
+    - institution_name
+    - international
+    - level
+    - missing_explanation
+    - non_uk_qualification_type
+    - other_uk_qualification_type
+    - predicted_grade
+    - public_id
+    - qualification_type
+    - qualification_type_hesa_code
+    - start_year
+    - subject
+    - subject_hesa_code
+    - updated_at
+  application_work_history_breaks:
+    - application_form_id
+    - created_at
+    - end_date
+    - id
+    - reason
+    - start_date
+    - updated_at
+  chasers_sent:
+    - chased_id
+    - chased_type
+    - chaser_type
+    - created_at
+    - id
+    - updated_at
+  contact_details:
+    - created_at
+    - id
+    - updated_at
+  course_options:
+    - course_id
+    - created_at
+    - id
+    - site_id
+    - site_still_valid
+    - study_mode
+    - updated_at
+    - vacancy_status
+  course_subjects:
+    - course_id
+    - created_at
+    - id
+    - subject_id
+    - updated_at
+  courses:
+    - accredited_provider_id
+    - age_range
+    - code
+    - course_length
+    - created_at
+    - description
+    - exposed_in_find
+    - financial_support
+    - funding_type
+    - id
+    - level
+    - name
+    - open_on_apply
+    - opened_on_apply_at
+    - program_type
+    - provider_id
+    - qualifications
+    - recruitment_cycle_year
+    - start_date
+    - study_mode
+    - updated_at
+    - uuid
+    - withdrawn
+  degrees:
+    - class_of_degree
+    - created_at
+    - id
+    - institution
+    - subject
+    - type_of_degree
+    - updated_at
+    - year
+  emails:
+    - application_form_id
+    - created_at
+    - delivery_status
+    - id
+    - mail_template
+    - mailer
+    - notify_reference
+    - subject
+    - updated_at
+  english_proficiencies:
+    - application_form_id
+    - created_at
+    - efl_qualification_id
+    - efl_qualification_type
+    - id
+    - qualification_status
+    - updated_at
+  feature_metrics_dashboards:
+    - created_at
+    - id
+    - metrics
+    - updated_at
+  find_feedback:
+    - created_at
+    - feedback
+    - find_controller
+    - path
+    - updated_at
+  ielts_qualifications:
+    - award_year
+    - band_score
+    - created_at
+    - id
+    - trf_number
+    - updated_at
+  interviews:
+    - application_choice_id
+    - cancelled_at
+    - created_at
+    - date_and_time
+    - id
+    - location
+    - provider_id
+    - updated_at
+  interviews:
+    - application_choice_id
+    - created_at
+    - id
+    - message
+    - provider_user_id
+    - updated_at
+  offer_conditions:
+    - created_at
+    - id
+    - offer_id
+    - status
+    - text
+    - updated_at
+  offers:
+    - application_choice_id
+    - created_at
+    - id
+    - updated_at
+  other_efl_qualifications:
+    - award_year
+    - created_at
+    - grade
+    - id
+    - name
+    - updated_at
+  provider_agreements:
+    - accepted_at
+    - agreement_type
+    - created_at
+    - id
+    - provider_id
+    - provider_user_id
+    - updated_at
+  provider_relationship_permissions:
+    - created_at
+    - id
+    - ratifying_provider_can_make_decisions
+    - ratifying_provider_can_view_diversity_information
+    - ratifying_provider_can_view_safeguarding_information
+    - ratifying_provider_id
+    - setup_at
+    - training_provider_can_make_decisions
+    - training_provider_can_view_diversity_information
+    - training_provider_can_view_safeguarding_information
+    - training_provider_id
+    - updated_at
+  provider_user_notifications:
+    - application_received
+    - application_rejected_by_default
+    - application_withdrawn
+    - created_at
+    - id
+    - offer_accepted
+    - offer_declined
+    - provider_user_id
+    - updated_at
+  provider_users:
+    - created_at
+    - dfe_sign_in_uid
+    - id
+    - last_signed_in_at
+    - updated_at
+  provider_users_providers:
+    - created_at
+    - id
+    - make_decisions
+    - manage_organisations
+    - manage_users
+    - provider_id
+    - provider_user_id
+    - set_up_interviews
+    - updated_at
+    - view_diversity_information
+    - view_safeguarding_information
+  providers:
+    - code
+    - created_at
+    - id
+    - latitude
+    - longitude
+    - name
+    - postcode
+    - provider_type
+    - region_code
+    - sync_courses
+    - updated_at
+  qualifications:
+    - created_at
+    - grade
+    - id
+    - institution
+    - subject
+    - type_of_qualification
+    - updated_at
+    - year
+  reference_tokens:
+    - application_reference_id
+    - created_at
+    - hashed_token
+    - id
+    - updated_at
+  references:
+    - application_form_id
+    - cancelled_at
+    - cancelled_at_end_of_cycle_at
+    - consent_to_be_contacted
+    - created_at
+    - duplicate
+    - email_bounced_at
+    - feedback_provided_at
+    - feedback_refused_at
+    - feedback_status
+    - hashed_sign_in_token
+    - id
+    - questionnaire
+    - referee_type
+    - reminder_sent_at
+    - replacement
+    - requested_at
+    - safeguarding_concerns_status
+    - selected
+    - updated_at
+  sites:
+    - address_line1
+    - address_line2
+    - address_line3
+    - address_line4
+    - code
+    - created_at
+    - id
+    - latitude
+    - longitude
+    - name
+    - postcode
+    - provider_id
+    - region
+    - updated_at
+  subjects:
+    - code
+    - created_at
+    - id
+    - name
+    - updated_at
+  toefl_qualifications:
+    - award_year
+    - created_at
+    - id
+    - registration_number
+    - total_score
+    - updated_at

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -169,10 +169,6 @@ shared:
     - created_at
     - id
     - updated_at
-  contact_details:
-    - created_at
-    - id
-    - updated_at
   course_options:
     - course_id
     - created_at
@@ -212,15 +208,6 @@ shared:
     - updated_at
     - uuid
     - withdrawn
-  degrees:
-    - class_of_degree
-    - created_at
-    - id
-    - institution
-    - subject
-    - type_of_degree
-    - updated_at
-    - year
   emails:
     - application_form_id
     - created_at
@@ -266,7 +253,7 @@ shared:
     - location
     - provider_id
     - updated_at
-  interviews:
+  notes:
     - application_choice_id
     - created_at
     - id
@@ -351,17 +338,7 @@ shared:
     - postcode
     - provider_type
     - region_code
-    - sync_courses
     - updated_at
-  qualifications:
-    - created_at
-    - grade
-    - id
-    - institution
-    - subject
-    - type_of_qualification
-    - updated_at
-    - year
   reference_tokens:
     - application_reference_id
     - created_at

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -1,0 +1,2 @@
+shared:
+  candidates:

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -1,2 +1,20 @@
 shared:
+  application_forms:
+    - support_reference
+    - candidate_id
+  application_choices:
+    - id
   candidates:
+    - id
+  support_users:
+    - dfe_sign_in_uid
+  provider_users:
+    - dfe_sign_in_uid
+  interviews:
+    - application_choice_id
+  notes:
+    - application_choice_id
+  offers:
+    - application_choice_id
+  ucas_matches:
+    - candidate_id

--- a/config/application.rb
+++ b/config/application.rb
@@ -78,6 +78,7 @@ module ApplyForPostgraduateTeacherTraining
     end
 
     config.analytics = config_for(:analytics)
+    config.analytics_pii = config_for(:analytics_pii)
 
     config.action_dispatch.default_headers = {
       'Feature-Policy' => "accelerometer 'none'; ambient-light-sensor: 'none', autoplay: 'none', battery: 'none', camera 'none'; display-capture: 'none', document-domain: 'none', fullscreen: 'none', geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; midi: 'none', payment 'none'; publickey-credentials-get: 'none', usb 'none', wake-lock: 'none', screen-wake-lock: 'none', web-share: 'none'",

--- a/spec/config/analytics_spec.rb
+++ b/spec/config/analytics_spec.rb
@@ -1,11 +1,27 @@
 require 'rails_helper'
 
-RSpec.describe 'analytics.yml' do
-  it 'is valid' do
-    config = Rails.configuration.analytics
+RSpec.describe 'analytics.yml and analytics_pii.yml' do
+  it 'are valid' do
+    # When model has a plural name or a custom table name,
+    # we can't map from symbol to class, though it works in the other direction
+    # (which is how the production code uses it).
+    #
+    # e.g.
+    #
+    # ProviderRelationshipPermissions.first.class.table_name.to_sym
+    # => :provider_relationship_permissions
+    #
+    # :provider_relationship_permissions.to_s_classify.constantize
+    # => unitialized constant ProviderRelationshipPermission
+    irregular_table_names = {
+      provider_relationship_permissions: ProviderRelationshipPermissions,
+      provider_user_notifications: ProviderUserNotificationPreferences,
+      provider_users_providers: ProviderPermissions,
+      references: ApplicationReference,
+    }
 
-    config.each do |table_name, fields|
-      model = table_name.to_s.classify.constantize
+    Rails.configuration.analytics.deep_merge(Rails.configuration.analytics_pii).each do |table_name, fields|
+      model = irregular_table_names[table_name.to_sym] || table_name.to_s.classify.constantize
       expect(fields & model.column_names).to match_array(fields)
     end
   end

--- a/spec/forms/candidate_interface/sign_up_form_spec.rb
+++ b/spec/forms/candidate_interface/sign_up_form_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe CandidateInterface::SignUpForm, type: :model do
       form.save
 
       expect(SendEventsToBigquery).to have_received(:perform_async)
+        .at_least(:once)
         .with(a_hash_including({ 'event_tags' => ['candidate_sign_up'] }))
     end
   end

--- a/spec/requests/emit_request_events_spec.rb
+++ b/spec/requests/emit_request_events_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe EmitRequestEvents, type: :request, with_bigquery: true do
             headers: { 'HTTP_USER_AGENT' => 'Test agent' })
       }.to change(SendEventsToBigquery.jobs, :size).by(1)
 
-      payload = SendEventsToBigquery.jobs.first['args'].first
+      payload = SendEventsToBigquery.jobs
+        .map { |j| j['args'].first }
+        .find { |bigquery_data| bigquery_data['event_type'] == 'web_request' }
 
       expect(payload['request_method']).to eq('GET')
       expect(payload['request_user_agent']).to eq('Test agent')


### PR DESCRIPTION
Updating the analytics.yml file to include more fields from the Apply database that we either currently report on or potentially may do in the future. Direct PII fields have NOT been included (names, email addresses etc).

Full list of database fields taken in Aug 2021 can be found in link below. Only fields labelled 'y' in column I are to be in the .yml file.

https://docs.google.com/spreadsheets/d/1DvIwEcKE_ifs8VEINgxzIkB1SMrHTpiZLQVmSnGa2gI/edit?usp=sharing

## Context

Change being made to ensure we are sending all relevant entity data to BigQuery

## Changes proposed in this pull request

Adding 353 fields to the .yml file

## Guidance to review

Please can you ensure all fields in link labelled 'y' in column I are in the yml file and none of the fields labelled 'n' are included in the .yml file.

## Link to Trello card

https://trello.com/c/86CruQ3l

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
