### PR TITLE
Update Duplicate Candidate query and table component

### DIFF
--- a/app/components/support_interface/duplicate_candidate_matches_table_component.html.erb
+++ b/app/components/support_interface/duplicate_candidate_matches_table_component.html.erb
@@ -7,6 +7,7 @@
       <th scope="col" class="govuk-table__header">Date of birth</th>
       <th scope="col" class="govuk-table__header">Postcode</th>
       <th scope="col" class="govuk-table__header">Email address</th>
+      <th scope="col" class="govuk-table__header">Submitted at</th>
     </tr>
   </thead>
 
@@ -35,6 +36,10 @@
 
         <td class="govuk-table__cell">
           <%= table_row[:email_address] %>
+        </td>
+
+        <td class="govuk-table__cell">
+          <%= table_row[:submitted_at] %>
         </td>
       </tr>
     <% end %>

--- a/app/queries/get_duplicate_candidate_matches.rb
+++ b/app/queries/get_duplicate_candidate_matches.rb
@@ -1,25 +1,40 @@
 class GetDuplicateCandidateMatches < ApplicationRecord
   def self.call
     ActiveRecord::Base.connection.exec_query(
-      "SELECT DISTINCT application_details.candidate_id, application_details.first_name, application_details.last_name, TRIM(UPPER(application_details.postcode)) postcode, application_details.date_of_birth, email_address
-    FROM application_forms application_details
-    JOIN(
-      SELECT application_forms.last_name, application_forms.date_of_birth, application_forms.postcode
-      FROM application_forms
-      WHERE application_forms.previous_application_form_id IS NULL
-      AND application_forms.submitted_at IS NOT NULL
-      GROUP BY application_forms.last_name, application_forms.date_of_birth, application_forms.postcode
-      HAVING (count(*) > 1)
-    ) duplicate_attributes
-    ON application_details.postcode = duplicate_attributes.postcode
-    AND application_details.date_of_birth = duplicate_attributes.date_of_birth
-    AND application_details.last_name = duplicate_attributes.last_name
-    JOIN(
-      SELECT candidates.id, candidates.email_address
-      FROM candidates
-    ) candidate_details
-    ON application_details.candidate_id = candidate_details.id
-    ORDER BY application_details.date_of_birth",
+      "SELECT DISTINCT application_details.candidate_id,
+          application_details.first_name,
+          application_details.last_name,
+          TRIM(UPPER(application_details.postcode)) postcode,
+          application_details.date_of_birth,
+          email_address,
+          submitted_at
+        FROM application_forms application_details
+        JOIN(
+          SELECT application_forms.last_name, application_forms.date_of_birth, application_forms.postcode
+          FROM application_forms
+          WHERE application_forms.previous_application_form_id IS NULL
+          GROUP BY application_forms.last_name, application_forms.date_of_birth, application_forms.postcode
+          HAVING (count(*) > 1)
+        ) duplicate_attributes
+        ON application_details.postcode = duplicate_attributes.postcode
+        AND application_details.date_of_birth = duplicate_attributes.date_of_birth
+        AND application_details.last_name = duplicate_attributes.last_name
+        JOIN(
+          SELECT application_forms.last_name, application_forms.date_of_birth, application_forms.postcode
+          FROM application_forms
+          WHERE application_forms.previous_application_form_id IS NULL
+          AND application_forms.submitted_at IS NOT NULL
+        ) duplicate_submitted_attributes
+        ON application_details.postcode = duplicate_submitted_attributes.postcode
+        AND application_details.date_of_birth = duplicate_submitted_attributes.date_of_birth
+        AND application_details.last_name = duplicate_submitted_attributes.last_name
+        JOIN(
+          SELECT candidates.id, candidates.email_address
+          FROM candidates
+        ) candidate_details
+        ON application_details.candidate_id = candidate_details.id
+        WHERE application_details.previous_application_form_id IS NULL
+        ORDER BY application_details.last_name, application_details.date_of_birth, postcode;",
     ).to_a
   end
 end

--- a/spec/components/support_interface/duplicate_candidate_matches_table_component_spec.rb
+++ b/spec/components/support_interface/duplicate_candidate_matches_table_component_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe SupportInterface::DuplicateCandidateMatchesTableComponent do
         'postcode' => 'W6 9BH',
         'date_of_birth' => '1998-08-08',
         'email_address' => 'exemplar1@example.com',
