### PR TITLE
Add degree requirement row and guidance

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -35,6 +35,7 @@ module CandidateInterface
         type_row(application_choice),
         course_length_row(application_choice),
         start_date_row(application_choice),
+        degree_required_row(application_choice),
         status_row(application_choice),
         rejection_reasons_row(application_choice),
         offer_withdrawal_reason_row(application_choice),
@@ -190,6 +191,15 @@ module CandidateInterface
           value: application_choice.current_course.start_date.to_s(:month_and_year),
         }
       end
+    end
+
+    def degree_required_row(application_choice)
+      return nil unless application_choice.current_course.degree_grade?
+
+      {
+        key: 'Degree requirements',
+        value: render(DegreeRequiredComponent.new(application_choice)),
+      }
     end
 
     def interview_row(application_choice)

--- a/app/components/candidate_interface/degree_required_component.html.erb
+++ b/app/components/candidate_interface/degree_required_component.html.erb
@@ -1,0 +1,17 @@
+<% if candidate_degree_grade_below_required_grade? %>
+  <%= govuk_inset_text(classes: 'govuk-inset-text app-inset-text--narrow-border app-inset-text--important govuk-!-margin-top-0 govuk-!-padding-bottom-1') do %>
+    <div class="app-inset-text__title"><%= COURSE_REQUIRED_GRADE_TEXT[@application_choice.course.degree_grade] %><div>
+      <div class="govuk-body">
+        <p>You said you have <%= DEGREE_GRADE_INSUFFICIENT_TEXT[@highest_candidate_degree_grade] %></p>
+        <p>You can:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+         <li>find a course that has a lower degree requirement</li>
+         <li>contact the provider to see if they will still consider your application</li>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+<% else %>
+  <%= COURSE_REQUIRED_GRADE_TEXT[@application_choice.course.degree_grade] %>
+<% end %>

--- a/app/components/candidate_interface/degree_required_component.html.erb
+++ b/app/components/candidate_interface/degree_required_component.html.erb
@@ -1,15 +1,13 @@
 <% if candidate_degree_grade_below_required_grade? %>
   <%= govuk_inset_text(classes: 'govuk-inset-text app-inset-text--narrow-border app-inset-text--important govuk-!-margin-top-0 govuk-!-padding-bottom-1') do %>
     <div class="app-inset-text__title"><%= COURSE_REQUIRED_GRADE_TEXT[@application_choice.course.degree_grade] %><div>
-      <div class="govuk-body">
-        <p>You said you have <%= DEGREE_GRADE_INSUFFICIENT_TEXT[@highest_candidate_degree_grade] %></p>
-        <p>You can:</p>
+      <p class="govuk-body">You said you have <%= DEGREE_GRADE_INSUFFICIENT_TEXT[@highest_degree_grade] %></p>
+      <p class="govuk-body">You can:</p>
 
-        <ul class="govuk-list govuk-list--bullet">
-         <li>find a course that has a lower degree requirement</li>
-         <li>contact the provider to see if they will still consider your application</li>
-        </ul>
-      </div>
+      <ul class="govuk-list govuk-list--bullet">
+       <li>find a course that has a lower degree requirement</li>
+       <li>contact the provider to see if they will still consider your application</li>
+      </ul>
     </div>
   <% end %>
 <% else %>

--- a/app/components/candidate_interface/degree_required_component.rb
+++ b/app/components/candidate_interface/degree_required_component.rb
@@ -1,5 +1,6 @@
 class CandidateInterface::DegreeRequiredComponent < ViewComponent::Base
   CANDIDATE_GRADES = {
+    'First class honours' => 4,
     'Upper second-class honours (2:1)' => 4,
     'Lower second-class honours (2:2)' => 3,
     'Third-class honours' => 2,
@@ -25,51 +26,49 @@ class CandidateInterface::DegreeRequiredComponent < ViewComponent::Base
     'Pass' => 'an Ordinary degree (pass).',
   }.freeze
 
+  attr_accessor :application_choice, :course_degree_requirements, :uk_bachelor_degrees
+
   def initialize(application_choice)
     @application_choice = application_choice
     @course_degree_requirements = application_choice.current_course.degree_grade
