### PR TITLE
Add ability to update personal statement and subject knowledge from the support UI

### DIFF
--- a/app/components/shared/personal_statement_component.html.erb
+++ b/app/components/shared/personal_statement_component.html.erb
@@ -1,7 +1,7 @@
-<section class="app-section govuk-!-width-two-thirds">
+<section id="personal-statement-section" class="app-section govuk-!-width-two-thirds">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="personal-statement">Personal statement</h2>
 
-  <h3 class="govuk-heading-s">Vocation</h3>
+  <h3 class="govuk-heading-s">Vocation <%= govuk_link_to 'Change', support_interface_application_form_edit_becoming_a_teacher_path, class: 'govuk-body' %></h3>
   <%= simple_format becoming_a_teacher, class: 'govuk-body' %>
 
   <h3 class="govuk-heading-s">Subject knowledge</h3>

--- a/app/components/shared/personal_statement_component.html.erb
+++ b/app/components/shared/personal_statement_component.html.erb
@@ -1,7 +1,10 @@
 <section id="personal-statement-section" class="app-section govuk-!-width-two-thirds">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="personal-statement">Personal statement</h2>
-
-  <h3 class="govuk-heading-s">Vocation <%= govuk_link_to 'Change', support_interface_application_form_edit_becoming_a_teacher_path, class: 'govuk-body' %></h3>
+  <% if @editable %>
+    <h3 class="govuk-heading-s">Vocation <%= govuk_link_to 'Change', support_interface_application_form_edit_becoming_a_teacher_path, class: 'govuk-body' %></h3>
+  <% else %>
+    <h3 class="govuk-heading-s">Vocation</h3>
+  <% end %>
   <%= simple_format becoming_a_teacher, class: 'govuk-body' %>
 
   <h3 class="govuk-heading-s">Subject knowledge</h3>

--- a/app/components/shared/personal_statement_component.html.erb
+++ b/app/components/shared/personal_statement_component.html.erb
@@ -2,13 +2,17 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="personal-statement">Personal statement</h2>
   <% if @editable %>
     <h3 class="govuk-heading-s">Vocation <%= govuk_link_to 'Change', support_interface_application_form_edit_becoming_a_teacher_path, class: 'govuk-body' %></h3>
+    <%= simple_format becoming_a_teacher, class: 'govuk-body' %>
+
+    <h3 class="govuk-heading-s">Subject knowledge <%= govuk_link_to 'Change', support_interface_application_form_edit_subject_knowledge_path, class: 'govuk-body' %></h3>
+    <%= simple_format subject_knowledge, class: 'govuk-body' %>
   <% else %>
     <h3 class="govuk-heading-s">Vocation</h3>
-  <% end %>
-  <%= simple_format becoming_a_teacher, class: 'govuk-body' %>
+    <%= simple_format becoming_a_teacher, class: 'govuk-body' %>
 
-  <h3 class="govuk-heading-s">Subject knowledge</h3>
-  <%= simple_format subject_knowledge, class: 'govuk-body' %>
+    <h3 class="govuk-heading-s">Subject knowledge </h3>
+    <%= simple_format subject_knowledge, class: 'govuk-body' %>
+  <% end %>
 
   <h3 class="govuk-heading-s">Further information</h3>
   <%= simple_format further_information, class: 'govuk-body' %>

--- a/app/components/shared/personal_statement_component.rb
+++ b/app/components/shared/personal_statement_component.rb
@@ -7,8 +7,9 @@ class PersonalStatementComponent < ViewComponent::Base
            :further_information,
            to: :application_form
 
-  def initialize(application_form:)
+  def initialize(application_form:, editable: false)
     @application_form = application_form
+    @editable = editable
   end
 
 private

