### PR TITLE
Add timeout and retries to BigQuery entity import & rake task for run all required imports

### DIFF
--- a/app/workers/send_events_to_bigquery.rb
+++ b/app/workers/send_events_to_bigquery.rb
@@ -6,7 +6,7 @@ class SendEventsToBigquery
 
   def perform(request_event_json)
     table_name = ENV.fetch('BIG_QUERY_TABLE_NAME', 'events')
-    bq = Google::Cloud::Bigquery.new(project: ENV.fetch('BIG_QUERY_PROJECT_ID'))
+    bq = Google::Cloud::Bigquery.new(project: ENV.fetch('BIG_QUERY_PROJECT_ID'), retries: 3, timeout: 120)
     dataset = bq.dataset(ENV.fetch('BIG_QUERY_DATASET'), skip_lookup: true)
     bq_table = dataset.table(table_name, skip_lookup: true)
     bq_table.insert([request_event_json])

--- a/lib/tasks/import_data_to_bigquery.rake
+++ b/lib/tasks/import_data_to_bigquery.rake
@@ -1,7 +1,32 @@
 DEFAULT_BATCH_SIZE = 200
 SLEEP_TIME = 2
+IRREGULAR_TABLE_NAMES = {
+  provider_relationship_permissions: 'ProviderRelationshipPermissions',
+  provider_user_notifications: 'ProviderUserNotificationPreferences',
+  provider_users_providers: 'ProviderPermissions',
+  references: 'ApplicationReference',
+}.freeze
+
+def entity_models
+  Rails.configuration.analytics.merge(Rails.configuration.analytics_pii).map do |table_name, _|
+    IRREGULAR_TABLE_NAMES[table_name.to_sym] || table_name.to_s.classify
+  end
+end
 
 namespace :bigquery do
+  desc 'Import all entity events to BigQuery'
+  task :import_all_entity_events, %i[sleep_time batch_size] do |_, args|
+    sleep_time = args.fetch(:sleep_time, SLEEP_TIME).to_i
+    batch_size = args.fetch(:batch_size, DEFAULT_BATCH_SIZE).to_i
+
+    entity_models.each do |model_name|
+      Rake::Task['bigquery:import_entity_events'].invoke(model_name,
+                                                         sleep_time,
+                                                         batch_size)
+      Rake::Task['bigquery:import_entity_events'].reenable
+    end
+  end
+
   desc 'Import model data to BigQuery as import_entity type events'
   task :import_entity_events, %i[model_name sleep_time batch_size start_at_id] => :environment do |_, args|
     abort('You must specify the model whose data you want to import to BigQuery e.g. rake bigquery:import_entity_events[ApplicationChoice]') if args[:model_name].blank?
@@ -11,6 +36,8 @@ namespace :bigquery do
     batch_size = args.fetch(:batch_size, DEFAULT_BATCH_SIZE).to_i
     id = start_at_id = args[:start_at_id] || 0
     model_class = Object.const_get(model_name)
+
+    Rails.logger.info("Processing data for #{model_name} with row count #{model_class.count}")
 
     model_class.order(:id).where('id > ?', start_at_id).find_in_batches(batch_size: batch_size) do |records|
       records.each do |record|


### PR DESCRIPTION
## Context

Increase BigQuery timeout (default is 60) and add retries. This way any timeouts should be handled and reprocessed by BigQuery who handles and each retry by doubling the existing timeout.

Also introduces rake task that imports all require data to BigQuery as manual importing each table is very time consuming.

## Link to Trello card

https://trello.com/c/SljGT6Dl/4261-backfill-bigquery-data-from-apply

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
