### PR TITLE
Start reading provider_ids and current_recruitment_cycle_year [Part 5/5]

### DIFF
--- a/app/queries/get_application_choices_for_providers.rb
+++ b/app/queries/get_application_choices_for_providers.rb
@@ -12,40 +12,32 @@ class GetApplicationChoicesForProviders
   ].freeze
 
   def self.call(providers:, vendor_api: false, includes: DEFAULT_INCLUDES, recruitment_cycle_year: RecruitmentCycle.years_visible_to_providers)
-    providers = Array.wrap(providers).select(&:present?)
+    raise MissingProvider if providers.blank? # super important!
 
-    raise MissingProvider if providers.none?
-
+    provider_ids = providers.map(&:id)
     statuses = vendor_api ? ApplicationStateChange.states_visible_to_provider_without_deferred : ApplicationStateChange.states_visible_to_provider
 
-    with_course_joins = ApplicationChoice
-      .joins('INNER JOIN course_options AS current_course_option ON current_course_option_id = current_course_option.id')
-      .joins('INNER JOIN course_options AS original_option ON course_option_id = original_option.id')
-      .joins('INNER JOIN courses AS current_course ON current_course_option.course_id = current_course.id')
-      .joins('INNER JOIN courses AS original_course ON original_option.course_id = original_course.id')
-
-    applications =
-      with_course_joins.where(
-        'original_course.provider_id' => providers,
-        'original_course.recruitment_cycle_year' => recruitment_cycle_year,
-      ).or(
-        with_course_joins.where(
-          'original_course.accredited_provider_id' => providers,
-          'original_course.recruitment_cycle_year' => recruitment_cycle_year,
-        ),
-      ).or(
-        with_course_joins.where(
-          'current_course.provider_id' => providers,
-          'current_course.recruitment_cycle_year' => recruitment_cycle_year,
-        ),
-      ).or(
-        with_course_joins.where(
-          'current_course.accredited_provider_id' => providers,
-          'current_course.recruitment_cycle_year' => recruitment_cycle_year,
-        ),
-      )
+    ApplicationChoice
+      .where(provider_ids_check(provider_ids))
+      .where(current_recruitment_cycle_year: recruitment_cycle_year)
       .where(status: statuses)
+      .includes(*includes)
+  end
 
-    applications.includes(*includes)
+  def self.provider_ids_check(provider_ids)
+    combine_with_or(
+      provider_ids.map { |id| id_in_provider_ids(id) },
+    )
+  end
+
+  def self.id_in_provider_ids(provider_id)
+    Arel::Nodes::Contains.new(
+      ApplicationChoice.arel_table[:provider_ids],
+      Arel::Nodes.build_quoted("{#{provider_id}}"),
+    )
+  end
+
+  def self.combine_with_or(conditions)
+    conditions.drop(1).inject(conditions[0]) { |a, b| a.or(b) }
   end
 end

--- a/app/queries/get_application_choices_for_providers.rb
+++ b/app/queries/get_application_choices_for_providers.rb
@@ -12,7 +12,10 @@ class GetApplicationChoicesForProviders
   ].freeze
 
   def self.call(providers:, vendor_api: false, includes: DEFAULT_INCLUDES, recruitment_cycle_year: RecruitmentCycle.years_visible_to_providers)
-    raise MissingProvider if providers.blank? # super important!
+    # It is very important to raise an error if no providers have been supplied
+    # because otherwise Rails omits the provider_ids where clause
+    # and all applications are returned
+    raise MissingProvider if providers.blank? || providers.any?(&:blank?)
 
     provider_ids = providers.map(&:id)
     statuses = vendor_api ? ApplicationStateChange.states_visible_to_provider_without_deferred : ApplicationStateChange.states_visible_to_provider
@@ -24,12 +27,27 @@ class GetApplicationChoicesForProviders
       .includes(*includes)
   end
 
+  # The reason we use separate where clauses for each provider id and
+  # combine them with ORs is that postgres doesn't support an ANY type
+  # lookup for multiple inputs e.g. '{26, 9}' = ANY(provider_ids)
+  # It allows checking that both '{26, 9}' exist in the provider_ids
+  # of an application choice, but this is not what we want.
   def self.provider_ids_check(provider_ids)
     combine_with_or(
       provider_ids.map { |id| id_in_provider_ids(id) },
     )
   end
 