--- a/app/controllers/support_interface/application_forms/personal_statement_controller.rb
+++ b/app/controllers/support_interface/application_forms/personal_statement_controller.rb
@@ -1,0 +1,34 @@
+module SupportInterface
+  module ApplicationForms
+    class PersonalStatementController < SupportInterfaceController
+      before_action :build_application_form
+
+      def edit_becoming_a_teacher
+        @becoming_a_teacher_form = EditBecomingATeacherForm.build_from_application(@application_form)
+      end
+
+      def update_becoming_a_teacher
+        @becoming_a_teacher_form = EditBecomingATeacherForm.new(becoming_a_teacher_params)
+
+        if @becoming_a_teacher_form.save(@application_form)
+          flash[:success] = 'Personal statement updated'
+          redirect_to support_interface_application_form_path(@application_form)
+        else
+          render :edit_becoming_a_teacher
+        end
+      end
+
+    private
+
+      def becoming_a_teacher_params
+        StripWhitespace.from_hash params
+          .require(:support_interface_application_forms_edit_becoming_a_teacher_form)
+          .permit(:becoming_a_teacher, :audit_comment)
+      end
+
+      def build_application_form
+        @application_form = ApplicationForm.find(params[:application_form_id])
+      end
+    end
+  end
+end

--- a/app/controllers/support_interface/application_forms/personal_statement_controller.rb
+++ b/app/controllers/support_interface/application_forms/personal_statement_controller.rb
@@ -18,12 +18,33 @@ module SupportInterface
         end
       end
 
+      def edit_subject_knowledge
+        @subject_knowledge_form = EditSubjectKnowledgeForm.build_from_application(@application_form)
+      end
+
+      def update_subject_knowledge
+        @subject_knowledge_form = EditSubjectKnowledgeForm.new(subject_knowledge_params)
+
+        if @subject_knowledge_form.save(@application_form)
+          flash[:success] = 'Subject knowledge updated'
+          redirect_to support_interface_application_form_path(@application_form)
+        else
+          render :edit_subject_knowledge
+        end
+      end
+
     private
 
       def becoming_a_teacher_params
         StripWhitespace.from_hash params
           .require(:support_interface_application_forms_edit_becoming_a_teacher_form)
           .permit(:becoming_a_teacher, :audit_comment)
+      end
+
+      def subject_knowledge_params
+        StripWhitespace.from_hash params
+          .require(:support_interface_application_forms_edit_subject_knowledge_form)
+          .permit(:subject_knowledge, :audit_comment)
       end
 
       def build_application_form

--- a/app/forms/support_interface/application_forms/edit_becoming_a_teacher_form.rb
+++ b/app/forms/support_interface/application_forms/edit_becoming_a_teacher_form.rb
@@ -1,0 +1,30 @@
+module SupportInterface
+  module ApplicationForms
+    class EditBecomingATeacherForm
+      include ActiveModel::Model
+
+      attr_accessor :becoming_a_teacher, :audit_comment
+
+      validates :becoming_a_teacher,
+                word_count: { maximum: 600 },
+                presence: true
+
+      validates :audit_comment, presence: true
+
+      def self.build_from_application(application_form)
+        new(
+          becoming_a_teacher: application_form.becoming_a_teacher,
+        )
+      end
+
+      def save(application_form)
+        return false unless valid?
+
+        application_form.update!(
+          becoming_a_teacher: becoming_a_teacher,
+          audit_comment: audit_comment,
+        )
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/application_forms/edit_subject_knowledge_form.rb
+++ b/app/forms/support_interface/application_forms/edit_subject_knowledge_form.rb
@@ -1,0 +1,30 @@
+module SupportInterface
+  module ApplicationForms
+    class EditSubjectKnowledgeForm
+      include ActiveModel::Model
+
+      attr_accessor :subject_knowledge, :audit_comment
+
+      validates :subject_knowledge,
+                word_count: { maximum: 400 },
+                presence: true
+
+      validates :audit_comment, presence: true
+
+      def self.build_from_application(application_form)
+        new(
+          subject_knowledge: application_form.subject_knowledge,
+        )
+      end
+
+      def save(application_form)
+        return false unless valid?
+
+        application_form.update!(
+          subject_knowledge: subject_knowledge,
+          audit_comment: audit_comment,
+        )
+      end
+    end
+  end
+end

