### PR TITLE
Stagger provider user emails for start of cycle

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -187,6 +187,14 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
+  def apply_service_is_now_open(provider_user)
+    @provider_user = provider_user
+  end
+
+  def find_service_is_now_open(provider_user)
+    @provider_user = provider_user
+  end
+
 private
 
   def email_for_provider(provider_user, application_form, args = {})

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -189,17 +189,31 @@ class ProviderMailer < ApplicationMailer
 
   def apply_service_is_now_open(provider_user)
     @provider_user = provider_user
+
+    notify_email(
+      to: @provider_user.email_address,
+      subject: I18n.t!('provider_mailer.apply_service_is_now_open.subject'),
+    )
   end
 
   def find_service_is_now_open(provider_user)
     @provider_user = provider_user
+
+    notify_email(
+      to: @provider_user.email_address,
+      subject: I18n.t!('provider_mailer.find_service_is_now_open.subject'),
+    )
   end
 
-  # rubocop:disable Naming/AccessorMethodName
-  def set_up_organisation_permissions(provider_user)
+  def set_up_organisation_permissions(provider_user, partner_organisations)
     @provider_user = provider_user
+    @partner_organisations = partner_organisations
+
+    notify_email(
+      to: @provider_user.email_address,
+      subject: I18n.t!('provider_mailer.set_up_organisation_permissions.subject'),
+    )
   end
-# rubocop:enable Naming/AccessorMethodName
 
 private
 

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -195,6 +195,12 @@ class ProviderMailer < ApplicationMailer
     @provider_user = provider_user
   end
 
+  # rubocop:disable Naming/AccessorMethodName
+  def set_up_organisation_permissions(provider_user)
+    @provider_user = provider_user
+  end
+# rubocop:enable Naming/AccessorMethodName
+
 private
 
   def email_for_provider(provider_user, application_form, args = {})

--- a/app/models/chaser_sent.rb
+++ b/app/models/chaser_sent.rb
@@ -15,5 +15,7 @@ class ChaserSent < ApplicationRecord
     set_up_organisation_permissions: 'set_up_organisation_permissions',
     apply_service_is_now_open: 'apply_service_is_now_open',
     find_service_is_now_open: 'find_service_is_now_open',
+    apply_service_open_organisation_notification: 'apply_service_open_organisation_notification',
+    find_service_open_organisation_notification: 'find_service_open_organisation_notification',
   }
 end

--- a/app/models/chaser_sent.rb
+++ b/app/models/chaser_sent.rb
@@ -12,5 +12,8 @@ class ChaserSent < ApplicationRecord
     eoc_deadline_reminder: 'eoc_deadline_reminder',
     find_has_opened: 'find_has_opened',
     new_cycle_has_started: 'new_cycle_has_started',
+    set_up_organisation_permissions: 'set_up_organisation_permissions',
+    apply_service_is_now_open: 'apply_service_is_now_open',
+    find_service_is_now_open: 'find_service_is_now_open',
   }
 end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -371,5 +371,14 @@ class CycleTimetable
     "#{year} to #{year + 1}"
   end
 
+  def self.service_opens_today?(service, year: RecruitmentCycle.current_year, end_of_business_day_hour: 16, end_of_business_day_min: 1)
+    service_opening_date = send("#{service}_opens", year)
+
+    Time.zone.now.between?(
+      service_opening_date,
+      service_opening_date.change(hour: end_of_business_day_hour, min: end_of_business_day_min),
+    )
+  end
+
   private_class_method :last_recruitment_cycle_year?
 end

--- a/app/services/support_interface/start_of_cycle_notifier.rb
+++ b/app/services/support_interface/start_of_cycle_notifier.rb
@@ -1,18 +1,9 @@
 module SupportInterface
   class StartOfCycleNotifier
-    def call(service:, batch_size: 500, year: 2022)
-      return unless service_opens_today?(service, year)
+    def call(service:, batch_size: 500, year: RecruitmentCycle.current_year)
+      return unless CycleTimetable.service_opens_today?(service, year: year)
 
       StartOfCycleNotificationWorker.perform_async(service, batch_size)
-    end
-
-  private
-
-    def service_opens_today?(service, year)
-      current_cycles = CycleTimetable::CYCLE_DATES[year]
-      service_opening_date = current_cycles[:"#{service}_opens"]
-
-      Time.zone.now.between?(service_opening_date, service_opening_date.change(hour: 16, min: 1))
     end
   end
 end

--- a/app/services/support_interface/start_of_cycle_notifier.rb
+++ b/app/services/support_interface/start_of_cycle_notifier.rb
@@ -1,68 +1,18 @@
 module SupportInterface
   class StartOfCycleNotifier
-    attr_reader :service, :batch_size, :year
+    def call(service:, batch_size: 500, year: 2022)
+      return unless service_opens_today?(service, year)
 
-    def initialize(service:, batch_size: 500, year: 2022)
-      @service = service
-      @batch_size = batch_size
-      @year = year
-
-      raise_unless_service_opens_today!
-    end
-
-    def call
-      provider_users_scope.find_each(batch_size: batch_size) do |user|
-        # TODO: We may need to pass a provider + permissions here
-        # to avoid the mailer doing additional db work.
-        ProviderMailer.send(mailer_method, user)
-      end
+      StartOfCycleNotificationWorker.perform_async(service, batch_size)
     end
 
   private
 
