### PR TITLE
Bigquery: send multiple events in each request

### DIFF
--- a/app/controllers/concerns/emit_request_events.rb
+++ b/app/controllers/concerns/emit_request_events.rb
@@ -15,7 +15,7 @@ module EmitRequestEvents
         .with_user_and_namespace(current_user, current_namespace)
         .with_request_uuid(RequestLocals.fetch(:request_id) { nil })
 
-      SendEventsToBigquery.perform_async(request_event.as_json)
+      SendEventsToBigquery.perform_async([request_event.as_json])
     end
   end
 end

--- a/app/lib/events/import_entity_events.rb
+++ b/app/lib/events/import_entity_events.rb
@@ -1,20 +1,22 @@
 module Events
-  class ImportEntityEvent
-    attr_accessor :table_name, :event_type, :record
+  class ImportEntityEvents
+    attr_accessor :table_name, :event_type, :records
 
-    def initialize(record)
-      @table_name = record.class.table_name
-      @record = record
+    def initialize(records)
+      @table_name = records.first.class.table_name
+      @records = records
       @event_type = 'import_entity'
     end
 
     def send
-      event = Events::Event.new
-        .with_type(event_type)
-        .with_entity_table_name(table_name)
-        .with_data(entity_data(record))
+      events = records.map do |record|
+        Events::Event.new
+          .with_type(event_type)
+          .with_entity_table_name(table_name)
+          .with_data(entity_data(record))
+      end
 
-      SendEventsToBigquery.perform_async(event.as_json)
+      SendEventsToBigquery.perform_async(events.as_json)
     end
 
   private

--- a/app/models/concerns/entity_events.rb
+++ b/app/models/concerns/entity_events.rb
@@ -36,7 +36,7 @@ module EntityEvents
       .with_tags(event_tags)
       .with_request_uuid(RequestLocals.fetch(:request_id) { nil })
 
-    SendEventsToBigquery.perform_async(event.as_json)
+    SendEventsToBigquery.perform_async([event.as_json])
   end
 
   def entity_data(changeset)

--- a/app/workers/send_events_to_bigquery.rb
+++ b/app/workers/send_events_to_bigquery.rb
@@ -4,11 +4,13 @@ class SendEventsToBigquery
 
   sidekiq_options retry: 3, queue: :big_query
 
-  def perform(request_event_json)
+  def perform(events)
     table_name = ENV.fetch('BIG_QUERY_TABLE_NAME', 'events')
     bq = Google::Cloud::Bigquery.new(project: ENV.fetch('BIG_QUERY_PROJECT_ID'), retries: 3, timeout: 120)
     dataset = bq.dataset(ENV.fetch('BIG_QUERY_DATASET'), skip_lookup: true)
     bq_table = dataset.table(table_name, skip_lookup: true)
-    bq_table.insert([request_event_json])
+    response = bq_table.insert(events)
+
+    Sentry.capture_message("SendEventsToBigquery: #{response} data: #{events}") if !response.success?
   end
 end

--- a/lib/tasks/import_data_to_bigquery.rake
+++ b/lib/tasks/import_data_to_bigquery.rake
@@ -40,13 +40,11 @@ namespace :bigquery do
     Rails.logger.info("Processing data for #{model_name} with row count #{model_class.count}")
 
     model_class.order(:id).where('id > ?', start_at_id).find_in_batches(batch_size: batch_size) do |records|
-      records.each do |record|
-        id = record.id
-        Events::ImportEntityEvent.new(record).send
-      end
+      id = records.first.id
+      Events::ImportEntityEvents.new(records).send
       sleep sleep_time
     end
   ensure
-    Rails.logger.info("Process ended while processing #{model_name} with id: #{id}")
+    Rails.logger.info("Process ended while processing #{model_name} within the id range #{id} to #{id + batch_size}")
   end
 end

--- a/spec/forms/candidate_interface/sign_up_form_spec.rb
+++ b/spec/forms/candidate_interface/sign_up_form_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe CandidateInterface::SignUpForm, type: :model do
 
       expect(SendEventsToBigquery).to have_received(:perform_async)
         .at_least(:once)
-        .with(a_hash_including({ 'event_tags' => ['candidate_sign_up'] }))
+        .with([a_hash_including({ 'event_tags' => ['candidate_sign_up'] })])
     end
   end
 

--- a/spec/requests/emit_request_events_spec.rb
+++ b/spec/requests/emit_request_events_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe EmitRequestEvents, type: :request, with_bigquery: true do
       }.to change(SendEventsToBigquery.jobs, :size).by(1)
 
       payload = SendEventsToBigquery.jobs
-        .map { |j| j['args'].first }
-        .find { |bigquery_data| bigquery_data['event_type'] == 'web_request' }
+        .map { |job| job['args'].first }
+        .find { |bigquery_data| bigquery_data.first['event_type'] == 'web_request' }.first
 
       expect(payload['request_method']).to eq('GET')
       expect(payload['request_user_agent']).to eq('Test agent')


### PR DESCRIPTION
## Context

Log failed responses to Senty so we can identify any issues with requests and bundle multiple events in a single request to reduce load on Sidekiq and make process faster and more efficient.


## Link to Trello card
https://trello.com/c/SljGT6Dl/4261-backfill-bigquery-data-from-apply

