### PR TITLE
Performance and usability improvements for the API monitoring dashboard

### DIFF
--- a/app/models/support_interface/vendor_api_monitor.rb
+++ b/app/models/support_interface/vendor_api_monitor.rb
@@ -1,39 +1,41 @@
 module SupportInterface
   class VendorAPIMonitor
-    def providers_with_api_usage_stats
-      Provider.select('providers.id,
-                      providers.name,
-                      last_syncs.last_sync as last_sync,
-                      last_decisions.last_decision as last_decision,
-                      errors.count as error_count,
-                      requests.count as request_count,
-                      all_time_requests.count,
-                      (CAST(errors.count AS FLOAT)/requests.count) * 100 as error_rate')
-        .joins("LEFT JOIN (#{VendorAPIRequest.successful.syncs.select('provider_id, MAX(vendor_api_requests.created_at) as last_sync').group('provider_id').to_sql}) last_syncs on last_syncs.provider_id = providers.id")
-        .joins("LEFT JOIN (#{VendorAPIRequest.successful.decisions.select('provider_id, MAX(vendor_api_requests.created_at) as last_decision').group('provider_id').to_sql}) last_decisions on last_decisions.provider_id = providers.id")
-        .joins("LEFT JOIN (#{VendorAPIRequest.errors.select('provider_id, COUNT(vendor_api_requests.id) as count').where("vendor_api_requests.created_at > current_date - interval '7 days'").group('provider_id').to_sql}) errors on errors.provider_id = providers.id")
-        .joins("LEFT JOIN (#{VendorAPIRequest.select('provider_id, COUNT(vendor_api_requests.id) as count').where("vendor_api_requests.created_at > current_date - interval '7 days'").group('provider_id').to_sql}) requests on requests.provider_id = providers.id").where(provider_type: 'university')
-        .joins("LEFT JOIN (#{VendorAPIRequest.select('provider_id, COUNT(vendor_api_requests.id) as count').group('provider_id').to_sql}) all_time_requests on all_time_requests.provider_id = providers.id").where(provider_type: 'university')
+    def all_providers
+      Provider.where(provider_type: 'university')
+    end
+
+    def connected
+      all_providers.select(:id, :name).where.not(id: never_connected.select(:id))
     end
 
     def never_connected
-      providers_with_api_usage_stats
-        .includes(:vendor_api_tokens)
-        .where(all_time_requests: { count: nil })
+      all_providers
+        .joins("LEFT JOIN (#{VendorAPIRequest.select('provider_id, COUNT(vendor_api_requests.id) as count').group('provider_id').to_sql}) all_time_requests on all_time_requests.provider_id = providers.id")
+        .includes(:vendor_api_tokens).where(all_time_requests: { count: nil })
     end
 
     def no_sync_in_24h
-      providers_with_api_usage_stats.where("last_sync < now() - interval '24 hours'").order('last_sync DESC')
+      connected
+        .select('last_syncs.last_sync as last_sync')
+        .joins("LEFT JOIN (#{VendorAPIRequest.successful.syncs.select('provider_id, MAX(vendor_api_requests.created_at) as last_sync').group('provider_id').to_sql}) last_syncs on last_syncs.provider_id = providers.id")
+        .where("last_sync < now() - interval '24 hours' OR last_sync IS NULL").order('last_sync DESC')
     end
 
     def no_decisions_in_7d
-      providers_with_api_usage_stats.where("last_decision < now() - interval '7 days'").order('last_decision DESC')
+      connected
+        .select('last_decisions.last_decision as last_decision')
+        .joins("LEFT JOIN (#{VendorAPIRequest.successful.decisions.select('provider_id, MAX(vendor_api_requests.created_at) as last_decision').group('provider_id').to_sql}) last_decisions on last_decisions.provider_id = providers.id")
+      .where("last_decision < now() - interval '7 days' OR last_decision IS NULL").order('last_decision DESC')
     end
 
     def providers_with_errors
-      providers_with_api_usage_stats.where.not(errors: { count: nil }).order('error_rate DESC')
+      connected
+        .select('errors.count as error_count,
+          requests.count as request_count,
+          (CAST(errors.count AS FLOAT)/requests.count) * 100 as error_rate')
+        .joins("LEFT JOIN (#{VendorAPIRequest.errors.select('provider_id, COUNT(vendor_api_requests.id) as count').where("vendor_api_requests.created_at > current_date - interval '7 days'").group('provider_id').to_sql}) errors on errors.provider_id = providers.id")
+        .joins("LEFT JOIN (#{VendorAPIRequest.select('provider_id, COUNT(vendor_api_requests.id) as count').where("vendor_api_requests.created_at > current_date - interval '7 days'").group('provider_id').to_sql}) requests on requests.provider_id = providers.id")
+        .where.not(errors: { count: nil }).order('error_rate DESC')
     end
-
-    alias all_providers providers_with_api_usage_stats
   end
 end

--- a/app/services/create_vendor_api_monitor_dummy_data.rb
+++ b/app/services/create_vendor_api_monitor_dummy_data.rb
@@ -1,0 +1,30 @@
+class CreateVendorAPIMonitorDummyData
+  def self.call
+    integrated_providers = Provider.where(provider_type: 'university').shuffle
+
+    # decision older than 7 days
+    FactoryBot.create(:vendor_api_request, :decision, provider: integrated_providers.pop, created_at: Faker::Date.between(from: 3.weeks.ago, to: 8.days.ago))
+
+    # sync older than one day
+    FactoryBot.create(:vendor_api_request, :sync, provider: integrated_providers.pop, created_at: Faker::Date.between(from: 7.days.ago, to: 2.days.ago))
+
+    # mix of errors and legitimate requests
+    error_provider = integrated_providers.pop
+    FactoryBot.create_list(:vendor_api_request, rand(3..9), :with_validation_error, provider: error_provider, created_at: Faker::Date.between(from: 1.week.ago, to: 2.days.ago))
+    FactoryBot.create_list(:vendor_api_request, rand(10..19), :sync, provider: error_provider, created_at: Faker::Date.between(from: 7.days.ago, to: 2.days.ago))
+
+    # token but never connected
+    token_but_no_connection = integrated_providers.pop
+    FactoryBot.create(:vendor_api_token, provider: token_but_no_connection)
+
+    # no token, never connected
+    integrated_providers.pop
+
+    # make some random traffic for the rest
+    integrated_providers.each do |provider|
+      FactoryBot.create(:vendor_api_request, :decision, provider: provider, created_at: Faker::Date.between(from: 6.weeks.ago, to: 6.days.ago))
+      FactoryBot.create(:vendor_api_request, :with_validation_error, provider: provider, created_at: Faker::Date.between(from: 2.weeks.ago, to: 2.days.ago))
+      FactoryBot.create_list(:vendor_api_request, rand(28), :sync, provider: provider, created_at: Faker::Date.between(from: 2.weeks.ago, to: 12.hours.ago))
+    end
+  end
+end

--- a/app/views/support_interface/vendor_api_monitoring/index.html.erb
+++ b/app/views/support_interface/vendor_api_monitoring/index.html.erb
@@ -41,8 +41,8 @@
   <table class="govuk-table" data-qa="not-connected">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Provider</th>
-        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">API token issued</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-half">Provider</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-half">API token issued</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -72,8 +72,9 @@
   <table class="govuk-table" data-qa="not-synced">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Provider</th>
-        <th class="govuk-table__header govuk-table__header">Last sync</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-half">Provider</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time since last sync</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time of last sync</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -84,7 +85,14 @@
           </td>
           <td class="govuk-table__cell">
             <% if provider.last_sync %>
-              <%= "#{provider.last_sync.to_s(:govuk_date_and_time)} (#{time_ago_in_words(provider.last_sync)} ago)" %>
+              <%= time_ago_in_words(provider.last_sync) %>
+            <% else %>
+              -
+            <% end %>
+          </td>
+          <td class="govuk-table__cell">
+            <% if provider.last_sync %>
+              <%= provider.last_sync.to_s(:govuk_date_and_time) %>
             <% else %>
               -
             <% end %>
@@ -103,8 +111,9 @@
   <table class="govuk-table" data-qa="not-posted-decision">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Provider</th>
-        <th class="govuk-table__header govuk-table__header">Last decision</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-half">Provider</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time since last decision</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time of last decision</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -115,7 +124,14 @@
           </td>
           <td class="govuk-table__cell">
             <% if provider.last_decision %>
-              <%= "#{provider.last_decision.to_s(:govuk_date_and_time)} (#{time_ago_in_words(provider.last_decision)} ago)" %>
+              <%= time_ago_in_words(provider.last_decision) %>
+            <% else %>
+              -
+            <% end %>
+          </td>
+          <td class="govuk-table__cell">
+            <% if provider.last_decision %>
+              <%= provider.last_decision.to_s(:govuk_date_and_time) %>
             <% else %>
               -
             <% end %>
@@ -135,9 +151,9 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Provider</th>
-        <th class="govuk-table__header govuk-table__header">Requests</th>
-        <th class="govuk-table__header govuk-table__header">Errors</th>
-        <th class="govuk-table__header govuk-table__header">Error rate</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Requests</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Errors</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Error rate</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">

--- a/app/views/support_interface/vendor_api_monitoring/index.html.erb
+++ b/app/views/support_interface/vendor_api_monitoring/index.html.erb
@@ -3,32 +3,32 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-quarter">
     <%= render SupportInterface::TileComponent.new(
-      count: @monitor.never_connected.count,
-      label: "#{'provider'.pluralize(@monitor.never_connected.count)} #{'has'.pluralize(@monitor.never_connected.count)} never connected to the API",
+      count: @monitor.never_connected.size,
+      label: "#{'provider'.pluralize(@monitor.never_connected.size)} (out of #{@monitor.all_providers.size}) #{'has'.pluralize(@monitor.never_connected.size)} never connected to the API",
       colour: :blue,
       href: '#not-connected',
     ) %>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <%= render SupportInterface::TileComponent.new(
-      count: @monitor.no_sync_in_24h.count,
-      label: "connected #{'provider'.pluralize(@monitor.no_sync_in_24h.count)} #{'has'.pluralize(@monitor.no_sync_in_24h.count)} not synced for at least 24 hours",
+      count: @monitor.no_sync_in_24h.size,
+      label: "connected #{'provider'.pluralize(@monitor.no_sync_in_24h.size)} #{'has'.pluralize(@monitor.no_sync_in_24h.size)} not synced for at least 24 hours",
       colour: :blue,
       href: '#not-synced',
     ) %>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <%= render SupportInterface::TileComponent.new(
-      count: @monitor.no_decisions_in_7d.count,
-      label: "connected #{'provider'.pluralize(@monitor.no_decisions_in_7d.count)} #{'has'.pluralize(@monitor.no_decisions_in_7d.count)} not posted a decision for at least 7 days",
+      count: @monitor.no_decisions_in_7d.size,
+      label: "connected #{'provider'.pluralize(@monitor.no_decisions_in_7d.size)} #{'has'.pluralize(@monitor.no_decisions_in_7d.size)} not posted a decision for at least 7 days",
       colour: :blue,
       href: '#not-posted-decision',
     ) %>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <%= render SupportInterface::TileComponent.new(
-      count: @monitor.providers_with_errors.count,
-      label: "connected #{'provider'.pluralize(@monitor.providers_with_errors.count)} #{'has'.pluralize(@monitor.providers_with_errors.count)} caused an error in the last 7 days",
+      count: @monitor.providers_with_errors.size,
+      label: "connected #{'provider'.pluralize(@monitor.providers_with_errors.size)} #{'has'.pluralize(@monitor.providers_with_errors.size)} caused an error in the last 7 days",
       colour: :blue,
       href: '#received-error-response',
     ) %>
@@ -153,7 +153,7 @@
             <%= number_with_delimiter(provider.error_count) %>
           </td>
           <td class="govuk-table__cell">
-            <%= number_with_delimiter(provider.error_rate) %>
+            <%= provider.error_rate.round(1) %>%
           </td>
         </tr>
       <% end %>

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -16,6 +16,9 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
   puts 'Generating a Vendor API token...'
   VendorAPIToken.create_with_random_token!(provider: Provider.find_by(code: '1JA'))
 
+  puts 'Generating fake API requests for the Vendor API Monitor...'
+  CreateVendorAPIMonitorDummyData.call
+
   Rake::Task['generate_test_applications'].invoke
 end
 
@@ -23,7 +26,7 @@ desc 'Sync some pilot-enabled providers and open all their courses'
 task sync_dev_providers_and_open_courses: :environment do
   puts 'Syncing data from TTAPI...'
 
-  provider_codes = %w[1JA 24J 24P D39 S72 1JB 4T7 1N1]
+  provider_codes = %w[1JA 24J 24P D39 S72 1JB 4T7 1N1 Y50 L34 D86 K60 H72]
   provider_codes.each do |code|
     provider_from_api = TeacherTrainingPublicAPI::Provider
         .where(year: RecruitmentCycle.current_year)

--- a/spec/factories/vendor_api_request.rb
+++ b/spec/factories/vendor_api_request.rb
@@ -10,6 +10,17 @@ FactoryBot.define do
     response_body { {} }
     created_at { Time.zone.now }
 
+    trait :sync do
+      request_path { '/api/v1/applications' }
+      request_method { 'GET' }
+      status_code { 200 }
+    end
+
+    trait :decision do
+      request_method { 'POST' }
+      status_code { 200 }
+    end
+
     trait :with_validation_error do
       status_code { 422 }
       response_body do

--- a/spec/factories/vendor_api_token.rb
+++ b/spec/factories/vendor_api_token.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :vendor_api_token do
     provider
 
-    hashed_token { '1234567890' }
+    hashed_token { SecureRandom.hex(16) }
 
     trait :with_random_token do
       hashed_token do

--- a/spec/models/support_interface/vendor_api_monitor_spec.rb
+++ b/spec/models/support_interface/vendor_api_monitor_spec.rb
@@ -20,14 +20,16 @@ RSpec.describe SupportInterface::VendorAPIMonitor do
     it 'returns only providers who have connected and who have not synced in 24h' do
       _never_connected = create(:provider, name: 'never', provider_type: 'university')
       synced_recently = create(:provider, name: 'recently', provider_type: 'university')
+      failed_recently = create(:provider, name: 'failed', provider_type: 'university')
       synced_1w_ago = create(:provider, name: '1 week ago', provider_type: 'university')
       synced_2d_ago = create(:provider, name: '3 hours', provider_type: 'university')
 
       create(:vendor_api_request, provider: synced_recently)
+      create(:vendor_api_request, provider: failed_recently, status_code: 422)
       create(:vendor_api_request, provider: synced_1w_ago, created_at: 1.week.ago)
       create(:vendor_api_request, provider: synced_2d_ago, created_at: 2.days.ago)
 
-      expect(monitor.no_sync_in_24h.map(&:id)).to eq [synced_2d_ago.id, synced_1w_ago.id]
+      expect(monitor.no_sync_in_24h.map(&:id)).to eq [failed_recently.id, synced_2d_ago.id, synced_1w_ago.id]
     end
   end
 
@@ -35,14 +37,16 @@ RSpec.describe SupportInterface::VendorAPIMonitor do
     it 'returns only providers who have connected and who have not made decisions in 7 days' do
       _never_connected = create(:provider, name: 'never', provider_type: 'university')
       decided_recently = create(:provider, name: 'recently', provider_type: 'university')
+      failed_recently = create(:provider, name: 'failed', provider_type: 'university')
       decided_over_2w_ago = create(:provider, name: '2 weeks', provider_type: 'university')
       decided_over_7d_ago = create(:provider, name: '7 days', provider_type: 'university')
 
       create(:vendor_api_request, request_method: 'POST', provider: decided_recently)
+      create(:vendor_api_request, request_method: 'POST', provider: failed_recently, status_code: 422)
       create(:vendor_api_request, request_method: 'POST', provider: decided_over_7d_ago, created_at: 8.days.ago)
       create(:vendor_api_request, request_method: 'POST', provider: decided_over_2w_ago, created_at: 15.days.ago)
 
-      expect(monitor.no_decisions_in_7d.map(&:id)).to eq [decided_over_7d_ago.id, decided_over_2w_ago.id]
+      expect(monitor.no_decisions_in_7d.map(&:id)).to eq [failed_recently.id, decided_over_7d_ago.id, decided_over_2w_ago.id]
     end
   end
 

--- a/spec/models/support_interface/vendor_api_monitor_spec.rb
+++ b/spec/models/support_interface/vendor_api_monitor_spec.rb
@@ -20,27 +20,29 @@ RSpec.describe SupportInterface::VendorAPIMonitor do
     it 'returns only providers who have connected and who have not synced in 24h' do
       _never_connected = create(:provider, name: 'never', provider_type: 'university')
       synced_recently = create(:provider, name: 'recently', provider_type: 'university')
-      synced_over_24h_ago = create(:provider, name: 'stale', provider_type: 'university')
+      synced_1w_ago = create(:provider, name: '1 week ago', provider_type: 'university')
+      synced_2d_ago = create(:provider, name: '3 hours', provider_type: 'university')
 
       create(:vendor_api_request, provider: synced_recently)
-      create(:vendor_api_request, provider: synced_over_24h_ago, created_at: 2.days.ago)
+      create(:vendor_api_request, provider: synced_1w_ago, created_at: 1.week.ago)
+      create(:vendor_api_request, provider: synced_2d_ago, created_at: 2.days.ago)
 
-      expect(monitor.no_sync_in_24h.count).to eq 1
-      expect(monitor.no_sync_in_24h.first.id).to eq synced_over_24h_ago.id
+      expect(monitor.no_sync_in_24h.map(&:id)).to eq [synced_2d_ago.id, synced_1w_ago.id]
     end
   end
 
   describe '#no_decisions_in_7d' do
-    it 'returns only providers who have connected and who have not synced in 7 days' do
+    it 'returns only providers who have connected and who have not made decisions in 7 days' do
       _never_connected = create(:provider, name: 'never', provider_type: 'university')
       decided_recently = create(:provider, name: 'recently', provider_type: 'university')
-      decided_over_7d_ago = create(:provider, name: 'stale', provider_type: 'university')
+      decided_over_2w_ago = create(:provider, name: '2 weeks', provider_type: 'university')
+      decided_over_7d_ago = create(:provider, name: '7 days', provider_type: 'university')
 
       create(:vendor_api_request, request_method: 'POST', provider: decided_recently)
       create(:vendor_api_request, request_method: 'POST', provider: decided_over_7d_ago, created_at: 8.days.ago)
+      create(:vendor_api_request, request_method: 'POST', provider: decided_over_2w_ago, created_at: 15.days.ago)
 
-      expect(monitor.no_decisions_in_7d.count).to eq 1
-      expect(monitor.no_decisions_in_7d.first.id).to eq decided_over_7d_ago.id
+      expect(monitor.no_decisions_in_7d.map(&:id)).to eq [decided_over_7d_ago.id, decided_over_2w_ago.id]
     end
   end
 
@@ -57,11 +59,11 @@ RSpec.describe SupportInterface::VendorAPIMonitor do
 
       create(:vendor_api_request, request_method: 'POST', status_code: 422, provider: errored_over_7d_ago, created_at: 8.days.ago)
 
-      expect(monitor.providers_with_errors.count).to eq 1
+      expect(monitor.providers_with_errors.size).to eq 1
       expect(monitor.providers_with_errors.first.id).to eq errored_recently.id
       expect(monitor.providers_with_errors.first.error_count).to be 1
       expect(monitor.providers_with_errors.first.request_count).to be 2
-      expect(monitor.providers_with_errors.first.error_rate).to eq '50.0%'
+      expect(monitor.providers_with_errors.first.error_rate).to eq 50.0
     end
   end
 end

--- a/spec/system/support_interface/vendor_api_monitoring_spec.rb
+++ b/spec/system/support_interface/vendor_api_monitoring_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Vendor API monitoring page' do
+RSpec.feature 'Vendor API monitoring page', mid_cycle: false do
   include DfESignInHelpers
 
   scenario 'rendering the page' do


### PR DESCRIPTION
## Context

The dashboard is slow because it makes a lot of queries, and it's quite hard to read.

## Changes proposed in this pull request

- Make it easy to generate plausible test data so it's easier to work on and review in Heroku
- Push more work into the database to make it faster
- Split the "time since" and the absolute time of requests we want to monitor for age into separate columns for readability
- Order those tables by recency of last request, or in the case of error rate, error rate