### PR TITLE
Touch application choices if a candidate updates their email

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -16,8 +16,22 @@ class Candidate < ApplicationRecord
   belongs_to :course_from_find, class_name: 'Course', optional: true
   belongs_to :fraud_match, optional: true
 
+  PUBLISHED_FIELDS = %w[email_address].freeze
+
   after_create do
     update!(candidate_api_updated_at: Time.zone.now)
+  end
+
+  before_save do |candidate|
+    if (candidate.changed & PUBLISHED_FIELDS).any?
+      touch_application_choices
+    end
+  end
+
+  def touch_application_choices
+    return unless application_choices.any?
+
+    application_choices.where(current_recruitment_cycle_year: RecruitmentCycle.current_year).touch_all
   end
 
   def self.for_email(email)

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -11,6 +11,35 @@ RSpec.describe Candidate, type: :model do
     it { is_expected.not_to allow_value(Faker::Lorem.characters(number: 251)).for(:email_address) }
   end
 
+  describe 'before_save' do
+    it 'touches the application choice when a field affecting the application choice is changed' do
+      candidate = create(:candidate)
+      application_form = create(:completed_application_form, application_choices_count: 1, candidate: candidate)
+
+      expect { candidate.update(email_address: 'new.email@example.com') }
+        .to(change { application_form.application_choices.first.updated_at })
+    end
+
+    it 'does not touch the application choice when a field not affecting the application choice is changed' do
+      candidate = create(:candidate)
+      application_form = create(:completed_application_form, application_choices_count: 1, candidate: candidate)
+
+      expect { candidate.update(last_signed_in_at: Time.zone.now) }
+        .not_to(change { application_form.application_choices.first.updated_at })
+    end
+
+    it 'does not touch the application choice when its in a previous recruitment cycle' do
+      candidate = create(:candidate)
+      application_choice = create(:application_choice, current_recruitment_cycle_year: RecruitmentCycle.previous_year)
+      application_form = ApplicationForm.with_unsafe_application_choice_touches do
+        create(:completed_application_form, application_choices: [application_choice], candidate: candidate, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      end
+
+      expect { candidate.update(email_address: 'new.email@example.com') }
+        .not_to(change { application_form.application_choices.first.updated_at })
+    end
+  end
+
   describe '#delete' do
     it 'deletes all dependent records through cascading deletes in the database' do
       candidate = create(:candidate)


### PR DESCRIPTION
## Context

Came from a provider testing updating Candidate emails and that not reflected in the API using the since parameter

## Changes proposed in this pull request

Touch application choices if a candidate's emails is updated

## Guidance to review

Probably should scope this to current recruitment cycle only

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
