### PR TITLE
Update referee content

### DIFF
--- a/app/components/referee_interface/feedback_hints_component.html.erb
+++ b/app/components/referee_interface/feedback_hints_component.html.erb
@@ -1,26 +1,14 @@
-<p class="govuk-body">Complete your reference in one sitting. You cannot save it and come back to it later.</p>
-<p class="govuk-body">When giving your reference try to cover the following, but do not worry if there are areas you cannot comment on:</p>
-<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+<p class="govuk-body">You could comment on things like their:</p>
+
+<ul class="govuk-list govuk-list--bullet">
   <% if @academic %>
-    <li>
-      <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Academic abilities</h2>
-      <p class="govuk-body">Does the candidate think critically and have good numeracy and literacy skills?</p>
-    </li>
+    <li>academic skills</li>
   <% end %>
-  <li>
-    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Teaching potential</h2>
-    <p class="govuk-body">Is the candidate emotionally resilient? Do they work well with others?</p>
-  </li>
-  <li>
-    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Reliability and professionalism</h2>
-    <p class="govuk-body">Can the candidate meet deadlines and manage their time?</p>
-  </li>
-  <li>
-    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Suitability to work with children</h2>
-    <p class="govuk-body">Does the candidate care about the wellbeing of children?</p>
-  </li>
-  <li>
-    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Transferable skills</h2>
-    <p class="govuk-body">What abilities would the candidate bring to teaching - for example, communication, creativity, project management?</p>
-  </li>
+  <li>communication skills</li>
+  <li>reliability and professionalism</li>
+  <li>ability to work with children</li>
+  <li>transferable skills</li>
 </ul>
+
+<p class="govuk-body">You can write up to 500 words. </p>
+<p class="govuk-body">If you need more time, save and return later using the link in your email.</p>

--- a/app/components/referee_interface/reference_review_component.rb
+++ b/app/components/referee_interface/reference_review_component.rb
@@ -55,9 +55,12 @@ module RefereeInterface
 
     def relationship_value
       return 'Not answered' if @reference.relationship_correction.nil?
-      return 'You’ve confirmed your relationship with the candidate' if @reference.relationship_correction.blank?
 
-      "Amended by referee to: #{@reference.relationship_correction}"
+      if @reference.relationship_correction.blank?
+        'You’ve confirmed your relationship with the candidate'
+      else
+        @reference.relationship_correction
+      end
     end
   end
 end

--- a/app/components/referee_interface/reference_review_component.rb
+++ b/app/components/referee_interface/reference_review_component.rb
@@ -17,7 +17,7 @@ module RefereeInterface
         key: 'Relationship',
         value: relationship_value,
         action: {
-          href: referee_interface_reference_relationship_path(token: @token_param),
+          href: referee_interface_reference_relationship_path(token: @token_param, from: 'review'),
           visually_hidden_text: 'relationship',
         },
       }
@@ -36,7 +36,7 @@ module RefereeInterface
         key: 'Concerns about candidate working with children',
         value: concerns,
         action: {
-          href: referee_interface_safeguarding_path(token: @token_param),
+          href: referee_interface_safeguarding_path(token: @token_param, from: 'review'),
           visually_hidden_text: 'concerns about candidate working with children',
         },
       }
@@ -47,7 +47,7 @@ module RefereeInterface
         key: 'Reference',
         value: @reference.feedback || 'Not answered',
         action: {
-          href: referee_interface_reference_feedback_path(token: @token_param),
+          href: referee_interface_reference_feedback_path(token: @token_param, from: 'review'),
           visually_hidden_text: 'reference',
         },
       }

--- a/app/components/referee_interface/reference_review_component.rb
+++ b/app/components/referee_interface/reference_review_component.rb
@@ -56,11 +56,7 @@ module RefereeInterface
     def relationship_value
       return 'Not answered' if @reference.relationship_correction.nil?
 
-      if @reference.relationship_correction.blank?
-        'You’ve confirmed your relationship with the candidate'
-      else
-        @reference.relationship_correction
-      end
+      @reference.relationship_correction.presence || 'You’ve confirmed your relationship with the candidate'
     end
   end
 end

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -100,6 +100,7 @@ module RefereeInterface
         SubmitReference.new(reference: reference).save!
         redirect_to referee_interface_confirmation_path(token: @token_param)
       else
