### PR TITLE
Improve performance of applications endpoint with batch find

### DIFF
--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -35,8 +35,9 @@ module VendorAPI
     def get_application_choices_for_provider_since(since:)
       application_choices_visible_to_provider
         .where('application_choices.updated_at > ?', since)
-        .order('application_choices.updated_at DESC')
         .find_each(batch_size: 500)
+        .sort_by(&:updated_at)
+        .reverse
     end
 
     def since_param

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -36,6 +36,7 @@ module VendorAPI
       application_choices_visible_to_provider
         .where('application_choices.updated_at > ?', since)
         .order('application_choices.updated_at DESC')
+        .find_each(batch_size: 500)
     end
 
     def since_param


### PR DESCRIPTION
## Context

We load-tested 3 different batch sizes (250, 500, 750) against the un-batched query and found that a size of 500 provided the best performance. The response times were lower that all other scenarios.

There's a caveat with ActiveRecord `find_each` in that it ignore order clauses, so we need to apply ordering in memory after fetching.

#### Fetching everything at once:

https://grafana-bat.london.cloudapps.digital/d/g7FHKhz7a/michael?orgId=1&from=1630509720000&to=1630511999000

#### Batch fetch with 500 items

https://grafana-bat.london.cloudapps.digital/d/g7FHKhz7a/michael?orgId=1&from=1630941060000&to=1630943519000


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Use `find_each(batch_size: 500)` when retrieving applications.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/y4UPGf9I/4173-vendor-api-investigation-20
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
