### PR TITLE
Add GCSE Equivalencies to course choice review

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -204,7 +204,9 @@ module CandidateInterface
     end
 
     def gcse_required_row(application_choice)
-      return nil unless candidate_has_pending_or_missing_gcses?(application_choice)
+      return nil unless candidate_has_pending_or_missing_gcses?(application_choice) &&
+                        !application_choice.current_course.accept_pending_gcse.nil? &&
+                        !application_choice.current_course.accept_gcse_equivalency.nil?
 
       {
         key: 'GCSE requirements',

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -204,6 +204,8 @@ module CandidateInterface
     end
 
     def gcse_required_row(application_choice)
+      return nil unless candidate_has_pending_or_missing_gcses?(application_choice)
+
       {
         key: 'GCSE requirements',
         value: render(GcseRequirementsComponent.new(application_choice)),
@@ -301,6 +303,12 @@ module CandidateInterface
 
     def application_choice_with_accepted_state_present?
       @application_form.application_choices.any? { |ac| ApplicationStateChange::ACCEPTED_STATES.include?(ac.status.to_sym) }
+    end
+
+    def candidate_has_pending_or_missing_gcses?(application_choice)
+      application_choice.application_form.application_qualifications
+      .where(level: 'gcse', qualification_type: 'missing')
+      .or(application_choice.application_form.application_qualifications.where(level: 'gcse', currently_completing_qualification: true)).any?
     end
 
     def change_path_params(application_choice)

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -206,7 +206,7 @@ module CandidateInterface
     def gcse_required_row(application_choice)
       {
         key: 'GCSE requirements',
-        value: render(PendingGcseRequiredComponent.new(application_choice)),
+        value: render(GcseRequirementsComponent.new(application_choice)),
       }
     end
 

--- a/app/components/candidate_interface/gcse_equivalency_required_component.html.erb
+++ b/app/components/candidate_interface/gcse_equivalency_required_component.html.erb
@@ -1,7 +1,9 @@
-<% if !provider_accepts_equivalencies? && @missing_uk_gcses.any? %>
+<% if provider_accepts_equivalencies_and_gcse_is_missing? %>
+  This provider will accept equivalency tests in <%= course_accepted_equivalencies_text %>
+<% else %>
   <%= govuk_inset_text(classes: 'govuk-inset-text app-inset-text--narrow-border app-inset-text--important govuk-!-margin-top-0 govuk-!-padding-bottom-1') do %>
     <div class="app-inset-text__title">This provider will not accept equivalency tests</div>
-      <p class="govuk-body">You said you do not have a qualification in <%= no_qualifications_text %></p>
+      <p class="govuk-body">You said you do not have a qualification in <%= no_qualifications_text %>.</p>
       <p class="govuk-body">You can:</p>
 
       <ul class="govuk-list govuk-list--bullet">
@@ -9,8 +11,4 @@
        <li>contact the provider to see if they will still consider your application</li>
       </ul>
   <% end %>
-<% elsif provider_accepts_equivalencies? %>
-  This provider will accept equivalency tests in <%= course_accepted_equivalencies %>
-<% else %>
-  This provider will not accept equivalency tests
 <% end %>

--- a/app/components/candidate_interface/gcse_equivalency_required_component.html.erb
+++ b/app/components/candidate_interface/gcse_equivalency_required_component.html.erb
@@ -1,0 +1,16 @@
+<% if !provider_accepts_equivalencies? && @missing_uk_gcses.any? %>
+  <%= govuk_inset_text(classes: 'govuk-inset-text app-inset-text--narrow-border app-inset-text--important govuk-!-margin-top-0 govuk-!-padding-bottom-1') do %>
+    <div class="app-inset-text__title">This provider will not accept equivalency tests</div>
+      <p class="govuk-body">You said you do not have a qualification in <%= no_qualifications_text %></p>
+      <p class="govuk-body">You can:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+       <li>find a course that does accept equivalency tests</li>
+       <li>contact the provider to see if they will still consider your application</li>
+      </ul>
+  <% end %>
+<% elsif provider_accepts_equivalencies? %>
+  This provider will accept equivalency tests in <%= course_accepted_equivalencies %>
+<% else %>
+  This provider will not accept equivalency tests
+<% end %>

--- a/app/components/candidate_interface/gcse_equivalency_required_component.rb
+++ b/app/components/candidate_interface/gcse_equivalency_required_component.rb
@@ -1,0 +1,35 @@
+class CandidateInterface::GcseEquivalencyRequiredComponent < ViewComponent::Base
+  attr_accessor :application_choice, :missing_uk_gcses
+
+  def initialize(application_choice)
+    @application_choice = application_choice
+    @missing_uk_gcses = find_missing_uk_gcses(application_choice)
+  end
+
+  def provider_accepts_equivalencies?
+    application_choice.course.accept_gcse_equivalency?
+  end
+
+private
+
+  def no_qualifications_text
+    subjects = missing_uk_gcses.map(&:subject)
+    subjects[0] = subjects[0].capitalize if subjects[0] == 'english'
+    subjects.to_sentence(last_word_connector: ' and ', two_words_connector: ' and ')
+  end
+
+  def course_accepted_equivalencies
+    subjects = []
+    subjects << 'English' if application_choice.course.accept_english_gcse_equivalency?
+    subjects << 'maths' if application_choice.course.accept_maths_gcse_equivalency?
+    subjects << 'science' if application_choice.course.accept_science_gcse_equivalency?
+
+    subjects.to_sentence(last_word_connector: ' and ', two_words_connector: ' and ')
+  end
+
+  def find_missing_uk_gcses(application_choice)
+    application_choice.application_form.application_qualifications
+      .where(level: 'gcse', qualification_type: 'missing', other_uk_qualification_type: nil, institution_country: [nil, 'GB'], currently_completing_qualification: false)
+      .sort_by(&:subject)
+  end
+end

--- a/app/components/candidate_interface/gcse_equivalency_required_component.rb
+++ b/app/components/candidate_interface/gcse_equivalency_required_component.rb
@@ -17,7 +17,7 @@ class CandidateInterface::GcseEquivalencyRequiredComponent < ViewComponent::Base
     accepted_equivalency_subjects << 'maths' if accept_maths_gcse_equivalency
     accepted_equivalency_subjects << 'science' if accept_science_gcse_equivalency
 
-    missing_gcse_subjects == accepted_equivalency_subjects
+    missing_gcse_subjects.all? { |missing_subject| accepted_equivalency_subjects.include?(missing_subject) }
   end
 
 private

--- a/app/components/candidate_interface/gcse_requirements_component.html.erb
+++ b/app/components/candidate_interface/gcse_requirements_component.html.erb
@@ -1,0 +1,2 @@
+<p class="govuk-body"><%= render(CandidateInterface::PendingGcseRequiredComponent.new(application_choice)) %></p>
+<p class="govuk-body"><%= render(CandidateInterface::GcseEquivalencyRequiredComponent.new(application_choice)) %></p>

--- a/app/components/candidate_interface/gcse_requirements_component.html.erb
+++ b/app/components/candidate_interface/gcse_requirements_component.html.erb
@@ -1,2 +1,6 @@
-<p class="govuk-body"><%= render(CandidateInterface::PendingGcseRequiredComponent.new(application_choice)) %></p>
-<p class="govuk-body"><%= render(CandidateInterface::GcseEquivalencyRequiredComponent.new(application_choice)) %></p>
+<% if candidate_has_pending_gcses? %>
+  <%= render(CandidateInterface::PendingGcseRequiredComponent.new(application_choice, pending_uk_gcses)) %>
+<% end %>
+<% if candidate_has_missing_gcses? %>
+  <%= render(CandidateInterface::GcseEquivalencyRequiredComponent.new(application_choice, missing_uk_gcses)) %>
+<% end %>

--- a/app/components/candidate_interface/gcse_requirements_component.rb
+++ b/app/components/candidate_interface/gcse_requirements_component.rb
@@ -1,9 +1,33 @@
 class CandidateInterface::GcseRequirementsComponent < ViewComponent::Base
   include ViewHelper
 
-  attr_accessor :application_choice
+  attr_accessor :application_choice, :missing_uk_gcses, :pending_uk_gcses
 
   def initialize(application_choice)
     @application_choice = application_choice
+    @missing_uk_gcses = find_missing_uk_gcses(application_choice)
+    @pending_uk_gcses = find_pending_uk_gcses(application_choice)
+  end
+
+private
+
+  def find_missing_uk_gcses(application_choice)
+    application_choice.application_form.application_qualifications
+      .where(level: 'gcse', qualification_type: 'missing', other_uk_qualification_type: nil, institution_country: [nil, 'GB'], currently_completing_qualification: false)
+      .sort_by(&:subject)
+  end
+
+  def find_pending_uk_gcses(application_choice)
+    application_choice.application_form.application_qualifications
+      .where(level: 'gcse', other_uk_qualification_type: nil, institution_country: [nil, 'GB'], currently_completing_qualification: true)
+      .sort_by(&:subject)
+  end
+
+  def candidate_has_missing_gcses?
+    missing_uk_gcses.any?
+  end
+
+  def candidate_has_pending_gcses?
+    pending_uk_gcses.any?
   end
 end

--- a/app/components/candidate_interface/gcse_requirements_component.rb
+++ b/app/components/candidate_interface/gcse_requirements_component.rb
@@ -1,0 +1,9 @@
+class CandidateInterface::GcseRequirementsComponent < ViewComponent::Base
+  include ViewHelper
+
+  attr_accessor :application_choice
+
+  def initialize(application_choice)
+    @application_choice = application_choice
+  end
+end

--- a/app/components/candidate_interface/pending_gcse_required_component.html.erb
+++ b/app/components/candidate_interface/pending_gcse_required_component.html.erb
@@ -9,8 +9,6 @@
        <li>contact the provider to see if they will still consider your application</li>
       </ul>
   <% end %>
-<% elsif @application_choice.course.accept_pending_gcse? %>
-  This provider will consider candidates with pending GCSEs
 <% else %>
-  This provider does not consider candidates with pending GCSEs
+  This provider will consider candidates with pending GCSEs
 <% end %>

--- a/app/components/candidate_interface/pending_gcse_required_component.rb
+++ b/app/components/candidate_interface/pending_gcse_required_component.rb
@@ -1,9 +1,9 @@
 class CandidateInterface::PendingGcseRequiredComponent < ViewComponent::Base
   attr_accessor :application_choice, :pending_uk_gcses
 
-  def initialize(application_choice)
+  def initialize(application_choice, pending_uk_gcses)
     @application_choice = application_choice
-    @pending_uk_gcses = find_pending_uk_gcses(application_choice)
+    @pending_uk_gcses = pending_uk_gcses
   end
 
   def pending_gcse_and_course_can_accept?
@@ -16,11 +16,5 @@ private
     subjects = pending_uk_gcses.map(&:subject)
     subjects[0] = subjects[0].capitalize if subjects[0] == 'english'
     subjects.to_sentence(last_word_connector: ' and ', two_words_connector: ' and ')
-  end
-
-  def find_pending_uk_gcses(application_choice)
-    application_choice.application_form.application_qualifications
-      .where(level: 'gcse', other_uk_qualification_type: nil, institution_country: [nil, 'GB'], currently_completing_qualification: true)
-      .sort_by(&:subject)
   end
 end

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -141,31 +141,33 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
 
     context 'When a candidate has a missing gcse' do
       let(:application_choice) { application_form.application_choices.first }
-      let(:application_qualification) { create(:gcse_qualification, :missing, currently_completing_qualification: false) }
+      let(:application_qualification) { build(:gcse_qualification, :missing, subject: 'english', currently_completing_qualification: false) }
       let(:result) { render_inline(described_class.new(application_form: application_form)) }
 
       before do
         application_choice.application_form.application_qualifications << application_qualification
+        application_choice.course.update!(accept_gcse_equivalency: true, accept_english_gcse_equivalency: true, accept_pending_gcse: false)
       end
 
       it 'renders the GCSE required row' do
         expect(result.text).to include('GCSE requirements')
-        expect(result.text).to include('This provider will not accept equivalency tests')
+        expect(result.text).to include('This provider will accept equivalency tests in English')
       end
     end
 
     context 'When a candidate has a pending gcse' do
       let(:application_choice) { application_form.application_choices.first }
-      let(:application_qualification) { create(:gcse_qualification, :missing) }
+      let(:application_qualification) { build(:gcse_qualification, :missing) }
       let(:result) { render_inline(described_class.new(application_form: application_form)) }
 
       before do
         application_choice.application_form.application_qualifications << application_qualification
+        application_choice.course.update!(accept_gcse_equivalency: false, accept_pending_gcse: true)
       end
 
       it 'renders the GCSE required row' do
         expect(result.text).to include('GCSE requirements')
-        expect(result.text).to include('This provider does not consider candidates with pending GCSEs')
+        expect(result.text).to include('This provider will consider candidates with pending GCSEs')
       end
     end
 

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
       expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.description)
       expect(result.css('.govuk-summary-list__value').to_html).to include('1 year')
       expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.start_date.to_s(:month_and_year))