+        @application = reference.application_form
         render :review
       end
     end

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -133,7 +133,7 @@ module RefereeInterface
         @refuse_feedback_form.save(reference)
         redirect_to referee_interface_thank_you_path(token: @token_param)
       else
-        redirect_to referee_interface_reference_relationship_path(token: @token_param)
+        redirect_to referee_interface_reference_relationship_path(token: @token_param, from: 'refuse')
       end
     end
 
@@ -149,6 +149,8 @@ module RefereeInterface
     def previous_path(previous_path_in_flow:)
       if params[:from] == 'review'
         referee_interface_reference_review_path(token: @token_param)
+      elsif params[:from] == 'refuse'
+        referee_interface_refuse_feedback_path(token: @token_param)
       elsif previous_path_in_flow
         previous_path_in_flow
       end

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -17,7 +17,7 @@ module RefereeInterface
       @relationship = reference.relationship
       @relationship_form = ReferenceRelationshipForm.build_from_reference(reference: reference)
 
-      set_previous_path(previous_path_in_flow: nil)
+      @previous_path = previous_path(previous_path_in_flow: nil)
     end
 
     def confirm_relationship
@@ -43,7 +43,7 @@ module RefereeInterface
       @application = reference.application_form
       @safeguarding_form = ReferenceSafeguardingForm.build_from_reference(reference: reference)
 
-      set_previous_path(previous_path_in_flow: referee_interface_reference_relationship_path(token: @token_param))
+      @previous_path = previous_path(previous_path_in_flow: referee_interface_reference_relationship_path(token: @token_param))
     end
 
     def confirm_safeguarding
@@ -68,7 +68,7 @@ module RefereeInterface
         feedback: reference.feedback,
       )
 
-      set_previous_path(previous_path_in_flow: referee_interface_safeguarding_path(token: @token_param))
+      @previous_path = previous_path(previous_path_in_flow: referee_interface_safeguarding_path(token: @token_param))
     end
 
     def submit_feedback
@@ -146,12 +146,11 @@ module RefereeInterface
 
   private
 
-    # Set previous path to review page or previous page in flow
-    def set_previous_path(previous_path_in_flow:)
+    def previous_path(previous_path_in_flow:)
       if params[:from] == 'review'
-        @previous_path = referee_interface_reference_review_path(token: @token_param)
+        referee_interface_reference_review_path(token: @token_param)
       elsif previous_path_in_flow
-        @previous_path = previous_path_in_flow
+        previous_path_in_flow
       end
     end
 

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -16,6 +16,8 @@ module RefereeInterface
       @application = reference.application_form
       @relationship = reference.relationship
       @relationship_form = ReferenceRelationshipForm.build_from_reference(reference: reference)
+
+      set_previous_path(previous_path_in_flow: nil)
     end
 
     def confirm_relationship
@@ -40,6 +42,8 @@ module RefereeInterface
     def safeguarding
       @application = reference.application_form
       @safeguarding_form = ReferenceSafeguardingForm.build_from_reference(reference: reference)
+
+      set_previous_path(previous_path_in_flow: referee_interface_reference_relationship_path(token: @token_param))
     end
 
     def confirm_safeguarding
@@ -63,6 +67,8 @@ module RefereeInterface
         reference: reference,
         feedback: reference.feedback,
       )
+
+      set_previous_path(previous_path_in_flow: referee_interface_safeguarding_path(token: @token_param))
     end
 
     def submit_feedback
@@ -79,6 +85,7 @@ module RefereeInterface
     end
 
     def review
+      @application = reference.application_form
       @reference_form = ReferenceReviewForm.new(
         reference: reference,
       )
@@ -138,6 +145,15 @@ module RefereeInterface
     def thank_you; end
 
   private
+
+    # Set previous path to review page or previous page in flow
+    def set_previous_path(previous_path_in_flow:)
+      if params[:from] == 'review'
+        @previous_path = referee_interface_reference_review_path(token: @token_param)
+      elsif previous_path_in_flow
+        @previous_path = previous_path_in_flow
+      end
+    end
 
     def show_finished_page_if_feedback_provided
       return if reference.feedback_requested?

