### PR TITLE
Cache applications as serialized JSON

### DIFF
--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -1,21 +1,23 @@
 module VendorAPI
   class ApplicationsController < VendorAPIController
     def index
-      render json: { data: serialized_application_choices }
+      render json: serialized_application_choices_data
     end
 
     def show
       application_choice = application_choices_visible_to_provider.find(params[:application_id])
 
-      render json: { data: SingleApplicationPresenter.new(application_choice).as_json }
+      render json: %({"data":#{SingleApplicationPresenter.new(application_choice).serialized_json}})
     end
 
   private
 
-    def serialized_application_choices
-      get_application_choices_for_provider_since(since: since_param).map do |application_choice|
-        SingleApplicationPresenter.new(application_choice).as_json
+    def serialized_application_choices_data
+      json_data = get_application_choices_for_provider_since(since: since_param).map do |application_choice|
+        SingleApplicationPresenter.new(application_choice).serialized_json
       end
+
+      %({"data":[#{json_data.join(',')}]})
     end
 
     def application_choices_visible_to_provider

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -67,7 +67,7 @@ module VendorAPI
     end
 
     def render_application
-      render json: { data: SingleApplicationPresenter.new(application_choice).as_json }
+      render json: %({"data":#{SingleApplicationPresenter.new(application_choice).serialized_json}})
     end
 
     def respond_to_decision(decision)

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -14,6 +14,12 @@ module VendorAPI
       @application_form = application_choice.application_form
     end
 
+    def serialized_json
+      Rails.cache.fetch(cache_key(application_choice), expires_in: CACHE_EXPIRES_IN) do
+        application_as_json.to_json
+      end
+    end
+
     def as_json
       Rails.cache.fetch(cache_key(application_choice), expires_in: CACHE_EXPIRES_IN) do
         application_as_json

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -1128,4 +1128,22 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       end
     end
   end
+
+  describe '#serialized_json' do
+    let(:application_form) { create(:application_form, :minimum_info) }
+    let(:application_choice) { create(:application_choice, :awaiting_provider_decision, application_form: application_form) }
+
+    it 'returns a valid JSON string' do
+      result = described_class.new(application_choice).serialized_json
+      expect(result).to be_a(String)
+      expect(JSON.parse(result)['attributes']).to be_a(Hash)
+    end
+
+    it 'caches the serialized JSON string' do
+      allow(Rails.cache).to receive(:fetch)
+      described_class.new(application_choice).serialized_json
+
+      expect(Rails.cache).to have_received(:fetch)
+    end
+  end
 end


### PR DESCRIPTION
## Context

There's a performance benefit in caching the application JSON string generated by `#to_json` as opposed to the underlying Ruby hash of data.
In load testing this had an average response time advantage of ~400ms for the `/api/v1/applications` endpoint.

#### Cached JSON strings
https://grafana-bat.london.cloudapps.digital/d/g7FHKhz7a/michael?orgId=1&from=1630917000000&to=1630919459000

#### Cached Ruby hashes
https://grafana-bat.london.cloudapps.digital/d/g7FHKhz7a/michael?orgId=1&from=1630509720000&to=1630511999000

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds a new method to the presenter `#serialized_json` which returns the cached string of JSON generated by `#as_json`.
- Passes a string to the relevant controllers' `#render` method so that Rails doesn't attempt to re-serialize the response data.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

The controller changes are a bit unusual as we do a trivial but manual construction of the outer JSON string.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/y4UPGf9I/4173-vendor-api-investigation-20

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
