### PR TITLE
Add course choices gcse requirements row and component

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -36,6 +36,7 @@ module CandidateInterface
         course_length_row(application_choice),
         start_date_row(application_choice),
         degree_required_row(application_choice),
+        gcse_required_row(application_choice),
         status_row(application_choice),
         rejection_reasons_row(application_choice),
         offer_withdrawal_reason_row(application_choice),
@@ -199,6 +200,13 @@ module CandidateInterface
       {
         key: 'Degree requirements',
         value: render(DegreeRequiredComponent.new(application_choice)),
+      }
+    end
+
+    def gcse_required_row(application_choice)
+      {
+        key: 'GCSE requirements',
+        value: render(PendingGcseRequiredComponent.new(application_choice)),
       }
     end
 

--- a/app/components/candidate_interface/degree_required_component.html.erb
+++ b/app/components/candidate_interface/degree_required_component.html.erb
@@ -1,6 +1,6 @@
 <% if candidate_degree_grade_below_required_grade? %>
   <%= govuk_inset_text(classes: 'govuk-inset-text app-inset-text--narrow-border app-inset-text--important govuk-!-margin-top-0 govuk-!-padding-bottom-1') do %>
-    <div class="app-inset-text__title"><%= COURSE_REQUIRED_GRADE_TEXT[@application_choice.course.degree_grade] %><div>
+    <div class="app-inset-text__title"><%= COURSE_REQUIRED_GRADE_TEXT[@application_choice.course.degree_grade] %></div>
       <p class="govuk-body">You said you have <%= DEGREE_GRADE_INSUFFICIENT_TEXT[@highest_degree_grade] %></p>
       <p class="govuk-body">You can:</p>
 
@@ -8,7 +8,6 @@
        <li>find a course that has a lower degree requirement</li>
        <li>contact the provider to see if they will still consider your application</li>
       </ul>
-    </div>
   <% end %>
 <% else %>
   <%= COURSE_REQUIRED_GRADE_TEXT[@application_choice.course.degree_grade] %>

--- a/app/components/candidate_interface/pending_gcse_required_component.html.erb
+++ b/app/components/candidate_interface/pending_gcse_required_component.html.erb
@@ -1,7 +1,7 @@
 <% if pending_gcse_and_course_can_accept? %>
   <%= govuk_inset_text(classes: 'govuk-inset-text app-inset-text--narrow-border app-inset-text--important govuk-!-margin-top-0 govuk-!-padding-bottom-1') do %>
     <div class="app-inset-text__title">This provider does not consider candidates with pending GCSEs</div>
-      <p class="govuk-body">You said you’re currently studying for a qualification in  <%= pending_gcse_text %></p>
+      <p class="govuk-body">You said you’re currently studying for a qualification in <%= pending_gcse_text %></p>
       <p class="govuk-body">You can:</p>
 
       <ul class="govuk-list govuk-list--bullet">

--- a/app/components/candidate_interface/pending_gcse_required_component.html.erb
+++ b/app/components/candidate_interface/pending_gcse_required_component.html.erb
@@ -1,0 +1,16 @@
+<% if pending_gcse_and_course_can_accept? %>
+  <%= govuk_inset_text(classes: 'govuk-inset-text app-inset-text--narrow-border app-inset-text--important govuk-!-margin-top-0 govuk-!-padding-bottom-1') do %>
+    <div class="app-inset-text__title">This provider does not consider candidates with pending GCSEs</div>
+      <p class="govuk-body">You said you’re currently studying for a qualification in  <%= pending_gcse_text %></p>
+      <p class="govuk-body">You can:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+       <li>find a course that does accept pending GCSEs</li>
+       <li>contact the provider to see if they will still consider your application</li>
+      </ul>
+  <% end %>
+<% elsif @application_choice.course.accept_pending_gcse? %>
+  This provider will consider candidates with pending GCSEs
+<% else %>
+  This provider does not consider candidates with pending GCSEs
+<% end %>

--- a/app/components/candidate_interface/pending_gcse_required_component.rb
+++ b/app/components/candidate_interface/pending_gcse_required_component.rb
@@ -14,12 +14,13 @@ private
 
   def pending_gcse_text
     subjects = pending_uk_gcses.map(&:subject)