-    def provider_users_scope
-      scope = service == :find ? all_provider_users : provider_users_who_need_to_set_up_org_permissions
-      scope = scope.includes(:providers).order('providers.name', 'provider_users.email_address')
-      scope.where.not(Arel.sql(email_exists_sql)).distinct
-    end
-
-    def email_exists_sql
-      <<-SQL.squish
-        EXISTS(
-          SELECT 1
-          FROM emails
-          WHERE emails.to = provider_users.email_address
-          AND emails.delivery_status IN ('delivered', 'pending')
-          AND emails.mailer = 'provider_mailer'
-          AND emails.mail_template = '#{mail_template}'
-        )
-      SQL
-    end
-
-    def all_provider_users
-      ProviderUser.all
-    end
-
-    def provider_users_who_need_to_set_up_org_permissions
-      ProviderUser
-        .joins(provider_permissions: :provider)
-        .joins('LEFT JOIN provider_relationship_permissions tprp ON providers.id = tprp.training_provider_id AND tprp.setup_at IS NULL')
-        .joins('LEFT JOIN provider_relationship_permissions rprp ON providers.id = rprp.ratifying_provider_id AND rprp.setup_at IS NULL')
-        .where(provider_permissions: { manage_organisations: true })
-    end
-
-    def mail_template
-      "#{service}_service_is_now_open"
-    end
-    alias mailer_method mail_template
-
-    def raise_unless_service_opens_today!
+    def service_opens_today?(service, year)
       current_cycles = CycleTimetable::CYCLE_DATES[year]
       service_opening_date = current_cycles[:"#{service}_opens"]
 
-      unless Time.zone.now.between?(service_opening_date.beginning_of_day, service_opening_date.end_of_day)
-        raise "Error: #{service} opens on #{service_opening_date.to_s(:govuk_date_and_time)}"
-      end
+      Time.zone.now.between?(service_opening_date, service_opening_date.change(hour: 16, min: 1))
     end
   end
 end

--- a/app/services/support_interface/start_of_cycle_notifier.rb
+++ b/app/services/support_interface/start_of_cycle_notifier.rb
@@ -1,0 +1,68 @@
+module SupportInterface
+  class StartOfCycleNotifier
+    attr_reader :service, :batch_size, :year
+
+    def initialize(service:, batch_size: 500, year: 2022)
+      @service = service
+      @batch_size = batch_size
+      @year = year
+
+      raise_unless_service_opens_today!
+    end
+
+    def call
+      provider_users_scope.find_each(batch_size: batch_size) do |user|
+        # TODO: We may need to pass a provider + permissions here
+        # to avoid the mailer doing additional db work.
+        ProviderMailer.send(mailer_method, user)
+      end
+    end
+
+  private
+
+    def provider_users_scope
+      scope = service == :find ? all_provider_users : provider_users_who_need_to_set_up_org_permissions
+      scope = scope.includes(:providers).order('providers.name', 'provider_users.email_address')
+      scope.where.not(Arel.sql(email_exists_sql)).distinct
+    end
+
+    def email_exists_sql
+      <<-SQL.squish
+        EXISTS(
+          SELECT 1
+          FROM emails
+          WHERE emails.to = provider_users.email_address
+          AND emails.delivery_status IN ('delivered', 'pending')
+          AND emails.mailer = 'provider_mailer'
+          AND emails.mail_template = '#{mail_template}'
+        )
+      SQL
+    end
+
+    def all_provider_users
+      ProviderUser.all
+    end
+
+    def provider_users_who_need_to_set_up_org_permissions
+      ProviderUser
+        .joins(provider_permissions: :provider)
+        .joins('LEFT JOIN provider_relationship_permissions tprp ON providers.id = tprp.training_provider_id AND tprp.setup_at IS NULL')
+        .joins('LEFT JOIN provider_relationship_permissions rprp ON providers.id = rprp.ratifying_provider_id AND rprp.setup_at IS NULL')
+        .where(provider_permissions: { manage_organisations: true })
+    end
+
+    def mail_template
+      "#{service}_service_is_now_open"
+    end
+    alias mailer_method mail_template
+
+    def raise_unless_service_opens_today!
+      current_cycles = CycleTimetable::CYCLE_DATES[year]
+      service_opening_date = current_cycles[:"#{service}_opens"]
+
+      unless Time.zone.now.between?(service_opening_date.beginning_of_day, service_opening_date.end_of_day)
+        raise "Error: #{service} opens on #{service_opening_date.to_s(:govuk_date_and_time)}"
+      end
+    end
+  end
+end

--- a/app/services/support_interface/start_of_cycle_notifier.rb
+++ b/app/services/support_interface/start_of_cycle_notifier.rb
@@ -1,9 +1,26 @@
 module SupportInterface
   class StartOfCycleNotifier
-    def call(service:, batch_size: 500, year: RecruitmentCycle.current_year)
+    attr_reader :service, :year
+
+    def initialize(service:, year: RecruitmentCycle.current_year)
+      @service = service
+      @year = year
+    end
+
+    def call
       return unless CycleTimetable.service_opens_today?(service, year: year)
 
-      StartOfCycleNotificationWorker.perform_async(service, batch_size)
+      StartOfCycleNotificationWorker.perform_async(service, hours_remaining)
+    end
+
+  private
+
+    def hours_remaining
+      notify_until.hour - Time.zone.now.hour
+    end
+
+    def notify_until
+      Time.zone.now.change(hour: 16)
     end
   end
 end

