### PR TITLE
display institution name for awaiting provider decision

### DIFF
--- a/app/components/shared/degree_qualification_cards_component.rb
+++ b/app/components/shared/degree_qualification_cards_component.rb
@@ -33,8 +33,8 @@ class DegreeQualificationCardsComponent < ViewComponent::Base
     # Always show the institution if the component has not been made aware of
     # any application choice state
     return true if application_choice_state.nil? || degree.international?
-
-    application_choice_state.to_sym.in? ApplicationStateChange::ACCEPTED_STATES
+    show_institution_states = ApplicationStateChange::ACCEPTED_STATES + ApplicationStateChange::DECISION_PENDING_STATUSES
+    application_choice_state.to_sym.in? show_institution_states
   end
 
   def formatted_institution(degree)

--- a/spec/components/utility/degree_qualification_cards_component_spec.rb
+++ b/spec/components/utility/degree_qualification_cards_component_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe DegreeQualificationCardsComponent, type: :component do
       end
 
       it 'is not visible when the application_choice state is not one of the ACCEPTED_STATES' do
-        (ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - ApplicationStateChange::ACCEPTED_STATES).each do |state|
+        (ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - ApplicationStateChange::ACCEPTED_STATES - ApplicationStateChange::DECISION_PENDING_STATUSES).each do |state|
           result = render_inline described_class.new([degree], application_choice_state: state)
           expect(result.text).to include 'Institution'
           expect(result.text).not_to include 'The University of Oxford'


### PR DESCRIPTION
## Context

We currently hide the institution details for UK degree level institutions until a candidate has accepted an offer, to avoid unconscious bias from certain institutions.

However, this is somewhat redundant as providers can see an applicants academic references, so have knowledge of the academic institution anyway. 

The API and data export required no changes as they do not obscure the institution.

## Changes proposed in this pull request

Remove text for obscuring degree institution.

## Link to Trello card

https://trello.com/c/GlaCbtOE/4175-surface-uk-degree-institution-details-to-providers-in-manage-for-applications-regardless-of-application-status-or-nationality
## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
