### PR TITLE
Use word-wrap in section content to ensure long words don't break UI

### DIFF
--- a/app/frontend/styles/_section.scss
+++ b/app/frontend/styles/_section.scss
@@ -4,6 +4,10 @@
   img {
     max-width: 100%;
   }
+
+  .govuk-body {
+    word-wrap: break-word;
+  }
 }
 
 .app-section--with-top-border {


### PR DESCRIPTION
## Context
Update `.app-section govuk-body` to ensure word wrap so that long words don’t result in breaking the UI.

Ensure that 
## Changes proposed in this pull request

**Before**
<img width="1394" alt="Screenshot 2021-10-04 at 13 37 45" src="https://user-images.githubusercontent.com/159200/135852632-70dd51df-55d8-4a2f-b9f0-02ceb02a53e9.png">

**After**
<img width="1286" alt="Screenshot 2021-10-04 at 13 37 20" src="https://user-images.githubusercontent.com/159200/135852659-2ca76167-e489-4381-ba2f-0206bbc4d22f.png">

## Link to Trello card

https://trello.com/c/gtIRpoYK/4188-long-words-mess-up-the-ui
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
