### PR TITLE
Fix back link on new interview page (wrong referer after error form submission)

### DIFF
--- a/app/components/provider_interface/interview_form_component.html.erb
+++ b/app/components/provider_interface/interview_form_component.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(
   model: form_model,
   url: form_url,
-  method: :post,
+  method: form_method,
 ) do |f| %>
 
   <%= f.govuk_error_summary %>

--- a/app/components/provider_interface/interview_form_component.rb
+++ b/app/components/provider_interface/interview_form_component.rb
@@ -1,12 +1,13 @@
 module ProviderInterface
   class InterviewFormComponent < ViewComponent::Base
-    attr_reader :application_choice, :form_model, :form_url, :form_heading
+    attr_reader :application_choice, :form_model, :form_url, :form_heading, :form_method
 
-    def initialize(application_choice:, form_model:, form_url:, form_heading:)
+    def initialize(application_choice:, form_model:, form_url:, form_heading:, form_method: :post)
       @application_choice = application_choice
       @form_model = form_model
       @form_url = form_url
       @form_heading = form_heading
+      @form_method = form_method
     end
 
     def application_providers

--- a/app/controllers/provider_interface/interviews/checks_controller.rb
+++ b/app/controllers/provider_interface/interviews/checks_controller.rb
@@ -1,0 +1,48 @@
+module ProviderInterface
+  module Interviews
+    class ChecksController < InterviewsController
+      def new
+        @wizard = InterviewWizard.new(interview_store, interview_form_context_params.merge(current_step: 'check', action: action))
+        @wizard.save_state!
+      end
+
+      def create
+        @wizard = InterviewWizard.new(interview_store, interview_params)
+        @wizard.save_state!
+
+        if @wizard.valid?
+          redirect_to new_provider_interface_interviews_check_path(@application_choice)
+        else
+          track_validation_error(@wizard)
+          render 'provider_interface/interviews/new'
+        end
+      end
+
+      def edit
+        @interview = @application_choice.interviews.find(interview_id)
+
+        @wizard = InterviewWizard.new(interview_store, interview_form_context_params.merge(current_step: 'check', action: action))
+        @wizard.save_state!
+      end
+
+      def update
+        @wizard = InterviewWizard.new(interview_store, interview_params)
+        @wizard.save_state!
+        @interview = @application_choice.interviews.find(interview_id)
+
+        if @wizard.valid?
+          redirect_to edit_provider_interface_application_choice_interview_check_path(@application_choice, @interview)
+        else
+          track_validation_error(@wizard)
+          render 'provider_interface/interviews/edit'
+        end
+      end
+
+    private
+
+      def interview_id
+        params.permit(:application_choice_interview_id)[:application_choice_interview_id]
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/interviews/checks_controller.rb
+++ b/app/controllers/provider_interface/interviews/checks_controller.rb
@@ -11,7 +11,7 @@ module ProviderInterface
         @wizard.save_state!
 
         if @wizard.valid?
-          redirect_to new_provider_interface_interviews_check_path(@application_choice)
+          redirect_to new_provider_interface_application_choice_interviews_check_path(@application_choice)
         else
           track_validation_error(@wizard)
           render 'provider_interface/interviews/new'

--- a/app/controllers/provider_interface/interviews/checks_controller.rb
+++ b/app/controllers/provider_interface/interviews/checks_controller.rb
@@ -21,12 +21,13 @@ module ProviderInterface
       def edit
         @interview = @application_choice.interviews.find(interview_id)
 
-        @wizard = InterviewWizard.new(interview_store, interview_form_context_params.merge(current_step: 'check', action: action))
+        @wizard = InterviewWizard.new(edit_interview_store(interview_id),
+                                      interview_form_context_params.merge(current_step: 'check', action: action))
         @wizard.save_state!
       end
 
       def update
-        @wizard = InterviewWizard.new(interview_store, interview_params)
+        @wizard = InterviewWizard.new(edit_interview_store(interview_id), interview_params)
         @wizard.save_state!
         @interview = @application_choice.interviews.find(interview_id)
 

