### PR TITLE
Surface course uuid to Register API

### DIFF
--- a/app/presenters/register_api/single_application_presenter.rb
+++ b/app/presenters/register_api/single_application_presenter.rb
@@ -91,6 +91,7 @@ module RegisterAPI
       {
         recruitment_cycle_year: course_option.course.recruitment_cycle_year,
         course_code: course_option.course.code,
+        course_uuid: course_option.course.uuid,
         training_provider_code: course_option.course.provider.code,
         training_provider_type: course_option.course.provider.provider_type,
         accredited_provider_type: course_option.course.accredited_provider&.provider_type,

--- a/config/register-api.yml
+++ b/config/register-api.yml
@@ -372,6 +372,7 @@ components:
       required:
       - recruitment_cycle_year
       - course_code
+      - course_uuid
       - training_provider_code
       - training_provider_type
       - accredited_provider_type
@@ -421,6 +422,11 @@ components:
           description: The course’s code
           example: 3CVK
           maxLength: 4
+        course_uuid:
+          type: string
+          description: The course’s uuid
+          example: "24a9590e-6b40-4096-9967-36b0a5904706"
+          maxLength: 36
         site_code:
           type: string
           description: The site’s code

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -48,6 +48,10 @@ FactoryBot.define do
       study_mode { :full_time }
     end
 
+    trait :uuid do
+      uuid { SecureRandom.uuid }
+    end
+
     trait :part_time do
       study_mode { :part_time }
     end

--- a/spec/factories/course_option.rb
+++ b/spec/factories/course_option.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
       association :course, :open_on_apply
     end
 
+    trait :with_course_uuid do
+      association :course, :uuid
+    end
+
     trait :full_time do
       study_mode { :full_time }
     end

--- a/spec/presenters/register_api/single_application_presenter_spec.rb
+++ b/spec/presenters/register_api/single_application_presenter_spec.rb
@@ -408,6 +408,10 @@ RSpec.describe RegisterAPI::SingleApplicationPresenter do
       expect(presenter.dig(:attributes, :course, :accredited_provider_code)).to eq(accredited_provider.code)
     end
 
+    it 'returns the course uuid' do
+      expect(presenter.dig(:attributes, :course, :uuid)).to eq(course.uuid)
+    end
+
     context 'with a self ratified course' do
       let(:accredited_provider) { nil }
 

--- a/spec/requests/register_api/get_multiple_applications_spec.rb
+++ b/spec/requests/register_api/get_multiple_applications_spec.rb
@@ -18,7 +18,12 @@ RSpec.describe 'GET /register-api/applications', type: :request do
   end
 
   it 'returns applications with equality and diversity data' do
-    create(:application_choice, :with_recruited, application_form: create(:completed_application_form, :with_equality_and_diversity_data))
+    create(
+      :application_choice,
+      :with_recruited,
+      course_option: create(:course_option, :with_course_uuid),
+      application_form: create(:completed_application_form, :with_equality_and_diversity_data),
+    )
 
     get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: register_api_token
 
@@ -26,7 +31,12 @@ RSpec.describe 'GET /register-api/applications', type: :request do
   end
 
   it 'returns applications without equality and diversity data' do
-    create(:application_choice, :with_recruited, application_form: create(:completed_application_form))
+    create(
+      :application_choice,
+      :with_recruited,
+      course_option: create(:course_option, :with_course_uuid),
+      application_form: create(:completed_application_form),
+    )
 
     get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: register_api_token
 

--- a/spec/system/register_api/register_receives_application_spec.rb
+++ b/spec/system/register_api/register_receives_application_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature 'Register receives an application data' do
       hesa_ethnicity: '39',
     }
     @application.update!(equality_and_diversity: equality_and_diversity_data)
+    @provider.courses.first.update!(uuid: SecureRandom.uuid)
     @application.application_choices.first.update!(
       status: :recruited,
       recruited_at: Time.zone.now,
@@ -82,6 +83,7 @@ RSpec.feature 'Register receives an application data' do
         course: {
           recruitment_cycle_year: RecruitmentCycle.current_year,
           course_code: '2XT2',
+          course_uuid: @provider.courses.first.uuid,
           training_provider_code: '1N1',
           training_provider_type: 'scitt',
           accredited_provider_type: nil,


### PR DESCRIPTION
## Context

We're currently using the course's `code` as a link between a Trainee and the course they're on. We've discovered that the `code` can change (providers tend to update the course's code). We'd like to use a constant alternative (the `uuid`). 

## Changes proposed in this pull request

- Add `uuid` to Register API payload

<img width="1032" alt="Screenshot 2021-10-07 at 17 04 59" src="https://user-images.githubusercontent.com/616080/136422209-0310a9d6-a2e5-4eff-a685-63326c24ac31.png">

## Link to Trello card

https://trello.com/c/bX7t5EGN/2858-m-use-course-uuid-in-apply-import

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