--- a/app/views/referee_interface/reference/feedback.html.erb
+++ b/app/views/referee_interface/reference/feedback.html.erb
@@ -10,7 +10,7 @@
     ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
+      <h1 class="govuk-heading-l">
         <%= t('page_titles.referee.feedback', full_name: @reference_form.application_form.full_name) %>
       </h1>
 

--- a/app/views/referee_interface/reference/feedback.html.erb
+++ b/app/views/referee_interface/reference/feedback.html.erb
@@ -18,7 +18,7 @@
 
       <%= f.govuk_text_area :feedback, label: { text: t('referee.feedback.label'), size: 'm' }, max_words: 500, rows: 15 %>
 
-      <%= f.govuk_submit t('continue') %>
+      <%= f.govuk_submit t('save') %>
     <% end %>
   </div>
 </div>

--- a/app/views/referee_interface/reference/feedback.html.erb
+++ b/app/views/referee_interface/reference/feedback.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.referee.feedback', full_name: @reference_form.application_form.full_name), @reference_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(referee_interface_safeguarding_path(token: @token_param)) %>
+<% content_for :before_content, govuk_back_link_to(@previous_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referee_interface/reference/relationship.html.erb
+++ b/app/views/referee_interface/reference/relationship.html.erb
@@ -1,5 +1,8 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.referee.relationship', full_name: @application.full_name), @relationship_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+
+<% if @previous_path %>
+  <% content_for :before_content, govuk_back_link_to(@previous_path) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referee_interface/reference/relationship.html.erb
+++ b/app/views/referee_interface/reference/relationship.html.erb
@@ -10,7 +10,7 @@
     ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
+      <h1 class="govuk-heading-l">
         <%= t('page_titles.referee.relationship', full_name: @application.full_name) %>
       </h1>
 

--- a/app/views/referee_interface/reference/relationship.html.erb
+++ b/app/views/referee_interface/reference/relationship.html.erb
@@ -28,7 +28,7 @@
         <% end %>
       <% end %>
 
-      <%= f.govuk_submit t('continue') %>
+      <%= f.govuk_submit t('save_and_continue') %>
     <% end %>
   </div>
 </div>

--- a/app/views/referee_interface/reference/review.html.erb
+++ b/app/views/referee_interface/reference/review.html.erb
@@ -14,6 +14,8 @@
         <%= t('page_titles.referee.review') %>
       </h1>
 
+      <p class="govuk-body">If you’re not ready to submit yet, you can return using the link in your email.</p>
+
       <%= render(RefereeInterface::ReferenceReviewComponent.new(reference: @reference_form.reference, token_param: @token_param)) %>
 
       <%= f.govuk_submit t('referee.review.submit') %>

--- a/app/views/referee_interface/reference/review.html.erb
+++ b/app/views/referee_interface/reference/review.html.erb
@@ -1,5 +1,4 @@
-<% content_for :title, t('page_titles.referee.review') %>
-<% content_for :before_content, govuk_back_link_to(referee_interface_reference_feedback_path(token: @token_param)) %>
+<% content_for :title, t('page_titles.referee.review', full_name: @application.full_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -10,8 +9,8 @@
     ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        <%= t('page_titles.referee.review') %>
+      <h1 class="govuk-heading-l">
+        <%= t('page_titles.referee.review', full_name: @application.full_name) %>
       </h1>
 
       <p class="govuk-body">If you’re not ready to submit yet, you can return using the link in your email.</p>

--- a/app/views/referee_interface/reference/safeguarding.html.erb
+++ b/app/views/referee_interface/reference/safeguarding.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.referee.safeguarding', full_name: @application.full_name), @safeguarding_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(referee_interface_reference_relationship_path(token: @token_param)) %>
+
+<% content_for :before_content, govuk_back_link_to(@previous_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referee_interface/reference/safeguarding.html.erb
+++ b/app/views/referee_interface/reference/safeguarding.html.erb
@@ -18,7 +18,7 @@
         <% end %>
       <% end %>
 
-      <%= f.govuk_submit t('continue') %>
+      <%= f.govuk_submit t('save_and_continue') %>
     <% end %>
   </div>
 </div>

--- a/app/views/referee_interface/reference/safeguarding.html.erb
+++ b/app/views/referee_interface/reference/safeguarding.html.erb
@@ -10,7 +10,7 @@
     ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :any_safeguarding_concerns, legend: { text: t('page_titles.referee.safeguarding', full_name: @application.full_name), size: 'xl', tag: 'h1' } do %>
+      <%= f.govuk_radio_buttons_fieldset :any_safeguarding_concerns, legend: { text: t('page_titles.referee.safeguarding', full_name: @application.full_name), size: 'l', tag: 'h1' } do %>
         <%= f.govuk_radio_button :any_safeguarding_concerns, :no, label: { text: t('referee.any_safeguarding_concerns.no.label') }, link_errors: true %>
         <%= f.govuk_radio_button :any_safeguarding_concerns, :yes, label: { text: t('referee.any_safeguarding_concerns.yes.label') } do %>
           <%= f.govuk_text_area :safeguarding_concerns, label: { text: t('referee.safeguarding_concerns.label', full_name: @application.full_name) }, max_words: 150, rows: 5 %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   continue: Continue
   save_and_continue: Save and continue
+  save: Save
   cancel: Cancel
   validation_errors:
     email_address_format: Enter an email address in the correct format, like name@example.com

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -173,8 +173,8 @@ en:
       refuse_feedback: Decline to give a reference
       relationship: Confirm how you know %{full_name}
       safeguarding: Do you know of any reason why %{full_name} should not work with children?
-      feedback: Your reference for %{full_name}
-      review: Check your answers before submitting your reference
+      feedback: Does %{full_name} have the potential to teach?
+      review: Your reference for %{full_name}
       confirmation: Your reference for %{full_name} has been submitted
       finish: Thank you
     providers: Courses on this service

--- a/spec/components/referee_interface/feedback_hints_component_spec.rb
+++ b/spec/components/referee_interface/feedback_hints_component_spec.rb
@@ -4,20 +4,20 @@ RSpec.describe RefereeInterface::FeedbackHintsComponent do
   context 'when it is an academic reference' do
     let(:reference) { build_stubbed(:reference, referee_type: :academic) }
 
-    it 'displays the academic abilities guidance' do
+    it 'displays the academic skills bullet point' do
       result = render_inline(described_class.new(reference: reference))
 
-      expect(result.text).to include('Academic abilities')
+      expect(result.text).to include('academic skills')
     end
   end
 
   context 'when it is non-academic reference' do
     let(:reference) { build_stubbed(:reference, referee_type: :school_based) }
 
-    it 'does not display that the academic abilities guidance' do
+    it 'does not display that the academic skills bullet point' do
       result = render_inline(described_class.new(reference: reference))
 
-      expect(result.text).not_to include('Academic abilities')
+      expect(result.text).not_to include('academic skills')
     end
   end
 end

--- a/spec/components/referee_interface/reference_review_component_spec.rb
+++ b/spec/components/referee_interface/reference_review_component_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RefereeInterface::ReferenceReviewComponent do
       result = render_inline(described_class.new(reference: reference))
 
       expect(result.css('.govuk-summary-list__key').text).to include('Relationship')
-      expect(result.css('.govuk-summary-list__value').text).to include('Amended by referee to: meh')
+      expect(result.css('.govuk-summary-list__value').text).to include('meh')
     end
   end
 

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_application_with_references_to_new_cycle_and_referee_provides_reference_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_application_with_references_to_new_cycle_and_referee_provides_reference_spec.rb
@@ -109,11 +109,11 @@ RSpec.feature 'Carry over' do
 
   def when_i_submit_the_outstanding_reference
     choose 'Yes'
-    click_button t('continue')
+    click_button t('save_and_continue')
     choose 'No'
-    click_button t('continue')
+    click_button t('save_and_continue')
     fill_in 'Your reference', with: 'This is a reference for the candidate.'
-    click_button t('continue')
+    click_button t('save')
     click_button t('referee.review.submit')
   end
 

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -36,10 +36,25 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
     and_i_click_on_save_and_continue
     then_i_see_the_reference_comment_page
 
+    # Go backwards
+    when_i_click_back
+    then_i_see_the_safeguarding_page
+    and_i_see_my_previous_safeguarding_answer
+
+    when_i_click_back
+    then_i_am_asked_to_confirm_my_relationship_with_the_candidate
+    and_i_see_my_previous_relationship_answer
+
+    # Go forwards again
+    when_i_click_on_save_and_continue
+    when_i_click_on_save_and_continue
+    then_i_see_the_reference_comment_page
+
     when_i_fill_in_the_reference_field
     and_i_click_on_save
     then_i_see_the_reference_review_page
 
+    # Changing answers from the review page
     when_i_click_change_relationship
     and_i_amend_the_relationship
     and_i_click_on_save_and_continue
@@ -50,6 +65,20 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
     and_i_click_on_save_and_continue
     then_i_can_review_the_amended_safeguarding_concerns
 
+    # Check back links from review page
+    when_i_click_change_relationship
+    when_i_click_back
+    then_i_see_the_reference_review_page
+
+    when_i_click_change_safeguarding_concerns
+    when_i_click_back
+    then_i_see_the_reference_review_page
+
+    when_i_click_change_reference
+    when_i_click_back
+    then_i_see_the_reference_review_page
+
+    # Submit
     and_i_click_the_submit_reference_button
     then_i_see_am_told_i_submitted_my_reference
     then_i_see_the_confirmation_page
@@ -112,7 +141,9 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
   end
 
   def when_i_confirm_that_the_described_relationship_is_not_correct
-    choose 'No'
+    within_fieldset('Is this correct?') do
+      choose 'No'
+    end
   end
 
   def then_i_see_an_error_to_enter_my_relationship_with_the_candidate
@@ -120,7 +151,15 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
   end
 
   def when_i_confirm_that_the_described_relationship_is_correct
-    choose 'Yes'
+    within_fieldset('Is this correct?') do
+      choose 'Yes'
+    end
+  end
+
+  def and_i_see_my_previous_relationship_answer
+    within_fieldset('Is this correct?') do
+      expect(page).to have_checked_field('Yes')
+    end
   end
 
   def then_i_see_the_safeguarding_page
@@ -141,6 +180,12 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
 
   def when_i_choose_the_candidate_is_suitable_for_working_with_children
     choose 'No'
+  end
+
+  def and_i_see_my_previous_safeguarding_answer
+    within_fieldset("Do you know of any reason why #{@application.full_name} should not work with children?") do
+      expect(page).to have_checked_field('No')
+    end
   end
 
   def and_i_click_on_save_and_continue
@@ -166,6 +211,14 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
 
   def when_i_click_change_relationship
     click_link 'Change relationship'
+  end
+
+  def when_i_click_change_reference
+    click_link 'Change reference'
+  end
+
+  def when_i_click_back
+    click_link 'Back'
   end
 
   def and_i_amend_the_relationship

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -161,7 +161,7 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
 
   def then_i_see_the_reference_review_page
     expect(page).to have_content("Your reference for #{@application.full_name}")
-    expect(page).to have_content("If you’re not ready to submit yet, you can return using the link in your email.")
+    expect(page).to have_content('If you’re not ready to submit yet, you can return using the link in your email.')
   end
 
   def when_i_click_change_relationship

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -14,40 +14,40 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
     when_i_click_on_the_link_within_the_email
     then_i_am_asked_to_confirm_my_relationship_with_the_candidate
 
-    when_i_click_on_continue
+    when_i_click_on_save_and_continue
     then_i_see_an_error_to_confirm_my_relationship_with_the_candidate
 
     when_i_confirm_that_the_described_relationship_is_not_correct
-    and_i_click_on_continue
+    and_i_click_on_save_and_continue
     then_i_see_an_error_to_enter_my_relationship_with_the_candidate
 
     when_i_confirm_that_the_described_relationship_is_correct
-    and_i_click_on_continue
+    and_i_click_on_save_and_continue
     then_i_see_the_safeguarding_page
 
-    when_i_click_on_continue
+    when_i_click_on_save_and_continue
     then_i_see_an_error_to_choose_if_i_know_any_safeguarding_concerns
 
     when_i_choose_the_candidate_is_not_suitable_for_working_with_children
-    and_i_click_on_continue
+    and_i_click_on_save_and_continue
     then_i_see_an_error_to_enter_my_safeguarding_concerns
 
     when_i_choose_the_candidate_is_suitable_for_working_with_children
-    and_i_click_on_continue
+    and_i_click_on_save_and_continue
     then_i_see_the_reference_comment_page
 
     when_i_fill_in_the_reference_field
-    and_i_click_on_continue
+    and_i_click_on_save
     then_i_see_the_reference_review_page
 
     when_i_click_change_relationship
     and_i_amend_the_relationship
-    and_i_click_on_continue
+    and_i_click_on_save_and_continue
     then_i_can_review_the_amended_relationship
 
     when_i_click_change_safeguarding_concerns
     and_i_amend_the_safeguarding_concerns
-    and_i_click_on_continue
+    and_i_click_on_save_and_continue
     then_i_can_review_the_amended_safeguarding_concerns
 
     and_i_click_the_submit_reference_button
@@ -99,8 +99,12 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
     expect(page).to have_content("Confirm how you know #{@application.full_name}")
   end
 
-  def when_i_click_on_continue
-    click_button t('continue')
+  def when_i_click_on_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def when_i_click_on_save
+    click_button t('save')
   end
 
   def then_i_see_an_error_to_confirm_my_relationship_with_the_candidate
@@ -139,12 +143,16 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
     choose 'No'
   end
 
-  def and_i_click_on_continue
-    click_button t('continue')
+  def and_i_click_on_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def and_i_click_on_save
+    click_button t('save')
   end
 
   def then_i_see_the_reference_comment_page
-    expect(page).to have_content("Your reference for #{@application.full_name}")
+    expect(page).to have_content("Does #{@application.full_name} have the potential to teach?")
   end
 
   def when_i_fill_in_the_reference_field
@@ -152,7 +160,8 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
   end
 
   def then_i_see_the_reference_review_page
-    expect(page).to have_content('Check your answers before submitting your reference')
+    expect(page).to have_content("Your reference for #{@application.full_name}")
+    expect(page).to have_content("If you’re not ready to submit yet, you can return using the link in your email.")
   end
 
   def when_i_click_change_relationship
@@ -165,8 +174,8 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
   end
 
   def then_i_can_review_the_amended_relationship
-    click_button t('continue')
-    expect(page).to have_content('Amended by referee to: he is not my friend')
+    click_button t('save_and_continue')
+    expect(page).to have_content('he is not my friend')
   end
 
   def when_i_click_change_safeguarding_concerns

--- a/spec/system/referee_interface/referee_tries_to_submit_incomplete_reference_spec.rb
+++ b/spec/system/referee_interface/referee_tries_to_submit_incomplete_reference_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Stop submission of incomplete references', with_audited: true do
   def and_i_confirm_my_relationship_with_the_candidate
     expect(page).to have_content("Confirm how you know #{@application.full_name}")
     choose 'Yes'
-    click_button t('continue')
+    click_button t('save_and_continue')
   end
 
   def and_i_manually_skip_ahead_to_the_review_page


### PR DESCRIPTION
We currently tell referees that they need to complete the reference in a "one sitting", which can be stressful. However they _can_ save and come back to it at any time, using the original link sent to their email.

These changes address this by:

* relabelling the buttons to "Save and continue" for the first 2 questions and just "Save" on the last question
* removing "Complete your reference in one sitting. You cannot save it and come back to it later."
* Adding content to the reference and review pages to tell referees that they can save and return using the link in their email

Additional changes (whilst reviewing this journey):

* Guidance on giving reference has been made more succinct (and in keeping with style guide)
* Back links fixes (were broken on first question and after changing answer from the review page)
* Font size of headings reduced from XL to L
* "Amended by referee to:" prefix removed from review summary

See also:

* [Changes made in prototype](https://github.com/DFE-Digital/apply-for-teacher-training-prototype/pull/548)
* [Updates to content of email sent to referees](https://github.com/DFE-Digital/apply-for-teacher-training/pull/5582)

➡️  [Trello card](https://trello.com/c/pGd8HUyy/3951-update-content-for-referee-journey)
