### PR TITLE
Prevent additional queries on qualifications

### DIFF
--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -1,10 +1,18 @@
 class ApplicationChoiceExportDecorator < SimpleDelegator
+  RELEVANT_SUBJECTS = [
+    ApplicationQualification::MATHS,
+    ApplicationQualification::ENGLISH,
+    ApplicationQualification::SCIENCE,
+    ApplicationQualification::SCIENCE_SINGLE_AWARD,
+    ApplicationQualification::SCIENCE_DOUBLE_AWARD,
+    ApplicationQualification::SCIENCE_TRIPLE_AWARD,
+  ].freeze
+
   def gcse_qualifications_summary
-    gcses = %i[maths_gcse english_gcse science_gcse]
-    summary_string = gcses
-      .map { |gcse| application_form.send(gcse) }
+    summary_string = application_form
+      .application_qualifications
+      .select { |qualification| qualification.level == 'gcse' && RELEVANT_SUBJECTS.include?(qualification.subject) }
       .map { |gcse| summary_for_gcse(gcse) }
-      .compact
       .join(',')
 
     summary_string.presence
@@ -25,9 +33,10 @@ class ApplicationChoiceExportDecorator < SimpleDelegator
   end
 
   def first_degree
-    application_form.application_qualifications
-                    .order(created_at: :asc)
-                    .find_by(level: 'degree')
+    application_form
+      .application_qualifications
+      .select { |qualification| qualification.level == 'degree' }
+      .min_by(&:created_at)
   end
 
   def nationalities

--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -1,17 +1,10 @@
 class ApplicationChoiceExportDecorator < SimpleDelegator
-  RELEVANT_SUBJECTS = [
-    ApplicationQualification::MATHS,
-    ApplicationQualification::ENGLISH,
-    ApplicationQualification::SCIENCE,
-    ApplicationQualification::SCIENCE_SINGLE_AWARD,
-    ApplicationQualification::SCIENCE_DOUBLE_AWARD,
-    ApplicationQualification::SCIENCE_TRIPLE_AWARD,
-  ].freeze
-
   def gcse_qualifications_summary
+    required_subjects = ApplicationQualification::REQUIRED_GCSE_SUBJECTS.reverse
     summary_string = application_form
       .application_qualifications
-      .select { |qualification| qualification.level == 'gcse' && RELEVANT_SUBJECTS.include?(qualification.subject) }
+      .select { |qualification| qualification.level == 'gcse' && required_subjects.include?(qualification.subject) }
+      .sort { |a, b| required_subjects.index(a.subject) <=> required_subjects.index(b.subject) }
       .map { |gcse| summary_for_gcse(gcse) }
       .join(',')
 

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
 
       summary = described_class.new(application_choice).gcse_qualifications_summary
 
-      expect(summary).to include('Gcse Maths', 'Gcse Science', 'Gcse English')
+      expect(summary).to match(/^Gcse Maths, [ABCD], \d{4}-\d{4},Gcse English, [ABCD], \d{4}-\d{4},Gcse Science, [ABCD], \d{4}-\d{4}$/)
     end
 
     it 'does not include gcses in other subjects' do


### PR DESCRIPTION
## Context

`ApplicationForm#qualification_in_subject` is being called multiple times per row of data when exporting applications.

This happens because we iterate over relevant gcse subjects in order to present a summary. We've already included associated `:application_qualifications` in the main data export query, so this commit avoids additional queries to re-retrieve gcse and degree qualifications and uses Ruby instead to collate the relevant information.

For a single row of data we were making an additional query to find the 'first' degree and 3 more queries to find gcses
of various subjects.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Use Ruby to determine the first degree by date and gcses of relevant subjects.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

These 4 queries are currently run **per row** for an applications export, the HESA export only uses `first_degree` so it still has an n+1 issue which is addressed by this PR.

```
ApplicationQualification Load (0.9ms)  SELECT "application_qualifications".* FROM "application_qualifications" WHERE "application_qualifications"."application_form_id" = $1 AND "application_qualifications"."level" = $2 AND "application_qualifications"."subject" = $3 ORDER BY "application_qualifications"."created_at" ASC LIMIT $4  [["application_form_id", 397], ["level", "gcse"], ["subject", "maths"], ["LIMIT", 1]]
↳ app/models/application_form.rb:141:in `qualification_in_subject'                                                          
ApplicationQualification Load (2.4ms)  SELECT "application_qualifications".* FROM "application_qualifications" WHERE "application_qualifications"."application_form_id" = $1 AND "application_qualifications"."level" = $2 AND "application_qualifications"."subject" = $3 ORDER BY "application_qualifications"."created_at" ASC LIMIT $4  [["application_form_id", 397], ["level", "gcse"], ["subject", "english"], ["LIMIT", 1]]                                                                                      
↳ app/models/application_form.rb:141:in `qualification_in_subject'                                                          
ApplicationQualification Load (1.2ms)  SELECT "application_qualifications".* FROM "application_qualifications" WHERE "application_qualifications"."application_form_id" = $1 AND "application_qualifications"."level" = $2 AND "application_qualifications"."subject" IN ($3, $4, $5, $6) ORDER BY "application_qualifications"."created_at" ASC LIMIT $7  [["application_form_id", 397], ["level", "gcse"], ["subject", "science"], ["subject", "science single award"], ["subject", "science double award"], ["subject", "science triple award"], ["LIMIT", 1]]                                                                                       
↳ app/models/application_form.rb:141:in `qualification_in_subject'                                                          
ApplicationQualification Load (0.9ms)  SELECT "application_qualifications".* FROM "application_qualifications" WHERE "application_qualifications"."application_form_id" = $1 AND "application_qualifications"."level" = $2 ORDER BY "application_qualifications"."created_at" ASC LIMIT $3  [["application_form_id", 399], ["level", "degree"], ["LIMIT", 1]]                             
↳ app/decorators/application_choice_export_decorator.rb:30:in `first_degree' 
```

This PR should prevent that.
There should be no changes to CSV output from this commit.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/nPjLMPC1/4048-spike-investigate-performance-of-data-exports-in-manage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