--- a/app/views/provider_mailer/apply_service_is_now_open.text.erb
+++ b/app/views/provider_mailer/apply_service_is_now_open.text.erb
@@ -1,0 +1,7 @@
+Dear <%= @provider_user.full_name || 'colleague' %>
+
+Candidates can now apply for teacher training courses on GOV.UK for the 2022 to 2023 recruitment cycle. 
+
+Sign in to manage applications:
+
+<%= provider_interface_sign_in_url %>

--- a/app/views/provider_mailer/find_service_is_now_open.text.erb
+++ b/app/views/provider_mailer/find_service_is_now_open.text.erb
@@ -1,0 +1,5 @@
+Dear <%= @provider_user.full_name || 'colleague' %>
+
+Candidates can now find teacher training courses on GOV.UK for the 2022 to 2023 recruitment cycle. 
+
+They’ll be able to apply on 12 October 2021 at 9am.

--- a/app/views/provider_mailer/set_up_organisation_permissions.text.erb
+++ b/app/views/provider_mailer/set_up_organisation_permissions.text.erb
@@ -1,0 +1,13 @@
+Dear <%= @provider_user.full_name || 'colleague' %>
+
+Candidates can now find courses on GOV.UK that you work on with:
+
+<% @partner_organisations.each do |organisation| -%>
+- <%= organisation.name %>
+<% end -%>
+
+Either you or these partner organisations must set up organisation permissions before you can manage teacher training applications.
+
+You’ll be asked to set up organisation permissions when you sign in, unless your partner organisations set them up first.
+
+<%= provider_interface_sign_in_url %>

--- a/app/workers/start_of_cycle_notification_worker.rb
+++ b/app/workers/start_of_cycle_notification_worker.rb
@@ -11,11 +11,7 @@ class StartOfCycleNotificationWorker
 
         next if service == :apply
         next unless provider_user.provider_permissions.find_by(provider: provider).manage_organisations
-
-        unset_permissions = provider.training_provider_permissions.where(setup_at: nil)
-        unset_permissions += provider.ratifying_provider_permissions.where(setup_at: nil)
-
-        next if unset_permissions.blank?
+        next if ProviderSetup.new(provider_user: provider_user).relationships_pending.blank?
         next if ChaserSent.exists?(chased: provider_user, chaser_type: setup_mailer_method)
 
         ProviderMailer.send(setup_mailer_method, provider_user)

--- a/app/workers/start_of_cycle_notification_worker.rb
+++ b/app/workers/start_of_cycle_notification_worker.rb
@@ -1,0 +1,53 @@
+class StartOfCycleNotificationWorker
+  include Sidekiq::Worker
+
+  def perform(service, batch_size = 500)
+    @service = service
+
+    provider_users_scope.find_each(batch_size: batch_size) do |user|
+      # TODO: We may need to pass a provider + permissions here
+      # to avoid the mailer doing additional db work.
+      ProviderMailer.send(mailer_method, user)
+    end
+  end
+
+private
+
+  attr_reader :service
+
+  def provider_users_scope
+    scope = service == :find ? all_provider_users : provider_users_who_need_to_set_up_org_permissions
+    scope = scope.includes(:providers).order('providers.name', 'provider_users.email_address')
+    scope.where.not(Arel.sql(email_exists_sql)).distinct
+  end
+
+  def email_exists_sql
+    <<-SQL.squish
+      EXISTS(
+        SELECT 1
+        FROM emails
+        WHERE emails.to = provider_users.email_address
+        AND emails.delivery_status IN ('delivered', 'pending')
+        AND emails.mailer = 'provider_mailer'
+        AND emails.mail_template = '#{mail_template}'
+      )
+    SQL
+  end
+
+  def all_provider_users
+    ProviderUser.all
+  end
+
+  def provider_users_who_need_to_set_up_org_permissions
+    ProviderUser
+      .joins(provider_permissions: :provider)
+      .joins('LEFT JOIN provider_relationship_permissions tprp ON providers.id = tprp.training_provider_id AND tprp.setup_at IS NULL')
+      .joins('LEFT JOIN provider_relationship_permissions rprp ON providers.id = rprp.ratifying_provider_id AND rprp.setup_at IS NULL')
+      .where(provider_permissions: { manage_organisations: true })
+  end
+
+  def mail_template
+    "#{service}_service_is_now_open"
+  end
+  alias mailer_method mail_template
+end

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -34,3 +34,9 @@ en:
       subject: "%{provider} has set up organisation permissions for teacher training courses you work on with them"
     organisation_permissions_updated:
       subject: "%{provider} has changed organisation permissions for teacher training courses you work on with them"
+    apply_service_is_now_open:
+      subject: "Candidates can now apply for teacher training courses for 2022 to 2023 - manage teacher training applications"
+    find_service_is_now_open:
+      subject: "Candidates can now find teacher training courses for 2022 to 2023 - manage teacher training applications"
+    set_up_organisation_permissions:
+      subject: "Set up organisation permissions - manage teacher training applications"

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -109,6 +109,23 @@ class ProviderMailerPreview < ActionMailer::Preview
     ProviderMailer.organisation_permissions_updated(provider_user, ratifying_provider, permissions)
   end
 