-      expect(result.css('.govuk-summary-list__value').to_html).to include('This provider does not consider candidates with pending GCSEs')
       expect(result.css('a').to_html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
     end
 
@@ -137,6 +136,36 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
 
       it 'renders the degree required row' do
         expect(result.text).to include('2:2 degree or higher (or equivalent)')
+      end
+    end
+
+    context 'When a candidate has a missing gcse' do
+      let(:application_choice) { application_form.application_choices.first }
+      let(:application_qualification) { create(:gcse_qualification, :missing, currently_completing_qualification: false) }
+      let(:result) { render_inline(described_class.new(application_form: application_form)) }
+
+      before do
+        application_choice.application_form.application_qualifications << application_qualification
+      end
+
+      it 'renders the GCSE required row' do
+        expect(result.text).to include('GCSE requirements')
+        expect(result.text).to include('This provider will not accept equivalency tests')
+      end
+    end
+
+    context 'When a candidate has a pending gcse' do
+      let(:application_choice) { application_form.application_choices.first }
+      let(:application_qualification) { create(:gcse_qualification, :missing) }
+      let(:result) { render_inline(described_class.new(application_form: application_form)) }
+
+      before do
+        application_choice.application_form.application_qualifications << application_qualification
+      end
+
+      it 'renders the GCSE required row' do
+        expect(result.text).to include('GCSE requirements')
+        expect(result.text).to include('This provider does not consider candidates with pending GCSEs')
       end
     end
 

--- a/spec/components/candidate_interface/gcse_equivalency_required_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_equivalency_required_component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CandidateInterface::GcseEquivalencyRequiredComponent, type: :comp
     )
   end
 
