### PR TITLE
Refactor actions in the UnsubmittedApplicationFormController

### DIFF
--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -8,8 +8,7 @@ module CandidateInterface
 
     def show
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
-      # @application_form = current_application
-      @application_cache_key = CacheKey.generate(@application_form_presenter.application_form.cache_key_with_version)
+      @application_cache_key = CacheKey.generate(@application_form_presenter.cache_key_with_version)
     end
 
     def review

--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -8,8 +8,8 @@ module CandidateInterface
 
     def show
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
-      @application_form = current_application
-      @application_cache_key = CacheKey.generate(@application_form.cache_key_with_version)
+      # @application_form = current_application
+      @application_cache_key = CacheKey.generate(@application_form_presenter.application_form.cache_key_with_version)
     end
 
     def review
@@ -18,8 +18,8 @@ module CandidateInterface
     end
 
     def submit_show
-      @application_form = current_application
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
+      @application_form = @application_form_presenter.application_form
 
       if @application_form_presenter.ready_to_submit?
         @further_information_form = FurtherInformationForm.new

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -1,14 +1,24 @@
 module CandidateInterface
   class ApplicationFormPresenter
-
     attr_reader :application_form
+
+    delegate :apply_2?,
+             :cache_key_with_version,
+             :candidate_has_previously_applied?,
+             :english_main_language,
+             :first_name,
+             :first_nationality,
+             :previous_application_form,
+             :phase,
+             :personal_details_completed,
+             :support_reference, to: :application_form
 
     def initialize(application_form)
       @application_form = application_form
     end
 
     def updated_at
-      "Last saved on #{@application_form.updated_at.to_s(:govuk_date_and_time)}"
+      "Last saved on #{application_form.updated_at.to_s(:govuk_date_and_time)}"
     end
 
     def sections_with_completion
@@ -28,7 +38,7 @@ module CandidateInterface
         [:degrees, degrees_completed?],
         [:maths_gcse, maths_gcse_completed?],
         [:english_gcse, english_gcse_completed?],
-        ([:science_gcse, science_gcse_completed?] if @application_form.science_gcse_needed?),
+        ([:science_gcse, science_gcse_completed?] if application_form.science_gcse_needed?),
         [:other_qualifications, other_qualifications_completed?],
         ([:efl, english_as_a_foreign_language_completed?] if display_efl_link?),
 
@@ -64,7 +74,7 @@ module CandidateInterface
 
     def application_choice_errors
       [].tap do |error_list|
