### PR TITLE
Convert hash fields to JSON to resolve BigQuery invalid record failures

### DIFF
--- a/app/lib/events/event.rb
+++ b/app/lib/events/event.rb
@@ -89,6 +89,8 @@ module Events
       hash.map do |(key, value)|
         if value.in? [true, false]
           value = value.to_s
+        elsif value.is_a?(Hash)
+          value = value.to_json
         end
 
         { 'key' => key, 'value' => Array.wrap(value) }

--- a/spec/lib/events/event_spec.rb
+++ b/spec/lib/events/event_spec.rb
@@ -61,6 +61,12 @@ RSpec.describe Events::Event do
       output = event.with_data(key: true).as_json
       expect(output['data'].first['value']).to eq ['true']
     end
+
+    it 'converts hashes to strings' do
+      event = described_class.new
+      output = event.with_data(key: { equality_and_diversity: { ethnic_background: 'Irish' } }).as_json
+      expect(output['data'].first['value']).to eq ['{"equality_and_diversity":{"ethnic_background":"Irish"}}']
+    end
   end
 
   def fake_request(overrides = {})


### PR DESCRIPTION
## Context
BigQuery results in invalid record failures for any row containing data in a hash format. This was identified by inspecting the failures. More specifically all `ApplicationForm` and `FeatureMetricsDashboard` records with any of their jsonb fields populated (`equality_and_diversity` for `ApplicationForm` and `metrics` for the `FeatureMetricsDashboard`) resulted in an invalid record BigQuery error.

Converting the data to json resolves the issue.
