### PR TITLE
Update content on nonuk GCSE qualfication grade hint text

### DIFF
--- a/app/views/candidate_interface/gcse/english/grade/_single_grade_form.html.erb
+++ b/app/views/candidate_interface/gcse/english/grade/_single_grade_form.html.erb
@@ -5,7 +5,7 @@
     <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }, link_errors: true %>
     <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' } %>
     <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>
-      <%= f.govuk_text_field :other_grade, label: { text: 'Grade' }, hint: { text: 'For example, ‘A’, ‘4.5’, ‘94%’' }, width: 10 %>
+      <%= f.govuk_text_field :other_grade, label: { text: 'Grade' }, hint: { text: 'For example, ‘A’, ‘4.5’, ‘94%’, ‘42/60’' }, width: 10 %>
     <% end %>
   <% end %>
 <% else %>

--- a/app/views/candidate_interface/gcse/maths/grade/_form.html.erb
+++ b/app/views/candidate_interface/gcse/maths/grade/_form.html.erb
@@ -5,7 +5,7 @@
     <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' } %>
     <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' } %>
     <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>
-      <%= f.govuk_text_field :other_grade, label: { text: 'Grade' }, hint: { text: 'For example, ‘A’, ‘4.5’, ‘94%’' }, width: 10 %>
+      <%= f.govuk_text_field :other_grade, label: { text: 'Grade' }, hint: { text: 'For example, ‘A’, ‘4.5’, ‘94%’, ‘42/60’' }, width: 10 %>
     <% end %>
   <% end %>
 <% else %>

--- a/app/views/candidate_interface/gcse/science/grade/_form.html.erb
+++ b/app/views/candidate_interface/gcse/science/grade/_form.html.erb
@@ -5,7 +5,7 @@
     <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }, link_errors: true %>
     <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' } %>
     <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>
-      <%= f.govuk_text_field :other_grade, label: { text: 'Grade' }, hint: { text: 'For example, ‘A’, ‘4.5’, ‘94%’' }, width: 10 %>
+      <%= f.govuk_text_field :other_grade, label: { text: 'Grade' }, hint: { text: 'For example, ‘A’, ‘4.5’, ‘94%’, ‘42/60’' }, width: 10 %>
     <% end %>
   <% end %>
 <% else %>


### PR DESCRIPTION
## Context

Additional hint text to cover specific grades out of a total number.

## Changes proposed in this pull request
<img width="601" alt="image" src="https://user-images.githubusercontent.com/62567622/132878327-53c62af3-f4e9-4476-a967-1e0474a17ab8.png">
<img width="601" alt="image" src="https://user-images.githubusercontent.com/62567622/132878358-5d847f09-eb19-4863-91c2-6feb4268b8d8.png">
<img width="601" alt="image" src="https://user-images.githubusercontent.com/62567622/132878376-ccf2ae1f-84a1-4375-942d-b85b3d973723.png">

## Guidance to review


## Link to Trello card

https://trello.com/c/I4QmQUCw/3922-add-additional-example-for-entering-international-grades

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
