### PR TITLE
Add all cycle dates for next year in fake schedules

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -194,6 +194,11 @@ class CycleTimetable
         previous_year => {
           find_opens: 9.days.ago,
           apply_opens: 8.days.ago,
+          show_deadline_banner: 7.days.ago,
+          apply_1_deadline: 6.days.ago,
+          apply_2_deadline: 5.days.ago,
+          reject_by_default: 4.days.ago,
+          find_closes: 3.days.ago,
         },
       },
       today_is_mid_cycle: {
@@ -218,6 +223,11 @@ class CycleTimetable
         previous_year => {
           find_opens: 9.days.ago,
           apply_opens: 8.days.ago,
+          show_deadline_banner: 7.days.ago,
+          apply_1_deadline: 6.days.ago,
+          apply_2_deadline: 5.days.ago,
+          reject_by_default: 4.days.ago,
+          find_closes: 3.days.ago,
         },
       },
       today_is_after_apply_1_deadline_passed: {
@@ -242,6 +252,11 @@ class CycleTimetable
         previous_year => {
           find_opens: 9.days.ago,
           apply_opens: 8.days.ago,
+          show_deadline_banner: 7.days.ago,
+          apply_1_deadline: 6.days.ago,
+          apply_2_deadline: 5.days.ago,
+          reject_by_default: 4.days.ago,
+          find_closes: 3.days.ago,
         },
       },
       today_is_after_apply_2_deadline_passed: {
@@ -266,6 +281,11 @@ class CycleTimetable
         previous_year => {
           find_opens: 9.days.ago,
           apply_opens: 8.days.ago,
+          show_deadline_banner: 7.days.ago,
+          apply_1_deadline: 6.days.ago,
+          apply_2_deadline: 5.days.ago,
+          reject_by_default: 4.days.ago,
+          find_closes: 3.days.ago,
         },
       },
       today_is_after_find_closes: {
@@ -290,6 +310,11 @@ class CycleTimetable
         previous_year => {
           find_opens: 9.days.ago,
           apply_opens: 8.days.ago,
+          show_deadline_banner: 7.days.ago,
+          apply_1_deadline: 6.days.ago,
+          apply_2_deadline: 5.days.ago,
+          reject_by_default: 4.days.ago,
+          find_closes: 3.days.ago,
         },
       },
       today_is_after_find_opens: {
@@ -314,6 +339,11 @@ class CycleTimetable
         previous_year => {
           find_opens: 9.days.ago,
           apply_opens: 8.days.ago,
+          show_deadline_banner: 7.days.ago,
+          apply_1_deadline: 6.days.ago,
+          apply_2_deadline: 5.days.ago,
+          reject_by_default: 4.days.ago,
+          find_closes: 3.days.ago,
         },
       },
       today_is_after_apply_opens: {
@@ -338,6 +368,11 @@ class CycleTimetable
         previous_year => {
           find_opens: 9.days.ago,
           apply_opens: 8.days.ago,
+          show_deadline_banner: 7.days.ago,
+          apply_1_deadline: 6.days.ago,
+          apply_2_deadline: 5.days.ago,
+          reject_by_default: 4.days.ago,
+          find_closes: 3.days.ago,
         },
       },
     }

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -185,6 +185,11 @@ class CycleTimetable
         next_year => {
           find_opens: 7.days.from_now,
           apply_opens: 8.days.from_now,
+          show_deadline_banner: 9.days.from_now,
+          apply_1_deadline: 10.days.from_now,
+          apply_2_deadline: 11.days.from_now,
+          reject_by_default: 12.days.from_now,
+          find_closes: 13.days.from_now,
         },
         previous_year => {
           find_opens: 9.days.ago,
@@ -204,6 +209,11 @@ class CycleTimetable
         next_year => {
           find_opens: 6.days.from_now,
           apply_opens: 7.days.from_now,
+          show_deadline_banner: 9.days.from_now,
+          apply_1_deadline: 10.days.from_now,
+          apply_2_deadline: 11.days.from_now,
+          reject_by_default: 12.days.from_now,
+          find_closes: 13.days.from_now,
         },
         previous_year => {
           find_opens: 9.days.ago,
@@ -223,6 +233,11 @@ class CycleTimetable
         next_year => {
           find_opens: 6.days.from_now,
           apply_opens: 7.days.from_now,
+          show_deadline_banner: 9.days.from_now,
+          apply_1_deadline: 10.days.from_now,
+          apply_2_deadline: 11.days.from_now,
+          reject_by_default: 12.days.from_now,
+          find_closes: 13.days.from_now,
         },
         previous_year => {
           find_opens: 9.days.ago,
@@ -242,6 +257,11 @@ class CycleTimetable
         next_year => {
           find_opens: 6.days.from_now,
           apply_opens: 7.days.from_now,
+          show_deadline_banner: 9.days.from_now,
+          apply_1_deadline: 10.days.from_now,
+          apply_2_deadline: 11.days.from_now,
+          reject_by_default: 12.days.from_now,
+          find_closes: 13.days.from_now,
         },
         previous_year => {
           find_opens: 9.days.ago,
@@ -261,6 +281,11 @@ class CycleTimetable
         next_year => {
           find_opens: 6.days.from_now,
           apply_opens: 7.days.from_now,
+          show_deadline_banner: 9.days.from_now,
+          apply_1_deadline: 10.days.from_now,
+          apply_2_deadline: 11.days.from_now,
+          reject_by_default: 12.days.from_now,
+          find_closes: 13.days.from_now,
         },
         previous_year => {
           find_opens: 9.days.ago,
@@ -280,6 +305,11 @@ class CycleTimetable
         next_year => {
           find_opens: 1.day.ago,
           apply_opens: 2.days.from_now,
+          show_deadline_banner: 4.days.from_now,
+          apply_1_deadline: 5.days.from_now,
+          apply_2_deadline: 6.days.from_now,
+          reject_by_default: 7.days.from_now,
+          find_closes: 8.days.from_now,
         },
         previous_year => {
           find_opens: 9.days.ago,
@@ -299,6 +329,11 @@ class CycleTimetable
         next_year => {
           find_opens: 2.days.ago,
           apply_opens: 1.day.ago,
+          show_deadline_banner: 2.days.from_now,
+          apply_1_deadline: 3.days.from_now,
+          apply_2_deadline: 4.days.from_now,
+          reject_by_default: 5.days.from_now,
+          find_closes: 6.days.from_now,
         },
         previous_year => {
           find_opens: 9.days.ago,


### PR DESCRIPTION
## Context

Some applications don't work correctly without having a full cycle for the upcoming year in the fake schedule.

## Changes proposed in this pull request

- Add full dates for next year in the fake cycle schedules

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
