### PR TITLE
Hide summer banner body after apply 2 deadline

### DIFF
--- a/app/components/provider_interface/summer_recruitment_banner.html.erb
+++ b/app/components/provider_interface/summer_recruitment_banner.html.erb
@@ -2,7 +2,10 @@
   <div class="govuk-grid-column-full">
     <%= govuk_notification_banner(title_text: t('summer_recruitment_banner.title')) do |notification_banner| %>
       <% notification_banner.heading(text: t('summer_recruitment_banner.header')) %>
-      <p class="govuk-body"><%= t('summer_recruitment_banner.body') %></p>
+
+      <% if render_body? %>
+        <p class="govuk-body"><%= t('summer_recruitment_banner.body') %></p>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/components/provider_interface/summer_recruitment_banner.rb
+++ b/app/components/provider_interface/summer_recruitment_banner.rb
@@ -3,5 +3,11 @@ module ProviderInterface
     def render?
       FeatureFlag.active?('summer_recruitment_banner')
     end
+
+  private
+
+    def render_body?
+      Time.zone.now < CycleTimetable.apply_2_deadline(2021)
+    end
   end
 end

--- a/app/components/provider_interface/summer_recruitment_banner.rb
+++ b/app/components/provider_interface/summer_recruitment_banner.rb
@@ -7,7 +7,7 @@ module ProviderInterface
   private
 
     def render_body?
-      Time.zone.now < CycleTimetable.apply_2_deadline(2021)
+      Time.zone.now < CycleTimetable.apply_2_deadline(RecruitmentCycle.current_year)
     end
   end
 end

--- a/spec/components/provider_interface/summer_recruitment_banner_spec.rb
+++ b/spec/components/provider_interface/summer_recruitment_banner_spec.rb
@@ -14,8 +14,28 @@ RSpec.describe ProviderInterface::SummerRecruitmentBanner do
       expect(result.text).to include(t('summer_recruitment_banner.header'))
     end
 
-    it 'renders the banner content' do
-      expect(result.text).to include(t('summer_recruitment_banner.body'))
+    describe 'rendering the banner content' do
+      around do |example|
+        Timecop.freeze(time) { example.run }
+      end
+
+      context 'when the current time is before the 2021 apply 2 deadline' do
+        let(:time) { CycleTimetable.apply_2_deadline(2021) - 1.day }
+
+        it 'renders the banner content' do
+          expect(result.text).to include(t('summer_recruitment_banner.body'))
+          expect(page).to have_selector('.govuk-body')
+        end
+      end
+
+      context 'when the current time is after the 2021 apply 2 deadline' do
+        let(:time) { CycleTimetable.apply_2_deadline(2021) + 1.day }
+
+        it 'does not render the banner content' do
+          expect(result.text).not_to include(t('summer_recruitment_banner.body'))
+          expect(page).not_to have_css('.govuk-body')
+        end
+      end
     end
   end
 

--- a/spec/components/provider_interface/summer_recruitment_banner_spec.rb
+++ b/spec/components/provider_interface/summer_recruitment_banner_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe ProviderInterface::SummerRecruitmentBanner do
         Timecop.freeze(time) { example.run }
       end
 
-      context 'when the current time is before the 2021 apply 2 deadline' do
-        let(:time) { CycleTimetable.apply_2_deadline(2021) - 1.day }
+      context 'when the current time is before the apply 2 deadline' do
+        let(:time) { CycleTimetable.apply_2_deadline(RecruitmentCycle.current_year) - 1.day }
 
         it 'renders the banner content' do
           expect(result.text).to include(t('summer_recruitment_banner.body'))
@@ -28,8 +28,8 @@ RSpec.describe ProviderInterface::SummerRecruitmentBanner do
         end
       end
 
-      context 'when the current time is after the 2021 apply 2 deadline' do
-        let(:time) { CycleTimetable.apply_2_deadline(2021) + 1.day }
+      context 'when the current time is after the apply 2 deadline' do
+        let(:time) { CycleTimetable.apply_2_deadline(RecruitmentCycle.current_year) + 1.day }
 
         it 'does not render the banner content' do
           expect(result.text).not_to include(t('summer_recruitment_banner.body'))


### PR DESCRIPTION


## Context
We currently say "Candidates can apply until 21 September at 6pm." but this content becomes irrelevant after the apply 2 deadline.

## Changes proposed in this pull request
Automatically hide the body after the 2021 apply 2 deadline

## Guidance to review
Automating this feels a bit weird, since this won't work next year. It does help with getting the timing right this year though.

## Link to Trello card
https://trello.com/c/YkMBQN5O/4280-implement-new-content-for-service-banner-to-let-users-know-about-the-end-of-the-cycle

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
