### PR TITLE
Index audits action attribute to speed up activity log

### DIFF
--- a/db/migrate/20210831143624_add_get_applications_indexes_to_application_choice.rb
+++ b/db/migrate/20210831143624_add_get_applications_indexes_to_application_choice.rb
@@ -10,6 +10,6 @@ class AddGetApplicationsIndexesToApplicationChoice < ActiveRecord::Migration[6.1
   def down
     safety_assured { execute 'SET statement_timeout = 0' }
     remove_index :application_choices, :provider_ids, if_exists: true, algorithm: :concurrently
-    remove_index :application_choices, :current_recruitment_cycle_year, if__exists: true, algorithm: :concurrently
+    remove_index :application_choices, :current_recruitment_cycle_year, if_exists: true, algorithm: :concurrently
   end
 end

--- a/db/migrate/20210909105834_add_action_index_to_audits.rb
+++ b/db/migrate/20210909105834_add_action_index_to_audits.rb
@@ -1,0 +1,13 @@
+class AddActionIndexToAudits < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured { execute 'SET statement_timeout = 0' }
+    add_index :audits, %i[auditable_type auditable_id action], if_not_exists: true, algorithm: :concurrently
+  end
+
+  def down
+    safety_assured { execute 'SET statement_timeout = 0' }
+    remove_index :audits, column: %i[auditable_type auditable_id action], if_exists: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_31_143624) do
+ActiveRecord::Schema.define(version: 2021_09_09_105834) do
 
   create_sequence "application_choices_id_seq"
   create_sequence "application_experiences_id_seq"
@@ -270,6 +270,7 @@ ActiveRecord::Schema.define(version: 2021_08_31_143624) do
     t.string "request_uuid"
     t.datetime "created_at"
     t.index ["associated_type", "associated_id"], name: "associated_index"
+    t.index ["auditable_type", "auditable_id", "action"], name: "index_audits_on_auditable_type_and_auditable_id_and_action"
     t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
     t.index ["auditable_type", "id"], name: "index_audits_on_auditable_type_and_id"
     t.index ["created_at"], name: "index_audits_on_created_at"


### PR DESCRIPTION
## Context

Minor improvements (~5-10%) were observed on the load-test environment when a index involving the `action` column of `audits` is present.

## Changes proposed in this pull request

Index `action` alongside `auditable_type` and `auditable_id`.

## Guidance to review

Probably related to this part of the activity log query:

```sql
    application_choices_join_sql = <<~COMBINE_AUDITS_WITH_APPLICATION_CHOICES_SCOPE_AND_FILTER.squish
      INNER JOIN (#{application_choices.to_sql}) ac
        ON (
          auditable_type = 'ApplicationChoice'
          AND auditable_id = ac.id
          AND action = 'update'
          AND ( #{application_choice_audits_filter_sql} )
        ) OR (
          associated_type = 'ApplicationChoice'
          AND associated_id = ac.id
          AND NOT auditable_type = 'OfferCondition'
        )
    COMBINE_AUDITS_WITH_APPLICATION_CHOICES_SCOPE_AND_FILTER
```

The two OR parts are evaluated in parallel, but the slower half determines the overall query performance, and the slower part is the first part, which contains a lot of custom sql-based filtering. The filtering is too complex to index, but we can help things along by having an index for the first 3 out of 4 elements of that query. 

Seems to save about 10ms of query time when the overall query takes about 100ms.

## Link to Trello card

https://trello.com/c/WqMkSEx8

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