-  context 'course accepts gcse equivalencies' do
+  context 'course accepts gcse equivalencies and has three missing gcses' do
     it 'renders the correct gcse row content without guidance' do
       create(
         :gcse_qualification,
@@ -58,8 +58,33 @@ RSpec.describe CandidateInterface::GcseEquivalencyRequiredComponent, type: :comp
         application_form: application_form,
       )
 
-      result = render_inline(described_class.new(application_choice1, application_form.application_qualifications))
+      result = render_inline(described_class.new(application_choice1, application_form.application_qualifications.sort_by(&:subject)))
       expect(result.text).to include('This provider will accept equivalency tests in English, maths and science')
+    end
+  end
+
+  context 'course accepts gcse equivalencies and has less than 3 gcses' do
+    it 'renders the correct gcse row content without guidance' do
+      create(
+        :gcse_qualification,
+        subject: 'english',
+        qualification_type: 'missing',
+        currently_completing_qualification: false,
+        application_form: application_form,
+      )
+      create(
+        :gcse_qualification,
+        subject: 'maths',
+        application_form: application_form,
+      )
+      create(
+        :gcse_qualification,
+        subject: 'science',
+        application_form: application_form,
+      )
+
+      result = render_inline(described_class.new(application_choice1, [application_form.application_qualifications.first]))
+      expect(result.text).to include('This provider will accept equivalency tests in English')
     end
   end
 
