### PR TITLE
Add study mode filter to provider interface 

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -11,7 +11,7 @@
     <div class="govuk-grid-column-two-thirds">
       <dl class="app-application-card__list">
         <dt class="govuk-visually-hidden">Course</dt>
-        <dd class="govuk-body-s"><%= course_name_and_code %> – <%= site_name_and_code %></dd>
+        <dd class="govuk-body-s govuk-!-margin-bottom-1"><%= course_name_and_code %> – <%= course_study_mode %> at <%= site_name %></dd>
         <dt class="govuk-visually-hidden">Provider</dt>
         <dd class="govuk-body-s govuk-!-font-size-16">
           <span data-qa="provider"><%= course_provider_name %></span>

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -11,7 +11,7 @@ module ProviderInterface
       @application_choice = application_choice
       @candidate_name = application_choice.application_form.full_name
       @course_name_and_code = application_choice.current_course.name_and_code
-      @course_study_mode = application_choice.current_course.study_mode.humanize.downcase
+      @course_study_mode = application_choice.current_course_option.study_mode.humanize.downcase
       @course_provider_name = application_choice.current_provider.name
       @changed_at = application_choice.updated_at.to_s(:govuk_date_and_time)
       @site_name = application_choice.current_site.name

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -20,7 +20,7 @@ module ProviderInterface
     end
 
     def filters
-      ([] << search_filter << recruitment_cycle_filter << status_filter << provider_filter << accredited_provider_filter << subject_filter).concat(provider_locations_filters).compact
+      ([] << search_filter << recruitment_cycle_filter << status_filter << provider_filter << accredited_provider_filter << subject_filter << study_modes_filter).concat(provider_locations_filters).compact
     end
 
     def filtered?
@@ -44,7 +44,7 @@ module ProviderInterface
   private
 
     def parse_params(params)
-      compact_params(params.permit(:remove, :candidate_name, recruitment_cycle_year: [], provider: [], status: [], accredited_provider: [], provider_location: [], subject: []).to_h)
+      compact_params(params.permit(:remove, :candidate_name, recruitment_cycle_year: [], provider: [], status: [], accredited_provider: [], provider_location: [], subject: [], study_mode: []).to_h)
     end
 
     def save_filter_state!
@@ -182,6 +182,21 @@ module ProviderInterface
             value: subject.id,
             label: subject.name,
             checked: applied_filters[:subject]&.include?(subject.id.to_s),
+          }
+        end,
+      }
+    end
+
+    def study_modes_filter
+      {
+        type: :checkboxes,
+        heading: 'Full time or part time',
+        name: 'study_mode',
+        options: CourseOption.study_modes.map do |study_mode|
+          {
+            value: study_mode.first,
+            label: study_mode.first.humanize,
+            checked: applied_filters[:study_mode]&.include?(study_mode.first.to_s),
           }
         end,
       }

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -70,6 +70,12 @@ class FilterApplicationChoicesForProviders
         .where(course_subjects: { subject_id: subject_ids })
     end
 
+    def study_mode(application_choices, study_mode)
+      return application_choices if study_mode.blank?
+
+      application_choices.where(current_course_option: { study_mode: study_mode })
+    end
+
     def create_filter_query(application_choices, filters)
       filtered_application_choices = search(application_choices, filters[:candidate_name])
       filtered_application_choices = recruitment_cycle_year(filtered_application_choices, filters[:recruitment_cycle_year])
@@ -77,6 +83,7 @@ class FilterApplicationChoicesForProviders
       filtered_application_choices = accredited_provider(filtered_application_choices, filters[:accredited_provider])
       filtered_application_choices = status(filtered_application_choices, filters[:status])
       filtered_application_choices = course_subject(filtered_application_choices, filters[:subject])
+      filtered_application_choices = study_mode(filtered_application_choices, filters[:study_mode])
       provider_location(filtered_application_choices, filters[:provider_location])
     end
   end

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
         name: 'Alchemy',
         provider: current_provider,
         accredited_provider: accredited_provider,
-        study_mode: 'part_time',
       ),
       site: create(
         :site,
@@ -37,6 +36,7 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
         name: 'Skywalker Training',
         provider: current_provider,
       ),
+      study_mode: 'part_time',
     )
   end
 

--- a/spec/models/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/models/provider_interface/provider_applications_filter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
   let(:provider_3_subjects) { create_list(:subject, 1) }
   let(:accredited_provider_subjects) { create_list(:subject, 1) }
 
