### PR TITLE
Validate RBD date based on the presence of the date field

### DIFF
--- a/app/forms/provider_interface/interview_wizard.rb
+++ b/app/forms/provider_interface/interview_wizard.rb
@@ -18,7 +18,7 @@ module ProviderInterface
     validate :time_is_valid, unless: -> { time.blank? }
     validate :date_and_time_in_future, if: %i[date_and_time],
                                        unless: ->(c) { %i[date time].any? { |d| c.errors.attribute_names.include?(d) } }
-    validate :date_after_rbd_date, if: %i[date_and_time date_and_time_in_future]
+    validate :date_after_rbd_date, if: %i[date]
     validates :provider_id, presence: true, if: %i[application_choice provider_user multiple_application_providers?]
     validates :location, presence: true, word_count: { maximum: 2000 }
     validates :additional_details, word_count: { maximum: 2000 }
@@ -94,8 +94,11 @@ module ProviderInterface
     end
 
     def date_after_rbd_date
-      rbd_date = application_choice.reject_by_default_at
-      errors.add(:date, :after_rdb, rbd_date: rbd_date.to_s(:govuk_date)) if date > rbd_date
+      rbd_date = application_choice&.reject_by_default_at
+
+      if rbd_date.present? && date.is_a?(Date) && date > rbd_date
+        errors.add(:date, :after_rdb, rbd_date: rbd_date.to_s(:govuk_date))
+      end
     end
 
     def time_in_correct_format?

--- a/spec/forms/provider_interface/interview_wizard_spec.rb
+++ b/spec/forms/provider_interface/interview_wizard_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe ProviderInterface::InterviewWizard do
       context 'when it is after the rdb date' do
         let(:application_choice) { build_stubbed(:application_choice, reject_by_default_at: Time.zone.local(2021, 2, 14)) }
         let(:day) { 15 }
+        let(:time) { '' }
 
         it 'is invalid with the correct error' do
           Timecop.freeze(2021, 1, 13) do


### PR DESCRIPTION
## Context

The time field is not relevant to this validation.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Scopes the RBD validation to the date field only. Time related validations are independent of this.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Oh01ViLI/4116-not-showing-interview-date-error-when-there-is-an-interview-time-error-on-the-schedule-interview-screen
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
