### PR TITLE
Allow permission setup to continue when permissions are setup by another user

### DIFF
--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -1,10 +1,12 @@
 module ProviderInterface
   class OrganisationPermissionsSetupController < ProviderInterfaceController
     before_action :require_manage_organisations_permission!
-    before_action :redirect_unless_permissions_to_setup, except: :success
+    before_action :redirect_unless_permissions_to_setup, only: :index
     before_action :restart_if_wizard_store_empty, only: %i[edit update check commit]
 
     def index
+      OrganisationPermissionsSetupWizard.new(organisation_permissions_wizard_store, {}).clear_state!
+
       permission_setup_presenter = ProviderRelationshipPermissionSetupPresenter.new(
         provider_relationship_permissions_needing_setup,
         current_provider_user,
@@ -79,7 +81,10 @@ module ProviderInterface
   private
 
     def redirect_unless_permissions_to_setup
-      redirect_to provider_interface_applications_path if provider_relationship_permissions_needing_setup.blank?
+      if provider_relationship_permissions_needing_setup.blank?
+        Sentry.capture_exception(NoPermissionsToSetUp.new)
+        redirect_to provider_interface_applications_path
+      end
     end
 
     def restart_if_wizard_store_empty
@@ -121,8 +126,8 @@ module ProviderInterface
     end
 
     def send_organisation_permissions_emails(relationships)
-      relationships.each do |permissions|
-        SendOrganisationPermissionsEmails.new(provider_user: current_provider_user, permissions: permissions).call
+      relationships.each do |relationship|
+        SendOrganisationPermissionsEmails.new(provider_user: current_provider_user, permissions: relationship).call
       end
     end
 
@@ -138,5 +143,7 @@ module ProviderInterface
                     view_safeguarding_information: [],
                     view_diversity_information: []).to_h
     end
+
+    class NoPermissionsToSetUp < StandardError; end
   end
 end

--- a/app/services/provider_interface/send_organisation_permissions_emails.rb
+++ b/app/services/provider_interface/send_organisation_permissions_emails.rb
@@ -1,9 +1,10 @@
 module ProviderInterface
   class SendOrganisationPermissionsEmails
-    def initialize(provider_user:, permissions:, provider: nil)
+    def initialize(provider_user:, permissions:, provider: nil, email_to_send: :updated)
       @provider_user = provider_user
       @permissions = permissions
       @provider = provider
+      @email_to_send = email_to_send
     end
 
     def call
@@ -14,15 +15,11 @@ module ProviderInterface
 
   private
 
-    attr_reader :permissions, :provider, :provider_user
+    attr_reader :permissions, :provider, :provider_user, :email_to_send
 
     def managing_users
       ProviderUser.joins(:provider_permissions)
         .where(ProviderPermissions.table_name => { provider: partner_organisation, manage_organisations: true })
-    end
-
-    def email_to_send
-      provider.nil? ? 'set_up' : 'updated'
     end
 
     def partner_organisation

