### PR TITLE
Update GIT/BAT API

### DIFF
--- a/app/controllers/candidate_api/candidates_controller.rb
+++ b/app/controllers/candidate_api/candidates_controller.rb
@@ -52,6 +52,8 @@ module CandidateAPI
                   id: application.id,
                   created_at: application.created_at,
                   updated_at: application.updated_at,
+                  application_status: ProcessState.new(application).state,
+                  application_phase: application.phase,
                 }
               end,
           },

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -95,6 +95,8 @@ class ApplicationForm < ApplicationRecord
     if (form.changed & PUBLISHED_FIELDS).any?
       touch_choices
     end
+
+    candidate.update!(candidate_api_updated_at: Time.zone.now) if form.changed.include?('phase')
   end
 
   after_commit :geocode_address_if_required

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -9,7 +9,7 @@ class SubmitApplication
   def call
     application_form.update!(submitted_at: Time.zone.now)
 
-    application_choices.includes(%i[course_option current_course_option provider accredited_provider]).each do |application_choice|
+    application_choices.includes(%i[course_option current_course_option provider accredited_provider application_form candidate]).each do |application_choice|
       SendApplicationToProvider.call(application_choice)
     end
 

--- a/config/candidate-api.yml
+++ b/config/candidate-api.yml
@@ -90,49 +90,49 @@ components:
         - application_forms
       properties:
         created_at:
-         type: string
-         format: date-time
-         description: Time of candidate creation
-         example: 2021-05-20T12:34:00Z
+          type: string
+          format: date-time
+          description: Time of candidate creation
+          example: 2021-05-20T12:34:00Z
         updated_at:
-         type: string
-         format: date-time
-         description: Time of last change
-         example: 2021-05-20T12:34:00Z
+          type: string
+          format: date-time
+          description: Time of last change
+          example: 2021-05-20T12:34:00Z
         email_address:
-         type: string
-         description: Candidate email address
-         example: email@example.com
+          type: string
+          description: Candidate email address
+          example: email@example.com
         application_status:
-         type: string
-         description: The status of the candidates current application form
-         enum:
-          - never_signed_in
-          - unsubmitted_not_started_form
-          - unsubmitted_in_progress
-          - awaiting_provider_decisions
-          - awaiting_candidate_response
-          - recruited
-          - pending_conditions
-          - offer_deferred
-          - ended_without_success
-          - unknown_state
-         example: awaiting_provider_decisions
+          type: string
+          description: The status of the candidates current application form
+          enum:
+            - never_signed_in
+            - unsubmitted_not_started_form
+            - unsubmitted_in_progress
+            - awaiting_provider_decisions
+            - awaiting_candidate_response
+            - recruited
+            - pending_conditions
+            - offer_deferred
+            - ended_without_success
+            - unknown_state
+          example: awaiting_provider_decisions
         application_phase:
-         type: string
-         nullable: true
-         description: The phase of the candidates current application. In the first phase, "Apply 1", the
+          type: string
+          nullable: true
+          description: The phase of the candidates current application. In the first phase, "Apply 1", the
             candidate can choose up to 3 courses. If all of those choices are rejected,
             declined, or withdrawn, the user can go into "Apply 2". This means
             they can choose 1 course at a time.
-         enum:
-          - apply_1
-          - apply_2
-         example: apply_1
+          enum:
+            - apply_1
+            - apply_2
+          example: apply_1
         application_forms:
-         type: array
-         items:
-          "$ref": "#/components/schemas/ApplicationForm"
+          type: array
+          items:
+            "$ref": "#/components/schemas/ApplicationForm"
     ApplicationForm:
       type: object
       required:
@@ -142,44 +142,44 @@ components:
         - application_phase
       properties:
         id:
-         type: integer
-         description: The unique ID of the candidates application form
-         example: 10
+          type: integer
+          description: The unique ID of the candidates application form
+          example: 10
         created_at:
-         type: string
-         format: date-time
-         description: The date an application was created
-         example: 2021-05-20T12:34:00Z
+          type: string
+          format: date-time
+          description: The date an application was created
+          example: 2021-05-20T12:34:00Z
         updated_at:
-         type: string
-         format: date-time
-         description: Time of last change
-         example: 2021-05-20T12:34:00Z
+          type: string
+          format: date-time
+          description: Time of last change
+          example: 2021-05-20T12:34:00Z
         application_status:
-         type: string
-         description: The status of the candidates current application form
-         enum:
-          - never_signed_in
-          - unsubmitted_not_started_form
-          - unsubmitted_in_progress
-          - awaiting_provider_decisions
-          - awaiting_candidate_response
-          - recruited
-          - pending_conditions
-          - offer_deferred
-          - ended_without_success
-          - unknown_state
-         example: awaiting_provider_decisions
+          type: string
+          description: The status of the candidates current application form
+          enum:
+            - never_signed_in
+            - unsubmitted_not_started_form
+            - unsubmitted_in_progress
+            - awaiting_provider_decisions
+            - awaiting_candidate_response
+            - recruited
+            - pending_conditions
+            - offer_deferred
+            - ended_without_success
+            - unknown_state
+          example: awaiting_provider_decisions
         application_phase:
