### PR TITLE
Remove Feature-Policy header from API responses

### DIFF
--- a/app/controllers/candidate_api/candidates_controller.rb
+++ b/app/controllers/candidate_api/candidates_controller.rb
@@ -1,6 +1,7 @@
 module CandidateAPI
   class CandidatesController < ActionController::API
     include ServiceAPIUserAuthentication
+    include RemoveBrowserOnlyHeaders
 
     rescue_from ActionController::ParameterMissing, with: :parameter_missing
     rescue_from ParameterInvalid, with: :parameter_invalid

--- a/app/controllers/concerns/remove_browser_only_headers.rb
+++ b/app/controllers/concerns/remove_browser_only_headers.rb
@@ -1,0 +1,11 @@
+module RemoveBrowserOnlyHeaders
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :remove_feature_policy_header
+  end
+
+  def remove_feature_policy_header
+    headers.delete('Feature-Policy')
+  end
+end

--- a/app/controllers/data_api/tad_data_exports_controller.rb
+++ b/app/controllers/data_api/tad_data_exports_controller.rb
@@ -1,6 +1,7 @@
 module DataAPI
   class TADDataExportsController < ActionController::API
     include ServiceAPIUserAuthentication
+    include RemoveBrowserOnlyHeaders
 
     # Makes PG::QueryCanceled statement timeout errors appear in Skylight
     # against the controller action that triggered them

--- a/app/controllers/register_api/applications_controller.rb
+++ b/app/controllers/register_api/applications_controller.rb
@@ -1,6 +1,7 @@
 module RegisterAPI
   class ApplicationsController < ActionController::API
     include ServiceAPIUserAuthentication
+    include RemoveBrowserOnlyHeaders
 
     rescue_from ActionController::ParameterMissing, with: :parameter_missing
     rescue_from ParameterInvalid, with: :parameter_invalid

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -2,6 +2,7 @@ module VendorAPI
   class VendorAPIController < ActionController::API
     include ActionController::HttpAuthentication::Token::ControllerMethods
     include RequestQueryParams
+    include RemoveBrowserOnlyHeaders
 
     rescue_from ActiveRecord::RecordNotFound, with: :application_not_found
     rescue_from ActionController::ParameterMissing, with: :parameter_missing

--- a/spec/requests/vendor_api/headers_spec.rb
+++ b/spec/requests/vendor_api/headers_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - headers for all requests', type: :request do
+  include VendorAPISpecHelpers
+
+  it 'does not include Feature-Policy headers' do
+    get_api_request "/api/v1/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
+
+    expect(response.headers['Feature-Policy']).not_to be_present
+  end
+end


### PR DESCRIPTION
This is meaningless to non-browser clients, so remove it from all APIs.