-    subjects[0] = subjects[0].capitalize
+    subjects[0] = subjects[0].capitalize if subjects[0] == 'english'
     subjects.to_sentence(last_word_connector: ' and ', two_words_connector: ' and ')
   end
 
   def find_pending_uk_gcses(application_choice)
     application_choice.application_form.application_qualifications
       .where(level: 'gcse', other_uk_qualification_type: nil, institution_country: [nil, 'GB'], currently_completing_qualification: true)
+      .sort_by(&:subject)
   end
 end

--- a/app/components/candidate_interface/pending_gcse_required_component.rb
+++ b/app/components/candidate_interface/pending_gcse_required_component.rb
@@ -1,0 +1,25 @@
+class CandidateInterface::PendingGcseRequiredComponent < ViewComponent::Base
+  attr_accessor :application_choice, :pending_uk_gcses
+
+  def initialize(application_choice)
+    @application_choice = application_choice
+    @pending_uk_gcses = find_pending_uk_gcses(application_choice)
+  end
+
+  def pending_gcse_and_course_can_accept?
+    @pending_uk_gcses.any? && !@application_choice.course.accept_pending_gcse?
+  end
+
+private
+
+  def pending_gcse_text
+    subjects = pending_uk_gcses.map(&:subject)
+    subjects[0] = subjects[0].capitalize
+    subjects.to_sentence(last_word_connector: ' and ', two_words_connector: ' and ')
+  end
+
+  def find_pending_uk_gcses(application_choice)
+    application_choice.application_form.application_qualifications
+      .where(level: 'gcse', other_uk_qualification_type: nil, institution_country: [nil, 'GB'], currently_completing_qualification: true)
+  end
+end

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
       expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.description)
       expect(result.css('.govuk-summary-list__value').to_html).to include('1 year')
       expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.start_date.to_s(:month_and_year))
