### PR TITLE
Scope Vendor dashboard to providers with vendors

### DIFF
--- a/app/models/support_interface/vendor_api_monitor.rb
+++ b/app/models/support_interface/vendor_api_monitor.rb
@@ -5,7 +5,7 @@ module SupportInterface
     end
 
     def all_providers
-      Provider.where(provider_type: 'university')
+      Provider.joins(:vendor)
     end
 
     def target_providers

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -19,4 +19,5 @@
   'Last updated' => @provider.updated_at.to_s(:govuk_date_and_time),
   'Data sharing agreement' => dsa,
   'Average distance to sites' => format_average_distance(@provider, @provider.sites),
+  'Vendor' => @provider.vendor&.name&.humanize,
 })) %>

--- a/spec/models/support_interface/vendor_api_monitor_spec.rb
+++ b/spec/models/support_interface/vendor_api_monitor_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe SupportInterface::VendorAPIMonitor do
 
   describe '#never_connected' do
     it 'returns only providers with no API request logs ever' do
-      provider_who_hasnt_connected = create(:provider, provider_type: 'university')
-      provider_who_has_connected = create(:provider, provider_type: 'university')
+      provider_who_hasnt_connected = create(:provider, :with_vendor)
+      provider_who_has_connected = create(:provider, :with_vendor)
 
       create(:vendor_api_request, provider: provider_who_has_connected)
 
@@ -18,10 +18,10 @@ RSpec.describe SupportInterface::VendorAPIMonitor do
     end
 
     it 'returns only providers with no API request logs ever for a specific vendor when the vendor is provided' do
-      provider_who_hasnt_connected_from_correct_vendor = create(:provider, provider_type: 'university', vendor: vendor)
-      provider_who_has_connected_from_correct_vendor = create(:provider, provider_type: 'university', vendor: vendor)
-      _provider_who_hasnt_connected_from_other_vendor = create(:provider, :with_vendor, provider_type: 'university')
-      _provider_who_hasnt_connected_with_no_vendor = create(:provider, provider_type: 'university')
+      provider_who_hasnt_connected_from_correct_vendor = create(:provider, vendor: vendor)
+      provider_who_has_connected_from_correct_vendor = create(:provider, vendor: vendor)
+      _provider_who_hasnt_connected_from_other_vendor = create(:provider, :with_vendor)
+      _provider_who_hasnt_connected_with_no_vendor = create(:provider)
 
       create(:vendor_api_request, provider: provider_who_has_connected_from_correct_vendor)
       expect(monitor(vendor: vendor).never_connected).to match_array [provider_who_hasnt_connected_from_correct_vendor]
@@ -30,11 +30,11 @@ RSpec.describe SupportInterface::VendorAPIMonitor do
 
   describe '#no_sync_in_24h' do
     it 'returns only providers who have connected and who have not synced in 24h' do
-      _never_connected = create(:provider, name: 'never', provider_type: 'university')
-      synced_recently = create(:provider, name: 'recently', provider_type: 'university')
-      failed_recently = create(:provider, name: 'failed', provider_type: 'university')
-      synced_1w_ago = create(:provider, name: '1 week ago', provider_type: 'university')
-      synced_2d_ago = create(:provider, name: '3 hours', provider_type: 'university')
+      _never_connected = create(:provider, :with_vendor, name: 'never')
+      synced_recently = create(:provider, :with_vendor, name: 'recently')
+      failed_recently = create(:provider, :with_vendor, name: 'failed')
+      synced_1w_ago = create(:provider, :with_vendor, name: '1 week ago')
+      synced_2d_ago = create(:provider, :with_vendor, name: '3 hours')
 
       create(:vendor_api_request, provider: synced_recently)
       create(:vendor_api_request, provider: failed_recently, status_code: 422)
@@ -45,11 +45,11 @@ RSpec.describe SupportInterface::VendorAPIMonitor do
     end
 
     it 'returns only providers who have connected and who have not synced in 24h for a specific vendor when provided' do
