### PR TITLE
Fix work history status for applications in the current cycle

### DIFF
--- a/app/services/data_migrations/backfill_work_history_status_for_current_cycle.rb
+++ b/app/services/data_migrations/backfill_work_history_status_for_current_cycle.rb
@@ -1,0 +1,21 @@
+module DataMigrations
+  class BackfillWorkHistoryStatusForCurrentCycle
+    TIMESTAMP = 20211001130340
+    MANUAL_RUN = false
+
+    def change
+      ApplicationForm
+      .joins(:application_work_experiences)
+      .where(work_history_status: nil, feature_restructured_work_history: true, recruitment_cycle_year: 2021)
+      .distinct
+      .find_each(&:can_complete!)
+
+      ApplicationForm
+      .left_outer_joins(:application_work_experiences)
+      .where(recruitment_cycle_year: 2021, work_history_status: nil, feature_restructured_work_history: true, application_work_experiences: { id: nil })
+      .where.not(work_history_explanation: nil)
+      .distinct
+      .find_each(&:can_not_complete!)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillWorkHistoryStatusForCurrentCycle',
   'DataMigrations::BackfillWorkHistoryStatus',
   'DataMigrations::AddVendorsToProvidersForFirstTime',
   'DataMigrations::BackfillNotCompletedExplanation',

--- a/spec/services/data_migrations/backfill_work_history_status_for_current_cycle_spec.rb
+++ b/spec/services/data_migrations/backfill_work_history_status_for_current_cycle_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillWorkHistoryStatusForCurrentCycle do
+  it 'updates `work_history_status` from `nil` to `can_complete` for application forms in the 2021 cycle with work experiences when the flag is active' do
+    application_form_with_experiences = create(
+      :application_form,
+      feature_restructured_work_history: true,
+      work_history_status: nil,
+      recruitment_cycle_year: 2021,
+    )
+    create(:application_work_experience, application_form: application_form_with_experiences)
+
+    application_form_without_flag_with_experiences = create(
+      :application_form,
+      feature_restructured_work_history: false,
+      work_history_status: nil,
+      recruitment_cycle_year: 2021,
+    )
+    create(:application_work_experience, application_form: application_form_without_flag_with_experiences)
+
+    application_form_with_experiences_from_next_cycle = create(
+      :application_form,
+      feature_restructured_work_history: true,
+      work_history_status: nil,
+      recruitment_cycle_year: 2022,
+    )
+    create(:application_work_experience, application_form: application_form_with_experiences_from_next_cycle)
+
+    application_form_without_experiences = create(
+      :application_form,
+      feature_restructured_work_history: true,
+      work_history_status: nil,
+      recruitment_cycle_year: 2021,
+    )
+
+    described_class.new.change
+
+    expect(application_form_with_experiences.reload.work_history_status).to eq 'can_complete'
+    expect(application_form_without_flag_with_experiences.reload.work_history_status).to eq nil
+    expect(application_form_with_experiences_from_next_cycle.reload.work_history_status).to eq nil
+    expect(application_form_without_experiences.reload.work_history_status).to eq nil
+  end
+
+  it 'updates `work_history_status` from `nil` to `can_not_complete` for application forms in the 2021 cycle with no work experiences and an explanation when the flag is active' do
+    application_form_with_an_explanation_and_flag_active = create(
+      :application_form,
+      feature_restructured_work_history: true,
+      work_history_status: nil,
+      recruitment_cycle_year: 2021,
+      work_history_explanation: 'I hate work',
+    )
+    application_form_with_an_explanation_and_flag_inactive = create(
+      :application_form,
+      feature_restructured_work_history: false,
+      work_history_status: nil,
+      recruitment_cycle_year: 2021,
+      work_history_explanation: 'I hate work',
+    )
+    application_form_with_an_explanation_from_next_cycle_and_flag_active = create(
+      :application_form,
+      feature_restructured_work_history: true,
+      work_history_status: nil,
+      recruitment_cycle_year: 2022,
+      work_history_explanation: 'I hate work',
+    )
+
+    described_class.new.change
+
+    expect(application_form_with_an_explanation_and_flag_active.reload.work_history_status).to eq 'can_not_complete'
+    expect(application_form_with_an_explanation_and_flag_inactive.reload.work_history_status).to eq nil
+    expect(application_form_with_an_explanation_from_next_cycle_and_flag_active.reload.work_history_status).to eq nil
+  end
+end


### PR DESCRIPTION
## Context

278 candidates in the current cycle are in a strange state where work_history_pattern is set to nil when they've already added a work history in the previous cycle. We should clean this data up so that if/when they carry over they are able to add new jobs.

There's also 12 who have work_history_pattern set to nil and have provided an explanation with the flag on

## Changes proposed in this pull request

- Clean up work_history_status in the current cycle 

## Guidance to review

If the flag is active on the application and they've added an explanation or work history then it should be set to `can_not_complete` and `can_complete` respectively.


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