+  # This is an Arel way of generating 'contains' where clauses
+  # e.g. provider_ids @> '{26}'
+  #
+  # The alternative syntax 26 = ANY(provider_ids) is not supported by Arel
+  # and couldn't use the GIN database index anyway
+  #
+  # Joining Arel constraints with .or is better than using ActiveRecord .or
+  # clauses, which results in separate queries combined together. The result
+  # of combining Arel constraints with .or can be fed to a single AR where
+  # clause.
   def self.id_in_provider_ids(provider_id)
     Arel::Nodes::Contains.new(
       ApplicationChoice.arel_table[:provider_ids],

--- a/app/services/provider_interface/sort_application_choices.rb
+++ b/app/services/provider_interface/sort_application_choices.rb
@@ -9,7 +9,7 @@ module ProviderInterface
     def self.for_task_view(application_choices)
       application_choices.from <<~WITH_TASK_VIEW_GROUP.squish
         (
-          SELECT a.*, c.recruitment_cycle_year,
+          SELECT a.*,
             CASE
               WHEN #{deferred_offers_pending_reconfirmation} THEN 1
               WHEN #{about_to_be_rejected_automatically} THEN 2
@@ -26,10 +26,6 @@ module ProviderInterface
             #{pg_days_left_to_respond} AS pg_days_left_to_respond
 
             FROM application_choices a
-            LEFT JOIN course_options option
-              ON option.id = a.current_course_option_id
-            LEFT JOIN courses c
-              ON c.id = option.course_id
         ) AS application_choices
       WITH_TASK_VIEW_GROUP
     end
@@ -38,7 +34,7 @@ module ProviderInterface
       <<~DEFERRED_OFFERS_PENDING_RECONFIRMATION.squish
         (
           status = 'offer_deferred'
-            AND c.recruitment_cycle_year = #{RecruitmentCycle.previous_year}
+            AND current_recruitment_cycle_year = #{RecruitmentCycle.previous_year}
         )
       DEFERRED_OFFERS_PENDING_RECONFIRMATION
     end
@@ -47,7 +43,7 @@ module ProviderInterface
       <<~PREVIOUS_CYCLE_PENDING_CONDITIONS.squish
         (
           status = 'pending_conditions'
-            AND c.recruitment_cycle_year = #{RecruitmentCycle.previous_year}
+            AND current_recruitment_cycle_year = #{RecruitmentCycle.previous_year}
         )
       PREVIOUS_CYCLE_PENDING_CONDITIONS
     end
@@ -56,7 +52,7 @@ module ProviderInterface
       <<~DEADLINE_APPROACHING.squish
         (
           (status = 'awaiting_provider_decision' OR status = 'interviewing')
-            AND c.recruitment_cycle_year = #{RecruitmentCycle.current_year}
+            AND current_recruitment_cycle_year = #{RecruitmentCycle.current_year}
             AND (
               DATE(reject_by_default_at)
               BETWEEN
@@ -106,7 +102,7 @@ module ProviderInterface
       <<~WAITING_ON_CANDIDATE.squish
         (
           status = 'offer'
-            AND c.recruitment_cycle_year = #{RecruitmentCycle.current_year}
+            AND current_recruitment_cycle_year = #{RecruitmentCycle.current_year}
         )
       WAITING_ON_CANDIDATE
     end
@@ -115,7 +111,7 @@ module ProviderInterface
       <<~CURRENT_CYCLE_PENDING_CONDITIONS.squish
         (
           status = 'pending_conditions'
-            AND c.recruitment_cycle_year = #{RecruitmentCycle.current_year}
+            AND current_recruitment_cycle_year = #{RecruitmentCycle.current_year}
         )
       CURRENT_CYCLE_PENDING_CONDITIONS
     end
@@ -124,7 +120,7 @@ module ProviderInterface
       <<~SUCCESSFUL_CANDIDATES.squish
         (
           status = 'recruited'
-            AND c.recruitment_cycle_year = #{RecruitmentCycle.current_year}
+            AND current_recruitment_cycle_year = #{RecruitmentCycle.current_year}
         )
       SUCCESSFUL_CANDIDATES
     end
@@ -133,7 +129,7 @@ module ProviderInterface
       <<~DEFERRED_OFFERS_CURRENT_CYCLE.squish
         (
           status = 'offer_deferred'
-            AND c.recruitment_cycle_year = #{RecruitmentCycle.current_year}
+            AND current_recruitment_cycle_year = #{RecruitmentCycle.current_year}
         )
       DEFERRED_OFFERS_CURRENT_CYCLE
     end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -83,6 +83,26 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "428e5a80ad2d4c0fdda6da0225a5a676f25a0e95c0e655344c02a4670ad0e460",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/provider_interface/sort_application_choices.rb",
+      "line": 13,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "application_choices.from(\"        (\\n          SELECT a.*,\\n            CASE\\n              WHEN #{deferred_offers_pending_reconfirmation} THEN 1\\n              WHEN #{about_to_be_rejected_automatically} THEN 2\\n              WHEN #{give_feedback_for_rbd} THEN 3\\n              WHEN #{awaiting_provider_decision_non_urgent} THEN 4\\n              WHEN #{interviewing_non_urgent} THEN 5\\n              WHEN #{pending_conditions_previous_cycle} THEN 6\\n              WHEN #{waiting_on_candidate} THEN 7\\n              WHEN #{pending_conditions_current_cycle} THEN 8\\n              WHEN #{successful_candidates} THEN 9\\n              WHEN #{deferred_offers_current_cycle} THEN 10\\n              ELSE 999\\n            END AS task_view_group,\\n            #{pg_days_left_to_respond} AS pg_days_left_to_respond\\n\\n            FROM application_choices a\\n        ) AS application_choices\\n\".squish)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ProviderInterface::SortApplicationChoices",
+        "method": "s(:self).for_task_view"
+      },
+      "user_input": "deferred_offers_pending_reconfirmation",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "471859383ef3e9fba03933907e1bb043a8a57520241d275846126e6a2425f2e1",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -183,26 +203,6 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "dece053fb978e9b4bae68ab806d70e0c144cd598ab227892133f2d61c790e2b6",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/services/provider_interface/sort_application_choices.rb",
-      "line": 13,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "application_choices.from(\"        (\\n          SELECT a.*, c.recruitment_cycle_year,\\n            CASE\\n              WHEN #{deferred_offers_pending_reconfirmation} THEN 1\\n              WHEN #{about_to_be_rejected_automatically} THEN 2\\n              WHEN #{give_feedback_for_rbd} THEN 3\\n              WHEN #{awaiting_provider_decision_non_urgent} THEN 4\\n              WHEN #{interviewing_non_urgent} THEN 5\\n              WHEN #{pending_conditions_previous_cycle} THEN 6\\n              WHEN #{waiting_on_candidate} THEN 7\\n              WHEN #{pending_conditions_current_cycle} THEN 8\\n              WHEN #{successful_candidates} THEN 9\\n              WHEN #{deferred_offers_current_cycle} THEN 10\\n              ELSE 999\\n            END AS task_view_group,\\n            #{pg_days_left_to_respond} AS pg_days_left_to_respond\\n\\n            FROM application_choices a\\n            LEFT JOIN course_options option\\n              ON option.id = a.current_course_option_id\\n            LEFT JOIN courses c\\n              ON c.id = option.course_id\\n        ) AS application_choices\\n\".squish)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ProviderInterface::SortApplicationChoices",
-        "method": "s(:self).for_task_view"
-      },
-      "user_input": "deferred_offers_pending_reconfirmation",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
       "fingerprint": "dee8e3d32c167d6090d7a67d1bc9add167f8ef7b154fcc1d1311fc7aad779a84",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -241,6 +241,6 @@
       "note": ""
     }
   ],
