### PR TITLE
Add link to the data request form to the data directory

### DIFF
--- a/app/views/support_interface/data_exports/directory.html.erb
+++ b/app/views/support_interface/data_exports/directory.html.erb
@@ -24,4 +24,19 @@
       </ul>
     </aside>
   </div>
+
+  <div class="govuk-grid-column-one-third govuk-!-margin-top-5">
+    <aside class="app-card" role="complementary">
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Can’t find what you’re looking for?</h3>
+      <p class="govuk-body">
+        You can request data by completing this
+        <%= govuk_link_to(
+            'google form',
+            'https://docs.google.com/forms/d/e/1FAIpQLSd-J_cFOgmy2TjhFo_cA0kqDoHT8NlcQvH13U2z-AMlR6JoEA/viewform',
+            target: '_blank',
+            rel: 'noopener',
+          ) %>.
+      </p>
+    </aside>
+  </div>
 </div>


### PR DESCRIPTION
## Context

We have a google form where people can request additional data from services in BAT. We also have a data directory. It makes sense to link to the form from there so people can request additional data if they can't find it.

## Changes proposed in this pull request

- Add link to the request additional data google form to the data directory

## Link to Trello card

https://trello.com/c/GdoN25S2/3836-create-link-to-data-request-form-candy

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
