### PR TITLE
Send delete_entity events to BQ

### DIFF
--- a/app/lib/events/event.rb
+++ b/app/lib/events/event.rb
@@ -1,6 +1,6 @@
 module Events
   class Event
-    EVENT_TYPES = %w[web_request create_entity update_entity].freeze
+    EVENT_TYPES = %w[web_request create_entity update_entity delete_entity].freeze
 
     def initialize
       @event_hash = {

--- a/app/models/concerns/entity_events.rb
+++ b/app/models/concerns/entity_events.rb
@@ -9,6 +9,11 @@ module EntityEvents
       send_event('create_entity', data) if data.any?
     end
 
+    after_destroy do
+      data = entity_data(attributes)
+      send_event('delete_entity', data) if data.any?
+    end
+
     after_update do
       # in this after_update hook we don’t have access to the new fields via
       # #attributes — we need to dig them out of saved_changes which stores

--- a/config/event-schema.json
+++ b/config/event-schema.json
@@ -11,7 +11,7 @@
     },
     "event_type": {
       "type": "string",
-      "enum": ["web_request", "create_entity", "update_entity"]
+      "enum": ["web_request", "create_entity", "update_entity", "delete_entity"]
     },
     "entity_table_name": {
       "type": "string"

--- a/spec/models/concerns/entity_events_spec.rb
+++ b/spec/models/concerns/entity_events_spec.rb
@@ -173,4 +173,22 @@ RSpec.describe EntityEvents do
       end
     end
   end
+
+  describe 'delete_entity events' do
+    let(:interesting_fields) { [:email_address] }
+
+    it 'sends events when objects are deleted' do
+      candidate = create(:candidate, email_address: 'boo@example.com')
+      candidate.destroy
+
+      expect(SendEventsToBigquery).to have_received(:perform_async)
+        .with a_hash_including({
+          'entity_table_name' => 'candidates',
+          'event_type' => 'delete_entity',
+          'data' => [
+            { 'key' => 'email_address', 'value' => ['boo@example.com'] },
+          ],
+        })
+    end
+  end
 end


### PR DESCRIPTION
## Context

We don't notify BigQuery about records being deleted. This seldom happens, but it does (eg `ProviderPermissions`). It's better to have this facility before we backfill everything.

## Changes proposed in this pull request

See commit

## Link to Trello card

https://trello.com/c/oFxhG5e2/476-decision-should-we-be-importing-the-entitydelete-data-yes
