### PR TITLE
Move SendEventsToBigquery to background thread

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,6 +128,8 @@ gem 'colorize'
 # Performance profiling - keep this below 'pg' gem
 gem 'rack-mini-profiler', require: ['prepend_net_http_patch']
 
+gem 'eventmachine'
+
 group :production do
   gem 'rails_semantic_logger'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,7 @@ GEM
       smart_properties
     errbase (0.2.1)
     erubi (1.10.0)
+    eventmachine (1.2.7)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -698,6 +699,7 @@ DEPENDENCIES
   discard
   dotenv-rails
   erb_lint
+  eventmachine
   factory_bot_rails
   faker
   geocoder

--- a/app/controllers/concerns/emit_request_events.rb
+++ b/app/controllers/concerns/emit_request_events.rb
@@ -15,7 +15,19 @@ module EmitRequestEvents
         .with_user_and_namespace(current_user, current_namespace)
         .with_request_uuid(RequestLocals.fetch(:request_id) { nil })
 
-      SendEventsToBigquery.perform_async(request_event.as_json)
+      EM.next_tick do
+        attempt_count = 0
+        begin
+          attempt_count += 1
+          SendEventsToBigquery.perform_async(request_event.as_json)
+        rescue Redis::CommandError
+          abort if attempt_count > 5
+          wait_time = 2 ** (attempt_count + 1)
+          puts "Waiting #{wait_time} seconds to SendEventsToBigquery..."
+          sleep wait_time
+          retry
+        end
+      end
     end
   end
 end

--- a/app/models/concerns/entity_events.rb
+++ b/app/models/concerns/entity_events.rb
@@ -31,7 +31,19 @@ module EntityEvents
       .with_tags(event_tags)
       .with_request_uuid(RequestLocals.fetch(:request_id) { nil })
 
-    SendEventsToBigquery.perform_async(event.as_json)
+    EM.next_tick do
+      attempt_count = 0
+      begin
+        attempt_count += 1
+        SendEventsToBigquery.perform_async(event.as_json)
+      rescue Redis::CommandError
+        abort if attempt_count > 5
+        wait_time = 2 ** (attempt_count + 1)
+        puts "Waiting #{wait_time} seconds to SendEventsToBigquery..."
+        sleep wait_time
+        retry
+      end
+    end
   end
 
   def entity_data(changeset)

--- a/config/initializers/event_machine.rb
+++ b/config/initializers/event_machine.rb
@@ -1,0 +1,8 @@
+require 'eventmachine'
+
+Thread.new do
+  # EventMachine.run is a event loop
+  EventMachine.run do
+    puts 'Starting EventMachine...'
+  end
+end


### PR DESCRIPTION
## Context

SendEventsToBigquery call fails when the redis instance's memory is full.
Also this happens in the request thread causing the request to fail.

## Changes proposed in this pull request

Use EventMachine[https://github.com/eventmachine/eventmachine/] to move the SendEventsToBigquery call to a background thread.
Also reattempt to SendEventsToBigquery  is enqueuing fails.

## Guidance to review

Correct?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
