### PR TITLE
Map env when disabling maintenance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ enable-maintenance: ## make qa enable-maintenance / make prod enable-maintenance
 disable-maintenance: ## make qa disable-maintenance / make prod disable-maintenance CONFIRM_PRODUCTION=y
 	$(if $(HOSTNAME), $(eval REAL_HOSTNAME=${HOSTNAME}), $(eval REAL_HOSTNAME=${APP_ENV}))
 	cf target -s ${SPACE}
-	cf map-route apply-qa apply-for-teacher-training.service.gov.uk --hostname ${REAL_HOSTNAME}
+	cf map-route apply-${APP_ENV} apply-for-teacher-training.service.gov.uk --hostname ${REAL_HOSTNAME}
 	echo Waiting 5s for route to be registered... && sleep 5
 	cf unmap-route apply-unavailable apply-for-teacher-training.service.gov.uk --hostname ${REAL_HOSTNAME}
 	cf delete -rf apply-unavailable


### PR DESCRIPTION
## Context

We should be using ENV passed in rather than qa

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
