### PR TITLE
Warn candidate when course not able to sponsor a required visa

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -39,6 +39,7 @@ module CandidateInterface
         rejection_reasons_row(application_choice),
         offer_withdrawal_reason_row(application_choice),
         interview_row(application_choice),
+        visa_details_row(application_choice),
       ].compact
     end
 
@@ -198,6 +199,20 @@ module CandidateInterface
           value: render(InterviewBookingsComponent.new(application_choice)),
         }
       end
+    end
+
+    def visa_details_row(application_choice)
+      return nil if has_right_to_work_or_study?(application_choice)
+
+      {
+        key: 'Visa sponsorship',
+        value: 'Visas can be sponsored',
+      }
+    end
+
+    def has_right_to_work_or_study?(application_choice)
+      application_choice.application_form.british_or_irish? ||
+        application_choice.application_form.right_to_work_or_study_yes?
     end
 
     def status_row(application_choice)

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -206,7 +206,7 @@ module CandidateInterface
 
       {
         key: 'Visa sponsorship',
-        value: 'Visas can be sponsored',
+        value: render(CourseChoicesReviewVisaStatusComponent.new(application_choice: application_choice)),
       }
     end
 

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -202,8 +202,8 @@ module CandidateInterface
     end
 
     def visa_details_row(application_choice)
-      return nil if has_right_to_work_or_study?(application_choice) ||
-        application_predates_visa_sponsorship_information?(application_choice)
+      return nil if right_to_work_or_study?(application_choice) ||
+                    application_predates_visa_sponsorship_information?(application_choice)
 
       {
         key: 'Visa sponsorship',
@@ -211,7 +211,7 @@ module CandidateInterface
       }
     end
 
-    def has_right_to_work_or_study?(application_choice)
+    def right_to_work_or_study?(application_choice)
       application_choice.application_form.british_or_irish? ||
         application_choice.application_form.right_to_work_or_study_yes?
     end

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -202,7 +202,8 @@ module CandidateInterface
     end
 
     def visa_details_row(application_choice)