-    @candidate_degrees = candidate_non_other_uk_degrees(application_choice)
-    @highest_candidate_degree_grade = ''
+    @uk_bachelor_degrees = find_uk_bachelor_degrees(application_choice)
   end
 
   def candidate_degree_grade_below_required_grade?
-    return false if @candidate_degrees.empty? || degrees_with_other_grades_only(@candidate_degrees)
+    return false if @uk_bachelor_degrees.empty? || degrees_with_other_grades_only? || bachelors_and_masters_degree?
 
-    find_highest_degree_grade(@candidate_degrees)
-
-    COURSE_REQUIRED_GRADES[@course_degree_requirements] > CANDIDATE_GRADES[@highest_candidate_degree_grade]
+    COURSE_REQUIRED_GRADES[@course_degree_requirements] > CANDIDATE_GRADES[highest_degree_grade]
   end
 
 private
 
-  def find_highest_degree_grade(candidate_degrees)
-    counter = 0
-    candidate_degrees.each do |degree|
-      if !CANDIDATE_GRADES[degree.grade].nil? && CANDIDATE_GRADES[degree.grade] > counter
-        counter = CANDIDATE_GRADES[degree.grade]
-        @highest_candidate_degree_grade = degree.grade
-      end
-    end
+  def highest_degree_grade
+    @highest_degree_grade ||= return_highest_degree_grade
   end
 
-  def degrees_with_other_grades_only(candidate_degrees)
-    grades = []
-    candidate_degrees.each do |degree|
-      if CANDIDATE_GRADES.keys.include?(degree.grade)
-        grades << degree.grade
-      end
-    end
-    grades.empty?
+  def return_highest_degree_grade
+    grades = uk_bachelor_degrees.map(&:grade)
+    grades.max_by { |grade| CANDIDATE_GRADES[grade] }
   end
 
-  def candidate_non_other_uk_degrees(application_choice)
+  def degrees_with_other_grades_only?
+    grades = uk_bachelor_degrees.map(&:grade)
+    grades.none? { |grade| CANDIDATE_GRADES.keys.include?(grade) }
+  end
+
+  def bachelors_and_masters_degree?
+    uk_bachelor_degrees.any? && candidate_has_masters_degree?
+  end
+
+  def candidate_has_masters_degree?
     application_choice.application_form.application_qualifications
-    .where(level: 'degree', other_uk_qualification_type: nil)
-    .where(institution_country: nil).or(
-      application_choice.application_form.application_qualifications.where(institution_country: 'GB'),
-    )
-    .where(qualification_type: HESA_DEGREE_TYPES.map(&:second)).or(
-      application_choice.application_form.application_qualifications.where(qualification_type: HESA_DEGREE_TYPES.map(&:third)),
-    )
+      .where(level: 'degree', other_uk_qualification_type: nil, institution_country: [nil, 'GB'])
+      .where(qualification_type_hesa_code: HESA_DEGREE_TYPES.select { |dt| dt[3] == :master }.collect(&:first)).any?
+  end
+
+  def find_uk_bachelor_degrees(application_choice)
+    application_choice.application_form.application_qualifications
+      .where(level: 'degree', other_uk_qualification_type: nil, institution_country: [nil, 'GB'])
+      .where(qualification_type_hesa_code: HESA_DEGREE_TYPES.select { |dt| dt[3] == :bachelor }.collect(&:first))
   end
 end

