### PR TITLE
filter accredited provider report by current cycle

### DIFF
--- a/app/queries/get_application_progress_data_by_course.rb
+++ b/app/queries/get_application_progress_data_by_course.rb
@@ -10,7 +10,7 @@ class GetApplicationProgressDataByCourse
       .joins(:provider)
       .left_joins(:accredited_provider)
       .where(recruitment_cycle_year: RecruitmentCycle.current_year, provider_id: provider.id)
-      .or(Course.where(accredited_provider_id: provider.id))
+      .or(Course.where(accredited_provider_id: provider.id, recruitment_cycle_year: RecruitmentCycle.current_year))
       .group('courses.id', 'courses.name', 'courses.code', 'application_choices.status', 'providers.name', 'accredited_providers_courses.name')
       .select('courses.provider_id', 'courses.accredited_provider_id', 'providers.name as provider_name',
               'accredited_providers_courses.name as accredited_provider_name', 'courses.name', 'courses.code',


### PR DESCRIPTION
## Context

Ensure the status of active application report now only displays results for the current cycle whilst viewing from an accredited provider perspective. 

## Guidance to review

Log in as a provider that accredits another course and look at the report numbers.
## Link to Trello card

https://trello.com/c/dXoOxUxw/4339-status-of-active-application-report-inconsistencies

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
