### PR TITLE
Cache candidate providers page

### DIFF
--- a/app/components/candidate_interface/grouped_provider_courses_component.html.erb
+++ b/app/components/candidate_interface/grouped_provider_courses_component.html.erb
@@ -1,6 +1,6 @@
 <% find_down = CycleTimetable.find_down? %>
 
-<% courses_by_provider_and_region.each do |region_code, courses_by_provider| %>
+<% courses_grouped_by_provider_and_region.each do |region_code, courses_by_provider| %>
   <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-8"><%= label_for(region_code) %></h2>
   <%= govuk_accordion(id: region_code) do |accordion| %>
     <% courses_by_provider.each_with_index do |provider, index| %>

--- a/app/components/candidate_interface/grouped_provider_courses_component.rb
+++ b/app/components/candidate_interface/grouped_provider_courses_component.rb
@@ -2,16 +2,12 @@ module CandidateInterface
   class GroupedProviderCoursesComponent < ViewComponent::Base
     include ViewHelper
 
-    def initialize(courses_by_provider_and_region:)
-      @courses_by_provider_and_region = courses_by_provider_and_region
-    end
-
     def label_for(region_code)
       region_code.present? ? I18n.t("provider_regions.#{region_code}") : I18n.t('provider_regions.no_region_specified')
     end
 
-  private
-
-    attr_reader :courses_by_provider_and_region
+    def courses_grouped_by_provider_and_region
+      GetOpenCoursesByProviderAndRegion.call
+    end
   end
 end

--- a/app/controllers/candidate_interface/content_controller.rb
+++ b/app/controllers/candidate_interface/content_controller.rb
@@ -30,24 +30,6 @@ module CandidateInterface
       render_content_page :complaints
     end
 
-    ProviderCourses = Struct.new(:provider_name, :courses)
-    RegionProviderCourses = Struct.new(:region_code, :provider_name, :courses)
-
-    def providers
-      @courses_by_provider_and_region = courses_grouped_by_provider_and_region
-    end
-
-  private
-
-    def courses_grouped_by_provider_and_region
-      Course
-        .open_on_apply
-        .current_cycle
-        .includes(:provider)
-        .order('providers.region_code', 'providers.name')
-        .group_by { |course| [course.provider.region_code, course.provider.name] }
-        .map { |region_provider, courses| RegionProviderCourses.new(region_provider[0], region_provider[1], courses) }
-        .group_by(&:region_code)
-    end
+    def providers; end
   end
 end

--- a/app/queries/get_open_courses_by_provider_and_region.rb
+++ b/app/queries/get_open_courses_by_provider_and_region.rb
@@ -1,0 +1,14 @@
+class GetOpenCoursesByProviderAndRegion
+  RegionProviderCourses = Struct.new(:region_code, :provider_name, :courses)
+
+  def self.call
+    Course
+      .open_on_apply
+      .current_cycle
+      .includes(:provider)
+      .order('providers.region_code', 'providers.name')
+      .group_by { |course| [course.provider.region_code, course.provider.name] }
+      .map { |region_provider, courses| RegionProviderCourses.new(region_provider[0], region_provider[1], courses) }
+      .group_by(&:region_code)
+  end
+end

--- a/app/views/candidate_interface/content/providers.html.erb
+++ b/app/views/candidate_interface/content/providers.html.erb
@@ -1,15 +1,17 @@
 <% content_for :title, t('page_titles.providers') %>
 
