### PR TITLE
Use the cycle timetable to determine which cycle to carry over to

### DIFF
--- a/app/services/carry_over_application.rb
+++ b/app/services/carry_over_application.rb
@@ -26,6 +26,10 @@ private
   end
 
   def recruitment_cycle_year
-    @application_form.recruitment_cycle_year + 1
+    if Time.zone.now > CycleTimetable.apply_1_deadline
+      RecruitmentCycle.next_year
+    else
+      RecruitmentCycle.current_year
+    end
   end
 end

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -34,6 +34,20 @@ RSpec.describe CarryOverApplication do
     it_behaves_like 'duplicates application form', 'apply_1', 2021
   end
 
+  context 'when original application is from multiple cycles ago' do
+    around do |example|
+      Timecop.freeze(after_apply_reopens) do
+        example.run
+      end
+    end
+
+    before do
+      Timecop.travel(-1.day) { original_application_form.update(recruitment_cycle_year: 2018) }
+    end
+
+    it_behaves_like 'duplicates application form', 'apply_1', 2021
+  end
+
   context 'when original application is from the current recruitment cycle but that cycle has now closed' do
     around do |example|
       Timecop.freeze(after_apply_2_deadline) do


### PR DESCRIPTION
## Context

At the moment, we use the current applications recruitment_cycle_year to determine which cycle to carry over the application to.

It does this by taking the current applications recruitment_cycle_year and adding 1 to it.

This works fine when someone is carrying an application over one cycle. However, if the application form is two years old, this causes two carry overs to happen.

Instead we should just figure out which cycle they should be in by using the cycle timetable to establish where they are in the cycle.

If it's after the apply1 deadline, but before cycle launch, it should be carried over the next cycle. If not then just carry over to the current cycle.

## Changes proposed in this pull request

- Use the cycle timetable to determine which recruitment cycle to carry over an application 

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