--- a/app/views/support_interface/application_forms/personal_statement/edit_becoming_a_teacher.html.erb
+++ b/app/views/support_interface/application_forms/personal_statement/edit_becoming_a_teacher.html.erb
@@ -1,0 +1,14 @@
+<% content_for :browser_title, title_with_error_prefix(t('page_titles.becoming_a_teacher'), @becoming_a_teacher_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@application_form.id)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @becoming_a_teacher_form, url: support_interface_application_form_edit_becoming_a_teacher_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('support_interface.edit_becoming_a_teacher_form.becoming_a_teacher.label'), size: 'xl' }, rows: 20, max_words: 600 %>
+      <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.edit_becoming_a_teacher_form.audit_comment.label'), size: 'm' }, hint: { text: t('support_interface.edit_becoming_a_teacher_form.audit_comment.hint') } %>
+      <%= f.govuk_submit 'Update' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/application_forms/personal_statement/edit_subject_knowledge.html.erb
+++ b/app/views/support_interface/application_forms/personal_statement/edit_subject_knowledge.html.erb
@@ -1,0 +1,14 @@
+<% content_for :browser_title, title_with_error_prefix('Edit subject knowledge', @subject_knowledge_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@application_form.id)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @subject_knowledge_form, url: support_interface_application_form_edit_subject_knowledge_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_text_area :subject_knowledge, label: { text: t('support_interface.edit_subject_knowledge_form.subject_knowledge.label'), size: 'xl' }, rows: 20, max_words: 400 %>
+      <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.edit_subject_knowledge_form.audit_comment.label'), size: 'm' }, hint: { text: t('support_interface.edit_subject_knowledge_form.audit_comment.hint') } %>
+      <%= f.govuk_submit 'Update' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -45,7 +45,7 @@
 
 <%= render LanguageSkillsComponent.new(application_form: @application_form) %>
 
-<%= render PersonalStatementComponent.new(application_form: @application_form) %>
+<%= render PersonalStatementComponent.new(application_form: @application_form, editable: true) %>
 
 <%= render InterviewPreferencesComponent.new(application_form: @application_form) %>
 

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -20,6 +20,12 @@ en:
         hint: This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here
       send_emails:
         label: Send notification emails to candidate and referee?
+    edit_becoming_a_teacher_form:
+      becoming_a_teacher:
+        label: Edit personal statement
+      audit_comment:
+        label: Audit log comment
+        hint: This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here
     edit_address_details_form:
       address_types:
         label: Where does the candidate live?
@@ -120,6 +126,13 @@ en:
             relationship:
               blank: Relationship cannot be blank
               too_long: Relationship must be %{count} characters or fewer
+            audit_comment:
+              blank: You must provide an audit comment
+        support_interface/application_forms/edit_becoming_a_teacher_form:
+          attributes:
+            becoming_a_teacher:
+              blank: Tell us why the candidate wants to be a teacher
+              too_many_words: Tell us why the candidate wants to be a teacher in %{count} words or fewer
             audit_comment:
               blank: You must provide an audit comment
         support_interface/application_forms/edit_gcse_form:

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -26,6 +26,12 @@ en:
       audit_comment:
         label: Audit log comment
         hint: This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here
+    edit_subject_knowledge_form:
+      subject_knowledge:
+        label: Edit subject knowledge
+      audit_comment:
+        label: Audit log comment
+        hint: This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here
     edit_address_details_form:
       address_types:
         label: Where does the candidate live?
@@ -133,6 +139,13 @@ en:
             becoming_a_teacher:
               blank: Tell us why the candidate wants to be a teacher
               too_many_words: Tell us why the candidate wants to be a teacher in %{count} words or fewer