@@ -74,7 +99,7 @@ RSpec.describe CandidateInterface::GcseEquivalencyRequiredComponent, type: :comp
           application_form: application_form,
         )
 
-        result = render_inline(described_class.new(application_choice2, application_form.application_qualifications))
+        result = render_inline(described_class.new(application_choice2, [application_form.application_qualifications.first]))
         expect(result.text).to include('This provider will not accept equivalency tests')
         expect(result.text).to include('You said you do not have a qualification in English')
       end
@@ -98,7 +123,7 @@ RSpec.describe CandidateInterface::GcseEquivalencyRequiredComponent, type: :comp
           application_form: application_form,
         )
 
-        result = render_inline(described_class.new(application_choice2, application_form.application_qualifications))
+        result = render_inline(described_class.new(application_choice2, application_form.application_qualifications.sort_by(&:subject)))
         expect(result.text).to include('This provider will not accept equivalency tests')
         expect(result.text).to include('You said you do not have a qualification in English and maths')
       end
@@ -128,7 +153,7 @@ RSpec.describe CandidateInterface::GcseEquivalencyRequiredComponent, type: :comp
           application_form: application_form,
         )
 
-        result = render_inline(described_class.new(application_choice2, application_form.application_qualifications))
+        result = render_inline(described_class.new(application_choice2, application_form.application_qualifications.sort_by(&:subject)))
         expect(result.text).to include('This provider will not accept equivalency tests')
         expect(result.text).to include('You said you do not have a qualification in English, maths and science')
       end