-      return nil if has_right_to_work_or_study?(application_choice)
+      return nil if has_right_to_work_or_study?(application_choice) ||
+        application_predates_visa_sponsorship_information?(application_choice)
 
       {
         key: 'Visa sponsorship',
@@ -213,6 +214,10 @@ module CandidateInterface
     def has_right_to_work_or_study?(application_choice)
       application_choice.application_form.british_or_irish? ||
         application_choice.application_form.right_to_work_or_study_yes?
+    end
+
+    def application_predates_visa_sponsorship_information?(application_choice)
+      application_choice.application_form.recruitment_cycle_year < 2022
     end
 
     def status_row(application_choice)

--- a/app/components/candidate_interface/course_choices_review_visa_status_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_visa_status_component.html.erb
@@ -12,7 +12,7 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>find a course that can sponsor student visas</li>
-      <li>find out about <a href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration" class="govuk-link">other visas that allow you to study in the UK</a></li>
+      <li>find out about <%= govuk_link_to('other visas that allow you to study in the UK', t('train_to_teach_in_england.url')) %></li>
     </ul>
   <% end %>
 <% end %>

--- a/app/components/candidate_interface/course_choices_review_visa_status_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_visa_status_component.html.erb
@@ -1,0 +1,18 @@
+<% if can_sponsor_visa? %>
+  <%= title %>
+<% else %>
+  <%= govuk_inset_text(classes: 'app-inset-text--narrow-border app-inset-text--important govuk-!-margin-top-0 govuk-!-padding-bottom-1') do %>
+    <p class="govuk-heading-s app-inset-text__title"><%= title %></p>
+
+    <p class="govuk-body">
+      You said that you do not yet have the right to work or study in the UK.
+    </p>
+
+    <p class="govuk-body">You can:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>find a course that can sponsor student visas</li>
+      <li>find out about <a href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration" class="govuk-link">other visas that allow you to study in the UK</a></li>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/components/candidate_interface/course_choices_review_visa_status_component.rb
+++ b/app/components/candidate_interface/course_choices_review_visa_status_component.rb
@@ -1,0 +1,32 @@
+module CandidateInterface
+  class CourseChoicesReviewVisaStatusComponent < ViewComponent::Base
+    include ViewHelper
+
+    def initialize(application_choice:)
+      @application_choice = application_choice
+    end
+
+  private
+
+    def can_sponsor_visa?
+      (
+        @application_choice.course.salary? &&
+        @application_choice.provider.can_sponsor_skilled_worker_visa?
+      ) ||
+      (
+        !@application_choice.course.salary? &&
+        @application_choice.provider.can_sponsor_student_visa?
+      )
+    end
+
+    def title
+      if can_sponsor_visa?
+        'Visas can be sponsored'
+      elsif @application_choice.course.salary?
+        'This provider cannot sponsor Skilled Worker visas'
+      else
+        'This provider cannot sponsor Student visas'
+      end
+    end
+  end
+end

--- a/app/components/candidate_interface/course_choices_review_visa_status_component.rb
+++ b/app/components/candidate_interface/course_choices_review_visa_status_component.rb
@@ -12,8 +12,7 @@ module CandidateInterface
       (
         @application_choice.course.salary? &&
         @application_choice.provider.can_sponsor_skilled_worker_visa?
-      ) ||
-      (
+      ) || (
         !@application_choice.course.salary? &&
         @application_choice.provider.can_sponsor_student_visa?
       )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,8 @@ en:
     url_training_with_a_disability: https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#training-to-teach-if-you-have-a-disability
     url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
     url_get_school_experience: https://getintoteaching.education.gov.uk/get-school-experience
+  train_to_teach_in_england:
+    url: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration
   page_titles:
     application_form: Your application
     application_dashboard: Your application

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -402,6 +402,32 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
     end
   end
 
+  describe 'Visa sponsorship details' do
+    context 'when the candidate does not need a visa' do
+      it 'does NOT render a Visa sponsorship row' do
+        application_choice = create(:application_choice, :with_completed_application_form)
+
+        result = render_inline(described_class.new(application_form: application_choice.application_form, editable: false, show_status: true))
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Visa sponsorship')
+      end
+    end
+
+    context 'when the candidate needs a visa' do
+      it 'does render a Visa sponsorship row' do
+        application_form = create(
+          :completed_application_form,
+          first_nationality: 'Indian',
+          second_nationality: nil,
+          right_to_work_or_study: :no,
+        )
+        create(:application_choice, application_form: application_form)
+
+        result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
+        expect(result.css('.govuk-summary-list__key').text).to include('Visa sponsorship')
+      end
+    end
+  end
+
   describe '#application_choices' do
     context "when one or more have an 'ACCEPTED_STATE'" do
       let(:application_form) { create_application_form_with_course_choices(statuses: %w[pending_conditions rejected]) }

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -403,27 +403,48 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
   end
 
   describe 'Visa sponsorship details' do
-    context 'when the candidate does not need a visa' do
+    context 'in 2022 cycle when the candidate does not need a visa' do
       it 'does NOT render a Visa sponsorship row' do
-        application_choice = create(:application_choice, :with_completed_application_form)
+        application_form = create(
+          :completed_application_form,
+          recruitment_cycle_year: 2022,
+        )
+        create(:application_choice, application_form: application_form)
 
-        result = render_inline(described_class.new(application_form: application_choice.application_form, editable: false, show_status: true))
+        result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
         expect(result.css('.govuk-summary-list__key').text).not_to include('Visa sponsorship')
       end
     end
 
-    context 'when the candidate needs a visa' do
+    context 'in 2022 cycle when the candidate needs a visa' do
       it 'does render a Visa sponsorship row' do
         application_form = create(
           :completed_application_form,
           first_nationality: 'Indian',
           second_nationality: nil,
           right_to_work_or_study: :no,
+          recruitment_cycle_year: 2022,
         )
         create(:application_choice, application_form: application_form)
 
         result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
         expect(result.css('.govuk-summary-list__key').text).to include('Visa sponsorship')
+      end
+    end
+
+    context 'in 2021 cycle when the candidate needs a visa' do
+      it 'does NOT render a Visa sponsorship row' do
+        application_form = create(
+          :completed_application_form,
+          first_nationality: 'Indian',
+          second_nationality: nil,
+          right_to_work_or_study: :no,
+          recruitment_cycle_year: 2021,
+        )
+        create(:application_choice, application_form: application_form)
+
+        result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Visa sponsorship')
       end
     end
   end

--- a/spec/components/candidate_interface/course_choices_review_visa_status_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_visa_status_component_spec.rb
@@ -4,21 +4,10 @@ RSpec.describe CandidateInterface::CourseChoicesReviewVisaStatusComponent do
   context 'when course is salaried' do
     context 'and provider does NOT sponsor Skilled Worker visas' do
       it 'renders component with warning' do
-        course_option = create(
-          :course_option,
-          course: create(
-            :course,
-            provider: create(
-              :provider,
-              can_sponsor_skilled_worker_visa: false,
-            ),
-            funding_type: :salary,
-          ),
-        )
-        application_choice = create(
-          :application_choice,
-          :with_completed_application_form,
-          course_option: course_option,
+        application_choice = setup_application(
+          funding_type: :salary,
+          can_sponsor_skilled_worker_visa: false,
+          can_sponsor_student_visa: false,
         )
         result = render_inline(described_class.new(application_choice: application_choice))
 
@@ -28,21 +17,10 @@ RSpec.describe CandidateInterface::CourseChoicesReviewVisaStatusComponent do
 
     context 'and provider does sponsor Skilled Worker visas' do
       it 'renders component with message that visas are sponsored' do
-        course_option = create(
-          :course_option,
-          course: create(
-            :course,
-            provider: create(
-              :provider,
-              can_sponsor_skilled_worker_visa: true,
-            ),
-            funding_type: :salary,
-          ),
-        )
-        application_choice = create(
-          :application_choice,
-          :with_completed_application_form,
-          course_option: course_option,
+        application_choice = setup_application(
+          funding_type: :salary,
+          can_sponsor_skilled_worker_visa: true,
+          can_sponsor_student_visa: false,
         )
         result = render_inline(described_class.new(application_choice: application_choice))
 
@@ -54,21 +32,10 @@ RSpec.describe CandidateInterface::CourseChoicesReviewVisaStatusComponent do
   context 'when course has a fee' do
     context 'and provider does NOT sponsor Student visas' do
       it 'renders component with warning' do
-        course_option = create(
-          :course_option,
-          course: create(
-            :course,
-            provider: create(
-              :provider,
-              can_sponsor_student_visa: false,
-            ),
-            funding_type: :fee,
-          ),
-        )
-        application_choice = create(
-          :application_choice,
-          :with_completed_application_form,
-          course_option: course_option,
+        application_choice = setup_application(
+          funding_type: :fee,
+          can_sponsor_skilled_worker_visa: false,
+          can_sponsor_student_visa: false,
         )
         result = render_inline(described_class.new(application_choice: application_choice))
 
@@ -78,26 +45,39 @@ RSpec.describe CandidateInterface::CourseChoicesReviewVisaStatusComponent do
 
     context 'and provider does sponsor Student visas' do
       it 'renders component with message that visas are sponsored' do
-        course_option = create(
-          :course_option,
-          course: create(
-            :course,
-            provider: create(
-              :provider,
-              can_sponsor_student_visa: true,
-            ),
-            funding_type: :fee,
-          ),
-        )
-        application_choice = create(
-          :application_choice,
-          :with_completed_application_form,
-          course_option: course_option,
+        application_choice = setup_application(
+          funding_type: :fee,
+          can_sponsor_skilled_worker_visa: false,
+          can_sponsor_student_visa: true,
         )
         result = render_inline(described_class.new(application_choice: application_choice))
 
         expect(result.text).to include('Visas can be sponsored')
       end
     end
+  end
+
+  def setup_application(
+    funding_type:,
+    can_sponsor_skilled_worker_visa:,
+    can_sponsor_student_visa:
+  )
+    course_option = create(
+      :course_option,
+      course: create(
+        :course,
+        provider: create(
+          :provider,
+          can_sponsor_skilled_worker_visa: can_sponsor_skilled_worker_visa,
+          can_sponsor_student_visa: can_sponsor_student_visa,
+        ),
+        funding_type: funding_type,
+      ),
+    )
+    create(
+      :application_choice,
+      :with_completed_application_form,
+      course_option: course_option,
+    )
   end
 end

--- a/spec/components/candidate_interface/course_choices_review_visa_status_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_visa_status_component_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::CourseChoicesReviewVisaStatusComponent do
+  context 'when course is salaried' do
+    context 'and provider does NOT sponsor Skilled Worker visas' do
+      it 'renders component with warning' do
+        course_option = create(
+          :course_option,
+          course: create(
+            :course,
+            provider: create(
+              :provider,
+              can_sponsor_skilled_worker_visa: false,
+            ),
+            funding_type: :salary,
+          ),
+        )
+        application_choice = create(
+          :application_choice,
+          :with_completed_application_form,
+          course_option: course_option,
+        )
+        result = render_inline(described_class.new(application_choice: application_choice))
+
+        expect(result.css('.app-inset-text__title').text).to include('This provider cannot sponsor Skilled Worker visas')
+      end
+    end
+
+    context 'and provider does sponsor Skilled Worker visas' do
+      it 'renders component with message that visas are sponsored' do
+        course_option = create(
+          :course_option,
+          course: create(
+            :course,
+            provider: create(
+              :provider,
+              can_sponsor_skilled_worker_visa: true,
+            ),
+            funding_type: :salary,
+          ),
+        )
+        application_choice = create(
+          :application_choice,
+          :with_completed_application_form,
+          course_option: course_option,
+        )
+        result = render_inline(described_class.new(application_choice: application_choice))
+
+        expect(result.text).to include('Visas can be sponsored')
+      end
+    end
+  end
+
+  context 'when course has a fee' do
+    context 'and provider does NOT sponsor Student visas' do
+      it 'renders component with warning' do
+        course_option = create(
+          :course_option,
+          course: create(
+            :course,
+            provider: create(
+              :provider,
+              can_sponsor_student_visa: false,
+            ),
+            funding_type: :fee,
+          ),
+        )
+        application_choice = create(
+          :application_choice,
+          :with_completed_application_form,
+          course_option: course_option,
+        )
+        result = render_inline(described_class.new(application_choice: application_choice))
+
+        expect(result.css('.app-inset-text__title').text).to include('This provider cannot sponsor Student visas')
+      end
+    end
+
+    context 'and provider does sponsor Student visas' do
+      it 'renders component with message that visas are sponsored' do
+        course_option = create(
+          :course_option,
+          course: create(
+            :course,
+            provider: create(
+              :provider,
+              can_sponsor_student_visa: true,
+            ),
+            funding_type: :fee,
+          ),
+        )
+        application_choice = create(
+          :application_choice,
+          :with_completed_application_form,
+          course_option: course_option,
+        )
+        result = render_inline(described_class.new(application_choice: application_choice))
+
+        expect(result.text).to include('Visas can be sponsored')
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -147,7 +147,6 @@ RSpec.feature 'International candidate submits the application' do
   def then_i_can_see_my_course_choices
     expect(page).to have_content 'Gorse SCITT'
     expect(page).to have_content 'Primary (2XT2)'
-    expect(page).to have_content 'Visa sponsorship'
   end
 
   def and_i_can_see_my_personal_details

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -147,6 +147,7 @@ RSpec.feature 'International candidate submits the application' do
   def then_i_can_see_my_course_choices
     expect(page).to have_content 'Gorse SCITT'
     expect(page).to have_content 'Primary (2XT2)'
+    expect(page).to have_content 'Visa sponsorship'
   end
 
   def and_i_can_see_my_personal_details


### PR DESCRIPTION
## Context

Now that we have information about candidates visa requirements and (will) have the information from providers about whether they sponsor those visas we can flag course selections that don't match the candidates needs.

## Changes proposed in this pull request

- [x] Add a new row to the `CourseChoicesReviewComponent` for visa sponsorship that is only visible to candidates that do not have a right to work in the UK.
- [x] New `CourseChoicesReviewVisaStatusComponent` to encapsulate the logic needed to render the correct message in the _Visa sponsorship_ row.
- [x] Don't show the _Visa sponsorship_ row until the 2022 cycle because we don't have data about the provider visa sponsorship capabilities until then.

<img width="567" alt="image" src="https://user-images.githubusercontent.com/450843/131875342-153be046-3f66-40db-8ba2-24499fee83a0.png">

<img width="663" alt="image" src="https://user-images.githubusercontent.com/450843/131875535-649d7d12-73c2-4a0e-af0b-290c1948dba7.png">

## Guidance to review

- I don't think the review app is much use as this feature is off until the 2022 cycle. You need to change the `ApplicationForm#recruitment_cycle_year` of the application you are viewing to 2022 so testing locally might be easier.

## Link to Trello card

https://trello.com/c/mihSanbR/3837-📐dev-apply-indicate-when-a-course-is-not-able-to-sponsor-a-visa-on-course-summary-card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