+  def apply_service_is_now_open
+    provider_user = FactoryBot.create(:provider_user)
+    ProviderMailer.apply_service_is_now_open(provider_user)
+  end
+
+  def find_service_is_now_open
+    provider_user = FactoryBot.create(:provider_user)
+    ProviderMailer.find_service_is_now_open(provider_user)
+  end
+
+  def set_up_organisation_permissions
+    provider1 = FactoryBot.create(:provider)
+    provider2 = FactoryBot.create(:provider)
+    provider_user = FactoryBot.create(:provider_user)
+    ProviderMailer.set_up_organisation_permissions(provider_user, [provider1, provider2])
+  end
+
 private
 
   def provider

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -270,4 +270,45 @@ RSpec.describe ProviderMailer, type: :mailer do
       'view diversity' => /View criminal convictions and professional misconduct:\s+- University of Purley\s+- University of Croydon/,
     )
   end
+
+  describe 'apply_service_is_now_open' do
+    let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English') }
+    let(:email) { described_class.apply_service_is_now_open(provider_user) }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Candidates can now apply for teacher training courses for 2022 to 2023 - manage teacher training applications',
+      'salutation' => 'Dear Johny English',
+      'main paragraph' => 'Candidates can now apply for teacher training courses on GOV.UK for the 2022 to 2023 recruitment cycle.',
+    )
+  end
+
+  describe 'find_service_is_now_open' do
+    let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English') }
+    let(:email) { described_class.find_service_is_now_open(provider_user) }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Candidates can now find teacher training courses for 2022 to 2023 - manage teacher training applications',
+      'salutation' => 'Dear Johny English',
+      'main paragraph' => 'Candidates can now find teacher training courses on GOV.UK for the 2022 to 2023 recruitment cycle.',
+      'Opening date paragraph' => 'They’ll be able to apply on 12 October 2021 at 9am.',
+    )
+  end
+
+  describe 'set_up_organisation_permissions' do
+    let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English') }
+    let(:provider1) { build_stubbed(:provider, name: 'University of Purley') }
+    let(:provider2) { build_stubbed(:provider, name: 'University of Croydon') }
+
+    let(:email) { described_class.set_up_organisation_permissions(provider_user, [provider1, provider2]) }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Set up organisation permissions - manage teacher training applications',
+      'salutation' => 'Dear Johny English',
+      'main paragraph' => 'Candidates can now find courses on GOV.UK that you work on with:',
+      'partner providers' => "- University of Purley\r\n- University of Croydon",
+    )
+  end
 end

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -400,6 +400,34 @@ RSpec.describe CycleTimetable do
     end
   end
 
+  describe '.service_opens_today?' do
+    let(:year) { RecruitmentCycle.current_year }
+
+    it 'is true when the service is Apply and the time is within business hours' do
+      Timecop.freeze(1.minute.since(described_class.apply_opens(year))) do
+        expect(described_class.service_opens_today?(:apply, year: year)).to be true
+      end
+    end
+
+    it 'is false when the service is Apply and the time is outside of business hours' do
+      Timecop.freeze(12.hours.since(described_class.apply_opens(year))) do
+        expect(described_class.service_opens_today?(:apply, year: year)).to be false
+      end
+    end
+
+    it 'is true when the service is Find and the time is within business hours' do
+      Timecop.freeze(1.minute.since(described_class.find_opens(year))) do
+        expect(described_class.service_opens_today?(:find, year: year)).to be true
+      end
+    end
+
+    it 'is false when the service is Find and the time is outside of business hours' do
+      Timecop.freeze(12.hours.since(described_class.find_opens(year))) do
+        expect(described_class.service_opens_today?(:find, year: year)).to be false
+      end
+    end
+  end
+
   describe '.send_new_cycle_has_started_email?' do
     context 'it is before apply reopens' do
       it 'returns false' do

--- a/spec/services/support_interface/start_of_cycle_notifier_spec.rb
+++ b/spec/services/support_interface/start_of_cycle_notifier_spec.rb
@@ -2,53 +2,55 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::StartOfCycleNotifier do
   describe '#call' do
+    let(:year) { RecruitmentCycle.current_year }
+
     it 'does nothing when called on a day that is not the start of the cycle for the service' do
-      Timecop.freeze(2021, 9, 7) do
+      Timecop.freeze(6.months.before(CycleTimetable.find_opens(year))) do
         expect {
-          described_class.new.call(service: :apply)
-          described_class.new.call(service: :find)
+          described_class.new.call(service: :apply, year: year)
+          described_class.new.call(service: :find, year: year)
         }.not_to change(StartOfCycleNotificationWorker.jobs, :size)
       end
     end
 
     it 'does nothing when called out of business hours for the service opening' do
-      Timecop.freeze(2021, 10, 5, 8, 59) do
+      Timecop.freeze(CycleTimetable.find_opens(year).change(hour: 8, min: 59)) do
         expect {
-          described_class.new.call(service: :find)
+          described_class.new.call(service: :find, year: year)
         }.not_to change(StartOfCycleNotificationWorker.jobs, :size)
       end
 
-      Timecop.freeze(2021, 10, 5, 16, 2) do
+      Timecop.freeze(CycleTimetable.find_opens(year).change(hour: 16, min: 2)) do
         expect {
-          described_class.new.call(service: :find)
+          described_class.new.call(service: :find, year: year)
         }.not_to change(StartOfCycleNotificationWorker.jobs, :size)
       end
 
-      Timecop.freeze(2021, 10, 12, 8, 59) do
+      Timecop.freeze(CycleTimetable.apply_opens(year).change(hour: 8, min: 59)) do
         expect {
-          described_class.new.call(service: :apply)
+          described_class.new.call(service: :apply, year: year)
         }.not_to change(StartOfCycleNotificationWorker.jobs, :size)
       end
 
