### PR TITLE
Fix carry over bug for degree award year

### DIFF
--- a/app/forms/candidate_interface/degree_award_year_form.rb
+++ b/app/forms/candidate_interface/degree_award_year_form.rb
@@ -5,7 +5,6 @@ module CandidateInterface
     attr_accessor :award_year, :degree
 
     validates :award_year, year: true, presence: true
-    validate :award_year_is_before_the_end_of_next_year, unless: ->(c) { c.errors.attribute_names.include?(:award_year) }
     validate :award_year_is_in_the_future_for_incomplete_degree, unless: ->(c) { c.errors.attribute_names.include?(:award_year) }
     validate :award_year_is_before_training_starts, unless: ->(c) { c.errors.attribute_names.include?(:award_year) }
 
@@ -23,17 +22,11 @@ module CandidateInterface
   private
 
     def award_year_is_in_the_future_for_incomplete_degree
-      errors.add(:award_year, :in_the_future) if degree.start_year.present? && degree.predicted_grade? && award_year.to_i < RecruitmentCycle.current_year
-    end
-
-    def award_year_is_before_the_end_of_next_year
-      upper_year_limit = RecruitmentCycle.current_year + 10
-
-      errors.add(:award_year, :greater_than_limit, date: upper_year_limit) if award_year.to_i >= upper_year_limit
+      errors.add(:award_year, :in_the_future) if degree.start_year.present? && degree.predicted_grade? && award_year.to_i < degree.application_form.recruitment_cycle_year.to_i
     end
 
     def award_year_is_before_training_starts
-      errors.add(:award_year, :in_time_for_training) if degree.predicted_grade? && award_year.to_i > RecruitmentCycle.current_year
+      errors.add(:award_year, :in_time_for_training) if degree.predicted_grade? && award_year.to_i > degree.application_form.recruitment_cycle_year.to_i
     end
   end
 end

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -146,6 +146,5 @@ en:
             award_year:
               blank: Enter your graduation year
               invalid_year: Enter a real graduation year
-              greater_than_limit: Enter a year before %{date}
               in_the_future: Enter a year that is in the future
               in_time_for_training: The date you graduate must be before the start of your teacher training


### PR DESCRIPTION
## Context

At the moment our validations for degree award year use `RecruitmentCycle.current_year`. This causes an issue with carried over applications as candidates should graduate in the next cycle.

## Changes proposed in this pull request

- Use the recruitment cycle year on the application form to determine the appropriate year to graduate in.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
