### PR TITLE
Make GetCourseOptionFromCodes more lenient about site_code

### DIFF
--- a/app/queries/get_course_option_from_codes.rb
+++ b/app/queries/get_course_option_from_codes.rb
@@ -3,16 +3,22 @@ class GetCourseOptionFromCodes
   attr_accessor :provider_code, :course_code, :recruitment_cycle_year, :study_mode, :site_code,
                 :provider, :course, :site, :course_option
 
+  validates_presence_of :provider_code, :course_code, :study_mode, :recruitment_cycle_year
+
   # Using validates_each because validation for each attribute depends on the values of other attributes
   # The act of validation also performs the relevant lookups and memoizes the results, which are then used
   # in subsequent validations.
 
   validates_each :provider_code do |record, attr, value|
+    next if record.provider_code.blank?
+
     record.provider ||= Provider.find_by(code: value)
     record.errors.add(attr, "Provider #{value} does not exist") unless record.provider
   end
 
   validates_each :course_code do |record, attr, value|
+    next if record.course_code.blank? || record.recruitment_cycle_year.blank?
+
     if record.provider
       record.course ||= record.provider.courses.find_by(
         code: value,
@@ -35,7 +41,7 @@ class GetCourseOptionFromCodes
   end
 
   validates_each :course_option do |record, attr, _value|
-    next unless record.course
+    next if record.course.blank? || record.study_mode.blank?
 
     get_unique_course_option(record, attr)
   end

--- a/app/queries/get_course_option_from_codes.rb
+++ b/app/queries/get_course_option_from_codes.rb
@@ -9,7 +9,7 @@ class GetCourseOptionFromCodes
 
   validates_each :provider_code do |record, attr, value|
     record.provider ||= Provider.find_by(code: value)
-    record.errors.add(attr, "provider #{value} does not exist") unless record.provider
+    record.errors.add(attr, "Provider #{value} does not exist") unless record.provider
   end
 
   validates_each :course_code do |record, attr, value|
@@ -21,7 +21,7 @@ class GetCourseOptionFromCodes
       unless record.course
         record.errors.add(
           attr,
-          "course #{value} does not exist for provider #{record.provider.code} and year #{record.recruitment_cycle_year}",
+          "Course #{value} does not exist for provider #{record.provider.code} and year #{record.recruitment_cycle_year}",
         )
       end
     end
@@ -30,7 +30,7 @@ class GetCourseOptionFromCodes
   validates_each :site_code do |record, attr, value|
     if record.provider && value.present?
       record.site ||= record.provider.sites.find_by(code: value)
-      record.errors.add(attr, "site #{value} does not exist for provider #{record.provider.code}") unless record.site
+      record.errors.add(attr, "Site #{value} does not exist for provider #{record.provider.code}") unless record.site
     end
   end
 
@@ -73,7 +73,7 @@ class GetCourseOptionFromCodes
   end
 
   def self.build_course_option_error_message(record, match_count)
-    error_message = match_count.zero? ? 'cannot find any' : 'found multiple'
+    error_message = match_count.zero? ? 'Cannot find any' : 'Found multiple'
 
     error_message << " #{record.study_mode} options"
     error_message << " at site #{record.site.code}" if record.site

--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+## 17th September
+
+The `site_code` attribute of `Course` is now optional when POSTing to `/application/:id/offer`.
+The `site_code` can be left blank if the other provided attributes uniquely define a course.
+If the other provided attributes define a course that is available at multiple sites, then the endpoint will respond with a 422.
+
 ## 15th July
 
 Documentation:

--- a/config/locales/vendor_api/make_offer.yml
+++ b/config/locales/vendor_api/make_offer.yml
@@ -1,0 +1,14 @@
+en:
+  activemodel:
+    errors:
+      models:
+        get_course_option_from_codes:
+          attributes:
+            provider_code:
+              blank: Provider code cannot be blank
+            course_code:
+              blank: Course code cannot be blank
+            study_mode:
+              blank: Study mode cannot be blank
+            recruitment_cycle_year:
+              blank: Recruitment cycle year cannot be blank

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -700,7 +700,6 @@ components:
       - recruitment_cycle_year
       - provider_code
       - course_code
-      - site_code
       - study_mode
       properties:
         recruitment_cycle_year:
@@ -719,9 +718,10 @@ components:
           maxLength: 4
         site_code:
           type: string
-          description: The site’s code
+          description: The site’s code. If left blank, then a course and site must be uniquely determined by the other attributes.
           example: K
           maxLength: 5
+          nullable: true
         study_mode:
           type: string
           description: Can be `full_time` or `part_time`

--- a/spec/queries/get_course_option_from_codes_spec.rb
+++ b/spec/queries/get_course_option_from_codes_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe GetCourseOptionFromCodes do
+RSpec.describe GetCourseOptionFromCodes, type: :model do
   include CourseOptionHelpers
 
   let(:course_option) { create(:course_option) }
@@ -16,11 +16,16 @@ RSpec.describe GetCourseOptionFromCodes do
   end
 
   describe 'validation' do
-    required_attributes = %w[provider_code course_code study_mode recruitment_cycle_year]
+    subject { service }
+
+    required_attributes = %i[provider_code course_code study_mode recruitment_cycle_year]
     required_attributes.each do |attr|
-      it "complains about missing #{attr}" do
+      it { is_expected.to validate_presence_of(attr).with_message("#{attr.to_s.humanize} cannot be blank") }
+
+      it "does not add errors to other attributes when #{attr} is blank" do
         service.send("#{attr}=", nil)
-        expect(service).not_to be_valid
+        expect(service).to be_invalid
+        expect(service.errors.keys).to contain_exactly(attr)
       end
     end
 

--- a/spec/queries/get_course_option_from_codes_spec.rb
+++ b/spec/queries/get_course_option_from_codes_spec.rb
@@ -16,11 +16,40 @@ RSpec.describe GetCourseOptionFromCodes do
   end
 
   describe 'validation' do
-    required_attributes = %w[provider_code course_code study_mode site_code recruitment_cycle_year]
+    required_attributes = %w[provider_code course_code study_mode recruitment_cycle_year]
     required_attributes.each do |attr|
       it "complains about missing #{attr}" do
-        service.send("#{attr}=".to_sym, 'random')
+        service.send("#{attr}=", nil)
         expect(service).not_to be_valid
+      end
+    end
+
+    context 'when the site code is given but does not match any course option' do
+      let!(:site_for_another_course) { create(:site, code: 'QQ', provider: course_option.provider) }
+
+      it 'is not valid' do
+        service.site_code = site_for_another_course.code
+        expect(service).to be_invalid
+        expected_message = "cannot find any #{course_option.course.study_mode} options at site #{site_for_another_course.code} for course #{course_option.course.code}"
+        expect(service.errors[:course_option]).to contain_exactly(expected_message)
+      end
+    end
+
+    context 'when the site code is blank but unambiguous' do
+      it 'is valid' do
+        service.site_code = nil
+        expect(service).to be_valid
+      end
+    end
+
+    context 'when the site code is blank and ambiguous' do
+      let!(:another_course_option) { create(:course_option, course: course_option.course) }
+
+      it 'is not valid' do
+        service.site_code = nil
+        expect(service).to be_invalid
+        expected_message = "found multiple #{course_option.course.study_mode} options for course #{course_option.course.code}"
+        expect(service.errors[:course_option]).to contain_exactly(expected_message)
       end
     end
   end

--- a/spec/queries/get_course_option_from_codes_spec.rb
+++ b/spec/queries/get_course_option_from_codes_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe GetCourseOptionFromCodes do
       it 'is not valid' do
         service.site_code = site_for_another_course.code
         expect(service).to be_invalid
-        expected_message = "cannot find any #{course_option.course.study_mode} options at site #{site_for_another_course.code} for course #{course_option.course.code}"
+        expected_message = "Cannot find any #{course_option.course.study_mode} options at site #{site_for_another_course.code} for course #{course_option.course.code}"
         expect(service.errors[:course_option]).to contain_exactly(expected_message)
       end
     end
@@ -48,7 +48,7 @@ RSpec.describe GetCourseOptionFromCodes do
       it 'is not valid' do
         service.site_code = nil
         expect(service).to be_invalid
-        expected_message = "found multiple #{course_option.course.study_mode} options for course #{course_option.course.code}"
+        expected_message = "Found multiple #{course_option.course.study_mode} options for course #{course_option.course.code}"
         expect(service.errors[:course_option]).to contain_exactly(expected_message)
       end
     end


### PR DESCRIPTION
## Context

API integrations are not necessarily aware of Apply/Publish site codes, and so cannot provide a site code when making/changing an offer.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This allows an API user to leave out a site code when changing an offer. If a single course option can be determined without the site, then good. Otherwise let the user know it is ambiguous.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Have I missed anything out?
I have also slightly tweaked the way we do the normal course_option finding, but I think the intention is the same.

## Link to Trello card
https://trello.com/c/d6UFJC1v/4225-relaxing-validations-for-site-codes-in-the-api

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