-      synced_recently = create(:provider, name: 'recently', provider_type: 'university', vendor: vendor)
-      failed_recently = create(:provider, name: 'failed', provider_type: 'university', vendor: vendor)
-      synced_1w_ago = create(:provider, name: '1 week ago', provider_type: 'university', vendor: vendor)
-      synced_2d_ago = create(:provider, name: '3 hours', provider_type: 'university', vendor: vendor)
-      failed_recently_with_other_vendor = create(:provider, :with_vendor, name: 'failed', provider_type: 'university')
+      synced_recently = create(:provider, name: 'recently', vendor: vendor)
+      failed_recently = create(:provider, name: 'failed', vendor: vendor)
+      synced_1w_ago = create(:provider, name: '1 week ago', vendor: vendor)
+      synced_2d_ago = create(:provider, name: '3 hours', vendor: vendor)
+      failed_recently_with_other_vendor = create(:provider, :with_vendor, name: 'failed')
 
       create(:vendor_api_request, provider: synced_recently)
       create(:vendor_api_request, provider: failed_recently, status_code: 422)
@@ -62,11 +62,11 @@ RSpec.describe SupportInterface::VendorAPIMonitor do
 
   describe '#no_decisions_in_7d' do
     it 'returns only providers who have connected and who have not made decisions in 7 days' do
-      _never_connected = create(:provider, name: 'never', provider_type: 'university')
-      decided_recently = create(:provider, name: 'recently', provider_type: 'university')
-      failed_recently = create(:provider, name: 'failed', provider_type: 'university')
-      decided_over_2w_ago = create(:provider, name: '2 weeks', provider_type: 'university')
-      decided_over_7d_ago = create(:provider, name: '7 days', provider_type: 'university')
+      _never_connected = create(:provider, :with_vendor, name: 'never')
+      decided_recently = create(:provider, :with_vendor, name: 'recently')
+      failed_recently = create(:provider, :with_vendor, name: 'failed')
+      decided_over_2w_ago = create(:provider, :with_vendor, name: '2 weeks')
+      decided_over_7d_ago = create(:provider, :with_vendor, name: '7 days')
 
       create(:vendor_api_request, request_method: 'POST', provider: decided_recently)
       create(:vendor_api_request, request_method: 'POST', provider: failed_recently, status_code: 422)
@@ -77,13 +77,13 @@ RSpec.describe SupportInterface::VendorAPIMonitor do
     end
 
     it 'returns only providers who have connected and who have not made decisions in 7 days for a given vendor' do
-      _never_connected = create(:provider, name: 'never', provider_type: 'university', vendor: vendor)
-      decided_recently = create(:provider, name: 'recently', provider_type: 'university', vendor: vendor)
-      failed_recently = create(:provider, name: 'failed', provider_type: 'university', vendor: vendor)
-      decided_over_2w_ago = create(:provider, name: '2 weeks', provider_type: 'university', vendor: vendor)
-      decided_over_7d_ago = create(:provider, name: '7 days', provider_type: 'university', vendor: vendor)
-      _decided_over_2w_ago_with_other_provider = create(:provider, :with_vendor, name: '2 weeks', provider_type: 'university')
-      _decided_over_7d_ago_with_other_provider = create(:provider, :with_vendor, name: '7 days', provider_type: 'university')
+      _never_connected = create(:provider, name: 'never', vendor: vendor)
+      decided_recently = create(:provider, name: 'recently', vendor: vendor)
+      failed_recently = create(:provider, name: 'failed', vendor: vendor)
+      decided_over_2w_ago = create(:provider, name: '2 weeks', vendor: vendor)
+      decided_over_7d_ago = create(:provider, name: '7 days', vendor: vendor)
+      _decided_over_2w_ago_with_other_provider = create(:provider, :with_vendor, name: '2 weeks')
+      _decided_over_7d_ago_with_other_provider = create(:provider, :with_vendor, name: '7 days')
 
       create(:vendor_api_request, request_method: 'POST', provider: decided_recently)
       create(:vendor_api_request, request_method: 'POST', provider: failed_recently, status_code: 422)
@@ -96,10 +96,10 @@ RSpec.describe SupportInterface::VendorAPIMonitor do
 
   describe '#providers_with_errors' do
     it 'returns structs with providers who have connected and who have caused errors in the last 7 days' do