-  let(:course1) { create(:course, subjects: provider_1_subjects) }
+  let(:course1) { create(:course, subjects: provider_1_subjects, study_mode: 'part_time') }
   let(:course2) { create(:course, subjects: provider_2_subjects) }
   let(:course3) { create(:course, subjects: provider_3_subjects) }
   let(:accredited_course) { create(:course, subjects: accredited_provider_subjects, accredited_provider: accredited_provider) }
@@ -27,7 +27,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
     let(:params) { ActionController::Parameters.new }
 
     context 'default filters' do
-      context 'for a user balonging to multiple providers' do
+      context 'for a user belonging to multiple providers' do
         let(:filter) do
           described_class.new(params: params,
                               provider_user: provider_user,
@@ -35,7 +35,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
         end
 
         it 'does not include the Locations filter' do
-          expected_number_of_filters = 5
+          expected_number_of_filters = 6
           recruitment_cycle_index = 1
           providers_array_index = 3
           number_of_courses = 2
@@ -56,7 +56,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
         end
 
         it 'does not include the Providers filter' do
-          expected_number_of_filters = 5
+          expected_number_of_filters = 6
 
           expect(filter.filters.size).to eq(expected_number_of_filters)
           expect(headings).not_to include('Provider')
@@ -77,11 +77,11 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
           relevant_provider_names = [provider1.sites.first.name, provider1.sites.last.name]
 
           expect(headings).to include("Locations for #{provider1.name}")
-          expect(relevant_provider_ids).to include(filter.filters[4][:options][0][:value])
-          expect(relevant_provider_ids).to include(filter.filters[4][:options][1][:value])
+          expect(relevant_provider_ids).to include(filter.filters[5][:options][0][:value])
+          expect(relevant_provider_ids).to include(filter.filters[5][:options][1][:value])
 
-          expect(relevant_provider_names).to include(filter.filters[4][:options][0][:label])
-          expect(relevant_provider_names).to include(filter.filters[4][:options][1][:label])
+          expect(relevant_provider_names).to include(filter.filters[5][:options][0][:label])
+          expect(relevant_provider_names).to include(filter.filters[5][:options][1][:label])
         end
       end
     end
@@ -100,11 +100,11 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
 
         expect(headings).to include("Locations for #{provider1.name}")
 
-        expect(relevant_provider_ids).to include(filter.filters[5][:options][0][:value])
-        expect(relevant_provider_ids).to include(filter.filters[5][:options][1][:value])
+        expect(relevant_provider_ids).to include(filter.filters[6][:options][0][:value])
+        expect(relevant_provider_ids).to include(filter.filters[6][:options][1][:value])
 
-        expect(relevant_provider_names).to include(filter.filters[5][:options][0][:label])
-        expect(relevant_provider_names).to include(filter.filters[5][:options][1][:label])
+        expect(relevant_provider_names).to include(filter.filters[6][:options][0][:label])
+        expect(relevant_provider_names).to include(filter.filters[6][:options][1][:label])
       end
     end
 
@@ -122,6 +122,23 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
 
         expect(headings).to include('Subject')
         expect(filter_subjects).to match_array(subjects.map(&:name))
+      end
+    end
+
+    context 'when a study mode is selected' do
+      let(:params) { ActionController::Parameters.new }
+      let(:filter) do
+        described_class.new(params: params,
+                            provider_user: provider_user,
+                            state_store: {})
+      end
+
+      it 'can return a filter config for a list of study modes' do
+        study_modes = %w[full_time part_time]
+        filter_study_modes = filter.filters[5][:options].map { |h| h[:value] }
+
+        expect(headings).to include('Full time or part time')
+        expect(filter_study_modes).to match_array(study_modes)
       end
     end
   end

--- a/spec/services/filter_application_choices_for_providers_spec.rb
+++ b/spec/services/filter_application_choices_for_providers_spec.rb
@@ -59,6 +59,13 @@ RSpec.describe FilterApplicationChoicesForProviders do
       expect(result).to eq([application_choices.first])
     end
 
+    it 'filters by study mode' do
+      application_choices.first.course_option.update(study_mode: 'part_time')
+      result = described_class.call(application_choices: application_choices, filters: { study_mode: 'part_time' })
+
+      expect(result).to eq([application_choices.first])
+    end
+
     it 'uses the updated course details when filtering by provider' do
       provider = create(:provider)
       course = create(:course, provider: provider)


### PR DESCRIPTION
## Context

Add in a full time/ part time filter option for providers to support workflows specifically relating to full time or part time courses.

## Changes proposed in this pull request

Add a new filter on the applications page for providers.

## Guidance to review

Run locally, apply the filter and see if it works.

## Link to Trello card

https://trello.com/c/TuoNSIrq/4346-implement-study-mode-filter
## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
