### PR TITLE
[DO NOT MERGE] Use and backfill the `not_completed_explanation` field instead of `missing_explanation`

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -99,11 +99,11 @@ module CandidateInterface
     end
 
     def failing_grade_explanation_row
-      return nil unless application_qualification.failed_required_gcse? && application_qualification.missing_explanation.present?
+      return nil unless application_qualification.failed_required_gcse? && application_qualification.not_completed_explanation.present?
 
       {
         key: 'How I expect to gain this qualification',
-        value: application_qualification.missing_explanation,
+        value: application_qualification.not_completed_explanation,
         action: {
           href: candidate_interface_gcse_details_edit_grade_explanation_path(change_path_params),
           visually_hidden_text: 'if you are working towards this qualification at grade 4 (C) or above, give us details',
@@ -158,7 +158,7 @@ module CandidateInterface
     def missing_qualification_row
       {
         key: 'How I expect to gain this qualification',
-        value: application_qualification.missing_explanation.presence || t('gcse_summary.not_specified'),
+        value: application_qualification.not_completed_explanation.presence || t('gcse_summary.not_specified'),
         action: {
           href: candidate_interface_gcse_details_edit_type_path(change_path_params),
           visually_hidden_text: 'how you expect to gain this qualification',

--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -12,7 +12,7 @@
             <dl class="app-qualification">
               <dd class="app-qualification__value"> <%= candidate_does_not_have %> </dd>
               <dt class="app-qualification__key">Reason given</dt>
-              <dd class="app-qualification__value"><%= qualification.missing_explanation %></dd>
+              <dd class="app-qualification__value"><%= qualification.not_completed_explanation %></dd>
             </dl>
 
           <% # International qualification %>

--- a/app/components/shared/qualification_row_component.html.erb
+++ b/app/components/shared/qualification_row_component.html.erb
@@ -4,7 +4,7 @@
     <%= render QualificationTitleComponent.new(qualification: qualification) %>
   </td>
   <% if qualification.missing_qualification? %>
-    <td colspan="2" class="govuk-table__cell"><%= qualification.missing_explanation %></td>
+    <td colspan="2" class="govuk-table__cell"><%= qualification.not_completed_explanation %></td>
   <% else %>
     <td class="govuk-table__cell"><%= qualification.award_year %></td>
     <td class="govuk-table__cell"><%= render QualificationGradeComponent.new(qualification: qualification) %></td>

--- a/app/controllers/candidate_interface/gcse/grade_explanation_controller.rb
+++ b/app/controllers/candidate_interface/gcse/grade_explanation_controller.rb
@@ -49,7 +49,7 @@ module CandidateInterface
     def update_params
       strip_whitespace params
         .require(:candidate_interface_gcse_grade_explanation_form)
-        .permit(:missing_explanation)
+        .permit(:not_completed_explanation)
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -57,7 +57,7 @@ module CandidateInterface
     def qualification_params
       strip_whitespace params
         .require(:candidate_interface_gcse_qualification_type_form)
-        .permit(:qualification_type, :other_uk_qualification_type, :missing_explanation, :non_uk_qualification_type)
+        .permit(:qualification_type, :other_uk_qualification_type, :not_completed_explanation, :non_uk_qualification_type)
         .merge!(
           subject: subject_param,
           level: ApplicationQualification.levels[:gcse],

--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -16,7 +16,7 @@ class ApplicationChoiceExportDecorator < SimpleDelegator
       .application_qualifications
       .select(&:gcse?)
       .select(&:missing_qualification?)
-      .map { |gcse| "#{gcse.subject.capitalize} GCSE or equivalent: #{gcse.missing_explanation}" }
+      .map { |gcse| "#{gcse.subject.capitalize} GCSE or equivalent: #{gcse.not_completed_explanation}" }
       .join(separator_string)
       .presence
   end
@@ -46,7 +46,7 @@ class ApplicationChoiceExportDecorator < SimpleDelegator
 private
 
   def missing_gcse_explanation(gcse)
-    "#{gcse.subject.capitalize} GCSE or equivalent: #{gcse.missing_explanation}"
+    "#{gcse.subject.capitalize} GCSE or equivalent: #{gcse.not_completed_explanation}"
   end
 
   def summary_for_gcse(gcse)

--- a/app/forms/candidate_interface/english_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/english_gcse_grade_form.rb
@@ -148,7 +148,7 @@ module CandidateInterface
       result = multiple_gcse? ? save_grades : save_grade
       return false unless result
 
-      reset_missing_explanation!(qualification)
+      reset_not_completed_explanation!(qualification)
       result
     end
 
@@ -162,10 +162,10 @@ module CandidateInterface
       qualification.update(grade: set_grade, constituent_grades: nil)
     end
 
-    def reset_missing_explanation!(qualification)
+    def reset_not_completed_explanation!(qualification)
       return true unless qualification.pass_gcse?
 
-      qualification.update(missing_explanation: nil)
+      qualification.update(not_completed_explanation: nil)
     end
 
     def save_grades

--- a/app/forms/candidate_interface/gcse_grade_explanation_form.rb
+++ b/app/forms/candidate_interface/gcse_grade_explanation_form.rb
@@ -2,18 +2,18 @@ module CandidateInterface
   class GcseGradeExplanationForm
     include ActiveModel::Model
 
-    attr_accessor :missing_explanation
+    attr_accessor :not_completed_explanation
 
     def self.build_from_qualification(qualification)
       new(
-        missing_explanation: qualification.missing_explanation,
+        not_completed_explanation: qualification.not_completed_explanation,
       )
     end
 
     def save(qualification)
       return false unless valid?
 
-      qualification.update!(missing_explanation: missing_explanation)
+      qualification.update!(not_completed_explanation: not_completed_explanation)
     end
   end
 end

--- a/app/forms/candidate_interface/gcse_qualification_type_form.rb
+++ b/app/forms/candidate_interface/gcse_qualification_type_form.rb
@@ -32,6 +32,7 @@ module CandidateInterface
         other_uk_qualification_type: other_uk_qualification_type,
         non_uk_qualification_type: non_uk_qualification_type,
         not_completed_explanation: not_completed_explanation,
+        currently_completing_qualification: not_completed_explanation.present?,
       )
     end
 
@@ -48,6 +49,7 @@ module CandidateInterface
         other_uk_qualification_type: other_uk_qualification_type,
         non_uk_qualification_type: non_uk_qualification_type,
         not_completed_explanation: not_completed_explanation,
+        currently_completing_qualification: not_completed_explanation.present?,
       )
     end
 

--- a/app/forms/candidate_interface/gcse_qualification_type_form.rb
+++ b/app/forms/candidate_interface/gcse_qualification_type_form.rb
@@ -5,7 +5,7 @@ module CandidateInterface
     include ActiveModel::Model
 
     attr_accessor :subject, :level, :qualification_type, :other_uk_qualification_type,
-                  :missing_explanation, :qualification_id, :non_uk_qualification_type
+                  :not_completed_explanation, :qualification_id, :non_uk_qualification_type
 
     validates :subject, :level, :qualification_type, presence: true
 
@@ -15,7 +15,7 @@ module CandidateInterface
     validates :non_uk_qualification_type, length: { maximum: 255 }
     validates :other_uk_qualification_type, length: { maximum: 100 }
 
-    validates :missing_explanation, word_count: { maximum: 200 }
+    validates :not_completed_explanation, word_count: { maximum: 200 }
 
     validates :subject, length: { maximum: 255 }
 
@@ -31,7 +31,7 @@ module CandidateInterface
         qualification_type: qualification_type,
         other_uk_qualification_type: other_uk_qualification_type,
         non_uk_qualification_type: non_uk_qualification_type,
-        missing_explanation: missing_explanation,
+        not_completed_explanation: not_completed_explanation,
       )
     end
 
@@ -47,7 +47,7 @@ module CandidateInterface
         qualification_type: qualification_type,
         other_uk_qualification_type: other_uk_qualification_type,
         non_uk_qualification_type: non_uk_qualification_type,
-        missing_explanation: missing_explanation,
+        not_completed_explanation: not_completed_explanation,
       )
     end
 
@@ -63,7 +63,7 @@ module CandidateInterface
         other_uk_qualification_type: qualification.other_uk_qualification_type,
         non_uk_qualification_type: qualification.non_uk_qualification_type,
         qualification_id: qualification.id,
-        missing_explanation: qualification.missing_explanation,
+        not_completed_explanation: qualification.not_completed_explanation,
       )
     end
 

