### PR TITLE
Configure StartOfCycleNotificationWorker jobs in clockwork

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -17,6 +17,11 @@ class Clock
   end
 
   # Hourly jobs
+
+  # StartOfCycleNotificationWorker only works the day the service opens. These two jobs won't run at the same time on the same day.
+  every(1.hour, 'SendFindStartOfCycleProviderEmails', at: '**:05') { StartOfCycleNotificationWorker.perform_async(:find) }
+  every(1.hour, 'SendApplyStartOfCycleProviderEmails', at: '**:05') { StartOfCycleNotificationWorker.perform_async(:apply) }
+
   every(1.hour, 'RejectApplicationsByDefault', at: '**:10') { RejectApplicationsByDefaultWorker.perform_async }
   every(1.hour, 'DeclineOffersByDefault', at: '**:15') { DeclineOffersByDefaultWorker.perform_async }
   every(1.hour, 'ChaseReferences', at: '**:20') { ChaseReferences.perform_async }


### PR DESCRIPTION
## Context

We'd like to notify providers when Find and Apply services open.
`StartOfCycleNotificationWorker` will only send emails on the day the relevant service opens.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Schedules `StartOfCycleNotificationWorker` jobs for Find and Apply services, these are configured on the same minute because the services do not open on the same day. The worker will not attempt to send mail unless it's the day the service opens.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/WTnGjL50/4274-spike-investigate-prototype-scheduling-of-staggered-provider-user-emails
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
