### PR TITLE
Add multiple-org setup email for start of cycle notifications

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -208,7 +208,7 @@ class ProviderMailer < ApplicationMailer
   def set_up_organisation_permissions(provider_user, relationships_to_set_up)
     @provider_user = provider_user
     @relationships_to_set_up = relationships_to_set_up
-    @multiple_relationships = @relationships_to_set_up.keys.size > 1
+    @single_or_multiple = @relationships_to_set_up.keys.size > 1 ? 'multiple' : 'single'
 
     notify_email(
       to: @provider_user.email_address,

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -205,9 +205,10 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
-  def set_up_organisation_permissions(provider_user, partner_organisations)
+  def set_up_organisation_permissions(provider_user, relationships_to_set_up)
     @provider_user = provider_user
-    @partner_organisations = partner_organisations
+    @relationships_to_set_up = relationships_to_set_up
+    @multiple_relationships = @relationships_to_set_up.keys.size > 1
 
     notify_email(
       to: @provider_user.email_address,

--- a/app/views/provider_mailer/_multiple_provider_relationship_set_up.text.erb
+++ b/app/views/provider_mailer/_multiple_provider_relationship_set_up.text.erb
@@ -1,0 +1,12 @@
+Candidates can now find courses on GOV.UK that you work on with the partner organisations listed below.
+
+You cannot manage applications to these courses until either you or your partner organisations have set up organisational permissions.
+
+<% @relationships_to_set_up.each do |organisation, partner_organisations| -%>
+
+For <%= organisation %>, you need to set up permissions for courses you work on with:
+
+<% partner_organisations.each do |partner_organisation| -%>
+- <%= partner_organisation %>
+<% end %>
+<% end -%>

--- a/app/views/provider_mailer/_single_provider_relationship_set_up.text.erb
+++ b/app/views/provider_mailer/_single_provider_relationship_set_up.text.erb
@@ -1,0 +1,7 @@
+Candidates can now find courses on GOV.UK that you work on with:
+
+<% @relationships_to_set_up.values.flatten.each do |partner_organisation| -%>
+- <%= partner_organisation %>
+<% end -%>
+
+Either you or these partner organisations must set up organisation permissions before you can manage teacher training applications.

--- a/app/views/provider_mailer/set_up_organisation_permissions.text.erb
+++ b/app/views/provider_mailer/set_up_organisation_permissions.text.erb
@@ -1,29 +1,7 @@
 Dear <%= @provider_user.full_name || 'colleague' %>
 
-<% if @multiple_relationships -%>
-Candidates can now find courses on GOV.UK that you work on with the partner organisations listed below.
+<%= render "#{@single_or_multiple}_provider_relationship_set_up" %>
 
-You cannot manage applications to these courses until either you or your partner organisations have set up organisational permissions.
-
-<% @relationships_to_set_up.each do |organisation, partner_organisations| -%>
-
-For <%= organisation %>, you need to set up permissions for courses you work on with:
-
-<% partner_organisations.each do |partner_organisation| -%>
-- <%= partner_organisation %>
-<% end %>
-<% end -%>
-
-<% else -%>
-Candidates can now find courses on GOV.UK that you work on with:
-
-<% @relationships_to_set_up.values.flatten.each do |partner_organisation| -%>
-- <%= partner_organisation %>
-<% end -%>
-
-Either you or these partner organisations must set up organisation permissions before you can manage teacher training applications.
-
-<% end -%>
 You’ll be asked to set up organisation permissions when you sign in, unless your partner organisations set them up first.
 
 <%= provider_interface_sign_in_url %>

--- a/app/views/provider_mailer/set_up_organisation_permissions.text.erb
+++ b/app/views/provider_mailer/set_up_organisation_permissions.text.erb
@@ -1,13 +1,29 @@
 Dear <%= @provider_user.full_name || 'colleague' %>
 
+<% if @multiple_relationships -%>
+Candidates can now find courses on GOV.UK that you work on with the partner organisations listed below.
+
+You cannot manage applications to these courses until either you or your partner organisations have set up organisational permissions.
+
+<% @relationships_to_set_up.each do |organisation, partner_organisations| -%>
+
+For <%= organisation %>, you need to set up permissions for courses you work on with:
+
+<% partner_organisations.each do |partner_organisation| -%>
+- <%= partner_organisation %>
+<% end %>
+<% end -%>
+
+<% else -%>
 Candidates can now find courses on GOV.UK that you work on with:
 
-<% @partner_organisations.each do |organisation| -%>
-- <%= organisation.name %>
+<% @relationships_to_set_up.values.flatten.each do |partner_organisation| -%>
+- <%= partner_organisation %>
 <% end -%>
 
 Either you or these partner organisations must set up organisation permissions before you can manage teacher training applications.
 
+<% end -%>
 You’ll be asked to set up organisation permissions when you sign in, unless your partner organisations set them up first.
 
 <%= provider_interface_sign_in_url %>

--- a/app/workers/start_of_cycle_notification_worker.rb
+++ b/app/workers/start_of_cycle_notification_worker.rb
@@ -15,17 +15,11 @@ class StartOfCycleNotificationWorker
 
         next if service == :apply
 
-        relationships_pending = relationships_user_can_setup(provider_user, provider)
-
-        next if relationships_pending.blank?
+        next unless provider_user.provider_permissions.find_by(provider: provider).manage_organisations
         next if ChaserSent.exists?(chased: provider_user, chaser_type: setup_mailer_method)
 
-        partner_organisations = relationships_pending.map { |relationship| relationship.partner_organisation(provider) }.compact
-
-        if partner_organisations.any?
-          ProviderMailer.send(setup_mailer_method, provider_user, partner_organisations).deliver_later
-          ChaserSent.create!(chased: provider_user, chaser_type: setup_mailer_method)
-        end
+        ProviderMailer.send(setup_mailer_method, provider_user, relationships_to_set_up(provider_user)).deliver_later
+        ChaserSent.create!(chased: provider_user, chaser_type: setup_mailer_method)
       end
 
       ChaserSent.create!(chased: provider, chaser_type: provider_chaser_type)
@@ -52,10 +46,19 @@ private
     Time.zone.now.change(hour: 16)
   end
 
-  def relationships_user_can_setup(provider_user, provider)
-    return [] unless provider_user.provider_permissions.find_by(provider: provider).manage_organisations
+  def relationships_to_set_up(provider_user)
+    relationships_pending = ProviderSetup.new(provider_user: provider_user).relationships_pending
+    training_providers = relationships_pending.map(&:training_provider) & provider_user.providers
 
-    ProviderSetup.new(provider_user: provider_user).relationships_pending
+    relationships_pending.each_with_object({}) do |rel, hash|
+      if training_providers.include?(rel.training_provider)
+        hash[rel.training_provider.name] ||= []
+        hash[rel.training_provider.name] << rel.ratifying_provider.name
+      else
+        hash[rel.ratifying_provider.name] ||= []
+        hash[rel.ratifying_provider.name] << rel.training_provider.name
+      end
+    end
   end
 
   def providers_scope

--- a/app/workers/start_of_cycle_notification_worker.rb
+++ b/app/workers/start_of_cycle_notification_worker.rb
@@ -50,7 +50,7 @@ private
     relationships_pending = ProviderSetup.new(provider_user: provider_user).relationships_pending
     training_providers = relationships_pending.map(&:training_provider) & provider_user.providers
 
-    relationships_pending.each_with_object({}) do |rel, hash|
+    relationships = relationships_pending.each_with_object({}) do |rel, hash|
       if training_providers.include?(rel.training_provider)
         hash[rel.training_provider.name] ||= []
         hash[rel.training_provider.name] << rel.ratifying_provider.name
@@ -59,6 +59,7 @@ private
         hash[rel.ratifying_provider.name] << rel.training_provider.name
       end
     end
+    relationships.sort_by { |k, v| [k, v.sort!] }.to_h
   end
 
   def providers_scope

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -120,10 +120,12 @@ class ProviderMailerPreview < ActionMailer::Preview
   end
 
   def set_up_organisation_permissions
-    provider1 = FactoryBot.create(:provider)
-    provider2 = FactoryBot.create(:provider)
+    relationships_to_set_up = {
+      'University of Dundee' => ['University of Broughty Ferry', 'University of Forfar', 'University of Wormit'],
+      'University of Selsdon' => ['University of Croydon', 'University of Purley'],
+    }
     provider_user = FactoryBot.create(:provider_user)
-    ProviderMailer.set_up_organisation_permissions(provider_user, [provider1, provider2])
+    ProviderMailer.set_up_organisation_permissions(provider_user, relationships_to_set_up)
   end
 
 private

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -298,17 +298,41 @@ RSpec.describe ProviderMailer, type: :mailer do
 
   describe 'set_up_organisation_permissions' do
     let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English') }
-    let(:provider1) { build_stubbed(:provider, name: 'University of Purley') }
-    let(:provider2) { build_stubbed(:provider, name: 'University of Croydon') }
+    let(:relationships_to_set_up) do
+      { 'University of Selsdon' => ['University of Croydon', 'University of Purley'] }
+    end
 
-    let(:email) { described_class.set_up_organisation_permissions(provider_user, [provider1, provider2]) }
+    let(:email) { described_class.set_up_organisation_permissions(provider_user, relationships_to_set_up) }
 
     it_behaves_like(
       'a mail with subject and content',
       'Set up organisation permissions - manage teacher training applications',
       'salutation' => 'Dear Johny English',
       'main paragraph' => 'Candidates can now find courses on GOV.UK that you work on with:',
-      'partner providers' => "- University of Purley\r\n- University of Croydon",
+      'partner providers' => "- University of Croydon\r\n- University of Purley",
+    )
+  end
+
+  describe 'set_up_organisation_permissions with multiple organisations' do
+    let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English') }
+    let(:relationships_to_set_up) do
+      {
+        'University of Dundee' => ['University of Broughty Ferry', 'University of Carnoustie'],
+        'University of Selsdon' => ['University of Croydon', 'University of Purley'],
+      }
+    end
+
+    let(:email) { described_class.set_up_organisation_permissions(provider_user, relationships_to_set_up) }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Set up organisation permissions - manage teacher training applications',
+      'salutation' => 'Dear Johny English',
+      'main paragraph' => 'Candidates can now find courses on GOV.UK that you work on with the partner organisations listed below.',
+      'first relationship group' => 'For University of Dundee, you need to set up permissions for courses you work on with:',
+      'first group of partner providers' => "- University of Broughty Ferry\r\n- University of Carnoustie",
+      'second relationship group' => 'For University of Selsdon, you need to set up permissions for courses you work on with:',
+      'second group of partner providers' => "- University of Croydon\r\n- University of Purley",
     )
   end
 end

--- a/spec/workers/start_of_cycle_notification_worker_spec.rb
+++ b/spec/workers/start_of_cycle_notification_worker_spec.rb
@@ -73,12 +73,12 @@ RSpec.describe StartOfCycleNotificationWorker do
                                :not_set_up_yet,
                                training_provider: providers_needing_set_up.first,
                                ratifying_provider: other_providers.first)