--- a/app/forms/candidate_interface/maths_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/maths_gcse_grade_form.rb
@@ -31,7 +31,7 @@ module CandidateInterface
     def save(qualification)
       if valid?
         qualification.update!(grade: set_grade)
-        reset_missing_explanation!(qualification)
+        reset_not_completed_explanation!(qualification)
       else
         log_validation_errors(:grade)
         false
@@ -93,10 +93,10 @@ module CandidateInterface
       end
     end
 
-    def reset_missing_explanation!(qualification)
+    def reset_not_completed_explanation!(qualification)
       return true unless qualification.pass_gcse?
 
-      qualification.update(missing_explanation: nil)
+      qualification.update(not_completed_explanation: nil)
     end
   end
 end

--- a/app/forms/candidate_interface/science_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/science_gcse_grade_form.rb
@@ -74,7 +74,7 @@ module CandidateInterface
         subject: subject,
       )
 
-      reset_missing_explanation!(qualification)
+      reset_not_completed_explanation!(qualification)
     end
 
     def assign_values(params)
@@ -240,10 +240,10 @@ module CandidateInterface
       qualification.qualification_type == 'gcse'
     end
 
-    def reset_missing_explanation!(qualification)
+    def reset_not_completed_explanation!(qualification)
       return true unless qualification.pass_gcse?
 
