### PR TITLE
Fix unchecked filters bug

### DIFF
--- a/app/components/utility/filter_component.html.erb
+++ b/app/components/utility/filter_component.html.erb
@@ -50,6 +50,7 @@
                   <% if filter[:type] == :search %>
                     <input class="govuk-input <%= filter[:css_classes] %>" id="<%= filter[:name] %>" name="<%= filter[:name] %>" type="text" value="<%= filter[:value] %>" aria-labelledby="filter-legend-<%= filter[:name] %>" autocomplete="off">
                   <% elsif filter[:type] == :checkboxes %>
+                    <input value="" name="<%= filter[:name] %>[]" type="hidden">
                     <% filter[:options].each do |option| %>
                       <div class="govuk-checkboxes govuk-checkboxes--small">
                         <div class="govuk-checkboxes__item">
@@ -78,6 +79,7 @@
                       <% end %>
                       <div class="app-checkbox-filter__container">
                         <div class="govuk-checkboxes govuk-checkboxes--small app-checkbox-filter__container-inner">
+                          <input value="" name="<%= filter[:name] %>[]" type="hidden">
                           <% filter[:options].each do |option| %>
                             <div class="govuk-checkboxes__item">
                               <input class="govuk-checkboxes__input" id="<%= filter[:name] %>-<%= option[:value] %>" name="<%= filter[:name] %>[]" type="checkbox" <%= 'checked' if option[:checked] %> value="<%= option[:value] %>">

--- a/app/controllers/support_interface/candidates_controller.rb
+++ b/app/controllers/support_interface/candidates_controller.rb
@@ -8,16 +8,16 @@ module SupportInterface
         .order(updated_at: :desc)
         .page(params[:page] || 1).per(30)
 
-      if params[:q].present?
-        @candidates = @candidates.where('CONCAT(email_address) ILIKE ?', "%#{params[:q]}%")
+      @filter = SupportInterface::CandidatesFilter.new(params: params)
+
+      if @filter.applied_filters[:q].present?
+        @candidates = @candidates.where('CONCAT(email_address) ILIKE ?', "%#{@filter.applied_filters[:q]}%")
       end
 
-      if params[:candidate_number].present?
-        candidate_number = params[:candidate_number].tr('^0-9', '')
+      if @filter.applied_filters[:candidate_number].present?
+        candidate_number = @filter.applied_filters[:candidate_number].tr('^0-9', '')
         @candidates = @candidates.where(id: candidate_number)
       end
-
-      @filter = SupportInterface::CandidatesFilter.new(params: params)
     end
 
     def show

--- a/app/controllers/support_interface/email_log_controller.rb
+++ b/app/controllers/support_interface/email_log_controller.rb
@@ -8,22 +8,22 @@ module SupportInterface
         .includes(:application_form)
         .page(params[:page] || 1).per(30)
 
-      if params[:q]
-        @emails = @emails.where("CONCAT(\"to\", ' ', subject, ' ', notify_reference, ' ', body) ILIKE ?", "%#{params[:q]}%")
+      if @filter.applied_filters[:q].present?
+        @emails = @emails.where("CONCAT(\"to\", ' ', subject, ' ', notify_reference, ' ', body) ILIKE ?", "%#{@filter.applied_filters[:q]}%")
       end
 
-      if params[:delivery_status]
-        @emails = @emails.where(delivery_status: params[:delivery_status])
+      if @filter.applied_filters[:delivery_status].present?
+        @emails = @emails.where(delivery_status: @filter.applied_filters[:delivery_status])
       end
 
-      if params[:mailer]
-        @emails = @emails.where(mailer: params[:mailer])
+      if @filter.applied_filters[:mailer].present?
+        @emails = @emails.where(mailer: @filter.applied_filters[:mailer])
       end
 
       %w[to subject mail_template notify_reference application_form_id].each do |column|
-        next unless params[column]
+        next if @filter.applied_filters[column].blank?
 
-        @emails = @emails.where(column => params[column])
+        @emails = @emails.where(column => @filter.applied_filters[column])
       end
     end
   end

--- a/app/helpers/filter_params_helper.rb
+++ b/app/helpers/filter_params_helper.rb
@@ -1,0 +1,9 @@
+module FilterParamsHelper
+  def compact_params(params)
+    params.transform_values do |param_value|
+      next param_value unless param_value.is_a?(Array)
+
+      param_value.compact_blank
+    end
+  end
+end

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -1,9 +1,11 @@
 module SupportInterface
   class ApplicationsFilter
+    include FilterParamsHelper
+
     attr_reader :applied_filters
 
     def initialize(params:)
-      @applied_filters = params
+      @applied_filters = compact_params(params)
     end
 
     def filter_records(application_forms)
@@ -18,7 +20,7 @@ module SupportInterface
         .order(updated_at: :desc)
         .page(applied_filters[:page] || 1).per(30)
 
