### PR TITLE
Fix tests that fail when find closes and reopens

### DIFF
--- a/spec/components/candidate_interface/grouped_provider_courses_component_spec.rb
+++ b/spec/components/candidate_interface/grouped_provider_courses_component_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::GroupedProviderCoursesComponent, mid_cycle: true do
+RSpec.describe CandidateInterface::GroupedProviderCoursesComponent do
   let(:course) { create(:course) }
 
   before do
@@ -23,12 +23,14 @@ RSpec.describe CandidateInterface::GroupedProviderCoursesComponent, mid_cycle: t
   end
 
   it 'renders all the region headings' do
-    result = render_inline(described_class.new)
+    Timecop.travel(CycleTimetable.find_opens + 1.hour) do
+      result = render_inline(described_class.new)
 
-    expect(result.css('h2').text).to include('South East')
-    expect(result.css('h2').text).to include('North West')
-    expect(result.css('h2').text).to include('No region')
-    expect(result.css('a').to_html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}")
+      expect(result.css('h2').text).to include('South East')
+      expect(result.css('h2').text).to include('North West')
+      expect(result.css('h2').text).to include('No region')
+      expect(result.css('a').to_html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}")
+    end
   end
 
   context 'when find is down' do

--- a/spec/components/candidate_interface/grouped_provider_courses_component_spec.rb
+++ b/spec/components/candidate_interface/grouped_provider_courses_component_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::GroupedProviderCoursesComponent do
+RSpec.describe CandidateInterface::GroupedProviderCoursesComponent, mid_cycle: true do
   let(:course) { create(:course) }
 
   before do

--- a/spec/components/candidate_interface/rejection_reasons_component_spec.rb
+++ b/spec/components/candidate_interface/rejection_reasons_component_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::RejectionReasonsComponent do
+RSpec.describe CandidateInterface::RejectionReasonsComponent, mid_cycle: true do
   let(:application_form) { create(:completed_application_form) }
   let!(:application_choice) { create(:application_choice, :with_rejection, application_form: application_form) }
 

--- a/spec/models/apply_again_feature_metrics_spec.rb
+++ b/spec/models/apply_again_feature_metrics_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ApplyAgainFeatureMetrics, with_audited: true do
       end
 
       it 'returns 1.0 when 100% of apply again applications are successful within given time range' do
-        @today = Time.zone.local(2020, 12, 31, 12)
+        @today = Time.zone.local(RecruitmentCycle.previous_year, 12, 31, 12)
         Timecop.freeze(@today - 20.days) do
           create_apply_again_application
           reject(create_apply_again_application)
@@ -79,7 +79,7 @@ RSpec.describe ApplyAgainFeatureMetrics, with_audited: true do
 
     context 'with apply again applications' do
       it 'returns correctly formatted values within given time ranges' do
-        @today = Time.zone.local(2020, 12, 31, 12)
+        @today = Time.zone.local(RecruitmentCycle.previous_year, 12, 31, 12)
         Timecop.freeze(@today - 20.days) do
           create_apply_again_application
           reject(create_apply_again_application)

--- a/spec/models/reference_feature_metrics_spec.rb
+++ b/spec/models/reference_feature_metrics_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ReferenceFeatureMetrics, with_audited: true do
 
   context 'with reference data' do
     before do
-      @today = Time.zone.local(2020, 12, 31, 12)
+      @today = Time.zone.local(RecruitmentCycle.current_year, 12, 31, 12)
       Timecop.freeze(@today - 12.days + 2.hours) do
         @application_form1 = create(:application_form)
         @references1 = create_list(:reference, 2, application_form: @application_form1)

--- a/spec/services/candidate_interface/find_changed_apply_again_applications_spec.rb
+++ b/spec/services/candidate_interface/find_changed_apply_again_applications_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::FindChangedApplyAgainApplications do
+RSpec.describe CandidateInterface::FindChangedApplyAgainApplications, mid_cycle: true do
   around do |example|
     Timecop.freeze do
       example.run

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -254,16 +254,14 @@ RSpec.describe CycleTimetable do
     end
   end
 
-  describe '.can_submit?' do
-    before { allow(RecruitmentCycle).to receive(:current_year).and_return(2021) }
-
+  describe '.can_submit?', mid_cycle: true do
     it 'returns true for an application in the current recruitment cycle' do
-      application_form = build :application_form, recruitment_cycle_year: 2021
+      application_form = build :application_form, recruitment_cycle_year: RecruitmentCycle.current_year
       expect(described_class.can_submit?(application_form)).to be true
     end
 
     it 'returns false for an application in the previous recruitment cycle' do
