### PR TITLE
Add self-ratifying check for component text

### DIFF
--- a/app/components/provider_interface/user_permission_summary_component.html.erb
+++ b/app/components/provider_interface/user_permission_summary_component.html.erb
@@ -6,7 +6,7 @@
       </dt>
       <dd class="govuk-summary-list__value">
         <p class="govuk-body"><%= can_perform_permission_y_n?(permission) %></p>
-        <% if ProviderRelationshipPermissions::PERMISSIONS.include?(permission) && can_perform_permission?(permission) %>
+        <% if display_provider_permissions_text?(permission) %>
           <p>This user permission is affected by organisation permissions.</p>
           <%= render ProviderInterface::ProviderPartnerPermissionBreakdownComponent.new(provider: provider, permission: permission) %>
         <% end %>

--- a/app/components/provider_interface/user_permission_summary_component.rb
+++ b/app/components/provider_interface/user_permission_summary_component.rb
@@ -10,8 +10,16 @@ module ProviderInterface
 
   private
 
+    def display_provider_permissions_text?(permission)
+      ProviderRelationshipPermissions::PERMISSIONS.include?(permission) && can_perform_permission?(permission) && !self_ratifying_provider?
+    end
+
     def can_perform_permission?(permission)
       provider_user.provider_permissions.exists?(provider: provider, permission => true)
+    end
+
+    def self_ratifying_provider?
+      ProviderRelationshipPermissions.all_relationships_for_providers([@provider]).providers_have_open_course.none?
     end
 
     def can_perform_permission_y_n?(permission)

--- a/spec/components/previews/provider_interface/user_permission_summary_component_preview.rb
+++ b/spec/components/previews/provider_interface/user_permission_summary_component_preview.rb
@@ -49,6 +49,8 @@ module ProviderInterface
                           ratifying_provider_can_view_safeguarding_information: !random_boolean_value,
                           training_provider_can_view_diversity_information: random_boolean_value,
                           ratifying_provider_can_view_diversity_information: !random_boolean_value)
+
+        FactoryBot.create(:course, :open_on_apply, provider: training_provider, accredited_provider: provider)
       end
 
       other_providers.each do |training_provider|
@@ -61,6 +63,8 @@ module ProviderInterface
                           ratifying_provider_can_view_safeguarding_information: other_random_boolean_value,
                           training_provider_can_view_diversity_information: !other_random_boolean_value,
                           ratifying_provider_can_view_diversity_information: other_random_boolean_value)
+
+        FactoryBot.create(:course, :open_on_apply, provider: training_provider, accredited_provider: provider)
       end
 
       provider_user

--- a/spec/components/provider_interface/user_permission_summary_component_spec.rb
+++ b/spec/components/provider_interface/user_permission_summary_component_spec.rb
@@ -16,33 +16,126 @@ RSpec.describe ProviderInterface::UserPermissionSummaryComponent, type: :control
                       view_diversity_information: Faker::Boolean.boolean(true_ratio: 0.5))
   end
 
-  let(:allowed_providers) { create_list(:provider, 3) }
-  let(:prohibited_providers) { create_list(:provider, 2) }
   let(:render) do
     render_inline(described_class.new(provider_user: provider_user,
                                       provider: provider,
                                       editable: editable))
   end
 
-  before do
-    allowed_providers.each do |training_provider|
-      FactoryBot.create(:provider_relationship_permissions,
-                        training_provider: training_provider,
-                        ratifying_provider: provider,
-                        training_provider_can_make_decisions: true,
-                        training_provider_can_view_safeguarding_information: true,
-                        training_provider_can_view_diversity_information: true)
+  context 'when the provider is not self ratifying' do
+    let(:allowed_providers) { create_list(:provider, 3) }
+    let(:prohibited_providers) { create_list(:provider, 2) }
+
+    before do
+      allowed_providers.each do |training_provider|
+        FactoryBot.create(:provider_relationship_permissions,
+                          training_provider: training_provider,
+                          ratifying_provider: provider,
+                          training_provider_can_make_decisions: true,
+                          training_provider_can_view_safeguarding_information: true,
+                          training_provider_can_view_diversity_information: true)
+      end
+
+      prohibited_providers.each do |training_provider|
+        FactoryBot.create(:provider_relationship_permissions,
+                          training_provider: training_provider,
+                          ratifying_provider: provider,
+                          training_provider_can_make_decisions: false,
+                          training_provider_can_view_safeguarding_information: false,
+                          training_provider_can_view_diversity_information: false,
+                          setup_at: nil)
+      end
+
+      create(:course, :open_on_apply, provider: allowed_providers.first, accredited_provider: provider)
     end
 
