### PR TITLE
Amend the label on withdrawing an offer

### DIFF
--- a/app/views/provider_interface/decisions/new_withdraw_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_withdraw_offer.html.erb
@@ -19,9 +19,7 @@
         { key: 'Preferred location', value: @application_choice.site.name },
       ]) %>
 
-      <%= f.govuk_fieldset legend: { text: 'Tell us why you’re withdrawing the offer', size: 'm' } do %>
-        <%= f.govuk_text_area :offer_withdrawal_reason, rows: 5, label: { text: '' }, hint: { text: 'We’ll forward your feedback to the candidate' } %>
-      <% end %>
+      <%= f.govuk_text_area :offer_withdrawal_reason, rows: 5, label: { text: 'Tell us why you’re withdrawing the offer', size: 'm' }, hint: { text: 'We’ll forward your feedback to the candidate' } %>
 
       <%= f.govuk_submit t('continue') %>
 


### PR DESCRIPTION
## Context

https://ukgovernmentdfe.slack.com/archives/CPH8J9G65/p1632915029172500

## Changes proposed in this pull request

Label was rendering incorrectly and missing, set the label to `nil` to only show the hint text

## Guidance to review

Find an offered application and attempt to withdraw

<img width="828" alt="Screenshot 2021-09-29 at 13 42 01" src="https://user-images.githubusercontent.com/2732945/135273993-d7e1ccc1-be45-4f89-810b-345376ed1f98.png">

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
