### PR TITLE
Componentise the review your application button and content

### DIFF
--- a/app/components/candidate_interface/review_application_component.html.erb
+++ b/app/components/candidate_interface/review_application_component.html.erb
@@ -1,0 +1,10 @@
+<section>
+  <% if CycleTimetable.between_cycles?(application_form.phase) %>
+    <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.review') %></h2>
+    <p class="govuk-body">You cannot submit your application until 9am on <%= reopen_date %>. You can keep making changes to the rest of your application until then.</p>
+    <%= govuk_button_link_to 'Review your application', candidate_interface_application_review_path %>
+  <% else %>
+    <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.check_and_submit') %></h2>
+    <%= govuk_button_link_to t('section_items.check_and_submit'), candidate_interface_application_review_path %>
+  <% end %>
+</section>

--- a/app/components/candidate_interface/review_application_component.rb
+++ b/app/components/candidate_interface/review_application_component.rb
@@ -1,0 +1,13 @@
+class CandidateInterface::ReviewApplicationComponent < ViewComponent::Base
+  attr_accessor :application_form
+
+  def initialize(application_form:)
+    @application_form = application_form
+  end
+
+private
+
+  def reopen_date
+    Time.zone.now < CycleTimetable.date(:apply_opens) ? CycleTimetable.apply_opens.to_s(:govuk_date) : CycleTimetable.apply_reopens.to_s(:govuk_date)
+  end
+end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -37,6 +37,10 @@ class CycleTimetable
       reject_by_default: Time.zone.local(2022, 9, 29, 23, 59, 59), # This is a placeholder till we know the real date
       find_closes: Time.zone.local(2022, 10, 4, 23, 59, 59), # This is a placeholder till we know the real date
     },
+    2023 => {
+      find_opens: Time.zone.local(2022, 10, 5, 9), # This is a placeholder till we know the real date
+      apply_opens: Time.zone.local(2022, 10, 12, 9), # This is a placeholder till we know the real date
+    },
   }.freeze
 
   def self.current_year
@@ -129,13 +133,15 @@ class CycleTimetable
   end
 
   def self.between_cycles_apply_1?
-    Time.zone.now > apply_1_deadline &&
-      Time.zone.now < apply_reopens
+    (Time.zone.now > apply_1_deadline &&
+      Time.zone.now < apply_reopens) ||
+      Time.zone.now < apply_opens
   end
 
   def self.between_cycles_apply_2?
-    Time.zone.now > apply_2_deadline &&
-      Time.zone.now < apply_reopens
+    (Time.zone.now > apply_2_deadline &&
+      Time.zone.now < apply_reopens) ||
+      Time.zone.now < apply_opens
   end
 
   def self.date(name, year = current_year)

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -64,20 +64,7 @@
       <%= render 'task_list', application_form: @application_form_presenter.application_form, application_form_presenter: @application_form_presenter %>
     <% end %>
 
-    <section>
-      <% if CycleTimetable.between_cycles?(@application_form_presenter.application_form.phase) %>
-        <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.review') %></h2>
-        <% if Time.zone.now < CycleTimetable.apply_opens %>
-          <p class="govuk-body">You cannot submit your application until 9am on <%= CycleTimetable.apply_opens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.</p>
-        <% else %>
-          <p class="govuk-body">You cannot submit your application until 9am on <%= CycleTimetable.apply_reopens.to_s(:govuk_date) %>. You can keep making changes to the rest of your application until then.</p>
-        <% end %>
-        <%= govuk_button_link_to 'Review your application', candidate_interface_application_review_path %>
-      <% elsif CycleTimetable.can_submit?(@application_form_presenter.application_form) %>
-        <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.check_and_submit') %></h2>
-        <%= govuk_button_link_to t('section_items.check_and_submit'), candidate_interface_application_review_path %>
-      <% end %>
-    </section>
+    <%= render(CandidateInterface::ReviewApplicationComponent.new(application_form: @application_form_presenter.application_form)) %>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/spec/components/candidate_interface/review_application_component_spec.rb
+++ b/spec/components/candidate_interface/review_application_component_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ReviewApplicationComponent do
+  context 'when mid cycle' do
+    around do |example|
+      Timecop.freeze(CycleTimetable.apply_1_deadline - 1.day) do
+        example.run
+      end
+    end
+
+    it 'renders the banner with the correct date for when apply reopens' do
+      application_form = create(:application_form)
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.text).to include('Check and submit your application')
+    end
+  end
+
+  context 'before the new cycle' do
+    around do |example|
+      Timecop.freeze(CycleTimetable.apply_2_deadline + 1.day) do
+        example.run
+      end
+    end
+
+    it 'renders the banner with the correct date for when apply reopens' do
+      application_form = create(:application_form)
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.text).to include("You cannot submit your application until 9am on #{CycleTimetable.apply_reopens.to_s(:govuk_date)}. You can keep making changes to the rest of your application until then.")
+    end
+  end
+
+  context 'after find opens' do
+    around do |example|
+      Timecop.freeze(CycleTimetable.find_reopens + 1.day) do
+        example.run
+      end
+    end
+
+    it 'renders the banner with the correct date for when apply reopens' do
+      application_form = create(:application_form)
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.text).to include("You cannot submit your application until 9am on #{CycleTimetable.apply_opens.to_s(:govuk_date)}. You can keep making changes to the rest of your application until then.")
+    end
+  end
+end

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -115,6 +115,12 @@ RSpec.describe CycleTimetable do
       end
     end
 
+    it 'returns true between find and apply reopening' do
+      Timecop.travel(one_hour_after_find_opens) do
+        expect(described_class.between_cycles_apply_2?).to be true
+      end
+    end
+
     it 'returns false after the new cycle opens' do
       Timecop.travel(one_hour_after_2021_cycle_opens) do
         expect(described_class.between_cycles_apply_1?).to be false
@@ -131,6 +137,12 @@ RSpec.describe CycleTimetable do
 
     it 'returns true after the configured date' do
       Timecop.travel(one_hour_after_apply2_deadline) do
+        expect(described_class.between_cycles_apply_2?).to be true
+      end
+    end
+
+    it 'returns true between find and apply reopening' do
+      Timecop.travel(one_hour_after_find_opens) do
         expect(described_class.between_cycles_apply_2?).to be true
       end
     end


### PR DESCRIPTION
## Context

Earlier on we found a bug with the dates in the review your application section of the unsubmitted application form show page.

We've shipped the fix, but the logic should be put in a component and unit tested. This actually drove out another bug in the `self.between_cycles_apply_1?` and `self.between_cycles_apply_2?` methods where they returned false between the new cycle launching and apply reopening

## Changes proposed in this pull request

- Refactor the review application section of the application form show page into a component 

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
