### PR TITLE
open next cycle courses on apply

### DIFF
--- a/app/services/data_migrations/backfill_courses_for_next_cycle.rb
+++ b/app/services/data_migrations/backfill_courses_for_next_cycle.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class BackfillCoursesForNextCycle
+    TIMESTAMP = 20210917140806
+    MANUAL_RUN = false
+
+    def change
+      Course.where(recruitment_cycle_year: RecruitmentCycle.next_year, open_on_apply: false).update_all(open_on_apply: true, opened_on_apply_at: Time.zone.now)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillCoursesForNextCycle',
   'DataMigrations::BackfillInvalidProviderRelationshipPermissions',
   'DataMigrations::PopulateApplicationChoiceCurrentRecruitmentCycleYear',
   'DataMigrations::PopulateApplicationChoiceProviderIds',

--- a/spec/services/data_migrations/backfill_courses_for_next_cycle_spec.rb
+++ b/spec/services/data_migrations/backfill_courses_for_next_cycle_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillCoursesForNextCycle do
+  describe '#change' do
+    it 'opens all courses in new cycle' do
+      course = create(:course, recruitment_cycle_year: RecruitmentCycle.next_year)
+      described_class.new.change
+      expect(course.reload).to be_open_on_apply
+    end
+
+    it 'doesnt open courses on apply which are in the current cycle' do
+      current_cycle_course = create(:course, recruitment_cycle_year: RecruitmentCycle.current_year)
+      described_class.new.change
+      expect(current_cycle_course.reload).not_to be_open_on_apply
+    end
+  end
+end


### PR DESCRIPTION
## Context

Migration to set any courses from next recruitment cycle to open on apply.

## Link to Trello card

https://trello.com/c/AY51eNIz/4208-open-all-courses-for-the-next-cycle-when-syncing
## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
