### PR TITLE
Update rejected by default email content

### DIFF
--- a/app/views/candidate_mailer/_rejected_by_default_intro.text.erb
+++ b/app/views/candidate_mailer/_rejected_by_default_intro.text.erb
@@ -1,1 +1,8 @@
 Your application to study <%= @course.name_and_code %> has been automatically rejected because <%= @course.provider.name %> did not make a decision before today’s deadline.
+
+Your application to study <%= @course.name_and_code %> cannot progress because <%= @course.provider.name %> did not make a decision before their deadline to respond.
+
+Unless the provider has indicated that they want to progress your application, you should consider this application closed and choose another course or provider.
+
+<%= @course.provider.name %> may still give you feedback on your application.
+If you think this is a mistake (for example, the provider has invited you for an interview) let us know at becomingateacher@education.gov.uk.

--- a/app/views/candidate_mailer/application_rejected_all_applications_rejected.text.erb
+++ b/app/views/candidate_mailer/application_rejected_all_applications_rejected.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>,
 
-# Update on your application
-
 <% if @application_choice.rejected_by_default %>
 
   <%= render 'rejected_by_default_intro' %>
@@ -10,9 +8,9 @@ Dear <%= @application_form.first_name %>,
 
   <%= render 'reasons_for_rejection' %>
 
-<% end %>
+  Contact <%= @course.provider.name %> directly if you have any questions about their feedback.
 
-Contact <%= @course.provider.name %> directly if you have any questions about their feedback.
+<% end %>
 
 # You can apply again
 

--- a/app/views/candidate_mailer/application_rejected_awaiting_decision_only.text.erb
+++ b/app/views/candidate_mailer/application_rejected_awaiting_decision_only.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>,
 
-# Update on your application
-
 <% if @application_choice.rejected_by_default %>
 
   <%= render 'rejected_by_default_intro' %>
@@ -10,9 +8,9 @@ Dear <%= @application_form.first_name %>,
 
   <%= render 'reasons_for_rejection' %>
 
-<% end %>
+  Contact <%= @course.provider.name %> directly if you have any questions about their feedback.
 
-Contact <%= @course.provider.name %> directly if you have any questions about their feedback.
+<% end %>
 
 <% if @awaiting_decision.length == 1 %>
 

--- a/app/views/candidate_mailer/application_rejected_offers_only.text.erb
+++ b/app/views/candidate_mailer/application_rejected_offers_only.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>,
 
-# Update on your application
-
 <% if @application_choice.rejected_by_default %>
 
   <%= render 'rejected_by_default_intro' %>
@@ -10,9 +8,9 @@ Dear <%= @application_form.first_name %>,
 
   <%= render 'reasons_for_rejection' %>
 
-<% end %>
+  Contact <%= @course.provider.name %> directly if you have any questions about their feedback.
 
-Contact <%= @course.provider.name %> directly if you have any questions about their feedback.
+<% end %>
 
 # Respond to your <%= 'offer'.pluralize(@offers.length) %> by <%= @respond_by_date %>
 


### PR DESCRIPTION
We don't want to use the term "rejected" in candidate-facing content.

Also removes "Contact [provider] directly if you have any questions about their feedback." if the candidate was rejected-by-default, as there won't be any feedback at this point.

[Trello card](https://trello.com/c/aFqNJCJx/3999-make-automatic-rejection-less-about-rejection)