### PR TITLE
Update subheadings of personal statement section

### DIFF
--- a/app/components/shared/personal_statement_component.html.erb
+++ b/app/components/shared/personal_statement_component.html.erb
@@ -1,19 +1,19 @@
 <section id="personal-statement-section" class="app-section govuk-!-width-two-thirds">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="personal-statement">Personal statement</h2>
+  <h2 class="govuk-heading-m govuk-!-font-size-27" id="personal-statement"><%= t('personal_statement.title') %></h2>
   <% if @editable %>
-    <h3 class="govuk-heading-s">Vocation <%= govuk_link_to 'Change', support_interface_application_form_edit_becoming_a_teacher_path, class: 'govuk-body' %></h3>
+    <h3 class="govuk-heading-s"><%= t('personal_statement.vocation') %><%= govuk_link_to 'Change', support_interface_application_form_edit_becoming_a_teacher_path, class: 'govuk-body' %></h3>
     <%= simple_format becoming_a_teacher, class: 'govuk-body' %>
 
-    <h3 class="govuk-heading-s">Subject knowledge <%= govuk_link_to 'Change', support_interface_application_form_edit_subject_knowledge_path, class: 'govuk-body' %></h3>
+    <h3 class="govuk-heading-s"><%= t('personal_statement.subject_knowledge') %><%= govuk_link_to 'Change', support_interface_application_form_edit_subject_knowledge_path, class: 'govuk-body' %></h3>
     <%= simple_format subject_knowledge, class: 'govuk-body' %>
   <% else %>
-    <h3 class="govuk-heading-s">Vocation</h3>
+    <h3 class="govuk-heading-s"><%= t('personal_statement.vocation') %></h3>
     <%= simple_format becoming_a_teacher, class: 'govuk-body' %>
 
-    <h3 class="govuk-heading-s">Subject knowledge </h3>
+    <h3 class="govuk-heading-s"><%= t('personal_statement.subject_knowledge') %></h3>
     <%= simple_format subject_knowledge, class: 'govuk-body' %>
   <% end %>
 
-  <h3 class="govuk-heading-s">Further information</h3>
+  <h3 class="govuk-heading-s"><%= t('personal_statement.further_information') %>
   <%= simple_format further_information, class: 'govuk-body' %>
 </section>

--- a/config/locales/components/shared.yml
+++ b/config/locales/components/shared.yml
@@ -1,0 +1,6 @@
+en:
+  personal_statement:
+    title: Personal statement
+    vocation: Why do you want to become a teacher?
+    subject_knowledge: What do you know about the subject you want to teach?
+    further_information: Further information


### PR DESCRIPTION
## Context
Update the personal statement subheadings on the application details page to playback the questions the candidate was asked when filling out their personal statement, in order to help them make a more informed decision on a candidate's application.


## Changes proposed in this pull request
<img width="923" alt="Screenshot 2021-10-07 at 00 19 12" src="https://user-images.githubusercontent.com/159200/136297643-2661a092-dd79-4c20-b7bf-8e59af3eb168.png">

## Link to Trello card

https://trello.com/c/g6IIIrVd/4347-update-subheadings-of-personal-statement-section-on-application-detail-to-playback-the-questions-that-the-candidate-was-asked-to

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