--- a/spec/services/provider_interface/send_organisation_permissions_emails_spec.rb
+++ b/spec/services/provider_interface/send_organisation_permissions_emails_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ProviderInterface::SendOrganisationPermissionsEmails do
     let!(:ratifying_provider_users) { create_list(:provider_user, 3, providers: [ratifying_provider]) }
     let(:message_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
 
-    subject(:service) { described_class.new(provider_user: provider_user, provider: provider, permissions: permissions) }
+    subject(:service) { described_class.new(provider_user: provider_user, provider: provider, permissions: permissions, email_to_send: email_to_send) }
 
     before do
       allow(ProviderMailer).to receive(:organisation_permissions_set_up).and_return(message_delivery)
@@ -20,12 +20,14 @@ RSpec.describe ProviderInterface::SendOrganisationPermissionsEmails do
     end
 
     context 'when permissions have not been set up' do
+      let(:provider) { nil }
+      let(:email_to_send) { :set_up }
+
       let(:permissions) do
         create(:provider_relationship_permissions, :not_set_up_yet, training_provider: training_provider, ratifying_provider: ratifying_provider)
       end
 
       context 'when the user is setting up permissions on behalf of the training provider' do
-        let(:provider) { nil }
         let(:provider_user) { training_provider_users.first }
 
         it 'sends a set up email to managing users for the ratifying provider' do
@@ -38,7 +40,6 @@ RSpec.describe ProviderInterface::SendOrganisationPermissionsEmails do
       end
 
       context 'when the user is setting up permissions on behalf of the ratifying provider' do
-        let(:provider) { nil }
         let(:provider_user) { ratifying_provider_users.first }
 
         it 'sends a set up email to managing users for the training provider' do
@@ -51,7 +52,6 @@ RSpec.describe ProviderInterface::SendOrganisationPermissionsEmails do
       end
 
       context 'when the user setting up permissions belongs to both orgs in the permissions relationship' do
-        let(:provider) { nil }
         let(:provider_user) { ratifying_provider_users.first }
 
         before do
@@ -72,6 +72,8 @@ RSpec.describe ProviderInterface::SendOrganisationPermissionsEmails do
     end
 
     context 'when permissions have already been set up' do
+      let(:email_to_send) { :updated }
+
       let(:permissions) do
         create(:provider_relationship_permissions, training_provider: training_provider, ratifying_provider: ratifying_provider)
       end
@@ -104,6 +106,8 @@ RSpec.describe ProviderInterface::SendOrganisationPermissionsEmails do
     end
 
     context 'when the user changing permissions belongs to both orgs in the permissions relationship' do
+      let(:email_to_send) { :updated }
+
       let(:permissions) do
         create(:provider_relationship_permissions, training_provider: training_provider, ratifying_provider: ratifying_provider)
       end

--- a/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
@@ -31,7 +31,8 @@ RSpec.feature 'Setting up organisation permissions' do
     and_i_click_on_continue
     then_i_see_the_check_relationship_permissions_page
 
-    when_i_click_on_save_organisation_permissions
+    when_a_permission_is_set_up_before_i_save
+    and_i_click_on_save_organisation_permissions
     then_i_see_the_success_page
     and_an_email_is_sent_to_managing_users_in_the_partner_organisations
     and_the_permissions_have_been_set_up_correctly
@@ -137,7 +138,16 @@ RSpec.feature 'Setting up organisation permissions' do
     within('[data-qa="view-diversity-information"]') { check @another_training_provider.name }
   end
 
-  def when_i_click_on_save_organisation_permissions
+  def when_a_permission_is_set_up_before_i_save
+    @training_provider_relationship.update(
+      training_provider_can_make_decisions: true,
+      training_provider_can_view_safeguarding_information: true,
+      training_provider_can_view_diversity_information: true,
+      setup_at: Time.zone.now,
+    )
+  end
+
+  def and_i_click_on_save_organisation_permissions
     click_on 'Save organisation permissions'
   end
 
@@ -153,7 +163,7 @@ RSpec.feature 'Setting up organisation permissions' do
 
     @another_ratifying_provider_users.each do |user|
       open_email(user.email_address)
-      expect(current_email.subject).to have_content t('provider_mailer.organisation_permissions_set_up.subject', provider: @training_provider.name)
+      expect(current_email.subject).to have_content t('provider_mailer.organisation_permissions_updated.subject', provider: @training_provider.name)
     end
   end
 


### PR DESCRIPTION
## Context

https://trello.com/c/0mjPHTP3/4281-do-not-kick-users-out-of-the-org-permissions-setup-flow

We want to avoid users being booted out midway through permission setup if another user sets them up at the same time

## Changes proposed in this pull request

We'll no longer redirect users out of the setup flow if the permissions they're working on get set up by someone else in the background. Instead, we'll let them complete the setup, and send out 'permissions updated' emails instead to account for the change in behaviour.

## Guidance to review

It's a bit tough to review - you can try and start permissions setup for a user, and modify the DB to set those permissions up while you're still partway through the setup wizard. 
