### PR TITLE
Fix UpdateFraudMatches worker

### DIFF
--- a/app/services/update_fraud_matches.rb
+++ b/app/services/update_fraud_matches.rb
@@ -10,14 +10,13 @@ class UpdateFraudMatches
       if fraud_match.present?
         fraud_match.candidates << candidate unless fraud_match.candidates.include?(candidate)
       else
-        fraud_match = FraudMatch.create!(
+        FraudMatch.create!(
           recruitment_cycle_year: RecruitmentCycle.current_year,
           last_name: match['last_name'],
           postcode: match['postcode'],
           date_of_birth: match['date_of_birth'],
+          candidates: [candidate],
         )
-
-        fraud_match.candidates << candidate
       end
     end
   end


### PR DESCRIPTION
## Context

Sentry Error on Prod shows UpdateFraudMatchesWorker failing due to Null value. It appears this is because the candidate needs to be added into the create clause as opposed to being separate.

## Changes proposed in this pull request

Refactoring create action clause to include candidate rather than pushing candidate in after creation

## Guidance to review

:shipit: 

## Link to Trello card

https://sentry.io/organizations/dfe-bat/issues/2694689785/?project=1765973&referrer=slack

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
