### PR TITLE
Fix specs that need are failing post AA deadline

### DIFF
--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -156,6 +156,10 @@ RSpec.describe CandidateMailer, type: :mailer do
     context 'when a candidate has 2 offers that were declined by default and a rejection' do
       let(:application_choices) { [dbd_application, dbd_application, build_stubbed(:application_choice, status: 'rejected')] }
 
+      before do
+        allow(CycleTimetable).to receive(:between_cycles_apply_2?).and_return(false)
+      end
+
       it_behaves_like(
         'a mail with subject and content',
         'You did not respond to your offers: next steps',

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Candidate can see their rejection reasons on apply again' do
+RSpec.feature 'Candidate can see their rejection reasons on apply again' do
   scenario 'when a candidate visits their apply again application form they can see apply1 rejection reasons' do
     given_i_am_signed_in
     and_i_have_an_apply1_application_with_3_rejections

--- a/spec/system/candidate_interface/rejection/candidate_reviews_reasons_for_rejection_spec.rb
+++ b/spec/system/candidate_interface/rejection/candidate_reviews_reasons_for_rejection_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Candidate can see their structured reasons for rejection when reviewing their application' do
+RSpec.feature 'Candidate can see their structured reasons for rejection when reviewing their application' do
   scenario 'when a candidate visits their apply again application form they can see apply1 rejection reasons' do
     given_i_am_signed_in
     and_i_have_an_apply1_application_with_2_rejections


### PR DESCRIPTION
## Context

There's a few specs that are failing post A2 deadline due to not being Timecop'd

## Changes proposed in this pull request

- Set them to a specific time (either by the helper) or stub a response from the CycleTimetable

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
