### PR TITLE
Add endpoints to the TAD Data API for the ministerial reports

### DIFF
--- a/app/controllers/data_api/tad_data_exports_controller.rb
+++ b/app/controllers/data_api/tad_data_exports_controller.rb
@@ -32,6 +32,26 @@ module DataAPI
       serve_export(data_export)
     end
 
+    def candidates
+      all = DataExport
+        .where(export_type: :ministerial_report_candidates_export)
+        .where.not(completed_at: nil)
+
+      data_export = all.last
+
+      serve_export(data_export)
+    end
+
+    def applications
+      all = DataExport
+        .where(export_type: :ministerial_report_applications_export)
+        .where.not(completed_at: nil)
+
+      data_export = all.last
+
+      serve_export(data_export)
+    end
+
   private
 
     def serve_export(export)

--- a/app/lib/data_api_specification.rb
+++ b/app/lib/data_api_specification.rb
@@ -10,9 +10,13 @@ class DataAPISpecification
   def self.spec
     openapi = YAML.load_file('config/data-api.yml')
 
-    dataset = DataSetDocumentation.for(DataAPI::TADExport)
+    tad_dataset = DataSetDocumentation.for(DataAPI::TADExport)
+    applications_dataset = DataSetDocumentation.for(SupportInterface::MinisterialReportApplicationsExport)
+    candidates_dataset = DataSetDocumentation.for(SupportInterface::MinisterialReportCandidatesExport)
 
-    openapi['components']['schemas']['TADExport']['properties'] = dataset
+    openapi['components']['schemas']['TADExport']['properties'] = tad_dataset
+    openapi['components']['schemas']['ApplicationsExport']['properties'] = applications_dataset
+    openapi['components']['schemas']['CandidatesExport']['properties'] = candidates_dataset
 
     openapi
   end

--- a/config/data-api.yml
+++ b/config/data-api.yml
@@ -53,9 +53,37 @@ paths:
             text/csv:
               schema:
                 "$ref": "#/components/schemas/TADExport"
+  "/ministerial-report/candidates/latest":
+    get:
+      summary: Get the ministerial report candidates export
+      description: This endpoint returns a CSV consisting of the latest ministerial report candidates export. Reports are generated daily
+      responses:
+        '200':
+          description: The CSV of the latest report
+          content:
+            text/csv:
+              schema:
+                "$ref": "#/components/schemas/CandidatesExport"
+  "/ministerial-report/applications/latest":
+    get:
+      summary: Get the ministerial report applications export
+      description: This endpoint returns a CSV consisting of the latest ministerial report applications export. Reports are generated daily
+      responses:
+        '200':
+          description: The CSV of the latest report
+          content:
+            text/csv:
+              schema:
+                "$ref": "#/components/schemas/ApplicationsExport"
 components:
   schemas:
     TADExport:
+      type: object
+      properties: # this is automatically populated from the CSV definition by DataAPISpecification
+    CandidatesExport:
+      type: object
+      properties: # this is automatically populated from the CSV definition by DataAPISpecification
+    ApplicationsExport:
       type: object
       properties: # this is automatically populated from the CSV definition by DataAPISpecification
     TADDataExportList:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -833,6 +833,8 @@ Rails.application.routes.draw do
 
   namespace :data_api, path: '/data-api' do
     get '/tad-data-exports/latest' => 'tad_data_exports#latest'
+    get '/ministerial-report/candidates/latest' => 'tad_data_exports#candidates'
+    get '/ministerial-report/applications/latest' => 'tad_data_exports#applications'
     get '/tad-data-exports' => 'tad_data_exports#index'
     get '/tad-data-exports/:id' => 'tad_data_exports#show', as: :tad_export
   end

--- a/spec/requests/data_api/ministerial_report_applications_export_spec.rb
+++ b/spec/requests/data_api/ministerial_report_applications_export_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /data-api/ministerial-report/applications/latest', type: :request, sidekiq: true do
+  include DataAPISpecHelper
+
+  it_behaves_like 'a TAD API endpoint', '/applications'
+
+  it 'returns the latest ministerial report applications export' do
+    create(:submitted_application_choice, :with_completed_application_form, status: 'rejected')
+
+    data_export = DataExport.create!(
+      name: 'Daily export of the applications ministerial report',
+      export_type: :ministerial_report_applications_export,
+    )
+    DataExporter.perform_async(SupportInterface::MinisterialReportApplicationsExport, data_export.id)
+
+    get_api_request '/data-api/ministerial-report/applications/latest', token: tad_api_token
+
+    expect(response).to have_http_status(:success)
+    expect(response.body).to start_with('subject,applications,offer_received,accepted,application_declined,application_rejected,application_withdrawn')
+  end
+end

--- a/spec/requests/data_api/ministerial_report_candidates_export_spec.rb
+++ b/spec/requests/data_api/ministerial_report_candidates_export_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /data-api/ministerial-report/candidates/latest', type: :request, sidekiq: true do
+  include DataAPISpecHelper
+
+  it_behaves_like 'a TAD API endpoint', '/candidates'
+
+  it 'returns the latest ministerial report candidates export' do
+    create(:submitted_application_choice, :with_completed_application_form, status: 'rejected')
+
+    data_export = DataExport.create!(
+      name: 'Daily export of the candidates ministerial report',
+      export_type: :ministerial_report_candidates_export,
+    )
+    DataExporter.perform_async(SupportInterface::MinisterialReportCandidatesExport, data_export.id)
+
+    get_api_request '/data-api/ministerial-report/candidates/latest', token: tad_api_token
+
+    expect(response).to have_http_status(:success)
+    expect(response.body).to start_with('subject,candidates,candidates_holding_offers,candidates_that_have_accepted_offers,declined_candidates,rejected_candidates,candidates_that_have_withdrawn_offers')
+  end
+end


### PR DESCRIPTION
## Context

Following on from [#5617](https://github.com/DFE-Digital/apply-for-teacher-training/pull/5617), this PR will add two new endpoints so that TAD can use the API to retrieve the new ministerial reports.

## Changes proposed in this pull request

Added:
`/data-api/ministerial-report/candidates/latest`
`/data-api/ministerial-report/applications/latest`
which will retrieve the latest exports.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
