### PR TITLE
Handle unconditional offers in all offer emails

### DIFF
--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -4,7 +4,11 @@ Dear <%= @application_form.first_name %>,
 
 You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
-<%= render "candidate_mailer/offer_conditions" %>
+<% if @conditions.blank? %>
+  They’ll let you know if they need further information before you can start training.
+<% else %>
+  <%= render "candidate_mailer/offer_conditions" %>
+<% end %>
 
 Contact <%= @provider_name %> if you have any questions about this.
 

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -4,7 +4,11 @@ Dear <%= @application_form.first_name %>,
 
 You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
-<%= render "candidate_mailer/offer_conditions" %>
+<% if @conditions.blank? %>
+  They’ll let you know if they need further information before you can start training.
+<% else %>
+  <%= render "candidate_mailer/offer_conditions" %>
+<% end %>
 
 Contact <%= @provider_name %> if you have any questions about this.
 


### PR DESCRIPTION
## Context

The `single_offer` and `multiple_offers` candidate email templates were missing logic which accounted for unconditional offers.
Apply the same logic as the `decisions_pending` email template.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Apply the same logic around rendering conditions in single and multiple offer email templates as we do in the pending decision email template.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

- Single offer : https://apply-for-te-4292-some--h8e1ff.herokuapp.com/rails/mailers/candidate_mailer/new_offer_single_offer
- Multiple offers : https://apply-for-te-4292-some--h8e1ff.herokuapp.com/rails/mailers/candidate_mailer/new_offer_multiple_offers

#### Before

![image](https://user-images.githubusercontent.com/93511/134495978-03a6d88b-b596-44ed-bc9d-0324cee08059.png)


#### After

![image](https://user-images.githubusercontent.com/93511/134496045-ab3f97cd-7a71-4ccb-bad3-6323efa96938.png)


<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/KNX1ZfHd/4292-some-unconditional-offer-emails-render-text-about-conditions
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
