### PR TITLE
Do not RBD sandbox applications at the end of the cycle

### DIFF
--- a/app/services/set_reject_by_default.rb
+++ b/app/services/set_reject_by_default.rb
@@ -29,6 +29,9 @@ class SetRejectByDefault
 private
 
   def beyond_end_of_cycle_reject_by_default_deadline?(date)
+    # keep RBD the same on Sandbox so we can keep Apply open for testing
+    return false if HostingEnvironment.sandbox_mode?
+
     date >= reject_by_default_date
   end
 

--- a/spec/services/set_reject_by_default_spec.rb
+++ b/spec/services/set_reject_by_default_spec.rb
@@ -33,6 +33,22 @@ RSpec.describe SetRejectByDefault do
         end
       end
     end
+
+    # we’re going to keep Sandbox open while Apply is closed irl, but we don’t want
+    # to set short RBDs due to the proximity of the deadline when we're using the
+    # cycle switcher
+    specify 'proximity to the deadline is ignored on Sandbox', sandbox: true do
+      submitted = '20 Sept 2021 0:00:00 AM BST'
+      correct_rbd = '18 Oct 2021 23:59:59 PM BST'
+
+      Timecop.freeze(Time.zone.parse(submitted)) do
+        choice = create(:application_choice, sent_to_provider_at: Time.zone.now)
+
+        call_service(choice)
+
+        expect(choice.reload.reject_by_default_at).to be_within(1.second).of(Time.zone.parse(correct_rbd))
+      end
+    end
   end
 
   def call_service(application_choice)


### PR DESCRIPTION
We are going to keep Sandbox open while Apply is closed during the change of cycles.

## Context

https://ukgovernmentdfe.slack.com/archives/C01EZFNUPLP/p1630665278030300?thread_ts=1630664744.025600&cid=C01EZFNUPLP

If we keep Sandbox in `today_is_mid_cycle` using the cycle switcher, the date for RBD'ing at end of cycle will always be 3 days away (see `CycleTimetable.fake_schedules`). This will result in a lot of short-lived applications. When calculating RBDs in the Sandbox, pretend we're not in sight of the end of cycle.

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
