### PR TITLE
Remove dual running (part 3)

### DIFF
--- a/app/controllers/candidate_interface/course_choices/provider_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/provider_selection_controller.rb
@@ -12,11 +12,7 @@ module CandidateInterface
         )
         render :new and return unless @pick_provider.valid?
 
-        if @pick_provider.courses_available?
-          redirect_to candidate_interface_course_choices_course_path(@pick_provider.provider_id)
-        else
-          redirect_to candidate_interface_course_choices_ucas_no_courses_path(@pick_provider.provider_id)
-        end
+        redirect_to candidate_interface_course_choices_course_path(@pick_provider.provider_id)
       end
     end
   end

--- a/app/forms/candidate_interface/pick_provider_form.rb
+++ b/app/forms/candidate_interface/pick_provider_form.rb
@@ -5,12 +5,8 @@ module CandidateInterface
     attr_accessor :provider_id
     validates :provider_id, presence: true
 
-    def courses_available?
-      Course.current_cycle.exposed_in_find.where(provider_id: provider_id).present?
-    end
-
     def available_providers
-      @available_providers ||= Provider.all.order(:name)
+      @available_providers ||= Provider.joins(:courses).where(courses: { recruitment_cycle_year: RecruitmentCycle.current_year, exposed_in_find: true }).order(:name).distinct
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,10 +49,6 @@ en:
     error_prefix: "Error: "
     success_prefix: "Success: "
     course_not_found: Course not found
-    apply_from_find: Apply for this course
-    apply_from_find_with_ucas: Apply for this course with UCAS
-    apply_to_course_on_ucas: You need to apply to this course on UCAS
-    apply_to_provider_on_ucas: You need to apply to this provider on UCAS
     unsubmitted_previous_application: Your previously unsubmitted application
     submitted_application: Your submitted application
     create_account_or_sign_in: Create an account or sign in

--- a/spec/forms/candidate_interface/pick_provider_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_provider_form_spec.rb
@@ -2,35 +2,15 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::PickProviderForm do
   describe '#available_providers' do
-    it 'returns all providers' do
+    it 'returns providers with a course exposed in find in the current cycle' do
       create(:provider, name: 'School without courses')
-      create(:course, open_on_apply: false, exposed_in_find: false, provider: create(:provider, name: 'School with disabled courses'))
+      create(:course, open_on_apply: true, exposed_in_find: false, provider: create(:provider, name: 'School with disabled courses'))
       create(:course, open_on_apply: true, exposed_in_find: true, provider: create(:provider, name: 'School with courses'))
+      create(:course, open_on_apply: true, exposed_in_find: true, recruitment_cycle_year: RecruitmentCycle.previous_year)
 
       form = described_class.new({})
 
-      expect(form.available_providers.map(&:name)).to eql(['School with courses', 'School with disabled courses', 'School without courses'])
-    end
-  end
-
-  describe '#courses_available?' do
-    it 'returns false if there are no exposed courses matched by provider id in the current cycle' do
-      unexposed_course = create(:course, exposed_in_find: false)
-      provider = unexposed_course.provider
-      create(:course, exposed_in_find: true, recruitment_cycle_year: RecruitmentCycle.previous_year, provider: unexposed_course.provider)
-
-      form = described_class.new(provider_id: provider.id)
-
-      expect(form.courses_available?).to eq false
-    end
-
-    it 'returns true if there are exposed courses matched by provider id' do
-      exposed_course = create(:course, exposed_in_find: true)
-      provider = exposed_course.provider
-
-      form = described_class.new(provider_id: provider.id)
-
-      expect(form.courses_available?).to eq true
+      expect(form.available_providers.map(&:name)).to eq(['School with courses'])
     end
   end
 end


### PR DESCRIPTION
## Context

Now we don't have the no courses page where we send a candidate to UCAS we need to ensure we only show providers in the dropdown who have a course available on Apply.

This also removes some unused locales

## Changes proposed in this pull request

- Filter the provider dropdown based on providers that have a course open in the current cycle

## Guidance to review

Does this make sense?

Maybe a quick sense check on the SQL

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
