### PR TITLE
Disable BQ feature flag in dev and on review apps

### DIFF
--- a/app/controllers/integrations/feature_flags_controller.rb
+++ b/app/controllers/integrations/feature_flags_controller.rb
@@ -5,7 +5,8 @@ module Integrations
         {
           name: feature_name.humanize,
           active: FeatureFlag.active?(feature_name),
-          type: FeatureFlag::FEATURES[feature_name].type,
+          type: FeatureFlag::FEATURES[feature_name].type, # deprecated
+          variant: FeatureFlag::VARIANT_FEATURES.include?(feature_name.to_sym),
         }
       end
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -5,7 +5,7 @@ class FeatureFlag
     self.name = name
     self.description = description
     self.owner = owner
-    self.type =  FEATURE_TYPES[name].presence || 'invariant'
+    self.type =  VARIANT_FEATURES.include?(name.to_sym) ? 'variant' : 'invariant'
   end
 
   def feature
@@ -44,9 +44,9 @@ class FeatureFlag
   # across environments and we won't be notified if inconsistent. All other features
   # will default to `invariant` which means they will need to be consistently marked
   # as active/inactive across all our environments, and we will be notified about otherwise.
-  FEATURE_TYPES = {
-    send_request_data_to_bigquery: 'variant',
-  }.with_indifferent_access.freeze
+  VARIANT_FEATURES = [
+    :send_request_data_to_bigquery,
+  ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map do |name, description, owner|
     [name, FeatureFlag.new(name: name, description: description, owner: owner)]

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -56,7 +56,7 @@ task copy_feature_flags_from_production: :environment do
   puts 'Synchronising feature flags with production...'
 
   FeatureFlag::FEATURES.each_key do |f|
-    if flags.dig(f, 'active')
+    if flags.dig(f, 'active') && flags.dig(f, 'type') != 'variant'
       puts "+ #{f}"
       FeatureFlag.activate(f)
     else

--- a/spec/requests/integrations/feature_flags_spec.rb
+++ b/spec/requests/integrations/feature_flags_spec.rb
@@ -8,14 +8,16 @@ RSpec.describe 'GET /integrations/feature-flags', type: :request do
 
     expect(parsed_response['feature_flags']['pilot_open']['name']).to eql('Pilot open')
     expect(parsed_response['feature_flags']['pilot_open']['active']).to be(true)
-    expect(parsed_response['feature_flags']['pilot_open']['type']).to eq('invariant')
+    expect(parsed_response['feature_flags']['pilot_open']['type']).to eq('invariant') # deprecated
+    expect(parsed_response['feature_flags']['pilot_open']['variant']).to be(false)
   end
 
   it 'returns variant feature flags' do
     get '/integrations/feature-flags'
 
     expect(parsed_response['feature_flags']['send_request_data_to_bigquery']['active']).to be(false)
-    expect(parsed_response['feature_flags']['send_request_data_to_bigquery']['type']).to eq('variant')
+    expect(parsed_response['feature_flags']['send_request_data_to_bigquery']['type']).to eq('variant') # deprecated
+    expect(parsed_response['feature_flags']['send_request_data_to_bigquery']['variant']).to be(true)
   end
 
   it 'tells us when Sandbox mode is on', sandbox: true do


### PR DESCRIPTION
This creates noisy errors wherever BQ isn't set up (ie Heroku and most local setups), so keep it turned off by default.