-    prohibited_providers.each do |training_provider|
-      FactoryBot.create(:provider_relationship_permissions,
-                        training_provider: training_provider,
-                        ratifying_provider: provider,
-                        training_provider_can_make_decisions: false,
-                        training_provider_can_view_safeguarding_information: false,
-                        training_provider_can_view_diversity_information: false,
-                        setup_at: nil)
+    describe 'rendering details about each permission' do
+      it 'displays the correct details for Managing users' do
+        expect(row_text_selector(:manage_users, render)).to include('Manage users')
+        expect(row_text_selector(:manage_users, render)).to include(y_n(permissions.manage_users))
+      end
+
+      it 'displays the correct details for Managing organisations' do
+        expect(row_text_selector(:manage_permissions, render)).to include('Manage organisation permissions')
+        expect(row_text_selector(:manage_permissions, render)).to include(y_n(permissions.manage_organisations))
+      end
+
+      it 'displays the correct details for Manage interviews' do
+        expect(row_text_selector(:set_up_interviews, render)).to include('Manage interviews')
+        expect(row_text_selector(:set_up_interviews, render)).to include(y_n(permissions.set_up_interviews))
+      end
+
+      it 'displays the correct details for Make decisions' do
+        expect(row_text_selector(:make_decisions, render)).to include('Make offers and reject applications')
+        expect(row_text_selector(:make_decisions, render)).to include(y_n(permissions.make_decisions))
+      end
+
+      it 'displays the correct details for Viewing safeguarding information' do
+        expect(row_text_selector(:view_safeguarding_information, render)).to include('View criminal convictions and professional misconduct')
+        expect(row_text_selector(:view_safeguarding_information, render)).to include(y_n(permissions.view_safeguarding_information))
+      end
+
+      it 'displays the correct details for Viewing diversity information' do
+        expect(row_text_selector(:view_diversity_information, render)).to include('View sex, disability and ethnicity information')
+        expect(row_text_selector(:view_diversity_information, render)).to include(y_n(permissions.view_diversity_information))
+      end
+
+      context 'when user level permissions are false' do
+        before do
+          permissions.update!(view_diversity_information: false)
+        end
+
+        it 'does not display organisation level permissions' do
+          expect(row_text_selector(:view_diversity_information, render)).to include('View sex, disability and ethnicity information')
+          expect(row_text_selector(:view_diversity_information, render)).to include('No')
+          expect(row_text_selector(:view_diversity_information, render)).not_to include('This user permission is affected by organisation permissions.')
+        end
+      end
+
+      context 'when user level permissions are true' do
+        before do
+          permissions.update!(view_diversity_information: true)
+        end
+
+        it 'displays organisation level permissions' do
+          expect(row_text_selector(:view_diversity_information, render)).to include('View sex, disability and ethnicity information')
+          expect(row_text_selector(:view_diversity_information, render)).to include('Yes')
+          expect(row_text_selector(:view_diversity_information, render)).to include('This user permission is affected by organisation permissions.')
+        end
+      end
+
+      context 'when editable is true' do
+        let(:editable) { true }
+
+        it 'displays a change link' do
+          expect(row_text_selector(:view_diversity_information, render)).to include('Change')
+        end
+      end
+
+      context 'when editable is false' do
+        let(:editable) { false }
+
+        it 'does not display a change link' do
+          expect(row_text_selector(:view_diversity_information, render)).not_to include('Change')
+        end
+      end
     end
+  end
+
+  context 'when the provider only self ratifies' do
+    before do
+      permissions.update!(view_diversity_information: true)
+    end
+
+    it 'displays organisation level permissions without explanatory text' do
+      expect(row_text_selector(:view_diversity_information, render)).to include('View sex, disability and ethnicity information')
+      expect(row_text_selector(:view_diversity_information, render)).to include('Yes')
+      expect(row_text_selector(:view_diversity_information, render)).not_to include('This user permission is affected by organisation permissions.')
+    end
+  end
+
+  def y_n(boolean)
+    boolean ? 'Yes' : 'No'
   end
 
   def row_text_selector(row_name, render)
@@ -56,81 +149,5 @@ RSpec.describe ProviderInterface::UserPermissionSummaryComponent, type: :control
     }
 
     render.css('.govuk-summary-list__row')[rows[row_name]].text
