### PR TITLE
Simplify diversity information shown to the provider

### DIFF
--- a/app/components/provider_interface/diversity_information_component.html.erb
+++ b/app/components/provider_interface/diversity_information_component.html.erb
@@ -1,12 +1,5 @@
 <section class="app-section govuk-!-width-two-thirds">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="diversity-information">Diversity information</h2>
 
-  <% if display_diversity_information? -%>
-    <%= render SummaryListComponent.new(rows: rows) %>
-  <% else -%>
-    <p class="govuk-body"><%= message %></p>
-    <% if diversity_information_declared? -%>
-      <p class="govuk-body"><%= details %></p>
-    <% end -%>
-  <% end -%>
+  <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/spec/components/provider_interface/diversity_information_component_spec.rb
+++ b/spec/components/provider_interface/diversity_information_component_spec.rb
@@ -31,10 +31,9 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
                                  course: course)
       result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
-      expect(result.text).to include('No information shared')
-      expect(result.text).not_to include('This will become available to users with permissions to `view diversity information` when an offer has been accepted')
-      expect(result.text).not_to include('This section is only available to users with permissions to `view diversity information`.')
-      expect(result.text).not_to include('You will be able to view this when an offer has been accepted.')
+      expect(result.text).to include('Do you want to answer a few questions about your sex, diability and ethnicity?No')
+      expect(result.text).not_to include('You cannot view this because you do not have permission to view sex, disability and ethnicity information.')
+      expect(result.text).not_to include("You'll be able to view this if the candidate accepts an offer for this application.")
     end
   end
 
@@ -66,18 +65,18 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
 
           expect(result.text).not_to include('The candidate disclosed information in the optional equality and diversity questionnaire.')
           expect(result.text).not_to include('This relates to their sex, ethnicity and disability status. We collect this data to help reduce discrimination on these grounds. (This is not the same as the information we request relating to the candidate’s disability, access and other needs)')
-          expect(result.text).to include('Sex')
+          expect(result.text).to include('What is your sex?')
           expect(result.text).to include('Male')
-          expect(result.text).to include('Ethnic group')
-          expect(result.text).to include('Asian or Asian British')
-          expect(result.text).to include('Ethnic background')
-          expect(result.text).to include('Chinese')
-          expect(result.text).to include('Disabled')
+          expect(result.text).to include('Are you disabled?')
           expect(result.text).to include('Yes')
-          expect(result.text).to include('The candidate disclosed the following disabilities:')
+          expect(result.text).to include('What disabilities do you have?')
           expect(result.text).to include('Mental health condition')
           expect(result.text).to include('Social or communication impairment')
           expect(result.text).to include('Acquired brain injury')
+          expect(result.text).to include('What is your ethnic group')
+          expect(result.text).to include('Asian or Asian British')
+          expect(result.text).to include('What is your ethnic background?')
+          expect(result.text).to include('Chinese')
         end
 
         it 'does not dispay Ethnic background and Disabilities if they are not declaired' do
@@ -132,9 +131,7 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
           provider_user.provider_permissions.find_by(provider: training_provider).update!(view_diversity_information: false)
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
-          expect(result.text).to include('The candidate disclosed information in the optional equality and diversity questionnaire.')
-          expect(result.text).to include('This relates to their sex, ethnicity and disability status. We collect this data to help reduce discrimination on these grounds. (This is not the same as the information we request relating to the candidate’s disability, access and other needs)')
-          expect(result.text).to include('This section is only available to users with permissions to `view diversity information`.')
+          expect(result.text).to include('You cannot view this because you do not have permission to view sex, disability and ethnicity information.')
         end
       end
 
@@ -146,9 +143,7 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
           )
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
-          expect(result.text).to include('The candidate disclosed information in the optional equality and diversity questionnaire.')
-          expect(result.text).to include('This relates to their sex, ethnicity and disability status. We collect this data to help reduce discrimination on these grounds. (This is not the same as the information we request relating to the candidate’s disability, access and other needs)')
-          expect(result.text).to include('This section is only available to users with permissions to `view diversity information`.')
+          expect(result.text).to include('You cannot view this because you do not have permission to view sex, disability and ethnicity information.')
         end
       end
     end