-        @application_form.application_choices.each do |choice|
+        application_form.application_choices.each do |choice|
           if choice.course_not_available?
             error_list << ApplicationChoiceError.new(
               choice.course_not_available_error, choice.id
@@ -111,7 +121,7 @@ module CandidateInterface
     def reference_section_errors
       [].tap do |errors|
         # A defensive check, in case the candidate somehow ends up in this state
-        if @application_form.references_completed? && @application_form.selected_incorrect_number_of_references?
+        if application_form.references_completed? && application_form.selected_incorrect_number_of_references?
           errors << OpenStruct.new(message: I18n.t('application_form.references.review.incorrect_number_selected'), anchor: '#references')
         end
       end
@@ -124,28 +134,26 @@ module CandidateInterface
     end
 
     def application_choices_added?
-      @application_form.application_choices.present?
+      application_form.application_choices.present?
     end
 
-    def personal_details_completed?
-      @application_form.personal_details_completed?
-    end
+    delegate :personal_details_completed?, to: :application_form
 
     def contact_details_completed?
-      @application_form.contact_details_completed
+      application_form.contact_details_completed
     end
 
     def contact_details_valid?
-      form = ContactDetailsForm.build_from_application(@application_form)
+      form = ContactDetailsForm.build_from_application(application_form)
       form.valid?(:base) && form.valid?(:address) && form.valid?(:address_type)
     end
 
     def work_experience_completed?
-      @application_form.work_history_completed
+      application_form.work_history_completed
     end
 
     def references_link_text
-      if @application_form.application_references.present?
+      if application_form.application_references.present?
         I18n.t('section_items.manage_references')
       else
         I18n.t('section_items.add_references')
@@ -153,7 +161,7 @@ module CandidateInterface
     end
 
     def references_selection_path
-      if @application_form.application_references.includes(:application_form).selected.count >= 2
+      if application_form.application_references.includes(:application_form).selected.count >= 2
         Rails.application.routes.url_helpers.candidate_interface_review_selected_references_path
       else
         Rails.application.routes.url_helpers.candidate_interface_select_references_path
@@ -161,13 +169,13 @@ module CandidateInterface
     end
 
     def work_experience_path
-      if @application_form.feature_restructured_work_history && FeatureFlag.active?(:restructured_work_history)
-        if @application_form.application_work_experiences.any? || @application_form.work_history_explanation.present?
+      if application_form.feature_restructured_work_history && FeatureFlag.active?(:restructured_work_history)
+        if application_form.application_work_experiences.any? || application_form.work_history_explanation.present?
           Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_review_path('return-to' => 'application-review')
         else
           Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_path
         end
-      elsif @application_form.application_work_experiences.any? || @application_form.work_history_explanation.present?
+      elsif application_form.application_work_experiences.any? || application_form.work_history_explanation.present?
         Rails.application.routes.url_helpers.candidate_interface_work_history_show_path
       else
         Rails.application.routes.url_helpers.candidate_interface_work_history_length_path
@@ -183,7 +191,7 @@ module CandidateInterface
     end
 
     def other_qualification_path
-      if other_qualifications_completed? || other_qualifications_added? || @application_form.no_other_qualifications
+      if other_qualifications_completed? || other_qualifications_added? || application_form.no_other_qualifications
         Rails.application.routes.url_helpers.candidate_interface_review_other_qualifications_path
       else
         Rails.application.routes.url_helpers.candidate_interface_other_qualification_type_path
@@ -191,7 +199,7 @@ module CandidateInterface
     end
 
     def english_as_a_foreign_language_path
-      if @application_form.english_proficiency.present?
+      if application_form.english_proficiency.present?
         Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_review_path
       else
         Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_start_path
@@ -207,55 +215,55 @@ module CandidateInterface
     end
 
     def degrees_completed?
-      @application_form.degrees_completed
+      application_form.degrees_completed
     end
 
     def degrees_added?
-      @application_form.application_qualifications.degrees.any?
+      application_form.application_qualifications.degrees.any?
     end
 
     def maths_gcse_completed?
-      @application_form.maths_gcse_completed
+      application_form.maths_gcse_completed
     end
 
     def maths_gcse_added?
-      @application_form.maths_gcse.present?
+      application_form.maths_gcse.present?
     end
 
     def english_gcse_completed?
-      @application_form.english_gcse_completed
+      application_form.english_gcse_completed
     end
 
     def english_gcse_added?
-      @application_form.english_gcse.present?
+      application_form.english_gcse.present?
     end
 
     def science_gcse_completed?
-      @application_form.science_gcse_completed
+      application_form.science_gcse_completed
     end
 
     def science_gcse_added?
-      @application_form.science_gcse.present?
+      application_form.science_gcse.present?
     end
 
     def other_qualifications_completed?
-      @application_form.other_qualifications_completed && no_incomplete_qualifications?
+      application_form.other_qualifications_completed && no_incomplete_qualifications?
     end
 
     def other_qualifications_added?
-      @application_form.application_qualifications.other.any?
+      application_form.application_qualifications.other.any?
     end
 
     def english_as_a_foreign_language_completed?
-      @application_form.efl_completed?
+      application_form.efl_completed?
     end
 
     def becoming_a_teacher_completed?
-      @application_form.becoming_a_teacher_completed
+      application_form.becoming_a_teacher_completed
     end
 
     def becoming_a_teacher_valid?
-      BecomingATeacherForm.build_from_application(@application_form).valid?
+      BecomingATeacherForm.build_from_application(application_form).valid?
     end
 
     def becoming_a_teacher_path
@@ -267,15 +275,15 @@ module CandidateInterface
     end
 
     def becoming_a_teacher_review_pending?
-      @application_form.review_pending?(:becoming_a_teacher)
+      application_form.review_pending?(:becoming_a_teacher)
     end
 
     def subject_knowledge_completed?
-      @application_form.subject_knowledge_completed
+      application_form.subject_knowledge_completed
     end
 
     def subject_knowledge_valid?
-      SubjectKnowledgeForm.build_from_application(@application_form).valid?
+      SubjectKnowledgeForm.build_from_application(application_form).valid?
     end
 
     def subject_knowledge_path
@@ -287,65 +295,73 @@ module CandidateInterface
     end
 
     def subject_knowledge_review_pending?
-      @application_form.review_pending?(:subject_knowledge)
+      application_form.review_pending?(:subject_knowledge)
     end
 
     def interview_preferences_completed?
-      @application_form.interview_preferences_completed
+      application_form.interview_preferences_completed
     end
 
     def interview_preferences_valid?
-      InterviewPreferencesForm.build_from_application(@application_form).valid?
+      InterviewPreferencesForm.build_from_application(application_form).valid?
     end
 
     def training_with_a_disability_completed?
-      @application_form.training_with_a_disability_completed
+      application_form.training_with_a_disability_completed
     end
 
     def training_with_a_disability_valid?
-      TrainingWithADisabilityForm.build_from_application(@application_form).valid?
+      TrainingWithADisabilityForm.build_from_application(application_form).valid?
     end
 
     def course_choices_completed?
-      @application_form.course_choices_completed
+      application_form.course_choices_completed
     end
 
     def volunteering_completed?
-      @application_form.volunteering_completed
+      application_form.volunteering_completed
     end
 
     def volunteering_added?
-      @application_form.application_volunteering_experiences.any?
+      application_form.application_volunteering_experiences.any?
     end
 
     def references_completed?
-      @application_form.references_completed
+      application_form.references_completed
     end
 
     def safeguarding_completed?
-      @application_form.safeguarding_issues_completed
+      application_form.safeguarding_issues_completed
     end
 
     def safeguarding_valid?
-      SafeguardingIssuesDeclarationForm.build_from_application(@application_form).valid?
+      SafeguardingIssuesDeclarationForm.build_from_application(application_form).valid?
     end
 
     def no_incomplete_qualifications?
-      @application_form.application_qualifications.other.select(&:incomplete_other_qualification?).blank?
+      application_form.application_qualifications.other.select(&:incomplete_other_qualification?).blank?
     end
 
     def display_efl_link?
-      @application_form.international_applicant?
+      application_form.international_applicant?
     end
 
     def references
-      @application_form.application_references.includes(:application_form)
+      application_form.application_references.includes(:application_form)
+    end
+
+    def previous_application_choices_rejected?
+      application_form.previous_application_form.application_choices.rejected.any?
+    end
+
+    def right_to_work_or_study_present?
+      application_form.right_to_work_or_study.present?
     end
 
   private
 
     def show_review_volunteering?
-      no_volunteering_confirmed = @application_form.volunteering_experience == false && @application_form.application_volunteering_experiences.empty?
+      no_volunteering_confirmed = application_form.volunteering_experience == false && application_form.application_volunteering_experiences.empty?
 
       volunteering_completed? || volunteering_added? || no_volunteering_confirmed
     end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -1,5 +1,8 @@
 module CandidateInterface
   class ApplicationFormPresenter
+
+    attr_reader :application_form
+
     def initialize(application_form)
       @application_form = application_form
     end

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render CandidateInterface::CarryOverInsetTextComponent.new(application_form: @application_form_presenter.application_form) %>
 <%= render CandidateInterface::DeadlineBannerComponent.new(application_form: @application_form_presenter.application_form, flash_empty: flash.empty?) %>
-<%= render CandidateInterface::ReopenBannerComponent.new(phase: @application_form_presenter.application_form.phase, flash_empty: flash.empty?) %>
+<%= render CandidateInterface::ReopenBannerComponent.new(phase: @application_form_presenter.phase, flash_empty: flash.empty?) %>
 
 <%= render ServiceInformationBanner.new(namespace: :candidate) %>
 
@@ -17,9 +17,9 @@
       <ol class="app-task-list">
         <li class="app-task-list__item">
           <% all_sections_completed = (
-            @application_form_presenter.application_form.first_name.present? &&
-            @application_form_presenter.application_form.first_nationality.present? &&
-            (!@application_form_presenter.application_form.english_main_language.nil? || @application_form_presenter.application_form.right_to_work_or_study.present?)
+            @application_form_presenter.first_name.present? &&
+            @application_form_presenter.first_nationality.present? &&
+            (!@application_form_presenter.english_main_language.nil? || @application_form_presenter.right_to_work_or_study_present?)
           ) %>
           <%= render(TaskListItemComponent.new(
             text: t('page_titles.personal_information'),
@@ -45,10 +45,10 @@
           </p>
       </section>
     <% else %>
-      <% if @application_form_presenter.application_form.candidate_has_previously_applied? && @application_form_presenter.application_form.previous_application_form.application_choices.rejected.any? %>
-        <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @application_form_presenter.application_form.previous_application_form)) %>
+      <% if @application_form_presenter.candidate_has_previously_applied? && @application_form_presenter.previous_application_choices_rejected? %>
+        <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @application_form_presenter.previous_application_form)) %>
       <% end %>
