### PR TITLE
Fix issue with backlink in the right to work section

### DIFF
--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.right_to_work'), @right_to_work_or_study_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(govuk_back_link_to(@return_to[:back_path])) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_edit_nationalities_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Context

If you click back on the this backlink 

![image](https://user-images.githubusercontent.com/42515961/133264166-0869eea8-5f1c-4377-a9d6-e87f21d80238.png)

It blows up (see url) 

![image](https://user-images.githubusercontent.com/42515961/133264240-b3b18efe-333e-4ab6-bfee-81e40b3935a4.png)


This backlink should send you back to the nationalities page as completing that is what sends you to the rtw page




## Changes proposed in this pull request


- Fix the backlink

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
