### PR TITLE
Update content for feedback sections

### DIFF
--- a/app/forms/candidate_interface/application_feedback_form.rb
+++ b/app/forms/candidate_interface/application_feedback_form.rb
@@ -29,7 +29,7 @@ module CandidateInterface
       when 'degrees', 'gcse', 'other_qualifications'
         'the qualifications'
       when 'personal_statement'
-        'the personal statement and interview'
+        'the personal statement'
       else
         'this'
       end

--- a/app/views/candidate_interface/application_feedback/new.html.erb
+++ b/app/views/candidate_interface/application_feedback/new.html.erb
@@ -10,10 +10,27 @@
       <%= f.hidden_field :original_controller %>
 
       <span class="govuk-caption-xl"><%= t('application_feedback.caption') %></span>
-      <%= f.govuk_text_area :feedback, label: { text: t('page_titles.application_feedback', section: @application_feedback_form.section_name), size: 'xl', tag: 'h1' }, rows: 5, max_words: 300, threshold: 90 %>
 
-      <%= f.govuk_radio_buttons_fieldset :consent_to_be_contacted, inline: true, legend: { text: t('application_feedback.consent_to_be_contacted.label'), size: 'm' } do %>
-        <%= f.govuk_radio_button :consent_to_be_contacted, true, label: { text: t('application_feedback.consent_to_be_contacted.yes') }, link_errors: true %>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.application_feedback', section: @application_feedback_form.section_name) %>
+      </h1>
+
+      <div class='govuk-body'>If you’re experiencing a technical issue the quickest way to get help is by emailing <%= bat_contact_mail_to %>.</div> 
+      <div class='govuk-body'>For advice about teacher training, <%= govuk_link_to('call us or chat online', t('get_into_teaching.url_online_chat')) %>.</div>
+
+      <%= f.govuk_text_area(
+        :feedback,
+        label: { text: t(
+          'application_section_feedback.details_label',
+          section: @application_feedback_form.section_name,
+        ), size: 'm' },
+        rows: 5,
+        max_words: 300,
+        threshold: 90,
+      ) %>
+
+      <%= f.govuk_radio_buttons_fieldset :consent_to_be_contacted, legend: { text: t('application_feedback.consent_to_be_contacted.label'), size: 'm' } do %>
+        <%= f.govuk_radio_button :consent_to_be_contacted, true, label: { text: t('application_feedback.consent_to_be_contacted.yes', email_address: current_candidate.email_address) }, link_errors: true %>
         <%= f.govuk_radio_button :consent_to_be_contacted, false, label: { text: t('application_feedback.consent_to_be_contacted.no') } %>
       <% end %>
 

--- a/app/views/candidate_interface/application_feedback/new.html.erb
+++ b/app/views/candidate_interface/application_feedback/new.html.erb
@@ -15,7 +15,7 @@
         <%= t('page_titles.application_feedback', section: @application_feedback_form.section_name) %>
       </h1>
 
-      <div class='govuk-body'>If you’re experiencing a technical issue the quickest way to get help is by emailing <%= bat_contact_mail_to %>.</div> 
+      <div class='govuk-body'>If you’re experiencing a technical issue the quickest way to get help is by emailing <%= bat_contact_mail_to %>.</div>
       <div class='govuk-body'>For advice about teacher training, <%= govuk_link_to('call us or chat online', t('get_into_teaching.url_online_chat')) %>.</div>
 
       <%= f.govuk_text_area(

--- a/config/locales/candidate_interface/application_feedback.yml
+++ b/config/locales/candidate_interface/application_feedback.yml
@@ -3,7 +3,9 @@ en:
     caption: Help us improve this service
     feedback_link: How can we improve this section? (Opens in a new tab)
     consent_to_be_contacted:
-      label: Can we contact you about your feedback?
-      'yes': 'Yes'
+      label: Can we contact you by email about your feedback?
+      'yes': 'Yes, you can contact me at %{email_address}'
       'no': 'No'
     submit: Submit feedback
+  application_section_feedback:
+    details_label: 'Your feedback on %{section} section'

--- a/spec/system/candidate_interface/feedback/candidate_provides_feedback_while_completing_their_application_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_provides_feedback_while_completing_their_application_spec.rb
@@ -39,8 +39,11 @@ RSpec.feature 'Candidate provides feedback during the application process' do
   end
 
   def when_i_fill_in_my_feedback
-    fill_in t('page_titles.application_feedback', section: 'the references'), with: 'Me no understand.'
-    choose t('application_feedback.consent_to_be_contacted.yes')
+    fill_in(
+      t('application_section_feedback.details_label', section: 'the references'),
+      with: 'Me no understand.',
+    )
+    choose t('application_feedback.consent_to_be_contacted.yes', email_address: @candidate.email_address)
 
     click_button t('application_feedback.submit')
   end


### PR DESCRIPTION
## Context

We have feedback prompts in 3 sections of the application form:

- qualifications
- references
- personal statement

We need to update the content of all 3 feedback forms to help encourage candidates to send their feed back to the right places.

## Changes proposed in this pull request

<img width="529" alt="image" src="https://user-images.githubusercontent.com/450843/131106709-2f1d99d9-528d-46ff-9896-0e2e5003e639.png">

## Guidance to review

- Does this match the design?
- Are the tests adequate? (no new ones added)

## Link to Trello card

https://trello.com/c/koFqYnw8/3881-dev-content-updates-for-feedback-sections

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
