### PR TITLE
Update equality and diversity error messages

### DIFF
--- a/config/locales/candidate_interface/equality_and_diversity.yml
+++ b/config/locales/candidate_interface/equality_and_diversity.yml
@@ -83,22 +83,20 @@ en:
         candidate_interface/equality_and_diversity/sex_form:
           attributes:
             sex:
-              blank: Choose your sex
+              blank: Select your sex or ‘Prefer not to say’
         candidate_interface/equality_and_diversity/disability_status_form:
           attributes:
             disability_status:
-              blank: Choose if you have a disability
+              blank: Select if you are disabled or ‘Prefer not to say’
         candidate_interface/equality_and_diversity/disabilities_form:
           attributes:
             disabilities:
-              blank: Select all disabilities that apply to you
-            other_disability:
-              blank: Describe your disability
+              blank: Select the disabilities you have or ‘Other’
         candidate_interface/equality_and_diversity/ethnic_background_form:
           attributes:
             ethnic_background:
-              blank: Choose your ethnic background
+              blank: Select your background or ‘Prefer not to say’
         candidate_interface/equality_and_diversity/ethnic_group_form:
           attributes:
             ethnic_group:
-              blank: Choose your ethnic group
+              blank: Select an ethnic group or ‘Prefer not to say’

--- a/spec/system/candidate_interface/entering_details/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_equality_and_diversity_information_spec.rb
@@ -144,7 +144,7 @@ RSpec.feature 'Entering their equality and diversity information' do
   end
 
   def then_i_see_an_error_to_choose_my_sex
-    expect(page).to have_content('Choose your sex')
+    expect(page).to have_content('Select your sex or ‘Prefer not to say’')
   end
 
   def when_i_choose_my_sex
@@ -184,7 +184,7 @@ RSpec.feature 'Entering their equality and diversity information' do
   end
 
   def then_i_see_an_error_to_choose_if_i_have_a_disability
-    expect(page).to have_content('Choose if you have a disability')
+    expect(page).to have_content('Select if you are disabled or ‘Prefer not to say’')
   end
 
   def when_i_choose_no_for_having_a_disability
@@ -200,7 +200,7 @@ RSpec.feature 'Entering their equality and diversity information' do
   end
 
   def then_i_see_an_error_to_choose_my_ethnic_group
-    expect(page).to have_content('Choose your ethnic group')
+    expect(page).to have_content('Select an ethnic group or ‘Prefer not to say’')
   end
 
   def when_i_choose_that_i_prefer_not_to_say_my_ethnic_group
@@ -224,7 +224,7 @@ RSpec.feature 'Entering their equality and diversity information' do
   end
 
   def then_i_see_an_error_to_select_disabilties
-    expect(page).to have_content('Select all disabilities that apply to you')
+    expect(page).to have_content('Select the disabilities you have or ‘Other’')
   end
 
   def when_i_check_my_disabilities
@@ -281,7 +281,7 @@ RSpec.feature 'Entering their equality and diversity information' do
   end
 
   def then_i_see_an_error_to_choose_my_ethnic_background
-    expect(page).to have_content('Choose your ethnic background')
+    expect(page).to have_content('Select your background or ‘Prefer not to say’')
   end
 
   def when_i_choose_my_ethnic_background


### PR DESCRIPTION
This brings the error messages in line with the [GOV.UK Design System guidance](https://design-system.service.gov.uk/patterns/equality-information/), which uses 'Select' for radios instead of 'Choose'. This is particularly important here as 'Choose' is a loaded word to use in the context of disability, ethnicity and sex/gender.

Adding " or ‘Prefer not to say’" alerts users to this option if they select a radio option because they didn't want to answer the question.