### PR TITLE
Add extra placeholder dates to the cycle timetable helper

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -40,6 +40,11 @@ class CycleTimetable
     2023 => {
       find_opens: Time.zone.local(2022, 10, 5, 9), # This is a placeholder till we know the real date
       apply_opens: Time.zone.local(2022, 10, 12, 9), # This is a placeholder till we know the real date
+      show_deadline_banner: Time.zone.local(2023, 8, 1, 9), # This is a placeholder till we know the real date
+      apply_1_deadline: Time.zone.local(2023, 9, 7, 18), # This is a placeholder till we know the real date
+      apply_2_deadline: Time.zone.local(2023, 9, 21, 18), # This is a placeholder till we know the real date
+      reject_by_default: Time.zone.local(2023, 9, 29, 23, 59, 59), # This is a placeholder till we know the real date
+      find_closes: Time.zone.local(2023, 10, 4, 23, 59, 59), # This is a placeholder till we know the real date
     },
   }.freeze
 


### PR DESCRIPTION
## Context

We need extra placeholder dates for when we use the cycle switcher in the upcoming (2022) cycle. Otherwise it will blow up

## Changes proposed in this pull request

- Add in some additional placeholder dates

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
