### PR TITLE
Reinstate the #prefill? check before populating application form

### DIFF
--- a/app/controllers/candidate_interface/prefill_application_form_controller.rb
+++ b/app/controllers/candidate_interface/prefill_application_form_controller.rb
@@ -10,8 +10,11 @@ module CandidateInterface
       @prefill_application_or_not_form = PrefillApplicationOrNotForm.new(prefill_application_or_not_params)
 
       if @prefill_application_or_not_form.valid?
-        prefill_candidate_application_form
-        flash[:info] = 'This application has been prefilled with example data'
+        if @prefill_application_or_not_form.prefill?
+          prefill_candidate_application_form
+          flash[:info] = 'This application has been prefilled with example data'
+        end
+
         redirect_to candidate_interface_application_form_path
       else
         track_validation_error(@prefill_application_or_not_form)

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_starts_blank_application_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_starts_blank_application_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate signs in and starts blank application in Sandbox', sandbox: true do
+  include SignInHelper
+
+  scenario 'User is directed to prefill option page and chooses to start a blank application' do
+    given_the_pilot_is_open
+    and_a_course_is_available
+    and_i_am_a_candidate_with_a_blank_application
+
+    when_i_fill_in_the_sign_in_form
+    and_i_click_on_the_link_in_my_email_and_sign_in
+    then_i_am_taken_to_the_prefill_application_page
+
+    when_i_select_blank_application_and_submit_the_form
+    then_i_am_taken_to_the_blank_application_page
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def and_a_course_is_available
+    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: RecruitmentCycle.current_year))
+  end
+
+  def and_i_am_a_candidate_with_a_blank_application
+    @candidate = create(:candidate)
+    @application_form = create(:application_form, candidate: @candidate)
+  end
+
+  def when_i_fill_in_the_sign_in_form
+    visit candidate_interface_sign_in_path
+    fill_in t('authentication.sign_up.email_address.label'), with: @candidate.email_address
+    click_on t('continue')
+  end
+
+  def and_i_click_on_the_link_in_my_email_and_sign_in
+    open_email(@candidate.email_address)
+    click_magic_link_in_email
+    confirm_sign_in
+  end
+
+  def then_i_am_taken_to_the_prefill_application_page
+    expect(page).to have_current_path(candidate_interface_prefill_path)
+  end
+
+  def when_i_select_blank_application_and_submit_the_form
+    choose 'Start with a blank application form'
+    click_on t('continue')
+  end
+
+  def then_i_am_taken_to_the_blank_application_page
+    expect(page).to have_current_path(candidate_interface_application_form_path)
+    expect(page).not_to have_content 'This application has been prefilled with example data'
+    expect(page).to have_content 'Personal information Incomplete'
+  end
+end


### PR DESCRIPTION
## Context

https://github.com/DFE-Digital/apply-for-teacher-training/commit/88984b34b84b186d8d0b9c3aef2b72143c52949d removed the check based on form params as to whether we prefill the application form or not.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Reinstates the `#prefill?` check and prefill application form accordingly.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/BLpx0JNb/4342-sandbox-starting-a-new-application-with-a-blank-application-form-still-pre-fills-an-application-form
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
