### PR TITLE
Only send emails to provider users with pending relationships

### DIFF
--- a/spec/workers/start_of_cycle_notification_worker_spec.rb
+++ b/spec/workers/start_of_cycle_notification_worker_spec.rb
@@ -91,8 +91,7 @@ RSpec.describe StartOfCycleNotificationWorker do
         allow(ProviderSetup).to receive(:new).and_return(instance_double(ProviderSetup, relationships_pending: []))
         described_class.new.perform(service)
 
-        expect(ProviderMailer).not_to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.first)
-        expect(ProviderMailer).not_to have_received(:set_up_organisation_permissions).with(provider_users_who_need_to_set_up_permissions.last)
+        expect(ProviderMailer).not_to have_received(:set_up_organisation_permissions)
       end
 
       it 'ignores providers with chasers sent' do


### PR DESCRIPTION
## Context

When find opens, we are sending users an email to inform them that find has opened and another if they have relationships to set up. If a provider user does manage organisations, but has no relationships pending we are sending an email to set up empty relationships anyway.

## Changes proposed in this pull request

To avoid this only send an email if a provider user can manage organisations and has relationships pending

## Guidance to review

The relationships pending checks for manage org permissions as well

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
