### PR TITLE
Fix anchor link to the other quals section on the app review page

### DIFF
--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -57,13 +57,20 @@ module CandidateInterface
     end
 
     def incomplete_sections
-      sections_with_completion
-        .reject(&:second)
-        .map { |sections_with_completion| OpenStruct.new(name: sections_with_completion.first, needs_review?: sections_with_completion.third) }
-        .map do |section|
-          message = section.needs_review? ? "review_application.#{section.name}.not_reviewed" : "review_application.#{section.name}.incomplete"
-          OpenStruct.new(name: section.name, message: message)
-        end
+      section_structs = sections_with_completion
+                          .reject(&:second)
+                          .map do |sections_with_completion|
+                            if sections_with_completion.first == :other_qualifications && application_form.international_applicant?
+                              OpenStruct.new(name: :other_qualifications_international)
+                            else
+                              OpenStruct.new(name: sections_with_completion.first, needs_review?: sections_with_completion.third)
+                            end
+                          end
+
+      section_structs.map do |section|
+        message = section.needs_review? ? "review_application.#{section.name}.not_reviewed" : "review_application.#{section.name}.incomplete"
+        OpenStruct.new(name: section.name, message: message)
+      end
     end
 
     ApplicationChoiceError = Struct.new(:message, :course_choice_id) do


### PR DESCRIPTION
## Context

UK and international candidates see a different section title for the a level/other quals section. This causes an issue with the
anchor link as it always points to the id based on the uk section title.

## Changes proposed in this pull request

- Pass in the correct anchor id for international quals when the section structs are created

Before 


![image](https://user-images.githubusercontent.com/42515961/134000983-75d23185-98d9-4b3e-a1bd-61b9582cd0cf.png)

After

![image](https://user-images.githubusercontent.com/42515961/134001041-2fd2de4b-34c8-49b1-bea0-48bc29e0b1bc.png)


## Guidance to review

Is the approach okay? Seems a bit clunky, but i'm not sure where else to intercept.

## Link to Trello card

https://trello.com/c/0NBHbsd9/3889-bug-validation-error-link-goes-nowhere-in-review-candidate-application

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
