### PR TITLE
Generate a different cache key for SingleApplicationPresenter#as_json

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -21,7 +21,7 @@ module VendorAPI
     end
 
     def as_json
-      Rails.cache.fetch(cache_key(application_choice), expires_in: CACHE_EXPIRES_IN) do
+      Rails.cache.fetch(cache_key(application_choice, 'as_json'), expires_in: CACHE_EXPIRES_IN) do
         application_as_json
       end
     end
@@ -422,8 +422,8 @@ module VendorAPI
       application_form.has_safeguarding_issues_to_declare? ? provider_interface_application_choice_url(application_choice, anchor: 'criminal-convictions-and-professional-misconduct') : nil
     end
 
-    def cache_key(model)
-      CacheKey.generate(model.cache_key_with_version)
+    def cache_key(model, method = '')
+      CacheKey.generate("#{model.cache_key_with_version}#{method}")
     end
   end
 end

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -1129,6 +1129,19 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     end
   end
 
+  describe '#as_json' do
+    let(:application_form) { create(:application_form, :minimum_info) }
+    let(:application_choice) { create(:application_choice, :awaiting_provider_decision, application_form: application_form) }
+
+    it 'caches the resulting hash with a specific key' do
+      allow(FeatureFlag).to receive(:feature_statuses).and_return({})
+      allow(Rails.cache).to receive(:fetch)
+      described_class.new(application_choice).as_json
+
+      expect(Rails.cache).to have_received(:fetch).with(CacheKey.generate("#{application_choice.cache_key_with_version}as_json"), expires_in: 1.day)
+    end
+  end
+
   describe '#serialized_json' do
     let(:application_form) { create(:application_form, :minimum_info) }
     let(:application_choice) { create(:application_choice, :awaiting_provider_decision, application_form: application_form) }
@@ -1144,7 +1157,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       allow(Rails.cache).to receive(:fetch)
       described_class.new(application_choice).serialized_json
 
-      expect(Rails.cache).to have_received(:fetch)
+      expect(Rails.cache).to have_received(:fetch).with(CacheKey.generate(application_choice.cache_key_with_version), expires_in: 1.day)
     end
   end
 end


### PR DESCRIPTION
## Context

`SingleApplicationPresenter#as_json` is sharing the same cache key as `SingleApplicationPresenter#serialized_json` but the return types are different (`Hash` vs. `String`).

`SingleApplicationPresenter#as_json` is [called by the Support UI `ApplicationChoiceComponent`](https://github.com/DFE-Digital/apply-for-teacher-training/blob/579fb869813a34849f13e03d92d22a2d65fe1ba3/app/components/support_interface/application_choice_component.rb#L128).

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Generate a different cache key when calling `SingleApplicationPresenter#as_json`

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
