### PR TITLE
Restrict reverting a rejection from the api

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -44,6 +44,10 @@ class Candidate < ApplicationRecord
     "C#{id}"
   end
 
+  def in_apply_2?
+    application_forms.exists?(phase: 'apply_2')
+  end
+
 private
 
   def downcase_email

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -32,6 +32,10 @@ class Candidate < ApplicationRecord
                         end
   end
 
+  def current_application_choice
+    current_application.application_choices.order(:created_at).last
+  end
+
   def last_updated_application
     application_forms.max_by(&:updated_at)
   end

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -45,7 +45,8 @@ private
   end
 
   def offer
-    @offer ||= OfferValidations.new(course_option: course_option,
+    @offer ||= OfferValidations.new(application_choice: application_choice,
+                                    course_option: course_option,
                                     conditions: update_conditions_service.conditions)
   end
 end

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -44,6 +44,10 @@ class OfferValidations
   end
 
   def restrict_reverting_rejection
+    if application_choice.rejected_by_default
+      errors.add(:base, :application_rejected_by_default)
+    end
+
     if !candidate_in_apply_2? && application_choice.application_form.apply_1? && any_accepted_offers?
       errors.add(:base, :other_offer_already_accepted)
     end

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -32,6 +32,8 @@ class OfferValidations
   end
 
   def identical_to_existing_offer?
+    return unless application_choice.offer?
+
     if application_choice.current_course_option == course_option && application_choice.offer.conditions_text.sort == conditions.sort
       raise IdenticalOfferError
     end

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -51,6 +51,10 @@ class OfferValidations
     if !candidate_in_apply_2? && application_choice.application_form.apply_1? && any_accepted_offers?
       errors.add(:base, :other_offer_already_accepted)
     end
+
+    if candidate_in_apply_2? && !application_choice.candidate.current_application.eql?(application_choice)
+      errors.add(:base, :only_latest_application_rejection_can_be_reverted_on_apply_2)
+    end
   end
 
 private

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -54,7 +54,7 @@ class OfferValidations
       errors.add(:base, :other_offer_already_accepted)
     end
 
-    if candidate_in_apply_2? && !application_choice.candidate.current_application.eql?(application_choice)
+    if candidate_in_apply_2? && !application_choice.candidate.current_application_choice.eql?(application_choice)
       errors.add(:base, :only_latest_application_rejection_can_be_reverted_on_apply_2)
     end
   end

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -89,3 +89,4 @@ en:
               different_ratifying_provider: The offered course's ratifying provider must be the same as the one originally requested
               other_offer_already_accepted: You cannot make an offer because the candidate has already accepted one
               application_rejected_by_default: You cannot make an offer because the application has been automatically rejected
+              only_latest_application_rejection_can_be_reverted_on_apply_2: You cannot make an offer because you can only do so for the last application you rejected

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -88,3 +88,4 @@ en:
               identical_to_existing: The new offer is identical to the current offer
               different_ratifying_provider: The offered course's ratifying provider must be the same as the one originally requested
               other_offer_already_accepted: You cannot make an offer because the candidate has already accepted one
+              application_rejected_by_default: You cannot make an offer because the application has been automatically rejected

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -89,4 +89,4 @@ en:
               different_ratifying_provider: The offered course's ratifying provider must be the same as the one originally requested
               other_offer_already_accepted: You cannot make an offer because the candidate has already accepted one
               application_rejected_by_default: You cannot make an offer because the application has been automatically rejected
-              only_latest_application_rejection_can_be_reverted_on_apply_2: You cannot make an offer because you can only do so for the last application you rejected
+              only_latest_application_rejection_can_be_reverted_on_apply_2: You cannot make an offer because you can only do so for the most recent application

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -87,3 +87,4 @@ en:
             base:
               identical_to_existing: The new offer is identical to the current offer
               different_ratifying_provider: The offered course's ratifying provider must be the same as the one originally requested
+              other_offer_already_accepted: You cannot make an offer because the candidate has already accepted one

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -84,6 +84,38 @@ RSpec.describe Candidate, type: :model do
     end
   end
 
+  describe '#current_application_choice' do
+    let(:candidate) { create(:candidate) }
+
+    context 'with a single application choice' do
+      let!(:application_choice) { create(:application_choice, candidate: candidate) }
+
+      it 'returns the application choice' do
+        expect(candidate.current_application_choice).to eq(application_choice)
+      end
+    end
+
+    context 'with multiple application choices' do
+      let!(:application_choice) { create(:application_choice, candidate: candidate, created_at: Time.zone.now - 1.week) }
+      let!(:most_recent_application_choice) { create(:application_choice, candidate: candidate) }
+
+      it 'returns the most recent application choice' do
+        expect(candidate.current_application_choice).to eq(most_recent_application_choice)
+      end
+    end
+
+    context 'with multiple application forms' do
+      let(:application_choice) { create(:application_choice, candidate: candidate) }
+      let(:most_recent_application_choice) { create(:application_choice, candidate: candidate) }
+      let!(:application_form_apply_1) { create(:application_form, candidate: candidate, application_choices: [application_choice], created_at: Time.zone.now - 1.week) }
+      let!(:application_form_apply_2) { create(:application_form, candidate: candidate, phase: 'apply_2', application_choices: [most_recent_application_choice]) }
+
+      it 'returns the most recent application choice' do
+        expect(candidate.current_application_choice).to eq(most_recent_application_choice)
+      end
+    end
+  end
+
   describe 'find_from_course' do
     it 'returns the correct course' do
       course = create(:course)

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -108,4 +108,24 @@ RSpec.describe Candidate, type: :model do
       expect(candidate.encrypted_id).to eq 'encrypted id value'
     end
   end
+
+  describe '#in_apply_2?' do
+    subject(:candidate) { build(:candidate) }
+
+    let!(:application_form) { create(:application_form, candidate: candidate) }
+
+    context 'when the candidate has no applications in apply again' do
+      it 'returns false' do
+        expect(candidate.in_apply_2?).to be false
+      end
+    end
+
+    context 'when the candidate has applications in apply again' do
+      let!(:application_form) { create(:application_form, candidate: candidate, phase: 'apply_2') }
+
+      it 'returns true' do
+        expect(candidate.in_apply_2?).to be true
+      end
+    end
+  end
 end

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -86,6 +86,21 @@ RSpec.describe OfferValidations, type: :model do
     end
 
     describe '#restrict_reverting_rejection' do
+      context 'when a provider attempts to revert an application rejected by default' do
+        let(:application_choice) { build_stubbed(:application_choice, :rejected, current_course_option: course_option, rejected_by_default: true) }
+        let(:application_form) { build_stubbed(:application_form, phase: 'apply_1', application_choices: [application_choice]) }
+        let(:candidate) { build_stubbed(:candidate, application_forms: [application_form]) }
+
+        before do
+          allow(application_choice).to receive(:candidate).and_return(candidate)
+        end
+
+        it 'adds an :application_rejected_by_default error' do
+          expect(offer).to be_invalid
+          expect(offer.errors[:base]).to contain_exactly('You cannot make an offer because the application has been automatically rejected')
+        end
+      end
+
       context 'when a provider attempts to revert an apply_1 rejection but other offers have already been accepted' do
         let!(:application_form) { create(:application_form, application_choices: [application_choice, other_application_choice]) }
         let(:application_choice) { build(:application_choice, :with_offer, current_course_option: course_option) }

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -111,6 +111,17 @@ RSpec.describe OfferValidations, type: :model do
           expect(offer.errors[:base]).to contain_exactly('You cannot make an offer because the candidate has already accepted one')
         end
       end
+
+      context 'when a provider attempts to revert a rejection on an application that is not the last one on apply_2' do
+        let!(:application_form) { create(:application_form, phase: 'apply_2', application_choices: [application_choice, other_application_choice]) }
+        let(:application_choice) { build(:application_choice, :with_offer, current_course_option: course_option) }
+        let!(:other_application_choice) { build(:application_choice, :awaiting_provider_decision) }
+
+        it 'adds an :only_latest_application_rejection_can_be_reverted_on_apply_2 error' do
+          expect(offer).to be_invalid
+          expect(offer.errors[:base]).to contain_exactly('You cannot make an offer because you can only do so for the last application you rejected')
+        end
+      end
     end
   end
 end

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe OfferValidations, type: :model do
 
         it 'adds an :only_latest_application_rejection_can_be_reverted_on_apply_2 error' do
           expect(offer).to be_invalid
-          expect(offer.errors[:base]).to contain_exactly('You cannot make an offer because you can only do so for the last application you rejected')
+          expect(offer.errors[:base]).to contain_exactly('You cannot make an offer because you can only do so for the most recent application')
         end
       end
     end

--- a/spec/system/vendor_api/vendor_reverts_a_rejection_spec.rb
+++ b/spec/system/vendor_api/vendor_reverts_a_rejection_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.feature 'Vendor reverts a rejection' do
+  include CandidateHelper
+
+  scenario 'A vendor reverts a rejection' do
+    given_a_candidate_has_multiple_rejected_application_and_is_in_apply_2
+    when_i_try_to_revert_the_rejection_on(@initial_application_choice)
+    then_i_can_see_a_validation_error
+
+    when_i_try_to_revert_the_rejection_on(@most_recent_application_choice)
+    then_i_can_see_the_offer_was_made_successfully
+  end
+
+  def given_a_candidate_has_multiple_rejected_application_and_is_in_apply_2
+    @initial_application_choice = create(:application_choice, :with_completed_application_form, :rejected)
+    @most_recent_application_choice = build(:application_choice, :rejected, course_option: @initial_application_choice.course_option)
+    create(:completed_application_form, phase: 'apply_2', candidate: @initial_application_choice.candidate, application_choices: [@most_recent_application_choice])
+    @provider = @initial_application_choice.provider
+  end
+
+  def when_i_try_to_revert_the_rejection_on(application_choice)
+    api_token = VendorAPIToken.create_with_random_token!(provider: @provider)
+    Capybara.current_session.driver.header('Authorization', "Bearer #{api_token}")
+    Capybara.current_session.driver.header('Content-Type', 'application/json')
+
+    @provider_user = create(:provider_user, :with_notifications_enabled, providers: [@provider])
+    uri = "/api/v1/applications/#{application_choice.id}/offer"
+
+    @api_response = page.driver.post(uri, offer_payload)
+
+    # Unset session headers
+    Capybara.current_session.driver.header('Authorization', nil)
+    Capybara.current_session.driver.header('Content-Type', nil)
+  end
+
+  def then_i_can_see_a_validation_error
+    parsed_response_body = JSON.parse(@api_response.body)
+    validation_errors = parsed_response_body['errors']
+
+    expect(@api_response.status).to eq 422
+    expect(validation_errors.first['message']).to eq('You cannot make an offer because you can only do so for the most recent application')
+  end
+
+  def then_i_can_see_the_offer_was_made_successfully
+    parsed_response_body = JSON.parse(@api_response.body)
+    application_attrs = parsed_response_body.dig('data', 'attributes')
+
+    expect(@api_response.status).to eq 200
+    expect(application_attrs['status']).to eq('offer')
+  end
+
+  def offer_payload
+    {
+      meta: {
+        attribution: {
+          full_name: 'Jane Smith',
+          email: 'jane.smith@example.com',
+          user_id: '12345',
+        },
+        timestamp: Time.zone.now.iso8601,
+      },
+      data: {
+        conditions: ['Example condition'],
+        course: nil,
+      },
+    }.to_json
+  end
+end


### PR DESCRIPTION
## Context
A vendor has reverted a rejected application, however this applicant had already gone into apply 2. Meaning this has broken the candidate interface.

## Changes proposed in this pull request

Extend offer validation service to  restrict when an application rejection can be reverted by raising an error if the conditions are not satisfied. This ensures consistency across the service - even though reverting a rejection is not currently possible through the manage interface.

## Guidance to review
Attempt to make an offer through the API on an application that has been rejected by default.

## Link to Trello card
https://trello.com/c/3glViMft/4159-restrict-reverting-a-rejection-from-the-api
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
