### PR TITLE
Weight sidekiq queues for load test

### DIFF
--- a/app/workers/send_events_to_bigquery.rb
+++ b/app/workers/send_events_to_bigquery.rb
@@ -1,7 +1,7 @@
 class SendEventsToBigquery
   include Sidekiq::Worker
 
-  sidekiq_options retry: 3, queue: :low_priority
+  sidekiq_options retry: 3, queue: :big_query
 
   def perform(request_event_json)
     table_name = ENV.fetch('BIG_QUERY_TABLE_NAME', 'events')

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,6 @@
 ---
 :queues:
-  - default
-  - mailers
-  - low_priority
+  - [default, 3]
+  - [mailers, 2]
+  - [low_priority, 1]
+  - [big_query, 1]


### PR DESCRIPTION
## Context

https://github.com/mperham/sidekiq/wiki/Advanced-Options

Weighting Sidekiq queues means that work is distributed in a ratio according to the weight given, this means that a queue with a weight of `2` is checked for jobs twice as often as a queue with a weight of `1`.

We tend to use the `low_priority` queue for our workflow tasks which would currently be blocked by jobs in the `mailers` queue because of the sequential priority of our current config.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This PR attempts to allow work on all queues to proceed while still applying priority to specific queues.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
