### PR TITLE
Fix visa sponsorship row to render correctly

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -212,7 +212,7 @@ module CandidateInterface
     end
 
     def visa_details_row(application_choice)
-      return nil if right_to_work_or_study?(application_choice) ||
+      return nil if immigration_right_to_work?(application_choice) ||
                     application_predates_visa_sponsorship_information?(application_choice)
 
       {
@@ -221,9 +221,9 @@ module CandidateInterface
       }
     end
 
-    def right_to_work_or_study?(application_choice)
+    def immigration_right_to_work?(application_choice)
       application_choice.application_form.british_or_irish? ||
-        application_choice.application_form.right_to_work_or_study_yes?
+        application_choice.application_form.immigration_right_to_work?
     end
 
     def application_predates_visa_sponsorship_information?(application_choice)

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -435,13 +435,13 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
           :completed_application_form,
           first_nationality: 'Indian',
           second_nationality: nil,
-          right_to_work_or_study: :no,
+          immigration_right_to_work: true,
           recruitment_cycle_year: 2022,
         )
         create(:application_choice, application_form: application_form)
 
         result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
-        expect(result.css('.govuk-summary-list__key').text).to include('Visa sponsorship')
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Visa sponsorship')
       end
     end
 
@@ -451,8 +451,40 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
           :completed_application_form,
           first_nationality: 'Indian',
           second_nationality: nil,
-          right_to_work_or_study: :no,
+          immigration_right_to_work: true,
           recruitment_cycle_year: 2021,
+        )
+        create(:application_choice, application_form: application_form)
+
+        result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Visa sponsorship')
+      end
+    end
+
+    context 'when candidate does not have right to work' do
+      it 'does render a Visa sponsorship row' do
+        application_form = create(
+          :completed_application_form,
+          first_nationality: 'Indian',
+          second_nationality: nil,
+          immigration_right_to_work: false,
+          recruitment_cycle_year: 2022,
+        )
+        create(:application_choice, application_form: application_form)
+
+        result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
+        expect(result.css('.govuk-summary-list__key').text).to include('Visa sponsorship')
+      end
+    end
+
+    context 'when candidate does have right to work' do
+      it 'does NOT render a Visa sponsorship row' do
+        application_form = create(
+          :completed_application_form,
+          first_nationality: 'Indian',
+          second_nationality: nil,
+          immigration_right_to_work: true,
+          recruitment_cycle_year: 2022,
         )
         create(:application_choice, application_form: application_form)
 


### PR DESCRIPTION
## Context

As part of the Visa soponsorship work the visa requirements are shown 
contextually in the course choice review component. The legacy attribute 
was being used in the conditional. 

## Changes proposed in this pull request

This PR updates the conditional to use the correct attribute and updates the spec to cover this scenario.

## Guidance to review

## Link to Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
