### PR TITLE
Redirect away from Invite flow if wizard store expires

### DIFF
--- a/app/controllers/provider_interface/user_invitation/base_controller.rb
+++ b/app/controllers/provider_interface/user_invitation/base_controller.rb
@@ -4,6 +4,7 @@ module ProviderInterface
       before_action :set_provider
       before_action :assert_can_manage_users!
       before_action :redirect_unless_feature_flag_on
+      before_action :redirect_to_index_if_store_cleared
 
     protected
 
@@ -26,6 +27,10 @@ module ProviderInterface
         return if FeatureFlag.active?(:account_and_org_settings_changes)
 
         redirect_to provider_interface_organisation_settings_path
+      end
+
+      def redirect_to_index_if_store_cleared
+        redirect_to provider_interface_organisation_settings_organisation_users_path(@provider) if invite_user_store.read.blank?
       end
 
       def next_page_path

--- a/app/controllers/provider_interface/user_invitation/personal_details_controller.rb
+++ b/app/controllers/provider_interface/user_invitation/personal_details_controller.rb
@@ -1,6 +1,8 @@
 module ProviderInterface
   module UserInvitation
     class PersonalDetailsController < BaseController
+      skip_before_action :redirect_to_index_if_store_cleared, only: :new
+
       def new
         @wizard = InviteUserWizard.new(
           invite_user_store,

--- a/spec/requests/provider_interface/user_invitation/permissions_controller_spec.rb
+++ b/spec/requests/provider_interface/user_invitation/permissions_controller_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::UserInvitation::PermissionsController do
+  include DfESignInHelpers
+
+  let(:managing_user) { create(:provider_user, :with_manage_organisations, :with_manage_users, providers: [provider]) }
+  let(:provider) { create(:provider, :with_signed_agreement) }
+
+  before do
+    allow(DfESignInUser).to receive(:load_from_session).and_return(managing_user)
+
+    user_exists_in_dfe_sign_in(email_address: managing_user.email_address)
+  end
+
+  context 'when the account_and_org_settings_changes feature flag is on' do
+    before { FeatureFlag.activate(:account_and_org_settings_changes) }
+
+    context 'when there is nothing in the wizard store' do
+      let(:store_data) { nil }
+
+      before do
+        store = instance_double(WizardStateStores::RedisStore, read: store_data, write: nil)
+        allow(WizardStateStores::RedisStore).to receive(:new).and_return(store)
+      end
+
+      it 'redirects to the users index page on GET new' do
+        get new_provider_interface_organisation_settings_organisation_user_invitation_permissions_path(provider)
+
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(provider_interface_organisation_settings_organisation_users_url(provider))
+      end
+
+      it 'redirects to the users index page on POST create' do
+        post provider_interface_organisation_settings_organisation_user_invitation_permissions_path(provider),
+             params: { provider_interface_invite_user_wizard: { permissions: [] } }
+
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(provider_interface_organisation_settings_organisation_users_url(provider))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
If a provider user leaves a tab open for a long time, then the wizard store can expire, meaning they need to enter information again.

## Changes proposed in this pull request
Redirect back to the users index page when the store expires and the flow needs the information.

## Guidance to review
Do we need a flash message warning when redirecting?

## Link to Trello card
https://trello.com/c/XVA6dp7E/4221-redirect-away-from-invite-user-flow-if-the-cache-has-expired

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