--- a/spec/components/candidate_interface/gcse_equivalency_required_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_equivalency_required_component_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::GcseEquivalencyRequiredComponent, type: :component do
+  let(:application_form) { create(:application_form) }
+
+  let(:course_option1) { create(:course_option, course: create(:course, :open_on_apply, accept_gcse_equivalency: true, accept_english_gcse_equivalency: true, accept_maths_gcse_equivalency: true, accept_science_gcse_equivalency: true)) }
+  let(:course_option2) { create(:course_option, course: create(:course, :open_on_apply, accept_gcse_equivalency: false)) }
+
+  let(:application_choice1) do
+    build_stubbed(
+      :application_choice,
+      status: :unsubmitted,
+      course_option: course_option1,
+      application_form: application_form,
+    )
+  end
+
+  let(:application_choice2) do
+    build_stubbed(
+      :application_choice,
+      status: :unsubmitted,
+      course_option: course_option2,
+      application_form: application_form,
+    )
+  end
+
+  context 'course accepts gcse equivalencies' do
+    it 'renders the correct gcse row content without guidance' do
+      result = render_inline(described_class.new(application_choice1))
+      expect(result.text).to include('This provider will accept equivalency tests in English, maths and science')
+    end
+  end
+
+  context 'application has no missing gcses and course does not accept gcse equivalencies' do
+    it 'renders the correct gcse row content without guidance' do
+      result = render_inline(described_class.new(application_choice2))
+      expect(result.text).to include('This provider will not accept equivalency tests')
+    end
+  end
+
+  context 'application has missing gcse(s) and equivalencies are not accepted' do
+    context 'application has one missing gcse and course does not accept them' do
+      it 'renders the gcse row with guidance' do
+        create(
+          :gcse_qualification,
+          subject: 'english',
+          qualification_type: 'missing',
+          currently_completing_qualification: false,
+          application_form: application_form,
+        )
+
+        result = render_inline(described_class.new(application_choice2))
+        expect(result.text).to include('You said you do not have a qualification in English')
+      end
+    end
+
+    context 'application has two pending gcses and course does not accept them' do
+      it 'renders the degree row with guidance' do
+        create(
+          :gcse_qualification,
+          subject: 'english',
+          qualification_type: 'missing',
+          currently_completing_qualification: false,
+          application_form: application_form,
+        )
+
+        create(
+          :gcse_qualification,
+          subject: 'maths',
+          qualification_type: 'missing',
+          currently_completing_qualification: false,
+          application_form: application_form,
+        )
+
+        result = render_inline(described_class.new(application_choice2))
+        expect(result.text).to include('You said you do not have a qualification in English and maths')
+      end
+    end
+
+    context 'application has three pending gcses and course does not accept them' do
+      it 'renders the gcse row with guidance' do
+        create(
+          :gcse_qualification,
+          subject: 'english',
+          qualification_type: 'missing',
+          currently_completing_qualification: false,
+          application_form: application_form,
+        )
+        create(
+          :gcse_qualification,
+          subject: 'maths',
+          qualification_type: 'missing',
+          currently_completing_qualification: false,
+          application_form: application_form,
+        )
+        create(
+          :gcse_qualification,
+          subject: 'science',
+          qualification_type: 'missing',
+          currently_completing_qualification: false,
+          application_form: application_form,
+        )
+
+        result = render_inline(described_class.new(application_choice2))
+        expect(result.text).to include('You said you do not have a qualification in English, maths and science')
+      end
+    end
+  end
+end

