### PR TITLE
Allow volunteering start date to be up until the next cycle starts

### DIFF
--- a/app/forms/candidate_interface/volunteering_role_form.rb
+++ b/app/forms/candidate_interface/volunteering_role_form.rb
@@ -24,7 +24,8 @@ module CandidateInterface
               presence: true
 
     validates :role, :organisation, length: { maximum: 60 }
-    validates :start_date, date: { presence: true, future: true, month_and_year: true, before: :end_date }
+    validates :start_date, date: { presence: true, month_and_year: true, before: :end_date }
+    validate :start_date_is_before_the_next_cycle, if: -> { start_date.is_a?(Date) }
 
     validates :start_date_unknown, inclusion: { in: %w[true false] }
     validates :end_date_unknown, inclusion: { in: %w[true false] }
@@ -114,6 +115,10 @@ module CandidateInterface
 
     def dont_validate_end_date
       start_date_blank?
+    end
+
+    def start_date_is_before_the_next_cycle
+      errors.add(:start_date, :after_training_starts) if Date.new(start_date_year.to_i, start_date_month.to_i) > CycleTimetable.find_reopens
     end
   end
 end

--- a/config/locales/candidate_interface/volunteering.yml
+++ b/config/locales/candidate_interface/volunteering.yml
@@ -6,7 +6,7 @@ en:
         change_action: relevant unpaid experience
       no_experience:
         summary_card_title: 'Children and young people: no volunteering or experience in school roles entered'
-        get_experience: Learn about how to get school experience 
+        get_experience: Learn about how to get school experience
       role:
         label: Your role
         review_label: Role
@@ -64,6 +64,8 @@ en:
               blank: Select whether or not you have experience volunteering with young people or in school
         candidate_interface/volunteering_role_form:
           attributes:
+            start_date:
+              after_training_starts: Must be before the start of your teacher training
             role:
               blank: Enter your role
               too_long: Role must be %{count} characters or fewer

--- a/spec/forms/candidate_interface/volunteering_role_form_spec.rb
+++ b/spec/forms/candidate_interface/volunteering_role_form_spec.rb
@@ -152,13 +152,24 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
     it { is_expected.not_to allow_value(long_text).for(:details) }
 
     context 'start_date validations' do
-      let(:model) do
-        described_class.new(start_date_day: start_date_day,
-                            start_date_month: start_date_month,
-                            start_date_year: start_date_year)
-      end
+      it 'allows award year to be valid for the next recruitment_cycle_year' do
+        valid_start_date = described_class.new(
+          start_date_year: CycleTimetable.find_reopens.year,
+          start_date_month: CycleTimetable.find_reopens.month,
+          start_date_day: nil,
+        )
+        invalid_start_date = described_class.new(
+          start_date_year: CycleTimetable.find_reopens.year,
+          start_date_month: CycleTimetable.find_reopens.month + 1,
+          start_date_day: nil,
+        )
 
-      include_examples 'month and year date validations', :start_date, verify_presence: true, future: true, before: :end_date
+        valid_start_date.valid?
+        invalid_start_date.valid?
+
+        expect(valid_start_date.errors.full_messages_for(:start_date)).to be_empty
+        expect(invalid_start_date.errors.full_messages_for(:start_date)).not_to be_empty
+      end
     end
 
     context 'end_date validations' do


### PR DESCRIPTION
**Need to wait for sign off from ProVendor before merging**

## Context

Based on some feedback Gaby gave from a TTA, it seems like candidates would like like the ability to add volunteering experiences they've signed up for, but have not yet completed. 

This will save them some word count in the personal statement.

## Changes proposed in this pull request

-Allow candidates to add volunteering experiences that start before the beginning of the next cycle


## Guidance to review

While looking at this it seemed to make sense to me that they would have to start their voluntary work before the launch of the next cycle. 

The only edge case i can think of is people who are applying with the intention of deferring. Seems like a fairly niche edge case though. Interested to hear what people think.

## Link to Trello card

https://trello.com/c/y6fUTOSX/4011-allow-candidates-to-enter-volunteering-experiences-before-the-start-of-the-next-cycle

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
