### PR TITLE
Increase timestamp precision for BigQuery events

### DIFF
--- a/app/lib/events/event.rb
+++ b/app/lib/events/event.rb
@@ -5,7 +5,7 @@ module Events
     def initialize
       @event_hash = {
         environment: HostingEnvironment.environment_name,
-        occurred_at: Time.zone.now.iso8601,
+        occurred_at: Time.zone.now.iso8601(6),
       }
     end
 


### PR DESCRIPTION
When two events happen to the same model at the same second, our BQ queries cannot determine which was later. Follow TVS _again_ https://github.com/DFE-Digital/teaching-vacancies/blob/e62958c603c2ffb4f32b5b4e8e862e32be8646f2/app/services/event.rb#L58
