### PR TITLE
Ensure correct submission date is shown on the submission copy

### DIFF
--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -67,7 +67,11 @@
     <section>
       <% if CycleTimetable.between_cycles?(@application_form_presenter.application_form.phase) %>
         <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.review') %></h2>
-        <p class="govuk-body">You cannot submit your application until 9am on <%= CycleTimetable.apply_opens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.</p>
+        <% if Time.zone.now < CycleTimetable.apply_opens %>
+          <p class="govuk-body">You cannot submit your application until 9am on <%= CycleTimetable.apply_opens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.</p>
+        <% else %>
+          <p class="govuk-body">You cannot submit your application until 9am on <%= CycleTimetable.apply_reopens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.</p>
+        <% end %>
         <%= govuk_button_link_to 'Review your application', candidate_interface_application_review_path %>
       <% elsif CycleTimetable.can_submit?(@application_form_presenter.application_form) %>
         <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.check_and_submit') %></h2>


### PR DESCRIPTION
## Context

At the moment we're showing an incorrect date here for carried over applications 

![image](https://user-images.githubusercontent.com/42515961/133439090-50b26d06-6c37-4e1b-80ed-942e40896cfc.png)


## Changes proposed in this pull request

- Add conditional logic to ensure we're rendering the correct date

## Guidance to review

In a second i'll pop this is a component and unit test it, but we should ship the fix out asap

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