--- a/app/components/candidate_interface/degree_required_component.rb
+++ b/app/components/candidate_interface/degree_required_component.rb
@@ -1,0 +1,75 @@
+class CandidateInterface::DegreeRequiredComponent < ViewComponent::Base
+  CANDIDATE_GRADES = {
+    'Upper second-class honours (2:1)' => 4,
+    'Lower second-class honours (2:2)' => 3,
+    'Third-class honours' => 2,
+    'Pass' => 1,
+  }.freeze
+
+  COURSE_REQUIRED_GRADES = {
+    'two_one' => 4,
+    'two_two' => 3,
+    'third_class' => 2,
+  }.freeze
+
+  COURSE_REQUIRED_GRADE_TEXT = {
+    'two_one' => '2:1 degree or higher (or equivalent)',
+    'two_two' => '2:2 degree or higher (or equivalent)',
+    'third_class' => 'Third-class degree or higher (or equivalent)',
+    'not_required' => 'Any degree grade',
+  }.freeze
+
+  DEGREE_GRADE_INSUFFICIENT_TEXT = {
+    'Lower second-class honours (2:2)' => 'a 2:2 degree.',
+    'Third-class honours' => 'a Third class degree.',
+    'Pass' => 'an Ordinary degree (pass).',
+  }.freeze
+
+  def initialize(application_choice)
+    @application_choice = application_choice
+    @course_degree_requirements = application_choice.current_course.degree_grade
+    @candidate_degrees = candidate_non_other_uk_degrees(application_choice)
+    @highest_candidate_degree_grade = ''
+  end
+
+  def candidate_degree_grade_below_required_grade?
+    return false if @candidate_degrees.empty? || degrees_with_other_grades_only(@candidate_degrees)
+
+    find_highest_degree_grade(@candidate_degrees)
+
+    COURSE_REQUIRED_GRADES[@course_degree_requirements] > CANDIDATE_GRADES[@highest_candidate_degree_grade]
+  end
+
+private
+
+  def find_highest_degree_grade(candidate_degrees)
+    counter = 0
+    candidate_degrees.each do |degree|
+      if !CANDIDATE_GRADES[degree.grade].nil? && CANDIDATE_GRADES[degree.grade] > counter
+        counter = CANDIDATE_GRADES[degree.grade]
+        @highest_candidate_degree_grade = degree.grade
+      end
+    end
+  end
+
+  def degrees_with_other_grades_only(candidate_degrees)
+    grades = []
+    candidate_degrees.each do |degree|
+      if CANDIDATE_GRADES.keys.include?(degree.grade)
+        grades << degree.grade
+      end
+    end
+    grades.empty?
+  end
+
+  def candidate_non_other_uk_degrees(application_choice)
+    application_choice.application_form.application_qualifications
+    .where(level: 'degree', other_uk_qualification_type: nil)
+    .where(institution_country: nil).or(
+      application_choice.application_form.application_qualifications.where(institution_country: 'GB'),
+    )
+    .where(qualification_type: HESA_DEGREE_TYPES.map(&:second)).or(
+      application_choice.application_form.application_qualifications.where(qualification_type: HESA_DEGREE_TYPES.map(&:third)),
+    )
+  end
+end

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -126,6 +126,19 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
       end
     end
 
+    context 'When a course has a required degree grade' do
+      let(:application_choice) { application_form.application_choices.first }
+      let(:result) { render_inline(described_class.new(application_form: application_form)) }
+
+      before do
+        application_choice.course.update!(degree_grade: 'two_two')
+      end
+
+      it 'renders the degree required row' do
+        expect(result.text).to include('2:2 degree or higher (or equivalent)')
+      end
+    end
+
     context 'when there are multiple site options for course' do
       before do
         create(:course_option, course: application_form.application_choices.first.course)

--- a/spec/components/candidate_interface/degree_required_component_spec.rb
+++ b/spec/components/candidate_interface/degree_required_component_spec.rb
@@ -30,9 +30,6 @@ RSpec.describe CandidateInterface::DegreeRequiredComponent, type: :component do
         institution_name: 'University of Doge',
         institution_country: 'GB',
         grade: 'Lower second-class honours (2:2)',
-        predicted_grade: false,
-        start_year: '2005',
-        award_year: '2008',
         application_form: application_form,
       )
 
@@ -46,13 +43,9 @@ RSpec.describe CandidateInterface::DegreeRequiredComponent, type: :component do
       create(
         :degree_qualification,
         qualification_type: 'Bachelor of Arts',
-        subject: 'Woof',
-        institution_name: 'University of Doge',
+        qualification_type_hesa_code: 51,
         institution_country: 'Armenia',
         grade: 'Lower second-class honours (2:2)',
-        predicted_grade: false,
-        start_year: '2005',
-        award_year: '2008',
         application_form: application_form,
       )
 