-  "updated": "2021-08-27 14:54:30 +0100",
+  "updated": "2021-09-02 10:50:35 +0100",
   "brakeman_version": "5.1.1"
 }

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -7,6 +7,12 @@ FactoryBot.define do
       if application_choice.current_course_option.blank?
         application_choice.current_course_option = application_choice.course_option
       end
+
+      if application_choice.current_recruitment_cycle_year.blank?
+        application_choice.current_recruitment_cycle_year = application_choice.current_course_option.course.recruitment_cycle_year
+      end
+
+      application_choice.provider_ids = application_choice.send(:provider_ids_for_access)
     end
 
     status { ApplicationStateChange.valid_states.sample }

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe ApplicationChoice, type: :model do
 
   describe '#update_course_option_and_associated_fields!' do
     let(:application_choice) { create(:application_choice, :awaiting_provider_decision) }
-    let(:course) { create(:course, :with_accredited_provider) }
+    let(:course) { create(:course, :with_accredited_provider, :previous_year) }
     let(:course_option) { create(:course_option, course: course) }
 
     it 'sets current_course_option_id' do

--- a/spec/queries/get_application_choices_for_providers_spec.rb
+++ b/spec/queries/get_application_choices_for_providers_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe GetApplicationChoicesForProviders do
       status: 'awaiting_provider_decision',
     )
 
