### PR TITLE
Tweak award year validation on other qualification details page

### DIFF
--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -13,7 +13,8 @@ module CandidateInterface
 
     validates :qualification_type, presence: true
 
-    validates :award_year, presence: true, year: { future: true }
+    validates :award_year, presence: true
+    validate :award_year_is_at_most_one_year_in_future, if: -> { award_year }
     validates :subject, :grade, presence: true, if: -> { should_validate_grade? }
     validates :subject, :grade, length: { maximum: 255 }
     validates :other_uk_qualification_type, length: { maximum: 100 }
@@ -110,7 +111,9 @@ module CandidateInterface
 
     def grade_hint
       if qualification_type == CandidateInterface::OtherQualificationTypeForm::GCSE_TYPE
-        { text: I18n.t('gcse_edit_grade.hint.other.gcse_single_and_double') }
+        { text: (I18n.t('gcse_edit_grade.hint.other.gcse_single_and_double') + ' ' + I18n.t('application_form.other_qualification.grade.hint_text')) }
+      else
+        { text: I18n.t('application_form.other_qualification.grade.hint_text') }
       end
     end
 
@@ -193,6 +196,10 @@ module CandidateInterface
       qualification_type.in? [OtherQualificationTypeForm::A_LEVEL_TYPE,
                               OtherQualificationTypeForm::AS_LEVEL_TYPE,
                               OtherQualificationTypeForm::GCSE_TYPE]
+    end
+
+    def award_year_is_at_most_one_year_in_future
+      errors.add(:award_year, :future) if award_year.to_i > RecruitmentCycle.next_year || award_year.to_i.zero?
     end
   end
 end

--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -111,7 +111,7 @@ module CandidateInterface
 
     def grade_hint
       if qualification_type == CandidateInterface::OtherQualificationTypeForm::GCSE_TYPE
-        { text: (I18n.t('gcse_edit_grade.hint.other.gcse_single_and_double') + ' ' + I18n.t('application_form.other_qualification.grade.hint_text')) }
+        { text: "#{I18n.t('gcse_edit_grade.hint.other.gcse_single_and_double')}. #{I18n.t('application_form.other_qualification.grade.hint_text')}" }
       else
         { text: I18n.t('application_form.other_qualification.grade.hint_text') }
       end

--- a/config/locales/candidate_interface/other_qualification.yml
+++ b/config/locales/candidate_interface/other_qualification.yml
@@ -23,9 +23,10 @@ en:
         label: Grade
         optional_label: Grade (optional)
         change_action: grade
+        hint_text: If you are studying for your qualification, give your predicted grade.
       award_year:
-        label: Year qualification was awarded
-        hint_text: For example, 1998
+        label: Year qualification awarded
+        hint_text: For example, 1998. If you are studying for your qualification, indicate when you’ll acheive it.
         review_label: Year awarded
         change_action: year
       another:
@@ -73,6 +74,6 @@ en:
               too_long: The grade must be %{count} characters or fewer
             award_year:
               blank: Enter the year the qualification was awarded
-              future: Assessment year must be this year or a previous year
+              future: Year qualification awarded must be this year, next year or a previous year
             choice:
               blank: Do you want to add another qualification?

--- a/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
   end
 
   describe '#grade_hint' do
-    it 'returns a GCSE hint if qualification_type is GCSE_TYPE' do
+    it 'returns a GCSE and predicted grade hint if qualification_type is GCSE_TYPE' do
       qualification = described_class.new(
         nil,
         nil,
@@ -367,10 +367,10 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
         qualification_type: 'GCSE',
       )
 
-      expect(qualification.grade_hint).to eq({ text: 'For example, ‘C’, ‘CD’, ‘4’ or ‘4-3’' })
+      expect(qualification.grade_hint).to eq({ text: 'For example, ‘C’, ‘CD’, ‘4’ or ‘4-3’. If you are studying for your qualification, give your predicted grade.' })
     end
 
-    it 'returns nil for any other qualification_type' do
+    it 'returns predicted grade hint for any other qualification_type' do
       namespace = CandidateInterface::OtherQualificationTypeForm
 
       (namespace::ALL_VALID_TYPES - [namespace::GCSE_TYPE]).each do |qualification_type|
@@ -381,7 +381,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
           qualification_type: qualification_type,
         )
 
-        expect(qualification.grade_hint).to eq nil
+        expect(qualification.grade_hint).to eq({ text: 'If you are studying for your qualification, give your predicted grade.' })
       end
     end
   end

--- a/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
@@ -105,13 +105,16 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
 
     describe 'award year' do
       context 'year validations' do
-        let(:model) do
-          described_class.new(nil, nil, award_year: award_year)
-        end
+        it 'allows award year to be valid for the next recruitment_cycle_year' do
+          valid_award_year = described_class.new(nil, nil, qualification_type: 'A level', award_year: RecruitmentCycle.next_year)
+          invalid_award_year = described_class.new(nil, nil, qualification_type: 'A level', award_year: RecruitmentCycle.next_year + 1)
 
-        include_examples 'year validations',
-                         :award_year,
-                         future: true
+          valid_award_year.valid?(:details)
+          invalid_award_year.valid?(:details)
+
+          expect(valid_award_year.errors.full_messages_for(:award_year)).to be_empty
+          expect(invalid_award_year.errors.full_messages_for(:award_year)).not_to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

A user wants to be able to add an in progress A level as they've been told by a TTA that if they submit it without adding it they will likely be rejected.


## Changes proposed in this pull request

- Allow award year for other quals to be one year in the future
- Update the hint text

![image](https://user-images.githubusercontent.com/42515961/135427554-5071e266-1b66-4247-99be-addd850ef4c4.png)

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
