### PR TITLE
Update the content of the hint text on the non-uk qual radio button

### DIFF
--- a/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
@@ -14,14 +14,14 @@
     <%= tag.div(id: 'other-uk-qualifications-autosuggest', data: { source: OTHER_UK_QUALIFICATIONS }) %>
   <% end %>
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::NON_UK_TYPE, label: { text: 'Non-UK qualification' } do %>
-    <%= f.govuk_text_field :non_uk_qualification_type, label: { text: 'Qualification name', size: 's' }, hint: { text: t('application_form.other_qualification.qualification_type.non_uk.hint_text') } %>
+    <%= f.govuk_text_field :non_uk_qualification_type, label: { text: 'Qualification name', size: 's' }, hint: { text: 'New hint text here' } %>
   <% end %>
   <% if (current_application.application_qualifications.other.blank? && params[:change] == 'true') || (current_application.application_qualifications.other.blank? && !current_application.no_other_qualifications) %>
     <%= f.govuk_radio_divider %>
     <%= f.govuk_radio_button :qualification_type,
       'no_other_qualifications',
       label: { text: current_application.international_applicant? ? 'I do not want to add any other qualifications' : 'I do not want to add any A levels and other qualifications' },
-      hint: -> { 'Providers look at A levels and other qualifications for evidence of subject knowledge not covered in your degree or work history' } %>
+      hint: -> { 'Providers look at A levels and  qualifications for evidence of subject knowledge not covered in your degree or work history' } %>
   <% end %>
 <% end %>
 

--- a/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
@@ -25,4 +25,7 @@
   <% end %>
 <% end %>
 
+new bit of work
+
+
 <%= f.govuk_submit t('continue') %>


### PR DESCRIPTION
## Context

(please ignore just showing Josh how a PR works)

We need to update the hint text on x page

## Changes proposed in this pull request

- Update content for the hint text on the non-uk qual radio button on the new other qual page

## Guidance to review

add link here to the document which covers the content changes

## Link to Trello card

trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
