### PR TITLE
Update HESA ethnicities lookup for 2021-2022

### DIFF
--- a/app/lib/hesa/ethnicity.rb
+++ b/app/lib/hesa/ethnicity.rb
@@ -3,13 +3,10 @@ module Hesa
     EthnicityStruct = Struct.new(:hesa_code, :value)
 
     def self.all(cycle_year)
-      if cycle_year == 2020
-        HESA_ETHNICITIES_2019_2020.map { |ethnicity| EthnicityStruct.new(*ethnicity) }
-      elsif cycle_year == 2021
-        HESA_ETHNICITIES_2020_2021.map { |ethnicity| EthnicityStruct.new(*ethnicity) }
-      else
-        raise ArgumentError, "Do not know Hesa Ethnicities codes for #{cycle_year}"
-      end
+      collection_name = "HESA_ETHNICITIES_#{cycle_year - 1}_#{cycle_year}"
+      HesaEthnicityCollections.const_get(collection_name).map { |ethnicity| EthnicityStruct.new(*ethnicity) }
+    rescue NameError
+      raise ArgumentError, "Do not know Hesa Ethnicities codes for #{cycle_year}"
     end
 
     def self.find(value, cycle_year)

--- a/config/initializers/hesa_ethnicities.rb
+++ b/config/initializers/hesa_ethnicities.rb
@@ -42,10 +42,8 @@ module HesaEthnicityCollections
     ['98', HesaEthnicityValues::INFORMATION_REFUSED],
   ].freeze
 
-  # Two codes have been dropped in 2020/21
   # https://www.hesa.ac.uk/collection/c20053/e/ethnic
   HESA_ETHNICITIES_2020_2021 = HESA_ETHNICITIES_2019_2020
-                                 .reject { |ethnicity| %w[90 98].include?(ethnicity.first) }
   # Unchanged from 2020-2021
   # https://www.hesa.ac.uk/collection/c21053/e/ethnic
   HESA_ETHNICITIES_2021_2022 = HESA_ETHNICITIES_2020_2021

--- a/config/initializers/hesa_ethnicities.rb
+++ b/config/initializers/hesa_ethnicities.rb
@@ -19,29 +19,34 @@ module HesaEthnicityValues
   INFORMATION_REFUSED = 'Information refused'.freeze
 end
 
-# https://www.hesa.ac.uk/collection/c19053/e/ethnic
-HESA_ETHNICITIES_2019_2020 = [
-  ['10', HesaEthnicityValues::WHITE],
-  ['15', HesaEthnicityValues::GYPSY_OR_TRAVELLER],
-  ['21', HesaEthnicityValues::CARIBBEAN],
-  ['22', HesaEthnicityValues::AFRICAN],
-  ['29', HesaEthnicityValues::OTHER_BLACK],
-  ['31', HesaEthnicityValues::INDIAN],
-  ['32', HesaEthnicityValues::PAKISTANI],
-  ['33', HesaEthnicityValues::BANGLADESHI],
-  ['34', HesaEthnicityValues::CHINESE],
-  ['39', HesaEthnicityValues::OTHER_ASIAN],
-  ['41', HesaEthnicityValues::WHITE_AND_BLACK_CARIBBEAN],
-  ['42', HesaEthnicityValues::WHITE_AND_BLACK_AFRICAN],
-  ['43', HesaEthnicityValues::WHITE_AND_ASIAN],
-  ['49', HesaEthnicityValues::OTHER_MIXED],
-  ['50', HesaEthnicityValues::ARAB],
-  ['80', HesaEthnicityValues::OTHER_ETHNIC],
-  ['90', HesaEthnicityValues::NOT_KNOWN],
-  ['98', HesaEthnicityValues::INFORMATION_REFUSED],
-].freeze
+module HesaEthnicityCollections
+  # https://www.hesa.ac.uk/collection/c19053/e/ethnic
+  HESA_ETHNICITIES_2019_2020 = [
+    ['10', HesaEthnicityValues::WHITE],
+    ['15', HesaEthnicityValues::GYPSY_OR_TRAVELLER],
+    ['21', HesaEthnicityValues::CARIBBEAN],
+    ['22', HesaEthnicityValues::AFRICAN],
+    ['29', HesaEthnicityValues::OTHER_BLACK],
+    ['31', HesaEthnicityValues::INDIAN],
+    ['32', HesaEthnicityValues::PAKISTANI],
+    ['33', HesaEthnicityValues::BANGLADESHI],
+    ['34', HesaEthnicityValues::CHINESE],
+    ['39', HesaEthnicityValues::OTHER_ASIAN],
+    ['41', HesaEthnicityValues::WHITE_AND_BLACK_CARIBBEAN],
+    ['42', HesaEthnicityValues::WHITE_AND_BLACK_AFRICAN],
+    ['43', HesaEthnicityValues::WHITE_AND_ASIAN],
+    ['49', HesaEthnicityValues::OTHER_MIXED],
+    ['50', HesaEthnicityValues::ARAB],
+    ['80', HesaEthnicityValues::OTHER_ETHNIC],
+    ['90', HesaEthnicityValues::NOT_KNOWN],
+    ['98', HesaEthnicityValues::INFORMATION_REFUSED],
+  ].freeze
 
