### PR TITLE
Fix RSpec failures due to cycle

### DIFF
--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
+RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true do
   context 'when course choices are editable' do
     let(:application_form) do
       create_application_form_with_course_choices(statuses: %w[unsubmitted])

--- a/spec/support/cycles.rb
+++ b/spec/support/cycles.rb
@@ -1,0 +1,21 @@
+require 'support/test_helpers/cycle_timetable_helper'
+
+RSpec.configure do |config|
+  config.include CycleTimetableHelper
+
+  config.around mid_cycle: true do |example|
+    Timecop.travel(mid_cycle) do
+      example.run
+    end
+  end
+
+  config.around(type: :feature) do |example|
+    if example.metadata[:mid_cycle] == false
+      example.run
+    else
+      Timecop.travel(mid_cycle) do
+        example.run
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/course_selection/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_edits_course_choices_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Candidate edits course choices' do
+RSpec.feature 'Candidate edits course choices' do
   include CandidateHelper
   include CourseOptionHelpers
 

--- a/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'An existing candidate arriving from Find with a course and provider code (with course selection page)' do
+RSpec.feature 'An existing candidate arriving from Find with a course and provider code (with course selection page)' do
   include CourseOptionHelpers
   include SignInHelper
 

--- a/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'A new candidate arriving from Find with a course and provider code' do
+RSpec.feature 'A new candidate arriving from Find with a course and provider code' do
   include SignInHelper
 
   scenario 'retaining their course selection through the sign up process' do

--- a/spec/system/candidate_interface/course_selection/candidate_sees_add_additional_courses_after_adding_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_sees_add_additional_courses_after_adding_course_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Add additional courses flow' do
+RSpec.feature 'Add additional courses flow' do
   include CandidateHelper
   include CourseOptionHelpers
 

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Selecting a full course' do
+RSpec.feature 'Selecting a full course' do
   include CandidateHelper
 
   scenario 'Candidate selects a full course' do

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'An existing candidate arriving from Find with course params selects a study mode' do
+RSpec.feature 'An existing candidate arriving from Find with course params selects a study mode' do
   include CourseOptionHelpers
 
   scenario 'Signed in user with Find course params selects a part time course' do

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'An existing candidate arriving from Find with a course and provider code' do
+RSpec.feature 'An existing candidate arriving from Find with a course and provider code' do
   include CourseOptionHelpers
   scenario 'candidate is signed in' do
     given_the_pilot_is_open

--- a/spec/system/candidate_interface/course_selection/sandbox_user_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/course_selection/sandbox_user_apply_from_find_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'A sandbox user arriving from Find with a course and provider code', sandbox: true do
+RSpec.feature 'A sandbox user arriving from Find with a course and provider code', sandbox: true do
   include SignInHelper
 
   scenario 'can prefill their application with their chosen course' do

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Entering their other qualifications' do
+RSpec.feature 'Entering their other qualifications', mid_cycle: false do
   include CandidateHelper
 
   scenario 'Candidate submits their other qualifications' do

--- a/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Non-uk Other qualifications' do
+RSpec.feature 'Non-uk Other qualifications', mid_cycle: false do
   include CandidateHelper
 
   scenario 'International candidate enters their other non-uk qualification' do

--- a/spec/system/candidate_interface/feedback/candidate_completes_the_feedback_form_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_completes_the_feedback_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Candidate feedback form' do
+RSpec.feature 'Candidate feedback form' do
   include CandidateHelper
 
   scenario 'Candidate completes the feedback form' do

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Providers should be able to filter applications' do
+RSpec.feature 'Providers should be able to filter applications', mid_cycle: false do
   include CourseOptionHelpers
   include DfESignInHelpers
 

--- a/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
+++ b/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Provider user exports applications to a csv' do
+RSpec.feature 'Provider user exports applications to a csv', mid_cycle: false do
   include CourseOptionHelpers
   include DfESignInHelpers
 

--- a/spec/system/reject_by_default_spec.rb
+++ b/spec/system/reject_by_default_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Reject by default' do
+RSpec.feature 'Reject by default', mid_cycle: false do
   include CourseOptionHelpers
 
   scenario 'An application is rejected by default', with_audited: true do

--- a/spec/system/support_interface/add_audit_comment_spec.rb
+++ b/spec/system/support_interface/add_audit_comment_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Add comments to the application history', with_audited: true do
+RSpec.feature 'Add comments to the application history', mid_cycle: false, with_audited: true do
   include DfESignInHelpers
 
   scenario 'Support user adds a comment to the application audit page' do

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Providers and courses' do
+RSpec.feature 'Providers and courses', mid_cycle: false do
   include DfESignInHelpers
   include TeacherTrainingPublicAPIHelper
 

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Service performance' do
+RSpec.feature 'Service performance', mid_cycle: false do
   include DfESignInHelpers
 
   scenario 'View service statistics' do

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -213,7 +213,7 @@ RSpec.feature 'Vendor receives the application' do
               description: 'I volunteered.',
             },
           ],
-          work_history_break_explanation: 'January 2019 to September 2021: Terraforming is tiring.',
+          work_history_break_explanation: 'January 2019 to October 2019: Terraforming is tiring.',
         },
       },
     }


### PR DESCRIPTION
## Context

The deadline for apply 1 passed, and quite a few specs started failing

## Changes proposed in this pull request

Add an RSpec around hook for features to travel to mid cycle. Allow disabling this as some specs can be run normally

## Guidance to review

too late to think, might need cleanup

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
