### PR TITLE
Add fraud matching service and worker

### DIFF
--- a/app/services/update_fraud_matches.rb
+++ b/app/services/update_fraud_matches.rb
@@ -1,0 +1,24 @@
+class UpdateFraudMatches
+  def initialize
+    @matches = GetDuplicateCandidateMatches.call
+  end
+
+  def save!
+    @matches.each do |match|
+      fraud_match = FraudMatch.find_by(last_name: match['last_name'], postcode: match['postcode'], date_of_birth: match['date_of_birth'])
+      candidate = Candidate.find(match['candidate_id'])
+      if fraud_match.present?
+        fraud_match.candidates << candidate unless fraud_match.candidates.include?(candidate)
+      else
+        fraud_match = FraudMatch.create!(
+          recruitment_cycle_year: RecruitmentCycle.current_year,
+          last_name: match['last_name'],
+          postcode: match['postcode'],
+          date_of_birth: match['date_of_birth'],
+        )
+
+        fraud_match.candidates << candidate
+      end
+    end
+  end
+end

--- a/app/workers/update_fraud_matches_worker.rb
+++ b/app/workers/update_fraud_matches_worker.rb
@@ -1,0 +1,10 @@
+class UpdateFraudMatchesWorker
+  include Sidekiq::Worker
+
+  sidekiq_options retry: 0, queue: :low_priority
+
+  def perform
+    matches = UpdateFraudMatches.new
+    matches.save!
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -61,7 +61,11 @@ class Clock
   every(1.day, 'SendFindHasOpenedEmailToCandidatesWorker', at: '12:00') { SendFindHasOpenedEmailToCandidatesWorker.new.perform }
   every(1.day, 'SendNewCycleStartedEmailToCandidatesWorker', at: '12:00') { SendNewCycleHasStartedEmailToCandidatesWorker.new.perform }
 
-  every(1.day, 'TriggerFullSyncIfFindClosed', at: '00:05') { TeacherTrainingPublicAPI::TriggerFullSyncIfFindClosed.call }
+  every(1.day, 'UpdateFraudAuditDashboard', at: '13:00') { UpdateFraudMatchesWorker.perform_async }
+
+  every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do
+    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false, RecruitmentCycle.current_year)
+  end
 
   every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do
     TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false)

--- a/spec/services/update_fraud_matches_spec.rb
+++ b/spec/services/update_fraud_matches_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe UpdateFraudMatches do
+  let(:candidate1) { create(:candidate, email_address: 'exemplar1@example.com') }
+  let(:candidate2) { create(:candidate, email_address: 'exemplar2@example.com') }
+
+  before do
+    Timecop.freeze(Time.zone.local(2020, 8, 23, 12, 0o0, 0o0)) do
+      create(:application_form, candidate: candidate1, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH', submitted_at: Time.zone.now)
+      create(:application_form, candidate: candidate2, first_name: 'Joffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH')
+    end
+  end
+
+  describe '#save!' do
+    it 'creates a fraud match with associated candidates for new match' do
+      described_class.new.save!
+
+      match = FraudMatch.first
+
+      expect(match.postcode).to eq('W6 9BH')
+      expect(match.date_of_birth).to eq(candidate1.application_forms.first.date_of_birth)
+      expect(match.last_name).to eq('Thompson')
+      expect(match.recruitment_cycle_year).to eq(RecruitmentCycle.current_year)
+      expect(match.candidates.first).to eq(candidate1)
+      expect(match.candidates.second).to eq(candidate2)
+    end
+
+    it 'updates an existing fraud match with new candidate' do
+      described_class.new.save!
+
+      match = FraudMatch.first
+      expect(match.candidates.third).to eq(nil)
+
+      create(:application_form, candidate: create(:candidate, email_address: 'exemplar3@example.com'), first_name: 'Jaffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH')
+      described_class.new.save!
+
+      match = FraudMatch.first
+
+      expect(match.candidates.third.email_address).to eq('exemplar3@example.com')
+
+      expect(match.postcode).to eq('W6 9BH')
+      expect(match.date_of_birth).to eq(candidate1.application_forms.first.date_of_birth)
+      expect(match.last_name).to eq('Thompson')
+      expect(match.recruitment_cycle_year).to eq(RecruitmentCycle.current_year)
+    end
+  end
+end


### PR DESCRIPTION
## Context

In order to periodically update the fraud_matches table.

## Changes proposed in this pull request

Adding service to create and update Fraud Matches periodically.
Worker is set to run once a day in clock.rb.

## Guidance to review
Test coverage?

## Link to Trello card
https://trello.com/c/uyeHnXSG/3971-fraud-add-matching-service-and-worker-to-update-fraudmatches-table

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