-      application_form = build :application_form, recruitment_cycle_year: 2020
+      application_form = build :application_form, recruitment_cycle_year: RecruitmentCycle.previous_year
       expect(described_class.can_submit?(application_form)).to be false
     end
   end

--- a/spec/services/open_provider_courses_spec.rb
+++ b/spec/services/open_provider_courses_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe OpenProviderCourses do
   end
 
   it 'sets the opened on apply timestamp' do
-    opened_on_apply = Time.zone.local(2021, 3, 24, 12)
+    opened_on_apply = Time.zone.local(RecruitmentCycle.current_year, 3, 24, 12)
     course = create(:course, provider: provider, exposed_in_find: true)
 
     Timecop.freeze(opened_on_apply) do

--- a/spec/support/test_helpers/teacher_training_public_api_helper.rb
+++ b/spec/support/test_helpers/teacher_training_public_api_helper.rb
@@ -90,7 +90,7 @@ module TeacherTrainingPublicAPIHelper
   end
 
   def stubbed_recruitment_cycle_year
-    @stubbed_recruitment_cycle_year || 2021
+    @stubbed_recruitment_cycle_year || RecruitmentCycle.current_year
   end
 
 private

--- a/spec/system/find_sync/syncing_providers_spec.rb
+++ b/spec/system/find_sync/syncing_providers_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Syncing providers', sidekiq: true do
+RSpec.feature 'Syncing providers', sidekiq: true do
   include TeacherTrainingPublicAPIHelper
 
   scenario 'Updates course subject codes' do

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Providers should be able to filter applications', mid_cycle: false do
+RSpec.feature 'Providers should be able to filter applications' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
@@ -166,7 +166,7 @@ RSpec.feature 'Providers should be able to filter applications', mid_cycle: fals
   end
 
   def and_i_expect_the_relevant_recruitment_cycle_tags_to_be_visible
-    tag_text = '2020 to 2021'
+    tag_text = "#{RecruitmentCycle.previous_year} to #{RecruitmentCycle.current_year}"
     expect(page).to have_css('.moj-filter-tags', text: tag_text)
   end
 

--- a/spec/system/reject_by_default_spec.rb
+++ b/spec/system/reject_by_default_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Reject by default', mid_cycle: false do
+RSpec.feature 'Reject by default' do
   include CourseOptionHelpers
 
   scenario 'An application is rejected by default', with_audited: true do
@@ -47,8 +47,8 @@ RSpec.feature 'Reject by default', mid_cycle: false do
   end
 
   def when_the_application_is_getting_close_to_the_reject_by_default_date
-    time_limit_in_buiness_days = TimeLimitCalculator.new(rule: :chase_provider_before_rbd, effective_date: Time.zone.now).call[:days]
-    Timecop.travel((time_limit_in_buiness_days.days - 1).before(@application_choice.reject_by_default_at)) do
+    time_limit = TimeLimitCalculator.new(rule: :chase_provider_before_rbd, effective_date: Time.zone.now).call[:time_in_future]
+    Timecop.travel(time_limit) do
       SendChaseEmailToProvidersWorker.perform_async
     end
   end

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Providers and courses', mid_cycle: false do
+RSpec.feature 'Providers and courses' do
   include DfESignInHelpers
   include TeacherTrainingPublicAPIHelper
 
@@ -291,7 +291,7 @@ RSpec.feature 'Providers and courses', mid_cycle: false do
   end
 
   def and_i_choose_to_open_all_courses
-    click_button 'Open all courses for the 2021 cycle'
+    click_button "Open all courses for the #{RecruitmentCycle.current_year} cycle"
   end
 
   def then_all_courses_should_be_open_on_apply

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Service performance', mid_cycle: false do
+RSpec.feature 'Service performance' do
   include DfESignInHelpers
 
   scenario 'View service statistics' do
@@ -35,10 +35,10 @@ RSpec.feature 'Service performance', mid_cycle: false do
   end
 
   def when_there_are_candidates_that_have_never_signed_in
-    Timecop.freeze(2019, 12, 25) do
+    Timecop.freeze(RecruitmentCycle.previous_year - 1, 12, 25) do
       create(:candidate)
     end
-    Timecop.freeze(2021, 1, 5) do
+    Timecop.freeze(RecruitmentCycle.current_year, 1, 5) do
       create_list(:candidate, 2)
     end
   end