-         type: string
-         description: The phase of the candidates current application. In the first phase, "Apply 1", the
+          type: string
+          description: The phase of the candidates current application. In the first phase, "Apply 1", the
             candidate can choose up to 3 courses. If all of those choices are rejected,
             declined, or withdrawn, the user can go into "Apply 2". This means
             they can choose 1 course at a time.
-         enum:
-          - apply_1
-          - apply_2
-         example: apply_1
+          enum:
+            - apply_1
+            - apply_2
+          example: apply_1
     UnauthorizedResponse:
       type: object
       required:

--- a/config/candidate-api.yml
+++ b/config/candidate-api.yml
@@ -155,6 +155,31 @@ components:
          format: date-time
          description: Time of last change
          example: 2021-05-20T12:34:00Z
+        application_status:
+         type: string
+         description: The status of the candidates current application form
+         enum:
+          - never_signed_in
+          - unsubmitted_not_started_form
+          - unsubmitted_in_progress
+          - awaiting_provider_decisions
+          - awaiting_candidate_response
+          - recruited
+          - pending_conditions
+          - offer_deferred
+          - ended_without_success
+          - unknown_state
+         example: awaiting_provider_decisions
+        application_phase:
+         type: string
+         description: The phase of the candidates current application. In the first phase, "Apply 1", the
+            candidate can choose up to 3 courses. If all of those choices are rejected,
+            declined, or withdrawn, the user can go into "Apply 2". This means
+            they can choose 1 course at a time.
+         enum:
+          - apply_1
+          - apply_2
+         example: apply_1
     UnauthorizedResponse:
       type: object
       required:

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -50,6 +50,13 @@ RSpec.describe ApplicationForm do
           end
         end
       end
+
+      it 'updates the candidates `candidate_api_updated_at` when phase is updated' do
+        application_form = create(:completed_application_form)
+
+        expect { application_form.update(phase: 'apply_2') }
+          .to(change { application_form.candidate.candidate_api_updated_at })
+      end
     end
   end
 

--- a/spec/requests/candidate_api/get_candidates_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_spec.rb
@@ -69,7 +69,11 @@ RSpec.describe 'GET /candidate-api/candidates', type: :request do
     expect(response_data.size).to eq(2)
 
     expect(response_data.first['id']).to eq(application_forms.second.id)
+    expect(response_data.first['application_phase']).to eq(application_forms.second.phase)
+    expect(response_data.first['application_status']).to eq(ProcessState.new(application_forms.second).state.to_s)
     expect(response_data.second['id']).to eq(application_forms.first.id)
+    expect(response_data.second['application_phase']).to eq(application_forms.first.phase)
+    expect(response_data.second['application_status']).to eq(ProcessState.new(application_forms.first).state.to_s)
 
     application_forms.first.update(created_at: 10.seconds.ago)
 

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -42,4 +42,23 @@ RSpec.describe ApplicationStateChange do
       expect(described_class.valid_states).to include(*described_class::STATES_NOT_VISIBLE_TO_PROVIDER)
     end
   end
+
+  describe '.persist_workflow_state' do
+    it 'updates the candidates `candidate_api_updated_at` when the state changes' do
+      application_form = create(:completed_application_form)
+      application_choice = create(:application_choice, :awaiting_provider_decision, application_form: application_form)
+
+      expect { described_class.new(application_choice).reject! }
+        .to(change { application_choice.candidate.candidate_api_updated_at })
+    end
+
+    it 'does not update the candidates `candidate_api_updated_at` when state does not change' do
+      application_form = create(:completed_application_form)
+      application_choice = create(:application_choice, :awaiting_provider_decision, application_form: application_form)
+      create(:application_choice, :awaiting_provider_decision, application_form: application_form)
+
+      expect { described_class.new(application_choice).reject! }
+        .not_to(change { application_choice.candidate.candidate_api_updated_at })
+    end
+  end
 end


### PR DESCRIPTION
## Context

We need to make a few more changes to the V1.1 API. We're going to move application status and phase to sit under each application form rather than at the top level on candidate. 

This will be done in 2 phases to avoid breaking changes. Firstly, we will add it to application form, once GIT have updated on their end. Once that is done we will remove it from the top level (candidate) on our end.

We also need to make sure we're updating the `candidate_api_updated_at`  when either of the above values are updated on any application form.

## Changes proposed in this pull request

- Update the `candidate_api_updated_at` when an application status or phase are updated
- Add application status and phase to the application forms

## Guidance to review

As application status is an abstracted state we need to see if an application forms status is updated when an application choices status is updated, as that is what triggers potential state changes at the application form level.

## Link to Trello card

https://trello.com/c/waFnqttv/3884-git-bat-api-v11-changes

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
