### PR TITLE
expose vendor api user full name in timeline event

### DIFF
--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -120,6 +120,8 @@ module ProviderInterface
         provider_name(change.user)
       elsif change_by_support?(change.audit)
         'Apply support'
+      elsif change.user.is_a?(VendorApiUser)
+        "#{change.user.full_name} (Vendor API)"
       else
         'System'
       end

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -191,11 +191,10 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
         created_at: 3.days.ago,
       )
     end
+    let(:application_choice) { application_choice_with_audits [audit] }
 
     context 'when change was done by a support user' do
       it 'renders Apply support' do
-        application_choice = application_choice_with_audits [audit]
-
         rendered = render_inline(described_class.new(application_choice: application_choice))
         expect(rendered.css('.app-timeline__actor_and_date').text).to include 'Apply support'
       end
@@ -206,8 +205,6 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       let(:username) { 'John Smith via the Rails console' }
 
       it 'renders Apply support' do
-        application_choice = application_choice_with_audits [audit]
-
         rendered = render_inline(described_class.new(application_choice: application_choice))
         expect(rendered.css('.app-timeline__actor_and_date').text).to include 'Apply support'
       end
@@ -218,10 +215,17 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       let(:username) { '(Automated process)' }
 
       it 'renders System' do
-        application_choice = application_choice_with_audits [audit]
-
         rendered = render_inline(described_class.new(application_choice: application_choice))
         expect(rendered.css('.app-timeline__actor_and_date').text).to include 'System'
+      end
+    end
+
+    context 'when change was done by the vendor api' do
+      let(:user) { create(:vendor_api_user) }
+
+      it 'exposes the vendor Api users name' do
+        rendered = render_inline(described_class.new(application_choice: application_choice))
+        expect(rendered.css('.app-timeline__actor_and_date').text).to include "#{user.full_name} (Vendor API)"
       end
     end
   end


### PR DESCRIPTION
## Context

When a user makes a change to an application have that users name exposed in the related timeline event. 

## Changes proposed in this pull request

Change message actor for an api user from 'system' -> 'full_name (Vendor API)'

## Link to Trello card

https://trello.com/c/dib5Cgji/4284-surface-vendor-api-actor-in-timeline

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
