### PR TITLE
Support: Disable add course for accepted offer applications

### DIFF
--- a/app/components/support_interface/application_add_course_component.html.erb
+++ b/app/components/support_interface/application_add_course_component.html.erb
@@ -2,6 +2,10 @@
   <p class="govuk-body">
     This candidate can add <%= application_form.maximum_number_of_course_choices %> course choices to this application.
   </p>
+<% elsif application_form.any_offer_accepted? %>
+  <p class="govuk-body">
+    This application has an accepted offer, so we can't add any more course choices.
+  </p>
 <% elsif application_form.support_cannot_add_course_choice? %>
   <p class="govuk-body">
     This application already has the maximum number of active course choices (<%= application_form.maximum_number_of_course_choices %>), so we can't add any more until the candidate withdraws one or more course choices.

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -221,6 +221,11 @@ class ApplicationForm < ApplicationRecord
       application_choices.map(&:status).map(&:to_sym).any? { |status| ApplicationStateChange::SUCCESSFUL_STATES.include?(status) }
   end
 
+  def any_offer_accepted?
+    application_choices.present? &&
+      application_choices.map(&:status).map(&:to_sym).any? { |status| ApplicationStateChange::ACCEPTED_STATES.include?(status) }
+  end
+
   def ended_without_success?
     application_choices.present? &&
       application_choices.map(&:status).map(&:to_sym).all? { |status| ApplicationStateChange::UNSUCCESSFUL_END_STATES.include?(status) }

--- a/spec/components/support_interface/application_add_course_component_spec.rb
+++ b/spec/components/support_interface/application_add_course_component_spec.rb
@@ -40,6 +40,21 @@ RSpec.describe SupportInterface::ApplicationAddCourseComponent do
     end
   end
 
+  context 'application has an accepted offer' do
+    it "does not render the 'add a course' button" do
+      application_form = create(:completed_application_form)
+
+      create_list(:submitted_application_choice, 2, application_form_id: application_form.id)
+      create(:application_choice, :with_accepted_offer, application_form_id: application_form.id)
+
+      application_form.reload
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-button').text).not_to include('Add a course')
+    end
+  end
+
   context 'application is unsubmitted and has less than three application choices' do
     it "does not render the 'add a course' button" do
       application_form = create(:application_form)

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -541,6 +541,22 @@ RSpec.describe ApplicationForm do
     end
   end
 
+  describe '#any_offer_accepted?' do
+    it 'returns false if there is no accepted offer on any of the application choices' do
+      offer_choice = create(:application_choice, :with_offer)
+      other_choice = create(:application_choice, :withdrawn)
+      application_form = create(:completed_application_form, application_choices: [offer_choice, other_choice])
+      expect(application_form.any_offer_accepted?).to eq(false)
+    end
+
+    it 'returns true if there is an application choice with an accepted offer' do
+      accepted_offer_choice = create(:application_choice, :with_accepted_offer)
+      other_choice = create(:application_choice, :with_rejection)
+      application_form = create(:completed_application_form, application_choices: [accepted_offer_choice, other_choice])
+      expect(application_form.any_offer_accepted?).to eq(true)
+    end
+  end
+
   describe '#all_provider_decisions_made?' do
     it 'returns false if the application choices are in awaiting provider decision state' do
       application_choice = create :submitted_application_choice


### PR DESCRIPTION
## Context
It's not possible to add courses to accepted offer applications, so the button is just broken at the moment

## Changes proposed in this pull request
Hide the button and show an explanation for why courses cannot be added to an application

## Link to Trello card

https://trello.com/c/tU9nUB1E/4286-prevent-new-courses-being-added-to-an-application-on-the-support-console-when-an-offer-has-been-accepted-by-the-candidate

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
