### PR TITLE
Disable editing in support when subsequent application exists

### DIFF
--- a/app/components/shared/degree_qualification_cards_component.html.erb
+++ b/app/components/shared/degree_qualification_cards_component.html.erb
@@ -33,7 +33,7 @@
                 </dd>
               <% end %>
             <% end %>
-            <% if in_support_console? %>
+            <% if editable? %>
               <br>
               <%= govuk_link_to 'Change', support_interface_application_form_edit_degree_path(degree_id: degree.id) %>
             <% end %>

--- a/app/components/shared/degree_qualification_cards_component.rb
+++ b/app/components/shared/degree_qualification_cards_component.rb
@@ -1,16 +1,16 @@
 # NOTE: This component is used by both provider and support UIs
 class DegreeQualificationCardsComponent < ViewComponent::Base
-  include ApplicationHelper
   include ViewHelper
 
   attr_reader :degrees, :application_choice_state, :show_hesa_codes
 
   alias show_hesa_codes? show_hesa_codes
 
-  def initialize(degrees, application_choice_state: nil, show_hesa_codes: false)
+  def initialize(degrees, application_choice_state: nil, show_hesa_codes: false, editable: false)
     @degrees = degrees
     @application_choice_state = application_choice_state
     @show_hesa_codes = show_hesa_codes
+    @editable = editable
   end
 
   def section_title
@@ -71,7 +71,7 @@ private
     degree.institution_name
   end
 
-  def in_support_console?
-    current_namespace == 'support_interface'
+  def editable?
+    @editable
   end
 end

--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -49,7 +49,7 @@
               <% end %>
             </dl>
           <% end %>
-          <% if in_support_console? %>
+          <% if editable? %>
             <br>
             <%= govuk_link_to 'Change', support_interface_application_form_edit_gcse_path(gcse_id: qualification.id) %>
           <% end %>

--- a/app/components/shared/gcse_qualification_cards_component.rb
+++ b/app/components/shared/gcse_qualification_cards_component.rb
@@ -1,12 +1,12 @@
 # NOTE: This component is used by both provider and support UIs
 class GcseQualificationCardsComponent < ViewComponent::Base
-  include ApplicationHelper
   include ViewHelper
 
   attr_reader :application_form
 
-  def initialize(application_form)
+  def initialize(application_form, editable: false)
     @application_form = application_form
+    @editable = editable
   end
 
   def maths
@@ -94,7 +94,7 @@ class GcseQualificationCardsComponent < ViewComponent::Base
     end
   end
 
-  def in_support_console?
-    current_namespace == 'support_interface'
+  def editable?
+    @editable
   end
 end

--- a/app/components/shared/qualifications_component.html.erb
+++ b/app/components/shared/qualifications_component.html.erb
@@ -1,8 +1,13 @@
 <section class="app-section">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="qualifications">Qualifications</h2>
 
-  <%= render DegreeQualificationCardsComponent.new(application_form.application_qualifications.degrees, application_choice_state: application_choice_state, show_hesa_codes: show_hesa_codes) %>
-  <%= render GcseQualificationCardsComponent.new(application_form) %>
+  <%= render DegreeQualificationCardsComponent.new(
+    application_form.application_qualifications.degrees,
+    application_choice_state: application_choice_state,
+    show_hesa_codes: show_hesa_codes,
+    editable: editable?,
+  ) %>
+  <%= render GcseQualificationCardsComponent.new(application_form, editable: editable?) %>
   <%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.other, header: 'Other qualifications') %>
   <%= render EflQualificationCardComponent.new(application_form) %>
 </section>

--- a/app/components/shared/qualifications_component.rb
+++ b/app/components/shared/qualifications_component.rb
@@ -1,5 +1,7 @@
 # NOTE: This component is used by both provider and support UIs
 class QualificationsComponent < ViewComponent::Base
