### PR TITLE
Surface accredited provider code to Register API

### DIFF
--- a/app/presenters/register_api/single_application_presenter.rb
+++ b/app/presenters/register_api/single_application_presenter.rb
@@ -94,6 +94,7 @@ module RegisterAPI
         training_provider_code: course_option.course.provider.code,
         training_provider_type: course_option.course.provider.provider_type,
         accredited_provider_type: course_option.course.accredited_provider&.provider_type,
+        accredited_provider_code: course_option.course.accredited_provider&.code,
         site_code: course_option.site.code,
         study_mode: course_option.study_mode,
       }

--- a/config/register-api.yml
+++ b/config/register-api.yml
@@ -375,6 +375,7 @@ components:
       - training_provider_code
       - training_provider_type
       - accredited_provider_type
+      - accredited_provider_code
       - site_code
       - study_mode
       properties:
@@ -409,6 +410,12 @@ components:
             - university
           example: university
           maxLength: 25
+        accredited_provider_code:
+          type: string
+          nullable: true
+          description: The accredited provider’s code
+          example: 2FR
+          maxLength: 3
         course_code:
           type: string
           description: The course’s code

--- a/spec/presenters/register_api/single_application_presenter_spec.rb
+++ b/spec/presenters/register_api/single_application_presenter_spec.rb
@@ -392,7 +392,7 @@ RSpec.describe RegisterAPI::SingleApplicationPresenter do
   describe 'attributes.course' do
     let(:application_choice) { create(:application_choice, :with_completed_application_form, :with_offer, :with_recruited, course: course) }
     let(:training_provider) { create(:provider, provider_type: 'scitt') }
-    let(:accredited_provider) { create(:provider, provider_type: 'university') }
+    let(:accredited_provider) { create(:provider, provider_type: 'university', code: 'ABC') }
     let(:course) { create(:course, provider: training_provider, accredited_provider: accredited_provider) }
     let(:presenter) { described_class.new(application_choice).as_json }
 
@@ -401,7 +401,11 @@ RSpec.describe RegisterAPI::SingleApplicationPresenter do
     end
 
     it 'returns the course accredited provider type' do
-      expect(presenter.dig(:attributes, :course, :accredited_provider_type)).to eq('university')
+      expect(presenter.dig(:attributes, :course, :accredited_provider_type)).to eq(accredited_provider.provider_type)
+    end
+
+    it 'returns the course accredited provider code' do
+      expect(presenter.dig(:attributes, :course, :accredited_provider_code)).to eq(accredited_provider.code)
     end
 
     context 'with a self ratified course' do

--- a/spec/system/register_api/register_receives_application_spec.rb
+++ b/spec/system/register_api/register_receives_application_spec.rb
@@ -85,6 +85,7 @@ RSpec.feature 'Register receives an application data' do
           training_provider_code: '1N1',
           training_provider_type: 'scitt',
           accredited_provider_type: nil,
+          accredited_provider_code: nil,
           site_code: '-',
           study_mode: 'full_time',
         },


### PR DESCRIPTION
## Context
While testing apply integration with the Register app, we discovered that some applications couldn't be imported because the application was associated with a training provider instead of an accredited provider. I order to fix this in Register, we need the Apply Register API to return `accredited_provider_code` so that we can determine the accredited provider in which there are two ways:

1. `accredited_provider_code` is not `nil` (nice and easy)
1. `accredited_provider_code` is `nil` but `training_provider_code` isn't (which means the training provider is also the accredited provider for the course)

## Changes proposed in this pull request
- Add `accredited_provider_code` to Register API payload

## Link to Trello card
https://trello.com/c/NZSTxBFm/2693-add-accredited-provider-code-to-api-course-attributes

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
