### PR TITLE
Invite Provider User - Permissions

### DIFF
--- a/app/components/provider_interface/provider_user_permissions_form_component.html.erb
+++ b/app/components/provider_interface/provider_user_permissions_form_component.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(
   model: form_model,
   url: form_path,
-  method: :patch,
+  method: form_method,
 ) do |f| %>
   <% unless provider_has_no_relationships? %>
     <h1 class="govuk-heading-l">

--- a/app/components/provider_interface/provider_user_permissions_form_component.rb
+++ b/app/components/provider_interface/provider_user_permissions_form_component.rb
@@ -1,11 +1,12 @@
 module ProviderInterface
   class ProviderUserPermissionsFormComponent < ViewComponent::Base
-    attr_reader :form_model, :provider, :form_path, :user_name
+    attr_reader :form_model, :provider, :form_path, :form_method, :user_name
 
-    def initialize(form_model:, form_path:, provider:, user_name: nil)
+    def initialize(form_model:, provider:, form_path:, form_method:, user_name: nil)
       @form_model = form_model
       @provider = provider
       @form_path = form_path
+      @form_method = form_method
       @user_name = user_name
     end
 

--- a/app/components/provider_interface/user_personal_details_component.rb
+++ b/app/components/provider_interface/user_personal_details_component.rb
@@ -1,0 +1,33 @@
+module ProviderInterface
+  class UserPersonalDetailsComponent < SummaryListComponent
+    def initialize(user:, change_path: nil)
+      @user = user
+      @change_path = change_path
+    end
+
+    def rows
+      %i[first_name last_name email_address].map do |field|
+        row_for_field(field)
+      end
+    end
+
+  private
+
+    attr_accessor :user, :change_path
+
+    def row_for_field(field)
+      field_label = field.to_s.humanize
+      row = {
+        key: field_label,
+        value: user.send(field),
+      }
+
+      return row if change_path.blank?
+
+      row.merge({
+        action: field_label,
+        change_path: change_path,
+      })
+    end
+  end
+end

--- a/app/controllers/provider_interface/user_invitation/base_controller.rb
+++ b/app/controllers/provider_interface/user_invitation/base_controller.rb
@@ -27,6 +27,28 @@ module ProviderInterface
 
         redirect_to provider_interface_organisation_settings_path
       end
+
+      def next_page_path
+        case @wizard.next_step
+        when :permissions
+          new_provider_interface_organisation_settings_organisation_user_invitation_permissions_path(@provider)
+        when :check
+          provider_interface_organisation_settings_organisation_user_invitation_check_path(@provider)
+        end
+      end
+
+      def previous_page_path
+        case @wizard.previous_step
+        when :personal_details
+          new_provider_interface_organisation_settings_organisation_user_invitation_personal_details_path(@provider)
+        when :permissions
+          new_provider_interface_organisation_settings_organisation_user_invitation_permissions_path(@provider)
+        when :check
+          provider_interface_organisation_settings_organisation_user_invitation_check_path(@provider)
+        end
+      end
+
+      helper_method :previous_page_path
     end
   end
 end

--- a/app/controllers/provider_interface/user_invitation/permissions_controller.rb
+++ b/app/controllers/provider_interface/user_invitation/permissions_controller.rb
@@ -8,6 +8,8 @@ module ProviderInterface
       def create
         @wizard = InviteUserWizard.new(invite_user_store, permissions_params)
         @wizard.save_state!
+
+        redirect_to provider_interface_organisation_settings_organisation_user_invitation_check_path(@provider)
       end
 
     private

--- a/app/controllers/provider_interface/user_invitation/permissions_controller.rb
+++ b/app/controllers/provider_interface/user_invitation/permissions_controller.rb
@@ -1,0 +1,20 @@
+module ProviderInterface
+  module UserInvitation
+    class PermissionsController < BaseController
+      def new
+        @wizard = InviteUserWizard.new(invite_user_store)
+      end
+
+      def create
+        @wizard = InviteUserWizard.new(invite_user_store, permissions_params)
+        @wizard.save_state!
+      end
+
+    private
+
+      def permissions_params
+        params.require(:provider_interface_invite_user_wizard).permit(permissions: [])
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/user_invitation/permissions_controller.rb
+++ b/app/controllers/provider_interface/user_invitation/permissions_controller.rb
@@ -2,14 +2,19 @@ module ProviderInterface
   module UserInvitation
     class PermissionsController < BaseController
       def new
