### PR TITLE
Point candidate mailer offers to current course

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -281,8 +281,8 @@ class CandidateMailer < ApplicationMailer
     @course_option = @application_choice.course_option
     @current_course_option = @application_choice.current_course_option
     @is_awaiting_decision = application_choice.self_and_siblings.decision_pending.any?
-    @offers = @application_choice.self_and_siblings.select(&:offer?).map do |offer|
-      "#{offer.course_option.course.name_and_code} at #{offer.course_option.course.provider.name}"
+    @offers = @application_choice.self_and_siblings.select(&:offer?).map do |choice|
+      "#{choice.current_course_option.course.name_and_code} at #{choice.current_course_option.course.provider.name}"
     end
 
     email_for_candidate(


### PR DESCRIPTION
## Context

If a course changes, we aren't displaying the latest course an offer is set to. Use current course option
instead of course option to surface the change

## Changes proposed in this pull request

In change offer email, display the current course in other offers section

## Guidance to review

Many of those mailers are also not pointing to the right course, we need an audit to fix

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
