### PR TITLE
Add missing calls to `deliver_later` on mailer methods

### DIFF
--- a/app/workers/start_of_cycle_notification_worker.rb
+++ b/app/workers/start_of_cycle_notification_worker.rb
@@ -8,7 +8,7 @@ class StartOfCycleNotificationWorker
     providers_scope.limit(fetch_limit).each do |provider|
       provider.provider_users.each do |provider_user|
         unless ChaserSent.exists?(chased: provider_user, chaser_type: mailer_method)
-          ProviderMailer.send(mailer_method, provider_user)
+          ProviderMailer.send(mailer_method, provider_user).deliver_later
           ChaserSent.create!(chased: provider_user, chaser_type: mailer_method)
         end
 
@@ -22,7 +22,7 @@ class StartOfCycleNotificationWorker
         partner_organisations = relationships_pending.map { |relationship| relationship.partner_organisation(provider) }.compact
 
         if partner_organisations.any?
-          ProviderMailer.send(setup_mailer_method, provider_user, partner_organisations)
+          ProviderMailer.send(setup_mailer_method, provider_user, partner_organisations).deliver_later
           ChaserSent.create!(chased: provider_user, chaser_type: setup_mailer_method)
         end
       end

--- a/spec/workers/start_of_cycle_notification_worker_spec.rb
+++ b/spec/workers/start_of_cycle_notification_worker_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe StartOfCycleNotificationWorker do
   describe '#perform' do
+    let(:mailer_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
     let(:providers_needing_set_up) { %w[AAA BBB].map { |name| create(:provider, :with_signed_agreement, name: name) } }
     let(:provider_users_who_need_to_set_up_permissions) do
       create_list(:provider_user, 2, providers: providers_needing_set_up)
@@ -30,9 +31,9 @@ RSpec.describe StartOfCycleNotificationWorker do
     end
 
     before do
-      allow(ProviderMailer).to receive(:apply_service_is_now_open)
-      allow(ProviderMailer).to receive(:find_service_is_now_open)
-      allow(ProviderMailer).to receive(:set_up_organisation_permissions)
+      allow(ProviderMailer).to receive(:apply_service_is_now_open).and_return(mailer_delivery)
+      allow(ProviderMailer).to receive(:find_service_is_now_open).and_return(mailer_delivery)
+      allow(ProviderMailer).to receive(:set_up_organisation_permissions).and_return(mailer_delivery)
       provider_users_who_need_to_set_up_permissions.map { |user| user.provider_permissions.update_all(manage_organisations: true) }
       other_provider_users.map { |user| user.provider_permissions.update_all(manage_organisations: true) }
       providers_needing_set_up.each { |provider| create(:provider_relationship_permissions, :not_set_up_yet, training_provider: provider) }


### PR DESCRIPTION
## Context

Omitted in https://github.com/DFE-Digital/apply-for-teacher-training/pull/5593

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Call `deliver_later` on mailer methods otherwise no emails get enqueued :)
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/WTnGjL50/4274-spike-investigate-prototype-scheduling-of-staggered-provider-user-emails

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
