### PR TITLE
Fix flakey data migration spec

### DIFF
--- a/spec/services/data_migrations/populate_application_choice_provider_ids_spec.rb
+++ b/spec/services/data_migrations/populate_application_choice_provider_ids_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe DataMigrations::PopulateApplicationChoiceProviderIds do
 
     expect(application_choices[3].reload.provider_ids.length).to eq(4)
     expected_arrays = application_choices.map { |a| expected_provider_ids(a) }
-    expect(ApplicationChoice.all.map(&:provider_ids)).to eq(expected_arrays)
+    actual_arrays = ApplicationChoice.order('created_at').all.map(&:provider_ids)
+
+    expect(actual_arrays).to contain_exactly(*expected_arrays)
   end
 end


### PR DESCRIPTION
## Context

This test fails from time to time because the order of returned application_choices seems to vary.

## Changes proposed in this pull request

Compare the contents of the array without worrying too much about the order.

## Guidance to review

Easy

## Link to Trello card

No card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
