### PR TITLE
Add indexes for provider_ids, current_recruitment_cycle_year [Part 4/5]

### DIFF
--- a/db/migrate/20210831143624_add_get_applications_indexes_to_application_choice.rb
+++ b/db/migrate/20210831143624_add_get_applications_indexes_to_application_choice.rb
@@ -1,0 +1,8 @@
+class AddGetApplicationsIndexesToApplicationChoice < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :application_choices, :provider_ids, using: 'gin', if_not_exists: true, algorithm: :concurrently
+    add_index :application_choices, :current_recruitment_cycle_year, if_not_exists: true, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20210831143624_add_get_applications_indexes_to_application_choice.rb
+++ b/db/migrate/20210831143624_add_get_applications_indexes_to_application_choice.rb
@@ -1,8 +1,15 @@
 class AddGetApplicationsIndexesToApplicationChoice < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 
-  def change
+  def up
+    safety_assured { execute 'SET statement_timeout = 0' }
     add_index :application_choices, :provider_ids, using: 'gin', if_not_exists: true, algorithm: :concurrently
     add_index :application_choices, :current_recruitment_cycle_year, if_not_exists: true, algorithm: :concurrently
+  end
+
+  def down
+    safety_assured { execute 'SET statement_timeout = 0' }
+    remove_index :application_choices, :provider_ids, if_exists: true, algorithm: :concurrently
+    remove_index :application_choices, :current_recruitment_cycle_year, if__exists: true, algorithm: :concurrently
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_26_113813) do
+ActiveRecord::Schema.define(version: 2021_08_31_143624) do
 
   create_sequence "application_choices_id_seq"
   create_sequence "application_experiences_id_seq"
@@ -102,6 +102,8 @@ ActiveRecord::Schema.define(version: 2021_08_26_113813) do
     t.index ["application_form_id", "course_option_id"], name: "index_course_option_to_application_form_id", unique: true
     t.index ["application_form_id"], name: "index_application_choices_on_application_form_id"
     t.index ["course_option_id"], name: "index_application_choices_on_course_option_id"
+    t.index ["current_recruitment_cycle_year"], name: "index_application_choices_on_current_recruitment_cycle_year"
+    t.index ["provider_ids"], name: "index_application_choices_on_provider_ids", using: :gin
   end
 
   create_table "application_experiences", force: :cascade do |t|


### PR DESCRIPTION
## Context

We are going to ship the contents of https://github.com/DFE-Digital/apply-for-teacher-training/tree/4111-improve-performance-of-get-applications using multiple PRs. This PR depends on https://github.com/DFE-Digital/apply-for-teacher-training/pull/5469, as in the data migration should be run before the indexes are created (for speed).

UPDATE: the relevant data migrations have been run, this is now ready to merge

## Changes proposed in this pull request

Add indexes for `provider_ids` and `current_recruitment_cycle_year` on application_choices.

## Guidance to review

Should be straight-forward

## Link to Trello card

https://trello.com/c/SWVm48T0

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
