### PR TITLE
Change candidate messaging to show current course

### DIFF
--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -31,7 +31,7 @@ module CandidateInterface
     def confirm_decline
       decline = DeclineOffer.new(application_choice: @application_choice.reload)
       decline.save!
-      flash[:success] = "You have declined your offer for #{@application_choice.course.name_and_code} at #{@application_choice.provider.name}"
+      flash[:success] = "You have declined your offer for #{@application_choice.current_course.name_and_code} at #{@application_choice.provider.name}"
       redirect_to candidate_interface_application_complete_path
     end
 
@@ -40,7 +40,7 @@ module CandidateInterface
     def confirm_accept
       accept = AcceptOffer.new(application_choice: @application_choice.reload)
       accept.save!
-      flash[:success] = "You have accepted your offer for #{@application_choice.course.name_and_code} at #{@application_choice.provider.name}"
+      flash[:success] = "You have accepted your offer for #{@application_choice.current_course.name_and_code} at #{@application_choice.provider.name}"
       redirect_to candidate_interface_application_complete_path
     end
 
@@ -56,7 +56,7 @@ module CandidateInterface
     def withdrawal_feedback
       @withdrawal_feedback_form = WithdrawalFeedbackForm.new
       @provider = @application_choice.provider
-      @course = @application_choice.course
+      @course = @application_choice.current_course
     end
 
     def confirm_withdrawal_feedback
@@ -69,7 +69,7 @@ module CandidateInterface
       else
         track_validation_error(@withdrawal_feedback_form)
         @provider = @application_choice.provider
-        @course = @application_choice.course
+        @course = @application_choice.current_course
 
         render :withdrawal_feedback
       end


### PR DESCRIPTION
## Context

https://ukgovernmentdfe.slack.com/archives/C01EZFNUPLP/p1631013925057700
## Changes proposed in this pull request

When an offer is made to a different course, this is updated in the current course options field. utilise this field
for feedback to the candidate instead when accepting offers, withdrawing etc.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
