### PR TITLE
Only scope apply again candidate check to current cycle

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -49,7 +49,7 @@ class Candidate < ApplicationRecord
   end
 
   def in_apply_2?
-    application_forms.exists?(phase: 'apply_2')
+    application_forms.current_cycle.exists?(phase: 'apply_2')
   end
 
 private

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -159,5 +159,14 @@ RSpec.describe Candidate, type: :model do
         expect(candidate.in_apply_2?).to be true
       end
     end
+
+    context 'when the candidate has applications in apply again in previous cycle' do
+      let!(:application_form_previous_year) { create(:application_form, candidate: candidate, phase: 'apply_2', recruitment_cycle_year: RecruitmentCycle.previous_year) }
+      let!(:application_form) { create(:application_form, candidate: candidate) }
+
+      it 'returns true' do
+        expect(candidate.in_apply_2?).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

We currently added offer validations to restrict reverting rejections. One of the validations checks if the candidate is in apply again. We have to scope this to the current year to avoid validation errors if the candidate had an apply again application in the previous cycle

## Changes proposed in this pull request

Scope apply again candidate check to current cycle

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
