### PR TITLE
remove guidance about references taking 8 days

### DIFF
--- a/app/components/candidate_interface/references_guidance_component.html.erb
+++ b/app/components/candidate_interface/references_guidance_component.html.erb
@@ -6,6 +6,6 @@
   <p class="govuk-body">Select the 2 references you want to include in your application.</p>
 <% else %>
   <p class="govuk-body">Your application needs to include 2 references.</p>
-  <p class="govuk-body">It takes 8 days to get a reference on average. You can request as many references as you like to increase the chances of getting 2 quickly.</p>
+  <p class="govuk-body">You can request as many references as you like to increase the chances of getting 2 quickly.</p>
   <p class="govuk-body">Once you’ve received 2 or more references, you can select the 2 you want to include in your application.</p>
 <% end %>

--- a/spec/system/candidate_interface/references/candidate_adds_a_new_reference_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adds_a_new_reference_spec.rb
@@ -107,7 +107,7 @@ RSpec.feature 'References' do
   end
 
   def then_i_should_see_the_references_section
-    expect(page).to have_content 'It takes 8 days to get a reference on average.'
+    expect(page).to have_content 'Your application needs to include 2 references.'
   end
 
   def when_i_click_through_to_add_my_references

--- a/spec/system/candidate_interface/references/candidate_submits_an_application_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_submits_an_application_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature 'Submitting an application' do
 
   def then_i_can_see_references_are_in_progress
     visit candidate_interface_application_form_path
-    expect(page).to have_content('It takes 8 days to get a reference on average. You can request as many references as you like to increase the chances of getting 2 quickly.')
+    expect(page).to have_content('You can request as many references as you like to increase the chances of getting 2 quickly.')
     within(all('.govuk-list')[0]) do
       expect(page).to have_content("#{@reference1.name}: Awaiting response")
       expect(page).to have_content("#{@reference2.name}: Awaiting response")
@@ -57,7 +57,7 @@ RSpec.feature 'Submitting an application' do
   end
 
   def then_i_can_see_references_are_incomplete
-    expect(page).to have_content('It takes 8 days to get a reference on average. You can request as many references as you like to increase the chances of getting 2 quickly.')
+    expect(page).to have_content('You can request as many references as you like to increase the chances of getting 2 quickly.')
     within(all('.app-task-list')[2]) do
       expect(page).to have_content('Cannot start yet')
     end


### PR DESCRIPTION
wasn't always clear for users, and they weren't reading it anyway


