### PR TITLE
Fix bug with science gcse grade

### DIFF
--- a/app/controllers/candidate_interface/gcse/science/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/science/grade_controller.rb
@@ -71,7 +71,7 @@ module CandidateInterface
     def science_details_params
       strip_whitespace params
         .require(:candidate_interface_science_gcse_grade_form)
-        .permit(%i[gcse_science grade single_award_grade double_award_grade biology_grade chemistry_grade physics_grade])
+        .permit(%i[gcse_science grade single_award_grade double_award_grade biology_grade chemistry_grade physics_grade other_grade])
     end
 
     def science_gcse_grade_form


### PR DESCRIPTION
## Context

The other grade parameter is not permitted in the science GCSE grade controller. This causing a validation error to trigger. 

## Changes proposed in this pull request

- Ensure other grade is passed into the form 

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
