### PR TITLE
Remove permissions denied text

### DIFF
--- a/app/views/provider_interface/organisation_permissions/index.html.erb
+++ b/app/views/provider_interface/organisation_permissions/index.html.erb
@@ -19,9 +19,7 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l"><%= @provider.name %></span>
     <h1 class="govuk-heading-l"><%= t('page_titles.provider.organisation_permissions') %></h1>
-    <% if FeatureFlag.active?(:account_and_org_settings_changes) && !@current_user_can_manage_organisation %>
-      <p class="govuk-body"><%= t('provider_relationship_permissions.no_permissions_explanation') %></p>
-    <% end %>
+
     <% @provider_relationships.each do |relationship| %>
       <%= render ProviderInterface::OrganisationPermissionsReviewCardComponent.new(
         provider_user: current_provider_user,

--- a/app/views/provider_interface/users/show.html.erb
+++ b/app/views/provider_interface/users/show.html.erb
@@ -13,13 +13,11 @@
     <span class="govuk-caption-l"><%= @provider.name %></span>
     <h1 class="govuk-heading-l"><%= @provider_user.full_name %></h1>
 
-    <p class="govuk-body">
       <% if @current_user_can_manage_users %>
-        <%= govuk_link_to 'Delete user', confirm_destroy_provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user) %>
-      <% else %>
-        <%= t('user_permissions.no_permissions_explanation') %>
+        <p class="govuk-body">
+          <%= govuk_link_to 'Delete user', confirm_destroy_provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user) %>
+        </p>
       <% end %>
-    </p>
 
     <h2 class="govuk-heading-m">Personal details</h2>
     <%= render SummaryListComponent.new(

--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -1,7 +1,6 @@
 en:
   provider_relationship_permissions:
     view_applications_explanation: All users can view applications.
-    no_permissions_explanation: You cannot change these permissions because you do not have permission to manage organisations.
     question: Who can %{permission_description}?
     make_decisions:
       description: Make offers and reject applications

--- a/config/locales/provider_interface/user_permisssions.yml
+++ b/config/locales/provider_interface/user_permisssions.yml
@@ -1,6 +1,5 @@
 en:
   user_permissions:
-    no_permissions_explanation: You cannot change these details because you do not have permission to manage users.
     make_decisions:
       description: Make offers and reject applications
     view_safeguarding_information:

--- a/spec/system/provider_interface/remove_provider_user_spec.rb
+++ b/spec/system/provider_interface/remove_provider_user_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe 'Organisation users' do
     when_i_click_on_the_users_link_for(@read_only_provider)
     and_i_click_on_the_user_to_remove
     then_i_cannot_see_a_link_to_delete_the_user
-    and_i_can_see_text_about_not_having_permissions
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -77,9 +76,5 @@ RSpec.describe 'Organisation users' do
 
   def then_i_cannot_see_a_link_to_delete_the_user
     expect(page).not_to have_link('Delete user')
-  end
-
-  def and_i_can_see_text_about_not_having_permissions
-    expect(page).to have_content('You cannot change these details because you do not have permission to manage users.')
   end
 end

--- a/spec/system/provider_interface/view_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/view_organisation_permissions_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature 'Organisation permissions' do
     and_i_click_on_organisation_permissions_for_the_provider_i_cannot_manage
     then_i_can_see_the_permissions_that_have_been_set_up_without_change_links
     and_i_can_see_non_set_up_permissions
-    and_i_can_see_information_about_managing_the_organisation
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -100,9 +99,5 @@ RSpec.feature 'Organisation permissions' do
   def and_i_can_see_non_set_up_permissions
     expect(page).to have_selector('h2', text: "#{@read_only_provider.name} and #{@not_set_up_read_only_partner.name}")
     expect(page).to have_selector('.govuk-summary-list__value', text: 'Neither organisation can do this')
-  end
-
-  def and_i_can_see_information_about_managing_the_organisation
-    expect(page).to have_content('You cannot change these permissions because you do not have permission to manage organisations.')
   end
 end


### PR DESCRIPTION
## Context
This was in the designs originally, but now they have been reviewed and we have decided to remove the explanation text

## Changes proposed in this pull request
Remove explanation text when users cannot either manage orgs or manage users

## Guidance to review
Per commit

## Link to Trello card
https://trello.com/c/xJDieIBG/4171-remove-permission-denied-text-from-org-permissions-users-flows

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
