### PR TITLE
Add a business_as_usual phase to the Cycle switcher

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -152,6 +152,21 @@ class CycleTimetable
 
   def self.fake_schedules
     {
+      today_is_business_as_usual: {
+        current_year => {
+          find_opens: 7.days.ago,
+          apply_opens: 6.days.ago,
+          show_deadline_banner: 1.day.from_now,
+          apply_1_deadline: 2.days.from_now,
+          apply_2_deadline: 3.days.from_now,
+          reject_by_default: 4.days.from_now,
+          find_closes: 5.days.from_now,
+        },
+        next_year => {
+          find_opens: 7.days.from_now,
+          apply_opens: 8.days.from_now,
+        },
+      },
       today_is_mid_cycle: {
         current_year => {
           find_opens: 7.days.ago,

--- a/config/locales/support_interface/cycles.yml
+++ b/config/locales/support_interface/cycles.yml
@@ -3,6 +3,9 @@ en:
     real:
       name: 'Same as production environment'
       description: ''
+    today_is_business_as_usual:
+      name: Mid cycle before deadlines are displayed
+      description: Candidates do not see upcoming application deadlines
     today_is_mid_cycle:
       name: Mid cycle and deadlines should be displayed
       description: Candidates can see upcoming application deadlines


### PR DESCRIPTION
## Context

We want to keep sandbox open right up until the start of the next cycle. Using the existing `today_is_mid_cycle` setting will result in providers thinking they won't be able to submit applications tomorrow... but tomorrow will never come. This will mean support queries, which we don't want.

## Changes proposed in this pull request

Add a new `today_is_business_as_usual` phase to the switcher, which keeps the cycle open but doesn't show the banners.