### PR TITLE
Re-add sync when find closes

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -61,6 +61,8 @@ class Clock
   every(1.day, 'SendFindHasOpenedEmailToCandidatesWorker', at: '12:00') { SendFindHasOpenedEmailToCandidatesWorker.new.perform }
   every(1.day, 'SendNewCycleStartedEmailToCandidatesWorker', at: '12:00') { SendNewCycleHasStartedEmailToCandidatesWorker.new.perform }
 
+  every(1.day, 'TriggerFullSyncIfFindClosed', at: '00:05') { TeacherTrainingPublicAPI::TriggerFullSyncIfFindClosed.call }
+
   every(1.day, 'UpdateFraudAuditDashboard', at: '13:00') { UpdateFraudMatchesWorker.perform_async }
 
   every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do


### PR DESCRIPTION
## Context

This was accidentally removed as part of https://github.com/DFE-Digital/apply-for-teacher-training/commit/ab062cb061ee490a9e1c6c483a10e568d11745cc#diff-10eb53c6e76bfe3876d283189edb80d0a0b26e22dae9fb135892c54b06cbae4d

## Changes proposed in this pull request

- Add back in the full sync that occurs after Find closes at the EoC

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