--- a/app/helpers/interview_path_helper.rb
+++ b/app/helpers/interview_path_helper.rb
@@ -8,9 +8,9 @@ module InterviewPathHelper
       edit_provider_interface_application_choice_interview_path(application_choice, interview, params)
     elsif step.to_sym == :check
       if interview
-        check_provider_interface_application_choice_interview_path(application_choice, interview, params)
+        edit_provider_interface_application_choice_interview_check_path(application_choice, interview, params)
       else
-        check_provider_interface_application_choice_interviews_path(application_choice, params)
+        new_provider_interface_interviews_check_path(application_choice, params)
       end
     end
   end

--- a/app/helpers/interview_path_helper.rb
+++ b/app/helpers/interview_path_helper.rb
@@ -1,0 +1,17 @@
+module InterviewPathHelper
+  def interview_path_for(application_choice, wizard, interview, step, params = {})
+    if step.to_sym == :referer
+      wizard.referer
+    elsif step.to_sym == :input
+      new_provider_interface_application_choice_interview_path(application_choice, params)
+    elsif step.to_sym == :edit
+      edit_provider_interface_application_choice_interview_path(application_choice, interview, params)
+    elsif step.to_sym == :check
+      if interview
+        check_provider_interface_application_choice_interview_path(application_choice, interview, params)
+      else
+        check_provider_interface_application_choice_interviews_path(application_choice, params)
+      end
+    end
+  end
+end

--- a/app/helpers/interview_path_helper.rb
+++ b/app/helpers/interview_path_helper.rb
@@ -10,7 +10,7 @@ module InterviewPathHelper
       if interview
         edit_provider_interface_application_choice_interview_check_path(application_choice, interview, params)
       else
-        new_provider_interface_interviews_check_path(application_choice, params)
+        new_provider_interface_application_choice_interviews_check_path(application_choice, params)
       end
     end
   end

--- a/app/views/provider_interface/interviews/check.html.erb
+++ b/app/views/provider_interface/interviews/check.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, t("#{@translation_prefix}.page_title") %>
-<% content_for :before_content, govuk_back_link_to(request.referer) %>
+<% content_for :before_content, govuk_back_link_to(interview_path_for(@application_choice, @wizard, @interview, @wizard.previous_step, back: true)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -13,7 +13,7 @@
     <% if @interview.present? %>
       <%= govuk_button_to t('.update.confirm'), { action: 'update', id: @interview.id }, method: :put %>
     <% else %>
-      <%= govuk_button_to t('.confirm'), { action: 'commit' }, method: :post %>
+      <%= govuk_button_to t('.confirm'), { action: 'create' }, method: :post %>
     <% end %>
 
     <p class="govuk-body">

--- a/app/views/provider_interface/interviews/checks/edit.html.erb
+++ b/app/views/provider_interface/interviews/checks/edit.html.erb
@@ -1,23 +1,18 @@
-<% content_for :browser_title, t("#{@translation_prefix}.page_title") %>
+<% content_for :browser_title, t('.page_title') %>
 <% content_for :before_content, govuk_back_link_to(interview_path_for(@application_choice, @wizard, @interview, @wizard.previous_step, back: true)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
-      <%= t("#{@translation_prefix}.title") %>
+      <%= t('.title') %>
     </h1>
 
     <%= render ProviderInterface::InterviewDetailsComponent.new(@wizard, @interview) %>
 
-    <% if @interview.present? %>
-      <%= govuk_button_to t('.update.confirm'), { action: 'update', id: @interview.id }, method: :put %>
-    <% else %>
-      <%= govuk_button_to t('.confirm'), { action: 'create' }, method: :post %>
-    <% end %>
-
+    <%= govuk_button_to t('.confirm'), provider_interface_application_choice_interview_path(@application_choice, @interview), method: :put %>
     <p class="govuk-body">
-      <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice.id), no_visited_state: true %>
+      <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice), class: 'govuk-link--no-visited-state' %>
     </p>
   </div>
 </div>