-        @wizard = InviteUserWizard.new(invite_user_store)
+        @wizard = InviteUserWizard.new(
+          invite_user_store,
+          current_step: :permissions,
+          checking_answers: params[:checking_answers] == 'true',
+        )
+        @wizard.save_state!
       end
 
       def create
         @wizard = InviteUserWizard.new(invite_user_store, permissions_params)
         @wizard.save_state!
 
-        redirect_to provider_interface_organisation_settings_organisation_user_invitation_check_path(@provider)
+        redirect_to next_page_path
       end
 
     private

--- a/app/controllers/provider_interface/user_invitation/personal_details_controller.rb
+++ b/app/controllers/provider_interface/user_invitation/personal_details_controller.rb
@@ -9,6 +9,7 @@ module ProviderInterface
         @wizard = InviteUserWizard.new(invite_user_store, personal_details_params.merge(provider: @provider))
         if @wizard.valid?
           @wizard.save_state!
+          redirect_to new_provider_interface_organisation_settings_organisation_user_invitation_permissions_path(@provider)
         else
           track_validation_error(@wizard)
           render :new

--- a/app/controllers/provider_interface/user_invitation/personal_details_controller.rb
+++ b/app/controllers/provider_interface/user_invitation/personal_details_controller.rb
@@ -2,14 +2,19 @@ module ProviderInterface
   module UserInvitation
     class PersonalDetailsController < BaseController
       def new
-        @wizard = InviteUserWizard.new(invite_user_store)
+        @wizard = InviteUserWizard.new(
+          invite_user_store,
+          current_step: :personal_details,
+          checking_answers: params[:checking_answers] == 'true',
+        )
+        @wizard.save_state!
       end
 
       def create
         @wizard = InviteUserWizard.new(invite_user_store, personal_details_params.merge(provider: @provider))
         if @wizard.valid?
           @wizard.save_state!
-          redirect_to new_provider_interface_organisation_settings_organisation_user_invitation_permissions_path(@provider)
+          redirect_to next_page_path
         else
           track_validation_error(@wizard)
           render :new

--- a/app/controllers/provider_interface/user_invitation/review_controller.rb
+++ b/app/controllers/provider_interface/user_invitation/review_controller.rb
@@ -4,6 +4,40 @@ module ProviderInterface
       def check
         @wizard = InviteUserWizard.new(invite_user_store)
       end
+
+      def commit
+        @wizard = InviteUserWizard.new(invite_user_store, provider: @provider)
+
+        save_service = AddUserToProvider.new(
+          actor: current_provider_user,
+          provider: @provider,
+          email_address: @wizard.email_address,
+          first_name: @wizard.first_name,
+          last_name: @wizard.last_name,
+          permissions: @wizard.permissions,
+        )
+        service = SaveAndInviteProviderUser.new(
+          form: @wizard,
+          save_service: save_service,
+          invite_service: InviteProviderUser.new(provider_user: @wizard.email_address),
+          new_user: new_user?(@wizard.email_address),
+        )
+        if service.call
+          @wizard.clear_state!
+
+          flash[:success] = 'User invited'
+          redirect_to provider_interface_organisation_settings_organisation_users_path(@provider)
+        else
+          track_validation_error(@wizard)
+          render :check
+        end
+      end
+
+    private
+
+      def new_user?(email)
+        !ProviderUser.exists?(email_address: email)
+      end
     end
   end
 end

--- a/app/controllers/provider_interface/user_invitation/review_controller.rb
+++ b/app/controllers/provider_interface/user_invitation/review_controller.rb
@@ -2,7 +2,10 @@ module ProviderInterface
   module UserInvitation
     class ReviewController < BaseController
       def check
-        @wizard = InviteUserWizard.new(invite_user_store)
+        @wizard = InviteUserWizard.new(
+          invite_user_store,
+          current_step: :check,
+        )
       end
 
       def commit

--- a/app/controllers/provider_interface/user_invitation/review_controller.rb
+++ b/app/controllers/provider_interface/user_invitation/review_controller.rb
@@ -1,0 +1,9 @@
+module ProviderInterface
+  module UserInvitation
+    class ReviewController < BaseController
+      def check
+        @wizard = InviteUserWizard.new(invite_user_store)
+      end
+    end
+  end
+end

