### PR TITLE
Amend Full sync settings

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -55,11 +55,11 @@ class Clock
   every(1.day, 'SendEocDeadlineReminderEmailToCandidatesWorker', at: '12:00') { SendEocDeadlineReminderEmailToCandidatesWorker.new.perform }
   every(1.day, 'SendNewCycleStartedEmailToCandidatesWorker', at: '12:00') { SendNewCycleHasStartedEmailToCandidatesWorker.new.perform }
 
-  every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: '00:59') do
+  every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do
     TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false, RecruitmentCycle.current_year)
   end
 
-  every(7.days, 'FullSyncNextCycleFromTeacherTrainingPublicAPI', at: '03:59') do
+  every(7.days, 'FullSyncNextCycleFromTeacherTrainingPublicAPI', at: 'Saturday 03:59') do
     if FeatureFlag.active?(:sync_next_cycle)
       TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false, RecruitmentCycle.next_year)
     end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -56,12 +56,12 @@ class Clock
   every(1.day, 'SendNewCycleStartedEmailToCandidatesWorker', at: '12:00') { SendNewCycleHasStartedEmailToCandidatesWorker.new.perform }
 
   every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: '00:59') do
-    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false, RecruitmentCycle.current_year, true)
+    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false, RecruitmentCycle.current_year)
   end
 
   every(7.days, 'FullSyncNextCycleFromTeacherTrainingPublicAPI', at: '03:59') do
     if FeatureFlag.active?(:sync_next_cycle)
-      TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false, RecruitmentCycle.next_year, true)
+      TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false, RecruitmentCycle.next_year)
     end
   end
 end


### PR DESCRIPTION
## Context

We ran a full sync for the current and next cycle, which yielded sync errors as there are data changes between both cycles. We also noted further sync errors around vacancies. The sync errors have now been fixed and the sync for the next cycle disabled on all envs. Enable the sync errors again to catch any issues in the meantime.

We have noted that clock is stateless and might reset every time we deploy. Set the cron job for a specific day every week to run as per: https://www.rubydoc.info/gems/clockwork/2.0.4

## Changes proposed in this pull request

- Enable sync errors to be raised in the full sync
- Change full sync to run on Saturdays
- 
## Guidance to review

Does it make sense? 

## Link to Trello card

https://trello.com/c/iWACtGSX/4101-api-invariant-check-valid-detail-changes-between-cycles

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
