### PR TITLE
Allow downloading a CSV of all a provider's run/ratified course options from Support

### DIFF
--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -1,5 +1,7 @@
 module SupportInterface
   class ProvidersController < SupportInterfaceController
+    include StreamableDataExport
+
     def index
       @filter = SupportInterface::ProvidersFilter.new(params: params)
 
@@ -91,6 +93,16 @@ module SupportInterface
 
     def open_all_courses
       update_provider('Successfully updated all courses') { |provider| OpenProviderCourses.new(provider: provider).call }
+    end
+
+    def courses_as_csv
+      provider = Provider.find(params[:provider_id])
+      rows = SupportInterface::ProviderCoursesCSVExport.new(provider: provider).rows
+      self.response_body = streamable_response(
+        filename: "#{provider.name_and_code.parameterize}-courses-#{RecruitmentCycle.current_year}.csv",
+        export_data: rows.map(&:values),
+        export_headings: rows.first.keys,
+      )
     end
 
   private

--- a/app/services/safe_csv.rb
+++ b/app/services/safe_csv.rb
@@ -1,6 +1,10 @@
 require 'csv'
 
 class SafeCSV
+  WHITELISTED_VALUES = [
+    '-', # this is used for course codes and it is not, on its own, a legitimate formula
+  ].freeze
+
   def self.generate(values, header_row = nil)
     CSV.generate do |rows|
       rows << header_row if header_row.present?
@@ -21,6 +25,6 @@ class SafeCSV
   end
 
   def self.sanitise_formulae(value)
-    value.to_s.starts_with?(/[\-+=@]/) ? value.gsub(/^([\-+=@].*)/, '.\1') : value
+    value.to_s.starts_with?(/[\-+=@]/) && !WHITELISTED_VALUES.include?(value) ? value.gsub(/^([\-+=@].*)/, '.\1') : value
   end
 end

--- a/app/services/support_interface/provider_courses_csv_export.rb
+++ b/app/services/support_interface/provider_courses_csv_export.rb
@@ -1,0 +1,32 @@
+module SupportInterface
+  class ProviderCoursesCSVExport
+    def initialize(provider:)
+      @provider = provider
+    end
+
+    def rows
+      course_options.map do |co|
+        {
+          recruitment_cycle_year: co.course.recruitment_cycle_year,
+          name: co.course.name,
+          code: co.course.code,
+          study_mode: co.study_mode,
+          site_name: co.site.name,
+          site_code: co.site.code,
+          provider_code: co.course.provider.code,
+          provider_name: co.course.provider.name,
+          accredited_provider_name: co.course.accredited_provider&.name,
+          accredited_provider_code: co.course.accredited_provider&.code,
+        }
+      end
+    end
+
+  private
+
+    def course_options
+      @provider.courses.current_cycle.or(
+        @provider.accredited_courses.current_cycle,
+      ).includes(:provider, :accredited_provider, course_options: [:site]).flat_map(&:course_options)
+    end
+  end
+end

--- a/app/views/support_interface/providers/courses.html.erb
+++ b/app/views/support_interface/providers/courses.html.erb
@@ -1,5 +1,9 @@
 <%= render 'provider_navigation', title: 'Courses' %>
 
+<% if @provider.courses.current_cycle.any? || @provider.accredited_courses.current_cycle.any? %>
+  <%= govuk_button_link_to "Download #{RecruitmentCycle.current_year} courses and ratified courses as CSV", support_interface_provider_courses_csv_path, secondary: true, class: 'govuk-!-margin-bottom-5' %>
+<% end %>
+
 <% if @provider.courses.any? %>
   <% unless @provider.all_courses_open_in_current_cycle? %>
     <%= form_with model: @provider, url: support_interface_provider_path(@provider), method: :post do |f| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -935,6 +935,7 @@ Rails.application.routes.draw do
       get '/' => 'providers#show', as: :provider
       get '/courses' => 'providers#courses', as: :provider_courses
       get '/ratified-courses' => 'providers#ratified_courses', as: :provider_ratified_courses
+      get '/courses-csv' => 'providers#courses_as_csv', as: :provider_courses_csv
       get '/vacancies' => 'providers#vacancies', as: :provider_vacancies
       get '/sites' => 'providers#sites', as: :provider_sites
       get '/users' => 'providers#users', as: :provider_user_list

--- a/spec/services/safe_csv_spec.rb
+++ b/spec/services/safe_csv_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe SafeCSV do
     it 'sanitises a single value' do
       expect(described_class.sanitise('=(A1,A6)')).to eq('.=(A1,A6)')
     end
+
+    it 'respects the whitelist' do
+      expect(described_class.sanitise('-')).to eq('-')
+    end
   end
 
   describe '.generate' do

--- a/spec/services/support_interface/provider_courses_csv_export_spec.rb
+++ b/spec/services/support_interface/provider_courses_csv_export_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ProviderCoursesCSVExport do
+  include CourseOptionHelpers
+
+  let(:provider) { create(:provider) }
+
+  subject(:csv_rows) { described_class.new(provider: provider).rows }
+
+  it 'returns self-ratified courses' do
+    course_option_for_provider(provider: provider)
+    expect(csv_rows.count).to eq 1
+  end
+
+  it 'returns ratified courses' do
+    course_option_for_accredited_provider(provider: create(:provider, name: 'SD', provider_type: 'lead_school'), accredited_provider: provider)
+    expect(csv_rows.count).to eq 1
+  end
+end

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -56,6 +56,10 @@ RSpec.feature 'Providers and courses', mid_cycle: false do
     then_all_courses_should_be_open_on_apply
     and_when_i_click_on_ratified_courses
     then_all_ratified_courses_should_be_open_on_apply
+
+    and_i_click_on_courses
+    and_i_click_on_the_csv_button
+    then_i_should_get_a_csv_with_all_the_courses
   end
 
   def given_i_am_a_support_user
@@ -312,5 +316,18 @@ RSpec.feature 'Providers and courses', mid_cycle: false do
 
   def no_ratified_courses_should_be_open_on_apply
     expect(page).to have_content 'ratifies 1 course (0 on DfE Apply)'
+  end
+
+  def and_i_click_on_the_csv_button
+    click_link 'courses as CSV'
+  end
+
+  def then_i_should_get_a_csv_with_all_the_courses
+    rows = CSV.parse(page.html, headers: :first_row).map(&:to_h)
+    expect(rows).to be_present
+    rows.each do |r|
+      bodies = [r['accredited_provider_code'], r['provider_code']]
+      expect(bodies).to include('GHI')
+    end
   end
 end


### PR DESCRIPTION
## Context

Providers need to set up their SRSs with course data from Apply. There is currently no easy way to get them a list of all the courses they run and ratify including site codes.

## Changes proposed in this pull request

Add a button to the Support UI 

## Link to Trello card

https://ukgovernmentdfe.slack.com/archives/C02BCATMW2H/p1632124419072300

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