@@ -168,9 +163,7 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
             .update!(view_diversity_information: true)
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
-          expect(result.text).to include('The candidate disclosed information in the optional equality and diversity questionnaire.')
-          expect(result.text).to include('This relates to their sex, ethnicity and disability status. We collect this data to help reduce discrimination on these grounds. (This is not the same as the information we request relating to the candidate’s disability, access and other needs)')
-          expect(result.text).to include('You’ll only be able to see this information after an offer has been accepted by the candidate.')
+          expect(result.text).to include("You'll be able to view this if the candidate accepts an offer for this application.")
         end
       end
 
@@ -184,9 +177,7 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
             .update!(view_diversity_information: false)
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
-          expect(result.text).to include('The candidate disclosed information in the optional equality and diversity questionnaire.')
-          expect(result.text).to include('This relates to their sex, ethnicity and disability status. We collect this data to help reduce discrimination on these grounds. (This is not the same as the information we request relating to the candidate’s disability, access and other needs)')
-          expect(result.text).to include(' Users with permission to see this information will only be able to do so after an offer has been accepted by the candidate')
+          expect(result.text).to include('You cannot view this because you do not have permission to view sex, disability and ethnicity information.')
         end
       end
 
@@ -199,9 +190,7 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
 
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
-          expect(result.text).to include('The candidate disclosed information in the optional equality and diversity questionnaire.')
-          expect(result.text).to include('This relates to their sex, ethnicity and disability status. We collect this data to help reduce discrimination on these grounds. (This is not the same as the information we request relating to the candidate’s disability, access and other needs)')
-          expect(result.text).to include('Users with permission to see this information will only be able to do so after an offer has been accepted by the candidate')
+          expect(result.text).to include('You cannot view this because you do not have permission to view sex, disability and ethnicity information.')
         end
       end
     end
@@ -221,7 +210,7 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
             .update!(view_diversity_information: true)
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
-          expect(result.text).to include('You’ll only be able to see this information after your offer has been accepted by the candidate')
+          expect(result.text).to include("You'll be able to view this if the candidate accepts an offer for this application.")
         end
       end
 
@@ -230,12 +219,12 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
           provider_relationship_permissions
         end
 
-        it 'displays the correct text with correct offer context' do
+        it 'displays the correct text' do
           provider_user.provider_permissions.find_by(provider: training_provider)
             .update!(view_diversity_information: false)
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
-          expect(result.text).to include('Users with permission to see this information will only be able to do so after your offer has been accepted by the candidate')
+          expect(result.text).to include('You cannot view this because you do not have permission to view sex, disability and ethnicity information.')
         end
       end
     end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This makes the diversity information component reflect the questions the candidate was asked in the application form.

#### Candidate diversity information on post-offer application (provider user has view diversity info permissions)

![image](https://user-images.githubusercontent.com/93511/136061550-3c2429ff-f24c-41f7-9c56-ac6c87ae7eb9.png)


#### Candidate did not provider diversity information

![image](https://user-images.githubusercontent.com/93511/136061678-aa4ed72d-1ca3-4396-9ab7-c35e7b59ec19.png)


#### Provider user does not have permissions to view diversity information

![image](https://user-images.githubusercontent.com/93511/136062609-878df910-1702-42fc-beae-10484b39cbe8.png)


#### Offer has not yet been made on application (provider user has permissions to view diversity info)

![image](https://user-images.githubusercontent.com/93511/136062019-df7ed646-9d99-4203-8148-7e9ecd6772c9.png)


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/RzwzagiT/4317-simplify-what-we-show-to-users-within-the-sex-disability-and-ethnicity-information-section-of-the-application-based-on-what-perm
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
