### PR TITLE
Cycle starts when find_opens for performance dashboard purposes

### DIFF
--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -233,17 +233,17 @@ private
   end
 
   def date_range_query_for_recruitment_cycle_year(cycle_year)
-    start_date = CycleTimetable.apply_opens(cycle_year)
+    start_date = CycleTimetable.find_opens(cycle_year)
 
     query = "created_at >= '#{start_date}'"
 
-    if CycleTimetable::CYCLE_DATES[cycle_year + 1].present?
-      end_date = CycleTimetable.apply_opens(cycle_year + 1)
+    end_date = CycleTimetable.find_opens(cycle_year + 1)
 
-      query += " AND created_at <= '#{end_date}'"
+    if end_date
+      query + " AND created_at <= '#{end_date}'"
+    else
+      query
     end
-
-    query
   end
 
   def application_form_status_total_counts(only: nil)

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -103,10 +103,10 @@ RSpec.describe PerformanceStatistics, type: :model do
 
   describe '#candidate_count' do
     it 'returns the total number of candidates that were created during a given cycle' do
-      Timecop.freeze(2020, 1, 5) do
+      Timecop.freeze(CycleTimetable.find_opens(2020) + 1.day) do
         create_list(:candidate, 2)
       end
-      Timecop.freeze(2020, 12, 25) do
+      Timecop.freeze(CycleTimetable.find_opens(2021) + 1.day) do
         create_list(:candidate, 3)
       end
 


### PR DESCRIPTION
## Context

We count 0 unique candidates on the Service Performance dashboard even tho Find's open — the dashboard was counting from when Apply opens (ie next week)