--- a/app/views/provider_interface/interviews/checks/new.html.erb
+++ b/app/views/provider_interface/interviews/checks/new.html.erb
@@ -1,0 +1,19 @@
+<% content_for :browser_title, t('.page_title') %>
+<% content_for :before_content, govuk_back_link_to(interview_path_for(@application_choice, @wizard, nil, @wizard.previous_step, back: true)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
+      <%= t('.title') %>
+    </h1>
+
+    <%= render ProviderInterface::InterviewDetailsComponent.new(@wizard, @interview) %>
+
+    <%= govuk_button_to t('.confirm'), provider_interface_application_choice_interviews_path, method: :post %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice), class: 'govuk-link--no-visited-state' %>
+    </p>
+  </div>
+</div>

--- a/app/views/provider_interface/interviews/edit.html.erb
+++ b/app/views/provider_interface/interviews/edit.html.erb
@@ -1,12 +1,12 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_interviews_path(@application_choice)) %>
+<% content_for :before_content, govuk_back_link_to(interview_path_for(@application_choice, @wizard, @interview, @wizard.previous_step, back: true)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render ProviderInterface::InterviewFormComponent.new(
       application_choice: @application_choice,
       form_model: @wizard,
-      form_url: check_provider_interface_application_choice_interview_path(@application_choice, @interview),
+      form_url: preview_provider_interface_application_choice_interview_path(@application_choice, @interview),
       form_heading: t('.title'),
     ) %>
 

--- a/app/views/provider_interface/interviews/edit.html.erb
+++ b/app/views/provider_interface/interviews/edit.html.erb
@@ -6,7 +6,8 @@
     <%= render ProviderInterface::InterviewFormComponent.new(
       application_choice: @application_choice,
       form_model: @wizard,
-      form_url: preview_provider_interface_application_choice_interview_path(@application_choice, @interview),
+      form_url: provider_interface_application_choice_interview_check_path(@application_choice, @interview),
+      form_method: :put,
       form_heading: t('.title'),
     ) %>
 

--- a/app/views/provider_interface/interviews/new.html.erb
+++ b/app/views/provider_interface/interviews/new.html.erb
@@ -1,12 +1,12 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(request.referer) %>
+<% content_for :before_content, govuk_back_link_to(interview_path_for(@application_choice, @wizard, nil, @wizard.previous_step, back: true)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render ProviderInterface::InterviewFormComponent.new(
       application_choice: @application_choice,
       form_model: @wizard,
-      form_url: new_check_provider_interface_application_choice_interviews_path(@application_choice),
+      form_url: preview_provider_interface_application_choice_interviews_path(@application_choice),
       form_heading: t('.title'),
     ) %>
 

--- a/app/views/provider_interface/interviews/new.html.erb
+++ b/app/views/provider_interface/interviews/new.html.erb
@@ -6,7 +6,7 @@
     <%= render ProviderInterface::InterviewFormComponent.new(
       application_choice: @application_choice,
       form_model: @wizard,
-      form_url: preview_provider_interface_application_choice_interviews_path(@application_choice),
+      form_url: provider_interface_interviews_check_path(@application_choice),
       form_heading: t('.title'),
     ) %>
 

--- a/app/views/provider_interface/interviews/new.html.erb
+++ b/app/views/provider_interface/interviews/new.html.erb
@@ -6,7 +6,7 @@
     <%= render ProviderInterface::InterviewFormComponent.new(
       application_choice: @application_choice,
       form_model: @wizard,
-      form_url: provider_interface_interviews_check_path(@application_choice),
+      form_url: provider_interface_application_choice_interviews_check_path(@application_choice),
       form_heading: t('.title'),
     ) %>
 

--- a/config/locales/provider_interface/interviews.yml
+++ b/config/locales/provider_interface/interviews.yml
@@ -7,11 +7,12 @@ en:
         title: Set up an interview
       edit:
         title: Change interview details
-      check:
-        page_title: Set up Interview
-        title: Check and send interview details
-        confirm: Send interview details
-        update:
+      checks:
+        new:
+          page_title: Set up Interview
+          title: Check and send interview details
+          confirm: Send interview details
+        edit:
           page_title: Change interview details
           title: Check and send new interview details
           confirm: Send new interview details

--- a/config/locales/provider_interface/interviews.yml
+++ b/config/locales/provider_interface/interviews.yml
@@ -15,7 +15,7 @@ en:
           page_title: Change interview details
           title: Check and send new interview details
           confirm: Send new interview details
-      commit:
+      create:
         success: Interview set up
       update:
         success: Interview changed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -730,7 +730,7 @@ Rails.application.routes.draw do
         resource :check, only: %i[edit update], controller: 'interviews/checks'
       end
 
-      namespace :interviews do
+      namespace :interviews, as: :application_choice_interviews do
         resource :check, only: %i[new create]
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -720,19 +720,19 @@ Rails.application.routes.draw do
 
       resources :notes, only: %i[index show new create], as: :application_choice_notes
 
-      resources :interviews, only: %i[new edit index], as: :application_choice_interviews do
+      resources :interviews, only: %i[new create update edit index], as: :application_choice_interviews do
         collection do
-          get '/new/check', to: 'interviews#check'
-          post '/new/check', to: 'interviews#check'
-          post '/confirm', to: 'interviews#commit'
+          post :preview
+          get :check
         end
 
         member do
+          get :check
+          post :preview
+
           get :cancel
           post '/cancel/review/', to: 'interviews#review_cancel'
           post '/cancel/confirm/', to: 'interviews#confirm_cancel'
-          post '/check', to: 'interviews#check'
-          put '/update', to: 'interviews#update'
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -721,19 +721,17 @@ Rails.application.routes.draw do
       resources :notes, only: %i[index show new create], as: :application_choice_notes
 
       resources :interviews, only: %i[new create update edit index], as: :application_choice_interviews do
-        collection do
-          post :preview
-          get :check
-        end
-
         member do
-          get :check
-          post :preview
-
           get :cancel
           post '/cancel/review/', to: 'interviews#review_cancel'
           post '/cancel/confirm/', to: 'interviews#confirm_cancel'
         end
+
+        resource :check, only: %i[edit update], controller: 'interviews/checks'
+      end
+
+      namespace :interviews do
+        resource :check, only: %i[new create]
       end
     end
 

--- a/spec/components/provider_interface/interview_form_component_spec.rb
+++ b/spec/components/provider_interface/interview_form_component_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ProviderInterface::InterviewFormComponent do
   let(:interview_preferences) { nil }
   let(:application_form) { build_stubbed(:application_form, interview_preferences: interview_preferences) }
   let(:application_choice) { build_stubbed(:submitted_application_choice, application_form: application_form) }
+  let(:form_method) { :post }
 
   let(:form_object_class) do
     Class.new do
@@ -17,6 +18,7 @@ RSpec.describe ProviderInterface::InterviewFormComponent do
     described_class.new(
       application_choice: application_choice,
       form_model: form_object,
+      form_method: form_method,
       form_url: '',
       form_heading: 'Heading',
     )
@@ -29,6 +31,22 @@ RSpec.describe ProviderInterface::InterviewFormComponent do
 
   it 'renders the title' do
     expect(render.css('h1').first.text).to eq('Heading')
+  end
+
+  describe 'form_method' do
+    context 'when none is specified' do
+      it 'defaults to POST', wip: true do
+        expect(render.css('form').attr('method').value).to eq('post')
+      end
+    end
+
+    context 'when one is specified', wip: true do
+      let(:form_method) { :get }
+
+      it 'updates the value to the one specified' do
+        expect(render.css('form').attr('method').value).to eq('get')
+      end
+    end
   end
 
   describe 'interview preferences' do

--- a/spec/helpers/interview_path_helper_spec.rb
+++ b/spec/helpers/interview_path_helper_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe InterviewPathHelper do
       context 'when there is no existing interview' do
         it 'returns the collection check path' do
           expect(helper.interview_path_for(application_choice, wizard, nil, 'check'))
-            .to eq(new_provider_interface_interviews_check_path(application_choice, {}))
+            .to eq(new_provider_interface_application_choice_interviews_check_path(application_choice, {}))
         end
       end
 

--- a/spec/helpers/interview_path_helper_spec.rb
+++ b/spec/helpers/interview_path_helper_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe InterviewPathHelper do
+  let(:application_choice) { build_stubbed(:application_choice) }
+  let(:wizard) { instance_double(ProviderInterface::InterviewWizard, referer: 'referer-url') }
+  let!(:interview) { build_stubbed(:interview) }
+
+  describe '#interview_path_for' do
+    context 'when mode is :input' do
+      it 'returns the new interview path' do
+        expect(helper.interview_path_for(application_choice, wizard, nil, 'input'))
+          .to eq(new_provider_interface_application_choice_interview_path(application_choice, {}))
+      end
+    end
+
+    context 'when mode is :edit' do
+      it 'returns the edit interview path' do
+        expect(helper.interview_path_for(application_choice, wizard, interview, 'edit'))
+          .to eq(edit_provider_interface_application_choice_interview_path(application_choice, interview, {}))
+      end
+    end
+
+    context 'when mode is :check' do
+      context 'when there is no existing interview' do
+        it 'returns the collection check path' do
+          expect(helper.interview_path_for(application_choice, wizard, nil, 'check'))
+            .to eq(check_provider_interface_application_choice_interviews_path(application_choice, {}))
+        end
+      end
+
+      context 'when there is an existing interview' do
+        it 'returns the interview check path' do
+          expect(helper.interview_path_for(application_choice, wizard, interview, 'check'))
+            .to eq(check_provider_interface_application_choice_interview_path(application_choice, interview, {}))
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/interview_path_helper_spec.rb
+++ b/spec/helpers/interview_path_helper_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe InterviewPathHelper do
       context 'when there is no existing interview' do
         it 'returns the collection check path' do
           expect(helper.interview_path_for(application_choice, wizard, nil, 'check'))
-            .to eq(check_provider_interface_application_choice_interviews_path(application_choice, {}))
+            .to eq(new_provider_interface_interviews_check_path(application_choice, {}))
         end
       end
 
       context 'when there is an existing interview' do
         it 'returns the interview check path' do
           expect(helper.interview_path_for(application_choice, wizard, interview, 'check'))
-            .to eq(check_provider_interface_application_choice_interview_path(application_choice, interview, {}))
+            .to eq(edit_provider_interface_application_choice_interview_check_path(application_choice, interview, {}))
         end
       end
     end

--- a/spec/requests/provider_interface/interviews/checks_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews/checks_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ProviderInterface::Interviews::ChecksController, type: :request d
 
     context 'POST create' do
       it 'redirects to the interviews index' do
-        post provider_interface_interviews_check_path(application_choice)
+        post provider_interface_application_choice_interviews_check_path(application_choice)
 
         expect(response.status).to eq(302)
         expect(response.redirect_url).to eq(provider_interface_application_choice_interviews_url(application_choice))
@@ -46,7 +46,7 @@ RSpec.describe ProviderInterface::Interviews::ChecksController, type: :request d
 
     it 'tracks validation errors on preview' do
       expect {
-        post provider_interface_interviews_check_path(application_choice),
+        post provider_interface_application_choice_interviews_check_path(application_choice),
              params: { provider_interface_interview_wizard: { location: 'here' } }
       }.to change(ValidationError, :count).by(1)
     end

--- a/spec/requests/provider_interface/interviews/checks_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews/checks_controller_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::Interviews::ChecksController, type: :request do
+  include DfESignInHelpers
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions, :with_set_up_interviews) }
+  let(:provider) { provider_user.providers.first }
+  let(:application_form) { build(:application_form, :minimum_info) }
+  let(:course) { build(:course, :open_on_apply, provider: provider) }
+  let(:course_option) { build(:course_option, course: course) }
+  let!(:interview) { create(:interview, application_choice: application_choice) }
+
+  before do
+    allow(DfESignInUser).to receive(:load_from_session).and_return(provider_user)
+
+    user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+  end
+
+  describe 'going back when the interview store has been cleared' do
+    let!(:application_choice) do
+      create(:application_choice, :awaiting_provider_decision, application_form: application_form, course_option: course_option)
+    end
+
+    let(:store) { instance_double(WizardStateStores::RedisStore, read: nil) }
+
+    before { allow(WizardStateStores::RedisStore).to receive(:new).and_return(store) }
+
+    context 'POST create' do
+      it 'redirects to the interviews index' do
+        post provider_interface_interviews_check_path(application_choice)
+
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(provider_interface_application_choice_interviews_url(application_choice))
+      end
+    end
+  end
+
+  describe 'validation errors' do
+    let(:application_choice) do
+      create(:application_choice, :awaiting_provider_decision, application_form: application_form, course_option: course_option)
+    end
+
+    let(:store) { instance_double(WizardStateStores::RedisStore, read: %({ "provider_user" : "#{provider_user.id}" }), write: true) }
+
+    before { allow(WizardStateStores::RedisStore).to receive(:new).and_return(store) }
+
+    it 'tracks validation errors on preview' do
+      expect {
+        post provider_interface_interviews_check_path(application_choice),
+             params: { provider_interface_interview_wizard: { location: 'here' } }
+      }.to change(ValidationError, :count).by(1)
+    end
+
+    it 'tracks validation errors on update' do
+      expect {
+        put provider_interface_application_choice_interview_check_path(application_choice, interview),
+            params: { provider_interface_interview_wizard: { location: 'here' } }
+      }.to change(ValidationError, :count).by(1)
+    end
+  end
+end

