### PR TITLE
Update to oj 3.13.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,7 +339,7 @@ GEM
       shellany (~> 0.0)
     notifications-ruby-client (5.3.0)
       jwt (>= 1.5, < 3)
-    oj (3.13.2)
+    oj (3.13.4)
     okcomputer (1.18.4)
     omniauth (1.9.1)
       hashie (>= 3.4.6)


### PR DESCRIPTION
## Context

Dependabot's #5483 broke `oj`. There is [a new version which fixes it](https://github.com/ohler55/oj/issues/699#issuecomment-912969255).
