### PR TITLE
Ensure that offered course from API is in the current cycle

### DIFF
--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -4,13 +4,7 @@ module VendorAPI
     rescue_from ValidationException, with: :render_validation_error
 
     def make_offer
-      course_data = params.dig(:data, :course)
-
-      course_option = if course_data.present?
-                        retrieve_course!(course_data)
-                      else
-                        application_choice.course_option
-                      end
+      validate_course_is_in_current_recruitment_cycle!
 
       respond_to_decision(offer_service_for(application_choice, course_option))
     end
@@ -133,6 +127,17 @@ module VendorAPI
       raise ValidationException, course_option_service.errors.messages.values.flatten
     end
 
+    def course_option
+      course_data = params.dig(:data, :course)
+
+      @course_option ||=
+        if course_data.present?
+          retrieve_course(course_data) || raise_no_course_found!
+        else
+          application_choice.course_option
+        end
+    end
+
     def render_validation_error(e)
       render status: :unprocessable_entity, json: e.as_json
     end
@@ -142,6 +147,12 @@ module VendorAPI
         ChangeOffer.new(offer_params(application_choice, course_option))
       else
         MakeOffer.new(offer_params(application_choice, course_option))
+      end
+    end
+
+    def validate_course_is_in_current_recruitment_cycle!
+      if course_option.course.recruitment_cycle_year != RecruitmentCycle.current_year
+        raise ValidationException, ["Course must be in #{RecruitmentCycle.current_year} recruitment cycle"]
       end
     end
   end

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -132,9 +132,9 @@ module VendorAPI
 
       @course_option ||=
         if course_data.present?
-          retrieve_course(course_data) || raise_no_course_found!
+          retrieve_course!(course_data) || raise_no_course_found!
         else
-          application_choice.course_option
+          application_choice.current_course_option
         end
     end
 

--- a/spec/system/vendor_api/vendor_makes_an_offer_for_course_in_past_cycle_spec.rb
+++ b/spec/system/vendor_api/vendor_makes_an_offer_for_course_in_past_cycle_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.feature 'Vendor makes an offer for a course in the past recruitment cycle' do
+  scenario 'A vendor makes an invalid offer' do
+    given_a_candidate_has_submitted_their_application
+    when_a_vendor_makes_an_offer_for_a_course_in_the_previous_cycle
+    then_i_can_see_a_validation_error
+
+    when_a_vendor_makes_an_offer_for_a_course_in_the_current_cycle
+    then_the_offer_is_successful
+  end
+
+  def given_a_candidate_has_submitted_their_application
+    @application_choice = create(:application_choice, :with_completed_application_form, :awaiting_provider_decision)
+    @provider = @application_choice.provider
+    @recruitment_cycle_year = RecruitmentCycle.previous_year
+    @course = create(:course, recruitment_cycle_year: @recruitment_cycle_year, provider: @provider)
+    @course_option = create(:course_option, course: @course)
+  end
+
+  def when_a_vendor_makes_an_offer_for_a_course_in_the_previous_cycle
+    @api_token = VendorAPIToken.create_with_random_token!(provider: @provider)
+    Capybara.current_session.driver.header('Authorization', "Bearer #{@api_token}")
+    Capybara.current_session.driver.header('Content-Type', 'application/json')
+
+    @provider_user = create(:provider_user, :with_notifications_enabled, providers: [@provider])
+    uri = "/api/v1/applications/#{@application_choice.id}/offer"
+
+    @api_response = page.driver.post(uri, offer_payload)
+
+    # Unset session headers
+    Capybara.current_session.driver.header('Authorization', nil)
+    Capybara.current_session.driver.header('Content-Type', nil)
+  end
+
+  def then_i_can_see_a_validation_error
+    parsed_response_body = JSON.parse(@api_response.body)
+    validation_errors = parsed_response_body['errors']
+
+    expect(@api_response.status).to eq 422
+    expect(validation_errors.first['message']).to eq("Course must be in #{RecruitmentCycle.current_year} recruitment cycle")
+  end
+
+  def when_a_vendor_makes_an_offer_for_a_course_in_the_current_cycle
+    @recruitment_cycle_year = RecruitmentCycle.current_year
+    @course = create(:course, recruitment_cycle_year: @recruitment_cycle_year, provider: @provider)
+    @course_option = create(:course_option, course: @course)
+
+    Capybara.current_session.driver.header('Authorization', "Bearer #{@api_token}")
+    Capybara.current_session.driver.header('Content-Type', 'application/json')
+
+    @provider_user = create(:provider_user, :with_notifications_enabled, providers: [@provider])
+    uri = "/api/v1/applications/#{@application_choice.id}/offer"
+
+    @api_response = page.driver.post(uri, offer_payload)
+
+    # Unset session headers
+    Capybara.current_session.driver.header('Authorization', nil)
+    Capybara.current_session.driver.header('Content-Type', nil)
+  end
+
+  def then_the_offer_is_successful
+    parsed_response_body = JSON.parse(@api_response.body)
+    expect(@api_response.status).to eq 200
+    expect(parsed_response_body.dig('data', 'attributes', 'status')).to eq('offer')
+  end
+
+  def offer_payload
+    {
+      meta: {
+        attribution: {
+          full_name: 'Jane Smith',
+          email: 'jane.smith@example.com',
+          user_id: '12345',
+        },
+        timestamp: Time.zone.now.iso8601,
+      },
+      data: {
+        conditions: ['Example condition'],
+        course: {
+          recruitment_cycle_year: @recruitment_cycle_year,
+          provider_code: @provider.code,
+          course_code: @course.code,
+          site_code: @course_option.site.code,
+          study_mode: 'full_time',
+        },
+      },
+    }.to_json
+  end
+end


### PR DESCRIPTION
## Context

We restrict offers to the current cycle via the provider interface in manage but this isn't enforced when making decisions in the API.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds a validation that the `recruitment_cycle_year` param from the course object matches the application choice recruitment cycle.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/JEeYnsJv/4226-restricting-api-to-make-change-offers-to-applications-in-current-cycle

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
