### PR TITLE
Touch forms and application choices

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -24,14 +24,15 @@ class Candidate < ApplicationRecord
 
   before_save do |candidate|
     if (candidate.changed & PUBLISHED_FIELDS).any?
-      touch_application_choices
+      touch_application_choices_and_forms
     end
   end
 
-  def touch_application_choices
+  def touch_application_choices_and_forms
     return unless application_choices.any?
 
     application_choices.where(current_recruitment_cycle_year: RecruitmentCycle.current_year).touch_all
+    application_forms.where(recruitment_cycle_year: RecruitmentCycle.current_year).touch_all
   end
 
   def self.for_email(email)

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -12,31 +12,61 @@ RSpec.describe Candidate, type: :model do
   end
 
   describe 'before_save' do
-    it 'touches the application choice when a field affecting the application choice is changed' do
-      candidate = create(:candidate)
-      application_form = create(:completed_application_form, application_choices_count: 1, candidate: candidate)
+    context 'with application choices' do
+      it 'touches the application choice when a field affecting the application choice is changed' do
+        candidate = create(:candidate)
+        application_form = create(:completed_application_form, application_choices_count: 1, candidate: candidate)
 
-      expect { candidate.update(email_address: 'new.email@example.com') }
-        .to(change { application_form.application_choices.first.updated_at })
-    end
-
-    it 'does not touch the application choice when a field not affecting the application choice is changed' do
-      candidate = create(:candidate)
-      application_form = create(:completed_application_form, application_choices_count: 1, candidate: candidate)
-
-      expect { candidate.update(last_signed_in_at: Time.zone.now) }
-        .not_to(change { application_form.application_choices.first.updated_at })
-    end
-
-    it 'does not touch the application choice when its in a previous recruitment cycle' do
-      candidate = create(:candidate)
-      application_choice = create(:application_choice, current_recruitment_cycle_year: RecruitmentCycle.previous_year)
-      application_form = ApplicationForm.with_unsafe_application_choice_touches do
-        create(:completed_application_form, application_choices: [application_choice], candidate: candidate, recruitment_cycle_year: RecruitmentCycle.previous_year)
+        expect { candidate.update(email_address: 'new.email@example.com') }
+          .to(change { application_form.application_choices.first.updated_at })
       end
 
-      expect { candidate.update(email_address: 'new.email@example.com') }
-        .not_to(change { application_form.application_choices.first.updated_at })
+      it 'does not touch the application choice when a field not affecting the application choice is changed' do
+        candidate = create(:candidate)
+        application_form = create(:completed_application_form, application_choices_count: 1, candidate: candidate)
+
+        expect { candidate.update(last_signed_in_at: Time.zone.now) }
+          .not_to(change { application_form.application_choices.first.updated_at })
+      end
+
+      it 'does not touch the application choice when its in a previous recruitment cycle' do
+        candidate = create(:candidate)
+        application_choice = create(:application_choice, current_recruitment_cycle_year: RecruitmentCycle.previous_year)
+        application_form = ApplicationForm.with_unsafe_application_choice_touches do
+          create(:completed_application_form, application_choices: [application_choice], candidate: candidate, recruitment_cycle_year: RecruitmentCycle.previous_year)
+        end
+
+        expect { candidate.update(email_address: 'new.email@example.com') }
+          .not_to(change { application_form.application_choices.first.updated_at })
+      end
+    end
+
+    context 'with application forms' do
+      it 'touches the application form when a field affecting the application form is changed' do
+        candidate = create(:candidate)
+        application_form = create(:completed_application_form, application_choices_count: 1, candidate: candidate)
+
+        expect { candidate.update(email_address: 'new.email@example.com') }
+          .to(change { application_form.reload.updated_at })
+      end
+
+      it 'does not touch the application form when a field not affecting the application form is changed' do
+        candidate = create(:candidate)
+        application_form = create(:completed_application_form, application_choices_count: 1, candidate: candidate)
+
+        expect { candidate.update(last_signed_in_at: Time.zone.now) }
+          .not_to(change { application_form.reload.updated_at })
+      end
+
+      it 'does not touch the application form when its in a previous recruitment cycle' do
+        candidate = create(:candidate)
+        application_form = ApplicationForm.with_unsafe_application_choice_touches do
+          create(:completed_application_form, application_choices_count: 1, candidate: candidate, recruitment_cycle_year: RecruitmentCycle.previous_year)
+        end
+
+        expect { candidate.update(email_address: 'new.email@example.com') }
+          .not_to(change { application_form.reload.updated_at })
+      end
     end
   end
 


### PR DESCRIPTION
## Context

Followup to https://github.com/DFE-Digital/apply-for-teacher-training/pull/5716 touch forms as well as choices when updating candidate emails

## Changes proposed in this pull request

Touch both forms and choices to avoid discrepancies in the touch model
 
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