-      Timecop.freeze(2021, 10, 12, 16, 2) do
+      Timecop.freeze(CycleTimetable.apply_opens(year).change(hour: 16, min: 2)) do
         expect {
-          described_class.new.call(service: :apply)
+          described_class.new.call(service: :apply, year: year)
         }.not_to change(StartOfCycleNotificationWorker.jobs, :size)
       end
     end
 
     it 'enqueues a StartOfCycleNotificationWorker job when called on the day Apply starts' do
-      Timecop.freeze(2021, 10, 12, 9, 1) do
+      Timecop.freeze(1.minute.since(CycleTimetable.apply_opens(year))) do
         expect {
-          described_class.new.call(service: :apply)
+          described_class.new.call(service: :apply, year: year)
         }.to change(StartOfCycleNotificationWorker.jobs, :size).by(1)
       end
     end
 
     it 'enqueues a StartOfCycleNotificationWorker job when called on the day Find starts' do
-      Timecop.freeze(2021, 10, 5, 9, 1) do
+      Timecop.freeze(1.minute.since(CycleTimetable.find_opens(year))) do
         expect {
-          described_class.new.call(service: :find)
+          described_class.new.call(service: :find, year: year)
         }.to change(StartOfCycleNotificationWorker.jobs, :size).by(1)
       end
     end

--- a/spec/services/support_interface/start_of_cycle_notifier_spec.rb
+++ b/spec/services/support_interface/start_of_cycle_notifier_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::StartOfCycleNotifier do
+  describe '#initialize' do
+    it 'raises when called on a day that is not the start of the cycle for the service' do
+      Timecop.freeze(2021, 9, 7) do
+        expect { described_class.new(service: :apply) }.to raise_error 'Error: apply opens on 12 October 2021 at 9am'
+        expect { described_class.new(service: :find) }.to raise_error 'Error: find opens on 5 October 2021 at 9am'
+      end
+    end
+  end
+
+  describe '#call' do
+    let(:providers_needing_set_up) { create_list(:provider, 2, :with_signed_agreement) }
+    let(:provider_users_who_need_to_set_up_permissions) do
+      create_list(:provider_user, 2, providers: providers_needing_set_up)
+    end
+
+    let(:other_providers) { create_list(:provider, 2, :with_signed_agreement) }
+    let(:other_provider_users) { create_list(:provider_user, 2, providers: other_providers) }
+
+    before do
+      allow(ProviderMailer).to receive(:apply_service_is_now_open)
+      allow(ProviderMailer).to receive(:find_service_is_now_open)
+      provider_users_who_need_to_set_up_permissions.map { |user| user.provider_permissions.update_all(manage_organisations: true) }
+      other_provider_users.map { |user| user.provider_permissions.update_all(manage_organisations: true) }
+    end
+
+    context 'when the specified service is :apply' do
+      it 'notifies provider users who need to set up permissions for their organisation' do
+        # A provider user without manage organisation permissions
+        create(:provider_user, providers: providers_needing_set_up)
+
+        Timecop.freeze(2021, 10, 12, 10, 0) do
+          described_class.new(service: :apply).call
+
+          expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.first)
+          expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.last)
+        end
+      end
+    end
+
+    context 'when the specified service is :find' do
+      it 'notifies all provider users' do
+        Timecop.freeze(2021, 10, 5, 10, 0) do
+          described_class.new(service: :find).call
+
+          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.first)
+          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.last)
+          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(other_provider_users.first)
+          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(other_provider_users.last)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/support_interface/start_of_cycle_notifier_spec.rb
+++ b/spec/services/support_interface/start_of_cycle_notifier_spec.rb
@@ -1,55 +1,55 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::StartOfCycleNotifier do
-  describe '#initialize' do
-    it 'raises when called on a day that is not the start of the cycle for the service' do
-      Timecop.freeze(2021, 9, 7) do
-        expect { described_class.new(service: :apply) }.to raise_error 'Error: apply opens on 12 October 2021 at 9am'
-        expect { described_class.new(service: :find) }.to raise_error 'Error: find opens on 5 October 2021 at 9am'
-      end
-    end
-  end
-
   describe '#call' do
-    let(:providers_needing_set_up) { create_list(:provider, 2, :with_signed_agreement) }
-    let(:provider_users_who_need_to_set_up_permissions) do
-      create_list(:provider_user, 2, providers: providers_needing_set_up)
-    end
-
-    let(:other_providers) { create_list(:provider, 2, :with_signed_agreement) }
-    let(:other_provider_users) { create_list(:provider_user, 2, providers: other_providers) }
-
-    before do
-      allow(ProviderMailer).to receive(:apply_service_is_now_open)
-      allow(ProviderMailer).to receive(:find_service_is_now_open)
-      provider_users_who_need_to_set_up_permissions.map { |user| user.provider_permissions.update_all(manage_organisations: true) }
-      other_provider_users.map { |user| user.provider_permissions.update_all(manage_organisations: true) }
-    end
-
-    context 'when the specified service is :apply' do
-      it 'notifies provider users who need to set up permissions for their organisation' do
-        # A provider user without manage organisation permissions
-        create(:provider_user, providers: providers_needing_set_up)
-
-        Timecop.freeze(2021, 10, 12, 10, 0) do
-          described_class.new(service: :apply).call
-
-          expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.first)
-          expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.last)
-        end
+    it 'does nothing when called on a day that is not the start of the cycle for the service' do
+      Timecop.freeze(2021, 9, 7) do
+        expect {
+          described_class.new.call(service: :apply)
+          described_class.new.call(service: :find)
+        }.not_to change(StartOfCycleNotificationWorker.jobs, :size)
       end
     end
 
