### PR TITLE
Add no provider user filter

### DIFF
--- a/app/models/support_interface/providers_filter.rb
+++ b/app/models/support_interface/providers_filter.rb
@@ -25,6 +25,7 @@ module SupportInterface
         :ratified_by,
         :onboarding_stages,
         :q,
+        :no_provider_users,
       )
     end
 
@@ -53,6 +54,18 @@ module SupportInterface
           heading: 'Ratified by (only applies to providers with synced courses)',
           options: hash_to_checkbox_options(:ratified_by, RATIFIED_BY),
           name: 'ratified_by',
+        },
+        {
+          type: :checkboxes,
+          heading: 'No provider users',
+          name: 'no_provider_users',
+          options: [
+            {
+              value: true,
+              label: 'Has no provider users',
+              checked: applied_filters[:no_provider_users]&.include?('true'),
+            },
+          ],
         },
       ]
     end
@@ -86,6 +99,10 @@ module SupportInterface
         providers = providers.joins(:training_provider_permissions)
           .where(provider_relationship_permissions: { ratifying_provider_id: ratifiers })
           .distinct
+      end
+
+      if applied_filters[:no_provider_users].present?
+        providers = providers.left_outer_joins(:provider_permissions).where(provider_users_providers: { id: nil })
       end
 
       @filtered_count = providers.count

--- a/spec/models/support_interface/providers_filter_spec.rb
+++ b/spec/models/support_interface/providers_filter_spec.rb
@@ -74,6 +74,17 @@ RSpec.describe SupportInterface::ProvidersFilter do
       ])
     end
 
+    it 'filters by providers with no provider users' do
+      provider_with_provider_user = create(:provider, :with_user)
+      provider_without_provider_user = create(:provider)
+
+      filter = described_class.new(params: { no_provider_users: %w[true] })
+      expect(filter.filter_records(Provider.all)).to eq [provider_without_provider_user]
+
+      filter = described_class.new(params: { remove: true })
+      expect(filter.filter_records(Provider.all)).to match_array [provider_with_provider_user, provider_without_provider_user]
+    end
+
     it 'defaults to showing all providers' do
       create(:provider, :with_signed_agreement)
       create(:provider)


### PR DESCRIPTION
## Context

As a... 
Support Agent
I need to... 
Know if a provider does not have users set up
So that... 
I can track their and action their onboarding

This should be on the providers page https://qa.apply-for-teacher-training.service.gov.uk/support/providers

## Changes proposed in this pull request

- Add a filter in that returns providers with no providers users

## Guidance to review

Probs give it a manual test

## Link to Trello card

https://trello.com/c/hCG7k2Im/3829-add-no-provider-user-filter-to-support-console-providers-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
