### PR TITLE
update sync_courses to set 2022 courses to open on apply

### DIFF
--- a/app/services/set_open_on_apply_for_new_course.rb
+++ b/app/services/set_open_on_apply_for_new_course.rb
@@ -6,7 +6,7 @@ class SetOpenOnApplyForNewCourse
   end
 
   def call
-    @course.open! if HostingEnvironment.sandbox_mode? || @course.in_previous_cycle&.open_on_apply?
+    @course.open! if HostingEnvironment.sandbox_mode? || @course.in_previous_cycle&.open_on_apply? || @course.recruitment_cycle_year == RecruitmentCycle.next_year
 
     if @course.provider.any_courses_open_in_current_cycle?(exclude_ratified_courses: true)
       auto_open = @course.provider.all_courses_open_in_current_cycle?(exclude_ratified_courses: true)
@@ -20,6 +20,8 @@ class SetOpenOnApplyForNewCourse
 private
 
   def notify_of_new_course!(provider, accredited_provider, auto_open)
+    return if @course.recruitment_cycle_year == RecruitmentCycle.next_year
+
     notification = [":seedling: #{provider.name}, which has courses open on Apply, added #{@course.name_and_code}"]
     notification << auto_open_message(auto_open)
     notification << accredited_body_message(accredited_provider)

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -41,6 +41,7 @@ module TeacherTrainingPublicAPI
       add_accredited_provider(course, course_from_api[:accredited_body_code], recruitment_cycle_year)
 
       new_course = course.new_record?
+
       @updates.merge!(courses: true) if !incremental_sync && course.changed?
 
       course.save!

--- a/spec/services/set_open_on_apply_for_new_course_spec.rb
+++ b/spec/services/set_open_on_apply_for_new_course_spec.rb
@@ -13,6 +13,21 @@ RSpec.describe SetOpenOnApplyForNewCourse do
     end
   end
 
+  context 'course is for the next year' do
+    let(:course) { create(:course, open_on_apply: false, recruitment_cycle_year: RecruitmentCycle.next_year) }
+
+    it 'opens the course' do
+      course_opener.call
+      expect(course.open_on_apply).to be true
+    end
+
+    it 'does not send a slack message' do
+      course_opener.call
+
+      expect_no_slack_message
+    end
+  end
+
   context 'the provider has no courses in the current cycle' do
     it 'does not open the course' do
       course_opener.call

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -400,6 +400,20 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
         expect(course.open_on_apply).to be true
         expect(course.opened_on_apply_at).not_to be_nil
       end
+
+      it 'sets courses to open on apply when if they are in the new cycle' do
+        stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                                   course_code: 'ABC1',
+                                                   course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
+                                                   site_code: 'A',
+                                                   vacancy_status: 'full_time_vacancies',
+                                                   recruitment_cycle_year: RecruitmentCycle.next_year)
+
+        described_class.new.perform(existing_provider.id, RecruitmentCycle.next_year)
+
+        course = Course.find_by(code: 'ABC1')
+        expect(course.reload.open_on_apply).to be true
+      end
     end
 
     context 'ingesting a provider when it existed in the previous recruitment cycle' do


### PR DESCRIPTION
## Context

All courses for the new cycle (2022) should be set to open on apply as we are deprecating the concept of open on apply.

## Guidance to review
Make some applications with the new cycle and check they sync correctly.
## Link to Trello card

https://trello.com/c/AY51eNIz/4208-open-all-courses-for-the-next-cycle-when-syncing

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