-      _never_connected = create(:provider, name: 'never', provider_type: 'university')
-      errored_recently = create(:provider, name: 'recently', provider_type: 'university')
-      errored_over_7d_ago = create(:provider, name: 'stale', provider_type: 'university')
-      no_errors = create(:provider, name: 'no-errors', provider_type: 'university')
+      _never_connected = create(:provider, :with_vendor, name: 'never')
+      errored_recently = create(:provider, :with_vendor, name: 'recently')
+      errored_over_7d_ago = create(:provider, :with_vendor, name: 'stale')
+      no_errors = create(:provider, :with_vendor, name: 'no-errors')
 
       create(:vendor_api_request, request_method: 'POST', status_code: 422, provider: errored_recently)
       create(:vendor_api_request, request_method: 'POST', status_code: 200, provider: errored_recently)
@@ -115,11 +115,11 @@ RSpec.describe SupportInterface::VendorAPIMonitor do
     end
 
     it 'returns structs with providers who have connected and who have caused errors in the last 7 days for a given vendor' do
-      _never_connected = create(:provider, name: 'never', provider_type: 'university')
-      errored_recently = create(:provider, name: 'recently', provider_type: 'university', vendor: vendor)
-      errored_recently_with_different_provider = create(:provider, :with_vendor, name: 'recently', provider_type: 'university')
-      errored_over_7d_ago = create(:provider, name: 'stale', provider_type: 'university')
-      no_errors = create(:provider, name: 'no-errors', provider_type: 'university')
+      _never_connected = create(:provider, :with_vendor, name: 'never')
+      errored_recently = create(:provider, name: 'recently', vendor: vendor)
+      errored_recently_with_different_provider = create(:provider, :with_vendor, name: 'recently')
+      errored_over_7d_ago = create(:provider, :with_vendor, name: 'stale')
+      no_errors = create(:provider, :with_vendor, name: 'no-errors')
 
       create(:vendor_api_request, request_method: 'POST', status_code: 422, provider: errored_recently)
       create(:vendor_api_request, request_method: 'POST', status_code: 422, provider: errored_recently_with_different_provider)

--- a/spec/system/support_interface/vendor_api_monitoring_spec.rb
+++ b/spec/system/support_interface/vendor_api_monitoring_spec.rb
@@ -28,11 +28,11 @@ RSpec.feature 'Vendor API monitoring page', mid_cycle: false do
   end
 
   def and_there_is_a_provider_who_has_not_connected_to_the_api
-    create(:provider, provider_type: 'university', name: 'Did not connect')
+    create(:provider, :with_vendor, name: 'Did not connect')
   end
 
   def and_there_is_a_provider_who_has_not_synced
-    provider = create(:provider, provider_type: 'university', name: 'Did not sync')
+    provider = create(:provider, :with_vendor, name: 'Did not sync')
     create(:vendor_api_request,
            provider: provider,
            request_path: '/api/v1/applications',
@@ -41,7 +41,7 @@ RSpec.feature 'Vendor API monitoring page', mid_cycle: false do
   end
 
   def and_there_is_a_provider_who_has_not_posted_a_decision
-    provider = create(:provider, provider_type: 'university', name: 'Did not post a decision')
+    provider = create(:provider, :with_vendor, name: 'Did not post a decision')
     create(:vendor_api_request,
            provider: provider,
            request_method: 'POST',
@@ -49,7 +49,7 @@ RSpec.feature 'Vendor API monitoring page', mid_cycle: false do
   end
 
   def and_there_is_a_provider_who_has_received_error_responses_from_the_api
-    provider = create(:provider, provider_type: 'university', name: 'Received an error response')
+    provider = create(:provider, :with_vendor, name: 'Received an error response')
     create(:vendor_api_request,
            provider: provider,
            status_code: 422)


### PR DESCRIPTION
## Context

This removes a lot of noise from the dashboard.

Also add the vendor name to the provider page in support.

<img width="1029" alt="Screenshot 2021-09-30 at 15 22 42" src="https://user-images.githubusercontent.com/642279/135473665-59496314-5b5e-4759-9122-f8adb7ebb79a.png">