+            audit_comment:
+              blank: You must provide an audit comment
+        support_interface/application_forms/edit_subject_knowledge_form:
+          attributes:
+            subject_knowledge:
+              blank: Tell us the candidates subject knowledge
+              too_many_words: Tell us about the candidates subject knowledge in %{count} words or fewer
             audit_comment:
               blank: You must provide an audit comment
         support_interface/application_forms/edit_gcse_form:

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -144,8 +144,8 @@ en:
         support_interface/application_forms/edit_subject_knowledge_form:
           attributes:
             subject_knowledge:
-              blank: Tell us the candidates subject knowledge
-              too_many_words: Tell us about the candidates subject knowledge in %{count} words or fewer
+              blank: Tell us the candidate’s subject knowledge
+              too_many_words: Tell us about the candidate’s subject knowledge in %{count} words or fewer
             audit_comment:
               blank: You must provide an audit comment
         support_interface/application_forms/edit_gcse_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -856,6 +856,9 @@ Rails.application.routes.draw do
       get '/references/:reference_id/feedback' => 'application_forms/references#edit_reference_feedback', as: :application_form_edit_reference_feedback
       post '/references/:reference_id/feedback' => 'application_forms/references#update_reference_feedback', as: :application_form_update_reference_feedback
 
+      get '/becoming-a-teacher' => 'application_forms/personal_statement#edit_becoming_a_teacher', as: :application_form_edit_becoming_a_teacher
+      patch '/becoming-a-teacher' => 'application_forms/personal_statement#update_becoming_a_teacher'
+
       get '/applicant-address-type' => 'application_forms/address_type#edit', as: :application_form_edit_address_type
       post '/applicant-address-type' => 'application_forms/address_type#update', as: :application_form_update_address_type
       get '/applicant-address-details' => 'application_forms/address_details#edit', as: :application_form_edit_address_details

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -859,6 +859,9 @@ Rails.application.routes.draw do
       get '/becoming-a-teacher' => 'application_forms/personal_statement#edit_becoming_a_teacher', as: :application_form_edit_becoming_a_teacher
       patch '/becoming-a-teacher' => 'application_forms/personal_statement#update_becoming_a_teacher'
 
+      get '/subject-knowledge' => 'application_forms/personal_statement#edit_subject_knowledge', as: :application_form_edit_subject_knowledge
+      patch '/subject-knowledge' => 'application_forms/personal_statement#update_subject_knowledge'
+
       get '/applicant-address-type' => 'application_forms/address_type#edit', as: :application_form_edit_address_type
       post '/applicant-address-type' => 'application_forms/address_type#update', as: :application_form_update_address_type
       get '/applicant-address-details' => 'application_forms/address_details#edit', as: :application_form_edit_address_details

--- a/spec/forms/support_interface/application_forms/edit_becoming_a_teacher_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_becoming_a_teacher_form_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationForms::EditBecomingATeacherForm, type: :model, with_audited: true do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:becoming_a_teacher) }
+    it { is_expected.to validate_presence_of(:audit_comment) }
+
+    valid_text = Faker::Lorem.sentence(word_count: 600)
+    invalid_text = Faker::Lorem.sentence(word_count: 601)
+
+    it { is_expected.to allow_value(valid_text).for(:becoming_a_teacher) }
+    it { is_expected.not_to allow_value(invalid_text).for(:becoming_a_teacher) }
+  end
+
+  describe '.build_from_application' do
+    it 'creates an object based on the provided ApplicationForm' do
+      application_form = create(:application_form, becoming_a_teacher: 'I really want to teach.')
+      form = described_class.build_from_application(
+        application_form,
+      )
+
+      expect(form.becoming_a_teacher).to eq 'I really want to teach.'
+    end
+  end
+
+  describe '#save' do
+    it 'returns false if not valid' do
+      application_form = double
+      form = described_class.new
+
+      expect(form.save(application_form)).to eq(false)
+    end
+
+    it 'updates the provided ApplicationForm if valid' do
+      application_form = create(:application_form)
+      form = described_class.new(becoming_a_teacher: 'I really want to teach.', audit_comment: 'It was on a zendesk ticket.')
+
+      form.save(application_form)
+
+      expect(application_form.becoming_a_teacher).to eq 'I really want to teach.'
+      expect(application_form.audits.last.comment).to eq 'It was on a zendesk ticket.'
+    end
+  end
+end

