### PR TITLE
Change filter labels for course run by and course ratified and captio…

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -11,11 +11,11 @@
     <div class="govuk-grid-column-two-thirds">
       <dl class="app-application-card__list">
         <dt class="govuk-visually-hidden">Course</dt>
-        <dd class="govuk-body-s"><%= course_name_and_code %> – <%= site_name_and_code %></dd>
+        <dd class="govuk-body-s govuk-!-margin-bottom-1"><%= course_name_and_code %> – <%= site_name_and_code %></dd>
         <dt class="govuk-visually-hidden">Provider</dt>
-        <dd class="govuk-hint govuk-!-font-size-16">
+        <dd class="govuk-body-s govuk-!-font-size-16">
           <span data-qa="provider"><%= course_provider_name %></span>
-          <% if !accredited_provider.nil? %>– ratified by <%= accredited_provider.name %><% end %>
+          <%= "(#{accredited_provider.name})" if accredited_provider.present? %>
         </dd>
       </dl>
     </div>

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -116,7 +116,7 @@ module ProviderInterface
 
       {
         type: :checkboxes,
-        heading: 'Courses run by',
+        heading: 'Training provider',
         name: 'provider',
         options: provider_options,
       }
@@ -137,7 +137,7 @@ module ProviderInterface
 
       {
         type: :checkboxes,
-        heading: 'Courses ratified by',
+        heading: 'Accredited provider',
         name: 'accredited_provider',
         options: accredited_providers_options,
       }

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature 'Providers should be able to filter applications' do
 
   def then_the_relevant_tag_headings_should_be_visible
     selected_filters = find(:css, '.moj-filter__selected')
-    expect(selected_filters).to have_text('Courses run by')
+    expect(selected_filters).to have_text('Training provider')
   end
 
   def then_only_withdrawn_and_offered_applications_of_that_name_should_be_visible


### PR DESCRIPTION
…n under each application

## Context
To ensure we're being consistent with the recent changes to permission, we want to remove mentions of  'run by' and 'ratified by' in service. 

We want to only show the training provider and accredited body filters when their are multiple options, because where this isn't the case, the filters don't affect the list of applications.

## Guidance to review

<img width="553" alt="Screenshot_2021-10-07_at_14_59_55" src="https://user-images.githubusercontent.com/159200/136400671-64ddcaf0-fdc1-4a57-aa41-15eb277927ae.png">
<img width="684" alt="Screenshot_2021-10-07_at_14_59_48" src="https://user-images.githubusercontent.com/159200/136400674-09fdc87c-f49a-4ecd-940f-e733aa527cfa.png">


## Link to Trello card

https://trello.com/c/AYUJGf2e/4310-change-filter-labels-for-course-run-by-and-course-ratified

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
