### PR TITLE
Remove duplicate govuk error summary from toefl page

### DIFF
--- a/app/views/candidate_interface/english_foreign_language/toefl/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/toefl/_form_fields.html.erb
@@ -1,5 +1,3 @@
-<%= f.govuk_error_summary %>
-
 <%= f.govuk_text_field(
   :registration_number,
   label: { text: 'TOEFL registration number', size: 'm' },


### PR DESCRIPTION
## Context

We're currently rendering the govuk error summary twice on the TOEFL page 

![image](https://user-images.githubusercontent.com/42515961/131489621-1466660a-d9c3-4214-b827-75e4413275ab.png)

## Changes proposed in this pull request

Remove the govuk error summary from the partial 

## Link to Trello card

https://trello.com/c/UfyqqLUl/3891-bug-duplicate-error-message

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
