### PR TITLE
Update service performance dashboard to accept 2022 as a year value

### DIFF
--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -15,7 +15,7 @@ module SupportInterface
     def courses_dashboard; end
 
     def service_performance_dashboard
-      year = params[:year] if %w[2020 2021].include?(params[:year])
+      year = params[:year] if %w[2020 2021 2022].include?(params[:year])
 
       @statistics = PerformanceStatistics.new(year)
     end


### PR DESCRIPTION
## Context

`2021 to 2022 (starts 2022)` values are currently not rendering on the Service performance dashboard as the controller checks to see if the selected year appears in an array of year values and 2022 is currently missing from this array.

## Changes proposed in this pull request
2022 added into:

`year = params[:year] if %w[2020 2021].include?(params[:year])`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
