### PR TITLE
Retrieve export data with batched find, batch size 150

### DIFF
--- a/app/controllers/provider_interface/application_data_export_controller.rb
+++ b/app/controllers/provider_interface/application_data_export_controller.rb
@@ -2,6 +2,8 @@ module ProviderInterface
   class ApplicationDataExportController < ProviderInterfaceController
     include StreamableDataExport
 
+    EXPORT_BATCH_SIZE = 150
+
     before_action :redirect_to_hesa_export_unless_feature_enabled
 
     def new
@@ -36,6 +38,7 @@ module ProviderInterface
           .where('courses.recruitment_cycle_year' => cycle_years)
           .where(status: statuses)
           .where('candidates.hide_in_reporting': false)
+          .find_each(batch_size: EXPORT_BATCH_SIZE)
 
         self.response_body = streamable_response(
           filename: csv_filename,


### PR DESCRIPTION
## Context

We'd like to see if performance can be improved using a batched find on the exported applications.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Uses `find_each` with a batch size of `150` when fetching applications for export.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/nPjLMPC1/4048-spike-investigate-performance-of-data-exports-in-manage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
