### PR TITLE
Merge request params into a field rather than top level payload fields

### DIFF
--- a/app/controllers/api_docs/api_docs_controller.rb
+++ b/app/controllers/api_docs/api_docs_controller.rb
@@ -8,7 +8,7 @@ module APIDocs
     def append_info_to_payload(payload)
       super
 
-      payload.merge!(request_query_params)
+      payload.merge!(query_params: request_query_params)
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,6 +37,6 @@ private
   def append_info_to_payload(payload)
     super
 
-    payload.merge!(request_query_params)
+    payload.merge!(query_params: request_query_params)
   end
 end

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -111,7 +111,7 @@ module CandidateInterface
       super
 
       payload.merge!({ candidate_id: current_candidate&.id })
-      payload.merge!(request_query_params)
+      payload.merge!(query_params: request_query_params)
     end
   end
 end

--- a/app/controllers/integrations/notify_controller.rb
+++ b/app/controllers/integrations/notify_controller.rb
@@ -59,7 +59,7 @@ module Integrations
     def append_info_to_payload(payload)
       super
 
-      payload.merge!(reference_status_parameters)
+      payload.merge!(query_params: reference_status_parameters)
     end
   end
 end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -73,7 +73,7 @@ module ProviderInterface
 
       payload.merge!(current_user_details) if current_provider_user
       payload.merge!(application_support_url) if @application_choice
-      payload.merge!(request_query_params)
+      payload.merge!(query_params: request_query_params)
     end
 
     # Set the `@application_choice` instance variable for use in views.

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -158,7 +158,7 @@ module RefereeInterface
       super
 
       payload.merge!({ reference_id: reference.id }) if reference.present?
-      payload.merge!(request_query_params)
+      payload.merge!(query_params: request_query_params)
     end
 
     def reference

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -40,7 +40,7 @@ module SupportInterface
       super
 
       payload.merge!({ support_user_id: current_support_user.id }) if current_support_user
-      payload.merge!(request_query_params)
+      payload.merge!(query_params: request_query_params)
     end
   end
 end

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -100,7 +100,7 @@ module VendorAPI
       }
 
       payload.merge!(user_info)
-      payload.merge!(request_query_params)
+      payload.merge!(query_params: request_query_params)
     end
 
     def validate_metadata!


### PR DESCRIPTION
## Context

We currently merge custom params into the logging payload. Rails logs default fields like status (an integer eg 200) etc. into payload and we enrich it with our own data. Sometimes our own data might override the default rails fields such as merging application choice request params with values of status as a string straight into the payload. Since the payload fields are indexed in Kibana this has been causing issues with Elastic Search as it expects those fields to have the same type, which we are not respecting.

## Changes proposed in this pull request

To avoid these issues merge request params into a nested field in the payload to avoid overwriting payload default fields. I have left some fields to be written into the top level payload as they do not clash with the default values.

a few examples:
Support Interface:
```
2021-08-23 19:32:45.798600 I [35203:puma server threadpool 004] (484.4ms) SupportInterface::ProvidersController -- Completed #index -- {:controller=>"SupportInterface::ProvidersController", :action=>"index", :format=>"HTML", :method=>"GET", :path=>"/support/providers", :status=>200, :view_runtime=>338.36, :db_runtime=>139.66, :request_query_params=>{"controller"=>"support_interface/providers", "action"=>"index"}, :support_user_id=>1, :allocations=>183287, :status_message=>"OK"}
```
Provider Interface:
```
2021-08-23 19:34:34.185301 I [35203:puma server threadpool 004] (440.1ms) ProviderInterface::ApplicationChoicesController -- Completed #index -- {:controller=>"ProviderInterface::ApplicationChoicesController", :action=>"index", :format=>"HTML", :method=>"GET", :path=>"/provider/applications", :status=>200, :view_runtime=>273.76, :db_runtime=>136.05, :request_query_params=>{"controller"=>"provider_interface/application_choices", "action"=>"index"}, :dfe_sign_in_uid=>"dev-support", :provider_user_admin_url=>"http://localhost:3000/support/users/provider/2", :support_user_email=>"support@example.com", :support_user_admin_url=>"http://localhost:3000/support/users/support/1", :allocations=>154849, :status_message=>"OK"}
```
Candidate Interface
```
2021-08-23 19:36:42.972997 I [35203:puma server threadpool 002] (281.4ms) CandidateInterface::StartPageController -- Completed #create_account_or_sign_in -- {:controller=>"CandidateInterface::StartPageController", :action=>"create_account_or_sign_in", :format=>"HTML", :method=>"GET", :path=>"/candidate/account", :status=>200, :view_runtime=>240.61, :db_runtime=>3.29, :request_query_params=>{"controller"=>"candidate_interface/start_page", "action"=>"create_account_or_sign_in"}, :candidate_id=>nil, :allocations=>123673, :status_message=>"OK"}
```

## Guidance to review

Does it all make sense and have I missed something?

## Link to Trello card

https://trello.com/c/92DxHQ2X/4160-improve-application-logging

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
