### PR TITLE
StatsSummary: add applications begun and candidate signups

### DIFF
--- a/app/services/stats_summary.rb
+++ b/app/services/stats_summary.rb
@@ -5,11 +5,21 @@ class StatsSummary
     <<~MARKDOWN
       *Today on Apply*
 
-      :email: #{pluralize(applications_submitted, 'application')} submitted
+      :wave: #{pluralize(candidate_signups, 'candidate signup')}
+      :pencil: #{pluralize(applications_begun, 'application')} begun
+      :#{mailbox_emoji(applications_submitted)}: #{pluralize(applications_submitted, 'application')} submitted
       :#{rand(2) == 1 ? 'wo' : nil}man-tipping-hand: #{pluralize(offers_made, 'offer')} made
       :#{rand(2) == 1 ? 'wo' : nil}man-gesturing-no: #{pluralize(rejections_issued, 'rejection')} issued#{rejections_issued.positive? ? ", of which #{pluralize(rbd_count, 'was')} RBD" : nil}
       :handshake: #{pluralize(candidates_recruited, 'candidate')} recruited
     MARKDOWN
+  end
+
+  def candidate_signups
+    Candidate.where('created_at > ?', beginning_of_period).count
+  end
+
+  def applications_begun
+    ApplicationForm.where('created_at > ?', beginning_of_period).count
   end
 
   def applications_submitted
@@ -36,5 +46,9 @@ private
 
   def beginning_of_period
     Time.zone.now.beginning_of_day
+  end
+
+  def mailbox_emoji(message_count)
+    message_count.zero? ? 'mailbox_with_no_mail' : 'mailbox_with_mail'
   end
 end

--- a/spec/services/stats_summary_spec.rb
+++ b/spec/services/stats_summary_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe StatsSummary do
 
     output = described_class.new.as_slack_message
 
+    expect(output).to match(/5 candidate signups/)
+    expect(output).to match(/5 applications begun/)
     expect(output).to match(/1 application submitted/)
     expect(output).to match(/1 candidate recruited/)
     expect(output).to match(/2 offers made/)


### PR DESCRIPTION
## Context

The current stats report looks quiet even on an extremely busy day. Include signups and forms started to give a sense that Apply is still alive.

## Changes proposed in this pull request

Add those stats. Finesse the emoji for "applications submitted"