### PR TITLE
New service banner content for when global rbd happens

### DIFF
--- a/app/components/provider_interface/summer_recruitment_banner.html.erb
+++ b/app/components/provider_interface/summer_recruitment_banner.html.erb
@@ -2,10 +2,6 @@
   <div class="govuk-grid-column-full">
     <%= govuk_notification_banner(title_text: t('summer_recruitment_banner.title')) do |notification_banner| %>
       <% notification_banner.heading(text: t('summer_recruitment_banner.header')) %>
-
-      <% if render_body? %>
-        <p class="govuk-body"><%= t('summer_recruitment_banner.body') %></p>
-      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/components/provider_interface/summer_recruitment_banner.html.erb
+++ b/app/components/provider_interface/summer_recruitment_banner.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= govuk_notification_banner(title_text: t('summer_recruitment_banner.title')) do |notification_banner| %>
-      <% notification_banner.heading(text: t('summer_recruitment_banner.header')) %>
+      <% notification_banner.heading(text: t("summer_recruitment_banner.#{time_of_year}.header")) %>
     <% end %>
   </div>
 </div>

--- a/app/components/provider_interface/summer_recruitment_banner.rb
+++ b/app/components/provider_interface/summer_recruitment_banner.rb
@@ -3,5 +3,15 @@ module ProviderInterface
     def render?
       FeatureFlag.active?('summer_recruitment_banner')
     end
+
+  private
+
+    def time_of_year
+      after_global_rbd? ? 'after_global_rbd' : 'before_global_rbd'
+    end
+
+    def after_global_rbd?
+      Time.zone.now > CycleTimetable.reject_by_default(2021)
+    end
   end
 end

--- a/app/components/provider_interface/summer_recruitment_banner.rb
+++ b/app/components/provider_interface/summer_recruitment_banner.rb
@@ -3,11 +3,5 @@ module ProviderInterface
     def render?
       FeatureFlag.active?('summer_recruitment_banner')
     end
-
-  private
-
-    def render_body?
-      Time.zone.now < CycleTimetable.apply_2_deadline(RecruitmentCycle.current_year)
-    end
   end
 end

--- a/config/locales/summer_recruitment_banner.yml
+++ b/config/locales/summer_recruitment_banner.yml
@@ -1,4 +1,7 @@
 en:
   summer_recruitment_banner:
     title: Important
-    header: Applications awaiting decisions will be automatically rejected on 29 September at 11:59pm, when the current recruitment cycle ends
+    before_global_rbd:
+      header: Applications awaiting decisions will be automatically rejected on 29 September at 11:59pm, when the current recruitment cycle ends
+    after_global_rbd:
+      header: Candidates will be able to apply for courses starting in 2022 to 2023 from 12 October 2021 at 9am

--- a/config/locales/summer_recruitment_banner.yml
+++ b/config/locales/summer_recruitment_banner.yml
@@ -2,4 +2,3 @@ en:
   summer_recruitment_banner:
     title: Important
     header: Applications awaiting decisions will be automatically rejected on 29 September at 11:59pm, when the current recruitment cycle ends
-    body: Candidates can apply until 21 September at 6pm.

--- a/spec/components/provider_interface/summer_recruitment_banner_spec.rb
+++ b/spec/components/provider_interface/summer_recruitment_banner_spec.rb
@@ -13,30 +13,6 @@ RSpec.describe ProviderInterface::SummerRecruitmentBanner do
     it 'renders the banner header' do
       expect(result.text).to include(t('summer_recruitment_banner.header'))
     end
-
-    describe 'rendering the banner content' do
-      around do |example|
-        Timecop.freeze(time) { example.run }
-      end
-
-      context 'when the current time is before the apply 2 deadline' do
-        let(:time) { CycleTimetable.apply_2_deadline(RecruitmentCycle.current_year) - 1.day }
-
-        it 'renders the banner content' do
-          expect(result.text).to include(t('summer_recruitment_banner.body'))
-          expect(page).to have_selector('.govuk-body')
-        end
-      end
-
-      context 'when the current time is after the apply 2 deadline' do
-        let(:time) { CycleTimetable.apply_2_deadline(RecruitmentCycle.current_year) + 1.day }
-
-        it 'does not render the banner content' do
-          expect(result.text).not_to include(t('summer_recruitment_banner.body'))
-          expect(page).not_to have_css('.govuk-body')
-        end
-      end
-    end
   end
 
   context 'when the provider information banner feature flag is off' do

--- a/spec/components/provider_interface/summer_recruitment_banner_spec.rb
+++ b/spec/components/provider_interface/summer_recruitment_banner_spec.rb
@@ -10,8 +10,26 @@ RSpec.describe ProviderInterface::SummerRecruitmentBanner do
       expect(result.text).to include('Important')
     end
 
-    it 'renders the banner header' do
-      expect(result.text).to include(t('summer_recruitment_banner.header'))
+    describe 'rendering the banner header' do
+      around do |example|
+        Timecop.freeze(time) { example.run }
+      end
+
+      context 'before the global reject by default date passes' do
+        let(:time) { CycleTimetable.reject_by_default(2021) - 1.hour }
+
+        it 'renders the before global rbd content' do
+          expect(result.text).to include(t('summer_recruitment_banner.before_global_rbd.header'))
+        end
+      end
+
+      context 'after the global reject by default date passes' do
+        let(:time) { CycleTimetable.reject_by_default(2021) + 1.hour }
+
+        it 'renders the after global rbd content' do
+          expect(result.text).to include(t('summer_recruitment_banner.after_global_rbd.header'))
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Context
Applications are all going to be rejected by default soon and the content is going to become irrelevant

## Changes proposed in this pull request
Remove the body text bit, which would have started showing up when find reopens.
Switch the heading text when rbd happens tonight

## Link to Trello card
https://trello.com/c/fGRPOdVP/4336