-  end
-
-  describe 'rendering details about each permission' do
-    it 'displays the correct details for Managing users' do
-      expect(row_text_selector(:manage_users, render)).to include('Manage users')
-      expect(row_text_selector(:manage_users, render)).to include(y_n(permissions.manage_users))
-    end
-
-    it 'displays the correct details for Managing organisations' do
-      expect(row_text_selector(:manage_permissions, render)).to include('Manage organisation permissions')
-      expect(row_text_selector(:manage_permissions, render)).to include(y_n(permissions.manage_organisations))
-    end
-
-    it 'displays the correct details for Manage interviews' do
-      expect(row_text_selector(:set_up_interviews, render)).to include('Manage interviews')
-      expect(row_text_selector(:set_up_interviews, render)).to include(y_n(permissions.set_up_interviews))
-    end
-
-    it 'displays the correct details for Make decisions' do
-      expect(row_text_selector(:make_decisions, render)).to include('Make offers and reject applications')
-      expect(row_text_selector(:make_decisions, render)).to include(y_n(permissions.make_decisions))
-    end
-
-    it 'displays the correct details for Viewing safeguarding information' do
-      expect(row_text_selector(:view_safeguarding_information, render)).to include('View criminal convictions and professional misconduct')
-      expect(row_text_selector(:view_safeguarding_information, render)).to include(y_n(permissions.view_safeguarding_information))
-    end
-
-    it 'displays the correct details for Viewing diversity information' do
-      expect(row_text_selector(:view_diversity_information, render)).to include('View sex, disability and ethnicity information')
-      expect(row_text_selector(:view_diversity_information, render)).to include(y_n(permissions.view_diversity_information))
-    end
-
-    context 'when user level permissions are false' do
-      before do
-        permissions.update!(view_diversity_information: false)
-      end
-
-      it 'does not display organisation level permissions' do
-        expect(row_text_selector(:view_diversity_information, render)).to include('View sex, disability and ethnicity information')
-        expect(row_text_selector(:view_diversity_information, render)).to include('No')
-        expect(row_text_selector(:view_diversity_information, render)).not_to include('This user permission is affected by organisation permissions.')
-      end
-    end
-
-    context 'when user level permissions are true' do
-      before do
-        permissions.update!(view_diversity_information: true)
-      end
-
-      it 'displays organisation level permissions' do
-        expect(row_text_selector(:view_diversity_information, render)).to include('View sex, disability and ethnicity information')
-        expect(row_text_selector(:view_diversity_information, render)).to include('Yes')
-        expect(row_text_selector(:view_diversity_information, render)).to include('This user permission is affected by organisation permissions.')
-      end
-    end
-
-    context 'when editable is true' do
-      let(:editable) { true }
-
-      it 'displays a change link' do
-        expect(row_text_selector(:view_diversity_information, render)).to include('Change')
-      end
-    end
-
-    context 'when editable is false' do
-      let(:editable) { false }
-
-      it 'does not display a change link' do
-        expect(row_text_selector(:view_diversity_information, render)).not_to include('Change')
-      end
-    end
-  end
-
-  def y_n(boolean)
-    boolean ? 'Yes' : 'No'
   end
 end

--- a/spec/system/provider_interface/provider_views_their_own_user_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_views_their_own_user_permissions_spec.rb
@@ -50,7 +50,6 @@ RSpec.feature 'User permissions page' do
       expect(element_text(selector: '.govuk-summary-list__key', index: 3)).to eq('Make offers and reject applications')
       expect(element_text(selector: '.govuk-summary-list__key', index: 4)).to eq('View criminal convictions and professional misconduct')
       expect(element_text(selector: '.govuk-summary-list__key', index: 5)).to eq('View sex, disability and ethnicity information')
-      expect(element_text(selector: '.govuk-summary-list__value', index: 5)).to include('This user permission is affected by organisation permissions.')
     end
   end
 


### PR DESCRIPTION
## Context

https://trello.com/c/eG1OX1ur/4183-do-not-show-org-permissions-text-on-user-permission-summary-for-self-ratified-providers

We don't want to show the text referring to how permissions work in relationships if we're talking about a self-ratifying provider - as there won't be any relationships to refer to anyway

## Changes proposed in this pull request

Add a condition to check if the provider has any relationships which would be shown in the component - if not, then don't even bother to show anything under the 'Yes' within the permission segment.
### Old
![image](https://user-images.githubusercontent.com/25597009/131531845-8d3b4786-d360-4727-bebd-632cb4f9df2e.png)


### New
![image](https://user-images.githubusercontent.com/25597009/131531688-772434f8-c281-4e9a-8c9b-77d0a7242c04.png)

