### PR TITLE
Trigger validation for a GCSE qualification that does not meet grade requirements and has missing fields

### DIFF
--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -88,6 +88,9 @@ class ApplicationQualification < ApplicationRecord
   def incomplete_gcse_information?
     return false if qualification_type == 'missing' && (currently_completing_qualification == true || currently_completing_qualification == false)
     return true if grade.nil? && constituent_grades.nil?
+    return true if qualification_type == 'gcse' &&
+                   failed_required_gcse? &&
+                   currently_completing_qualification.nil?
 
     return true if EXPECTED_GCSE_DATA.any? do |field_name|
       send(field_name).blank?

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -80,6 +80,44 @@ RSpec.describe ApplicationQualification, type: :model do
     end
   end
 
+  describe '#incomplete_gcse_information' do
+    context "a GCSE qualification that does not meet grade requirements and 'currently_completing_qualification' is nil" do
+      it 'returns true' do
+        qualification = build(:gcse_qualification, grade: 'D', currently_completing_qualification: nil)
+        expect(qualification.incomplete_gcse_information?).to eq true
+      end
+    end
+
+    context "a GCSE qualification with 'grade' and 'constituent_grades' equal to 'nil'" do
+      it 'returns true' do
+        qualification = build(:gcse_qualification, grade: nil, constituent_grades: nil)
+        expect(qualification.incomplete_gcse_information?).to eq true
+      end
+    end
+
+    context 'a GCSE qualification with missing data' do
+      it 'returns true' do
+        qualification = build(:gcse_qualification, subject: nil)
+        expect(qualification.incomplete_gcse_information?).to eq true
+      end
+    end
+
+    context "a qualification with a 'type' equal to 'missing' and 'currently_completing_qualification' is not nil" do
+      it 'returns false' do
+        qualification = build(:gcse_qualification, qualification_type: 'missing', currently_completing_qualification: true)
+        expect(qualification.incomplete_gcse_information?).to eq false
+      end
+    end
+
+    context 'a complete GCSE qualification' do
+      it 'returns false' do
+        qualification = build(:gcse_qualification)
+
+        expect(qualification.incomplete_gcse_information?).to eq false
+      end
+    end
+  end
+
   describe '#incomplete_other_qualification?' do
     context 'when a non_uk qualification' do
       it 'returns false if not an other_qualification' do


### PR DESCRIPTION
## Context

When a candidate fills out a GCSE qualification with a grade that meets minimum requirements (e.g A, B, C) but then updates the grade to one that does not meet minimum requirements (e.g D) they are taken through a separate flow where they need to provide answer whether they are retaking the qualification and if not, why. However once they reach this point it is possible to click the 'back' link until they get to the review page, mark the section as completed and submit without having answered the 'Are you currently studying to retake your GCSE in maths?' question.


## Changes proposed in this pull request

- On the qualification review page, validation will now be triggered if the grade does not meet minimum requirements and there is no value set for the `currently_completing_qualification` field
- Add specs for the '#incomplete_gcse_information?' method on the `ApplicationQualification` model 

<img width="901" alt="validation" src="https://user-images.githubusercontent.com/5256922/135446573-00dab55b-ea84-47a4-bf52-d618bace569a.png">

## Guidance to review

You should no longer be ale to replicate the bug described in the contexct section above

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
