### PR TITLE
replace internal query error with generic message

### DIFF
--- a/app/controllers/candidate_api/candidates_controller.rb
+++ b/app/controllers/candidate_api/candidates_controller.rb
@@ -25,7 +25,14 @@ module CandidateAPI
     end
 
     def statement_timeout
-      render json: { errors: [{ error: 'QueryCanceled', message: 'There is a problem with the service' }] }, status: :internal_server_error
+      render json: {
+        errors: [
+          {
+            error: 'InternalServerError',
+            message: 'The server encountered an unexpected condition that prevented it from fulfilling the request',
+          },
+        ],
+      }, status: :internal_server_error
     end
 
   private

--- a/app/controllers/data_api/tad_data_exports_controller.rb
+++ b/app/controllers/data_api/tad_data_exports_controller.rb
@@ -39,8 +39,15 @@ module DataAPI
       send_data export.data, filename: export.filename
     end
 
-    def statement_timeout(e)
-      render json: { errors: [{ error: 'QueryCanceled', message: e }] }, status: :internal_server_error
+    def statement_timeout
+      render json: {
+        errors: [
+          {
+            error: 'InternalServerError',
+            message: 'The server encountered an unexpected condition that prevented it from fulfilling the request',
+          },
+        ],
+      }, status: :internal_server_error
     end
   end
 end

--- a/app/controllers/register_api/applications_controller.rb
+++ b/app/controllers/register_api/applications_controller.rb
@@ -24,8 +24,15 @@ module RegisterAPI
       render json: { errors: [{ error: 'ParameterInvalid', message: e }] }, status: :unprocessable_entity
     end
 
-    def statement_timeout(e)
-      render json: { errors: [{ error: 'QueryCanceled', message: e }] }, status: :internal_server_error
+    def statement_timeout
+      render json: {
+        errors: [
+          {
+            error: 'InternalServerError',
+            message: 'The server encountered an unexpected condition that prevented it from fulfilling the request',
+          },
+        ],
+      }, status: :internal_server_error
     end
 
   private

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -51,8 +51,15 @@ module VendorAPI
       render json: { errors: [{ error: 'ParameterInvalid', message: e }] }, status: :unprocessable_entity
     end
 
-    def statement_timeout(e)
-      render json: { errors: [{ error: 'QueryCanceled', message: e }] }, status: :internal_server_error
+    def statement_timeout
+      render json: {
+        errors: [
+          {
+            error: 'InternalServerError',
+            message: 'The server encountered an unexpected condition that prevented it from fulfilling the request',
+          },
+        ],
+      }, status: :internal_server_error
     end
 
     def set_cors_headers


### PR DESCRIPTION
## Context

Remove visibility from user as to why an error has occured, replace with a generic message. 

## Guidance to review

Create a timed out request and see if you can get any visibility as to the casuse. 
## Link to Trello card

https://trello.com/c/wAD8ii3h/3840-do-not-expose-query-timed-out-error-through-vendor-api

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