-    context 'when the specified service is :find' do
-      it 'notifies all provider users' do
-        Timecop.freeze(2021, 10, 5, 10, 0) do
-          described_class.new(service: :find).call
+    it 'does nothing when called out of business hours for the service opening' do
+      Timecop.freeze(2021, 10, 5, 8, 59) do
+        expect {
+          described_class.new.call(service: :find)
+        }.not_to change(StartOfCycleNotificationWorker.jobs, :size)
+      end
 
-          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.first)
-          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.last)
-          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(other_provider_users.first)
-          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(other_provider_users.last)
-        end
+      Timecop.freeze(2021, 10, 5, 16, 2) do
+        expect {
+          described_class.new.call(service: :find)
+        }.not_to change(StartOfCycleNotificationWorker.jobs, :size)
+      end
+
+      Timecop.freeze(2021, 10, 12, 8, 59) do
+        expect {
+          described_class.new.call(service: :apply)
+        }.not_to change(StartOfCycleNotificationWorker.jobs, :size)
+      end
+
+      Timecop.freeze(2021, 10, 12, 16, 2) do
+        expect {
+          described_class.new.call(service: :apply)
+        }.not_to change(StartOfCycleNotificationWorker.jobs, :size)
+      end
+    end
+
+    it 'enqueues a StartOfCycleNotificationWorker job when called on the day Apply starts' do
+      Timecop.freeze(2021, 10, 12, 9, 1) do
+        expect {
+          described_class.new.call(service: :apply)
+        }.to change(StartOfCycleNotificationWorker.jobs, :size).by(1)
+      end
+    end
+
+    it 'enqueues a StartOfCycleNotificationWorker job when called on the day Find starts' do
+      Timecop.freeze(2021, 10, 5, 9, 1) do
+        expect {
+          described_class.new.call(service: :find)
+        }.to change(StartOfCycleNotificationWorker.jobs, :size).by(1)
       end
     end
   end

--- a/spec/services/support_interface/start_of_cycle_notifier_spec.rb
+++ b/spec/services/support_interface/start_of_cycle_notifier_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe SupportInterface::StartOfCycleNotifier do
     it 'does nothing when called on a day that is not the start of the cycle for the service' do
       Timecop.freeze(6.months.before(CycleTimetable.find_opens(year))) do
         expect {
-          described_class.new.call(service: :apply, year: year)
-          described_class.new.call(service: :find, year: year)
+          described_class.new(service: :apply, year: year).call
+          described_class.new(service: :find, year: year).call
         }.not_to change(StartOfCycleNotificationWorker.jobs, :size)
       end
     end
@@ -16,25 +16,25 @@ RSpec.describe SupportInterface::StartOfCycleNotifier do
     it 'does nothing when called out of business hours for the service opening' do
       Timecop.freeze(CycleTimetable.find_opens(year).change(hour: 8, min: 59)) do
         expect {
-          described_class.new.call(service: :find, year: year)
+          described_class.new(service: :find, year: year).call
         }.not_to change(StartOfCycleNotificationWorker.jobs, :size)
       end
 
       Timecop.freeze(CycleTimetable.find_opens(year).change(hour: 16, min: 2)) do
         expect {
-          described_class.new.call(service: :find, year: year)
+          described_class.new(service: :find, year: year).call
         }.not_to change(StartOfCycleNotificationWorker.jobs, :size)
       end
 
       Timecop.freeze(CycleTimetable.apply_opens(year).change(hour: 8, min: 59)) do
         expect {
-          described_class.new.call(service: :apply, year: year)
+          described_class.new(service: :apply, year: year).call
         }.not_to change(StartOfCycleNotificationWorker.jobs, :size)
       end
 
       Timecop.freeze(CycleTimetable.apply_opens(year).change(hour: 16, min: 2)) do
         expect {
-          described_class.new.call(service: :apply, year: year)
+          described_class.new(service: :apply, year: year).call
         }.not_to change(StartOfCycleNotificationWorker.jobs, :size)
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe SupportInterface::StartOfCycleNotifier do
     it 'enqueues a StartOfCycleNotificationWorker job when called on the day Apply starts' do
       Timecop.freeze(1.minute.since(CycleTimetable.apply_opens(year))) do
         expect {
-          described_class.new.call(service: :apply, year: year)
+          described_class.new(service: :apply, year: year).call
         }.to change(StartOfCycleNotificationWorker.jobs, :size).by(1)
       end
     end
@@ -50,8 +50,18 @@ RSpec.describe SupportInterface::StartOfCycleNotifier do
     it 'enqueues a StartOfCycleNotificationWorker job when called on the day Find starts' do
       Timecop.freeze(1.minute.since(CycleTimetable.find_opens(year))) do
         expect {
-          described_class.new.call(service: :find, year: year)
+          described_class.new(service: :find, year: year).call
         }.to change(StartOfCycleNotificationWorker.jobs, :size).by(1)