-      if applied_filters[:q]
+      if applied_filters[:q].present?
         application_forms = application_forms.where("CONCAT(application_forms.first_name, ' ', application_forms.last_name, ' ', candidates.email_address, ' ', application_forms.support_reference) ILIKE ?", "%#{applied_filters[:q]}%")
       end
 
@@ -26,19 +28,19 @@ module SupportInterface
         application_forms = application_forms.joins(:application_choices).where(application_choices: { id: applied_filters[:application_choice_id].to_i })
       end
 
-      if applied_filters[:phase]
+      if applied_filters[:phase].present?
         application_forms = application_forms.where(phase: applied_filters[:phase])
       end
 
-      if applied_filters[:interviews]
+      if applied_filters[:interviews].present?
         application_forms = application_forms.joins(application_choices: [:interviews]).group('id')
       end
 
-      if applied_filters[:year]
+      if applied_filters[:year].present?
         application_forms = application_forms.where(recruitment_cycle_year: applied_filters[:year])
       end
 
-      if applied_filters[:status]
+      if applied_filters[:status].present?
         application_forms = application_forms.joins(:application_choices).where(application_choices: { status: applied_filters[:status] })
       end
 

--- a/app/models/support_interface/candidates_filter.rb
+++ b/app/models/support_interface/candidates_filter.rb
@@ -1,9 +1,11 @@
 module SupportInterface
   class CandidatesFilter
+    include FilterParamsHelper
+
     attr_reader :applied_filters
 
     def initialize(params:)
-      @applied_filters = params
+      @applied_filters = compact_params(params)
     end
 
     def filters

--- a/app/models/support_interface/emails_filter.rb
+++ b/app/models/support_interface/emails_filter.rb
@@ -1,9 +1,11 @@
 module SupportInterface
   class EmailsFilter
+    include FilterParamsHelper
+
     attr_reader :applied_filters
 
     def initialize(params:)
-      @applied_filters = params
+      @applied_filters = compact_params(params)
     end
 
     def filters

--- a/app/models/support_interface/provider_users_filter.rb
+++ b/app/models/support_interface/provider_users_filter.rb
@@ -1,9 +1,11 @@
 module SupportInterface
   class ProviderUsersFilter
+    include FilterParamsHelper
+
     attr_reader :applied_filters
 
     def initialize(params:)
-      @applied_filters = params
+      @applied_filters = compact_params(params)
     end
 
     def filters

--- a/app/models/support_interface/providers_filter.rb
+++ b/app/models/support_interface/providers_filter.rb
@@ -1,5 +1,7 @@
 module SupportInterface
   class ProvidersFilter
+    include FilterParamsHelper
+
     attr_reader :applied_filters
     ONBOARDING_STAGES = {
       'with_courses' => 'With courses',
@@ -19,14 +21,16 @@ module SupportInterface
     }.freeze
 
     def initialize(params:)