--- a/spec/components/candidate_interface/gcse_requirements_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_requirements_component_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::GcseRequirementsComponent, type: :component do
+  let(:application_form) { create(:application_form) }
+
+  let(:course_option) { create(:course_option, course: create(:course, :open_on_apply, accept_pending_gcse: true, accept_gcse_equivalency: true, accept_english_gcse_equivalency: true)) }
+
+  let(:application_choice) do
+    build_stubbed(
+      :application_choice,
+      status: :unsubmitted,
+      course_option: course_option,
+      application_form: application_form,
+    )
+  end
+
+  context 'candidate has no relevant qualifications' do
+    it 'renders no content' do
+      create(
+        :gcse_qualification,
+        subject: 'maths',
+        application_form: application_form,
+      )
+
+      result = render_inline(described_class.new(application_choice))
+      expect(result.text).to eq ''
+    end
+  end
+
+  context 'candidate has pending gcse only' do
+    it 'renders the pending gcse component' do
+      create(
+        :gcse_qualification,
+        subject: 'maths',
+        currently_completing_qualification: true,
+        application_form: application_form,
+      )
+
+      result = render_inline(described_class.new(application_choice))
+      expect(result.text).to include('This provider will consider candidates with pending GCSEs')
+      expect(result.text).not_to include('This provider will not accept equivalency test')
+    end
+  end
+
+  context 'candidate has missing gcse only' do
+    it 'renders the missing gcse component' do
+      create(
+        :gcse_qualification,
+        subject: 'english',
+        qualification_type: 'missing',
+        currently_completing_qualification: false,
+        application_form: application_form,
+      )
+
+      result = render_inline(described_class.new(application_choice))
+      expect(result.text).to include('This provider will accept equivalency tests in English')
+      expect(result.text).not_to include('This provider will consider candidates with pending GCSEs')
+    end
+  end
+
+  context 'course accepts gcse equivalencies' do
+    it 'renders the correct gcse row content without guidance' do
+      create(
+        :gcse_qualification,
+        subject: 'english',
+        qualification_type: 'missing',
+        currently_completing_qualification: false,
+        application_form: application_form,
+      )
+      create(
+        :gcse_qualification,
+        subject: 'maths',
+        currently_completing_qualification: true,
+        application_form: application_form,
+      )
+
+      result = render_inline(described_class.new(application_choice))
+      expect(result.text).to include('This provider will consider candidates with pending GCSEs')
+      expect(result.text).to include('This provider will accept equivalency tests in English')
+    end
+  end
+end

--- a/spec/components/candidate_interface/pending_gcse_required_component_spec.rb
+++ b/spec/components/candidate_interface/pending_gcse_required_component_spec.rb
@@ -26,15 +26,8 @@ RSpec.describe CandidateInterface::PendingGcseRequiredComponent, type: :componen
 
   context 'course accepts pending gcses' do
     it 'renders the correct gcse row content without guidance' do
-      result = render_inline(described_class.new(application_choice1))
+      result = render_inline(described_class.new(application_choice1, application_form.application_qualifications))
       expect(result.text).to include('This provider will consider candidates with pending GCSEs')
-    end
-  end
-
-  context 'application has no pending gcses and course does not accept them' do
-    it 'renders the correct gcse row content without guidance' do
-      result = render_inline(described_class.new(application_choice2))
-      expect(result.text).to include('This provider does not consider candidates with pending GCSEs')
     end
   end
 
@@ -48,7 +41,7 @@ RSpec.describe CandidateInterface::PendingGcseRequiredComponent, type: :componen
           application_form: application_form,
         )
 
-        result = render_inline(described_class.new(application_choice2))
+        result = render_inline(described_class.new(application_choice2, application_form.application_qualifications))
         expect(result.text).to include('You said you’re currently studying for a qualification in English')
       end
     end
@@ -69,7 +62,7 @@ RSpec.describe CandidateInterface::PendingGcseRequiredComponent, type: :componen
           application_form: application_form,
         )
 
-        result = render_inline(described_class.new(application_choice2))
+        result = render_inline(described_class.new(application_choice2, application_form.application_qualifications))
         expect(result.text).to include('You said you’re currently studying for a qualification in English and maths')
       end
     end
@@ -95,7 +88,7 @@ RSpec.describe CandidateInterface::PendingGcseRequiredComponent, type: :componen
           application_form: application_form,
         )
 
-        result = render_inline(described_class.new(application_choice2))
+        result = render_inline(described_class.new(application_choice2, application_form.application_qualifications))
         expect(result.text).to include('You said you’re currently studying for a qualification in English, maths and science')
       end
     end

--- a/spec/components/candidate_interface/pending_gcse_required_component_spec.rb
+++ b/spec/components/candidate_interface/pending_gcse_required_component_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe CandidateInterface::PendingGcseRequiredComponent, type: :componen
           application_form: application_form,
         )
 
-        result = render_inline(described_class.new(application_choice2, application_form.application_qualifications))
+        result = render_inline(described_class.new(application_choice2, application_form.application_qualifications.sort_by(&:subject)))
         expect(result.text).to include('You said you’re currently studying for a qualification in English and maths')
       end
     end
@@ -88,7 +88,7 @@ RSpec.describe CandidateInterface::PendingGcseRequiredComponent, type: :componen
           application_form: application_form,
         )
 
-        result = render_inline(described_class.new(application_choice2, application_form.application_qualifications))
+        result = render_inline(described_class.new(application_choice2, application_form.application_qualifications.sort_by(&:subject)))
         expect(result.text).to include('You said you’re currently studying for a qualification in English, maths and science')
       end
     end