+      end
+    end
+
+    it 'enqueues a job with the hours remaining argument' do
+      Timecop.freeze(CycleTimetable.apply_opens(year).change(hour: 13, min: 20)) do
+        test_subject = described_class.new(service: :apply, year: year)
+
+        test_subject.call
+
+        expect(StartOfCycleNotificationWorker.jobs.last['args']).to eq(['apply', 3])
       end
     end
   end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -58,6 +58,9 @@ RSpec.feature 'Docs' do
       provider_mailer-confirm_sign_in
       provider_mailer-organisation_permissions_set_up
       provider_mailer-organisation_permissions_updated
+      provider_mailer-apply_service_is_now_open
+      provider_mailer-find_service_is_now_open
+      provider_mailer-set_up_organisation_permissions
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/workers/start_of_cycle_notification_worker_spec.rb
+++ b/spec/workers/start_of_cycle_notification_worker_spec.rb
@@ -9,37 +9,69 @@ RSpec.describe StartOfCycleNotificationWorker do
 
     let(:other_providers) { create_list(:provider, 2, :with_signed_agreement) }
     let(:other_provider_users) { create_list(:provider_user, 2, providers: other_providers) }
+    let(:user_who_has_received_mail) do
+      user = create(:provider_user, providers: providers_needing_set_up)
+      user.provider_permissions.update_all(manage_organisations: true)
+      user
+    end
+
+    let!(:delivered_email) do
+      create(
+        :chaser_sent,
+        chased: user_who_has_received_mail,
+        chaser_type: "#{service}_service_is_now_open",
+      )
+      create(
+        :chaser_sent,
+        chased: user_who_has_received_mail,
+        chaser_type: 'set_up_organisation_permissions',
+      )
+    end
 
     before do
       allow(ProviderMailer).to receive(:apply_service_is_now_open)
       allow(ProviderMailer).to receive(:find_service_is_now_open)
+      allow(ProviderMailer).to receive(:set_up_organisation_permissions)
       provider_users_who_need_to_set_up_permissions.map { |user| user.provider_permissions.update_all(manage_organisations: true) }
       other_provider_users.map { |user| user.provider_permissions.update_all(manage_organisations: true) }
+      providers_needing_set_up.each { |provider| create(:provider_relationship_permissions, :not_set_up_yet, training_provider: provider) }
     end
 
-    context 'when the specified service is :apply' do
+    context 'when the specified service is :find' do
+      let(:service) { :find }
+
       it 'notifies provider users who need to set up permissions for their organisation' do
         # A provider user without manage organisation permissions
         create(:provider_user, providers: providers_needing_set_up)
 
-        Timecop.freeze(2021, 10, 12, 10, 0) do
-          described_class.new.perform(:apply)
-
-          expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.first)
-          expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.last)
-        end
-      end
-    end
-
-    context 'when the specified service is :find' do
-      it 'notifies all provider users' do
-        Timecop.freeze(2021, 10, 5, 10, 0) do
-          described_class.new.perform(:find)
+        Timecop.freeze(2021, 10, 12, 9, 1) do
+          described_class.new.perform(service)
 
           expect(ProviderMailer).to have_received(:find_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.first)
           expect(ProviderMailer).to have_received(:find_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.last)
           expect(ProviderMailer).to have_received(:find_service_is_now_open).with(other_provider_users.first)
           expect(ProviderMailer).to have_received(:find_service_is_now_open).with(other_provider_users.last)
+          expect(ProviderMailer).not_to have_received(:find_service_is_now_open).with(user_who_has_received_mail)
+
+          expect(ProviderMailer).to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.first)
+          expect(ProviderMailer).to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.last)
+          expect(ProviderMailer).not_to have_received(:set_up_organisation_permissions).with(user_who_has_received_mail)
+        end
+      end
+    end
+
+    context 'when the specified service is :apply' do
+      let(:service) { :apply }
+
+      it 'notifies all provider users' do
+        Timecop.freeze(2021, 10, 12, 9, 1) do
+          described_class.new.perform(service)
+
+          expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.first)
+          expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.last)
+          expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(other_provider_users.first)
+          expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(other_provider_users.last)
+          expect(ProviderMailer).not_to have_received(:apply_service_is_now_open).with(user_who_has_received_mail)
         end
       end
     end

--- a/spec/workers/start_of_cycle_notification_worker_spec.rb
+++ b/spec/workers/start_of_cycle_notification_worker_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe StartOfCycleNotificationWorker do
+  describe '#perform' do
+    let(:providers_needing_set_up) { create_list(:provider, 2, :with_signed_agreement) }
+    let(:provider_users_who_need_to_set_up_permissions) do
+      create_list(:provider_user, 2, providers: providers_needing_set_up)
+    end
+
+    let(:other_providers) { create_list(:provider, 2, :with_signed_agreement) }
+    let(:other_provider_users) { create_list(:provider_user, 2, providers: other_providers) }
+
+    before do
+      allow(ProviderMailer).to receive(:apply_service_is_now_open)
+      allow(ProviderMailer).to receive(:find_service_is_now_open)
+      provider_users_who_need_to_set_up_permissions.map { |user| user.provider_permissions.update_all(manage_organisations: true) }
+      other_provider_users.map { |user| user.provider_permissions.update_all(manage_organisations: true) }
+    end
+
+    context 'when the specified service is :apply' do
+      it 'notifies provider users who need to set up permissions for their organisation' do
+        # A provider user without manage organisation permissions
+        create(:provider_user, providers: providers_needing_set_up)
+
+        Timecop.freeze(2021, 10, 12, 10, 0) do
+          described_class.new.perform(:apply)
+
+          expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.first)
+          expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.last)
+        end
+      end
+    end
+
+    context 'when the specified service is :find' do
+      it 'notifies all provider users' do
+        Timecop.freeze(2021, 10, 5, 10, 0) do
+          described_class.new.perform(:find)
+
+          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.first)
+          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.last)
+          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(other_provider_users.first)
+          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(other_provider_users.last)
+        end
+      end
+    end
+  end
+end