-      @applied_filters = params.slice(
-        :remove,
-        :provider_types,
-        :ratified_by,
-        :onboarding_stages,
-        :q,
-        :no_provider_users,
-        :accredited_provider,
+      @applied_filters = compact_params(
+        params.slice(
+          :remove,
+          :provider_types,
+          :ratified_by,
+          :onboarding_stages,
+          :q,
+          :no_provider_users,
+          :accredited_provider,
+        ),
       )
     end
 

--- a/app/models/support_interface/ucas_matches_filter.rb
+++ b/app/models/support_interface/ucas_matches_filter.rb
@@ -1,13 +1,15 @@
 module SupportInterface
   class UCASMatchesFilter
+    include FilterParamsHelper
+
     attr_reader :applied_filters
 
     def initialize(params:)
-      @applied_filters = params
+      @applied_filters = compact_params(params)
     end
 
     def filter_records(ucas_matches)
-      if applied_filters[:years]
+      if applied_filters[:years].present?
         ucas_matches = ucas_matches.where(recruitment_cycle_year: applied_filters[:years])
       end
 
@@ -16,7 +18,7 @@ module SupportInterface
         ucas_matches = ucas_matches.where(id: action_needed_ids)
       end
 
-      if applied_filters[:action_taken]
+      if applied_filters[:action_taken].present?
         ucas_matches = ucas_matches.where(action_taken: applied_filters[:action_taken])
       end
 

--- a/app/models/support_interface/vendor_api_requests_filter.rb
+++ b/app/models/support_interface/vendor_api_requests_filter.rb
@@ -1,9 +1,11 @@
 module SupportInterface
   class VendorAPIRequestsFilter
+    include FilterParamsHelper
+
     attr_reader :applied_filters
 
     def initialize(params:)
-      @applied_filters = params
+      @applied_filters = compact_params(params)
     end
 
     def filters
@@ -11,24 +13,24 @@ module SupportInterface
     end
 
     def filter_records(vendor_api_requests)
-      if applied_filters[:q]
+      if applied_filters[:q].present?
         vendor_api_requests = vendor_api_requests.where("CONCAT(request_path, ' ', request_body, ' ', response_body) ILIKE ?", "%#{applied_filters[:q]}%")
       end
 
-      if applied_filters[:status_code]
+      if applied_filters[:status_code].present?
         vendor_api_requests = vendor_api_requests.where(status_code: applied_filters[:status_code])
       end
 
-      if applied_filters[:request_method]
+      if applied_filters[:request_method].present?
         vendor_api_requests = vendor_api_requests.where(request_method: applied_filters[:request_method])
       end
 
-      if applied_filters[:provider_id]
+      if applied_filters[:provider_id].present?
         vendor_api_requests = vendor_api_requests.where(provider_id: applied_filters[:provider_id])
       end
 
       %w[created_at request_path].each do |column|
-        next unless applied_filters[column]
+        next if applied_filters[column].blank?
 
         vendor_api_requests = vendor_api_requests.where(column => applied_filters[column])
       end

--- a/spec/helpers/filter_params_helper_spec.rb
+++ b/spec/helpers/filter_params_helper_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe FilterParamsHelper, type: :helper do
+  describe '#compact_params' do
+    let(:params) { ActionController::Parameters.new(params_hash) }
+    let(:result) { compact_params(params) }
+
+    context 'when the params contain only string values' do
+      let(:params_hash) { { name: 'Bob', age: '21' } }
+
+      it 'has no affect on the params' do
+        expect(result[:name]).to eq('Bob')
+        expect(result[:age]).to eq('21')
+      end
+    end
+
+    context 'when the params contain arrays with non-present values' do
+      let(:params_hash) { { name: 'Bob', sports: [''] } }
+
+      it 'removes the non-present values from the array params' do
+        expect(result[:name]).to eq('Bob')
+        expect(result[:sports]).to eq([])
+      end
+    end
+
+    context 'when the params contain arrays with some present values' do
+      let(:params_hash) { { name: 'Bob', sports: ['', 'Golf'] } }
+
+      it 'only keeps the present values in the array params' do
+        expect(result[:name]).to eq('Bob')
+        expect(result[:sports]).to eq(['Golf'])
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -39,7 +39,9 @@ RSpec.feature 'Providers should be able to filter applications' do
     then_i_search_for_candidate_name
     then_only_withdrawn_and_offered_applications_of_that_name_should_be_visible
 
-    when_i_clear_the_filters
+    when_i_manually_clear_all_filters_and_apply_them
+    then_i_expect_all_applications_to_be_visible
+
     when_i_search_for_a_candidate_that_does_not_exist
     then_i_should_see_the_no_filter_results_error_message
 
@@ -79,7 +81,7 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def and_the_relevant_tags_should_be_visible
-    tags = find(:css, '.moj-filter-tags:nth-of-type(2)')
+    tags = find(:css, '.moj-filter-tags:nth-of-type(1)')
     expect(tags).to have_text('Hoth Teacher Training')
     expect(tags).to have_text('Caladan University')
   end
@@ -130,6 +132,14 @@ RSpec.feature 'Providers should be able to filter applications' do
   def then_i_filter_for_withdrawn_and_offered_applications
     find(:css, '#status-withdrawn').set(true)
     find(:css, '#status-offer').set(true)
+    click_button('Apply filters')
+  end
+
+  def when_i_manually_clear_all_filters_and_apply_them
+    fill_in 'Search by candidate name or reference', with: ''
+    click_button('Search')
+    find(:css, '#status-withdrawn').set(false)
+    find(:css, '#status-offer').set(false)
     click_button('Apply filters')
   end
 
@@ -210,7 +220,7 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_i_should_see_the_no_filter_results_error_message
-    expect(page).to have_content("There are no results for 'Simon Says' and the selected filter.")
+    expect(page).to have_content("There are no results for 'Simon Says'.")
   end
 
   def when_i_filter_by_provider


### PR DESCRIPTION
## Context
We store previous filter state for the provider applications filter. This means when you go to the filter page with no query parameters, the saved state of the filter is used. An issue arises when you uncheck all filters and apply them: since there are no applied filters, there are no query parameters, so the saved state is used (rather than clearing).

## Changes proposed in this pull request
For each checkbox type filter (including the search checkbox one for subects), include an empty hidden field which will always be submitted with the form. This means that even when there are no checkboxes selected, we still send params for the checkbox group, where previously we'd omit it.

This is the method the formbuilder uses to get around the same issue

To test this:
1. Go to the provider applications page and apply some filters.
2. Manually go through the filters list and uncheck all of the filters, and click "Apply filters"
3. Ensure that there are now no applied filters.

It may also be useful to sanity check the other filters in the service (which I've touched in this PR) because their behaviour may have inadvertently changed.

## Guidance to review
Per commit

## Link to Trello card
https://trello.com/c/svrZMToG/4069-when-your-uncheck-filters-on-the-view-application-screen-so-none-are-selected-it-retains-the-previous-value

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