--- a/app/forms/provider_interface/invite_user_wizard.rb
+++ b/app/forms/provider_interface/invite_user_wizard.rb
@@ -2,7 +2,8 @@ module ProviderInterface
   class InviteUserWizard
     include ActiveModel::Model
 
-    attr_accessor :first_name, :last_name, :email_address, :provider, :permissions
+    attr_accessor :first_name, :last_name, :email_address, :provider, :permissions, :checking_answers
+    attr_writer :current_step
 
     validates :first_name, presence: true
     validates :last_name, presence: true
@@ -14,6 +15,30 @@ module ProviderInterface
       @state_store = state_store
 
       super(last_saved_state.merge(attrs))
+
+      self.checking_answers = false if current_step == :check
+    end
+
+    def current_step
+      @current_step&.to_sym
+    end
+
+    def next_step
+      if checking_answers || current_step == :permissions
+        :check
+      elsif current_step == :personal_details
+        :permissions
+      end
+    end
+
+    def previous_step
+      if checking_answers
+        :check
+      elsif current_step == :check
+        :permissions
+      elsif current_step == :permissions
+        :personal_details
+      end
     end
 
     def save_state!

--- a/app/forms/provider_interface/invite_user_wizard.rb
+++ b/app/forms/provider_interface/invite_user_wizard.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   class InviteUserWizard
     include ActiveModel::Model
 
-    attr_accessor :first_name, :last_name, :email_address, :provider
+    attr_accessor :first_name, :last_name, :email_address, :provider, :permissions
 
     validates :first_name, presence: true
     validates :last_name, presence: true

--- a/app/services/provider_interface/add_user_to_provider.rb
+++ b/app/services/provider_interface/add_user_to_provider.rb
@@ -1,0 +1,62 @@
+module ProviderInterface
+  class AddUserToProvider
+    include ImpersonationAuditHelper
+
+    attr_accessor :actor, :provider, :email_address, :first_name, :last_name, :permissions
+
+    def initialize(actor:, provider:, email_address:, first_name:, last_name:, permissions:)
+      @actor = actor
+      @provider = provider
+      @email_address = email_address
+      @first_name = first_name
+      @last_name = last_name
+      @permissions = permissions
+    end
+
+    def call!
+      audit(actor) do
+        ActiveRecord::Base.transaction do
+          assert_actor_can_manage_users_for_provider!
+
+          provider_user = find_or_create_provider_user!
+          create_provider_permissions!(provider_user)
+        end
+      end
+    end
+
+  private
+
+    def assert_actor_can_manage_users_for_provider!
+      return if actor.authorisation.can_manage_users_for?(provider: provider)
+
+      raise ProviderAuthorisation::NotAuthorisedError, 'You are not allowed to add users to this provider'
+    end
+
+    def find_or_create_provider_user!
+      provider_user = ProviderUser.find_or_initialize_by(email_address: email_address)
+      provider_user.first_name = first_name
+      provider_user.last_name = last_name
+
+      new_user = provider_user.new_record?
+      provider_user.save!
+
+      if new_user
+        create_notification_preferences!(provider_user)
+      end
+
+      provider_user
+    end
+
+    def create_notification_preferences!(provider_user)
+      ProviderUserNotificationPreferences.create!(provider_user: provider_user)
+    end
+
+    def create_provider_permissions!(provider_user)
+      ProviderPermissions.create!(provider: provider, provider_user: provider_user) do |provider_permissions|
+        ProviderPermissions::VALID_PERMISSIONS.each do |permission|
+          provider_permissions.send("#{permission}=", permissions.include?(permission.to_s))
+        end
+      end
+    end
+  end
+end

--- a/app/views/provider_interface/personal_details/show.html.erb
+++ b/app/views/provider_interface/personal_details/show.html.erb
@@ -10,13 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('page_titles.provider.your_personal_details') %></h1>
-    <%= render SummaryListComponent.new(
-      rows: [
-        { key: 'First name', value: current_provider_user.first_name },
-        { key: 'Last name', value: current_provider_user.last_name },
-        { key: 'Email address', value: current_provider_user.email_address },
-      ],
-    ) %>
+    <%= render ProviderInterface::UserPersonalDetailsComponent.new(user: current_provider_user) %>
 
     <p class="govuk-body">
       <%= govuk_link_to 'Change your details or password in DfE Sign-in', @dsi_profile_url %>

