### PR TITLE
Guard against destroyed reference in the email controller

### DIFF
--- a/app/controllers/candidate_interface/references/email_address_controller.rb
+++ b/app/controllers/candidate_interface/references/email_address_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   module References
     class EmailAddressController < BaseController
-      before_action :verify_email_is_editable
+      before_action :verify_email_is_editable, :redirect_to_review_page_unless_reference_is_editable
       before_action :set_edit_backlink, only: %i[edit update]
 
       def new


### PR DESCRIPTION
## Context

A user either navigated back to or left the page open for a destroyed reference. This caused a 500 here https://sentry.io/organizations/dfe-bat/issues/2683729790/?project=1765973&referrer=slack

We guard against this in the other controllers, but this one was missed.

## Changes proposed in this pull request

- Redirect to the references review page if a reference doesn't exist.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
