### PR TITLE
Extend the start/end time range to allow 3 job runs

### DIFF
--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Clockwork, clockwork: true do
     describe 'worker schedule' do
       it 'runs the job every hour' do
         start_time = Time.zone.now
-        end_time = Time.zone.now + 3.hours
+        end_time = Time.zone.now + 3.hours + 1.minute
         Clockwork::Test.run(
           start_time: start_time,
           end_time: end_time,


### PR DESCRIPTION
## Context

We get sporadic failures with this spec like:

```
Failure/Error: expect(Clockwork::Test.times_run(worker[:task])).to eq 3
       Expected 2 to eq 3.
```

It's possible that depending on when this spec is run, ie which minute, the 3 hour window is not enough for 3 clock loops to complete. The clock tasks are configured at specific minutes past the hour.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Extend the start/end period for Clock::Test so that 3 clock runs can complete.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/91RjobhW/4358-flakey-test-clockworkspec
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
