### PR TITLE
Pass string args to StartOfCycleNotificationWorker

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -376,7 +376,7 @@ class CycleTimetable
     "#{year} to #{year + 1}"
   end
 
-  def self.service_opens_today?(service, year: RecruitmentCycle.current_year, end_of_business_day_hour: 16, end_of_business_day_min: 1)
+  def self.service_opens_today?(service, year: RecruitmentCycle.current_year, end_of_business_day_hour: 17, end_of_business_day_min: 0)
     service_opening_date = send("#{service}_opens", year)
 
     Time.zone.now.between?(

--- a/app/workers/start_of_cycle_notification_worker.rb
+++ b/app/workers/start_of_cycle_notification_worker.rb
@@ -3,6 +3,7 @@ class StartOfCycleNotificationWorker
 
   def perform(service)
     return unless CycleTimetable.service_opens_today?(service, year: RecruitmentCycle.current_year)
+    return unless hours_remaining.positive?
 
     @service = service
 
@@ -43,7 +44,7 @@ private
   end
 
   def notify_until
-    Time.zone.now.change(hour: 16)
+    Time.zone.now.change(hour: 17)
   end
 
   def relationships_to_set_up(provider_user)

--- a/app/workers/start_of_cycle_notification_worker.rb
+++ b/app/workers/start_of_cycle_notification_worker.rb
@@ -13,7 +13,7 @@ class StartOfCycleNotificationWorker
           ChaserSent.create!(chased: provider_user, chaser_type: mailer_method)
         end
 
-        next if service == :apply
+        next if service == 'apply'
 
         next unless provider_user.provider_permissions.find_by(provider: provider).manage_organisations
         next if ChaserSent.exists?(chased: provider_user, chaser_type: setup_mailer_method)

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -17,8 +17,8 @@ class Clock
   # Hourly jobs
 
   # StartOfCycleNotificationWorker only works the day the service opens. These two jobs won't run at the same time on the same day.
-  every(1.hour, 'SendFindStartOfCycleProviderEmails', at: '**:05') { StartOfCycleNotificationWorker.perform_async(:find) }
-  every(1.hour, 'SendApplyStartOfCycleProviderEmails', at: '**:05') { StartOfCycleNotificationWorker.perform_async(:apply) }
+  every(1.hour, 'SendFindStartOfCycleProviderEmails', at: '**:05') { StartOfCycleNotificationWorker.perform_async('find') }
+  every(1.hour, 'SendApplyStartOfCycleProviderEmails', at: '**:05') { StartOfCycleNotificationWorker.perform_async('apply') }
 
   every(1.hour, 'RejectApplicationsByDefault', at: '**:10') { RejectApplicationsByDefaultWorker.perform_async }
   every(1.hour, 'DeclineOffersByDefault', at: '**:15') { DeclineOffersByDefaultWorker.perform_async }

--- a/spec/workers/start_of_cycle_notification_worker_spec.rb
+++ b/spec/workers/start_of_cycle_notification_worker_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe StartOfCycleNotificationWorker do
       providers_needing_set_up.each { |provider| create(:provider_relationship_permissions, :not_set_up_yet, training_provider: provider) }
     end
 
-    context 'when the specified service is :find' do
-      let(:service) { :find }
+    context 'when the specified service is find' do
+      let(:service) { 'find' }
 
       around do |example|
         Timecop.freeze(CycleTimetable.find_opens.change(hour: 15)) do
@@ -137,8 +137,8 @@ RSpec.describe StartOfCycleNotificationWorker do
       end
     end
 
-    context 'when the specified service is :apply' do
-      let(:service) { :apply }
+    context 'when the specified service is apply' do
+      let(:service) { 'apply' }
 
       around do |example|
         Timecop.freeze(CycleTimetable.apply_opens.change(hour: 15)) do
@@ -161,10 +161,18 @@ RSpec.describe StartOfCycleNotificationWorker do
 
         expect { described_class.new.perform(service) }.not_to change(ChaserSent.where(chased: provider_with_chaser_sent), :count)
       end
+
+      it 'does not send permissions set up emails' do
+        allow(ProviderMailer).to receive(:set_up_organisation_permissions).and_return(mailer_delivery)
+
+        described_class.new.perform(service)
+
+        expect(ProviderMailer).not_to have_received(:set_up_organisation_permissions)
+      end
     end
 
     context 'with multiple hours remaining' do
-      let(:service) { :apply }
+      let(:service) { 'apply' }
 
       it 'divides the providers with users who should be notified across the hours remaining' do
         Timecop.freeze(CycleTimetable.apply_opens.change(hour: 14)) do
@@ -185,7 +193,7 @@ RSpec.describe StartOfCycleNotificationWorker do
     end
 
     context 'when called out of hours for the Find service opening' do
-      let(:service) { :find }
+      let(:service) { 'find' }
 
       it 'does nothing' do
         Timecop.freeze(CycleTimetable.find_opens.change(hour: 8, min: 59)) do
@@ -195,7 +203,7 @@ RSpec.describe StartOfCycleNotificationWorker do
     end
 
     context 'when called out of hours for the Apply service opening' do
-      let(:service) { :apply }
+      let(:service) { 'apply' }
 
       it 'does nothing' do
         Timecop.freeze(CycleTimetable.apply_opens.change(hour: 16, min: 2)) do

--- a/spec/workers/start_of_cycle_notification_worker_spec.rb
+++ b/spec/workers/start_of_cycle_notification_worker_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe StartOfCycleNotificationWorker do
       let(:service) { 'find' }
 
       around do |example|
-        Timecop.freeze(CycleTimetable.find_opens.change(hour: 15)) do
+        Timecop.freeze(CycleTimetable.find_opens.change(hour: 16)) do
           example.run
         end
       end
@@ -141,7 +141,7 @@ RSpec.describe StartOfCycleNotificationWorker do
       let(:service) { 'apply' }
 
       around do |example|
-        Timecop.freeze(CycleTimetable.apply_opens.change(hour: 15)) do
+        Timecop.freeze(CycleTimetable.apply_opens.change(hour: 16)) do
           example.run
         end
       end
@@ -175,7 +175,7 @@ RSpec.describe StartOfCycleNotificationWorker do
       let(:service) { 'apply' }
 
       it 'divides the providers with users who should be notified across the hours remaining' do
-        Timecop.freeze(CycleTimetable.apply_opens.change(hour: 14)) do
+        Timecop.freeze(CycleTimetable.apply_opens.change(hour: 15)) do
           described_class.new.perform(service)
 
           expect(ProviderMailer).to have_received(:apply_service_is_now_open).with(provider_users_who_need_to_set_up_permissions.first)
@@ -206,7 +206,7 @@ RSpec.describe StartOfCycleNotificationWorker do
       let(:service) { 'apply' }
 
       it 'does nothing' do
-        Timecop.freeze(CycleTimetable.apply_opens.change(hour: 16, min: 2)) do
+        Timecop.freeze(CycleTimetable.apply_opens.change(hour: 17, min: 1)) do
           expect { described_class.new.perform(service) }.not_to change(ChaserSent, :count)
         end
       end


### PR DESCRIPTION
## Context

Sidekiq serializes and deserializes arguments in Redis which means using symbols is problematic.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Pass the service name as a string to `StartOfCycleNotificationWorker.perform_async`

Also fixes https://sentry.io/organizations/dfe-bat/issues/2684421148/ `ZeroDivisionError` if `hours_remaining` returns `0`
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/WTnGjL50/4274-spike-investigate-prototype-scheduling-of-staggered-provider-user-emails

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