--- a/spec/system/candidate_interface/course_selection/candidate_can_view_gcse_requirements_and_guidance_for_selected_courses_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_view_gcse_requirements_and_guidance_for_selected_courses_spec.rb
@@ -9,8 +9,7 @@ RSpec.feature 'Viewing course choices' do
 
     when_i_add_an_english_gcse
     and_i_visit_the_course_choice_review_page
-    then_i_can_view_course_choices_without_pending_guidance_text
-    and_i_can_view_course_choices_without_equivalency_guidance_text
+    then_i_can_view_course_choices_without_gcse_requirements
 
     when_i_change_the_completed_gcse_to_a_pending_gcse
     and_i_visit_the_course_choice_review_page
@@ -61,15 +60,25 @@ RSpec.feature 'Viewing course choices' do
     visit candidate_interface_course_choices_review_path
   end
 
+  def then_i_can_view_course_choices_without_gcse_requirements
+    within "#course-choice-#{@choice1.id}" do
+      expect(page).not_to have_content('GCSE requirements')
+    end
+
+    within "#course-choice-#{@choice2.id}" do
+      expect(page).not_to have_content('GCSE requirements')
+    end
+  end
+
   def then_i_can_view_course_choices_without_pending_guidance_text
     within "#course-choice-#{@choice1.id}" do
       expect(page).to have_content('GCSE requirements')
-      expect(page).to have_content('This provider will consider candidates with pending GCSEs')
+      expect(page).not_to have_content('This provider will consider candidates with pending GCSEs')
     end
 
     within "#course-choice-#{@choice2.id}" do
       expect(page).to have_content('GCSE requirements')
-      expect(page).to have_content('This provider does not consider candidates with pending GCSEs')
+      expect(page).not_to have_content('This provider does not consider candidates with pending GCSEs')
       expect(page).not_to have_content('You said you’re currently studying for a qualification in English')
       expect(page).not_to have_content("You can:\nfind a course that does accept pending GCSEs contact the provider to see if they will still consider your application")
     end
@@ -78,14 +87,14 @@ RSpec.feature 'Viewing course choices' do
   def and_i_can_view_course_choices_without_equivalency_guidance_text
     within "#course-choice-#{@choice1.id}" do
       expect(page).to have_content('GCSE requirements')
-      expect(page).to have_content('This provider will not accept equivalency tests')
+      expect(page).not_to have_content('This provider will not accept equivalency tests')
       expect(page).not_to have_content('You said you do not have a qualification in English')
       expect(page).not_to have_content('You can:\nfind a course that does accept equivalency tests contact the provider to see if they will still consider your application')
     end
 
     within "#course-choice-#{@choice2.id}" do
       expect(page).to have_content('GCSE requirements')
-      expect(page).to have_content('This provider will accept equivalency tests in English')
+      expect(page).not_to have_content('This provider will accept equivalency tests in English')
     end
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_can_view_gcse_requirements_and_guidance_for_selected_courses_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_view_gcse_requirements_and_guidance_for_selected_courses_spec.rb
@@ -9,11 +9,18 @@ RSpec.feature 'Viewing course choices' do
 
     when_i_add_an_english_gcse
     and_i_visit_the_course_choice_review_page
-    then_i_can_view_course_choices_without_guidance_text
+    then_i_can_view_course_choices_without_pending_guidance_text
+    and_i_can_view_course_choices_without_equivalency_guidance_text
 
     when_i_change_the_completed_gcse_to_a_pending_gcse
     and_i_visit_the_course_choice_review_page
-    then_i_can_view_course_choices_with_guidance_text
+    then_i_can_view_course_choices_with_pending_guidance_text
+    and_i_can_view_course_choices_without_equivalency_guidance_text
+
+    when_i_change_the_pending_gcse_to_a_missing_gcse
+    and_i_visit_the_course_choice_review_page
+    then_i_can_view_course_choices_without_pending_guidance_text
+    and_i_can_view_course_choices_with_equivalency_guidance_text
   end
 
   def given_i_am_signed_in
@@ -21,8 +28,8 @@ RSpec.feature 'Viewing course choices' do
   end
 
   def and_i_have_two_chosen_courses_with_different_pending_gcse_requirements
