### PR TITLE
Hide work experience details when candidate did not enter them

### DIFF
--- a/app/components/shared/work_history_item_component.rb
+++ b/app/components/shared/work_history_item_component.rb
@@ -21,8 +21,11 @@ class WorkHistoryItemComponent < ViewComponent::Base
   end
 
   def details
-    return item.details if item.respond_to?(:details)
     return item.reason if item.respond_to?(:reason)
+
+    return nil if item.is_a?(ApplicationWorkExperience) && item.try(:application_form)&.feature_restructured_work_history
+
+    return item.details if item.respond_to?(:details)
   end
 
   def working_with_children?

--- a/spec/components/utility/work_history_component_spec.rb
+++ b/spec/components/utility/work_history_component_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe WorkHistoryComponent do
       experiences = [
         build(
           :application_work_experience,
-          :deprecated,
           start_date: 6.years.ago,
+          start_date_unknown: false,
           end_date: 3.months.ago,
           role: 'Sheep herder',
           commitment: 'full_time',
@@ -36,8 +36,8 @@ RSpec.describe WorkHistoryComponent do
         ),
         build(
           :application_work_experience,
-          :deprecated,
           start_date: 3.months.ago,
+          start_date_unknown: false,
           end_date: nil,
           role: 'Pig herder',
           commitment: 'part_time',
@@ -65,14 +65,15 @@ RSpec.describe WorkHistoryComponent do
     it 'renders work experience details and worked with children flag' do
       experiences = [
         build(:application_work_experience,
-              :deprecated,
               start_date: 6.years.ago,
+              start_date_unknown: false,
               end_date: nil,
               role: 'Nursery manager',
               commitment: 'part_time',
               working_pattern: '',
               organisation: 'Bobs Farm',
               details: 'I run the staff nursery',
+              relevant_skills: false,
               working_with_children: true),
       ]
       allow(application_form).to receive(:application_work_experiences).and_return(experiences)
@@ -85,13 +86,66 @@ RSpec.describe WorkHistoryComponent do
     end
   end
 
+  context 'with work experiences using relevant skills' do
+    it 'renders work experience details and relevant skills flag' do
+      experiences = [
+        build(:application_work_experience,
+              start_date: 6.years.ago,
+              start_date_unknown: false,
+              end_date: nil,
+              role: 'Nursery manager',
+              commitment: 'part_time',
+              working_pattern: '',
+              organisation: 'Bobs Farm',
+              details: 'I run the staff nursery',
+              relevant_skills: true),
+      ]
+      allow(experiences.first).to receive(:application_form).and_return(application_form)
+      allow(application_form).to receive(:feature_restructured_work_history).and_return(true)
+      allow(application_form).to receive(:application_work_experiences).and_return(experiences)
+      allow(application_form).to receive(:application_work_history_breaks).and_return([])
+
+      rendered = render_inline(described_class.new(application_form: application_form))
+      expect(rendered.text).to include "#{6.years.ago.to_s(:month_and_year)} - Present"
+      expect(rendered.text).to include 'Nursery manager - Part time'
+      expect(rendered.text).not_to include 'I run the staff nursery'
+      expect(rendered.text).to include 'This role used skills relevant to teaching'
+    end
+  end
+
+  context 'with old style work experiences using relevant skills' do
+    it 'renders work experience details and relevant skills flag' do
+      experiences = [
+        build(:application_work_experience,
+              :deprecated,
+              start_date: 6.years.ago,
+              start_date_unknown: false,
+              end_date: nil,
+              role: 'Nursery manager',
+              commitment: 'part_time',
+              working_pattern: '',
+              organisation: 'Bobs Farm',
+              details: 'I run the staff nursery'),
+      ]
+      allow(application_form).to receive(:feature_restructured_work_history).and_return(false)
+      allow(application_form).to receive(:application_work_experiences).and_return(experiences)
+      allow(application_form).to receive(:application_work_history_breaks).and_return([])
+
+      rendered = render_inline(described_class.new(application_form: application_form))
+      expect(rendered.text).to include "#{6.years.ago.to_s(:month_and_year)} - Present"
+      expect(rendered.text).to include 'Nursery manager - Part time'
+      expect(rendered.text).to include 'I run the staff nursery'
+      expect(rendered.text).not_to include 'This role used skills relevant to teaching'
+    end
+  end
+
   context 'with work experiences with relevant skills' do
     it 'renders work experience details and relevant skills flag' do
       experiences = [
         build(
           :application_work_experience,
-          :deprecated,
           start_date: 6.years.ago,
+          start_date_unknown: false,
           end_date: nil,
           role: 'Nursery manager',
           commitment: 'part_time',
@@ -118,9 +172,10 @@ RSpec.describe WorkHistoryComponent do
       experiences = [
         build(
           :application_work_experience,
-          :deprecated,
           start_date: 6.years.ago,
+          start_date_unknown: false,
           end_date: 2.years.ago,
+          end_date_unknown: false,
           role: 'Sheep herder',
           commitment: 'full_time',
           working_pattern: '',
@@ -129,8 +184,8 @@ RSpec.describe WorkHistoryComponent do
         ),
         build(
           :application_work_experience,
-          :deprecated,
           start_date: 2.months.ago,
+          start_date_unknown: false,
           end_date: nil,
           role: 'Pig herder',
           commitment: 'part_time',
@@ -164,9 +219,10 @@ RSpec.describe WorkHistoryComponent do
       experiences = [
         build(
           :application_work_experience,
-          :deprecated,
           start_date: 6.years.ago,
+          start_date_unknown: false,
           end_date: 26.months.ago,
+          end_date_unknown: false,
           role: 'Sheep herder',
           commitment: 'full_time',
           working_pattern: '',
@@ -175,8 +231,8 @@ RSpec.describe WorkHistoryComponent do
         ),
         build(
           :application_work_experience,
-          :deprecated,
           start_date: 3.months.ago,
+          start_date_unknown: false,
           end_date: nil,
           role: 'Pig herder',
           commitment: 'part_time',
@@ -212,7 +268,6 @@ RSpec.describe WorkHistoryComponent do
       experiences = [
         build(
           :application_work_experience,
-          :deprecated,
           start_date: Date.new(2014, 10, 1),
           end_date: Date.new(2018, 2, 1),
           start_date_unknown: true,
@@ -225,7 +280,6 @@ RSpec.describe WorkHistoryComponent do
         ),
         build(
           :application_work_experience,
-          :deprecated,
           start_date: Date.new(2020, 1, 1),
           end_date: nil,
           start_date_unknown: true,


### PR DESCRIPTION
## Context
In the (relatively) new work experience flow, candidates do not need to enter information. Instead they just say whether or not it was using relevant skills. We still populate the details field for use in the API.

## Changes proposed in this pull request
If a candidate filled in the new work experience flow, then hide the details text in the component shown to providers.

This does not apply to unpaid experience though, since they do put details in for that.

## Guidance to review
This component and the work experience model is quite confusing! Have I missed anything?

## Link to Trello card
https://trello.com/c/thpyNuxy/4318-work-history-rendering-both-old-and-new-flows

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
