### PR TITLE
Add big query sidekiq queue

### DIFF
--- a/app/workers/detect_invariants_hourly_check.rb
+++ b/app/workers/detect_invariants_hourly_check.rb
@@ -1,7 +1,7 @@
 # Detect state that *should* be impossible in the system and report them to Sentry
 class DetectInvariantsHourlyCheck
   include Sidekiq::Worker
-  SIDEKIQ_QUEUE_NAMES = %w[low_priority default mailers].freeze
+  SIDEKIQ_QUEUE_NAMES = %w[low_priority default mailers big_query].freeze
   SIDEKIQ_LATENCY_THRESHOLD = 120
 
   def perform

--- a/app/workers/send_events_to_bigquery.rb
+++ b/app/workers/send_events_to_bigquery.rb
@@ -1,7 +1,7 @@
 class SendEventsToBigquery
   include Sidekiq::Worker
 
-  sidekiq_options retry: 3, queue: :low_priority
+  sidekiq_options retry: 3, queue: :big_query
 
   def perform(request_event_json)
     table_name = ENV.fetch('BIG_QUERY_TABLE_NAME', 'events')

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,3 +3,4 @@
   - default
   - mailers
   - low_priority
+  - big_query


### PR DESCRIPTION
## Context

We send request events to Bigquery via Sidekiq, currently these jobs are enqueued on the `low_priority` queue along with other apply workflow jobs.
Load testing identified that under unusual loads the Bigquery jobs would back up to the point where Redis memory is exhausted.

We'd like to separate the BQ work so that:

- We can monitor the Bigquery jobs easily.
- We have the ability to clear the `big_query` queue in extreme circumstances.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Add a lower-than-low-priority queue for Bigquery jobs.
- Send events to Bigquery on the `big_query` queue.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Should we lower the retry count?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