@@ -66,13 +59,9 @@ RSpec.describe CandidateInterface::DegreeRequiredComponent, type: :component do
       create(
         :degree_qualification,
         qualification_type: 'Master of Arts',
-        subject: 'Woof',
-        institution_name: 'University of Doge',
         institution_country: nil,
+        qualification_type_hesa_code: 200,
         grade: 'Merit',
-        predicted_grade: false,
-        start_year: '2005',
-        award_year: '2008',
         application_form: application_form,
       )
 
@@ -86,13 +75,9 @@ RSpec.describe CandidateInterface::DegreeRequiredComponent, type: :component do
       create(
         :degree_qualification,
         qualification_type: 'Bachelor of Arts',
-        subject: 'Woof',
-        institution_name: 'University of Doge',
         institution_country: 'GB',
         grade: 'Upper second-class honours (2:1)',
-        predicted_grade: false,
-        start_year: '2005',
-        award_year: '2008',
+        qualification_type_hesa_code: 51,
         application_form: application_form,
       )
 
@@ -106,13 +91,9 @@ RSpec.describe CandidateInterface::DegreeRequiredComponent, type: :component do
       create(
         :degree_qualification,
         qualification_type: 'Bachelor of Arts',
-        subject: 'Woof',
-        institution_name: 'University of Doge',
         institution_country: 'GB',
         grade: 'Lower second-class honours (2:2)',
-        predicted_grade: false,
-        start_year: '2005',
-        award_year: '2008',
+        qualification_type_hesa_code: 51,
         application_form: application_form,
       )
       result = render_inline(described_class.new(application_choice))
@@ -120,6 +101,34 @@ RSpec.describe CandidateInterface::DegreeRequiredComponent, type: :component do
       expect(result.text).to include('You said you have a 2:2 degree.')
       expect(result.text).to include('find a course that has a lower degree requirement')
       expect(result.text).to include('contact the provider to see if they will still consider your application')
+    end
+  end
+
+  context 'application has a masters degree and a bachelors degree below requirement' do
+    it 'renders the degree row without guidance' do
+      create(
+        :degree_qualification,
+        qualification_type: 'Bachelor of Arts',
+        institution_country: 'GB',
+        grade: 'Lower second-class honours (2:2)',
+        qualification_type_hesa_code: 51,
+        application_form: application_form,
+      )
+
+      create(
+        :degree_qualification,
+        qualification_type: 'Master of Arts',
+        institution_country: nil,
+        qualification_type_hesa_code: 200,
+        grade: 'Merit',
+        application_form: application_form,
+      )
+
+      result = render_inline(described_class.new(application_choice))
+      expect(result.text).to include('2:1 degree or higher (or equivalent)')
+      expect(result.text).not_to include('You said you have a 2:2 degree.')
+      expect(result.text).not_to include('find a course that has a lower degree requirement')
+      expect(result.text).not_to include('contact the provider to see if they will still consider your application')
     end
   end
 end

