### PR TITLE
Fix GenerateTestApplications for the 2022 cycle

### DIFF
--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -4,46 +4,49 @@ class GenerateTestApplications
   def perform
     raise 'You cannot generate test data in production' if HostingEnvironment.production?
 
-    create recruitment_cycle_year: 2020, states: %i[rejected rejected]
-    create recruitment_cycle_year: 2020, states: %i[offer_withdrawn]
-    create recruitment_cycle_year: 2020, states: %i[offer_deferred]
-    create recruitment_cycle_year: 2020, states: %i[offer_deferred]
-    create recruitment_cycle_year: 2020, states: %i[declined]
-    create recruitment_cycle_year: 2020, states: %i[accepted]
-    create recruitment_cycle_year: 2020, states: %i[recruited]
-    create recruitment_cycle_year: 2020, states: %i[conditions_not_met]
-    create recruitment_cycle_year: 2020, states: %i[withdrawn]
-    create recruitment_cycle_year: 2020, states: %i[application_not_sent]
+    current_cycle = RecruitmentCycle.current_year
+    previous_cycle = RecruitmentCycle.previous_year
+
+    create recruitment_cycle_year: previous_cycle, states: %i[rejected rejected]
+    create recruitment_cycle_year: previous_cycle, states: %i[offer_withdrawn]
+    create recruitment_cycle_year: previous_cycle, states: %i[offer_deferred]
+    create recruitment_cycle_year: previous_cycle, states: %i[offer_deferred]
+    create recruitment_cycle_year: previous_cycle, states: %i[declined]
+    create recruitment_cycle_year: previous_cycle, states: %i[accepted]
+    create recruitment_cycle_year: previous_cycle, states: %i[recruited]
+    create recruitment_cycle_year: previous_cycle, states: %i[conditions_not_met]
+    create recruitment_cycle_year: previous_cycle, states: %i[withdrawn]
+    create recruitment_cycle_year: previous_cycle, states: %i[application_not_sent]
 
     # The cancelled state doesn't exist anymore, but we'll still have
     # applications from 2020 in that state.
     create recruitment_cycle_year: 2020, states: %i[cancelled]
 
-    create recruitment_cycle_year: 2021, states: %i[unsubmitted]
-    create recruitment_cycle_year: 2021, states: %i[unsubmitted], course_full: true
-    create recruitment_cycle_year: 2021, states: %i[unsubmitted_with_completed_references]
-    create recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
-    create recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
-    create recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
-    create recruitment_cycle_year: 2021, states: %i[interviewing awaiting_provider_decision offer]
-    create recruitment_cycle_year: 2021, states: %i[interviewing interviewing]
-    create recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision], apply_again: true
-    create recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision], carry_over: true
-    create recruitment_cycle_year: 2021, states: %i[offer offer]
-    create recruitment_cycle_year: 2021, states: %i[offer_changed]
-    create recruitment_cycle_year: 2021, states: %i[offer rejected]
-    create recruitment_cycle_year: 2021, states: %i[offer rejected], carry_over: true
-    create recruitment_cycle_year: 2021, states: %i[offer], apply_again: true
-    create recruitment_cycle_year: 2021, states: %i[rejected rejected]
-    create recruitment_cycle_year: 2021, states: %i[offer_withdrawn]
-    create recruitment_cycle_year: 2021, states: %i[offer_deferred]
-    create recruitment_cycle_year: 2021, states: %i[offer_deferred]
-    create recruitment_cycle_year: 2021, states: %i[declined]
-    create recruitment_cycle_year: 2021, states: %i[accepted]
-    create recruitment_cycle_year: 2021, states: %i[accepted_no_conditions]
-    create recruitment_cycle_year: 2021, states: %i[recruited]
-    create recruitment_cycle_year: 2021, states: %i[conditions_not_met]
-    create recruitment_cycle_year: 2021, states: %i[withdrawn]
+    create recruitment_cycle_year: current_cycle, states: %i[unsubmitted]
+    create recruitment_cycle_year: current_cycle, states: %i[unsubmitted], course_full: true
+    create recruitment_cycle_year: current_cycle, states: %i[unsubmitted_with_completed_references]
+    create recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
+    create recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
+    create recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
+    create recruitment_cycle_year: current_cycle, states: %i[interviewing awaiting_provider_decision offer]
+    create recruitment_cycle_year: current_cycle, states: %i[interviewing interviewing]
+    create recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision], apply_again: true
+    create recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision], carry_over: true
+    create recruitment_cycle_year: current_cycle, states: %i[offer offer]
+    create recruitment_cycle_year: current_cycle, states: %i[offer_changed]
+    create recruitment_cycle_year: current_cycle, states: %i[offer rejected]
+    create recruitment_cycle_year: current_cycle, states: %i[offer rejected], carry_over: true
+    create recruitment_cycle_year: current_cycle, states: %i[offer], apply_again: true
+    create recruitment_cycle_year: current_cycle, states: %i[rejected rejected]
+    create recruitment_cycle_year: current_cycle, states: %i[offer_withdrawn]
+    create recruitment_cycle_year: current_cycle, states: %i[offer_deferred]
+    create recruitment_cycle_year: current_cycle, states: %i[offer_deferred]
+    create recruitment_cycle_year: current_cycle, states: %i[declined]
+    create recruitment_cycle_year: current_cycle, states: %i[accepted]
+    create recruitment_cycle_year: current_cycle, states: %i[accepted_no_conditions]
+    create recruitment_cycle_year: current_cycle, states: %i[recruited]
+    create recruitment_cycle_year: current_cycle, states: %i[conditions_not_met]
+    create recruitment_cycle_year: current_cycle, states: %i[withdrawn]
 
     StateChangeNotifier.disable_notifications do
       RejectApplicationsByDefault.new.call

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -2,13 +2,19 @@ require 'rails_helper'
 
 RSpec.describe GenerateTestApplications do
   it 'generates test candidates with applications in various states', sidekiq: true do
-    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: 2020))
-    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: 2020))
+    previous_cycle = RecruitmentCycle.previous_year
+    current_cycle = RecruitmentCycle.current_year
+
+    # necessary to test 'cancelled' state
     create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: 2020))
 
-    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: 2021))
-    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: 2021))
-    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: 2021))
+    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: previous_cycle))
+    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: previous_cycle))
+    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: previous_cycle))
+
+    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: current_cycle))
+    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: current_cycle))
+    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: current_cycle))
 
     slack_request = stub_request(:post, 'https://example.com')
 


### PR DESCRIPTION
This should create applications in the current and previous cycles, so hardcoded years aren’t useful