### PR TITLE
Add left margin that matches box outline to ensure that left hand sid…

### DIFF
--- a/app/components/utility/filter_component.html.erb
+++ b/app/components/utility/filter_component.html.erb
@@ -115,7 +115,7 @@
               Search by candidate name or reference
             </label>
 
-            <input class="govuk-input <%= primary_filter[:css_classes] %>" id="<%= primary_filter[:name] %>" name="<%= primary_filter[:name] %>" type="text" value="<%= primary_filter[:value] %>" aria-labelledby="filter-legend-<%= primary_filter[:name] %>" autocomplete="off">
+            <input class="govuk-input app-search__input <%= primary_filter[:css_classes] %>" id="<%= primary_filter[:name] %>" name="<%= primary_filter[:name] %>" type="text" value="<%= primary_filter[:value] %>" aria-labelledby="filter-legend-<%= primary_filter[:name] %>" autocomplete="off">
           </div>
           <button class="govuk-button app-search__button" data-module="govuk-button">
             Search

--- a/app/frontend/styles/provider/_all.scss
+++ b/app/frontend/styles/provider/_all.scss
@@ -12,5 +12,6 @@
 @import "notes";
 @import "offer-panel";
 @import "rejection";
+@import "search";
 @import "timeline";
 @import "user-card";

--- a/app/frontend/styles/provider/_search.scss
+++ b/app/frontend/styles/provider/_search.scss
@@ -1,0 +1,3 @@
+.app-search__input {
+  margin-left: $govuk-focus-width;
+}


### PR DESCRIPTION
…e of outline is visible.

## Context

On the application review page, a yellow outline should appear on all sides of search input (see image). Currently, it does not appear on the left-hand-side.

## Changes proposed in this pull request
Introduce left margin to ensure that entire input is visible.

This does however also introduce the margin on the unfocused component as well (as introducing it only when focused would cause the input to move to the right, which doesnt seem right), which means that it's not aligned with the left hand side of any other elements in the pane that it lives in.

The fundamental problem is that the overflow property of `.moj-filter-layout__content` is set to hidden, but making that visible results in breaking the current layout; more specifically it results in the application-cards expanding after the end of the filter panel, which is a lot more complex to address.

## Guidance to review
### Before
<img width="750" alt="before" src="https://user-images.githubusercontent.com/159200/131036636-671c8c44-07b9-4aca-89ea-e1c13a3ae125.png">

### After
<img width="702" alt="after" src="https://user-images.githubusercontent.com/159200/131036632-9483b13b-811f-4349-bbef-de0b73dab381.png">

## Link to Trello card
https://trello.com/c/dEF7spHF/4174-focus-ring-missing-on-left-side-of-search-form

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
