### PR TITLE
Use the restructured work history flow as default in the factory

### DIFF
--- a/spec/components/provider_interface/work_history_and_unpaid_experience_component_spec.rb
+++ b/spec/components/provider_interface/work_history_and_unpaid_experience_component_spec.rb
@@ -12,12 +12,14 @@ RSpec.describe ProviderInterface::WorkHistoryAndUnpaidExperienceComponent, type:
 
   let(:work_experiences) do
     [build(:application_work_experience,
+           :deprecated,
            start_date: 6.years.ago,
            end_date: 2.years.ago,
            role: 'Sheep herder',
            commitment: 'full_time',
            details: 'Livestock management'),
      build(:application_work_experience,
+           :deprecated,
            start_date: 2.months.ago,
            end_date: nil,
            role: 'Pig herder',

--- a/spec/components/restructured_work_history/job_component_spec.rb
+++ b/spec/components/restructured_work_history/job_component_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe RestructuredWorkHistory::JobComponent do
         organisation: 'Mallowpond Secondary College',
         start_date: Time.zone.local(2018, 12, 1),
         end_date: Time.zone.local(2019, 12, 1),
+        start_date_unknown: nil,
+        end_date_unknown: nil,
         relevant_skills: true,
         commitment: :full_time,
       }.merge(attrs),

--- a/spec/components/utility/work_history_component_spec.rb
+++ b/spec/components/utility/work_history_component_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe WorkHistoryComponent do
       experiences = [
         build(
           :application_work_experience,
+          :deprecated,
           start_date: 6.years.ago,
           end_date: 3.months.ago,
           role: 'Sheep herder',
@@ -35,6 +36,7 @@ RSpec.describe WorkHistoryComponent do
         ),
         build(
           :application_work_experience,
+          :deprecated,
           start_date: 3.months.ago,
           end_date: nil,
           role: 'Pig herder',
@@ -62,17 +64,16 @@ RSpec.describe WorkHistoryComponent do
   context 'with work experiences working with children' do
     it 'renders work experience details and worked with children flag' do
       experiences = [
-        build(
-          :application_work_experience,
-          start_date: 6.years.ago,
-          end_date: nil,
-          role: 'Nursery manager',
-          commitment: 'part_time',
-          working_pattern: '',
-          organisation: 'Bobs Farm',
-          details: 'I run the staff nursery',
-          working_with_children: true,
-        ),
+        build(:application_work_experience,
+              :deprecated,
+              start_date: 6.years.ago,
+              end_date: nil,
+              role: 'Nursery manager',
+              commitment: 'part_time',
+              working_pattern: '',
+              organisation: 'Bobs Farm',
+              details: 'I run the staff nursery',
+              working_with_children: true),
       ]
       allow(application_form).to receive(:application_work_experiences).and_return(experiences)
       allow(application_form).to receive(:application_work_history_breaks).and_return([])
@@ -89,6 +90,7 @@ RSpec.describe WorkHistoryComponent do
       experiences = [
         build(
           :application_work_experience,
+          :deprecated,
           start_date: 6.years.ago,
           end_date: nil,
           role: 'Nursery manager',
@@ -116,6 +118,7 @@ RSpec.describe WorkHistoryComponent do
       experiences = [
         build(
           :application_work_experience,
+          :deprecated,
           start_date: 6.years.ago,
           end_date: 2.years.ago,
           role: 'Sheep herder',
@@ -126,6 +129,7 @@ RSpec.describe WorkHistoryComponent do
         ),
         build(
           :application_work_experience,
+          :deprecated,
           start_date: 2.months.ago,
           end_date: nil,
           role: 'Pig herder',
@@ -160,6 +164,7 @@ RSpec.describe WorkHistoryComponent do
       experiences = [
         build(
           :application_work_experience,
+          :deprecated,
           start_date: 6.years.ago,
           end_date: 26.months.ago,
           role: 'Sheep herder',
@@ -170,6 +175,7 @@ RSpec.describe WorkHistoryComponent do
         ),
         build(
           :application_work_experience,
+          :deprecated,
           start_date: 3.months.ago,
           end_date: nil,
           role: 'Pig herder',
@@ -206,6 +212,7 @@ RSpec.describe WorkHistoryComponent do
       experiences = [
         build(
           :application_work_experience,
+          :deprecated,
           start_date: Date.new(2014, 10, 1),
           end_date: Date.new(2018, 2, 1),
           start_date_unknown: true,
@@ -218,6 +225,7 @@ RSpec.describe WorkHistoryComponent do
         ),
         build(
           :application_work_experience,
+          :deprecated,
           start_date: Date.new(2020, 1, 1),
           end_date: nil,
           start_date_unknown: true,

--- a/spec/factories/application_volunteering_experience.rb
+++ b/spec/factories/application_volunteering_experience.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :application_experience do
+  factory :application_volunteering_experience do
     role { ['Teacher', 'Teaching Assistant'].sample }
     organisation { Faker::Educator.secondary_school }
     details { Faker::Lorem.paragraph_by_chars(number: 300) }
@@ -9,12 +9,4 @@ FactoryBot.define do
     commitment { %w[full_time part_time].sample }
     working_pattern { Faker::Lorem.paragraph_by_chars(number: 30) }
   end
-
-  factory :application_volunteering_experience,
-          parent: :application_experience,
-          class: 'ApplicationVolunteeringExperience'
-
-  factory :application_work_experience,
-          parent: :application_experience,
-          class: 'ApplicationWorkExperience'
 end

--- a/spec/factories/application_work_experience.rb
+++ b/spec/factories/application_work_experience.rb
@@ -1,0 +1,28 @@
+FactoryBot.define do
+  factory :application_work_experience do
+    organisation { Faker::Educator.secondary_school }
+    role { ['Teacher', 'Teaching Assistant'].sample }
+    commitment { %w[full_time part_time].sample }
+    start_date { Faker::Date.between(from: 20.years.ago, to: 5.years.ago) }
+    start_date_unknown { [true, false].sample }
+    end_date { [Faker::Date.between(from: 4.years.ago, to: Time.zone.today), nil].sample }
+    end_date_unknown { [true, false].sample }
+    currently_working { false }
+    relevant_skills { true }
+    details { 'I used skills relevant to teaching in this job.' }
+  end
+
+  trait :deprecated do
+    role { ['Teacher', 'Teaching Assistant'].sample }
+    organisation { Faker::Educator.secondary_school }
+    details { Faker::Lorem.paragraph_by_chars(number: 300) }
+    working_with_children { [true, true, true, false].sample }
+    start_date { Faker::Date.between(from: 20.years.ago, to: 5.years.ago) }
+    end_date { [Faker::Date.between(from: 4.years.ago, to: Time.zone.today), nil].sample }
+    commitment { %w[full_time part_time].sample }
+    working_pattern { Faker::Lorem.paragraph_by_chars(number: 30) }
+    start_date_unknown { nil }
+    end_date_unknown { nil }
+    relevant_skills { nil }
+  end
+end

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe CarryOverApplication do
       first_job.update(start_date: 3.years.ago, end_date: 2.years.ago)
 
       second_job = original_application_form.application_work_experiences.last
-      second_job.update(start_date: 1.year.ago, end_date: nil)
+      second_job.update(start_date: 1.year.ago, end_date: nil, currently_working: nil)
 
       described_class.new(original_application_form.reload).call
 

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -104,7 +104,9 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
            working_with_children: false,
            start_date: 36.months.ago,
            end_date: 30.months.ago,
-           commitment: 'part_time')
+           commitment: 'part_time',
+           start_date_unknown: false,
+           end_date_unknown: false)
 
     create(:application_work_experience,
            application_form: application_form,
@@ -115,7 +117,9 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
            working_with_children: false,
            start_date: 24.months.ago,
            end_date: 18.months.ago,
-           commitment: 'full_time')
+           commitment: 'full_time',
+           start_date_unknown: false,
+           end_date_unknown: false)
 
     create(:application_work_history_break,
            application_form: application_form,


### PR DESCRIPTION
## Context

We're still using the old work history attrs in the factory. This doesn't really make sense as the bulk of our candidates going forward will be using the new flow (and the boolean defaults to true on the app form when it's created).

## Changes proposed in this pull request

- Break out the volunteering and work factories into their own files
- Use the latest work history flow attributes as default
- add a trait for the deprecated version

## Trello card 

https://trello.com/c/w5XbhIR5/4005-eoc-bug-high-use-restructured-work-history-attrs-in-the-factory

## Guidance to review

Does this all seem reasonable?

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
