### PR TITLE
Ensure bulk emails exclude unsubscribed candidates

### DIFF
--- a/app/workers/send_eoc_deadline_reminder_email_to_candidates_worker.rb
+++ b/app/workers/send_eoc_deadline_reminder_email_to_candidates_worker.rb
@@ -11,9 +11,15 @@ class SendEocDeadlineReminderEmailToCandidatesWorker
 
   def applications_to_send_reminders_to
     if CycleTimetable.need_to_send_deadline_reminder? == :apply_1
-      ApplicationForm.where(submitted_at: nil, phase: 'apply_1', recruitment_cycle_year: RecruitmentCycle.current_year)
+      ApplicationForm
+      .joins(:candidate)
+      .where(submitted_at: nil, phase: 'apply_1', recruitment_cycle_year: RecruitmentCycle.current_year)
+      .where.not(candidate: { unsubscribed_from_emails: true })
     elsif CycleTimetable.need_to_send_deadline_reminder? == :apply_2
-      ApplicationForm.where(submitted_at: nil, phase: 'apply_2', recruitment_cycle_year: RecruitmentCycle.current_year)
+      ApplicationForm
+      .joins(:candidate)
+      .where(submitted_at: nil, phase: 'apply_2', recruitment_cycle_year: RecruitmentCycle.current_year)
+      .where.not(candidate: { unsubscribed_from_emails: true })
     end
   end
 end

--- a/spec/queries/get_unsuccessful_and_unsubmitted_candidates_spec.rb
+++ b/spec/queries/get_unsuccessful_and_unsubmitted_candidates_spec.rb
@@ -41,5 +41,12 @@ RSpec.describe GetUnsuccessfulAndUnsubmittedCandidates do
           ],
         )
     end
+
+    it 'does not return candidates who have unsubscribed_from_emails' do
+      unsubscribed_candidate = create(:candidate, unsubscribed_from_emails: true)
+      create(:application_form, :minimum_info, candidate: unsubscribed_candidate)
+
+      expect(described_class.call).to be_empty
+    end
   end
 end

--- a/spec/workers/send_eoc_deadline_reminder_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_eoc_deadline_reminder_email_to_candidates_worker_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, sidekiq: true do
         end
       end
 
+      it 'does not return an application where the candidate is unsubscribed' do
+        Timecop.travel(CycleTimetable.apply_1_deadline_first_reminder) do
+          unsubscribed_candidate = create(:candidate, unsubscribed_from_emails: true)
+          create(:application_form, candidate: unsubscribed_candidate)
+
+          described_class.new.perform
+
+          expect(SendEocDeadlineReminderEmailToCandidate).not_to have_received(:call)
+        end
+      end
+
       it 'returns an application when the deadline is 1 month away' do
         Timecop.travel(CycleTimetable.apply_1_deadline_second_reminder) do
           application_form = create(:application_form)
@@ -62,6 +73,17 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, sidekiq: true do
           described_class.new.perform
 
           expect(SendEocDeadlineReminderEmailToCandidate).to have_received(:call).with(application_form: application_form)
+        end
+      end
+
+      it 'does not return an application where the candidate is unsubscribed' do
+        Timecop.travel(CycleTimetable.apply_2_deadline_first_reminder) do
+          unsubscribed_candidate = create(:candidate, unsubscribed_from_emails: true)
+          create(:application_form, phase: 'apply_2', candidate: unsubscribed_candidate)
+
+          described_class.new.perform
+
+          expect(SendEocDeadlineReminderEmailToCandidate).not_to have_received(:call)
         end
       end
 


### PR DESCRIPTION
## Context

Some candidates are contacting us and asking to unsubscribe from our emails. We should make sure that they are not sent any of our bulk emails. 

## Changes proposed in this pull request

- Exclude candidates from our bulk emails 

## Guidance to review

Does this approach seem sound? 

## Link to Trello card

https://trello.com/c/FzmTbOAL/4020-candidates-who-want-to-stop-receiving-emails-from-apply

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
