### PR TITLE
Ensure not provided yet shows when candidate has not provided `not_completed_explanation`

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -179,7 +179,7 @@ module CandidateInterface
     def not_completed_explanation_row
       {
         key: 'Are you currently studying for this qualification?',
-        value: application_qualification.not_completed_explanation || 'No',
+        value: not_completed_explanation_value_row,
         action: {
           href: candidate_interface_gcse_edit_not_yet_completed_path(change_path_params),
           visually_hidden_text: 'how you expect to gain this qualification',
@@ -326,6 +326,8 @@ module CandidateInterface
     end
 
     def failing_grade_row_value
+      return application_qualification.not_completed_explanation if application_qualification.not_completed_explanation.present?
+
       case application_qualification.currently_completing_qualification
       when true
         'Yes'
@@ -335,5 +337,6 @@ module CandidateInterface
         'Not provided'
       end
     end
+    alias not_completed_explanation_value_row failing_grade_row_value
   end
 end


### PR DESCRIPTION
## Context

Small bug where the `Are you currently studying for this qualification?` row of the gcse review component is not rendering not provided when it is nil. 

## Changes proposed in this pull request

- render `not selected` when  `Are you currently studying for this qualification?` is nil

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
