### PR TITLE
Change TTAPI ENV to point to QA locally

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 REDIS_URL=redis://localhost:6379/0
-TEACHER_TRAINING_API_BASE_URL=https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1
+TEACHER_TRAINING_API_BASE_URL=https://qa.api.publish-teacher-training-courses.service.gov.uk/api/public/v1
 HOSTING_ENVIRONMENT_NAME=development
 STATE_CHANGE_SLACK_URL=
 GOOGLE_ANALYTICS_APPLY=UA-APPLY-XX

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 REDIS_URL=redis://localhost:6379/0
-TEACHER_TRAINING_API_BASE_URL=https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1
+TEACHER_TRAINING_API_BASE_URL=https://qa.api.publish-teacher-training-courses.service.gov.uk/api/public/v1
 GOVUK_NOTIFY_API_KEY=
 LOGSTASH_ENABLE=false
 LOGSTASH_REMOTE=false


### PR DESCRIPTION
## Context

We've had our local ENVs pointed to the live API, change this to QA to avoid accidentally overloading the live API.

## Changes proposed in this pull request

Change example and development ENV to point to QA TTAPI

## Guidance to review

Did I miss anything? We've also pointed apply QA and apply Staging to the relevant TTAPI endpoints.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
