### PR TITLE
Remove validation for O Levels

### DIFF
--- a/app/forms/candidate_interface/english_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/english_gcse_grade_form.rb
@@ -256,7 +256,6 @@ module CandidateInterface
     def invalid_grades
       {
         gcse: /[^1-9A-GU*\s\-]/i,
-        gce_o_level: /[^A-EU\s\-]/i,
         scottish_national_5: /[^A-D1-7\s\-]/i,
       }
     end

--- a/app/forms/candidate_interface/maths_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/maths_gcse_grade_form.rb
@@ -59,7 +59,6 @@ module CandidateInterface
     def invalid_grades
       {
         gcse: /[^1-9A-GU*\s\-]/i,
-        gce_o_level: /[^A-EU\s\-]/i,
         scottish_national_5: /[^A-D1-7\s\-]/i,
       }
     end

--- a/app/forms/candidate_interface/science_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/science_gcse_grade_form.rb
@@ -111,7 +111,8 @@ module CandidateInterface
 
       if %w[gce_o_level scottish_national_5 gcse].include?(qualification.qualification_type) && subject == ApplicationQualification::SCIENCE
         qualification_rexp = invalid_grades[qualification.qualification_type.to_sym]
-        errors.add(:grade, :invalid) if grade.match(qualification_rexp)
+
+        errors.add(:grade, :invalid) if qualification_rexp && grade.match(qualification_rexp)
       end
 
       if gsce_qualification_type? && single_award?
@@ -154,7 +155,6 @@ module CandidateInterface
     def invalid_grades
       {
         gcse: /[^1-9A-GU*\s\-]/i,
-        gce_o_level: /[^A-EU\s\-]/i,
         scottish_national_5: /[^A-D1-7\s\-]/i,
       }
     end

--- a/spec/forms/candidate_interface/english_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/english_gcse_grade_form_spec.rb
@@ -67,25 +67,14 @@ RSpec.describe CandidateInterface::EnglishGcseGradeForm, type: :model do
       let(:qualification) { build_stubbed(:application_qualification, qualification_type: 'gce_o_level', level: 'gcse', subject: 'english') }
       let(:form) { described_class.build_from_qualification(qualification) }
 
-      it 'returns no errors if grade is valid' do
-        valid_grades = ['ABC', 'AB', 'AA', 'abc', 'A B C', 'A-B-C']
+      it 'allows any value for the grade' do
+        valid_grades = ['ABC', 'AB', 'AA', 'abc', 'A B C', 'A-B-C', '6', 'O']
 
         valid_grades.each do |grade|
           form.grade = grade
           form.validate(:grade)
 
           expect(form.errors[:grade]).to be_empty
-        end
-      end
-
-      it 'return validation error if grade is invalid' do
-        invalid_grades = %w[123 A* XYZ]
-
-        invalid_grades.each do |grade|
-          form.grade = grade
-          form.validate(:grade)
-
-          expect(form.errors[:grade]).to include('Enter a real grade')
         end
       end
     end

--- a/spec/forms/candidate_interface/maths_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/maths_gcse_grade_form_spec.rb
@@ -55,25 +55,14 @@ RSpec.describe CandidateInterface::MathsGcseGradeForm, type: :model do
     context 'when qualification type is GCE O LEVEL' do
       let(:form) { described_class.new(qualification_type: 'gce_o_level') }
 
-      it 'returns no errors if grade is valid' do
-        valid_grades = ['ABC', 'AB', 'AA', 'abc', 'A B C', 'A-B-C']
+      it 'allows any value for the grade' do
+        valid_grades = ['ABC', 'AB', 'AA', 'abc', 'A B C', 'A-B-C', '6', 'O']
 
         valid_grades.each do |grade|
           form.grade = grade
           form.validate
 
           expect(form.errors[:grade]).to be_empty
-        end
-      end
-
-      it 'return validation error if grade is invalid' do
-        invalid_grades = %w[123 A* XYZ]
-
-        invalid_grades.each do |grade|
-          form.grade = grade
-          form.validate(:grade)
-
-          expect(form.errors[:grade]).to include('Enter a real grade')
         end
       end
     end

--- a/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
@@ -174,25 +174,14 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
       let(:qualification) { FactoryBot.build_stubbed(:application_qualification, qualification_type: 'gce_o_level', level: 'gcse', subject: 'science') }
       let(:form) { described_class.build_from_qualification(qualification) }
 
-      it 'returns no errors if grade is valid' do
-        valid_grades = ['ABC', 'AB', 'AA', 'abc', 'A B C', 'A-B-C']
+      it 'allows any value for the grade' do
+        valid_grades = ['ABC', 'AB', 'AA', 'abc', 'A B C', 'A-B-C', '6', 'O']
 
         valid_grades.each do |grade|
           form.grade = grade
           form.validate
 
           expect(form.errors[:grade]).to be_empty
-        end
-      end
-
-      it 'return validation error if grade is invalid' do
-        invalid_grades = %w[123 A* XYZ]
-
-        invalid_grades.each do |grade|
-          form.grade = grade
-          form.validate
-
-          expect(form.errors[:grade]).to include('Enter a real science grade')
         end
       end
     end


### PR DESCRIPTION
## Context

A candidate reported being unable to put in valid O level grades. 

## Changes proposed in this pull request

We are incorrectly limiting the values a candidate can enter into O level grades. Remove the validation for now.

## Guidance to review

Discussed in slack: https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1632745162285200

## Link to Trello card

https://trello.com/c/lTCAfvCr/791-apply-for-teacher-training-o-level-grade-not-accepted-by-form

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