-    returned_applications = described_class.call(providers: current_provider)
+    returned_applications = described_class.call(providers: [current_provider])
     expect(returned_applications.size).to eq(2)
   end
 
@@ -39,7 +39,7 @@ RSpec.describe GetApplicationChoicesForProviders do
       status: 'awaiting_provider_decision',
     )
 
-    returned_applications = described_class.call(providers: current_provider)
+    returned_applications = described_class.call(providers: [current_provider])
 
     expect(returned_applications.first.association(:site)).to be_loaded
     expect(returned_applications.first.association(:application_form)).to be_loaded
@@ -79,10 +79,6 @@ RSpec.describe GetApplicationChoicesForProviders do
     }.to raise_error(MissingProvider)
 
     expect {
-      described_class.call(providers: [''])
-    }.to raise_error(MissingProvider)
-
-    expect {
       described_class.call(providers: '')
     }.to raise_error(MissingProvider)
 
@@ -115,7 +111,7 @@ RSpec.describe GetApplicationChoicesForProviders do
       status: 'offer_deferred',
     )
 
-    returned_applications = described_class.call(providers: current_provider)
+    returned_applications = described_class.call(providers: [current_provider])
     expect(returned_applications.size).to eq(5)
   end
 
@@ -157,7 +153,7 @@ RSpec.describe GetApplicationChoicesForProviders do
       application_form: create(:application_form, first_name: 'Alex'),
     )
 
-    returned_applications = described_class.call(providers: current_provider)
+    returned_applications = described_class.call(providers: [current_provider])
     returned_application_names = returned_applications.map { |a| a.application_form.first_name }
 
     expect(returned_application_names).to include('Aaron', 'Jim', 'Harry')
@@ -195,7 +191,7 @@ RSpec.describe GetApplicationChoicesForProviders do
       course_option: ratified_course_option_for_past_cycle,
     )
 
-    returned_applications = described_class.call(providers: current_provider)
+    returned_applications = described_class.call(providers: [current_provider])
 
     expect(returned_applications.map(&:id)).to include(choice_for_this_cycle.id)
     expect(returned_applications.map(&:id)).not_to include(choice_for_past_cycle.id)
@@ -236,7 +232,7 @@ RSpec.describe GetApplicationChoicesForProviders do
       course_option: ratified_course_option_for_previous_cycle,
     )
 
-    returned_applications = described_class.call(providers: current_provider, recruitment_cycle_year: RecruitmentCycle.current_year)
+    returned_applications = described_class.call(providers: [current_provider], recruitment_cycle_year: RecruitmentCycle.current_year)
 
     expect(returned_applications.map(&:id)).to include(choice_for_current_cycle.id)
     expect(returned_applications.map(&:id)).not_to include(choice_for_previous_cycle.id)
@@ -260,7 +256,7 @@ RSpec.describe GetApplicationChoicesForProviders do
         status: 'offer_deferred',
       )
 
-      returned_applications = described_class.call(providers: current_provider, vendor_api: true)
+      returned_applications = described_class.call(providers: [current_provider], vendor_api: true)
       expect(returned_applications.size).to eq(1)
     end
   end
@@ -276,7 +272,7 @@ RSpec.describe GetApplicationChoicesForProviders do
         status: 'awaiting_provider_decision',
       )
 
-      returned_applications = described_class.call(providers: current_provider, includes: [course_option: :course])
+      returned_applications = described_class.call(providers: [current_provider], includes: [course_option: :course])
 
       expect(returned_applications.first.association(:site)).not_to be_loaded
       expect(returned_applications.first.association(:application_form)).not_to be_loaded

