### PR TITLE
Remove case sensitivity from invite user

### DIFF
--- a/app/forms/provider_interface/invite_user_wizard.rb
+++ b/app/forms/provider_interface/invite_user_wizard.rb
@@ -9,7 +9,7 @@ module ProviderInterface
     validates :last_name, presence: true
 
     validates :email_address, presence: true, valid_for_notify: true
-    validate :email_not_already_used_for_provider
+    validate :email_not_already_used_for_provider, if: -> { email_address.present? }
 
     def initialize(state_store, attrs = {})
       @state_store = state_store
@@ -61,7 +61,7 @@ module ProviderInterface
     end
 
     def email_not_already_used_for_provider
-      return unless provider.provider_users.exists?(email_address: email_address)
+      return unless provider.provider_users.exists?(email_address: email_address.downcase)
 
       errors.add(:email_address, :email_already_associated, provider_name: provider.name)
     end

--- a/app/services/invite_provider_user.rb
+++ b/app/services/invite_provider_user.rb
@@ -56,7 +56,7 @@ private
 
   def lookup_provider_user
     if @provider_user.is_a?(String)
-      @provider_user = ProviderUser.find_by!(email_address: @provider_user)
+      @provider_user = ProviderUser.find_by!(email_address: @provider_user.downcase)
     end
   end
 end

--- a/app/services/provider_interface/add_user_to_provider.rb
+++ b/app/services/provider_interface/add_user_to_provider.rb
@@ -7,7 +7,7 @@ module ProviderInterface
     def initialize(actor:, provider:, email_address:, first_name:, last_name:, permissions:)
       @actor = actor
       @provider = provider
-      @email_address = email_address
+      @email_address = email_address.downcase
       @first_name = first_name
       @last_name = last_name
       @permissions = permissions

--- a/spec/forms/provider_interface/invite_user_wizard_spec.rb
+++ b/spec/forms/provider_interface/invite_user_wizard_spec.rb
@@ -51,6 +51,16 @@ RSpec.describe ProviderInterface::InviteUserWizard do
           expect(wizard).to be_valid
         end
       end
+
+      context 'an email with different capitalisation is already associated with the provider' do
+        let(:email) { 'DifferentlyCased@Alphabet.Com' }
+        let!(:existing_user) { create(:provider_user, email_address: email, providers: [provider]) }
+
+        it 'validates the email address is a duplicate' do
+          expect(wizard).to be_invalid
+          expect(wizard.errors[:email_address]).to contain_exactly("A user with this email address already has access to #{provider.name}")
+        end
+      end
     end
   end
 end

--- a/spec/services/provider_interface/add_user_to_provider_spec.rb
+++ b/spec/services/provider_interface/add_user_to_provider_spec.rb
@@ -69,6 +69,15 @@ RSpec.describe ProviderInterface::AddUserToProvider do
       it 'does not create another notification preferences object' do
         expect { service.call! }.not_to change(ProviderUserNotificationPreferences, :count)
       end
+
+      context 'the given email is a differently cased version of the existing provider user' do
+        let(:email_address) { 'EmailAddress@Email.Com' }
+        let!(:existing_user) { create(:provider_user, email_address: email_address.downcase) }
+
+        it "doesn't raise an error" do
+          expect { service.call! }.not_to raise_error
+        end
+      end
     end
 
     context 'when the provider user does not exist yet' do


### PR DESCRIPTION
## Context

https://trello.com/c/T5MJHPa7/4214-fix-capitalisation-error-for-invite-user-email-field

## Changes proposed in this pull request

There are a couple of changes made to how the invite user wizard and downstream services handle emails - each one has been hardened against the same email but with different capitalisation. 

## Guidance to review

Try the invite user flow (with the :account_and_org_permissions_changes feature flag on), and enter an email address that's the same as an already existing user for that provider, but with capitalised letters. This should not raise an error, which it was doing before!