+        'submitted_at' => '2021-08-08',
       },
       {
         'candidate_id' => 26,
@@ -21,6 +22,7 @@ RSpec.describe SupportInterface::DuplicateCandidateMatchesTableComponent do
         'postcode' => 'W6 9BH',
         'date_of_birth' => '1998-08-08',
         'email_address' => 'exemplar2@example.com',
+        'submitted_at' => '2021-08-08',
       },
     ]
   }
@@ -40,12 +42,14 @@ RSpec.describe SupportInterface::DuplicateCandidateMatchesTableComponent do
     expect(result.css('td')[3].text).to include('1998-08-08')
     expect(result.css('td')[4].text).to include('W6 9BH')
     expect(result.css('td')[5].text).to include('exemplar1@example.com')
+    expect(result.css('td')[6].text).to include('2021-08-08')
 
-    expect(result.css('td')[6].text).to include('26')
-    expect(result.css('td')[7].text).to include('Joffrey')
-    expect(result.css('td')[8].text).to include('Thompson')
-    expect(result.css('td')[9].text).to include('1998-08-08')
-    expect(result.css('td')[10].text).to include('W6 9BH')
-    expect(result.css('td')[11].text).to include('exemplar2@example.com')
+    expect(result.css('td')[7].text).to include('26')
+    expect(result.css('td')[8].text).to include('Joffrey')
+    expect(result.css('td')[9].text).to include('Thompson')
+    expect(result.css('td')[10].text).to include('1998-08-08')
+    expect(result.css('td')[11].text).to include('W6 9BH')
+    expect(result.css('td')[12].text).to include('exemplar2@example.com')
+    expect(result.css('td')[13].text).to include('2021-08-08')
   end
 end

--- a/spec/queries/get_duplicate_candidate_matches_spec.rb
+++ b/spec/queries/get_duplicate_candidate_matches_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe GetDuplicateCandidateMatches do
   let(:candidate2) { create(:candidate, id: '2', email_address: 'exemplar2@example.com') }
 
   before do
-    create(:application_form, candidate: candidate1, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: Time.zone.now - 7.days)
-    create(:application_form, candidate: candidate2, first_name: 'Joffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: Time.zone.now - 7.days)
-    create(:application_form, candidate: candidate1, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: Time.zone.now - 1.day)
+    Timecop.freeze(Time.zone.local(2020, 8, 23, 12, 0o0, 0o0)) do
+      create(:application_form, candidate: candidate1, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: Time.zone.now)
+      create(:application_form, candidate: candidate2, first_name: 'Joffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: Time.zone.now)
+    end
   end
 
   describe '#call' do
@@ -16,7 +17,7 @@ RSpec.describe GetDuplicateCandidateMatches do
     it 'returns an array of hashes with the correct keys' do
       expect(returned_array_of_hashes.count).to eq(2)
       expect(returned_array_of_hashes.first.keys).to \
-        eq %w[candidate_id first_name last_name postcode date_of_birth email_address]
+        eq %w[candidate_id first_name last_name postcode date_of_birth email_address submitted_at]
     end
 
     it 'returns an array of hashes the correct values' do
@@ -26,6 +27,7 @@ RSpec.describe GetDuplicateCandidateMatches do
       expect(returned_array_of_hashes.first['date_of_birth']).to eq('1998-08-08')
       expect(returned_array_of_hashes.first['postcode']).to eq('W6 9BH')
       expect(returned_array_of_hashes.first['email_address']).to eq('exemplar1@example.com')
+      expect(returned_array_of_hashes.first['submitted_at'].strftime('%F')).to eq('2020-08-23')
 
       expect(returned_array_of_hashes.second['candidate_id']).to eq(2)
       expect(returned_array_of_hashes.second['first_name']).to eq('Joffrey')
@@ -33,6 +35,7 @@ RSpec.describe GetDuplicateCandidateMatches do
       expect(returned_array_of_hashes.second['date_of_birth']).to eq('1998-08-08')
       expect(returned_array_of_hashes.second['postcode']).to eq('W6 9BH')
       expect(returned_array_of_hashes.second['email_address']).to eq('exemplar2@example.com')
+      expect(returned_array_of_hashes.second['submitted_at'].strftime('%F')).to eq('2020-08-23')
     end
   end
 end


### PR DESCRIPTION
## Context
Table should now include duplicate applicants
with at least one submitted application.

## Changes proposed in this pull request

Query now contains an extra join to allow separation of submitted values
from unsubmitted values extra exclusion of previous application id prevents
duplicate records being loaded. 

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/62567622/130515070-f19589d7-a1e7-4560-ab9e-79e903340d8d.png">

## Guidance to review

## Link to Trello card

https://trello.com/c/CFjJIKrp/3865-update-duplicate-applications-tab-on-support-ui

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
