### PR TITLE
Fix degrees completion status to update award year

### DIFF
--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -186,7 +186,7 @@ module CandidateInterface
     def award_year_row(degree)
       {
         key: t('application_form.degree.award_year.review_label'),
-        value: degree.award_year,
+        value: degree.award_year || t('application_form.degree.review.not_specified'),
         action: {
           href: candidate_interface_edit_degree_award_year_path(degree.id, return_to_params),
           visually_hidden_text: generate_action(degree: degree, attribute: t('application_form.degree.award_year.change_action')),

--- a/app/controllers/candidate_interface/degrees/completion_status_controller.rb
+++ b/app/controllers/candidate_interface/degrees/completion_status_controller.rb
@@ -26,7 +26,7 @@ module CandidateInterface
         @completion_status_form = DegreeCompletionStatusForm.new(completion_status_params)
         @return_to = return_to_after_edit(default: candidate_interface_degrees_review_path)
 
-        if @completion_status_form.save(current_degree)
+        if @completion_status_form.update(current_degree)
           redirect_to @return_to[:back_path]
         else
           track_validation_error(@completion_status_form)

--- a/app/forms/candidate_interface/degree_completion_status_form.rb
+++ b/app/forms/candidate_interface/degree_completion_status_form.rb
@@ -12,6 +12,12 @@ module CandidateInterface
       degree.update!(predicted_grade: grade_is_predicted?)
     end
 
+    def update(degree)
+      return false unless valid?
+
+      degree.update!(predicted_grade: grade_is_predicted?, award_year: nil)
+    end
+
     def assign_form_values(degree)
       unless degree.predicted_grade.nil?
         self.degree_completed = degree.predicted_grade? ? 'no' : 'yes'

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -59,8 +59,10 @@ en:
         hint_text: "For example, %{example_year}"
         review_label: Graduation year
         change_action: year
+
       review:
         complete_hint_text: Check the entry requirements for your chosen course. Providers usually ask for a degree at 2:2 or above. Contact the training provider if you do not have the right degree level.
+        not_specified: Not entered
       another:
         button: Add another degree
       delete: Delete degree

--- a/spec/components/candidate_interface/degrees_review_component_spec.rb
+++ b/spec/components/candidate_interface/degrees_review_component_spec.rb
@@ -111,6 +111,27 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
       )
     end
 
+    context 'when the degree does not have an award_year' do
+      let(:degree1) do
+        build_stubbed(
+          :degree_qualification,
+          level: 'degree',
+          qualification_type: 'BSc/Education',
+          subject: 'Woof',
+          grade: 'First class honours',
+          start_year: '2007',
+          award_year: nil,
+        )
+      end
+
+      it 'renders component with correct values for an award year' do
+        result = render_inline(described_class.new(application_form: application_form))
+
+        expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.degree.award_year.review_label'))
+        expect(result.css('.govuk-summary-list__value').text).to include(t('application_form.degree.review.not_specified'))
+      end
+    end
+
     it 'renders component with correct values for a known degree grade' do
       allow(application_form).to receive(:application_qualifications).and_return(
         ActiveRecordRelationStub.new(ApplicationQualification, [degree1, degree2], scopes: [:degrees]),

--- a/spec/forms/candidate_interface/degree_completion_status_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_completion_status_form_spec.rb
@@ -27,6 +27,28 @@ RSpec.describe CandidateInterface::DegreeCompletionStatusForm, type: :model do
     end
   end
 
+  describe '#update' do
+    it 'sets degree.predicted_grade to false when previously true and sets award year to nil' do
+      degree = build(:degree_qualification, predicted_grade: true, award_year: RecruitmentCycle.next_year)
+      form = described_class.new(degree_completed: 'yes')
+
+      form.update(degree)
+
+      expect(degree.reload.predicted_grade).to eq false
+      expect(degree.award_year).to eq nil
+    end
+
+    it 'sets degree.predicted_grade to true when previously false and sets award year to nil' do
+      degree = build(:degree_qualification, predicted_grade: false, award_year: RecruitmentCycle.current_year)
+      form = described_class.new(degree_completed: 'no')
+
+      form.update(degree)
+
+      expect(degree.reload.predicted_grade).to eq true
+      expect(degree.award_year).to eq nil
+    end
+  end
+
   describe '#assign_form_values(degree)' do
     it 'sets degree_completed to "no" if degree.predicted_grade? is true' do
       degree = build_stubbed(:degree_qualification, predicted_grade: true)

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
@@ -207,6 +207,8 @@ RSpec.feature 'Editing a degree' do
     choose 'No'
     and_i_click_on_save_and_continue
     completion_status_row = page.all('.govuk-summary-list__row').find { |r| r.has_link? 'Change completion status' }
+    award_year_row = find('.govuk-summary-list__row', text: 'Not entered')
     expect(completion_status_row).to have_content 'No'
+    expect(award_year_row).to have_content t('application_form.degree.review.not_specified')
   end
 end


### PR DESCRIPTION
## Context

Bug spotted in EoC dress rehearsal that when updating completion status 
ward year persists meaning that invalid years can remain in place for 
both completed and pending degrees. 

## Changes proposed in this pull request

This PR adds a new form method to update the award year to nil whenever completion status is edited.

<img width="981" alt="image" src="https://user-images.githubusercontent.com/62567622/135488295-bc876b43-8536-4ce4-a289-8f6028f4af1e.png">

## Guidance to review

:shipit: 

## Link to Trello card
https://trello.com/c/OJBDNQ8U/4007-eoc-bug-medium-can-submit-complete-degree-with-award-year-in-future-by-switching-from-pending-to-complete-degree

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