+      expect(result.css('.govuk-summary-list__value').to_html).to include('This provider does not consider candidates with pending GCSEs')
       expect(result.css('a').to_html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
     end
 

--- a/spec/components/candidate_interface/degree_required_component_spec.rb
+++ b/spec/components/candidate_interface/degree_required_component_spec.rb
@@ -26,8 +26,6 @@ RSpec.describe CandidateInterface::DegreeRequiredComponent, type: :component do
       create(
         :degree_qualification,
         qualification_type: 'Other Qual',
-        subject: 'Woof',
-        institution_name: 'University of Doge',
         institution_country: 'GB',
         grade: 'Lower second-class honours (2:2)',
         application_form: application_form,

--- a/spec/components/candidate_interface/pending_gcse_required_component_spec.rb
+++ b/spec/components/candidate_interface/pending_gcse_required_component_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe CandidateInterface::PendingGcseRequiredComponent, type: :componen
 
   context 'application has pending gcse(s) that are not accepted' do
     context 'application has one pending gcse and course does not accept them' do
-      it 'renders the degree row with guidance' do
+      it 'renders the gcse row with guidance' do
         create(
           :gcse_qualification,
           subject: 'english',
@@ -49,12 +49,12 @@ RSpec.describe CandidateInterface::PendingGcseRequiredComponent, type: :componen
         )
 
         result = render_inline(described_class.new(application_choice2))
-        expect(result.text).to include('You said you’re currently studying for a qualification in  English')
+        expect(result.text).to include('You said you’re currently studying for a qualification in English')
       end
     end
 
     context 'application has two pending gcses and course does not accept them' do
-      it 'renders the degree row with guidance' do
+      it 'renders the gcse row with guidance' do
         create(
           :gcse_qualification,
           subject: 'english',
@@ -70,12 +70,12 @@ RSpec.describe CandidateInterface::PendingGcseRequiredComponent, type: :componen
         )
 
         result = render_inline(described_class.new(application_choice2))
-        expect(result.text).to include('You said you’re currently studying for a qualification in  English and maths')
+        expect(result.text).to include('You said you’re currently studying for a qualification in English and maths')
       end
     end
 
     context 'application has three pending gcses and course does not accept them' do
-      it 'renders the degree row with guidance' do
+      it 'renders the gcse row with guidance' do
         create(
           :gcse_qualification,
           subject: 'english',
@@ -96,7 +96,7 @@ RSpec.describe CandidateInterface::PendingGcseRequiredComponent, type: :componen
         )
 
         result = render_inline(described_class.new(application_choice2))
-        expect(result.text).to include('You said you’re currently studying for a qualification in  English, maths and science')
+        expect(result.text).to include('You said you’re currently studying for a qualification in English, maths and science')
       end
     end
   end

--- a/spec/components/candidate_interface/pending_gcse_required_component_spec.rb
+++ b/spec/components/candidate_interface/pending_gcse_required_component_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::PendingGcseRequiredComponent, type: :component do
+  let(:application_form) { create(:application_form) }
+
+  let(:course_option1) { create(:course_option, course: create(:course, :open_on_apply, accept_pending_gcse: true)) }
+  let(:course_option2) { create(:course_option, course: create(:course, :open_on_apply, accept_pending_gcse: false)) }
+
+  let(:application_choice1) do
+    build_stubbed(
+      :application_choice,
+      status: :unsubmitted,
+      course_option: course_option1,
+      application_form: application_form,
+    )
+  end
+
+  let(:application_choice2) do
+    build_stubbed(
+      :application_choice,
+      status: :unsubmitted,
+      course_option: course_option2,
+      application_form: application_form,
+    )
+  end
+
+  context 'course accepts pending gcses' do
+    it 'renders the correct gcse row content without guidance' do
+      result = render_inline(described_class.new(application_choice1))
+      expect(result.text).to include('This provider will consider candidates with pending GCSEs')
+    end
+  end
+
+  context 'application has no pending gcses and course does not accept them' do
+    it 'renders the correct gcse row content without guidance' do
+      result = render_inline(described_class.new(application_choice2))
+      expect(result.text).to include('This provider does not consider candidates with pending GCSEs')
+    end
+  end
+
+  context 'application has pending gcse(s) that are not accepted' do
+    context 'application has one pending gcse and course does not accept them' do
+      it 'renders the degree row with guidance' do
+        create(
+          :gcse_qualification,
+          subject: 'english',
+          currently_completing_qualification: true,
+          application_form: application_form,
+        )
+
+        result = render_inline(described_class.new(application_choice2))
+        expect(result.text).to include('You said you’re currently studying for a qualification in  English')
+      end
+    end
+
+    context 'application has two pending gcses and course does not accept them' do
+      it 'renders the degree row with guidance' do
+        create(
+          :gcse_qualification,
+          subject: 'english',
+          currently_completing_qualification: true,
+          application_form: application_form,
+        )
+
+        create(
+          :gcse_qualification,
+          subject: 'maths',
+          currently_completing_qualification: true,
+          application_form: application_form,
+        )
+
+        result = render_inline(described_class.new(application_choice2))
+        expect(result.text).to include('You said you’re currently studying for a qualification in  English and maths')
+      end
+    end
+
+    context 'application has three pending gcses and course does not accept them' do
+      it 'renders the degree row with guidance' do
+        create(
+          :gcse_qualification,
+          subject: 'english',
+          currently_completing_qualification: true,
+          application_form: application_form,
+        )
+        create(
+          :gcse_qualification,
+          subject: 'maths',
+          currently_completing_qualification: true,
+          application_form: application_form,
+        )
+        create(
+          :gcse_qualification,
+          subject: 'science',
+          currently_completing_qualification: true,
+          application_form: application_form,
+        )
+
+        result = render_inline(described_class.new(application_choice2))
+        expect(result.text).to include('You said you’re currently studying for a qualification in  English, maths and science')
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/course_selection/candidate_can_view_gcse_requirements_and_guidance_for_selected_courses_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_view_gcse_requirements_and_guidance_for_selected_courses_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.feature 'Viewing course choices' do
+  include CandidateHelper
+
+  scenario 'candidate can view pending gcse requirements and guidance for selected courses' do
+    given_i_am_signed_in
+    and_i_have_two_chosen_courses_with_different_pending_gcse_requirements
+
+    when_i_add_an_english_gcse
+    and_i_visit_the_course_choice_review_page
+    then_i_can_view_course_choices_without_guidance_text
+
+    when_i_change_the_completed_gcse_to_a_pending_gcse
+    and_i_visit_the_course_choice_review_page
+    then_i_can_view_course_choices_with_guidance_text
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_have_two_chosen_courses_with_different_pending_gcse_requirements
+    course_option1 = create(:course_option, course: create(:course, :open_on_apply, accept_pending_gcse: true))
+    course_option2 = create(:course_option, course: create(:course, :open_on_apply, accept_pending_gcse: false))
+    @choice1 = create(
+      :application_choice,
+      status: :unsubmitted,
+      course_option: course_option1,
+      application_form: current_candidate.current_application,
+    )
+    @choice2 = create(
+      :application_choice,
+      status: :unsubmitted,
+      course_option: course_option2,
+      application_form: current_candidate.current_application,
+    )
+  end
+
+  def when_i_add_an_english_gcse
+    visit candidate_interface_gcse_details_new_type_path(subject: 'english')
+    choose 'GCSE'
+    click_button t('save_and_continue')
+    check 'English (Single award)'
+    within '#candidate-interface-english-gcse-grade-form-english-gcses-english-single-award-conditional' do
+      fill_in 'Grade', with: 'C'
+    end
+    click_button t('save_and_continue')
+    fill_in 'Enter year', with: '2008'
+    click_button t('save_and_continue')
+  end
+
+  def and_i_visit_the_course_choice_review_page
+    visit candidate_interface_course_choices_review_path
+  end
+
+  def then_i_can_view_course_choices_without_guidance_text
+    within "#course-choice-#{@choice1.id}" do
+      expect(page).to have_content('GCSE requirements')
+      expect(page).to have_content('This provider will consider candidates with pending GCSEs')
+    end
+
+    within "#course-choice-#{@choice2.id}" do
+      expect(page).to have_content('GCSE requirements')
+      expect(page).to have_content('This provider does not consider candidates with pending GCSEs')
+      expect(page).not_to have_content('You said you’re currently studying for a qualification in English')
+      expect(page).not_to have_content("You can:\nfind a course that does accept pending GCSEs contact the provider to see if they will still consider your application")
+    end
+  end
+
+  def when_i_change_the_completed_gcse_to_a_pending_gcse
+    visit candidate_interface_gcse_review_path(subject: 'english')
+    click_change_link('qualification for GCSE, english')
+    choose 'I do not have a GCSE in English (or equivalent) yet'
+    click_button t('save_and_continue')
+    click_change_link('how you expect to gain this qualification')
+    choose 'Yes'
+    fill_in 'Details of the qualification you’re studying for', with: 'GCSE English'
+    click_button t('save_and_continue')
+  end
+
+  def then_i_can_view_course_choices_with_guidance_text
+    within "#course-choice-#{@choice1.id}" do
+      expect(page).to have_content('GCSE requirements')
+      expect(page).to have_content('This provider will consider candidates with pending GCSEs')
+    end
+
+    within "#course-choice-#{@choice2.id}" do
+      expect(page).to have_content('GCSE requirements')
+      expect(page).to have_content('This provider does not consider candidates with pending GCSEs')
+      expect(page).to have_content('You said you’re currently studying for a qualification in English')
+      expect(page).to have_content("You can:\nfind a course that does accept pending GCSEs contact the provider to see if they will still consider your application")
+    end
+  end
+end


### PR DESCRIPTION
## Context

In order to give better guidance to candidates applying for courses we need better contextual prompts if they do not meet course requirements. We need to be able to let candidate know if they have pending GCSE's where they are not accepted.

## Changes proposed in this pull request

Component has three states of content.

`accept_pending_gcse == true`
<img width="715" alt="image" src="https://user-images.githubusercontent.com/62567622/133331258-bf4bee00-0400-4efd-930e-60cee3908c2e.png">

`accept_pending_gcse == false or nil`
<img width="715" alt="image" src="https://user-images.githubusercontent.com/62567622/133331237-33f6ca2a-aa1f-4431-8d2b-c1cfd3f3a318.png">

`accept_pending_gcse == false or nil` and candidate has pending gcses
<img width="715" alt="image" src="https://user-images.githubusercontent.com/62567622/133331270-862e44ef-fcef-4add-8984-0ca512cb6981.png">

## Guidance to review

## Link to Trello card

https://trello.com/c/pmS8NaDt/3840-%F0%9F%93%90dev-apply-indicate-when-a-course-has-gcse-requirements-that-the-candidate-doesnt-meet

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
