### PR TITLE
Introduce Event::ImportEntityEvent to backfill BigQuery data from apply

### DIFF
--- a/app/lib/events/event.rb
+++ b/app/lib/events/event.rb
@@ -1,6 +1,6 @@
 module Events
   class Event
-    EVENT_TYPES = %w[web_request create_entity update_entity delete_entity].freeze
+    EVENT_TYPES = %w[web_request create_entity update_entity delete_entity import_entity].freeze
 
     def initialize
       @event_hash = {

--- a/app/lib/events/import_entity_event.rb
+++ b/app/lib/events/import_entity_event.rb
@@ -1,0 +1,37 @@
+module Events
+  class ImportEntityEvent
+    attr_accessor :table_name, :event_type, :record
+
+    def initialize(record)
+      @table_name = record.class.table_name
+      @record = record
+      @event_type = 'import_entity'
+    end
+
+    def send
+      event = Events::Event.new
+        .with_type(event_type)
+        .with_entity_table_name(table_name)
+        .with_data(entity_data(record))
+
+      SendEventsToBigquery.perform_async(event.as_json)
+    end
+
+  private
+
+    def entity_data(attributes)
+      exportable_attrs = Rails.configuration.analytics[table_name.to_sym].presence || []
+      pii_attrs = Rails.configuration.analytics_pii[table_name.to_sym].presence || []
+      exportable_pii_attrs = exportable_attrs & pii_attrs
+
+      to_send = attributes.slice(*exportable_attrs&.map(&:to_s))
+      to_obfuscate = attributes.slice(*exportable_pii_attrs&.map(&:to_s))
+
+      to_send.deep_merge(to_obfuscate.transform_values { |value| anonymise(value) })
+    end
+
+    def anonymise(value)
+      Digest::SHA2.hexdigest(value.to_s)
+    end
+  end
+end

--- a/config/event-schema.json
+++ b/config/event-schema.json
@@ -11,7 +11,7 @@
     },
     "event_type": {
       "type": "string",
-      "enum": ["web_request", "create_entity", "update_entity", "delete_entity"]
+      "enum": ["web_request", "create_entity", "update_entity", "delete_entity", "import_entity"]
     },
     "entity_table_name": {
       "type": "string"

--- a/lib/tasks/import_data_to_bigquery.rake
+++ b/lib/tasks/import_data_to_bigquery.rake
@@ -3,15 +3,16 @@ SLEEP_TIME = 2
 
 namespace :bigquery do
   desc 'Import model data to BigQuery as import_entity type events'
-  task :import_entity_events, %i[model_name sleep_time start_at_id] => :environment do |_, args|
+  task :import_entity_events, %i[model_name sleep_time batch_size start_at_id] => :environment do |_, args|
     abort('You must specify the model whose data you want to import to BigQuery e.g. rake bigquery:import_entity_events[ApplicationChoice]') if args[:model_name].blank?
 
     model_name = args[:model_name]
     sleep_time = args.fetch(:sleep_time, SLEEP_TIME).to_i
+    batch_size = args.fetch(:batch_size, DEFAULT_BATCH_SIZE).to_i
     id = start_at_id = args[:start_at_id] || 0
     model_class = Object.const_get(model_name)
 
-    model_class.order(:id).where('id > ?', start_at_id).find_in_batches(batch_size: DEFAULT_BATCH_SIZE) do |records|
+    model_class.order(:id).where('id > ?', start_at_id).find_in_batches(batch_size: batch_size) do |records|
       records.each do |record|
         id = record.id
         Events::ImportEntityEvent.new(record).send

--- a/lib/tasks/import_data_to_bigquery.rake
+++ b/lib/tasks/import_data_to_bigquery.rake
@@ -1,0 +1,24 @@
+DEFAULT_BATCH_SIZE = 200
+SLEEP_TIME = 2
+
+namespace :bigquery do
+  desc 'Import model data to BigQuery as import_entity type events'
+  task :import_entity_events, %i[model_name sleep_time start_at_id] => :environment do |_, args|
+    abort('You must specify the model whose data you want to import to BigQuery e.g. rake bigquery:import_entity_events[ApplicationChoice]') if args[:model_name].blank?
+
+    model_name = args[:model_name]
+    sleep_time = args.fetch(:sleep_time, SLEEP_TIME).to_i
+    id = start_at_id = args[:start_at_id] || 0
+    model_class = Object.const_get(model_name)
+
+    model_class.order(:id).where('id > ?', start_at_id).find_in_batches(batch_size: DEFAULT_BATCH_SIZE) do |records|
+      records.each do |record|
+        id = record.id
+        Events::ImportEntityEvent.new(record).send
+      end
+      sleep sleep_time
+    end
+  ensure
+    Rails.logger.info("Process ended while processing #{model_name} with id: #{id}")
+  end
+end

--- a/spec/lib/events/import_entity_event_spec.rb
+++ b/spec/lib/events/import_entity_event_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe Events::ImportEntityEvent do
+  let(:candidate) { create(:candidate) }
+  let(:pii_fields) { [] }
+  let(:interesting_fields) { [] }
+
+  before do
+    allow(Rails.configuration).to receive(:analytics).and_return({
+      candidates: interesting_fields,
+    })
+
+    allow(Rails.configuration).to receive(:analytics_pii).and_return({
+      candidates: pii_fields,
+    })
+  end
+
+  it 'defaults the event type to import_entity' do
+    event = described_class.new(candidate)
+
+    expect(event.event_type).to eq('import_entity')
+  end
+
+  context 'when fields are specified in the analytics file' do
+    let(:interesting_fields) { [:id] }
+
+    it 'only includes attributes specified in the settings file' do
+      described_class.new(candidate).send
+
+      expect(SendEventsToBigquery).to have_received(:perform_async)
+        .with a_hash_including({
+          'entity_table_name' => 'candidates',
+          'event_type' => 'import_entity',
+          'data' => [
+            { 'key' => 'id', 'value' => [candidate.id] },
+          ],
+        })
+    end
+
+    it 'sends events that are valid according to the schema' do
+      described_class.new(candidate).send
+
+      expect(SendEventsToBigquery).to have_received(:perform_async) do |payload|
+        schema = File.read('config/event-schema.json')
+        schema_validator = JSONSchemaValidator.new(schema, payload)
+
+        expect(schema_validator).to be_valid, schema_validator.failure_message
+      end
+    end
+  end
+
+  context 'the specified fields are listed as PII' do
+    let(:interesting_fields) { [:email_address] }
+    let(:pii_fields) { [:email_address] }
+    let(:candidate) { create(:candidate, email_address: 'adrienne@example.com') }
+
+    it 'hashes those fields' do
+      described_class.new(candidate).send
+
+      expect(SendEventsToBigquery).to have_received(:perform_async)
+        .with a_hash_including({
+          'data' => [
+            { 'key' => 'email_address', 'value' => ['928b126cb77de8a61bf6714b4f6b0147be7f9d5eb60158930c34ef70f4d502d6'] },
+          ],
+        })
+    end
+  end
+end


### PR DESCRIPTION
Usage

` bigquery:import_entity_events[model_name,sleep_time,start_id]`

> e.g. rake bigquery:import_entity_events[ApplicationChoice,2,200]

## Context

Backfill the existing data so that and BAs/PAs can begin running analysis on the whole corpus of Apply data.

## Changes proposed in this pull request
Introduce ImportEntityEvent and rake task that handles retrieving and converting data from a specified model to entity events and posting to BigQuery.

## Link to Trello card

<https://trello.com/c/SljGT6Dl/4261-backfill-bigquery-data-from-apply

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