-        allow(ProviderSetup).to receive(:new).and_return(instance_double(ProviderSetup, relationships_pending: [relationship1, relationship2, relationship3]))
+        allow(ProviderSetup).to receive(:new).and_return(instance_double(ProviderSetup, relationships_pending: [relationship2, relationship1, relationship3]))
 
         described_class.new.perform(service)
 
         expected_relationships = {
-          providers_needing_set_up.first.name => [ratifying_provider.name, other_providers.first.name],
+          providers_needing_set_up.first.name => [other_providers.first.name, ratifying_provider.name],
           providers_needing_set_up.last.name => [another_provider.name],
         }
 

--- a/spec/workers/start_of_cycle_notification_worker_spec.rb
+++ b/spec/workers/start_of_cycle_notification_worker_spec.rb
@@ -60,16 +60,30 @@ RSpec.describe StartOfCycleNotificationWorker do
 
       it 'notifies provider users who need to set up permissions for their organisation' do
         ratifying_provider = create(:provider, :with_signed_agreement, name: 'QQQ')
-        relationship = create(:provider_relationship_permissions,
-                              :not_set_up_yet,
-                              training_provider: providers_needing_set_up.first,
-                              ratifying_provider: ratifying_provider)
-        allow(ProviderSetup).to receive(:new).and_return(instance_double(ProviderSetup, relationships_pending: [relationship]))
+        another_provider = create(:provider, :with_signed_agreement, name: 'RRR')
+        relationship1 = create(:provider_relationship_permissions,
+                               :not_set_up_yet,
+                               training_provider: providers_needing_set_up.first,
+                               ratifying_provider: ratifying_provider)
+        relationship2 = create(:provider_relationship_permissions,
+                               :not_set_up_yet,
+                               training_provider: another_provider,
+                               ratifying_provider: providers_needing_set_up.last)
+        relationship3 = create(:provider_relationship_permissions,
+                               :not_set_up_yet,
+                               training_provider: providers_needing_set_up.first,
+                               ratifying_provider: other_providers.first)
+        allow(ProviderSetup).to receive(:new).and_return(instance_double(ProviderSetup, relationships_pending: [relationship1, relationship2, relationship3]))
 
         described_class.new.perform(service)
 
