### PR TITLE
[DO NOT MERGE] Update summer banner content since we passed apply 1 deadline

### DIFF
--- a/config/locales/summer_recruitment_banner.yml
+++ b/config/locales/summer_recruitment_banner.yml
@@ -1,5 +1,5 @@
 en:
   summer_recruitment_banner:
     title: Important
-    header: The deadline for candidates to apply for the first time in this recruitment cycle is 6pm on 7 September
-    body: Candidates who apply before the deadline will be able to apply again until 6pm on 21 September.
+    header: Applications awaiting decisions will be automatically rejected on 29 September at 11:59pm, when the current recruitment cycle ends
+    body: Candidates can apply until 21 September at 6pm.

--- a/spec/components/provider_interface/summer_recruitment_banner_spec.rb
+++ b/spec/components/provider_interface/summer_recruitment_banner_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe ProviderInterface::SummerRecruitmentBanner do
     end
 
     it 'renders the banner header' do
-      expect(result.text).to include('The deadline for candidates to apply for the first time in this recruitment cycle is 6pm on 7 September')
+      expect(result.text).to include(t('summer_recruitment_banner.header'))
     end
 
     it 'renders the banner content' do
-      expect(result.text).to include('Candidates who apply before the deadline will be able to apply again until 6pm on 21 September.')
+      expect(result.text).to include(t('summer_recruitment_banner.body'))
     end
   end
 


### PR DESCRIPTION
## Context

Apply 1 deadline is today at 6, we want to show this straight after

## Changes proposed in this pull request

Update summer recruitment banner content 

## Guidance to review

This will be merged closer to the time at 6pm as we don't like automation 🔥 

## Link to Trello card

https://trello.com/c/cftuHioP/4219-update-content-of-banner-to-tell-users-about-automatic-rejection-at-the-end-of-the-cycle

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
