### PR TITLE
Add request id to BigQuery events

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,13 @@ Style/OptionalBooleanParameter:
   Exclude:
     - 'app/workers/**/*'
 
+# These files call RequestLocals.fetch. Unlike Hash#fetch it requires the
+# fallback to be passed in a block
+Style/RedundantFetchBlock:
+  Exclude:
+    - 'app/controllers/concerns/emit_request_events.rb'
+    - 'app/models/concerns/entity_events.rb'
+
 Govuk:
   Include:
     - 'app/views/**/*'

--- a/app/controllers/concerns/emit_request_events.rb
+++ b/app/controllers/concerns/emit_request_events.rb
@@ -13,6 +13,7 @@ module EmitRequestEvents
         .with_request_details(request)
         .with_response_details(response)
         .with_user_and_namespace(current_user, current_namespace)
+        .with_request_uuid(RequestLocals.fetch(:request_id) { nil })
 
       SendEventsToBigquery.perform_async(request_event.as_json)
     end

--- a/app/lib/events/event.rb
+++ b/app/lib/events/event.rb
@@ -77,6 +77,12 @@ module Events
       self
     end
 
+    def with_request_uuid(request_id)
+      @event_hash[:request_uuid] = request_id if request_id
+
+      self
+    end
+
   private
 
     def hash_to_kv_pairs(hash)

--- a/app/middlewares/request_identity_middleware.rb
+++ b/app/middlewares/request_identity_middleware.rb
@@ -1,0 +1,10 @@
+class RequestIdentityMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    RequestLocals.store[:request_id] = env.fetch('action_dispatch.request_id')
+    @app.call(env)
+  end
+end

--- a/app/models/concerns/entity_events.rb
+++ b/app/models/concerns/entity_events.rb
@@ -29,6 +29,7 @@ module EntityEvents
       .with_entity_table_name(self.class.table_name)
       .with_data(data)
       .with_tags(event_tags)
+      .with_request_uuid(RequestLocals.fetch(:request_id) { nil })
 
     SendEventsToBigquery.perform_async(event.as_json)
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,7 @@ require './app/lib/hosting_environment'
 require './app/middlewares/redirect_to_service_gov_uk_middleware'
 require './app/middlewares/vendor_api_request_middleware'
 require './app/middlewares/service_unavailable_middleware'
+require './app/middlewares/request_identity_middleware'
 
 require_relative "../lib/modules/aws_ip_ranges"
 
@@ -65,6 +66,7 @@ module ApplyForPostgraduateTeacherTraining
 
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
 
+    config.middleware.use RequestIdentityMiddleware
     config.middleware.use ServiceUnavailableMiddleware
     config.middleware.insert_after ActionDispatch::HostAuthorization, RedirectToServiceGovUkMiddleware
     config.middleware.use VendorAPIRequestMiddleware

--- a/spec/models/concerns/entity_events_spec.rb
+++ b/spec/models/concerns/entity_events_spec.rb
@@ -54,6 +54,17 @@ RSpec.describe EntityEvents do
           expect(schema_validator).to be_valid, schema_validator.failure_message
         end
       end
+
+      it 'sends events with the request UUID, if available' do
+        RequestLocals.store[:request_id] = 'example-request-id'
+
+        create(:candidate)
+
+        expect(SendEventsToBigquery).to have_received(:perform_async)
+          .with a_hash_including({
+            'request_uuid' => 'example-request-id',
+          })
+      end
     end
 
     context 'when no fields are specified in the analytics file' do

--- a/spec/requests/emit_request_events_spec.rb
+++ b/spec/requests/emit_request_events_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe EmitRequestEvents, type: :request, with_bigquery: true do
         { 'key' => 'per_page', 'value' => ['25'] },
         { 'key' => 'array_param[]', 'value' => %w[1 2] },
       ])
+      expect(payload['request_uuid']).to be_present
 
       schema = File.read('config/event-schema.json')
       schema_validator = JSONSchemaValidator.new(schema, payload)


### PR DESCRIPTION
## Context

Requests can trigger multiple events. Allow them to be grouped by sending a `request_id` to BigQuery.

## Changes proposed in this pull request

Middleware picks up the `request_id` [from ActionDispatch](https://api.rubyonrails.org/classes/ActionDispatch/RequestId.html) and assigns it to a thread-safe global variable using `RequestLocals`. `EntityEvents` and `EmitRequestEvents` then append it to the events they send to BigQuery. We use a field called `request_uuid` for consistency with other apps.

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