--- a/spec/requests/provider_interface/interviews_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews_controller_spec.rb
@@ -89,15 +89,6 @@ RSpec.describe ProviderInterface::InterviewsController, type: :request do
         expect(response.redirect_url).to eq(provider_interface_application_choice_interviews_url(application_choice))
       end
     end
-
-    context 'POST to preview' do
-      it 'redirects to the interviews index' do
-        post preview_provider_interface_application_choice_interviews_path(application_choice)
-
-        expect(response.status).to eq(302)
-        expect(response.redirect_url).to eq(provider_interface_application_choice_interviews_url(application_choice))
-      end
-    end
   end
 
   describe 'validation errors' do
@@ -108,13 +99,6 @@ RSpec.describe ProviderInterface::InterviewsController, type: :request do
     let(:store) { instance_double(WizardStateStores::RedisStore, read: %({ "provider_user" : "#{provider_user.id}" }), write: true) }
 
     before { allow(WizardStateStores::RedisStore).to receive(:new).and_return(store) }
-
-    it 'tracks validation errors on preview' do
-      expect {
-        post preview_provider_interface_application_choice_interviews_path(application_choice),
-             params: { provider_interface_interview_wizard: { location: 'here' } }
-      }.to change(ValidationError, :count).by(1)
-    end
 
     it 'tracks validation errors on create' do
       expect {

--- a/spec/requests/provider_interface/interviews_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews_controller_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe ProviderInterface::InterviewsController, type: :request do
       end
     end
 
-    context 'POST commit' do
+    context 'POST create' do
       it 'responds with 302' do
-        post confirm_provider_interface_application_choice_interviews_path(application_choice)
+        post provider_interface_application_choice_interviews_path(application_choice)
 
         expect(response.status).to eq(302)
       end
@@ -57,7 +57,7 @@ RSpec.describe ProviderInterface::InterviewsController, type: :request do
 
     context 'PUT update' do
       it 'responds with 302' do
-        put update_provider_interface_application_choice_interview_path(application_choice, interview)
+        put provider_interface_application_choice_interview_path(application_choice, interview)
 
         expect(response.status).to eq(302)
       end
@@ -81,18 +81,18 @@ RSpec.describe ProviderInterface::InterviewsController, type: :request do
 
     before { allow(WizardStateStores::RedisStore).to receive(:new).and_return(store) }
 
-    context 'POST to commit' do
+    context 'POST to create' do
       it 'redirects to the interviews index' do
-        post confirm_provider_interface_application_choice_interviews_path(application_choice)
+        post provider_interface_application_choice_interviews_path(application_choice)
 
         expect(response.status).to eq(302)
         expect(response.redirect_url).to eq(provider_interface_application_choice_interviews_url(application_choice))
       end
     end
 
-    context 'POST to check' do
+    context 'POST to preview' do
       it 'redirects to the interviews index' do
-        post new_check_provider_interface_application_choice_interviews_path(application_choice)
+        post preview_provider_interface_application_choice_interviews_path(application_choice)
 
         expect(response.status).to eq(302)
         expect(response.redirect_url).to eq(provider_interface_application_choice_interviews_url(application_choice))
@@ -109,23 +109,23 @@ RSpec.describe ProviderInterface::InterviewsController, type: :request do
 
     before { allow(WizardStateStores::RedisStore).to receive(:new).and_return(store) }
 
-    it 'tracks validation errors on check' do
+    it 'tracks validation errors on preview' do
       expect {
-        post new_check_provider_interface_application_choice_interviews_path(application_choice),
+        post preview_provider_interface_application_choice_interviews_path(application_choice),
              params: { provider_interface_interview_wizard: { location: 'here' } }
       }.to change(ValidationError, :count).by(1)
     end
 
-    it 'tracks validation errors on commit' do
+    it 'tracks validation errors on create' do
       expect {
-        post confirm_provider_interface_application_choice_interviews_path(application_choice),
+        post provider_interface_application_choice_interviews_path(application_choice),
              params: { provider_interface_interview_wizard: { location: 'here' } }
       }.to change(ValidationError, :count).by(1)
     end
 
     it 'tracks validation errors on update' do
       expect {
-        put update_provider_interface_application_choice_interview_path(application_choice, interview),
+        put provider_interface_application_choice_interview_path(application_choice, interview),
             params: { provider_interface_interview_wizard: { location: 'here' } }
       }.to change(ValidationError, :count).by(1)
     end

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
     when_i_visit_that_application_in_the_provider_interface
     and_i_click_set_up_an_interview
+    and_i_fill_out_the_interview_form(days_in_future: -1, time: '12pm')
+    then_i_see_an_error_message
+
+    and_i_go_back
+    then_i_should_be_on_the_application_page
+
+    and_i_click_set_up_an_interview
     and_i_fill_out_the_interview_form(days_in_future: 1, time: '10pm')
     then_i_can_check_the_interview_details(time: '10pm')
 
@@ -154,6 +161,14 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
   def and_i_go_back
     click_on 'Back'
+  end
+
+  def then_i_see_an_error_message
+    expect(page).to have_content 'There is a problem'
+  end
+
+  def then_i_should_be_on_the_application_page
+    expect(page).to have_current_path(provider_interface_application_choice_path(application_choice))
   end
 
   def then_i_see_a_success_message


### PR DESCRIPTION
## Context
When there is an error in the form submission the request referer mapped to the back link becomes the current page, which is an issue.


## Changes proposed in this pull request

Store the initial request referer on the wizard and use that instead to ensure that the back link always takes you back to the correct previous page.

## Guidance to review

Click continue on interview page without filling in any information
You should then see an error
Attempt to go back
You should be taken back to the page you were before you got to the interviews page

(doing this in QA or sandbox should result you staying on the same page)

## Link to Trello card
https://trello.com/c/2p22AdVh/4118-back-link-in-add-notes-workflow-takes-you-to-the-page-youre-already-on-after-an-error-message
(Issue and solution identical to attached trello task so resolving as part of the same ticket)

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
