### PR TITLE
Add missing params to application header component

### DIFF
--- a/app/controllers/provider_interface/notes_controller.rb
+++ b/app/controllers/provider_interface/notes_controller.rb
@@ -5,7 +5,12 @@ module ProviderInterface
     def index
       @provider_can_respond = current_provider_user.authorisation.can_make_decisions?(
         application_choice: @application_choice,
-        course_option_id: @application_choice.current_course_option.id,
+        course_option: @application_choice.current_course_option,
+      )
+
+      @provider_can_set_up_interviews = current_provider_user.authorisation.can_set_up_interviews?(
+        application_choice: @application_choice,
+        course_option: @application_choice.current_course_option,
       )
 
       @notes = @application_choice.notes.order('created_at DESC')

--- a/app/views/provider_interface/application_choices/timeline.html.erb
+++ b/app/views/provider_interface/application_choices/timeline.html.erb
@@ -1,5 +1,9 @@
 <% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Timeline" %>
 
-<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: @provider_can_respond) %>
+<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(
+  application_choice: @application_choice,
+  provider_can_respond: @provider_can_respond,
+  provider_can_set_up_interviews: @provider_can_set_up_interviews,
+) %>
 
 <%= render ProviderInterface::ApplicationTimelineComponent.new(application_choice: @application_choice) %>

--- a/app/views/provider_interface/notes/index.html.erb
+++ b/app/views/provider_interface/notes/index.html.erb
@@ -1,6 +1,10 @@
 <% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Notes" %>
 
-<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: @provider_can_respond) %>
+<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(
+  application_choice: @application_choice,
+  provider_can_respond: @provider_can_respond,
+  provider_can_set_up_interviews: @provider_can_set_up_interviews,
+) %>
 
 <%= govuk_button_link_to 'Add note', new_provider_interface_application_choice_note_path(@application_choice), secondary: true %>
 

--- a/spec/system/provider_interface/provider_adds_note_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_adds_note_to_application_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
     when_i_visit_that_application_in_the_provider_interface
     and_i_visit_the_notes_tab
-    and_i_click_to_add_a_note
+    then_i_see_workflow_actions
+
+    when_i_click_to_add_a_note
     and_i_attempt_to_create_a_note_with_no_text
     then_i_see_an_error_message
 
@@ -29,6 +31,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     @provider = create(:provider, :with_signed_agreement)
     provider_user = create(:provider_user, dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
     provider_user.providers << @provider
+    provider_user.provider_permissions.update_all(make_decisions: true, set_up_interviews: true)
     user_exists_in_dfe_sign_in
   end
 
@@ -45,9 +48,16 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     click_on 'Notes'
   end
 
+  def then_i_see_workflow_actions
+    expect(page).to have_link('Set up interview')
+    expect(page).to have_link('Make decision')
+  end
+
   def and_i_click_to_add_a_note
     click_on 'Add note'
   end
+
+  alias_method :when_i_click_to_add_a_note, :and_i_click_to_add_a_note
 
   def and_i_attempt_to_create_a_note_with_no_text
     fill_in 'Note', with: ''


### PR DESCRIPTION
## Context

An additional parameter was passed to the application choice header component to signify that the user had permission to set up interviews, this wasn't implemented on the notes and timeline views.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Set `@provider_can_set_up_interviews` instance var in the relevant controller actions and pass this to `ProviderInterface::ApplicationChoiceHeaderComponent`

<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/132365459-0cdde89f-e9e0-4d55-b36c-cad9c6792ea9.png)


## Guidance to review

If you have set up interviews permissions the 'Set up interview' button should appear in the notes and timeline tabs of the application.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Jdek9f6q/4178-bug-the-set-up-interview-button-is-not-displayed-on-the-application-header-when-switching-to-the-notes-or-timeline-tabs

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