--- a/spec/components/candidate_interface/degree_required_component_spec.rb
+++ b/spec/components/candidate_interface/degree_required_component_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::DegreeRequiredComponent, type: :component do
+  let(:application_form) { create(:application_form) }
+
+  let(:course_option1) { create(:course_option, course: create(:course, :open_on_apply, degree_grade: 'two_one')) }
+
+  let(:application_choice) do
+    build_stubbed(
+      :application_choice,
+      status: :unsubmitted,
+      course_option: course_option1,
+      application_form: application_form,
+    )
+  end
+
+  context 'application has no degree and course has requirement' do
+    it 'renders the degree row without guidance' do
+      result = render_inline(described_class.new(application_choice))
+      expect(result.text).to include('2:1 degree or higher (or equivalent)')
+    end
+  end
+
+  context 'application has other degree and course has requirement' do
+    it 'renders the degree row without guidance' do
+      create(
+        :degree_qualification,
+        qualification_type: 'Other Qual',
+        subject: 'Woof',
+        institution_name: 'University of Doge',
+        institution_country: 'GB',
+        grade: 'Lower second-class honours (2:2)',
+        predicted_grade: false,
+        start_year: '2005',
+        award_year: '2008',
+        application_form: application_form,
+      )
+
+      result = render_inline(described_class.new(application_choice))
+      expect(result.text).to include('2:1 degree or higher (or equivalent)')
+    end
+  end
+
+  context 'application has non_uk degree' do
+    it 'renders the degree row without guidance' do
+      create(
+        :degree_qualification,
+        qualification_type: 'Bachelor of Arts',
+        subject: 'Woof',
+        institution_name: 'University of Doge',
+        institution_country: 'Armenia',
+        grade: 'Lower second-class honours (2:2)',
+        predicted_grade: false,
+        start_year: '2005',
+        award_year: '2008',
+        application_form: application_form,
+      )
+
+      result = render_inline(described_class.new(application_choice))
+      expect(result.text).to include('2:1 degree or higher (or equivalent)')
+    end
+  end
+
+  context 'application has degree with non standard type grade' do
+    it 'renders the degree row without guidance' do
+      create(
+        :degree_qualification,
+        qualification_type: 'Master of Arts',
+        subject: 'Woof',
+        institution_name: 'University of Doge',
+        institution_country: nil,
+        grade: 'Merit',
+        predicted_grade: false,
+        start_year: '2005',
+        award_year: '2008',
+        application_form: application_form,
+      )
+
+      result = render_inline(described_class.new(application_choice))
+      expect(result.text).to include('2:1 degree or higher (or equivalent)')
+    end
+  end
+
+  context 'application has degree at required level' do
+    it 'renders the degree row without guidance' do
+      create(
+        :degree_qualification,
+        qualification_type: 'Bachelor of Arts',
+        subject: 'Woof',
+        institution_name: 'University of Doge',
+        institution_country: 'GB',
+        grade: 'Upper second-class honours (2:1)',
+        predicted_grade: false,
+        start_year: '2005',
+        award_year: '2008',
+        application_form: application_form,
+      )
+
+      result = render_inline(described_class.new(application_choice))
+      expect(result.text).to include('2:1 degree or higher (or equivalent)')
+    end
+  end
+
+  context 'application has a degree with grade below required level' do
+    it 'renders the degree row with guidance' do
+      create(
+        :degree_qualification,
+        qualification_type: 'Bachelor of Arts',
+        subject: 'Woof',
+        institution_name: 'University of Doge',
+        institution_country: 'GB',
+        grade: 'Lower second-class honours (2:2)',
+        predicted_grade: false,
+        start_year: '2005',
+        award_year: '2008',
+        application_form: application_form,
+      )
+      result = render_inline(described_class.new(application_choice))
+      expect(result.text).to include('2:1 degree or higher (or equivalent)')
+      expect(result.text).to include('You said you have a 2:2 degree.')
+      expect(result.text).to include('find a course that has a lower degree requirement')
+      expect(result.text).to include('contact the provider to see if they will still consider your application')
+    end
+  end
+end