-      <% if @application_form_presenter.application_form.candidate_has_previously_applied? && @application_form_presenter.application_form.apply_2? %>
+      <% if @application_form_presenter.candidate_has_previously_applied? && @application_form_presenter.apply_2? %>
         <%= render(CandidateInterface::ApplicationFormCourseChoiceComponent.new(
           completed: @application_form_presenter.course_choices_completed?,
         )) %>
@@ -77,9 +77,9 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
-    <%= render partial: '/candidate_interface/shared/support', locals: { support_reference: @application_form_presenter.application_form.support_reference } %>
+    <%= render partial: '/candidate_interface/shared/support', locals: { support_reference: @application_form_presenter.support_reference } %>
 
-    <% if @application_form_presenter.application_form.candidate_has_previously_applied? %>
+    <% if @application_form_presenter.candidate_has_previously_applied? %>
       <h2 class="govuk-heading-s"><%= t('section_groups.previous_applications') %></h2>
       <%= render(CandidateInterface::LinksToPreviousApplicationsComponent.new(application_form: @application_form_presenter.application_form)) %>
     <% end %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -1,8 +1,8 @@
 <% content_for :title, t('page_titles.application_form') %>
 
-<%= render CandidateInterface::CarryOverInsetTextComponent.new(application_form: @application_form) %>
-<%= render CandidateInterface::DeadlineBannerComponent.new(application_form: @application_form, flash_empty: flash.empty?) %>
-<%= render CandidateInterface::ReopenBannerComponent.new(phase: @application_form.phase, flash_empty: flash.empty?) %>
+<%= render CandidateInterface::CarryOverInsetTextComponent.new(application_form: @application_form_presenter.application_form) %>
+<%= render CandidateInterface::DeadlineBannerComponent.new(application_form: @application_form_presenter.application_form, flash_empty: flash.empty?) %>
+<%= render CandidateInterface::ReopenBannerComponent.new(phase: @application_form_presenter.application_form.phase, flash_empty: flash.empty?) %>
 
 <%= render ServiceInformationBanner.new(namespace: :candidate) %>
 
