### PR TITLE
Fix issue with carried over applications not being able to add jobs

### DIFF
--- a/app/services/data_migrations/backfill_work_history_status.rb
+++ b/app/services/data_migrations/backfill_work_history_status.rb
@@ -1,0 +1,15 @@
+module DataMigrations
+  class BackfillWorkHistoryStatus
+    TIMESTAMP = 20210930132233
+    MANUAL_RUN = false
+
+    def change
+      ApplicationForm
+      .joins(:application_work_experiences)
+      .where(recruitment_cycle_year: 2022, work_history_status: nil)
+      .where.not(application_work_experiences: { id: nil })
+      .distinct
+      .each(&:can_complete!)
+    end
+  end
+end

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -31,6 +31,7 @@ class DuplicateApplication
       new_application_form.update(
         feature_restructured_work_history: true,
         work_history_completed: false,
+        work_history_status: new_application_form.application_work_experiences.present? ? 'can_complete' : nil,
       )
     end
     if !original_application_form.restructured_immigration_status? &&

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillWorkHistoryStatus',
   'DataMigrations::AddVendorsToProvidersForFirstTime',
   'DataMigrations::BackfillNotCompletedExplanation',
   'DataMigrations::BackfillCoursesForNextCycle',

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -128,6 +128,21 @@ RSpec.describe CarryOverApplication do
       expect(carried_over_application_form.work_history_completed).to be(false)
     end
 
+    it 'sets `work_history_status` to `can_complete` if the candidate has a work history' do
+      described_class.new(original_application_form).call
+      carried_over_application_form = ApplicationForm.last
+
+      expect(carried_over_application_form.work_history_status).to eq 'can_complete'
+    end
+
+    it 'does not set `work_history_status`if the candidate has no work history' do
+      application_form = create(:completed_application_form)
+      described_class.new(application_form).call
+      carried_over_application_form = ApplicationForm.last
+
+      expect(carried_over_application_form.work_history_status).to eq nil
+    end
+
     describe 'personal_details_completed' do
       before { FeatureFlag.activate(:restructured_immigration_status) }
 

--- a/spec/services/data_migrations/backfill_work_history_status_spec.rb
+++ b/spec/services/data_migrations/backfill_work_history_status_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillWorkHistoryStatus do
+  it 'updates `work_history_status` from `nil` to `can_complete` for application forms in the 2022 cycle with work experiences' do
+    application_form_with_experiences = create(:application_form, work_history_status: nil, recruitment_cycle_year: 2022)
+    create(:application_work_experience, application_form: application_form_with_experiences)
+
+    application_form_with_experiences_from_previous_cycle = create(:application_form, work_history_status: nil, recruitment_cycle_year: 2021)
+    create(:application_work_experience, application_form: application_form_with_experiences_from_previous_cycle)
+
+    application_form_without_experiences = create(:application_form, work_history_status: nil, recruitment_cycle_year: 2022)
+
+    described_class.new.change
+
+    expect(application_form_with_experiences.reload.work_history_status).to eq 'can_complete'
+    expect(application_form_with_experiences_from_previous_cycle.reload.work_history_status).to eq nil
+    expect(application_form_without_experiences.reload.work_history_status).to eq nil
+  end
+end


### PR DESCRIPTION
## Context

Currently, if a candidate with work experience carries over their application, they're unable to add another job due to this bit of code.

![image](https://user-images.githubusercontent.com/42515961/135456702-ff2518c4-2c50-421b-a40e-2fab0e013945.png)

The button only appears if they've indicated they can provide work history.

This is currently affecting 128 candidates (although just 1 zendesk ticket)

![image](https://user-images.githubusercontent.com/42515961/135457148-7e041b02-d9cb-48ec-984a-e48fa9b73b59.png)

## Changes proposed in this pull request

- Set the work_history_status enum to `can_complete` if they have provided a work history
- Backfill the work_history_status enum for carried over applications

## Guidance to review

We should probably have a look at this flow again at some point because the logic seems a bit janky. But we don't really have time atm.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
