### PR TITLE
Check if column exists when trying to remove it

### DIFF
--- a/db/migrate/20210923154118_remove_submitted_at_from_fraud_matches.rb
+++ b/db/migrate/20210923154118_remove_submitted_at_from_fraud_matches.rb
@@ -1,5 +1,5 @@
 class RemoveSubmittedAtFromFraudMatches < ActiveRecord::Migration[6.1]
   def change
-    safety_assured { remove_column :fraud_matches, :submitted_at, :datetime }
+    safety_assured { remove_column :fraud_matches, :submitted_at, :datetime, if_exists: true }
   end
 end


### PR DESCRIPTION
## Context

Deploys are failing because the column does not exist in the table. That might be due to the migrations to create and remove being in the same deploy.

## Changes proposed in this pull request

Somehow this column does not exist on the table although it seems fine when running all the migrations locally.
To not block the deploy check if it exists before removing.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
