### PR TITLE
Extend daily invariant check to check for applications with more than…

### DIFF
--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -123,7 +123,7 @@ class DetectInvariantsDailyCheck
   def detect_submitted_applications_with_more_than_three_course_choices
     applications_with_too_many_choices = ApplicationForm
       .joins(:application_choices)
-      .where(application_choices: { status: (ApplicationStateChange::DECISION_PENDING_STATUSES + ApplicationStateChange::ACCEPTED_STATES) })
+      .where(application_choices: { status: (ApplicationStateChange::DECISION_PENDING_STATUSES + ApplicationStateChange::ACCEPTED_STATES + ApplicationStateChange::SUCCESSFUL_STATES) })
       .group('application_forms.id')
       .having('count(application_choices) > 3')
       .sort

--- a/spec/workers/detect_invariants_daily_check_spec.rb
+++ b/spec/workers/detect_invariants_daily_check_spec.rb
@@ -139,7 +139,8 @@ RSpec.describe DetectInvariantsDailyCheck do
 
     it 'detects submitted applications with more than three course choices' do
       create(:completed_application_form, submitted_application_choices_count: 3)
-      bad_application_form = create(:completed_application_form, submitted_application_choices_count: 4)
+      bad_application_form = create(:completed_application_form, submitted_application_choices_count: 2)
+      bad_application_form.application_choices << build_list(:submitted_application_choice, 2, status: :offer)
 
       described_class.new.perform
 


### PR DESCRIPTION
… three course choices to include choices with offers.

## Context

We recently came across an issue where a support agent added a fourth application choice to the application form of an applicant with an existing offer.This was not flagged by this check (which runs as part of  DetectInvariants). Investigate why, and if we can amend the service to check for all the appropriate states.

## Link to Trello card

https://trello.com/c/fkTWfm9X/4279-investigate-detectsubmittedapplicationswithmorethanthreecoursechoices

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
