### PR TITLE
Fix back link on invite user personal details page

### DIFF
--- a/app/controllers/provider_interface/user_invitation/base_controller.rb
+++ b/app/controllers/provider_interface/user_invitation/base_controller.rb
@@ -45,6 +45,8 @@ module ProviderInterface
           new_provider_interface_organisation_settings_organisation_user_invitation_permissions_path(@provider)
         when :check
           provider_interface_organisation_settings_organisation_user_invitation_check_path(@provider)
+        else
+          provider_interface_organisation_settings_organisation_users_path(@provider)
         end
       end
 


### PR DESCRIPTION
## Context
Spotted a bug with the back link on the invite user flow

## Trello
https://trello.com/c/1hhu74tg/4222-back-link-on-invite-user-personal-details-page-goes-to-the-current-page