-<h1 class="govuk-heading-xl govuk-!-width-two-thirds">
-  <%= t('page_titles.providers') %>
-</h1>
+<% cache 'courses-grouped-by-region-and-provider', expires_in: 15.minutes do %>
+  <h1 class="govuk-heading-xl govuk-!-width-two-thirds">
+    <%= t('page_titles.providers') %>
+  </h1>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">Use <%= govuk_link_to service_name, candidate_interface_path %> if the courses you want to do are listed on this page.</p>
-    <p class="govuk-body">Otherwise, apply through <%= govuk_link_to 'UCAS Teacher Training', UCAS.apply_url %>.</p>
-    <p class="govuk-body">Do not apply for the same courses on both services.<p>
-    <p class="govuk-body">You can apply for up to 3 courses in total.<p>
-    <%= render CandidateInterface::GroupedProviderCoursesComponent.new(courses_by_provider_and_region: @courses_by_provider_and_region) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">Use <%= govuk_link_to service_name, candidate_interface_path %> if the courses you want to do are listed on this page.</p>
+      <p class="govuk-body">Otherwise, apply through <%= govuk_link_to 'UCAS Teacher Training', UCAS.apply_url %>.</p>
+      <p class="govuk-body">Do not apply for the same courses on both services.<p>
+      <p class="govuk-body">You can apply for up to 3 courses in total.<p>
+      <%= render CandidateInterface::GroupedProviderCoursesComponent.new %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/spec/components/candidate_interface/grouped_provider_courses_component_spec.rb
+++ b/spec/components/candidate_interface/grouped_provider_courses_component_spec.rb
@@ -4,26 +4,26 @@ RSpec.describe CandidateInterface::GroupedProviderCoursesComponent do
   let(:course) { create(:course) }
 
   before do
-    @courses_by_provider_and_region = {
-      'north_west' => [
-        CandidateInterface::ContentController::RegionProviderCourses.new('north_west', course.provider.name, [course]),
-        CandidateInterface::ContentController::RegionProviderCourses.new('north_west', 'Westerly Sixth Form', []),
-      ],
-      'south_east' => [
-        CandidateInterface::ContentController::RegionProviderCourses.new('south_east', 'Southerly College', []),
-        CandidateInterface::ContentController::RegionProviderCourses.new('south_east', 'Easterly Sixth Form', []),
-      ],
-      nil => [
-        CandidateInterface::ContentController::RegionProviderCourses.new(nil, 'Wimbley College', []),
-        CandidateInterface::ContentController::RegionProviderCourses.new(nil, 'Worbley Sixth Form', []),
-      ],
-    }
+    allow(GetOpenCoursesByProviderAndRegion).to receive(:call).and_return(
+      {
+        'north_west' => [
+          GetOpenCoursesByProviderAndRegion::RegionProviderCourses.new('north_west', course.provider.name, [course]),
+          GetOpenCoursesByProviderAndRegion::RegionProviderCourses.new('north_west', 'Westerly Sixth Form', []),
+        ],
+        'south_east' => [
+          GetOpenCoursesByProviderAndRegion::RegionProviderCourses.new('south_east', 'Southerly College', []),
+          GetOpenCoursesByProviderAndRegion::RegionProviderCourses.new('south_east', 'Easterly Sixth Form', []),
+        ],
+        nil => [
+          GetOpenCoursesByProviderAndRegion::RegionProviderCourses.new(nil, 'Wimbley College', []),
+          GetOpenCoursesByProviderAndRegion::RegionProviderCourses.new(nil, 'Worbley Sixth Form', []),
+        ],
+      },
+    )
   end
 
   it 'renders all the region headings' do
-    result = render_inline(
-      described_class.new(courses_by_provider_and_region: @courses_by_provider_and_region),
-    )
+    result = render_inline(described_class.new)
 
     expect(result.css('h2').text).to include('South East')
     expect(result.css('h2').text).to include('North West')
@@ -34,9 +34,7 @@ RSpec.describe CandidateInterface::GroupedProviderCoursesComponent do
   context 'when find is down' do
     it 'does not include a link to find' do
       Timecop.travel(CycleTimetable.find_closes.end_of_day + 1.hour) do
-        result = render_inline(
-          described_class.new(courses_by_provider_and_region: @courses_by_provider_and_region),
-        )
+        result = render_inline(described_class.new)
         expect(result.css('a').to_html).not_to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}")
       end
     end


### PR DESCRIPTION
## Context
According to Skylight this page is quite slow. It has a high rating
because it's also fairly popular. One of the main issues appears to be
a high number of object allocations when rendering the page.

We're also planning on removing the page prior to the start of the next
cycle. Therefore, rather than changing its design or performance tuning
the existing code, it probably makes sense to just cache it instead.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Enclosing most of the template in a cache block with a 15 minute expiry
means that:

- We ease the performance burden of the page in the short term
- In case we don't quite get round to removing it prior to the start of
  the cycle, we reduce its impact on overall site performance during the
  expected spike in traffic
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Is the cache expiry time sensible?
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
na
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
