### PR TITLE
Update ISO country codes

### DIFF
--- a/config/initializers/nationalities.rb
+++ b/config/initializers/nationalities.rb
@@ -168,7 +168,7 @@ NATIONALITIES = [
   ['GB', 'Prydeinig'],
   ['PR', 'Puerto Rican'],
   ['QA', 'Qatari'],
-  ['RP', 'Romanian'],
+  ['RO', 'Romanian'],
   ['RU', 'Russian'],
   ['RW', 'Rwandan'],
   ['SV', 'Salvadorean'],

--- a/config/initializers/nationalities.rb
+++ b/config/initializers/nationalities.rb
@@ -229,11 +229,6 @@ NATIONALITIES = [
 NATIONALITIES_BY_NAME = NATIONALITIES.map(&:reverse).to_h
 NATIONALITY_DEMONYMS = NATIONALITIES.map(&:second)
 
-# Last updated on 21/12/2020. To update run the following code in irb and update the EU_COUNTRY_CODES array with the result.
-# require 'net/http' # require 'json'
-# response = Net::HTTP.get('restcountries.eu', '/rest/v2/regionalbloc/eu?fields=alpha2Code;name')
-# JSON.parse(response).inject([]) { |response, country| response << [ country['alpha2Code'], country['name'] ] }
-
 EU_COUNTRY_CODES = [
   'AX',
   'AT',


### PR DESCRIPTION
## Context
We haven't updated the codes for a while and there is an issue with Romanian nationality country code

## Guidance to review
Romania was the only nationality we had with the wrong code.

There don't seem to be any on the list that we don't have: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/664133/CH_Nationality_List_20171130_v1.csv/preview

## Link to Trello card
https://trello.com/c/xExSGQol/4324-update-nationality-list-and-codes

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