--- a/spec/queries/get_application_choices_for_providers_spec.rb
+++ b/spec/queries/get_application_choices_for_providers_spec.rb
@@ -74,17 +74,10 @@ RSpec.describe GetApplicationChoicesForProviders do
   end
 
   it 'raises an error if the provider argument is missing' do
-    expect {
-      described_class.call(providers: [])
-    }.to raise_error(MissingProvider)
-
-    expect {
-      described_class.call(providers: '')
-    }.to raise_error(MissingProvider)
-
-    expect {
-      described_class.call(providers: nil)
-    }.to raise_error(MissingProvider)
+    expect { described_class.call(providers: []) }.to raise_error(MissingProvider)
+    expect { described_class.call(providers: ['']) }.to raise_error(MissingProvider)
+    expect { described_class.call(providers: '') }.to raise_error(MissingProvider)
+    expect { described_class.call(providers: nil) }.to raise_error(MissingProvider)
   end
 
   it 'returns applications that are in a state visible to providers' do


### PR DESCRIPTION
## Context

We are going to ship the contents of https://github.com/DFE-Digital/apply-for-teacher-training/tree/4111-improve-performance-of-get-applications using multiple PRs. This PR is the final (fifth) part in the series.

This PR makes the application read from `provider_ids` and `current_recruitment_cycle_year` when `GetApplicationChoicesForProviders` and `ProviderInterface::SortApplicationChoices` are called.

## Changes proposed in this pull request

Read from `provider_ids` and `current_recruitment_cycle_year` in `GetApplicationChoicesForProviders` and `ProviderInterface::SortApplicationChoices` to avoid joins when looking for applications associated with a group of providers and a particular year.

## Guidance to review

Old GetApplicationChoicesForProviders SQL:

```sql
SELECT 
  "application_choices".* 
FROM 
  "application_choices" 
  INNER JOIN course_options AS current_course_option ON current_course_option_id = current_course_option.id 
  INNER JOIN course_options AS original_option ON course_option_id = original_option.id 
  INNER JOIN courses AS current_course ON current_course_option.course_id = current_course.id 
  INNER JOIN courses AS original_course ON original_option.course_id = original_course.id 
WHERE 
  (
    "original_course"."recruitment_cycle_year" IN (2021, 2020) 
    AND (
      "original_course"."provider_id" IN (26, 19) 
      OR "original_course"."accredited_provider_id" IN (26, 19)
    ) 
    OR "current_course"."provider_id" IN (26, 19) 
    AND "current_course"."recruitment_cycle_year" IN (2021, 2020) 
    OR "current_course"."accredited_provider_id" IN (26, 19) 
    AND "current_course"."recruitment_cycle_year" IN (2021, 2020)
  ) 
  AND "application_choices"."status" IN (
    'awaiting_provider_decision', 'interviewing', 
    'offer', 'pending_conditions', 'recruited', 
    'rejected', 'declined', 'withdrawn', 
    'conditions_not_met', 'offer_withdrawn', 
    'offer_deferred'
  )
```

Old GetApplicationChoicesForProviders query plan:

![image](https://user-images.githubusercontent.com/107591/131804611-8d47f67f-6d9c-43aa-9e2c-ac1c5d87e2aa.png)

New GetApplicationChoicesForProviders SQL:

```sql
SELECT 
  "application_choices".* 
FROM 
  "application_choices" 
WHERE 
  (
    "application_choices"."provider_ids" @ > '{26}' 
    OR "application_choices"."provider_ids" @ > '{19}'
  ) 
  AND "application_choices"."current_recruitment_cycle_year" IN (2021, 2020) 
  AND "application_choices"."status" IN (
    'awaiting_provider_decision', 'interviewing', 
    'offer', 'pending_conditions', 'recruited', 
    'rejected', 'declined', 'withdrawn', 
    'conditions_not_met', 'offer_withdrawn', 
    'offer_deferred'
  )
```

New GetApplicationChoicesForProviders query plan:

![image](https://user-images.githubusercontent.com/107591/131804756-0ec641b0-7b4f-4bf0-8eeb-e085dd7b8ff8.png)

## Link to Trello card

https://trello.com/c/SWVm48T0

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
