### PR TITLE
Load test export n query enhancement

### DIFF
--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
 
       summary = described_class.new(application_choice).gcse_qualifications_summary
 
-      expect(summary).to include('Gcse Maths', 'Gcse Science', 'Gcse English')
+      expect(summary).to match(/^Gcse Maths, [ABCD], \d{4}-\d{4},Gcse English, [ABCD], \d{4}-\d{4},Gcse Science, [ABCD], \d{4}-\d{4}$/)
     end
 
     it 'does not include gcses in other subjects' do


### PR DESCRIPTION
## Context

Load test PR - this will be merged into `load-test` branch

We've discovered that data exports are triggering up to 4 additional queries per row.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This PR includes commits from https://github.com/DFE-Digital/apply-for-teacher-training/pull/5453 which prevent `N+` queries.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
