### PR TITLE
Data migrations for provider_ids and current_recruitment_cycle_year [Part 3/5]

### DIFF
--- a/app/services/data_migrations/populate_application_choice_current_recruitment_cycle_year.rb
+++ b/app/services/data_migrations/populate_application_choice_current_recruitment_cycle_year.rb
@@ -1,0 +1,15 @@
+module DataMigrations
+  class PopulateApplicationChoiceCurrentRecruitmentCycleYear
+    TIMESTAMP = 20210823135628
+    MANUAL_RUN = true
+
+    def change
+      ApplicationChoice.find_each(batch_size: 100) do |application_choice|
+        year = application_choice.current_course.recruitment_cycle_year
+
+        application_choice.update_columns(current_recruitment_cycle_year: year) or
+          raise "Unable to update ApplicationChoice ##{application_choice.id}"
+      end
+    end
+  end
+end

--- a/app/services/data_migrations/populate_application_choice_provider_ids.rb
+++ b/app/services/data_migrations/populate_application_choice_provider_ids.rb
@@ -1,0 +1,20 @@
+module DataMigrations
+  class PopulateApplicationChoiceProviderIds
+    TIMESTAMP = 20210819144725
+    MANUAL_RUN = true
+
+    def change
+      ApplicationChoice.find_each(batch_size: 100) do |application_choice|
+        provider_ids = [
+          application_choice.provider&.id,
+          application_choice.accredited_provider&.id,
+          application_choice.current_provider&.id,
+          application_choice.current_accredited_provider&.id,
+        ].compact.uniq
+
+        application_choice.update_columns(provider_ids: provider_ids) or
+          raise "Unable to update ApplicationChoice ##{application_choice.id}"
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,6 +1,8 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
   'DataMigrations::BackfillInvalidProviderRelationshipPermissions',
+  'DataMigrations::PopulateApplicationChoiceCurrentRecruitmentCycleYear',
+  'DataMigrations::PopulateApplicationChoiceProviderIds',
   'DataMigrations::RemoveDuplicateProvider',
   'DataMigrations::BackfillReferencesCompleted',
   'DataMigrations::CleanseEocChasersSentData',

--- a/spec/services/data_migrations/populate_application_choice_current_recruitment_cycle_year_spec.rb
+++ b/spec/services/data_migrations/populate_application_choice_current_recruitment_cycle_year_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::PopulateApplicationChoiceCurrentRecruitmentCycleYear do
+  let!(:application_choice) { create(:application_choice) }
+  let!(:application_choice_previous_year) { create(:application_choice, :previous_year) }
+
+  it 'sets current_recruitment_cycle_year' do
+    ApplicationChoice.update_all(current_recruitment_cycle_year: nil)
+
+    described_class.new.change
+
+    expected_years = [RecruitmentCycle.current_year, RecruitmentCycle.previous_year]
+    years = ApplicationChoice.order('id').all.map(&:current_recruitment_cycle_year)
+    expect(years).to eq(expected_years)
+  end
+end

--- a/spec/services/data_migrations/populate_application_choice_provider_ids_spec.rb
+++ b/spec/services/data_migrations/populate_application_choice_provider_ids_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::PopulateApplicationChoiceProviderIds do
+  let(:with_accredited_provider_a) do
+    create(:course_option, course: create(:course, :with_accredited_provider))
+  end
+
+  let(:with_accredited_provider_b) do
+    create(:course_option, course: create(:course, :with_accredited_provider))
+  end
+
+  def expected_provider_ids(application_choice)
+    [
+      application_choice.provider&.id,
+      application_choice.accredited_provider&.id,
+      application_choice.current_provider&.id,
+      application_choice.current_accredited_provider&.id,
+    ].compact.uniq
+  end
+
+  it 'adds all relevant provider ids to provider_ids array' do
+    application_choices = [
+      create(:application_choice),
+      create(:application_choice, course_option: with_accredited_provider_a),
+      create(:application_choice),
+      create(:application_choice, course_option: with_accredited_provider_a),
+    ]
+    application_choices[2].update(current_course_option: with_accredited_provider_b)
+    application_choices[3].update(current_course_option: with_accredited_provider_b)
+
+    described_class.new.change
+
+    expect(application_choices[3].reload.provider_ids.length).to eq(4)
+    expected_arrays = application_choices.map { |a| expected_provider_ids(a) }
+    expect(ApplicationChoice.all.map(&:provider_ids)).to eq(expected_arrays)
+  end
+end


### PR DESCRIPTION
## Context

We are going to ship the contents of https://github.com/DFE-Digital/apply-for-teacher-training/tree/4111-improve-performance-of-get-applications using multiple PRs. This PR depends on https://github.com/DFE-Digital/apply-for-teacher-training/pull/5466

This PR introduces a couple of manual data migrations to populate `provider_ids` and `current_recruitment_cycle_year` for existing ApplicationChoice records.

## Changes proposed in this pull request

Add two manual data migrations.

## Guidance to review

Do these migrations make sense?

## Link to Trello card

https://trello.com/c/SWVm48T0

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
