### PR TITLE
Redirect to course choices choose path when candidate has no choices

### DIFF
--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -30,7 +30,7 @@ module CandidateInterface
       @application_form = current_application
       @section_complete_form = SectionCompleteForm.new(form_params)
 
-      render :index and return if @application_form.application_choices.count.zero?
+      redirect_to candidate_interface_course_choices_choose_path and return if @application_form.application_choices.count.zero?
 
       if @section_complete_form.save(current_application, :course_choices_completed)
         redirect_to candidate_interface_application_form_path


### PR DESCRIPTION
## Changes proposed in this pull request
Redirect to the course choose path instead of rendering the removed index view.

## Guidance to review
Is the logic correct here? I don't really have all the context on this, so a double check would be good!

## Sentry
https://sentry.io/organizations/dfe-bat/issues/2694344078/?project=1765973&referrer=slack

