### PR TITLE
Update marketing page

### DIFF
--- a/app/controllers/provider_interface/start_page_controller.rb
+++ b/app/controllers/provider_interface/start_page_controller.rb
@@ -10,7 +10,6 @@ module ProviderInterface
       @course_count = courses.count
       @provider_count = courses.map(&:provider).uniq.count
 
-      @pilot_enrolment_form_url = 'https://forms.gle/D7GQ5XCoJnsneniH9'
       session['post_dfe_sign_in_path'] = provider_interface_applications_path
     end
 

--- a/app/frontend/styles/provider/_masthead.scss
+++ b/app/frontend/styles/provider/_masthead.scss
@@ -24,10 +24,11 @@
 }
 
 .app-masthead__alternative-action {
-  @include govuk-font($size: 19);
-  white-space: nowrap;
-  position: relative;
-  top: govuk-spacing(2);
+  @include govuk-responsive-margin(6, "top");
+
+  * {
+    color: inherit;
+  }
 
   .govuk-link {
     color: inherit;

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -9,11 +9,13 @@
           <p class="govuk-body-l">Try our new service to see how easy it is to use. It’s free for providers and candidates.</p>
         </div>
         <%= govuk_start_now_button(
-              text: 'Get started',
-              href: @pilot_enrolment_form_url,
+              text: 'Sign in',
+              href: provider_interface_sign_in_path,
               classes: 'govuk-!-margin-bottom-0 app-button--inverted',
             ) %>
-        <span class="app-masthead__alternative-action">or <%= govuk_link_to 'sign in', provider_interface_sign_in_path %> if you’ve used it before</span>
+        <div class="app-masthead__alternative-action">
+          <p class="govuk-body-m">If your organisation has not been setup to use this service, email <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>
+        </div>
       </div>
       <div class="govuk-grid-column-one-third">
         <div class="app-masthead__image">

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -14,7 +14,9 @@ module DfESignInHelpers
 
   def provider_signs_in_using_dfe_sign_in
     visit provider_interface_path
-    click_on 'sign in'
+    within '.app-masthead' do
+      click_on 'Sign in'
+    end
     click_button 'Sign in using DfE Sign-in'
   end
 


### PR DESCRIPTION
## Context

The sign in page as its out of date and we no longer need to link to the google doc as we initially had to

## Changes proposed in this pull request

Replace `Get started` button with `Sign in` button. Add text for contacting support.


<img width="1128" alt="Screenshot 2021-08-25 at 18 17 32" src="https://user-images.githubusercontent.com/159200/130836780-cff64eb1-6636-43ac-85bd-523b5fa4e005.png">

## Guidance to review
Open the review app and go to the provider start page.

## Link to Trello card
https://trello.com/c/Lg0aZFJZ/4168-marketing-page-updates
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
