### PR TITLE
Support interface provider applications - show applications accredited by provider

### DIFF
--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -75,8 +75,10 @@ module SupportInterface
 
     def applications
       @provider = Provider.find(params[:provider_id])
-      @filter = SupportInterface::ApplicationsFilter.new(params: params)
-      @application_forms = @filter.filter_records(@provider.application_forms)
+      @filter = SupportInterface::ApplicationsFilter.new(
+        params: params.merge(provider_id: @provider.id),
+      )
+      @application_forms = @filter.filter_records(ApplicationForm.all)
     end
 
     def sites

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -44,6 +44,12 @@ module SupportInterface
         application_forms = application_forms.joins(:application_choices).where(application_choices: { status: applied_filters[:status] })
       end
 
+      if applied_filters[:provider_id]
+        application_forms = application_forms
+          .joins(:application_choices)
+          .where('application_choices.provider_ids @> ?', "{#{applied_filters[:provider_id]}}")
+      end
+
       application_forms
     end
 

--- a/app/queries/get_application_choices_for_providers.rb
+++ b/app/queries/get_application_choices_for_providers.rb
@@ -11,7 +11,12 @@ class GetApplicationChoicesForProviders
     },
   ].freeze
 
-  def self.call(providers:, vendor_api: false, includes: DEFAULT_INCLUDES, recruitment_cycle_year: RecruitmentCycle.years_visible_to_providers)
+  def self.call(
+    providers:,
+    vendor_api: false,
+    includes: DEFAULT_INCLUDES,
+    recruitment_cycle_year: RecruitmentCycle.years_visible_to_providers
+  )
     # It is very important to raise an error if no providers have been supplied
     # because otherwise Rails omits the provider_ids where clause
     # and all applications are returned

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -77,7 +77,8 @@ RSpec.feature 'Providers and courses', mid_cycle: false do
     create :provider, :with_signed_agreement, code: 'DOF', name: 'An Unsynced Provider'
     somerset_scitt = create :provider, :with_signed_agreement, code: 'GHI', name: 'Somerset SCITT Consortium'
 
-    create(:course_option, course: create(:course, accredited_provider: provider))
+    course_option_with_accredited_provider = create(:course_option, course: create(:course, accredited_provider: provider))
+    create(:application_choice, application_form: create(:application_form, support_reference: 'TUV123'), course_option: course_option_with_accredited_provider)
 
     create(:course_option, course: create(:course, exposed_in_find: true, accredited_provider: somerset_scitt))
     create(:course_option, course: create(:course, exposed_in_find: true, provider: somerset_scitt))
@@ -214,6 +215,7 @@ RSpec.feature 'Providers and courses', mid_cycle: false do
 
   def then_i_see_the_provider_applications
     expect(page).to have_content 'XYZ123'
+    expect(page).to have_content 'TUV123'
   end
 
   def then_i_see_the_provider_courses


### PR DESCRIPTION
## Context

In the support interface when viewing the applications for a provider show applications to courses accredited by the given provider not just ones that they run themselves.

As a side-effect of this change (I think) we have fixed a bug in the filtering for provider applications. When filtering by status we were returning applications that had any application choice in the given state that also had an often separate application choice for the given provider. What we want in this circumstance is to show only applications that have an application choice to the given provider _and_ the given status. By adding the new condition to the same join that the existing status filter uses we can fix this problem.

## Changes proposed in this pull request

- [x] Adapt `SupportInterface::ApplicationsFilter` to use `ApplicationForm#provider_ids` to match applications to courses that are accredited as well as run by the given provider.
- [x] Include an accredited provider match in the relevant system spec.

## Guidance to review

- Is the query correct?
- Does it fix the related bug described above?
- Are the tests sufficient?

## Link to Trello card

https://trello.com/c/imzPasBT/3826-make-applications-for-courses-an-accredited-body-accredits-visible-on-the-provider-applications-page-on-support-console

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
