### PR TITLE
report table now handles empty rows array

### DIFF
--- a/app/components/provider_interface/report_table_component.html.erb
+++ b/app/components/provider_interface/report_table_component.html.erb
@@ -23,7 +23,7 @@
     <% end %>
   </tbody>
 
-  <% if show_footer %>
+  <% if footer.any? %>
     <tfoot>
       <tr class='govuk-table__row'>
         <th class='govuk-table__header' scope='row'>Total</th>

--- a/app/components/provider_interface/report_table_component.rb
+++ b/app/components/provider_interface/report_table_component.rb
@@ -11,7 +11,7 @@ module ProviderInterface
     end
 
     def footer
-      [] unless show_footer
+      return [] unless show_footer && rows.any?
 
       @footer = Array.new(rows.first[:values].length) { 0 }
       rows.each do |row|

--- a/spec/components/provider_interface/report_table_component_spec.rb
+++ b/spec/components/provider_interface/report_table_component_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe ProviderInterface::ReportTableComponent do
       expect(render.css('tfoot td')[3].text).to eq('10')
       expect(render.css('tfoot td')[4].text).to eq('10')
     end
+
+    context 'when there are no rows' do
+      let(:data) { { headers: headers, rows: [] } }
+
+      it 'attempt to calculate the totals in the footer' do
+        expect(render.css('tfoot')).to be_empty
+      end
+    end
   end
 
   describe 'when show_footer is set to false' do


### PR DESCRIPTION
## Context

https://sentry.io/organizations/dfe-bat/issues/2683791563/?project=1765973&query=url%3A%22https%3A%2F%2Fwww.apply-for-teacher-training.service.gov.uk%2Fprovider%2Freports%2F1973%2Fstatus-of-active-applications%22

Sentry error caused by empty rows array being passed to the report table component. Report table component now correctly handles there being no rows array.  

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