-      qualification.update(missing_explanation: nil)
+      qualification.update(not_completed_explanation: nil)
     end
 
     def grade_contains_two_numbers?(grade)

--- a/app/services/data_migrations/backfill_not_completed_explanation.rb
+++ b/app/services/data_migrations/backfill_not_completed_explanation.rb
@@ -1,0 +1,21 @@
+module DataMigrations
+  class BackfillNotCompletedExplanation
+    TIMESTAMP = 20210915172449
+    MANUAL_RUN = false
+
+    def change
+      ApplicationQualification
+      .gcse
+      .where.not(missing_explanation: nil)
+      .where.not(missing_explanation: '')
+      .find_each(batch_size: 100) do |gcse|
+        missing_explanation = gcse.missing_explanation
+        gcse.update_columns(
+          not_completed_explanation: missing_explanation,
+          currently_completing_qualification: true,
+          missing_explanation: nil,
+        )
+      end
+    end
+  end
+end

--- a/app/views/candidate_interface/gcse/grade_explanation/_form.html.erb
+++ b/app/views/candidate_interface/gcse/grade_explanation/_form.html.erb
@@ -8,7 +8,7 @@
   <p class="govuk-body">You can still apply for teacher training if you do not have this. However, it will need to be in place by the start of your course.</p>
   <p class="govuk-body">For advice, contact your chosen training provider or <a href="https://getintoteaching.education.gov.uk/">Get Into Teaching</a>.</p>
   <%= f.govuk_text_area(
-    :missing_explanation,
+    :not_completed_explanation,
     label: { text: 'If you are working towards this qualification at grade 4 (C) or above, give us details (optional)', size: 'm' },
     rows: 6,
     max_words: 200,

--- a/app/views/candidate_interface/gcse/type/_form.html.erb
+++ b/app/views/candidate_interface/gcse/type/_form.html.erb
@@ -21,7 +21,7 @@
       <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? do %>
         <p class="govuk-hint">You can still apply for teacher training if you are missing this qualification or its equivalent. However, you will need to have completed it by the start of your course.</p>
         <p class="govuk-hint">For advice, contact your training provider or speak to a <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_online_chat') %> adviser.</p>
-        <%= f.govuk_text_area :missing_explanation, label: { text: t('application_form.gcse.missing_explanation.label'), size: 's' }, rows: 12, max_words: 200 do %>
+        <%= f.govuk_text_area :not_completed_explanation, label: { text: t('application_form.gcse.not_completed_explanation.label'), size: 's' }, rows: 12, max_words: 200 do %>
         <% end %>
       <% end %>
     <% else %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -143,7 +143,7 @@ shared:
     - institution_name
     - international
     - level
-    - missing_explanation
+    - not_completed_explanation
     - non_uk_qualification_type
     - other_uk_qualification_type
     - predicted_grade

--- a/config/locales/candidate_interface/gcse.yml
+++ b/config/locales/candidate_interface/gcse.yml
@@ -17,7 +17,7 @@ en:
       non_uk:
         label: Qualification name
         hint_text: For example, High School Diploma, Higher Secondary School Certificate, Baccalauréat Général, Título de Bachiller
-      missing_explanation:
+      not_completed_explanation:
         label: If you are working towards this qualification, give us details (optional)
       grade:
         label: Please specify your grade
@@ -126,7 +126,7 @@ en:
               too_long: Type of degree must be %{count} characters or fewer
             non_uk_qualification_type:
               blank: Enter the type of qualification
-            missing_explanation:
+            not_completed_explanation:
               blank: Give us some details
               too_many_words: Details must be %{count} words or fewer
         candidate_interface/gcse_institution_country_form:

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillNotCompletedExplanation',
   'DataMigrations::BackfillCoursesForNextCycle',
   'DataMigrations::BackfillInvalidProviderRelationshipPermissions',
   'DataMigrations::PopulateApplicationChoiceCurrentRecruitmentCycleYear',

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
         level: 'gcse',
         grade: 'D',
         subject: 'maths',
-        missing_explanation: 'I am going to work harder',
+        not_completed_explanation: 'I am going to work harder',
       )
       result = render_inline(
         described_class.new(application_form: application_form, application_qualification: application_qualification, subject: 'maths'),
@@ -101,7 +101,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
       expect(result.text).to match(/Qualification+GCSE/)
       expect(result.text).to match(/Year awarded+#{@qualification.award_year}/)
       expect(result.text).to match(/Grade+#{@qualification.grade}/)
-      expect(result.text).to match(/How I expect to gain this qualification+#{@qualification.missing_explanation}/)
+      expect(result.text).to match(/How I expect to gain this qualification+#{@qualification.not_completed_explanation}/)
       expect(result.text).not_to match(/Country+#{@qualification.institution_country}/)
     end
   end

--- a/spec/components/utility/qualification_row_component_spec.rb
+++ b/spec/components/utility/qualification_row_component_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe QualificationRowComponent do
     expect(result.text).to include('I did my best')
   end
 
-  it 'renders a qualification with a missing_explanation' do
+  it 'renders a qualification with a not_completed_explanation' do
     qualification = build_stubbed(
       :application_qualification,
       level: :gcse,
@@ -65,7 +65,7 @@ RSpec.describe QualificationRowComponent do
       subject: 'Maths',
       grade: nil,
       award_year: nil,
-      missing_explanation: 'I am taking the exam this summer',
+      not_completed_explanation: 'I am taking the exam this summer',
     )
 
     result = render_inline(described_class.new(qualification: qualification))

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
 
       explanation = described_class.new(application_choice).missing_gcses_explanation
 
-      expect(explanation).to include('Maths GCSE or equivalent', missing_gcse.missing_explanation)
+      expect(explanation).to include('Maths GCSE or equivalent', missing_gcse.not_completed_explanation)
     end
 
     it 'returns nil if a form has no missing gcses' do

--- a/spec/factories/application_qualification.rb
+++ b/spec/factories/application_qualification.rb
@@ -32,7 +32,7 @@ FactoryBot.define do
         qualification_type { 'missing' }
         grade { nil }
         predicted_grade { nil }
-        missing_explanation { 'I will be taking an equivalency test in a few weeks' }
+        not_completed_explanation { 'I will be taking an equivalency test in a few weeks' }
       end
 
       trait :multiple_english_gcses do

--- a/spec/forms/candidate_interface/gcse_qualification_type_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_qualification_type_form_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
     it 'creates a new qualification if valid' do
       application_form = create(:application_form)
 
-      form = described_class
-                                  .new(subject: 'maths', level: 'gcse', qualification_type: 'gcse')
+      form = described_class.new(subject: 'maths', level: 'gcse', qualification_type: 'gcse')
 
       form.save(application_form)
 
@@ -61,6 +60,44 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
 
         expect(form.valid?).to eq false
         expect(form.errors[:other_uk_qualification_type]).to include('Enter the type of qualification')
+      end
+
+      context 'missing qualification type with an explanation provided' do
+        it 'creates a new qualification with the correct attrs' do
+          application_form = create(:application_form)
+
+          form = described_class.new(
+            level: 'gcse',
+            subject: 'maths',
+            qualification_type: 'missing',
+            not_completed_explanation: 'I hate maths.',
+          )
+
+          form.save(application_form)
+
+          expect(application_form.application_qualifications.first.qualification_type).to eq 'missing'
+          expect(application_form.application_qualifications.first.not_completed_explanation).to eq 'I hate maths.'
+          expect(application_form.application_qualifications.first.currently_completing_qualification).to eq true
+        end
+      end
+
+      context 'missing qualification type without an explanation provided' do
+        it 'creates a new qualification with the correct attrs' do
+          application_form = create(:application_form)
+
+          form = described_class.new(
+            level: 'gcse',
+            subject: 'maths',
+            qualification_type: 'missing',
+            not_completed_explanation: '',
+          )
+
+          form.save(application_form)
+
+          expect(application_form.application_qualifications.first.qualification_type).to eq 'missing'
+          expect(application_form.application_qualifications.first.not_completed_explanation).to eq ''
+          expect(application_form.application_qualifications.first.currently_completing_qualification).to eq false
+        end
       end
     end
 

--- a/spec/services/data_migrations/backfill_not_completed_explanation_spec.rb
+++ b/spec/services/data_migrations/backfill_not_completed_explanation_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillNotCompletedExplanation do
+  it 'sets not_completed_yet to missing_explanation and set missing_explanation to nil' do
+    Timecop.freeze do
+      missing_gcse = create(
+        :gcse_qualification,
+        :missing,
+        not_completed_explanation: nil,
+        missing_explanation: 'Should get copied over.',
+        updated_at: 1.day.ago,
+      )
+
+      non_missing_gcse = create(
+        :gcse_qualification,
+        missing_explanation: '',
+      )
+
+      described_class.new.change
+
+      expect(missing_gcse.reload.not_completed_explanation).to eq 'Should get copied over.'
+      expect(missing_gcse.currently_completing_qualification).to eq true
+      expect(missing_gcse.missing_explanation).to eq nil
+      expect(missing_gcse.updated_at).to be_within(1.second).of(1.day.ago)
+      expect(non_missing_gcse.reload.missing_explanation).to eq ''
+    end
+  end
+end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -449,7 +449,7 @@ module CandidateHelper
 
   def candidate_explains_a_missing_gcse
     choose('I do not have this qualification yet')
-    fill_in t('application_form.gcse.missing_explanation.label'), with: 'I will sit the exam at my local college this summer.'
+    fill_in t('application_form.gcse.not_completed_explanation.label'), with: 'I will sit the exam at my local college this summer.'
     click_button t('save_and_continue')
     choose t('application_form.completed_radio')
     click_button t('continue')

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_with_missing_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_with_missing_qualification_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Candidate entering GCSE details' do
     when_i_visit_the_candidate_application_page
     and_i_click_on_the_maths_gcse_link
     and_i_select_i_do_not_have_yet
-    and_i_enter_the_missing_explanation
+    and_i_enter_the_not_completed_explanation
     and_i_click_save_and_continue
 
     then_i_see_the_review_page_with_correct_details
@@ -29,8 +29,8 @@ RSpec.feature 'Candidate entering GCSE details' do
     choose('I do not have this qualification yet')
   end
 
-  def and_i_enter_the_missing_explanation
-    fill_in t('application_form.gcse.missing_explanation.label'),
+  def and_i_enter_the_not_completed_explanation
+    fill_in t('application_form.gcse.not_completed_explanation.label'),
             with: 'I’m expecting to complete my Biology course on next July'
   end
 

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Candidate entering GCSE details but without a pass grade' do
     when_i_click_to_change_grade
     and_i_change_to_a_pass_grade
     then_i_see_the_review_page_with_new_details
-    and_the_missing_explanation_has_been_reset
+    and_the_not_completed_explanation_has_been_reset
 
     when_i_click_to_change_grade
     and_i_change_to_a_fail_grade
@@ -114,8 +114,8 @@ RSpec.feature 'Candidate entering GCSE details but without a pass grade' do
     expect(page).to have_content "Grade\nB"
   end
 
-  def and_the_missing_explanation_has_been_reset
+  def and_the_not_completed_explanation_has_been_reset
     expect(page).not_to have_content 'Hard work and dedication'
-    expect(ApplicationQualification.last.missing_explanation).to be_nil
+    expect(ApplicationQualification.last.not_completed_explanation).to be_nil
   end
 end


### PR DESCRIPTION
## Context

As part of the work to implement the new GCSE flow on the candidate UI, we have added the `not_completed_explanation` field. This essentially asks the same question that is currently captured by the `missing_explanation` field. If you don't have your GCSE or a C grade or higher, are you currently working towards it.

The `missing explanation` field will now be used to capture a candidates explanation for why they feel they don't need one. I.e. they are working towards an equivalency test.

## Changes proposed in this pull request

- Port the code over to use `not_completed_explanation` instead of `missing_explanation`
- Backfill the `not_completed_explanation` field

## Link to Trello card

https://trello.com/c/BRfAz4n1/3841-%F0%9F%93%90-dev-apply-update-gcse-questions-and-guidance

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
