### PR TITLE
Add a preview of the single provider relationship permissions set up email

### DIFF
--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -128,6 +128,14 @@ class ProviderMailerPreview < ActionMailer::Preview
     ProviderMailer.set_up_organisation_permissions(provider_user, relationships_to_set_up)
   end
 
+  def set_up_organisation_permissions_single_provider
+    relationships_to_set_up = {
+      'University of Dundee' => ['University of Broughty Ferry', 'University of Forfar', 'University of Wormit'],
+    }
+    provider_user = FactoryBot.create(:provider_user)
+    ProviderMailer.set_up_organisation_permissions(provider_user, relationships_to_set_up)
+  end
+
 private
 
   def provider


### PR DESCRIPTION
## Context

We render 2 different blocks of content depending on whether the email recipient needs to set up permissions for multiple organisations or for one organisation.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds a mailer preview method to render the single organisation relationship version, the multi-org version already has a preview method.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Check the review app `ProviderMailer#set_up_organisation_permissions_single_provider` preview 
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/j6AXBzwy/4291-create-start-of-cycle-provider-emails-for-find-and-apply

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