--- a/spec/workers/start_of_cycle_notification_worker_spec.rb
+++ b/spec/workers/start_of_cycle_notification_worker_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe StartOfCycleNotificationWorker do
     let(:provider_users_who_need_to_set_up_permissions) do
       create_list(:provider_user, 2, providers: providers_needing_set_up)
     end
+    let(:provider_with_chaser_sent) { create(:provider, :with_signed_agreement) }
 
     let(:other_providers) { create_list(:provider, 2, :with_signed_agreement) }
     let(:other_provider_users) { create_list(:provider_user, 2, providers: other_providers) }
@@ -44,18 +45,35 @@ RSpec.describe StartOfCycleNotificationWorker do
         # A provider user without manage organisation permissions
         create(:provider_user, providers: providers_needing_set_up)
 
-        Timecop.freeze(2021, 10, 12, 9, 1) do
-          described_class.new.perform(service)
+        described_class.new.perform(service)
 
-          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.first)
-          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.last)
-          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(other_provider_users.first)
-          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(other_provider_users.last)
-          expect(ProviderMailer).not_to have_received(:find_service_is_now_open).with(user_who_has_received_mail)
+        expect(ProviderMailer).to have_received(:find_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.first)
+        expect(ProviderMailer).to have_received(:find_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.last)
+        expect(ProviderMailer).to have_received(:find_service_is_now_open).with(other_provider_users.first)
+        expect(ProviderMailer).to have_received(:find_service_is_now_open).with(other_provider_users.last)
+        expect(ProviderMailer).not_to have_received(:find_service_is_now_open).with(user_who_has_received_mail)
 
-          expect(ProviderMailer).to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.first)
-          expect(ProviderMailer).to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.last)
-          expect(ProviderMailer).not_to have_received(:set_up_organisation_permissions).with(user_who_has_received_mail)
+        expect(ProviderMailer).to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.first)
+        expect(ProviderMailer).to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.last)
+        expect(ProviderMailer).not_to have_received(:set_up_organisation_permissions).with(user_who_has_received_mail)
+      end
+
+      it 'ignores providers with chasers sent' do
+        create(:chaser_sent, chased: provider_with_chaser_sent, chaser_type: "#{service}_service_open_organisation_notification")
+
+        expect { described_class.new.perform(service) }.not_to change(ChaserSent.where(chased: provider_with_chaser_sent), :count)
+      end
+
+      context 'when the mailer raises an error' do
+        before { allow(ProviderMailer).to receive(:find_service_is_now_open).and_raise('badness') }
+
+        it 'does not create chaser sent records' do
+          expect { described_class.new.perform(service) }.to raise_error('badness')
+
+          expect(ChaserSent.where(chased: providers_needing_set_up)).to be_empty
+          expect(ChaserSent.where(chased: provider_users_who_need_to_set_up_permissions + other_provider_users)).to be_empty
+          expect(ProviderMailer).not_to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.first)
+          expect(ProviderMailer).not_to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.last)
         end
       end
     end
@@ -64,15 +82,19 @@ RSpec.describe StartOfCycleNotificationWorker do
       let(:service) { :apply }
 
       it 'notifies all provider users' do
-        Timecop.freeze(2021, 10, 12, 9, 1) do
-          described_class.new.perform(service)
+        described_class.new.perform(service)
 
-          expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.first)
-          expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.last)
-          expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(other_provider_users.first)
-          expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(other_provider_users.last)
-          expect(ProviderMailer).not_to have_received(:apply_service_is_now_open).with(user_who_has_received_mail)
-        end
+        expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.first)
+        expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.last)
+        expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(other_provider_users.first)
+        expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(other_provider_users.last)
+        expect(ProviderMailer).not_to have_received(:apply_service_is_now_open).with(user_who_has_received_mail)
+      end
+
+      it 'ignores providers with chasers sent' do
+        create(:chaser_sent, chased: provider_with_chaser_sent, chaser_type: "#{service}_service_open_organisation_notification")
+
+        expect { described_class.new.perform(service) }.not_to change(ChaserSent.where(chased: provider_with_chaser_sent), :count)
       end
     end
   end


### PR DESCRIPTION
## Context

We'd like to notify provider users about the start of cycle on the day that Find opens and on the day that Apply opens.
We'd also like to spread the sending of notifications across the working day between 9am and 4pm in an attempt to spread load of users visiting the organisation permissions pages after receiving the emails.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds a Support service which can be called via `cron\clockwork` repeatedly, this service will only work between 9am and 4pm on the days the relevant services open.
- The service enqueues a job which iterates over providers where the users have not yet been emailed and sends the relevant service open reminder.
- When Find opens, users with manage organisation permissions where the organisation has relationships/permissions to set up will receive an additional email alerting them to permissions set up.


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Emails are not defined in this PR. I've added stubs to the relevant mailer.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/WTnGjL50/4274-spike-investigate-prototype-scheduling-of-staggered-provider-user-emails

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
