### PR TITLE
Add a search filter for accredited providers to the providers page on the support UI

### DIFF
--- a/spec/models/support_interface/providers_filter_spec.rb
+++ b/spec/models/support_interface/providers_filter_spec.rb
@@ -85,6 +85,21 @@ RSpec.describe SupportInterface::ProvidersFilter do
       expect(filter.filter_records(Provider.all)).to match_array [provider_with_provider_user, provider_without_provider_user]
     end
 
+    it 'filters by accredited provider' do
+      accredited_provider = create(:provider, name: 'Accredited Provider')
+      training_provider1 = create(:provider)
+      training_provider2 = create(:provider)
+      create(:course, provider: training_provider1, accredited_provider: accredited_provider)
+      create(:course, provider: training_provider2, accredited_provider: accredited_provider)
+      course_from_previous_cycle = create(:course, recruitment_cycle_year: RecruitmentCycle.previous_year, accredited_provider: accredited_provider)
+
+      filter = described_class.new(params: { accredited_provider: 'accredited prov' })
+      expect(filter.filter_records(Provider.all)).to match_array [training_provider1, training_provider2]
+
+      filter = described_class.new(params: { remove: true })
+      expect(filter.filter_records(Provider.all)).to match_array [accredited_provider, training_provider1, training_provider2, course_from_previous_cycle.provider]
+    end
+
     it 'defaults to showing all providers' do
       create(:provider, :with_signed_agreement)
       create(:provider)


### PR DESCRIPTION
## Context

```
As a... 
Support Agent
I need to... 
Know what providers from a certain accrediting body still need to be onboarded
So that... 
I can track their onboarding and, combined with other filters, I can action the onboarding of their users
```

## Changes proposed in this pull request

Add in a search box to the providers page which allows you to search for providers based on who accredits their courses.

This returns any provider who has one or more courses accredited by the providers matched on name/code.

## Guidance to review

Probs best to just have a go locally and see if it works/you can break it.

## Link to Trello card

https://trello.com/c/vlEb4zyM/3830-add-accrediting-body-filter-to-support-console-providers-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
