### PR TITLE
Remove application status and phase from candidate level of the candidates API

### DIFF
--- a/app/controllers/candidate_api/candidates_controller.rb
+++ b/app/controllers/candidate_api/candidates_controller.rb
@@ -36,8 +36,6 @@ module CandidateAPI
                             .order('application_forms.created_at DESC')
 
       candidates.map do |candidate|
-        current_application = candidate.application_forms.order(:created_at).last
-
         {
           id: candidate.public_id,
           type: 'candidate',
@@ -45,8 +43,6 @@ module CandidateAPI
             created_at: candidate.created_at,
             updated_at: candidate.candidate_api_updated_at,
             email_address: candidate.email_address,
-            application_status: ProcessState.new(current_application).state,
-            application_phase: current_application&.phase,
             application_forms:
               candidate.application_forms.map do |application|
                 {

--- a/config/candidate-api.yml
+++ b/config/candidate-api.yml
@@ -103,32 +103,6 @@ components:
           type: string
           description: Candidate email address
           example: email@example.com
-        application_status:
-          type: string
-          description: The status of the candidates current application form
-          enum:
-            - never_signed_in
-            - unsubmitted_not_started_form
-            - unsubmitted_in_progress
-            - awaiting_provider_decisions
-            - awaiting_candidate_response
-            - recruited
-            - pending_conditions
-            - offer_deferred
-            - ended_without_success
-            - unknown_state
-          example: awaiting_provider_decisions
-        application_phase:
-          type: string
-          nullable: true
-          description: The phase of the candidates current application. In the first phase, "Apply 1", the
-            candidate can choose up to 3 courses. If all of those choices are rejected,
-            declined, or withdrawn, the user can go into "Apply 2". This means
-            they can choose 1 course at a time.
-          enum:
-            - apply_1
-            - apply_2
-          example: apply_1
         application_forms:
           type: array
           items:


### PR DESCRIPTION
## Context

Ross has removed the dependency on these attributes and is now using the application_forms nesting to derive the latest status/phase. They can now be removed from the top level of the json.

## Changes proposed in this pull request

- Remove application_status and application_phase from the top level of the JSON blob

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
