### PR TITLE
Show other rejection reasons in candidate rejection email

### DIFF
--- a/app/components/shared/reasons_for_rejection_component.html.erb
+++ b/app/components/shared/reasons_for_rejection_component.html.erb
@@ -185,7 +185,7 @@
 
 <% if reasons_for_rejection.why_are_you_rejecting_this_application.present? %>
   <div class="app-rejection">
-    <%= content_tag(subheading_tag_name, 'Reasons why your application was unsuccessful', class: 'govuk-heading-s') %>
+    <%= content_tag(subheading_tag_name, I18n.t('reasons_for_rejection.why_are_you_rejecting_this_application.title'), class: 'govuk-heading-s') %>
     <p class="govuk-body"><%= reasons_for_rejection.why_are_you_rejecting_this_application %></p>
     <% if editable? %>
       <p class="app-rejection__actions">

--- a/app/presenters/rejected_application_choice_presenter.rb
+++ b/app/presenters/rejected_application_choice_presenter.rb
@@ -5,7 +5,8 @@ class RejectedApplicationChoicePresenter < SimpleDelegator
     @rejection_reasons ||= [candidate_behaviour, quality_of_application, qualifications,
                             interview_performance, full_course, offered_other_course,
                             honesty_and_professionalism_reasons, safeguarding_issues, cannot_sponsor_visa,
-                            additional_advice, interested_in_future_applications].reduce({}, :merge)
+                            additional_advice, interested_in_future_applications,
+                            other_reasons_for_rejection].reduce({}, :merge)
   end
 
   def reasons
@@ -119,6 +120,12 @@ private
       [I18n.t("reasons_for_rejection.interested_in_future_applications.reason.#{reasons.interested_in_future_applications_y_n.downcase}",
               provider_name: course_option.course.provider.name)],
     )
+  end
+
+  def other_reasons_for_rejection
+    return {} if reasons.why_are_you_rejecting_this_application.blank?
+
+    reason_details('why_are_you_rejecting_this_application', [reasons.why_are_you_rejecting_this_application])
   end
 
   def reason_details(key, reason = nil)

--- a/config/locales/provider_interface/reasons_for_rejection.yml
+++ b/config/locales/provider_interface/reasons_for_rejection.yml
@@ -47,6 +47,8 @@ en:
       other_details: Cannot sponsor visa - details
     additional_advice:
       title: 'Additional advice'
+    why_are_you_rejecting_this_application:
+      title: 'Reasons why your application was unsuccessful'
     interested_in_future_applications:
       title: 'Future applications'
       reason:

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -147,6 +147,26 @@ RSpec.describe CandidateMailer, type: :mailer do
         end
       end
 
+      context 'when no main structured reasons for rejection were given' do
+        let(:rejection_reasons) do
+          {
+            why_are_you_rejecting_this_application: 'You could not correctly guess the number of jelly beans in the jar',
+            other_advice_or_feedback_y_n: 'Yes',
+            other_advice_or_feedback_details: 'There were actually 1567 jelly beans in the jar',
+          }
+        end
+
+        it 'includes the other feedback section' do
+          expect(email.body).to include('Reasons why your application was unsuccessful')
+          expect(email.body).to include(rejection_reasons[:why_are_you_rejecting_this_application])
+        end
+
+        it 'includes the additional advice section' do
+          expect(email.body).to include('Additional advice')
+          expect(email.body).to include(rejection_reasons[:other_advice_or_feedback_details])
+        end
+      end
+
       context 'when it is before the apply_2_deadline' do
         before do
           allow(CycleTimetable).to receive(:between_cycles_apply_2?).and_return(false)

--- a/spec/presenters/rejected_application_choice_presenter_spec.rb
+++ b/spec/presenters/rejected_application_choice_presenter_spec.rb
@@ -159,6 +159,20 @@ RSpec.describe RejectedApplicationChoicePresenter do
       end
     end
 
+    describe 'why_are_you_rejecting_this_application' do
+      it 'returns a hash with the relevant title and reasons' do
+        reasons_for_rejection = {
+          why_are_you_rejecting_this_application: 'That zoom background...',
+        }
+        application_choice.structured_rejection_reasons = reasons_for_rejection
+        rejected_application_choice = described_class.new(application_choice)
+
+        expect(rejected_application_choice.rejection_reasons).to eq(
+          { 'Reasons why your application was unsuccessful' => ['That zoom background...'] },
+        )
+      end
+    end
+
     describe 'interested_in_future_applications' do
       let(:application_choice) { build_stubbed(:application_choice, course_option: course_option) }
       let(:course_option) { build_stubbed(:course_option, course: build_stubbed(:course, provider: provider)) }

--- a/spec/presenters/vendor_api/rejection_reason_presenter_spec.rb
+++ b/spec/presenters/vendor_api/rejection_reason_presenter_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe VendorAPI::RejectionReasonPresenter do
         "Safeguarding issues:\nYou seemed very angry",
         "Additional advice:\nTry again soon",
         "Future applications:\nUoG would be interested in future applications from you.",
+        "Reasons why your application was unsuccessful:\nSo many reasons",
       ])
     end
 


### PR DESCRIPTION
## Context
We were omitting some provider given feedback from candidate rejection emails.

## Changes proposed in this pull request
Include the `why_are_you_rejecting_this_application` feedback in reasons for rejection presenter.

## Guidance to review
Have I missed. any edge cases with the way structure rejections work?

## Link to Trello card
https://trello.com/c/egpIdQGc/4234-reasons-why-your-application-was-unsuccessful-feedback-not-being-sent-within-candidate-email

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