-        expect(ProviderMailer).to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.first, [ratifying_provider])
-        expect(ProviderMailer).to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.last, [ratifying_provider])
+        expected_relationships = {
+          providers_needing_set_up.first.name => [ratifying_provider.name, other_providers.first.name],
+          providers_needing_set_up.last.name => [another_provider.name],
+        }
+
+        expect(ProviderMailer).to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.first, expected_relationships)
+        expect(ProviderMailer).to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.last, expected_relationships)
         expect(ProviderMailer).not_to have_received(:set_up_organisation_permissions).with(user_who_has_received_mail)
       end
 
@@ -112,11 +126,13 @@ RSpec.describe StartOfCycleNotificationWorker do
 
           described_class.new.perform(service)
 
+          expected_relationships = { providers_needing_set_up.first.name => [ratifying_provider.name] }
+
           expect(ProviderMailer).not_to have_received(:find_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.first)
-          expect(ProviderMailer).to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.first, [ratifying_provider])
+          expect(ProviderMailer).to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.first, expected_relationships)
 
           expect(ProviderMailer).to have_received(:find_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.last)
-          expect(ProviderMailer).to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.last, [ratifying_provider])
+          expect(ProviderMailer).to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.last, expected_relationships)
         end
       end
     end


### PR DESCRIPTION
## Context

We have 2 different designs for users who need to set up organisation permissions, one for users who belong to a single organisation which has permissions to set up and another for users who belong to multiple organisations with permissions to set up.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Groups the pending relationships into a hash keyed by provider names which the user belongs to, and values which are the partner organisations which relate to the set up.
 
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/j6AXBzwy/4291-create-start-of-cycle-provider-emails-for-find-and-apply
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