+  include ApplicationHelper
+
   attr_reader :application_form, :application_choice_state, :show_hesa_codes
 
   alias show_hesa_codes? show_hesa_codes
@@ -8,5 +10,9 @@ class QualificationsComponent < ViewComponent::Base
     @application_form = application_form
     @application_choice_state = application_choice_state
     @show_hesa_codes = show_hesa_codes
+  end
+
+  def editable?
+    application_form.editable? && current_namespace == 'support_interface'
   end
 end

--- a/app/components/support_interface/application_add_course_component.html.erb
+++ b/app/components/support_interface/application_add_course_component.html.erb
@@ -2,6 +2,10 @@
   <p class="govuk-body">
     This candidate can add <%= application_form.maximum_number_of_course_choices %> course choices to this application.
   </p>
+<% elsif !application_form.editable? %>
+  <p class="govuk-body">
+    This candidate has a subsequent application, so we can't add any more course choices to this application.
+  </p>
 <% elsif application_form.any_offer_accepted? %>
   <p class="govuk-body">
     This application has an accepted offer, so we can't add any more course choices.

--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -187,6 +187,8 @@ module SupportInterface
     end
 
     def status_action_link
+      return {} unless @application_choice.application_form.editable?
+
       if FeatureFlag.active?(:support_user_reinstate_offer) && application_choice.declined? && !application_choice.declined_by_default
         {
           action: {

--- a/app/components/support_interface/personal_details_component.rb
+++ b/app/components/support_interface/personal_details_component.rb
@@ -39,58 +39,78 @@ module SupportInterface
   private
 
     def first_name_row
-      {
+      row = {
         key: 'First name',
         value: first_name,
+      }
+      return row unless editable?
+
+      row.merge(
         action: {
           href: support_interface_application_form_edit_applicant_details_path(application_form),
           visually_hidden_text: 'first name',
         },
-      }
+      )
     end
 
     def last_name_row
-      {
+      row = {
         key: 'Last name',
         value: last_name,
+      }
+      return row unless editable?
+
+      row.merge(
         action: {
           href: support_interface_application_form_edit_applicant_details_path(application_form),
           visually_hidden_text: 'last name',
         },
-      }
+      )
     end
 
     def email_row
-      {
+      row = {
         key: 'Email address',
         value: govuk_mail_to(email_address, email_address),
+      }
+      return row unless editable?
+
+      row.merge(
         action: {
           href: support_interface_application_form_edit_applicant_details_path(application_form),
           visually_hidden_text: 'email address',
         },
-      }
+      )
     end
 
     def phone_number_row
-      {
+      row = {
         key: 'Phone number',
         value: phone_number || MISSING,
+      }
+      return row unless editable?
+
+      row.merge(
         action: {
           href: support_interface_application_form_edit_applicant_details_path(application_form),
           visually_hidden_text: 'phone number',
         },
-      }
+      )
     end
 
     def nationality_row
-      {
+      row = {
         key: 'Nationality',
         value: application_form.nationalities.to_sentence(last_word_connector: ' and '),
+      }
+      return row unless editable?
+
+      row.merge(
         action: {
           href: support_interface_application_form_edit_nationalities_path(application_form),
           visually_hidden_text: 'nationality',
         },
-      }
+      )
     end
 
     def domicile_row
@@ -103,49 +123,65 @@ module SupportInterface
     def right_to_work_or_study_row
       return if application_form.right_to_work_or_study.blank?
 
-      {
+      row = {
         key: 'Has the right to work or study in the UK?',
         value: RIGHT_TO_WORK_OR_STUDY_DISPLAY_VALUES.fetch(application_form.right_to_work_or_study),
+      }
+      return row unless editable?
+
+      row.merge(
         action: {
           href: support_interface_application_form_edit_right_to_work_or_study_path(application_form),
           visually_hidden_text: 'right to work or study',
         },
-      }
+      )
     end
 
     def residency_details_row
       return unless application_form.right_to_work_or_study == 'yes'
 
-      {
+      row = {
         key: 'Residency details',
         value: application_form.right_to_work_or_study_details,
+      }
+      return row unless editable?
+
+      row.merge(
         action: {
           href: support_interface_application_form_edit_right_to_work_or_study_path(application_form),
           visually_hidden_text: 'residency details',
         },
-      }
+      )
     end
 
     def date_of_birth_row
-      {
+      row = {
         key: 'Date of birth',
         value: application_form.date_of_birth ? application_form.date_of_birth.to_s(:govuk_date) : MISSING,
+      }
+      return row unless editable?
+
+      row.merge(
         action: {
           href: support_interface_application_form_edit_applicant_details_path(application_form),
           visually_hidden_text: 'date of birth',
         },
-      }
+      )
     end
 
     def address_row
-      {
+      row = {
         key: 'Address',
         value: full_address,
+      }
+      return row unless editable?
+
+      row.merge(
         action: {
           href: support_interface_application_form_edit_address_type_path(application_form),
           visually_hidden_text: 'address',
         },
-      }
+      )
     end
 
     def full_address
@@ -167,5 +203,9 @@ module SupportInterface
     end
 
     attr_reader :application_form
+
+    def editable?
+      application_form.editable?
+    end
   end
 end

--- a/app/components/support_interface/reference_with_feedback_component.html.erb
+++ b/app/components/support_interface/reference_with_feedback_component.html.erb
@@ -1,7 +1,7 @@
 <div data-qa="reference">
   <%= render SummaryCardComponent.new(rows: rows, editable: true) do %>
     <%= render(SummaryCardHeaderComponent.new(title: title, heading_level: 3)) do %>
-      <% if reference.feedback_refused? %>
+      <% if @editable && reference.feedback_refused? %>
         <div class='app-summary-card__actions'>
           <%= govuk_link_to support_interface_reinstate_reference_path(reference) do %>
           Undo refusal<span class="govuk-visually-hidden"> for <%= reference.name %></span>

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -10,9 +10,10 @@ module SupportInterface
              :consent_to_be_contacted,
              to: :reference
 
-    def initialize(reference:, reference_number:)
+    def initialize(reference:, reference_number:, editable:)
       @reference = reference
       @reference_number = reference_number
+      @editable = editable
     end
 
     def rows
@@ -112,44 +113,60 @@ module SupportInterface
     end
 
     def name_row
-      {
+      row = {
         key: 'Name',
         value: name,
+      }
+      return row unless @editable
+
+      row.merge(
         action: {
           href: support_interface_application_form_edit_reference_details_path(reference.application_form, reference),
         },
-      }
+      )
     end
 
     def email_address_row
-      {
+      row = {
         key: 'Email address',
         value: email_address,
+      }
+      return row unless @editable
+
+      row.merge(
         action: {
           href: support_interface_application_form_edit_reference_details_path(reference.application_form, reference),
         },
-      }
+      )
     end
 
     def relationship_row
-      {
+      row = {
         key: 'Relationship to candidate',
         value: relationship,
+      }
+      return row unless @editable
+
+      row.merge(
         action: {
           href: support_interface_application_form_edit_reference_details_path(reference.application_form, reference),
         },
-      }
+      )
     end
 
     def feedback_row
-      {
+      row = {
         key: 'Reference',
         value: feedback,
+      }
+      return row unless @editable
+
+      row.merge(
         action: {
           href: support_interface_application_form_edit_reference_feedback_path(reference.application_form, reference),
           visually_hidden_text: 'feedback',
         },
-      }
+      )
     end
 
     def consent_row

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -302,6 +302,10 @@ class ApplicationForm < ApplicationRecord
     end
   end
 
+  def editable?
+    subsequent_application_form.blank?
+  end
+
   def contains_course?(course)
     potential_course_option_ids = CourseOption.where(course_id: course.id).map(&:id)
     current_course_option_ids = application_choices.map(&:course_option_id)

--- a/app/views/support_interface/application_forms/_application_navigation.html.erb
+++ b/app/views/support_interface/application_forms/_application_navigation.html.erb
@@ -20,6 +20,15 @@
   </div>
 </div>
 
+<% unless @application_form.editable? %>
+  <%= govuk_notification_banner(title_text: t('notification_banner.info')) do |notification_banner| %>
+    <% notification_banner.heading(text: 'Candidate has a more recent application') %>
+    <p class="govuk-body">This application can no longer be edited as the candidate has applied again. Edit the
+      more recent application instead of this one</p>
+    <p class="govuk-body"><%= govuk_link_to 'More recent application', support_interface_application_form_path(@application_form.subsequent_application_form) %></p>
+  <% end %>
+<% end %>
+
 <%= render TabNavigationComponent.new(items: [
   { name: 'Details', url: support_interface_application_form_path(@application_form) },
   { name: 'History', url: support_interface_application_form_audit_path(@application_form) },

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -45,7 +45,7 @@
 
 <%= render LanguageSkillsComponent.new(application_form: @application_form) %>
 
-<%= render PersonalStatementComponent.new(application_form: @application_form, editable: true) %>
+<%= render PersonalStatementComponent.new(application_form: @application_form, editable: @application_form.editable?) %>
 
 <%= render InterviewPreferencesComponent.new(application_form: @application_form) %>
 

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -27,7 +27,7 @@
 
 <% if @application_form.application_references.any? %>
   <% @application_form.application_references.includes(%i[application_form audits]).each_with_index do |reference, i| %>
-    <%= render SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: i + 1) %>
+    <%= render SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: i + 1, editable: @application_form.editable?) %>
   <% end %>
 <% end %>
 

--- a/spec/components/support_interface/application_add_course_component_spec.rb
+++ b/spec/components/support_interface/application_add_course_component_spec.rb
@@ -40,6 +40,20 @@ RSpec.describe SupportInterface::ApplicationAddCourseComponent do
     end
   end
 
+  context 'candidate has a subsequent application' do
+    it "does not render the 'add a course' button" do
+      application_form = create(:completed_application_form)
+
+      create(:completed_application_form, previous_application_form: application_form)
+
+      application_form.reload
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-button').text).not_to include('Add a course')
+    end
+  end
+
   context 'application has an accepted offer' do
     it "does not render the 'add a course' button" do
       application_form = create(:completed_application_form)

--- a/spec/components/support_interface/personal_details_component_spec.rb
+++ b/spec/components/support_interface/personal_details_component_spec.rb
@@ -53,6 +53,28 @@ RSpec.describe SupportInterface::PersonalDetailsComponent do
     expect(result.text).not_to include('Residency details')
   end
 
+  it 'shows change links' do
+    expect(result.css('a').first.text).to eq('Change first name')
+  end
+
+  context 'when the application form has a subsequent application' do
+    let(:application_form) do
+      create(
+        :completed_application_form,
+        support_reference: 'AB123',
+        date_of_birth: Date.new(2000, 1, 1),
+        first_nationality: 'British',
+        second_nationality: 'Irish',
+        third_nationality: 'Spanish',
+      )
+    end
+    let!(:subsequent_application_form) { create(:application_form, previous_application_form: application_form) }
+
+    it 'does not shows change links' do
+      expect(result.css('a').text).not_to include('Change')
+    end
+  end
+
   context 'a candidate whose nationality is neither British or Irish' do
     let(:application_form) do
       build_stubbed(

--- a/spec/components/support_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/support_interface/reference_with_feedback_component_spec.rb
@@ -3,58 +3,79 @@ require 'rails_helper'
 RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
   include CandidateHelper
 
+  let(:reference) { create(:reference) }
+  let(:editable) { true }
+
+  subject! { render_inline(described_class.new(reference: reference, reference_number: 1, editable: editable)) }
+
+  context 'when editable' do
+    it 'shows change links' do
+      expect(page).to have_selector('a', text: 'Change')
+    end
+  end
+
+  context 'when not editable' do
+    let(:editable) { false }
+
+    it 'shows change links' do
+      expect(page).not_to have_selector('a', text: 'Change')
+    end
+  end
+
   describe 'Undo refusal link' do
+    let(:reference) { create(:reference, feedback_status: 'feedback_refused') }
+
     it 'is present when the reference is refused' do
-      reference = create(:reference, feedback_status: 'feedback_refused')
-
-      render_inline(described_class.new(reference: reference, reference_number: 1))
-
       expect(rendered_component).to include('Undo refusal')
+    end
+
+    context 'when not editable' do
+      let(:editable) { false }
+
+      it 'is not present' do
+        expect(rendered_component).not_to include('Undo refusal')
+      end
     end
   end
 
   describe 'title' do
     it 'includes the supplied reference number' do
-      reference = create(:reference)
-
-      render_inline(described_class.new(reference: reference, reference_number: 1))
-
       expect(rendered_component).to include('1st reference')
     end
 
-    it 'says if the reference is a replacement' do
-      reference = create(:reference, replacement: true)
-
-      render_inline(described_class.new(reference: reference, reference_number: 1))
-
-      expect(rendered_component).to include('(replacement)')
+    it 'includes the id of the reference' do
+      expect(rendered_component).to include("##{reference.id}")
     end
 
-    it 'includes the id of the reference' do
-      reference = create(:reference)
+    context 'when a reference is a replacement' do
+      let(:reference) { create(:reference, replacement: true) }
 
-      render_inline(described_class.new(reference: reference, reference_number: 1))
-
-      expect(rendered_component).to include("##{reference.id}")
+      it 'says that the reference is a replacement' do
+        expect(rendered_component).to include('(replacement)')
+      end
     end
   end
 
   describe 'selected row' do
-    it 'indicates selected when the reference is selected' do
-      reference = create(:reference, selected: true)
-      render_inline(described_class.new(reference: reference, reference_number: 1))
+    let(:reference) { create(:reference, selected: selected) }
 
-      within_summary_row('Selected?') do
-        expect(page).to include 'Yes'
+    context 'when the reference is selected' do
+      let(:selected) { true }
+
+      it 'indicates selected' do
+        within_summary_row('Selected?') do
+          expect(page).to include 'Yes'
+        end
       end
     end
 
-    it 'indicates not selected when the reference is not selected' do
-      reference = create(:reference, selected: false)
-      render_inline(described_class.new(reference: reference, reference_number: 1))
+    context 'when the reference is not selected' do
+      let(:selected) { false }
 
-      within_summary_row('Selected?') do
-        expect(page).to include 'No'
+      it 'indicates not selected' do
+        within_summary_row('Selected?') do
+          expect(page).to include 'No'
+        end
       end
     end
   end


### PR DESCRIPTION
## Context
We currently allow editing of details on any application form in support. When a candidate has an apply 1 form followed by an apply 2 form, we generally want to only edit the latest entry as their old form is no longer relevant.

## Changes proposed in this pull request
Hide edit links in support on an application form when the application is not the latest one in the chain.

Add a banner to the application page in support to explain why the application is no longer editable
<img width="1130" alt="Screenshot 2021-09-30 at 09 24 28" src="https://user-images.githubusercontent.com/30071178/135415785-ba38e954-68c7-46b4-82de-b2f1abefa462.png">


## Guidance to review
Per commit.
Does the logic make sense?
Are there any cases I've missed here?

## Link to Trello card
https://trello.com/c/UNpmwpgT/4287-prevent-changes-being-made-to-an-applicants-application-in-apply1-when-they-have-an-application-in-apply2

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
