### PR TITLE
Bug fix not required degree courses need conditon

### DIFF
--- a/app/components/candidate_interface/degree_required_component.rb
+++ b/app/components/candidate_interface/degree_required_component.rb
@@ -11,6 +11,7 @@ class CandidateInterface::DegreeRequiredComponent < ViewComponent::Base
     'two_one' => 4,
     'two_two' => 3,
     'third_class' => 2,
+    'not_required' => 1,
   }.freeze
 
   COURSE_REQUIRED_GRADE_TEXT = {

--- a/spec/components/candidate_interface/degree_required_component_spec.rb
+++ b/spec/components/candidate_interface/degree_required_component_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.describe CandidateInterface::DegreeRequiredComponent, type: :component do
   let(:application_form) { create(:application_form) }
 
-  let(:course_option1) { create(:course_option, course: create(:course, :open_on_apply, degree_grade: 'two_one')) }
+  let(:course_option) { create(:course_option, course: create(:course, :open_on_apply, degree_grade: 'two_one')) }
 
   let(:application_choice) do
     build_stubbed(
       :application_choice,
       status: :unsubmitted,
-      course_option: course_option1,
+      course_option: course_option,
       application_form: application_form,
     )
   end
@@ -18,6 +18,32 @@ RSpec.describe CandidateInterface::DegreeRequiredComponent, type: :component do
     it 'renders the degree row without guidance' do
       result = render_inline(described_class.new(application_choice))
       expect(result.text).to include('2:1 degree or higher (or equivalent)')
+    end
+  end
+
+  context 'application has uk degree and but degree grade marked as not_required' do
+    let(:course_option) { create(:course_option, course: create(:course, :open_on_apply, degree_grade: 'not_required')) }
+    let(:application_choice) do
+      build_stubbed(
+        :application_choice,
+        status: :unsubmitted,
+        course_option: course_option,
+        application_form: application_form,
+      )
+    end
+
+    it 'renders the degree row without guidance' do
+      create(
+        :degree_qualification,
+        qualification_type: 'Bachelor of Arts',
+        institution_country: 'GB',
+        grade: 'Upper second-class honours (2:1)',
+        qualification_type_hesa_code: 51,
+        application_form: application_form,
+      )
+
+      result = render_inline(described_class.new(application_choice))
+      expect(result.text).to include('Any degree grade')
     end
   end
 


### PR DESCRIPTION
## Context

During the EoC rehearsal it was found that candidates with a uk degree 
caused an error when choosing degrees with `not_required` degree grades. 
This condition was missing from the hash and was not caught by the guard 
clause. 

## Changes proposed in this pull request

This PR adds the condition so that the correct text is displayed.

<img width="1255" alt="image" src="https://user-images.githubusercontent.com/62567622/135083962-a6e35521-6806-45a1-afd1-7f2f8628c320.png">

## Guidance to review

## Link to Trello card
https://ukgovernmentdfe.slack.com/archives/C02FK85GG10/p1632826158006700

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
