### PR TITLE
Start writing provider_ids and current_recruitment_cycle_year [Part 2/5]

### DIFF
--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -21,7 +21,7 @@ module VendorAPI
     def application_choices_visible_to_provider
       GetApplicationChoicesForProviders
         .call(
-          providers: current_provider,
+          providers: [current_provider],
           vendor_api: true,
           includes: [
             offer: %i[conditions],

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -63,7 +63,7 @@ module VendorAPI
   private
 
     def application_choice
-      @application_choice ||= GetApplicationChoicesForProviders.call(providers: current_provider, vendor_api: true).find(params[:application_id])
+      @application_choice ||= GetApplicationChoicesForProviders.call(providers: [current_provider], vendor_api: true).find(params[:application_id])
     end
 
     def render_application

--- a/app/forms/support_interface/application_forms/update_offered_course_option_form.rb
+++ b/app/forms/support_interface/application_forms/update_offered_course_option_form.rb
@@ -13,10 +13,7 @@ module SupportInterface
 
         return false unless valid?
 
-        application_choice.update!(
-          current_course_option_id: course_option_id,
-          audit_comment: audit_comment,
-        )
+        application_choice.update_course_option!(course_option, audit_comment: audit_comment)
       end
 
       def course_option

--- a/app/forms/support_interface/application_forms/update_offered_course_option_form.rb
+++ b/app/forms/support_interface/application_forms/update_offered_course_option_form.rb
@@ -13,7 +13,7 @@ module SupportInterface
 
         return false unless valid?
 
-        application_choice.update_course_option!(course_option, audit_comment: audit_comment)
+        application_choice.update_course_option_and_associated_fields!(course_option, audit_comment: audit_comment)
       end
 
       def course_option

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -157,13 +157,6 @@ class ApplicationChoice < ApplicationRecord
     [provider, accredited_provider].compact.uniq
   end
 
-  def configure_initial_course_choice!(course_option)
-    update!(
-      course_option: course_option,
-      current_course_option: course_option,
-    )
-  end
-
   def unconditional_offer?
     offer&.unconditional?
   end
@@ -185,9 +178,38 @@ class ApplicationChoice < ApplicationRecord
     )
   end
 
+  def configure_initial_course_choice!(course_option)
+    update!(
+      course_option: course_option,
+      current_course_option: course_option,
+    )
+    update_course_option!(course_option)
+  end
+
+  def update_course_option!(course_option, other_fields: {}, audit_comment: nil)
+    with_this_hash = {
+      current_course_option: course_option,
+      provider_ids: provider_ids_for_access,
+      current_recruitment_cycle_year: course_option.course.recruitment_cycle_year,
+    }.merge(other_fields)
+
+    with_this_hash[:audit_comment] = audit_comment if audit_comment.present?
+
+    update!(with_this_hash)
+  end
+
 private
 
   def set_initial_status
     self.status ||= 'unsubmitted'
+  end
+
+  def provider_ids_for_access
+    [
+      course_option.course.provider.id,
+      course_option.course.accredited_provider&.id,
+      current_course_option.course.provider.id,
+      current_course_option.course.accredited_provider&.id,
+    ].compact.uniq
   end
 end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -179,25 +179,26 @@ class ApplicationChoice < ApplicationRecord
   end
 
   def configure_initial_course_choice!(course_option)
-    update!(
-      course_option: course_option,
-      current_course_option: course_option,
+    self.course_option = course_option
+
+    update_course_option_and_associated_fields!(
+      course_option,
+      other_fields: { course_option: course_option },
     )
-    update_course_option!(course_option)
   end
 
-  def update_course_option!(new_course_option, other_fields: {}, audit_comment: nil)
+  def update_course_option_and_associated_fields!(new_course_option, other_fields: {}, audit_comment: nil)
     self.current_course_option = new_course_option # provider_ids_for_access needs this
 
-    with_this_hash = {
+    attrs = {
       current_course_option: new_course_option,
       provider_ids: provider_ids_for_access,
       current_recruitment_cycle_year: new_course_option.course.recruitment_cycle_year,
     }.merge(other_fields)
 
-    with_this_hash[:audit_comment] = audit_comment if audit_comment.present?
+    attrs[:audit_comment] = audit_comment if audit_comment.present?
 
-    update!(with_this_hash)
+    update!(attrs)
   end
 
 private

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -186,11 +186,13 @@ class ApplicationChoice < ApplicationRecord
     update_course_option!(course_option)
   end
 
-  def update_course_option!(course_option, other_fields: {}, audit_comment: nil)
+  def update_course_option!(new_course_option, other_fields: {}, audit_comment: nil)
+    self.current_course_option = new_course_option # provider_ids_for_access needs this
+
     with_this_hash = {
-      current_course_option: course_option,
+      current_course_option: new_course_option,
       provider_ids: provider_ids_for_access,
-      current_recruitment_cycle_year: course_option.course.recruitment_cycle_year,
+      current_recruitment_cycle_year: new_course_option.course.recruitment_cycle_year,
     }.merge(other_fields)
 
     with_this_hash[:audit_comment] = audit_comment if audit_comment.present?

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -23,9 +23,10 @@ class ChangeOffer
 
           update_conditions_service.save
 
-          application_choice.current_course_option = course_option
-          application_choice.offer_changed_at = Time.zone.now
-          application_choice.save!
+          application_choice.update_course_option!(
+            course_option,
+            other_fields: { offer_changed_at: Time.zone.now },
+          )
 
           SetDeclineByDefault.new(application_form: application_choice.application_form).call
         end

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -23,7 +23,7 @@ class ChangeOffer
 
           update_conditions_service.save
 
-          application_choice.update_course_option!(
+          application_choice.update_course_option_and_associated_fields!(
             course_option,
             other_fields: { offer_changed_at: Time.zone.now },
           )

--- a/app/services/generate_test_applications_for_provider.rb
+++ b/app/services/generate_test_applications_for_provider.rb
@@ -63,6 +63,7 @@ private
                                         .joins(:course_options)
                                         .distinct
                                         .where(provider: provider)
+                                        .includes(%i[provider accredited_provider])
   end
 
   def courses_run_by_test_provider

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -23,9 +23,10 @@ class MakeOffer
 
           update_conditions_service.save
 
-          application_choice.current_course_option = course_option
-          application_choice.offered_at = Time.zone.now
-          application_choice.save!
+          application_choice.update_course_option!(
+            course_option,
+            other_fields: { offered_at: Time.zone.now },
+          )
 
           SetDeclineByDefault.new(application_form: application_choice.application_form).call
         end

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -23,7 +23,7 @@ class MakeOffer
 
           update_conditions_service.save
 
-          application_choice.update_course_option!(
+          application_choice.update_course_option_and_associated_fields!(
             course_option,
             other_fields: { offered_at: Time.zone.now },
           )

--- a/app/services/reinstate_conditions_met.rb
+++ b/app/services/reinstate_conditions_met.rb
@@ -28,7 +28,7 @@ class ReinstateConditionsMet
         ActiveRecord::Base.transaction do
           ApplicationStateChange.new(application_choice).reinstate_conditions_met!
 
-          application_choice.update_course_option!(
+          application_choice.update_course_option_and_associated_fields!(
             @course_option,
             other_fields: { recruited_at: new_recruited_at },
           )

--- a/app/services/reinstate_pending_conditions.rb
+++ b/app/services/reinstate_pending_conditions.rb
@@ -22,9 +22,9 @@ class ReinstatePendingConditions
         ActiveRecord::Base.transaction do
           ApplicationStateChange.new(application_choice).reinstate_pending_conditions!
           application_choice.offer.conditions.each(&:pending!)
-          @application_choice.update(
-            current_course_option_id: course_option.id,
-            recruited_at: nil,
+          @application_choice.update_course_option!(
+            course_option,
+            other_fields: { recruited_at: nil },
           )
           CandidateMailer.reinstated_offer(application_choice).deliver_later
         end

--- a/app/services/reinstate_pending_conditions.rb
+++ b/app/services/reinstate_pending_conditions.rb
@@ -22,7 +22,7 @@ class ReinstatePendingConditions
         ActiveRecord::Base.transaction do
           ApplicationStateChange.new(application_choice).reinstate_pending_conditions!
           application_choice.offer.conditions.each(&:pending!)
-          @application_choice.update_course_option!(
+          @application_choice.update_course_option_and_associated_fields!(
             course_option,
             other_fields: { recruited_at: nil },
           )

--- a/app/services/support_interface/add_course_choice_after_submission.rb
+++ b/app/services/support_interface/add_course_choice_after_submission.rb
@@ -8,12 +8,12 @@ module SupportInterface
     end
 
     def call
-      application_choice = ApplicationChoice.create!(
+      application_choice = ApplicationChoice.new(
         application_form: application_form,
-        course_option: course_option,
-        current_course_option: course_option,
         status: 'unsubmitted',
       )
+
+      application_choice.configure_initial_course_choice!(course_option)
 
       SendApplicationToProvider.call(application_choice)
 

--- a/spec/forms/candidate_interface/pick_site_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_site_form_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe CandidateInterface::PickSiteForm, type: :model do
   end
 
   describe '#save' do
-    it 'updates the course_option for an existing course choice' do
-      application_form = create(:application_form)
-      course_option = create(:course_option)
+    let(:application_form) { create(:application_form) }
+    let(:course_option) { create(:course_option) }
 
+    it 'sets course_option on the new course choice' do
       described_class.new(
         application_form: application_form,
         course_option_id: course_option.id,
@@ -50,13 +50,23 @@ RSpec.describe CandidateInterface::PickSiteForm, type: :model do
       expect(application_choice.course_option.id).to eq(course_option.id)
       expect(application_choice.current_course_option_id).to eq(course_option.id)
     end
+
+    it 'sets provider_ids when creating the application choice' do
+      described_class.new(
+        application_form: application_form,
+        course_option_id: course_option.id,
+      ).save
+
+      application_choice = application_form.reload.application_choices.first
+      expect(application_choice.provider_ids).not_to be_empty
+    end
   end
 
   describe '#update' do
-    it 'updates the course_option for an existing course choice' do
-      application_choice = create(:application_choice)
-      new_course_option = create(:course_option)
+    let(:application_choice) { create(:application_choice) }
+    let(:new_course_option) { create(:course_option) }
 
+    it 'updates the course_option for an existing course choice' do
       expect(application_choice.course_option.id).not_to eq(new_course_option.id)
 
       described_class.new(
@@ -66,6 +76,17 @@ RSpec.describe CandidateInterface::PickSiteForm, type: :model do
 
       expect(application_choice.course_option.id).to eq(new_course_option.id)
       expect(application_choice.current_course_option_id).to eq(new_course_option.id)
+    end
+
+    it 'updates provider_ids for existing course choice' do
+      expect(application_choice.course_option.id).not_to eq(new_course_option.id)
+
+      expect {
+        described_class.new(
+          application_form: application_choice.application_form,
+          course_option_id: new_course_option.id,
+        ).update(application_choice)
+      }.to change(application_choice, :provider_ids)
     end
   end
 end

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -298,13 +298,13 @@ RSpec.describe ApplicationChoice, type: :model do
     end
   end
 
-  describe '#update_course_option!' do
+  describe '#update_course_option_and_associated_fields!' do
     let(:application_choice) { create(:application_choice, :awaiting_provider_decision) }
     let(:course) { create(:course, :with_accredited_provider) }
     let(:course_option) { create(:course_option, course: course) }
 
     it 'sets current_course_option_id' do
-      expect { application_choice.update_course_option! course_option }
+      expect { application_choice.update_course_option_and_associated_fields! course_option }
         .to change(application_choice, :current_course_option_id).to(course_option.id)
     end
 
@@ -315,27 +315,27 @@ RSpec.describe ApplicationChoice, type: :model do
         course.accredited_provider.id,
       ]
 
-      expect { application_choice.update_course_option! course_option }
+      expect { application_choice.update_course_option_and_associated_fields! course_option }
         .to change(application_choice, :provider_ids).to(expected_ids)
     end
 
     it 'sets current_recruitment_cycle_year' do
       expected_year = course.recruitment_cycle_year
 
-      expect { application_choice.update_course_option! course_option }
+      expect { application_choice.update_course_option_and_associated_fields! course_option }
         .to change(application_choice, :current_recruitment_cycle_year).to(expected_year)
     end
 
     it 'can set additional fields in same operation' do
       expect {
-        application_choice.update_course_option!(course_option, other_fields: {
+        application_choice.update_course_option_and_associated_fields!(course_option, other_fields: {
           recruited_at: Time.zone.now,
         })
       }.to change(application_choice, :recruited_at)
     end
 
     it 'supports setting audit_comment', with_audited: true do
-      application_choice.update_course_option!(course_option, audit_comment: 'zendesk')
+      application_choice.update_course_option_and_associated_fields!(course_option, audit_comment: 'zendesk')
       expect(application_choice.audits.last.comment).to eq('zendesk')
     end
   end

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -61,16 +61,18 @@ RSpec.describe ChangeOffer do
                providers: [application_choice.course_option.provider])
       end
 
-      it 'then it executes the service without errors ' do
+      it 'then it calls various services' do
         set_declined_by_default = instance_double(SetDeclineByDefault, call: true)
         allow(SetDeclineByDefault)
             .to receive(:new).with(application_form: application_choice.application_form)
                     .and_return(set_declined_by_default)
+        allow(application_choice).to receive(:update_course_option!)
 
         change_offer.save!
 
         expect(update_conditions_service).to have_received(:save)
         expect(set_declined_by_default).to have_received(:call)
+        expect(application_choice).to have_received(:update_course_option!)
       end
     end
 

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -66,13 +66,13 @@ RSpec.describe ChangeOffer do
         allow(SetDeclineByDefault)
             .to receive(:new).with(application_form: application_choice.application_form)
                     .and_return(set_declined_by_default)
-        allow(application_choice).to receive(:update_course_option!)
+        allow(application_choice).to receive(:update_course_option_and_associated_fields!)
 
         change_offer.save!
 
         expect(update_conditions_service).to have_received(:save)
         expect(set_declined_by_default).to have_received(:call)
-        expect(application_choice).to have_received(:update_course_option!)
+        expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
       end
     end
 

--- a/spec/services/make_offer_spec.rb
+++ b/spec/services/make_offer_spec.rb
@@ -67,14 +67,14 @@ RSpec.describe MakeOffer do
         allow(SendNewOfferEmailToCandidate)
             .to receive(:new).with(application_choice: application_choice)
                     .and_return(send_new_offer_email_to_candidate)
-        allow(application_choice).to receive(:update_course_option!)
+        allow(application_choice).to receive(:update_course_option_and_associated_fields!)
 
         make_offer.save!
 
         expect(set_declined_by_default).to have_received(:call)
         expect(send_new_offer_email_to_candidate).to have_received(:call)
         expect(update_conditions_service).to have_received(:save)
-        expect(application_choice).to have_received(:update_course_option!)
+        expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
       end
     end
 

--- a/spec/services/make_offer_spec.rb
+++ b/spec/services/make_offer_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe MakeOffer do
     end
 
     describe 'if the provided details are correct' do
-      it 'then it executes the service without errors ' do
+      it 'then calls various services' do
         set_declined_by_default = instance_double(SetDeclineByDefault, call: true)
         send_new_offer_email_to_candidate = instance_double(SendNewOfferEmailToCandidate, call: true)
         allow(SetDeclineByDefault)
@@ -67,12 +67,14 @@ RSpec.describe MakeOffer do
         allow(SendNewOfferEmailToCandidate)
             .to receive(:new).with(application_choice: application_choice)
                     .and_return(send_new_offer_email_to_candidate)
+        allow(application_choice).to receive(:update_course_option!)
 
         make_offer.save!
 
         expect(set_declined_by_default).to have_received(:call)
         expect(send_new_offer_email_to_candidate).to have_received(:call)
         expect(update_conditions_service).to have_received(:save)
+        expect(application_choice).to have_received(:update_course_option!)
       end
     end
 

--- a/spec/services/reinstate_conditions_met_spec.rb
+++ b/spec/services/reinstate_conditions_met_spec.rb
@@ -91,10 +91,10 @@ RSpec.describe ReinstateConditionsMet do
   end
 
   describe 'other dependencies' do
-    it 'calls update_course_option!' do
-      allow(application_choice).to receive(:update_course_option!)
+    it 'calls update_course_option_and_associated_fields!' do
+      allow(application_choice).to receive(:update_course_option_and_associated_fields!)
       service.save
-      expect(application_choice).to have_received(:update_course_option!)
+      expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
     end
   end
 end

--- a/spec/services/reinstate_conditions_met_spec.rb
+++ b/spec/services/reinstate_conditions_met_spec.rb
@@ -89,4 +89,12 @@ RSpec.describe ReinstateConditionsMet do
       expect(reinstate.errors[:course_option]).to include('does not belong to the current cycle')
     end
   end
+
+  describe 'other dependencies' do
+    it 'calls update_course_option!' do
+      allow(application_choice).to receive(:update_course_option!)
+      service.save
+      expect(application_choice).to have_received(:update_course_option!)
+    end
+  end
 end

--- a/spec/services/reinstate_pending_conditions_spec.rb
+++ b/spec/services/reinstate_pending_conditions_spec.rb
@@ -80,10 +80,10 @@ RSpec.describe ReinstatePendingConditions do
   end
 
   describe 'other dependencies' do
-    it 'calls update_course_option!' do
-      allow(application_choice).to receive(:update_course_option!)
+    it 'calls update_course_option_and_associated_fields!' do
+      allow(application_choice).to receive(:update_course_option_and_associated_fields!)
       service.save
-      expect(application_choice).to have_received(:update_course_option!)
+      expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
     end
   end
 end

--- a/spec/services/reinstate_pending_conditions_spec.rb
+++ b/spec/services/reinstate_pending_conditions_spec.rb
@@ -78,4 +78,12 @@ RSpec.describe ReinstatePendingConditions do
       expect(reinstate.errors[:course_option]).to include('does not belong to the current cycle')
     end
   end
+
+  describe 'other dependencies' do
+    it 'calls update_course_option!' do
+      allow(application_choice).to receive(:update_course_option!)
+      service.save
+      expect(application_choice).to have_received(:update_course_option!)
+    end
+  end
 end

--- a/spec/services/support_interface/add_course_choice_after_submission_spec.rb
+++ b/spec/services/support_interface/add_course_choice_after_submission_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe SupportInterface::AddCourseChoiceAfterSubmission do
       expect(called.application_form).to eq(application_form)
       expect(called.course_option).to eq(course_option)
       expect(called.status).to eq('unsubmitted')
+      expect(called.provider_ids).not_to be_empty
+      expect(called.current_recruitment_cycle_year).to be_present
       expect(SendApplicationToProvider).to have_received(:call).with(called)
     end
   end


### PR DESCRIPTION
## Context

We are going to ship the contents of https://github.com/DFE-Digital/apply-for-teacher-training/tree/4111-improve-performance-of-get-applications using multiple PRs. This PR builds on https://github.com/DFE-Digital/apply-for-teacher-training/pull/5462

This PR makes the application write to `provider_ids` and `current_recruitment_cycle_year` whenever the course option is updated.

## Changes proposed in this pull request

Write to these fields when:
- candidate adds or updates a course choice
- provider makes an offer
- provider changes an offer
- provider reinstates a deferred offer (either into pending_conditions or recruited state)

## Guidance to review

I've added an `#update_course_option!` directly on ApplicationChoice because we already have multiple services for different types of events which would set `current_course_option_id` on an application choice directly and adding an intermediate service for this felt like overkill. Plus this way we also have `provider_ids_for_access` defined in one place. Does this make sense?

Factories will be updated to populate these fields in the last PR of the series, when services start reading from the new fields.

I have changed `GetApplicationChoicesForProviders.call(providers: provider)` calls to `GetApplicationChoicesForProviders.call(providers: [provider])` because when the new version of the service is in, passing a provider rather than an array will not work anymore.

## Link to Trello card

https://trello.com/c/SWVm48T0

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