--- a/spec/forms/support_interface/application_forms/edit_subject_knowledge_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_subject_knowledge_form_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationForms::EditSubjectKnowledgeForm, type: :model, with_audited: true do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:subject_knowledge) }
+    it { is_expected.to validate_presence_of(:audit_comment) }
+
+    valid_text = Faker::Lorem.sentence(word_count: 400)
+    invalid_text = Faker::Lorem.sentence(word_count: 401)
+
+    it { is_expected.to allow_value(valid_text).for(:subject_knowledge) }
+    it { is_expected.not_to allow_value(invalid_text).for(:subject_knowledge) }
+  end
+
+  describe '.build_from_application' do
+    it 'creates an object based on the provided ApplicationForm' do
+      application_form = create(:application_form, subject_knowledge: 'I really want to teach.')
+      form = described_class.build_from_application(
+        application_form,
+      )
+
+      expect(form.subject_knowledge).to eq 'I really want to teach.'
+    end
+  end
+
+  describe '#save' do
+    it 'returns false if not valid' do
+      application_form = double
+      form = described_class.new
+
+      expect(form.save(application_form)).to eq(false)
+    end
+
+    it 'updates the provided ApplicationForm if valid' do
+      application_form = create(:application_form)
+      form = described_class.new(subject_knowledge: 'I really want to teach.', audit_comment: 'It was on a zendesk ticket.')
+
+      form.save(application_form)
+
+      expect(application_form.subject_knowledge).to eq 'I really want to teach.'
+      expect(application_form.audits.last.comment).to eq 'It was on a zendesk ticket.'
+    end
+  end
+end

--- a/spec/system/support_interface/editing_personal_statment_spec.rb
+++ b/spec/system/support_interface/editing_personal_statment_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.feature 'Editing reference' do
+  include DfESignInHelpers
+  include CandidateHelper
+
+  scenario 'Support user edits reference', with_audited: true do
+    given_i_am_a_support_user
+    and_an_application_exists
+
+    when_i_visit_the_application_page
+    and_i_click_the_change_link_on_personal_statement
+    then_i_should_see_a_prepopulated_personal_statement_form
+
+    when_i_submit_the_update_form
+    then_i_should_see_blank_audit_comment_error_message
+
+    when_i_complete_the_form
+    and_i_submit_the_form
+    then_i_should_be_told_i_updated_the_section
+    and_i_should_see_the_new_personal_statement
+    and_i_should_see_my_comment_in_the_audit_log
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_an_application_exists
+    @application_form = create(:completed_application_form, becoming_a_teacher: 'i can spel real gud')
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@application_form)
+  end
+
+  def and_i_click_the_change_link_on_personal_statement
+    within('#personal-statement-section') do
+      click_link 'Change', match: :first
+    end
+  end
+
+  def then_i_should_see_a_prepopulated_personal_statement_form
+    expect(page).to have_content('Edit personal statement')
+    expect(page).to have_selector('#support-interface-application-forms-edit-becoming-a-teacher-form-becoming-a-teacher-field', text: 'i can spel real gud')
+  end
+
+  def when_i_submit_the_update_form
+    click_button 'Update'
+  end
+
+  def then_i_should_see_blank_audit_comment_error_message
+    expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_becoming_a_teacher_form.attributes.audit_comment.blank')
+  end
+
+  def when_i_complete_the_form
+    fill_in 'Edit personal statement', with: 'My spelling is phenomenal.'
+    fill_in 'Audit log comment', with: 'Updated as part of Zen Desk ticket #12345'
+  end
+
+  def and_i_submit_the_form
+    when_i_submit_the_update_form
+  end
+
+  def then_i_should_be_told_i_updated_the_section
+    expect(page).to have_content 'Personal statement updated'
+  end
+
+  def and_i_should_see_the_new_personal_statement
+    expect(page).to have_content 'My spelling is phenomenal.'
+  end
+
+  def and_i_should_see_my_comment_in_the_audit_log
+    click_on 'History'
+    expect(page).to have_content 'Updated as part of Zen Desk ticket #12345'
+  end
+end