@@ -17,9 +17,9 @@
       <ol class="app-task-list">
         <li class="app-task-list__item">
           <% all_sections_completed = (
-            @application_form.first_name.present? &&
-            @application_form.first_nationality.present? &&
-            (!@application_form.english_main_language.nil? || @application_form.right_to_work_or_study.present?)
+            @application_form_presenter.application_form.first_name.present? &&
+            @application_form_presenter.application_form.first_nationality.present? &&
+            (!@application_form_presenter.application_form.english_main_language.nil? || @application_form_presenter.application_form.right_to_work_or_study.present?)
           ) %>
           <%= render(TaskListItemComponent.new(
             text: t('page_titles.personal_information'),
@@ -37,7 +37,7 @@
       </ol>
     </section>
 
-    <% if !CycleTimetable.can_add_course_choice?(@application_form) %>
+    <% if !CycleTimetable.can_add_course_choice?(@application_form_presenter.application_form) %>
       <section class="govuk-!-margin-bottom-8">
         <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.courses') %></h2>
           <p class="govuk-body">
@@ -45,10 +45,10 @@
           </p>
       </section>
     <% else %>
-      <% if @application_form.candidate_has_previously_applied? && @application_form.previous_application_form.application_choices.rejected.any? %>
-        <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @application_form.previous_application_form)) %>
+      <% if @application_form_presenter.application_form.candidate_has_previously_applied? && @application_form_presenter.application_form.previous_application_form.application_choices.rejected.any? %>
+        <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @application_form_presenter.application_form.previous_application_form)) %>
       <% end %>