-# Two codes have been dropped in 2020/21
-# https://www.hesa.ac.uk/collection/c20053/e/ethnic
-HESA_ETHNICITIES_2020_2021 = HESA_ETHNICITIES_2019_2020
-                               .reject { |ethnicity| %w[90 98].include?(ethnicity.first) }
+  # Two codes have been dropped in 2020/21
+  # https://www.hesa.ac.uk/collection/c20053/e/ethnic
+  HESA_ETHNICITIES_2020_2021 = HESA_ETHNICITIES_2019_2020
+                                 .reject { |ethnicity| %w[90 98].include?(ethnicity.first) }
+  # Unchanged from 2020-2021
+  # https://www.hesa.ac.uk/collection/c21053/e/ethnic
+  HESA_ETHNICITIES_2021_2022 = HESA_ETHNICITIES_2020_2021
+end

--- a/spec/lib/hesa/ethnicity_spec.rb
+++ b/spec/lib/hesa/ethnicity_spec.rb
@@ -29,6 +29,20 @@ RSpec.describe Hesa::Ethnicity do
         expect(chinese.value).to eq HesaEthnicityValues::CHINESE
       end
     end
+
+    context 'Recruitment cycle 2021 - 2022' do
+      it 'returns a list of HESA ethnicity structs' do
+        cycle_year = 2022
+        ethnicity_values = described_class.all(cycle_year)
+
+        expect(ethnicity_values.size).to eq 16
+
+        chinese = ethnicity_values.find { |e| e.hesa_code == '34' }
+
+        expect(chinese.hesa_code).to eq '34'
+        expect(chinese.value).to eq HesaEthnicityValues::CHINESE
+      end
+    end
   end
 
   describe '.find' do

--- a/spec/lib/hesa/ethnicity_spec.rb
+++ b/spec/lib/hesa/ethnicity_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Hesa::Ethnicity do
         cycle_year = 2021
         ethnicity_values = described_class.all(cycle_year)
 
-        expect(ethnicity_values.size).to eq 16
+        expect(ethnicity_values.size).to eq 18
 
         chinese = ethnicity_values.find { |e| e.hesa_code == '34' }
 
@@ -35,7 +35,7 @@ RSpec.describe Hesa::Ethnicity do
         cycle_year = 2022
         ethnicity_values = described_class.all(cycle_year)
 
-        expect(ethnicity_values.size).to eq 16
+        expect(ethnicity_values.size).to eq 18
 
         chinese = ethnicity_values.find { |e| e.hesa_code == '34' }
 
@@ -58,9 +58,9 @@ RSpec.describe Hesa::Ethnicity do
 
     context 'given an unrecognised value' do
       it 'returns nil' do
-        result = described_class.find('Information refused', 2021)
+        result = described_class.find('Dunno', 2021)
 
-        expect(result).to eq nil
+        expect(result.value).to eq HesaEthnicityValues::NOT_KNOWN
       end
     end
   end

--- a/spec/services/candidate_interface/hesa_code_backfill_spec.rb
+++ b/spec/services/candidate_interface/hesa_code_backfill_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
             'ethnic_group' => 'Prefer not to say',
             'disabilities' => [],
             'hesa_disabilities' => nil,
-            'hesa_ethnicity' => nil,
+            'hesa_ethnicity' => '98',
             'hesa_sex' => nil,
           )
         end


### PR DESCRIPTION
## Context

We lookup HESA ethnicity codes based on the current recruitment year as some values are particular to specific years.
The data remains unchanged for the 2021-2022 cycle but we don't currently support this year.
See https://www.hesa.ac.uk/collection/c21053/revision_history for changes.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Refactored the lookup method to allow a dynamic lookup based on the year.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/6rTx4hAJ/4185-investigation-review-hesa-data-cycle-awareness-and-storage

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
