### PR TITLE
Remove specific downtime content on service page

### DIFF
--- a/app/components/shared/service_unavailable_component.html.erb
+++ b/app/components/shared/service_unavailable_component.html.erb
@@ -3,7 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title_content %></h1>
-    <p class="govuk-body"><%= downtime_content %></p>
     <p class="govuk-body"><%= t('service_unavailable.body') %></p>
   </div>
 </div>

--- a/app/components/shared/service_unavailable_component.rb
+++ b/app/components/shared/service_unavailable_component.rb
@@ -4,8 +4,4 @@ class ServiceUnavailableComponent < ViewComponent::Base
   def title_content
     HostingEnvironment.sandbox_mode? ? t('service_unavailable.sandbox_title') : t('service_unavailable.title')
   end
-
-  def downtime_content
-    HostingEnvironment.sandbox_mode? ? t('service_unavailable.sandbox_downtime') : t('service_unavailable.downtime')
-  end
 end

--- a/config/locales/service_unavailable.yml
+++ b/config/locales/service_unavailable.yml
@@ -1,7 +1,5 @@
 en:
   service_unavailable:
     sandbox_title: Sorry, the sandbox is unavailable
-    sandbox_downtime: You will be able to use the sandbox from 9am on Tuesday 25 May.
     title: Sorry, this service is unavailable
-    downtime: You will be able to use this service from 9am on Wednesday 26 May.
     body: If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.

--- a/spec/components/utility/service_unavailable_component_spec.rb
+++ b/spec/components/utility/service_unavailable_component_spec.rb
@@ -7,17 +7,9 @@ RSpec.describe ServiceUnavailableComponent do
     expect(result.text).to include('Sorry, this service is unavailable')
   end
 
-  it 'renders the page downtime' do
-    expect(result.text).to include('use this service')
-  end
-
   context 'when the hosting environment is sandbox', sandbox: true do
     it 'renders the page title' do
       expect(result.text).to include('Sorry, the sandbox is unavailable')
-    end
-
-    it 'renders the page downtime', sandbox: true do
-      expect(result.text).to include('use the sandbox')
     end
   end
 end


### PR DESCRIPTION
## Context

In the event of an incident we'd like to have a generic maintenance page to set. The current page content we have is very specific to a previous planned maintenance window. Remove that content

## Changes proposed in this pull request

Remove irrelevant downtime content

<img width="850" alt="Screenshot 2021-09-22 at 20 00 31" src="https://user-images.githubusercontent.com/2732945/134405418-96aabefd-7c92-4e87-bbc4-20db9d2f5da6.png">


## Guidance to review

We're creating a similar page to route to when the containers go down as well

## Link to Trello card

https://trello.com/c/LhWCWZiq/4266-update-service-maintenance-page

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