--- a/spec/system/candidate_interface/course_selection/candidate_can_view_degree_requirements_and_guidance_for_selected_courses_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_view_degree_requirements_and_guidance_for_selected_courses_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+RSpec.feature 'Handling duplicate course choices' do
+  include CandidateHelper
+
+  scenario 'candidate can view degree requirements and guidance for selected courses' do
+    given_i_am_signed_in
+    and_i_have_three_chosen_courses_with_different_requirements
+
+    when_i_add_a_two_two_degree
+    and_i_visit_the_course_choice_review_page
+    then_i_can_course_choices_choices_with_relevant_guidance_for_one_course
+
+    when_i_change_my_degree_grade_to_a_pass
+    and_i_visit_the_course_choice_review_page
+    then_i_can_course_choices_choices_with_relevant_guidance_for_all_courses
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_have_three_chosen_courses_with_different_requirements
+    course_option1 = create(:course_option, course: create(:course, :open_on_apply, degree_grade: 'two_one'))
+    course_option2 = create(:course_option, course: create(:course, :open_on_apply, degree_grade: 'two_two'))
+    course_option3 = create(:course_option, course: create(:course, :open_on_apply, degree_grade: 'third_class'))
+    @choice1 = create(
+      :application_choice,
+      status: :unsubmitted,
+      course_option: course_option1,
+      application_form: current_candidate.current_application,
+    )
+    @choice2 = create(
+      :application_choice,
+      status: :unsubmitted,
+      course_option: course_option2,
+      application_form: current_candidate.current_application,
+    )
+    @choice3 = create(
+      :application_choice,
+      status: :unsubmitted,
+      course_option: course_option3,
+      application_form: current_candidate.current_application,
+    )
+  end
+
+  def when_i_add_a_two_two_degree
+    visit candidate_interface_new_degree_path
+
+    choose 'UK degree'
+    fill_in 'Type of degree', with: 'BA'
+    click_button t('save_and_continue')
+
+    fill_in 'What subject is your degree?', with: 'Doge'
+    click_button t('save_and_continue')
+
+    fill_in 'Which institution did you study at?', with: 'University of Much Wow'
+    click_button t('save_and_continue')
+
+    expect(page).to have_content('Have you completed your degree?')
+    choose 'Yes'
+    click_button t('save_and_continue')
+
+    choose 'Lower second-class honours (2:2)'
+    click_button t('save_and_continue')
+
+    year_with_trailing_space = '2006 '
+    fill_in t('page_titles.what_year_did_you_start_your_degree'), with: year_with_trailing_space
+    click_button t('save_and_continue')
+    year_with_preceding_space = ' 2009'
+    fill_in t('page_titles.what_year_did_you_graduate'), with: year_with_preceding_space
+    click_button t('save_and_continue')
+    choose t('application_form.completed_radio')
+    click_button t('continue')
+  end
+
+  def and_i_visit_the_course_choice_review_page
+    visit candidate_interface_course_choices_review_path
+  end
+
+  def then_i_can_course_choices_choices_with_relevant_guidance_for_one_course
+    within "#course-choice-#{@choice1.id}" do
+      expect(page).to have_content('Degree requirements')
+      expect(page).to have_content('2:1 degree or higher (or equivalent)')
+      expect(page).to have_content('You said you have a 2:2 degree.')
+      expect(page).to have_content("You can:\nfind a course that has a lower degree requirement contact the provider to see if they will still consider your application")
+    end
+
+    within "#course-choice-#{@choice2.id}" do
+      expect(page).to have_content('Degree requirements')
+      expect(page).to have_content('2:2 degree or higher (or equivalent)')
+      expect(page).not_to have_content('You said you have a 2:2 degree.')
+      expect(page).not_to have_content("You can:\nfind a course that has a lower degree requirement contact the provider to see if they will still consider your application")
+    end
+
+    within "#course-choice-#{@choice3.id}" do
+      expect(page).to have_content('Degree requirements')
+      expect(page).to have_content('Third-class degree or higher (or equivalent)')
+      expect(page).not_to have_content('You said you have a 2:2 degree.')
+      expect(page).not_to have_content("You can:\nfind a course that has a lower degree requirement contact the provider to see if they will still consider your application")
+    end
+  end
+
+  def when_i_change_my_degree_grade_to_a_pass
+    visit candidate_interface_degrees_review_path
+    click_change_link('grade')
+    choose 'Pass'
+    click_button t('save_and_continue')
+  end
+
+  def then_i_can_course_choices_choices_with_relevant_guidance_for_all_courses
+    within "#course-choice-#{@choice1.id}" do
+      expect(page).to have_content('Degree requirements')
+      expect(page).to have_content('2:1 degree or higher (or equivalent)')
+      expect(page).to have_content('You said you have an Ordinary degree (pass).')
+      expect(page).to have_content("You can:\nfind a course that has a lower degree requirement contact the provider to see if they will still consider your application")
+    end
+
+    within "#course-choice-#{@choice2.id}" do
+      expect(page).to have_content('Degree requirements')
+      expect(page).to have_content('2:2 degree or higher (or equivalent)')
+      expect(page).to have_content('You said you have an Ordinary degree (pass).')
+      expect(page).to have_content("You can:\nfind a course that has a lower degree requirement contact the provider to see if they will still consider your application")
+    end
+
+    within "#course-choice-#{@choice3.id}" do
+      expect(page).to have_content('Degree requirements')
+      expect(page).to have_content('Third-class degree or higher (or equivalent)')
+      expect(page).to have_content('You said you have an Ordinary degree (pass).')
+      expect(page).to have_content("You can:\nfind a course that has a lower degree requirement contact the provider to see if they will still consider your application")
+    end
+  end
+end

