### PR TITLE
Restrict paths considered to be valid API requests

### DIFF
--- a/app/middlewares/vendor_api_request_middleware.rb
+++ b/app/middlewares/vendor_api_request_middleware.rb
@@ -68,6 +68,6 @@ private
   end
 
   def vendor_api_path?
-    @request.path =~ /^\/api\/.*$/
+    @request.path =~ /^\/api\/v1\/.*$/
   end
 end

--- a/spec/middlewares/vendor_api_request_middleware_spec.rb
+++ b/spec/middlewares/vendor_api_request_middleware_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe VendorAPIRequestMiddleware, type: :request do
 
   describe '#call on a non-API path' do
     it 'does not enqueue a background job' do
-      get '/candidate'
+      get '/api/v2'
 
       expect(VendorAPIRequestWorker).not_to have_received(:perform_async)
     end


### PR DESCRIPTION
## Context

We currently define the vendor API in the routing namespace as [api/v1](https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/config/routes.rb#L615) so make the `VendorAPIRequestMiddleware` only treat requests under this path as API requests.

We've logged a few 404s where the path has started with `/api` but not conformed to the `v1/` path fragment.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Restricts the regex in `VendorAPIRequestMiddleware` to `/api/v1` subpaths.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/OS2gM6dj/3844-vendor-api-logs-missing-provider-id
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
