### PR TITLE
correct automatic rejection email

### DIFF
--- a/app/views/candidate_mailer/_rejected_by_default_intro.text.erb
+++ b/app/views/candidate_mailer/_rejected_by_default_intro.text.erb
@@ -1,8 +1,7 @@
-Your application to study <%= @course.name_and_code %> has been automatically rejected because <%= @course.provider.name %> did not make a decision before today’s deadline.
-
 Your application to study <%= @course.name_and_code %> cannot progress because <%= @course.provider.name %> did not make a decision before their deadline to respond.
 
 Unless the provider has indicated that they want to progress your application, you should consider this application closed and choose another course or provider.
 
 <%= @course.provider.name %> may still give you feedback on your application.
+
 If you think this is a mistake (for example, the provider has invited you for an interview) let us know at becomingateacher@education.gov.uk.


### PR DESCRIPTION
delete: 

Your application to study Architectural Technology (DGTX) has been automatically rejected because Francie Hartmann University did not make a decision before today’s deadline.

(this was the old line before the recent edit, shouldn't be there anymore)


