### PR TITLE
Reduce support channel updates

### DIFF
--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -9,6 +9,8 @@ class StateChangeNotifier
   end
 
   def application_outcome_notification
+    return true if FeatureFlag.active?(:disable_application_outcome_notifications)
+
     candidate_name = application_choice.application_form.first_name
 
     other_applications = application_choice.self_and_siblings.where.not(id: application_choice.id)

--- a/app/services/confirm_offer_conditions.rb
+++ b/app/services/confirm_offer_conditions.rb
@@ -19,6 +19,8 @@ class ConfirmOfferConditions
       CandidateMailer.conditions_met(application_choice).deliver_later
       StateChangeNotifier.new(:recruited, application_choice).application_outcome_notification
     end
+
+    true
   rescue Workflow::NoTransitionAllowed
     errors.add(
       :base,

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -35,6 +35,7 @@ class FeatureFlag
     [:support_user_change_offered_course, 'Allows support users to offer a different course option for an application choice', 'David Gisbey'],
     [:withdraw_at_candidates_request, "Allows providers to withdraw an application at the candidate's request", 'Steve Laing'],
     [:summer_recruitment_banner, 'Show a banner to indicate a shorter recruitment timeframe during summer', 'Richard Pattinson'],
+    [:disable_application_outcome_notifications, 'Suppress Slack notifications about application outcomes', 'Duncan Brown'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/app/services/stats_summary.rb
+++ b/app/services/stats_summary.rb
@@ -1,0 +1,40 @@
+class StatsSummary
+  include ActionView::Helpers::TextHelper
+
+  def as_slack_message
+    <<~MARKDOWN
+      *Today on Apply*
+
+      :email: #{pluralize(applications_submitted, 'application')} submitted
+      :#{rand(2) == 1 ? 'wo' : nil}man-tipping-hand: #{pluralize(offers_made, 'offer')} made
+      :#{rand(2) == 1 ? 'wo' : nil}man-gesturing-no: #{pluralize(rejections_issued, 'rejection')} issued#{rejections_issued.positive? ? ", of which #{pluralize(rbd_count, 'was')} RBD" : nil}
+      :handshake: #{pluralize(candidates_recruited, 'candidate')} recruited
+    MARKDOWN
+  end
+
+  def applications_submitted
+    ApplicationForm.where('submitted_at > ?', beginning_of_period).count
+  end
+
+  def offers_made
+    Offer.where('created_at > ?', beginning_of_period).count
+  end
+
+  def candidates_recruited
+    ApplicationChoice.where('recruited_at > ?', beginning_of_period).count
+  end
+
+  def rejections_issued
+    ApplicationChoice.where('rejected_at > ?', beginning_of_period).count
+  end
+
+  def rbd_count
+    ApplicationChoice.where('rejected_at > ?', beginning_of_period).where(rejected_by_default: true).count
+  end
+
+private
+
+  def beginning_of_period
+    Time.zone.now.beginning_of_day
+  end
+end

--- a/app/services/update_accepted_offer_conditions.rb
+++ b/app/services/update_accepted_offer_conditions.rb
@@ -19,6 +19,8 @@ class UpdateAcceptedOfferConditions
     end
 
     StateChangeNotifier.new(:recruited, @application_choice).application_outcome_notification
+
+    true
   rescue Workflow::NoTransitionAllowed
     false
   end

--- a/app/workers/send_stats_summary_to_slack.rb
+++ b/app/workers/send_stats_summary_to_slack.rb
@@ -1,0 +1,7 @@
+class SendStatsSummaryToSlack
+  include Sidekiq::Worker
+
+  def perform
+    SlackNotificationWorker.perform_async(StatsSummary.new.as_slack_message)
+  end
+end

--- a/app/workers/slack_notification_worker.rb
+++ b/app/workers/slack_notification_worker.rb
@@ -3,11 +3,11 @@ require 'http'
 class SlackNotificationWorker
   include Sidekiq::Worker
 
-  def perform(text, url)
+  def perform(text, url = nil)
     @webhook_url = ENV['STATE_CHANGE_SLACK_URL']
 
     if @webhook_url.present?
-      message = hyperlink text, url
+      message = url.present? ? hyperlink(text, url) : text
       post_to_slack message
     end
   end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -50,6 +50,8 @@ class Clock
     end
   end
 
+  every(1.day, 'SendStatsSummaryToSlack', at: '17:00') { SendStatsSummaryToSlack.new.perform }
+
   every(1.day, 'Generate export for TAD', at: '23:59') { DataAPI::TADExport.run_daily }
 
   every(1.day, 'SendEocDeadlineReminderEmailToCandidatesWorker', at: '12:00') { SendEocDeadlineReminderEmailToCandidatesWorker.new.perform }

--- a/config/initializers/inflector.rb
+++ b/config/initializers/inflector.rb
@@ -8,4 +8,5 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.irregular 'chaser_sent', 'chasers_sent'
   inflect.irregular 'provider_permissions', 'provider_permissions'
   inflect.irregular 'has', 'have'
+  inflect.irregular 'was', 'were'
 end

--- a/spec/services/stats_summary_spec.rb
+++ b/spec/services/stats_summary_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe StatsSummary do
+  it 'generates correct stats' do
+    create(:application_form, submitted_at: 1.minute.ago)
+    create(:application_choice, :with_recruited)
+    create(:application_choice, :with_offer)
+    create(:application_choice, :with_rejection)
+    create(:application_choice, :with_rejection_by_default)
+
+    output = described_class.new.as_slack_message
+
+    expect(output).to match(/1 application submitted/)
+    expect(output).to match(/1 candidate recruited/)
+    expect(output).to match(/2 offers made/)
+    expect(output).to match(/2 rejections issued/)
+    expect(output).to match(/of which 1 was RBD/)
+  end
+end


### PR DESCRIPTION
## Context

The support channel is very noisy so we'd like to condense the updates into summaries.

## Changes proposed in this pull request

Once a day, generate a summary of what's happened on Apply that day.

The summary is intentionally minimal. No other state change updates are removed as part of this PR, but a feature flag is introduced which will enable us to turn them off.

<img width="415" alt="Screenshot 2021-09-20 at 23 07 20" src="https://user-images.githubusercontent.com/642279/134083180-e0176c1e-f943-4c54-be86-75f1f5c7b05f.png">

## Link to Trello card

https://ukgovernmentdfe.slack.com/archives/CQA64BETU/p1631784060240900

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