--- a/spec/system/teacher_training_public_api/site_is_deleted_spec.rb
+++ b/spec/system/teacher_training_public_api/site_is_deleted_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Sync sites' do
+RSpec.feature 'Sync sites' do
   include TeacherTrainingPublicAPIHelper
 
   scenario 'a site is removed between syncs' do

--- a/spec/system/teacher_training_public_api/sync_course_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_course_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Sync courses', sidekiq: true do
+RSpec.feature 'Sync courses', sidekiq: true do
   include TeacherTrainingPublicAPIHelper
 
   scenario 'Creates and updates courses' do

--- a/spec/system/teacher_training_public_api/sync_provider_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_provider_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Sync provider', sidekiq: true do
+RSpec.feature 'Sync provider', sidekiq: true do
   include TeacherTrainingPublicAPIHelper
 
   scenario 'Creates and updates providers' do

--- a/spec/system/teacher_training_public_api/sync_site_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_site_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Sync sites', sidekiq: true do
+RSpec.feature 'Sync sites', sidekiq: true do
   include TeacherTrainingPublicAPIHelper
 
   scenario 'Creates and updates sites' do

--- a/spec/workers/detect_invariants_daily_check_spec.rb
+++ b/spec/workers/detect_invariants_daily_check_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe DetectInvariantsDailyCheck do
       this_year_course = create(:course_option)
       last_year_course = create(:course_option, :previous_year)
 
-      bad_form_this_year = create(:completed_application_form, submitted_at: Time.zone.now)
-      good_form_this_year = create(:completed_application_form, submitted_at: Time.zone.now)
+      bad_form_this_year = create(:completed_application_form, submitted_at: Time.zone.local(RecruitmentCycle.current_year, 10, 6, 9), recruitment_cycle_year: RecruitmentCycle.current_year)
+      good_form_this_year = create(:completed_application_form, submitted_at: Time.zone.local(RecruitmentCycle.current_year, 10, 6, 9), recruitment_cycle_year: RecruitmentCycle.current_year)
       good_form_last_year = create(:application_form, submitted_at: 1.year.ago)
 
       create(:application_choice, application_form: bad_form_this_year, course_option: last_year_course)

--- a/spec/workers/open_all_courses_on_apply_worker_spec.rb
+++ b/spec/workers/open_all_courses_on_apply_worker_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe OpenAllCoursesOnApplyWorker do
   it 'opens courses that are closed on Apply and in the current cycle' do
-    Timecop.freeze(CycleTimetable.apply_reopens) do
+    Timecop.freeze(CycleTimetable.find_opens(2022) + 1.day) do
       open_course = create(:course, open_on_apply: true)
       closed_course = create(:course, open_on_apply: false)
-      course_in_the_previous_cycle = create(:course, open_on_apply: false, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      course_in_the_previous_cycle = create(:course, open_on_apply: false, recruitment_cycle_year: 2021)
 
       described_class.new.perform
 
@@ -16,7 +16,7 @@ RSpec.describe OpenAllCoursesOnApplyWorker do
   end
 
   it 'sets the opened on apply timestamp' do
-    opened_on_apply = CycleTimetable.apply_reopens + 2.days
+    opened_on_apply = CycleTimetable.find_opens(2022) + 2.days
 
     Timecop.freeze(opened_on_apply) do
       course = create(:course, open_on_apply: false)
@@ -29,7 +29,7 @@ RSpec.describe OpenAllCoursesOnApplyWorker do
   it 'wont open courses if Apply is not in the new cycle' do
     course = create(:course, open_on_apply: false)
 
-    Timecop.freeze(CycleTimetable.apply_reopens - 1.day) do
+    Timecop.freeze(CycleTimetable.find_opens(2022) - 1.day) do
       described_class.new.perform
       expect(course.reload.open_on_apply).to eq false
     end

--- a/spec/workers/teacher_training_public_api/sync_all_providers_and_courses_worker_spec.rb
+++ b/spec/workers/teacher_training_public_api/sync_all_providers_and_courses_worker_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker do
+RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker, mid_cycle: true do
   describe '#perform' do
     let!(:stubbed_sync_subjects_service) do
       sync_subjects_service = instance_double(TeacherTrainingPublicAPI::SyncSubjects, perform: nil)


### PR DESCRIPTION
## Context

Tests are failing when cycle dates change

## Changes proposed in this pull request

make sure tests don't fail when cycle switches

## Guidance to review

I ran now, when find closes, find opens and apply opens and all passes

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
