### PR TITLE
Add placeholder keys to cycle timetable

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -31,6 +31,11 @@ class CycleTimetable
     2022 => {
       find_opens: Time.zone.local(2021, 10, 5, 9),
       apply_opens: Time.zone.local(2021, 10, 12, 9),
+      show_deadline_banner: Time.zone.local(2022, 8, 1, 9), # This is a placeholder till we know the real date
+      apply_1_deadline: Time.zone.local(2022, 9, 7, 18), # This is a placeholder till we know the real date
+      apply_2_deadline: Time.zone.local(2022, 9, 21, 18), # This is a placeholder till we know the real date
+      reject_by_default: Time.zone.local(2022, 9, 29, 23, 59, 59), # This is a placeholder till we know the real date
+      find_closes: Time.zone.local(2022, 10, 4, 23, 59, 59), # This is a placeholder till we know the real date
     },
   }.freeze
 


### PR DESCRIPTION
## Context

We've added logic to check apply closes in some partials, however for the new cycle those dates have not been decided. 

## Changes proposed in this pull request

Add placeholder dates for now, until we know the real dates. Those are far in the future so we don't need to worry about them.

## Guidance to review

This is a temp solution till we figure out how to do this nicely

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