--- a/spec/system/support_interface/editing_subject_knowledge_spec.rb
+++ b/spec/system/support_interface/editing_subject_knowledge_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.feature 'Editing reference' do
+  include DfESignInHelpers
+  include CandidateHelper
+
+  scenario 'Support user edits reference', with_audited: true do
+    given_i_am_a_support_user
+    and_an_application_exists
+
+    when_i_visit_the_application_page
+    and_i_click_the_change_link_on_subject_knowledge
+    then_i_should_see_a_prepopulated_subject_knowledge_form
+
+    when_i_submit_the_form
+    then_i_should_see_blank_audit_comment_error_message
+
+    when_i_complete_the_form
+    and_i_submit_the_form
+    then_i_should_be_told_i_updated_the_section
+    and_i_should_see_the_new_subject_knowledge
+    and_i_should_see_my_comment_in_the_audit_log
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_an_application_exists
+    @application_form = create(:completed_application_form, subject_knowledge: 'I know a little.')
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@application_form)
+  end
+
+  def and_i_click_the_change_link_on_subject_knowledge
+    within('#personal-statement-section') do
+      all('a').last.click
+    end
+  end
+
+  def then_i_should_see_a_prepopulated_subject_knowledge_form
+    expect(page).to have_content('Edit subject knowledge')
+    expect(page).to have_selector('#support-interface-application-forms-edit-subject-knowledge-form-subject-knowledge-field', text: 'I know a little.')
+  end
+
+  def when_i_submit_the_form
+    click_button 'Update'
+  end
+
+  def then_i_should_see_blank_audit_comment_error_message
+    expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_subject_knowledge_form.attributes.audit_comment.blank')
+  end
+
+  def when_i_complete_the_form
+    fill_in 'Edit subject knowledge', with: 'I know a lot.'
+    fill_in 'Audit log comment', with: 'Updated as part of Zen Desk ticket #12345'
+  end
+
+  def and_i_submit_the_form
+    when_i_submit_the_form
+  end
+
+  def then_i_should_be_told_i_updated_the_section
+    expect(page).to have_content 'Subject knowledge updated'
+  end
+
+  def and_i_should_see_the_new_subject_knowledge
+    expect(page).to have_content 'I know a lot.'
+  end
+
+  def and_i_should_see_my_comment_in_the_audit_log
+    click_on 'History'
+    expect(page).to have_content 'Updated as part of Zen Desk ticket #12345'
+  end
+end


### PR DESCRIPTION
## Context

A common support request is a candidate wanting to update their personal statement. Currently, this requires developer intervention.

This PR adds in the ability to to do this via the candidates application form on the support UI.


## Changes proposed in this pull request

- Add change links from the application form show page

![image](https://user-images.githubusercontent.com/42515961/134163435-0227a2a2-246e-4873-9f75-da3018962613.png)


- Adds in the edit personal statement page

![image](https://user-images.githubusercontent.com/42515961/134163401-b9d4e154-1d6c-490b-a18f-e19d347159c1.png)


- Adds in the edit subject knowledge page 

![image](https://user-images.githubusercontent.com/42515961/134163571-bdd867a8-e2fb-439a-a173-1c65328f3b33.png)

## Guidance to review

The change links are a bit ugly but it seems better than doing the work to add in the candy component. Do you think they're fine?

## Link to Trello card

https://trello.com/c/0HQVsKGN/3835-editing-personal-statements-on-applications-candy

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
