### PR TITLE
Cache course/provider count in Redis

### DIFF
--- a/app/controllers/provider_interface/start_page_controller.rb
+++ b/app/controllers/provider_interface/start_page_controller.rb
@@ -1,14 +1,19 @@
 module ProviderInterface
   class StartPageController < ProviderInterfaceController
+    COURSES_COUNT_CACHE_KEY = 'provider_interface_courses_count'.freeze
+    PROVIDERS_COUNT_CACHE_KEY = 'provider_interface_providers_count'.freeze
     before_action :redirect_authenticated_provider_user
     skip_before_action :authenticate_provider_user!
 
     layout 'base'
 
     def show
-      courses = Course.current_cycle.includes(:provider).open_on_apply
-      @course_count = courses.count
-      @provider_count = courses.map(&:provider).uniq.count
+      @course_count = Rails.cache.fetch(COURSES_COUNT_CACHE_KEY, expires_in: 24.hours) do
+        Course.current_cycle.open_on_apply.count
+      end
+      @provider_count = Rails.cache.fetch(PROVIDERS_COUNT_CACHE_KEY, expires_in: 24.hours) do
+        Course.current_cycle.includes(:provider).open_on_apply.map(&:provider).uniq.count
+      end
 
       session['post_dfe_sign_in_path'] = provider_interface_applications_path
     end

--- a/app/controllers/provider_interface/start_page_controller.rb
+++ b/app/controllers/provider_interface/start_page_controller.rb
@@ -1,20 +1,14 @@
 module ProviderInterface
   class StartPageController < ProviderInterfaceController
-    COURSES_COUNT_CACHE_KEY = 'provider_interface_courses_count'.freeze
-    PROVIDERS_COUNT_CACHE_KEY = 'provider_interface_providers_count'.freeze
+    PROVIDERS_AND_COURSES_COUNT_CACHE_KEY = 'provider_interface_providers_and_courses_count'.freeze
     before_action :redirect_authenticated_provider_user
     skip_before_action :authenticate_provider_user!
 
     layout 'base'
 
     def show
-      @course_count = Rails.cache.fetch(COURSES_COUNT_CACHE_KEY, expires_in: 24.hours) do
-        Course.current_cycle.open_on_apply.count
-      end
-      @provider_count = Rails.cache.fetch(PROVIDERS_COUNT_CACHE_KEY, expires_in: 24.hours) do
-        Course.current_cycle.includes(:provider).open_on_apply.map(&:provider).uniq.count
-      end
-
+      @provider_and_courses_cache_key = PROVIDERS_AND_COURSES_COUNT_CACHE_KEY
+      @open_courses = Course.current_cycle.includes(:provider).open_on_apply
       session['post_dfe_sign_in_path'] = provider_interface_applications_path
     end
 

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -73,26 +73,28 @@
     </div>
   </section>
 
-  <section class="app-section app-section--with-top-border">
-    <h2 class="govuk-heading-m">Who’s using Apply?</h2>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
-        <dl class="app-count">
-          <%= govuk_link_to candidate_interface_providers_path, no_visited_state: true, class: 'app-count__item' do %>
-            <dt class="app-count__key">Providers</dt>
-            <dd class="app-count__value"><%= number_with_delimiter(@provider_count) %></dd>
-          <% end %>
-          <%= govuk_link_to candidate_interface_providers_path, no_visited_state: true, class: 'app-count__item' do %>
-            <dt class="app-count__key">Courses</dt>
-            <dd class="app-count__value"><%= number_with_delimiter(@course_count) %></dd>
-          <% end %>
-        </dl>
+  <% cache @provider_and_courses_cache_key, expires_in: 24.hours do %>
+    <section class="app-section app-section--with-top-border">
+      <h2 class="govuk-heading-m">Who’s using Apply?</h2>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+          <dl class="app-count">
+            <%= govuk_link_to candidate_interface_providers_path, no_visited_state: true, class: 'app-count__item' do %>
+              <dt class="app-count__key">Providers</dt>
+              <dd class="app-count__value"><%= number_with_delimiter(@open_courses.map(&:provider).uniq.count) %></dd>
+            <% end %>
+            <%= govuk_link_to candidate_interface_providers_path, no_visited_state: true, class: 'app-count__item' do %>
+              <dt class="app-count__key">Courses</dt>
+              <dd class="app-count__value"><%= number_with_delimiter(@open_courses.count) %></dd>
+            <% end %>
+          </dl>
+        </div>
+        <div class="govuk-grid-column-two-thirds">
+          <img src="/provider/providers.png" alt="Logos for Royal Academy of Dance, Shotton Hall SCITT, Suffolk and Norfolk SCITT, Gorse SCITT, Alliance of Leading Learning and SCITTELS.">
+        </div>
       </div>
-      <div class="govuk-grid-column-two-thirds">
-        <img src="/provider/providers.png" alt="Logos for Royal Academy of Dance, Shotton Hall SCITT, Suffolk and Norfolk SCITT, Gorse SCITT, Alliance of Leading Learning and SCITTELS.">
-      </div>
-    </div>
-  </section>
+    </section>
+  <% end %>
 
   <section class="app-section app-section--with-top-border">
     <h2 class="govuk-heading-m">What providers say</h2>


### PR DESCRIPTION
## Context

see https://ukgovernmentdfe.slack.com/archives/C022NFSQADU/p1629377125046400

## Changes proposed in this pull request

Add course and provider count as a hash to redis

## Guidance to review

Correct?

## Link to Trello card

https://trello.com/c/s8RNlDyh/4165-investigate-improve-performance-of-provider-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
