### PR TITLE
Fix date in RBD email

### DIFF
--- a/app/views/candidate_mailer/_still_interested_content.text.erb
+++ b/app/views/candidate_mailer/_still_interested_content.text.erb
@@ -2,7 +2,7 @@
 
 You can apply again for courses starting in the <%= "#{RecruitmentCycle.next_year} to #{RecruitmentCycle.next_year + 1}" %> academic year.
 
-Your last application has been saved. Make any changes and re-submit from <%= CycleTimetable.apply_opens.to_s(:govuk_time) %> on <%= CycleTimetable.apply_opens.to_s(:govuk_date) %>.
+Your last application has been saved. Make any changes and re-submit from <%= CycleTimetable.apply_reopens.to_s(:govuk_time) %> on <%= CycleTimetable.apply_reopens.to_s(:govuk_date) %>.
 
 <% else %>
 


### PR DESCRIPTION
## Context

At the moment the RBD email is using the date for apply opening (i.e. the start of the current cycle) when it should be using the apply reopens date (the start of the next cycle)

## Changes proposed in this pull request

- Update the date in the RBD email to use the apply_reopens date

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
