### PR TITLE
Sync new courses when find closes

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -22,7 +22,6 @@ class FeatureFlag
     [:service_unavailable_page, 'Displays a maintenance page on the whole application', 'Apply team'],
     [:send_request_data_to_bigquery, 'Send request data to Google Bigquery via background worker', 'Apply team'],
     [:enable_chat_support, 'Enable Zendesk chat support', 'Apply team'],
-    [:sync_next_cycle, 'Sync courses for the next recruitment cycle. Turn on after rollover', 'Apply team'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [

--- a/app/services/teacher_training_public_api/trigger_full_sync_if_find_closed.rb
+++ b/app/services/teacher_training_public_api/trigger_full_sync_if_find_closed.rb
@@ -1,0 +1,9 @@
+module TeacherTrainingPublicAPI
+  class TriggerFullSyncIfFindClosed
+    def self.call
+      if Time.zone.now.between?(CycleTimetable.find_closes, CycleTimetable.find_closes + 1.day)
+        TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false, ::RecruitmentCycle.next_year, true)
+      end
+    end
+  end
+end

--- a/app/workers/teacher_training_public_api/sync_all_providers_and_courses_worker.rb
+++ b/app/workers/teacher_training_public_api/sync_all_providers_and_courses_worker.rb
@@ -4,11 +4,27 @@ module TeacherTrainingPublicAPI
 
     sidekiq_options retry: 3, queue: :low_priority
 
-    def perform(incremental = true, year = ::RecruitmentCycle.current_year, suppress_sync_update_errors = false)
+    def perform(incremental = true, year = nil, suppress_sync_update_errors = false)
       return if HostingEnvironment.review?
 
+      year ||= year_to_sync
+
       SyncSubjects.new.perform
-      SyncAllProvidersAndCourses.call(recruitment_cycle_year: year, incremental_sync: incremental, suppress_sync_update_errors: suppress_sync_update_errors)
+      SyncAllProvidersAndCourses.call(
+        recruitment_cycle_year: year,
+        incremental_sync: incremental,
+        suppress_sync_update_errors: suppress_sync_update_errors,
+      )
+    end
+
+  private
+
+    def year_to_sync
+      if CycleTimetable.find_down?
+        ::RecruitmentCycle.next_year
+      else
+        ::RecruitmentCycle.current_year
+      end
     end
   end
 end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -9,11 +9,9 @@ class Clock
   error_handler { |error| Sentry.capture_exception(error) if defined? Sentry }
 
   # More-than-hourly jobs
-  every(10.minutes, 'IncrementalSyncAllFromTeacherTrainingPublicAPI', skip_first_run: true) { TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async }
-  every(11.minutes, 'IncrementalSyncNextCycleFromTeacherTrainingPublicAPI', skip_first_run: true) do
-    if FeatureFlag.active?(:sync_next_cycle)
-      TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(true, RecruitmentCycle.next_year)
-    end
+
+  every(10.minutes, 'IncrementalSyncAllFromTeacherTrainingPublicAPI', skip_first_run: true) do
+    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(true)
   end
 
   # Hourly jobs
@@ -59,12 +57,6 @@ class Clock
   every(1.day, 'SendNewCycleStartedEmailToCandidatesWorker', at: '12:00') { SendNewCycleHasStartedEmailToCandidatesWorker.new.perform }
 
   every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do
-    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false, RecruitmentCycle.current_year)
-  end
-
-  every(7.days, 'FullSyncNextCycleFromTeacherTrainingPublicAPI', at: 'Saturday 03:59') do
-    if FeatureFlag.active?(:sync_next_cycle)
-      TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false, RecruitmentCycle.next_year)
-    end
+    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false)
   end
 end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -56,6 +56,8 @@ class Clock
   every(1.day, 'SendFindHasOpenedEmailToCandidatesWorker', at: '12:00') { SendFindHasOpenedEmailToCandidatesWorker.new.perform }
   every(1.day, 'SendNewCycleStartedEmailToCandidatesWorker', at: '12:00') { SendNewCycleHasStartedEmailToCandidatesWorker.new.perform }
 
+  every(1.day, 'TriggerFullSyncIfFindClosed', at: '00:05') { TeacherTrainingPublicAPI::TriggerFullSyncIfFindClosed.call }
+
   every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do
     TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false)
   end

--- a/spec/services/teacher_training_public_api/trigger_full_sync_if_find_closed_spec.rb
+++ b/spec/services/teacher_training_public_api/trigger_full_sync_if_find_closed_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe TeacherTrainingPublicAPI::TriggerFullSyncIfFindClosed do
+  before { allow(TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker).to receive(:perform_async) }
+
+  context 'when find closed within the last day' do
+    before { allow(CycleTimetable).to receive(:find_closes).and_return(5.minutes.ago) }
+
+    it 'triggers a full sync for the next year ignoring update errors' do
+      described_class.call
+      expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker).to have_received(:perform_async).with(false, RecruitmentCycle.next_year, true)
+    end
+  end
+
+  context 'when find is yet to close' do
+    before { allow(CycleTimetable).to receive(:find_closes).and_return(2.hours.from_now) }
+
+    it 'does not trigger a sync' do
+      described_class.call
+      expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker).not_to have_received(:perform_async)
+    end
+  end
+
+  context 'when find closed over a day ago' do
+    before { allow(CycleTimetable).to receive(:find_closes).and_return((1.day + 1.hour).ago) }
+
+    it 'does not trigger a sync' do
+      described_class.call
+      expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker).not_to have_received(:perform_async)
+    end
+  end
+end


### PR DESCRIPTION
## Context
Find is going to close at midnight on 4th Oct and reopen at 9am on the 5th. This gives us 9 hours to sync the courses for the new cycle before it starts.

## Changes proposed in this pull request
When find closes, start syncing the new year and stop syncing the next year.

Add an hourly job that checks if find has just closed, and trigger a sync if so

## Guidance to review
For the new hourly job, I thought about making a new worker that does the check and triggers the sync. I now can't see a strong reason to put that in now though. It would allow us to test the check, but also it could cause us unforeseen issues (e.g if that job gets held up then maybe the sync is never triggered)

## Link to Trello card
https://trello.com/c/zfxjZXId/4285-sync-courses-from-next-cycle-when-find-closes

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
