### PR TITLE
Amend provider RDB email content

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -40,13 +40,14 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
-  def application_rejected_by_default(provider_user, application_choice)
+  def application_rejected_by_default(provider_user, application_choice, can_make_decisions:)
     @application = map_application_choice_params(application_choice)
+    @provider_can_give_feedback = can_make_decisions
 
     email_for_provider(
       provider_user,
       application_choice.application_form,
-      subject: I18n.t!('provider_mailer.application_rejected_by_default.subject', candidate_name: @application.candidate_name, support_reference: @application.support_reference),
+      subject: I18n.t!('provider_mailer.application_rejected_by_default.subject', candidate_name: @application.candidate_name),
     )
   end
 

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -95,8 +95,7 @@ class ProviderAuthorisation
       raise ValidationException, ['Please provide a course_option or course_option_id']
     end
 
-    course_option_id ||= course_option.id
-    course = CourseOption.find(course_option_id).course
+    course = course_option_id.present? ? CourseOption.find(course_option_id).course : course_option.course
 
     add_error(:make_decisions, :requires_application_choice_visibility) unless
       application_choice_visible_to_user?(application_choice: application_choice)

--- a/app/services/send_reject_by_default_email_to_provider.rb
+++ b/app/services/send_reject_by_default_email_to_provider.rb
@@ -9,7 +9,9 @@ class SendRejectByDefaultEmailToProvider
     return false unless application_choice.rejected?
 
     NotificationsList.for(application_choice, event: :application_rejected_by_default).each do |provider_user|
-      ProviderMailer.application_rejected_by_default(provider_user, application_choice).deliver_later
+      can_make_decisions = provider_user.authorisation.can_make_decisions?(application_choice: application_choice,
+                                                                           course_option: application_choice.current_course_option)
+      ProviderMailer.application_rejected_by_default(provider_user, application_choice, can_make_decisions: can_make_decisions).deliver_later
     end
   end
 end

--- a/app/views/provider_mailer/application_rejected_by_default.text.erb
+++ b/app/views/provider_mailer/application_rejected_by_default.text.erb
@@ -1,10 +1,11 @@
 <% content_for :additional_footer_content do %><%= render 'unsubscribe' %><% end %>
 Dear <%= @provider_user_name || 'colleague' %>
 
-# Application rejected by default
+<%= @application.candidate_name %>'s application to study <%= @application.course_name_and_code %> was automatically rejected.
 
-<%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %> on <%= @application.submitted_at %>.
+This is because you did not respond within <%= @application.rbd_days %> working days.
 
-This application has been rejected automatically because you did not respond within <%= @application.rbd_days %> working days.
-
-<%= provider_interface_application_choice_url(@application.application_choice_id) %>
+<% if @provider_can_give_feedback %>
+  You need to tell <%= @application.candidate_name %> why their application was unsuccessful:
+  <%= provider_interface_application_choice_url(@application.application_choice_id) %>
+<% end %>

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -15,7 +15,7 @@ en:
     application_submitted_with_safeguarding_issues:
       subject: Application with safeguarding issues received for %{course_name_and_code}
     application_rejected_by_default:
-      subject: "%{candidate_name}’s (%{support_reference}) application was rejected automatically"
+      subject: "%{candidate_name}’s application was automatically rejected - manage teacher training applications"
     application_waiting_for_decision:
       subject: "Respond to %{candidate_name}’s (%{support_reference}) application"
     application_withdrawn:

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -21,8 +21,12 @@ class ProviderMailerPreview < ActionMailer::Preview
     ProviderMailer.application_submitted_with_safeguarding_issues(provider_user, application_choice)
   end
 
-  def application_rejected_by_default
-    ProviderMailer.application_rejected_by_default(provider_user, application_choice)
+  def application_rejected_by_default__provider_can_make_decisions
+    ProviderMailer.application_rejected_by_default(provider_user, application_choice, can_make_decisions: true)
+  end
+
+  def application_rejected_by_default__provider_cant_make_decisions
+    ProviderMailer.application_rejected_by_default(provider_user, application_choice, can_make_decisions: false)
   end
 
   def chase_provider_decision

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -52,16 +52,30 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe 'Send application rejected by default email' do
-    let(:email) { described_class.application_rejected_by_default(provider_user, application_choice) }
+    context 'when the provider user can make decisions' do
+      let(:email) { described_class.application_rejected_by_default(provider_user, application_choice, can_make_decisions: true) }
 
-    it_behaves_like('a mail with subject and content',
-                    I18n.t!('provider_mailer.application_rejected_by_default.subject',
-                            candidate_name: 'Harry Potter', support_reference: '123A'),
-                    'provider name' => 'Dear Johny English',
-                    'candidate name' => 'Harry Potter',
-                    'course name and code' => 'Computer Science (6IND)',
-                    'reject by default days' => 'within 123 working days',
-                    'submission date' => 5.days.ago.to_s(:govuk_date))
+      it_behaves_like('a mail with subject and content',
+                      I18n.t!('provider_mailer.application_rejected_by_default.subject',
+                              candidate_name: 'Harry Potter'),
+                      'provider name' => 'Dear Johny English',
+                      'candidate name' => 'Harry Potter',
+                      'course name and code' => 'Computer Science (6IND)',
+                      'reject by default days' => 'within 123 working days',
+                      'feedback_text' => 'You need to tell Harry Potter why their application was unsuccessful')
+    end
+
+    context 'when the provider user cannot make decisions' do
+      let(:email) { described_class.application_rejected_by_default(provider_user, application_choice, can_make_decisions: false) }
+
+      it_behaves_like('a mail with subject and content',
+                      I18n.t!('provider_mailer.application_rejected_by_default.subject',
+                              candidate_name: 'Harry Potter'),
+                      'provider name' => 'Dear Johny English',
+                      'candidate name' => 'Harry Potter',
+                      'course name and code' => 'Computer Science (6IND)',
+                      'reject by default days' => 'within 123 working days')
+    end
   end
 
   describe 'Send provider decision chaser email' do


### PR DESCRIPTION
## Context
Redesign of RBD email to improve content


## Changes proposed in this pull request

**When the user can leave feedback**

<img width="1154" alt="application_rdb_allow_feedback" src="https://user-images.githubusercontent.com/159200/135876121-eeeaf494-7876-46d7-8c0c-2573820ea9fb.png">

**When the user cannot leave feedback**

<img width="1195" alt="application_rdb_dont_allow_feedback" src="https://user-images.githubusercontent.com/159200/135876637-99b71ea1-0ee9-4659-9933-f924dea314c2.png">

## Link to Trello card

https://trello.com/c/tyg0MEAU/4319-improve-reject-by-default-email-content

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