--- a/spec/system/candidate_interface/course_selection/candidate_can_view_degree_requirements_and_guidance_for_selected_courses_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_view_degree_requirements_and_guidance_for_selected_courses_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Handling duplicate course choices' do
+RSpec.feature 'Viewing course choices' do
   include CandidateHelper
 
   scenario 'candidate can view degree requirements and guidance for selected courses' do
@@ -13,7 +13,7 @@ RSpec.feature 'Handling duplicate course choices' do
 
     when_i_change_my_degree_grade_to_a_pass
     and_i_visit_the_course_choice_review_page
-    then_i_can_course_choices_choices_with_relevant_guidance_for_all_courses
+    then_i_can_view_course_choices_with_relevant_guidance_for_all_courses
   end
 
   def given_i_am_signed_in
@@ -48,7 +48,7 @@ RSpec.feature 'Handling duplicate course choices' do
     visit candidate_interface_new_degree_path
 
     choose 'UK degree'
-    fill_in 'Type of degree', with: 'BA'
+    fill_in 'Type of degree', with: 'Bachelor of Arts'
     click_button t('save_and_continue')
 
     fill_in 'What subject is your degree?', with: 'Doge'
@@ -64,11 +64,9 @@ RSpec.feature 'Handling duplicate course choices' do
     choose 'Lower second-class honours (2:2)'
     click_button t('save_and_continue')
 
-    year_with_trailing_space = '2006 '
-    fill_in t('page_titles.what_year_did_you_start_your_degree'), with: year_with_trailing_space
+    fill_in t('page_titles.what_year_did_you_start_your_degree'), with: '2006'
     click_button t('save_and_continue')
-    year_with_preceding_space = ' 2009'
-    fill_in t('page_titles.what_year_did_you_graduate'), with: year_with_preceding_space
+    fill_in t('page_titles.what_year_did_you_graduate'), with: '2009'
     click_button t('save_and_continue')
     choose t('application_form.completed_radio')
     click_button t('continue')
@@ -108,7 +106,7 @@ RSpec.feature 'Handling duplicate course choices' do
     click_button t('save_and_continue')
   end
 
-  def then_i_can_course_choices_choices_with_relevant_guidance_for_all_courses
+  def then_i_can_view_course_choices_with_relevant_guidance_for_all_courses
     within "#course-choice-#{@choice1.id}" do
       expect(page).to have_content('Degree requirements')
       expect(page).to have_content('2:1 degree or higher (or equivalent)')


### PR DESCRIPTION
## Context

```
As a candidate...
I need to be able to see more easily if the course I have chosen has a minimum degree requirement and if I do not meet it...
So that I can avoid applying for the wrong courses
```

## Changes proposed in this pull request
<img width="729" alt="image" src="https://user-images.githubusercontent.com/62567622/131719217-84fca910-79fd-4b40-9e5b-be63e6a147c1.png">
<img width="711" alt="image" src="https://user-images.githubusercontent.com/62567622/131719245-84c49b51-af9c-44d9-bdb0-60e92e16c423.png">

## Guidance to review
Please let me know any notes RE a possible refactor or test coverage.

Frankie - check that the stlying is acceptable :)

## Link to Trello card
https://trello.com/c/1Gq83X0g/3838-%F0%9F%93%90dev-apply-indicate-when-a-course-has-higher-degree-grade-requirement-than-the-candidates-own-grade

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
