### PR TITLE
Back link should take you to the page you were on before coming to th…

### DIFF
--- a/app/controllers/provider_interface/notes_controller.rb
+++ b/app/controllers/provider_interface/notes_controller.rb
@@ -34,7 +34,7 @@ module ProviderInterface
   private
 
     def note_params
-      params.require(:provider_interface_new_note_form).permit(:message)
+      params.require(:provider_interface_new_note_form).permit(:message, :referer)
         .merge(application_choice: @application_choice, provider_user: current_provider_user)
     end
   end

--- a/app/forms/provider_interface/new_note_form.rb
+++ b/app/forms/provider_interface/new_note_form.rb
@@ -1,7 +1,7 @@
 module ProviderInterface
   class NewNoteForm
     include ActiveModel::Model
-    attr_accessor :application_choice, :message, :provider_user
+    attr_accessor :application_choice, :message, :provider_user, :referer
 
     validates :application_choice, :provider_user, presence: true
     validates :message, length: { maximum: 500 }, presence: true

--- a/app/views/provider_interface/notes/new.html.erb
+++ b/app/views/provider_interface/notes/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix("#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Add Note", @new_note_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(request.referer) %>
+<% content_for :before_content, govuk_back_link_to(@new_note_form.referer || request.referer) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -14,6 +14,7 @@
       <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
       <h1 class="govuk-heading-l">Add note</h1>
 
+      <%= f.hidden_field :referer, value: @new_note_form.referer || request.referer %>
       <%= f.govuk_text_area :message, label: { text: 'Note', size: 'm' }, max_chars: 500 %>
 
       <%= f.govuk_submit 'Save note' %>

--- a/spec/system/provider_interface/provider_adds_note_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_adds_note_to_application_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     when_i_visit_that_application_in_the_provider_interface
     and_i_visit_the_notes_tab
     and_i_click_to_add_a_note
+    and_i_attempt_to_create_a_note_with_no_text
+    then_i_see_an_error_message
+
+    when_i_click_back_i_go_to_the_notes_page
+    and_i_click_to_add_a_note
     and_i_write_a_note_with_some_text
 
     then_i_am_still_on_the_notes_tab
@@ -42,6 +47,22 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
   def and_i_click_to_add_a_note
     click_on 'Add note'
+  end
+
+  def and_i_attempt_to_create_a_note_with_no_text
+    fill_in 'Note', with: ''
+    click_on 'Save note'
+  end
+
+  def then_i_see_an_error_message
+    within '.govuk-error-summary__list' do
+      expect(page).to have_content('Enter a note')
+    end
+  end
+
+  def when_i_click_back_i_go_to_the_notes_page
+    click_on 'Back'
+    expect(page).to have_current_path(provider_interface_application_choice_notes_path(@application_choice))
   end
 
   def and_i_write_a_note_with_some_text


### PR DESCRIPTION
…e new note page

## Context

When you are adding a note, if you try to submit the note and generate an error, and then click the internal backlink, the page refreshers without the error rather than taking you away from the add note screen.

## Changes proposed in this pull request

Set the request referer on a hidden field and store that on the form, unless the field value is already set. This ensures that the referer value on the form will only be set on entry and enables us to map the Back link to the correct path.

## Guidance to review

- Go to applicaiton note tab, click Add note
- Leave field blank, press Save note
- Click back
- You should not be on the right page

Or

- From any other page update the url to take you to an application's new note
- http://localhost:3000/provider/applications/<application_id>/notes/new
- Click add note
- Leave field blank, press Save note
- Click back
- You should not be on the right page


## Link to Trello card

https://trello.com/c/2p22AdVh/4118-back-link-in-add-notes-workflow-takes-you-to-the-page-youre-already-on-after-an-error-message

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
