### PR TITLE
Render "new" when address type selection invalid

### DIFF
--- a/app/controllers/candidate_interface/contact_details/address_type_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_type_controller.rb
@@ -13,7 +13,7 @@ module CandidateInterface
         redirect_to candidate_interface_new_address_path
       else
         track_validation_error(@contact_details_form)
-        render :edit
+        render :new
       end
     end
 

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
@@ -15,7 +15,10 @@ RSpec.feature 'Entering their contact information' do
 
     when_i_fill_in_my_phone_number
     and_i_submit_my_phone_number
-    and_i_select_live_in_uk
+    and_i_submit_no_address_type
+    then_i_should_see_validation_errors_for_my_address_type
+
+    when_i_select_live_in_uk
     and_i_incorrectly_fill_in_my_address
     and_i_submit_my_address
     then_i_should_see_validation_errors_for_my_address
@@ -92,7 +95,15 @@ RSpec.feature 'Entering their contact information' do
     fill_in t('application_form.contact_details.phone_number.label'), with: '07700 900 982'
   end
 
-  def and_i_select_live_in_uk
+  def and_i_submit_no_address_type
+    click_button t('save_and_continue')
+  end
+
+  def then_i_should_see_validation_errors_for_my_address_type
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.address_type.blank')
+  end
+
+  def when_i_select_live_in_uk
     expect(page).to have_content('Where do you live?')
     choose 'In the UK'
     click_button t('save_and_continue')


### PR DESCRIPTION
## Context
When a candidate does not select an address type they are getting an error:
https://sentry.io/organizations/dfe-bat/issues/2636874292/events/1b4b9a650baa45fb831a5c5ed87da5dc/?project=1765973

This is because after creation we are rendering the edit form which requires extra variables `@return_to` which is not defined in the `create` action

## Changes proposed in this pull request

render "new" if the form is invalid as this is a create action

## Guidance to review

Did I miss anything?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
