### PR TITLE
Add recruited filter to support applications list

### DIFF
--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -162,9 +162,9 @@ module SupportInterface
             checked: applied_filters[:status]&.include?('pending_conditions'),
           },
           {
-            value: 'conditions_met',
-            label: 'Conditions met',
-            checked: applied_filters[:status]&.include?('conditions_met'),
+            value: 'recruited',
+            label: 'Recruited',
+            checked: applied_filters[:status]&.include?('recruited'),
           },
           {
             value: 'rejected',

--- a/spec/models/support_interface/applications_filter_spec.rb
+++ b/spec/models/support_interface/applications_filter_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe SupportInterface::ApplicationsFilter do
     create(:application_choice, :with_completed_application_form, :with_offer, :previous_year)
   end
   let!(:application_choice_with_interview) { create(:application_choice, :with_scheduled_interview) }
+  let!(:application_choice_recruited) { create(:application_choice, :with_recruited) }
 
   def verify_filtered_applications_for_params(expected_applications, params:)
     applications = ApplicationForm.all
@@ -73,6 +74,17 @@ RSpec.describe SupportInterface::ApplicationsFilter do
         [expected_form],
         params: {
           status: %w[offer],
+        },
+      )
+    end
+
+    it 'can filter by the recruited status' do
+      expected_form = application_choice_recruited.application_form
+
+      verify_filtered_applications_for_params(
+        [expected_form],
+        params: {
+          status: %w[recruited],
         },
       )
     end


### PR DESCRIPTION
## Context

https://trello.com/c/oKK5AWgD/4321-add-recruited-to-support-dashboard-search

## Changes proposed in this pull request

Added the `Recruited` status to the list of available filters (at the bottom of the list)

![image](https://user-images.githubusercontent.com/25597009/135812376-942a0d38-0a07-4e59-b16d-5fe3de48ad93.png)

## Guidance to review

Log into the support interface, and modify the search filters with the newly added `Recruited` status. 