-      <% if @application_form.candidate_has_previously_applied? && @application_form.apply_2? %>
+      <% if @application_form_presenter.application_form.candidate_has_previously_applied? && @application_form_presenter.application_form.apply_2? %>
         <%= render(CandidateInterface::ApplicationFormCourseChoiceComponent.new(
           completed: @application_form_presenter.course_choices_completed?,
         )) %>
@@ -61,15 +61,15 @@
     <% end %>
 
     <% cache(@application_cache_key, expires_in: 5.minutes) do %>
-      <%= render 'task_list', application_form: @application_form, application_form_presenter: @application_form_presenter %>
+      <%= render 'task_list', application_form: @application_form_presenter.application_form, application_form_presenter: @application_form_presenter %>
     <% end %>
 
     <section>
-      <% if CycleTimetable.between_cycles?(@application_form.phase) %>
+      <% if CycleTimetable.between_cycles?(@application_form_presenter.application_form.phase) %>
         <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.review') %></h2>
         <p class="govuk-body">You cannot submit your application until 9am on <%= CycleTimetable.apply_opens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.</p>
         <%= govuk_button_link_to 'Review your application', candidate_interface_application_review_path %>
-      <% elsif CycleTimetable.can_submit?(@application_form) %>
+      <% elsif CycleTimetable.can_submit?(@application_form_presenter.application_form) %>
         <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.check_and_submit') %></h2>
         <%= govuk_button_link_to t('section_items.check_and_submit'), candidate_interface_application_review_path %>
       <% end %>
@@ -77,11 +77,11 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
-    <%= render partial: '/candidate_interface/shared/support', locals: { support_reference: @application_form.support_reference } %>
+    <%= render partial: '/candidate_interface/shared/support', locals: { support_reference: @application_form_presenter.application_form.support_reference } %>
 
-    <% if @application_form.candidate_has_previously_applied? %>
+    <% if @application_form_presenter.application_form.candidate_has_previously_applied? %>
       <h2 class="govuk-heading-s"><%= t('section_groups.previous_applications') %></h2>
-      <%= render(CandidateInterface::LinksToPreviousApplicationsComponent.new(application_form: @application_form)) %>
+      <%= render(CandidateInterface::LinksToPreviousApplicationsComponent.new(application_form: @application_form_presenter.application_form)) %>
     <% end %>
   </div>
 </div>

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -1,6 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::ApplicationFormPresenter do
+  describe 'delegating methods to application form' do
+    let(:application_form_spy) { spy }
+
+    %i[
+      apply_2?
+      cache_key_with_version
+      candidate_has_previously_applied?
+      english_main_language
+      first_name
+      first_nationality
+      previous_application_form
+      phase
+      personal_details_completed
+      support_reference
+    ].each do |method|
+      it "delegates '##{method}' to the application form" do
+        described_class.new(application_form_spy).send(method)
+
+        expect(application_form_spy).to have_received(method)
+      end
+    end
+  end
+
   describe '#personal_details_completed?' do
     it 'returns true if personal details section is completed' do
       application_form = FactoryBot.build(:application_form, personal_details_completed: true)


### PR DESCRIPTION
## Context

Some of the actions in the `UnsubmittedApplicationFormController` use two objects to access all the logic it needs to render a page - an application form instance, and the same instance wrapped in a presenter.

We want to simplify this because:
- It should only need one of these things, having both seems unnecessary and confusing.
- This may be the root cause behind Skylight flagging this page as having a high object allocation.
 
## Changes proposed in this pull request

- Make the application form instance accessible via the ApplicationFormPresenter
- Delegate methods to the application form instance where appropriate 

## Guidance to review

- In terms of testing,  I'm guessing this may be a case of trial and error - we will need to deploy to see if this has an impact on Skylight metrics

## Link to Trello card

https://trello.com/c/irjmuWVe/3788-refactor-the-show-action-in-unsubmitted-application-form-controller

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
