### PR TITLE
Test data: always fast_forward by at least 1 day

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -542,7 +542,7 @@ private
 
     # We want to spread out actions that happen on an application over time. This ensures we don't use up
     # the entire time budget in one go, and that we have a good chance of jumping forward a bit
-    time_to_jump = [rand(0..2), rand(1..@time_budget)].min
+    time_to_jump = [rand(1..2), rand(1..@time_budget)].min
 
     @time_budget -= time_to_jump
     @time = time + time_to_jump.days


### PR DESCRIPTION
This caused problems when we wanted to create an apply 2 test
application in the offer state. The original A1 application needed to
exist and have been rejected, but it was possible for it to have been
created_at at the same second as the A2 application receiving the offer.
This triggered an OfferValidation error: "You cannot make an offer
because you can only do so for the most recent application"

Failing build:
https://github.com/DFE-Digital/apply-for-teacher-training/pull/5625/checks?check_run_id=3677159485