### PR TITLE
Fix flaky Rack::Attack spec

### DIFF
--- a/spec/requests/vendor_api/throttling_spec.rb
+++ b/spec/requests/vendor_api/throttling_spec.rb
@@ -3,28 +3,19 @@ require 'rails_helper'
 RSpec.describe 'Vendor API throttling', rack_attack: true do
   include VendorAPISpecHelpers
 
-  it 'returns 429 responses when the rate limit is exceeded' do
-    VENDOR_API_MAX_REQS_PER_MINUTE.times do
-      get_api_request '/api/v1/applications?since=2021-01-01T12:00:00Z'
-    end
-
-    expect(response).to have_http_status(:success)
-
+  # Calling Rack::Attack.cache.count will increment the current request count
+  # value and return it. (The cache key is calculated according to private
+  # logic in Rack::Attack::Cache). This means we can prove whether a request
+  # was eligible for throttling by testing whether or not it bumped the count.
+  it 'counts requests to Vendor API paths' do
     get_api_request '/api/v1/applications?since=2021-01-01T12:00:00Z'
-    expect(response).to have_http_status(:too_many_requests)
 
-    Timecop.travel(1.minute.from_now) do
-      get_api_request '/api/v1/applications?since=2021-01-01T12:00:00Z'
-      expect(response).to have_http_status(:success)
-    end
+    expect(Rack::Attack.cache.count('vendor_api/ip:127.0.0.1', 1.minute)).to eq 2
   end
 
-  it 'does not apply to other paths' do
-    VENDOR_API_MAX_REQS_PER_MINUTE.times do
-      get_api_request '/provider'
-    end
-
+  it 'does not count requests to other paths' do
     get_api_request '/provider'
-    expect(response).to have_http_status(:success)
+
+    expect(Rack::Attack.cache.count('vendor_api/ip:127.0.0.1', 1.minute)).to eq 1
   end
 end


### PR DESCRIPTION
Instead of testing the limit, which was hard work and flaky, test only whether we've configured Rack::Attack correctly, and trust that it works