-    course_option1 = create(:course_option, course: create(:course, :open_on_apply, accept_pending_gcse: true))
-    course_option2 = create(:course_option, course: create(:course, :open_on_apply, accept_pending_gcse: false))
+    course_option1 = create(:course_option, course: create(:course, :open_on_apply, accept_pending_gcse: true, accept_gcse_equivalency: false))
+    course_option2 = create(:course_option, course: create(:course, :open_on_apply, accept_pending_gcse: false, accept_gcse_equivalency: true, accept_english_gcse_equivalency: true))
     @choice1 = create(
       :application_choice,
       status: :unsubmitted,
@@ -54,7 +61,7 @@ RSpec.feature 'Viewing course choices' do
     visit candidate_interface_course_choices_review_path
   end
 
-  def then_i_can_view_course_choices_without_guidance_text
+  def then_i_can_view_course_choices_without_pending_guidance_text
     within "#course-choice-#{@choice1.id}" do
       expect(page).to have_content('GCSE requirements')
       expect(page).to have_content('This provider will consider candidates with pending GCSEs')
@@ -65,6 +72,20 @@ RSpec.feature 'Viewing course choices' do
       expect(page).to have_content('This provider does not consider candidates with pending GCSEs')
       expect(page).not_to have_content('You said you’re currently studying for a qualification in English')
       expect(page).not_to have_content("You can:\nfind a course that does accept pending GCSEs contact the provider to see if they will still consider your application")
+    end
+  end
+
+  def and_i_can_view_course_choices_without_equivalency_guidance_text
+    within "#course-choice-#{@choice1.id}" do
+      expect(page).to have_content('GCSE requirements')
+      expect(page).to have_content('This provider will not accept equivalency tests')
+      expect(page).not_to have_content('You said you do not have a qualification in English')
+      expect(page).not_to have_content('You can:\nfind a course that does accept equivalency tests contact the provider to see if they will still consider your application')
+    end
+
+    within "#course-choice-#{@choice2.id}" do
+      expect(page).to have_content('GCSE requirements')
+      expect(page).to have_content('This provider will accept equivalency tests in English')
     end
   end
 
@@ -79,7 +100,7 @@ RSpec.feature 'Viewing course choices' do
     click_button t('save_and_continue')
   end
 
-  def then_i_can_view_course_choices_with_guidance_text
+  def then_i_can_view_course_choices_with_pending_guidance_text
     within "#course-choice-#{@choice1.id}" do
       expect(page).to have_content('GCSE requirements')
       expect(page).to have_content('This provider will consider candidates with pending GCSEs')
@@ -90,6 +111,27 @@ RSpec.feature 'Viewing course choices' do
       expect(page).to have_content('This provider does not consider candidates with pending GCSEs')
       expect(page).to have_content('You said you’re currently studying for a qualification in English')
       expect(page).to have_content("You can:\nfind a course that does accept pending GCSEs contact the provider to see if they will still consider your application")
+    end
+  end
+
+  def when_i_change_the_pending_gcse_to_a_missing_gcse
+    visit candidate_interface_gcse_review_path(subject: 'english')
+    click_change_link('how you expect to gain this qualification')
+    choose 'No'
+    click_button t('save_and_continue')
+  end
+
+  def and_i_can_view_course_choices_with_equivalency_guidance_text
+    within "#course-choice-#{@choice1.id}" do
+      expect(page).to have_content('GCSE requirements')
+      expect(page).to have_content('This provider will not accept equivalency tests')
+      expect(page).to have_content('You said you do not have a qualification in English')
+      expect(page).to have_content("You can:\nfind a course that does accept equivalency tests contact the provider to see if they will still consider your application")
+    end
+
+    within "#course-choice-#{@choice2.id}" do
+      expect(page).to have_content('GCSE requirements')
+      expect(page).to have_content('This provider will accept equivalency tests in English')
     end
   end
 end


### PR DESCRIPTION
## Context

In order to give candidate more relevant guidance depending on their application. Inset text guidance is displayed to candidates without gcses where equivalencies are not accepted. Otherwise, there is plain statement  of whether equivalencies are accepted or not.

## Changes proposed in this pull request

I've extracted the pending gcse component into a parent component along with the new equivalency component  added in this PR.

equivalencies accepted - when candidate has missing gcse's in that subject
<img width="715" alt="image" src="https://user-images.githubusercontent.com/62567622/133630377-5f27bdb8-c61a-4b92-9845-f111acda6388.png">

equivalencies not accepted and candidate does not have missing gcse
row will not render

equivalencies not accepted and candidate has stated they have a missing gcse
<img width="715" alt="image" src="https://user-images.githubusercontent.com/62567622/133630432-052c2809-cb95-4b7e-93a8-0bc588177a70.png">

## Guidance to review

## Link to Trello card

https://trello.com/c/pmS8NaDt/3840-%F0%9F%93%90dev-apply-indicate-when-a-course-has-gcse-requirements-that-the-candidate-doesnt-meet

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
