### PR TITLE
Change TTAPI sync timing to once a week

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -55,11 +55,11 @@ class Clock
   every(1.day, 'SendEocDeadlineReminderEmailToCandidatesWorker', at: '12:00') { SendEocDeadlineReminderEmailToCandidatesWorker.new.perform }
   every(1.day, 'SendNewCycleStartedEmailToCandidatesWorker', at: '12:00') { SendNewCycleHasStartedEmailToCandidatesWorker.new.perform }
 
-  every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do
+  every(1.week, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do
     TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false, RecruitmentCycle.current_year)
   end
 
-  every(7.days, 'FullSyncNextCycleFromTeacherTrainingPublicAPI', at: 'Saturday 03:59') do
+  every(1.week, 'FullSyncNextCycleFromTeacherTrainingPublicAPI', at: 'Saturday 03:59') do
     if FeatureFlag.active?(:sync_next_cycle)
       TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false, RecruitmentCycle.next_year)
     end


### PR DESCRIPTION
## Context

see #5430

## Changes proposed in this pull request

Appears the sync job has run last night after the changes in 5430

Change every 7.days to every 1.week

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