--- a/app/views/provider_interface/user_invitation/permissions/new.html.erb
+++ b/app/views/provider_interface/user_invitation/permissions/new.html.erb
@@ -1,0 +1,17 @@
+<% content_for :browser_title, t('page_titles.provider.user_permissions') %>
+<% content_for :before_content, govuk_back_link_to(new_provider_interface_organisation_settings_organisation_user_invitation_personal_details_path(@provider)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render ProviderInterface::ProviderUserPermissionsFormComponent.new(
+      form_model: @wizard,
+      provider: @provider,
+      form_path: provider_interface_organisation_settings_organisation_user_invitation_permissions_path(@provider),
+      form_method: :post,
+    ) %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t('cancel'), provider_interface_organisation_settings_organisation_users_path(@provider) %>
+    </p>
+  </div>
+</div>

--- a/app/views/provider_interface/user_invitation/permissions/new.html.erb
+++ b/app/views/provider_interface/user_invitation/permissions/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, t('page_titles.provider.user_permissions') %>
-<% content_for :before_content, govuk_back_link_to(new_provider_interface_organisation_settings_organisation_user_invitation_personal_details_path(@provider)) %>
+<% content_for :before_content, govuk_back_link_to(previous_page_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/user_invitation/personal_details/new.html.erb
+++ b/app/views/provider_interface/user_invitation/personal_details/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, t('page_titles.provider.personal_details') %>
-<% content_for :before_content, govuk_back_link_to(provider_interface_organisation_settings_organisation_users_path(@provider)) %>
+<% content_for :before_content, govuk_back_link_to(previous_page_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/user_invitation/review/check.html.erb
+++ b/app/views/provider_interface/user_invitation/review/check.html.erb
@@ -1,0 +1,32 @@
+<% content_for :browser_title, t('page_titles.provider.check_user_invitation_permissions') %>
+<% content_for :before_content, govuk_back_link_to(new_provider_interface_organisation_settings_organisation_user_invitation_permissions_path(@provider)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= "Invite user - #{@provider.name}" %></span>
+      <%= t('page_titles.provider.check_user_invitation_permissions') %>
+    </h1>
+
+    <h2 class="govuk-heading-m"><%= t('page_titles.provider.personal_details') %></h2>
+    <%= render ProviderInterface::UserPersonalDetailsComponent.new(
+      user: @wizard,
+      change_path: new_provider_interface_organisation_settings_organisation_user_invitation_personal_details_path(@provider, checking_answers: true),
+    ) %>
+
+    <h2 class="govuk-heading-m"><%= t('page_titles.provider.user_permissions') %></h2>
+
+    <p class="govuk-body"><%= t('provider_relationship_permissions.view_applications_explanation') %></p>
+
+    <%= render ProviderInterface::UserPermissionsReviewComponent.new(
+      permissions: @wizard.permissions,
+      change_path: new_provider_interface_organisation_settings_organisation_user_invitation_permissions_path(@provider, checking_answers: true),
+    ) %>
+
+    <%= govuk_button_to 'Invite user', provider_interface_organisation_settings_organisation_user_invitation_commit_path(@provider) %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t('cancel'), provider_interface_organisation_settings_organisation_users_path(@provider) %>
+    </p>
+  </div>
+</div>

--- a/app/views/provider_interface/user_invitation/review/check.html.erb
+++ b/app/views/provider_interface/user_invitation/review/check.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, t('page_titles.provider.check_user_invitation_permissions') %>
-<% content_for :before_content, govuk_back_link_to(new_provider_interface_organisation_settings_organisation_user_invitation_permissions_path(@provider)) %>
+<% content_for :before_content, govuk_back_link_to(previous_page_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/user_invitation/review/check.html.erb
+++ b/app/views/provider_interface/user_invitation/review/check.html.erb
@@ -3,27 +3,31 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l"><%= "Invite user - #{@provider.name}" %></span>
-      <%= t('page_titles.provider.check_user_invitation_permissions') %>
-    </h1>
+    <%= form_with model: @wizard, url: provider_interface_organisation_settings_organisation_user_invitation_commit_path(@provider) do |f| %>
+      <%= f.govuk_error_summary %>
 
-    <h2 class="govuk-heading-m"><%= t('page_titles.provider.personal_details') %></h2>
-    <%= render ProviderInterface::UserPersonalDetailsComponent.new(
-      user: @wizard,
-      change_path: new_provider_interface_organisation_settings_organisation_user_invitation_personal_details_path(@provider, checking_answers: true),
-    ) %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= "Invite user - #{@provider.name}" %></span>
+        <%= t('page_titles.provider.check_user_invitation_permissions') %>
+      </h1>
 
-    <h2 class="govuk-heading-m"><%= t('page_titles.provider.user_permissions') %></h2>
+      <h2 class="govuk-heading-m"><%= t('page_titles.provider.personal_details') %></h2>
+      <%= render ProviderInterface::UserPersonalDetailsComponent.new(
+        user: @wizard,
+        change_path: new_provider_interface_organisation_settings_organisation_user_invitation_personal_details_path(@provider, checking_answers: true),
+      ) %>
 
-    <p class="govuk-body"><%= t('provider_relationship_permissions.view_applications_explanation') %></p>
+      <h2 class="govuk-heading-m"><%= t('page_titles.provider.user_permissions') %></h2>
 
-    <%= render ProviderInterface::UserPermissionsReviewComponent.new(
-      permissions: @wizard.permissions,
-      change_path: new_provider_interface_organisation_settings_organisation_user_invitation_permissions_path(@provider, checking_answers: true),
-    ) %>
+      <p class="govuk-body"><%= t('provider_relationship_permissions.view_applications_explanation') %></p>
 
-    <%= govuk_button_to 'Invite user', provider_interface_organisation_settings_organisation_user_invitation_commit_path(@provider) %>
+      <%= render ProviderInterface::UserPermissionsReviewComponent.new(
+        permissions: @wizard.permissions,
+        change_path: new_provider_interface_organisation_settings_organisation_user_invitation_permissions_path(@provider, checking_answers: true),
+      ) %>
+
+      <%= f.govuk_submit 'Invite user' %>
+    <% end %>
 
     <p class="govuk-body">
       <%= govuk_link_to t('cancel'), provider_interface_organisation_settings_organisation_users_path(@provider) %>

--- a/app/views/provider_interface/user_permissions/edit.html.erb
+++ b/app/views/provider_interface/user_permissions/edit.html.erb
@@ -5,8 +5,9 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render ProviderInterface::ProviderUserPermissionsFormComponent.new(
       form_model: @wizard,
-      form_path: provider_interface_organisation_settings_organisation_user_permissions_path(@provider, @provider_user),
       provider: @provider,
+      form_path: provider_interface_organisation_settings_organisation_user_permissions_path(@provider, @provider_user),
+      form_method: :patch,
       user_name: @provider_user.full_name,
     ) %>
     <p class="govuk-body">

--- a/app/views/provider_interface/users/show.html.erb
+++ b/app/views/provider_interface/users/show.html.erb
@@ -20,13 +20,8 @@
       <% end %>
 
     <h2 class="govuk-heading-m">Personal details</h2>
-    <%= render SummaryListComponent.new(
-      rows: [
-        { key: 'First name', value: @provider_user.first_name },
-        { key: 'Last name', value: @provider_user.last_name },
-        { key: 'Email address', value: @provider_user.email_address },
-      ],
-    ) %>
+    <%= render ProviderInterface::UserPersonalDetailsComponent.new(user: @provider_user) %>
+
     <h2 class="govuk-heading-m">User permissions</h2>
     <p class="govuk-body"><%= t('provider_relationship_permissions.view_applications_explanation') %></p>
     <%= render ProviderInterface::UserPermissionSummaryComponent.new(provider_user: @provider_user, provider: @provider, editable: @current_user_can_manage_users) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -214,6 +214,7 @@ en:
       your_user_permissions: Your user permissions
       user_permissions: User permissions
       check_user_permissions: Check and save user permissions
+      check_user_invitation_permissions: Check permissions and invite user
       email_notifications: Your email notifications
       organisation_settings: Organisation settings
       organisation_permissions: Organisation permissions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -802,6 +802,7 @@ Rails.application.routes.draw do
         namespace :user_invitation, path: 'user' do
           resource :personal_details, path: '', only: %i[new create]
           resource :permissions, only: %i[new create]
+          get 'check' => 'review#check', as: :check
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -803,6 +803,7 @@ Rails.application.routes.draw do
           resource :personal_details, path: '', only: %i[new create]
           resource :permissions, only: %i[new create]
           get 'check' => 'review#check', as: :check
+          post 'commit' => 'review#commit', as: :commit
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -801,6 +801,7 @@ Rails.application.routes.draw do
 
         namespace :user_invitation, path: 'user' do
           resource :personal_details, path: '', only: %i[new create]
+          resource :permissions, only: %i[new create]
         end
       end
     end

--- a/spec/components/provider_interface/provider_user_permissions_form_component_spec.rb
+++ b/spec/components/provider_interface/provider_user_permissions_form_component_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe ProviderInterface::ProviderUserPermissionsFormComponent do
   let(:form_model) { double }
   let(:provider) { provider_user.providers.first }
   let(:path) { '/path' }
+  let(:method) { :post }
   let(:user_name) { nil }
-  let(:render) { render_inline(described_class.new(form_model: form_model, form_path: path, provider: provider, user_name: user_name)) }
+  let(:render) { render_inline(described_class.new(form_model: form_model, provider: provider, form_path: path, form_method: method, user_name: user_name)) }
 
   before do
     provider_permissions = provider_user.provider_permissions.first
@@ -22,6 +23,10 @@ RSpec.describe ProviderInterface::ProviderUserPermissionsFormComponent do
 
   it 'uses the given path for the form' do
     expect(render.css('form').first.attributes['action'].value).to eq(path)
+  end
+
+  it 'uses the given method for the form' do
+    expect(render.css('form').first.attributes['method'].value).to eq('post')
   end
 
   context 'when the provider has no partner organisations' do

--- a/spec/components/provider_interface/user_personal_details_component_spec.rb
+++ b/spec/components/provider_interface/user_personal_details_component_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::UserPersonalDetailsComponent do
+  let(:change_path) { nil }
+  let(:user) { build_stubbed(:provider_user) }
+
+  subject!(:render) { render_inline(described_class.new(user: user, change_path: change_path)) }
+
+  it 'renders each field with the correct values' do
+    expect(render.css('.govuk-summary-list__row')[0].text).to include('First name', user.first_name)
+    expect(render.css('.govuk-summary-list__row')[1].text).to include('Last name', user.last_name)
+    expect(render.css('.govuk-summary-list__row')[2].text).to include('Email address', user.email_address)
+  end
+
+  context 'when the change_path is nil' do
+    it 'does not render change links' do
+      expect(page).not_to have_selector('a')
+    end
+  end
+
+  context 'when the change_path is given' do
+    let(:change_path) { '/change-path' }
+
+    it 'renders change links' do
+      expect(page).to have_link('Change First name', href: change_path)
+      expect(page).to have_link('Change Last name', href: change_path)
+      expect(page).to have_link('Change Email address', href: change_path)
+    end
+  end
+end

--- a/spec/requests/provider_interface/user_invitation/review_controller_spec.rb
+++ b/spec/requests/provider_interface/user_invitation/review_controller_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::UserInvitation::ReviewController do
+  include DfESignInHelpers
+  include DsiAPIHelper
+  include ModelWithErrorsStubHelper
+
+  let(:managing_user) { create(:provider_user, :with_manage_organisations, :with_manage_users, providers: [provider]) }
+  let(:provider) { create(:provider, :with_signed_agreement) }
+
+  before do
+    allow(DfESignInUser).to receive(:load_from_session).and_return(managing_user)
+
+    user_exists_in_dfe_sign_in(email_address: managing_user.email_address)
+  end
+
+  context 'when the account_and_org_settings_changes feature flag is on' do
+    before { FeatureFlag.activate(:account_and_org_settings_changes) }
+
+    context 'when the wizard is invalid' do
+      before do
+        stub_model_instance_with_errors(
+          ProviderInterface::InviteUserWizard,
+          valid?: false,
+          email_address: '',
+          first_name: '',
+          last_name: '',
+          permissions: [],
+          previous_step: :permissions,
+        )
+      end
+
+      it 'tracks validation errors on POST commit' do
+        expect {
+          post provider_interface_organisation_settings_organisation_user_invitation_commit_path(provider),
+               params: {}
+        }.to change(ValidationError, :count).by(1)
+      end
+    end
+
+    context 'when a user does not have manage users permissions' do
+      let(:managing_user) { create(:provider_user, :with_manage_organisations, providers: [provider]) }
+
+      it 'responds with a 403 on GET check' do
+        get provider_interface_organisation_settings_organisation_user_invitation_check_path(provider)
+
+        expect(response.status).to eq(403)
+      end
+
+      it 'responds with a 403 on POST commit' do
+        post provider_interface_organisation_settings_organisation_user_invitation_commit_path(provider)
+
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+
+  context 'when the account_and_org_settings_changes feature flag is off' do
+    before { FeatureFlag.deactivate(:account_and_org_settings_changes) }
+
+    it 'redirects to the org settings page' do
+      get provider_interface_organisation_settings_organisation_user_invitation_check_path(provider)
+
+      expect(response.status).to eq(302)
+      expect(response.redirect_url).to eq(provider_interface_organisation_settings_url)
+    end
+  end
+end

--- a/spec/services/provider_interface/add_user_to_provider_spec.rb
+++ b/spec/services/provider_interface/add_user_to_provider_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::AddUserToProvider do
+  let(:actor) { create(:provider_user, :with_provider, :with_manage_users) }
+  let(:provider) { actor.providers.first }
+  let(:email_address) { Faker::Internet.email }
+  let(:first_name) { 'Firstman' }
+  let(:last_name) { 'Lastson' }
+  let(:permissions) { ProviderPermissions::VALID_PERMISSIONS.map(&:to_s).sample(3) }
+  let!(:service) do
+    described_class.new(
+      actor: actor,
+      provider: provider,
+      email_address: email_address,
+      first_name: first_name,
+      last_name: last_name,
+      permissions: permissions,
+    )
+  end
+
+  describe '#call!' do
+    it 'attributes audits to the actor', with_audited: true do
+      expect { service.call! }.to change(Audited::Audit, :count).by(2)
+
+      expect(Audited::Audit.second_to_last.auditable_type).to eq('ProviderUser')
+      expect(Audited::Audit.second_to_last.user).to eq(actor)
+      expect(Audited::Audit.last.auditable_type).to eq('ProviderPermissions')
+      expect(Audited::Audit.last.user).to eq(actor)
+    end
+
+    context 'when the actor cannot manage users' do
+      let(:actor) { create(:provider_user, :with_provider) }
+
+      it 'raises a NotAuthorisedError' do
+        expect { service.call! }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
+      end
+    end
+
+    context 'when the user already belongs to the provider' do
+      let!(:existing_user) { create(:provider_user, providers: [provider], email_address: email_address) }
+
+      it 'raises a RecordNotUnique error and does not update the user’s details' do
+        expect { service.call! }.to raise_error(ActiveRecord::RecordNotUnique)
+
+        expect(existing_user.reload.first_name).not_to eq(first_name)
+        expect(existing_user.reload.last_name).not_to eq(last_name)
+      end
+    end
+
+    context 'when the provider user already exists but does not belong to the provider' do
+      let!(:existing_user) { create(:provider_user, email_address: email_address) }
+
+      it 'updates the name of the user' do
+        expect { service.call! }.to change { existing_user.reload.first_name }.to(first_name)
+                                .and change { existing_user.reload.last_name }.to(last_name)
+      end
+
+      it 'creates a new ProviderPermissions object for the relationship with the specified permissions' do
+        service.call!
+
+        expect(existing_user.providers).to include(provider)
+
+        provider_permissions = existing_user.provider_permissions.find_by(provider: provider)
+        ProviderPermissions::VALID_PERMISSIONS.each do |permission|
+          expect(provider_permissions.send(permission)).to eq(expected_permission_value(permission))
+        end
+      end
+
+      it 'does not create another notification preferences object' do
+        expect { service.call! }.not_to change(ProviderUserNotificationPreferences, :count)
+      end
+    end
+
+    context 'when the provider user does not exist yet' do
+      it 'creates a new ProviderUser with notification preferences' do
+        expect { service.call! }.to change(ProviderUser, :count).by(1)
+
+        new_user = ProviderUser.last
+        expect(new_user.first_name).to eq(first_name)
+        expect(new_user.last_name).to eq(last_name)
+        expect(new_user.email_address).to eq(email_address)
+
+        expect(new_user.notification_preferences).not_to be_nil
+      end
+
+      it 'creates a new ProviderPermissions object for the relationship with the specified permissions' do
+        expect { service.call! }.to change(ProviderPermissions, :count).by(1)
+
+        new_user = ProviderUser.last
+        expect(new_user.providers).to include(provider)
+
+        provider_permissions = new_user.provider_permissions.find_by(provider: provider)
+        ProviderPermissions::VALID_PERMISSIONS.each do |permission|
+          expect(provider_permissions.send(permission)).to eq(expected_permission_value(permission))
+        end
+      end
+    end
+  end
+
+  def expected_permission_value(permission)
+    permissions.include? permission.to_s
+  end
+end

--- a/spec/system/provider_interface/invite_user_spec.rb
+++ b/spec/system/provider_interface/invite_user_spec.rb
@@ -22,6 +22,29 @@ RSpec.feature 'Provider user invitation' do
     when_i_fill_in_personal_details_with_an_email_that_already_exists
     and_i_click_continue
     then_i_see_a_duplicate_email_validation_error
+
+    when_i_fill_in_unique_personal_details
+    and_i_click_continue
+    then_i_see_a_permissions_form
+
+    when_i_select_some_permissions
+    and_i_click_continue
+    then_i_see_a_check_page
+    and_i_see_the_specified_personal_details
+    and_i_see_the_selected_permissions
+
+    when_i_click_to_change_the_first_name
+    then_i_see_a_personal_details_form
+
+    when_i_change_the_first_name
+    and_i_click_continue
+    then_i_see_a_check_page
+    and_i_see_the_first_name_has_been_updated
+
+    when_i_commit_the_changes
+    then_i_see_a_success_message
+    and_the_new_user_appears_in_the_user_list
+    and_the_new_user_gets_an_invitation_email
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -73,5 +96,71 @@ RSpec.feature 'Provider user invitation' do
 
   def then_i_see_a_duplicate_email_validation_error
     expect(page).to have_content("A user with this email address already has access to #{@provider.name}")
+  end
+
+  def when_i_fill_in_unique_personal_details
+    fill_in 'First name', with: 'Johnathy'
+    fill_in 'Last name', with: 'Smithinson'
+    fill_in 'Email address', with: 'john.smith@example.com'
+  end
+
+  def then_i_see_a_permissions_form
+    expect(page).to have_selector('h1', text: 'User permissions')
+  end
+
+  def when_i_select_some_permissions
+    check 'Manage users'
+    check 'View sex, disability and ethnicity information'
+  end
+
+  def then_i_see_a_check_page
+    expect(page).to have_selector('h1', text: 'Check permissions and invite user')
+  end
+
+  def and_i_see_the_specified_personal_details
+    expect(page).to have_selector('h2', text: 'Personal details')
+    expect(page).to have_selector('.govuk-summary-list__row', text: "First name\nJohnathy")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Last name\nSmithinson")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Email address\njohn.smith@example.com")
+  end
+
+  def and_i_see_the_selected_permissions
+    expect(page).to have_selector('h2', text: 'User permissions')
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Manage users\nYes")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Manage organisation permissions\nNo")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Manage interviews\nNo")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "Make offers and reject applications\nNo")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "View criminal convictions and professional misconduct\nNo")
+    expect(page).to have_selector('.govuk-summary-list__row', text: "View sex, disability and ethnicity information\nYes")
+  end
+
+  def when_i_click_to_change_the_first_name
+    click_on 'Change First name'
+  end
+
+  def when_i_change_the_first_name
+    fill_in 'First name', with: 'Jack'
+  end
+
+  def and_i_see_the_first_name_has_been_updated
+    expect(page).to have_selector('.govuk-summary-list__row', text: "First name\nJack")
+  end
+
+  def when_i_commit_the_changes
+    dsi_api_response(success: true)
+    when_i_click_on_invite_user
+  end
+
+  def then_i_see_a_success_message
+    expect(page).to have_content('User invited')
+  end
+
+  def and_the_new_user_appears_in_the_user_list
+    expect(page).to have_content('Jack Smithinson - john.smith@example.com')
+  end
+
+  def and_the_new_user_gets_an_invitation_email
+    open_email('john.smith@example.com')
+    expect(current_email.subject).to have_content t('provider_mailer.account_created.subject')
   end
 end


### PR DESCRIPTION
## Context
We have updated the flow for inviting provider users to the service.
Previously there was a single page for viewing users that you could manage, and you could invite users to any number of providers you manage in one go.
The new design scopes user pages to specific providers. So you can now only invite a user to one provider at a time.

## Changes proposed in this pull request
Add a controller for handling permissions for new provider users
Add a controller for handling check + commit on inviting a new provider user
Add a new save service for inviting a user to a single provider

## Guidance to review
Per commit

We have tried to reuse as much of the old provider invitation services as possible, but we had to make a new "save" service. Otherwise we are relying on the old logic – are there potential issues there?

## Link to Trello card
https://trello.com/c/tilyJyaH/4157-invite-provider-user-permissions-and-summary

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
