### PR TITLE
Include vendors on API monitoring dashboard

### DIFF
--- a/app/models/support_interface/vendor_api_monitor.rb
+++ b/app/models/support_interface/vendor_api_monitor.rb
@@ -5,7 +5,7 @@ module SupportInterface
     end
 
     def all_providers
-      Provider.joins(:vendor)
+      Provider.joins(:vendor).includes([:vendor])
     end
 
     def target_providers
@@ -24,14 +24,14 @@ module SupportInterface
 
     def no_sync_in_24h
       connected
-        .select('last_syncs.last_sync as last_sync')
+        .select('last_syncs.last_sync as last_sync, vendor_id')
         .joins("LEFT JOIN (#{VendorAPIRequest.successful.syncs.select('provider_id, MAX(vendor_api_requests.created_at) as last_sync').group('provider_id').to_sql}) last_syncs on last_syncs.provider_id = providers.id")
         .where("last_sync < now() - interval '24 hours' OR last_sync IS NULL").order('last_sync DESC')
     end
 
     def no_decisions_in_7d
       connected
-        .select('last_decisions.last_decision as last_decision')
+        .select('last_decisions.last_decision as last_decision, vendor_id')
         .joins("LEFT JOIN (#{VendorAPIRequest.successful.decisions.select('provider_id, MAX(vendor_api_requests.created_at) as last_decision').group('provider_id').to_sql}) last_decisions on last_decisions.provider_id = providers.id")
       .where("last_decision < now() - interval '7 days' OR last_decision IS NULL").order('last_decision DESC')
     end
@@ -40,7 +40,8 @@ module SupportInterface
       connected
         .select('errors.count as error_count,
           requests.count as request_count,
-          (CAST(errors.count AS FLOAT)/requests.count) * 100 as error_rate')
+          (CAST(errors.count AS FLOAT)/requests.count) * 100 as error_rate,
+          vendor_id')
         .joins("LEFT JOIN (#{VendorAPIRequest.errors.select('provider_id, COUNT(vendor_api_requests.id) as count').where("vendor_api_requests.created_at > current_date - interval '7 days'").group('provider_id').to_sql}) errors on errors.provider_id = providers.id")
         .joins("LEFT JOIN (#{VendorAPIRequest.select('provider_id, COUNT(vendor_api_requests.id) as count').where("vendor_api_requests.created_at > current_date - interval '7 days'").group('provider_id').to_sql}) requests on requests.provider_id = providers.id")
         .where.not(errors: { count: nil }).order('error_rate DESC')

--- a/app/views/support_interface/vendor_api_monitoring/index.html.erb
+++ b/app/views/support_interface/vendor_api_monitoring/index.html.erb
@@ -41,8 +41,9 @@
   <table class="govuk-table" data-qa="not-connected">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header govuk-table__header govuk-!-width-one-half">Provider</th>
-        <th class="govuk-table__header govuk-table__header govuk-!-width-one-half">API token issued</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-third">Provider</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-third">Vendor</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-third">API token issued</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -50,6 +51,9 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
             <%= govuk_link_to provider.name, support_interface_provider_path(provider) %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= provider.vendor.name.humanize %>
           </td>
           <td class="govuk-table__cell">
             <% if token = provider.vendor_api_tokens.first %>
@@ -72,7 +76,8 @@
   <table class="govuk-table" data-qa="not-synced">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header govuk-table__header govuk-!-width-one-half">Provider</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Provider</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Vendor</th>
         <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time since last sync</th>
         <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time of last sync</th>
       </tr>
@@ -82,6 +87,9 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
             <%= govuk_link_to provider.name, support_interface_provider_path(provider.id) %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= provider.vendor.name.humanize %>
           </td>
           <td class="govuk-table__cell">
             <% if provider.last_sync %>
@@ -111,7 +119,8 @@
   <table class="govuk-table" data-qa="not-posted-decision">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header govuk-table__header govuk-!-width-one-half">Provider</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Provider</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Vendor</th>
         <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time since last decision</th>
         <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time of last decision</th>
       </tr>
@@ -121,6 +130,9 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
             <%= govuk_link_to provider.name, support_interface_provider_path(provider.id) %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= provider.vendor.name.humanize %>
           </td>
           <td class="govuk-table__cell">
             <% if provider.last_decision %>
@@ -151,9 +163,9 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Provider</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Vendor</th>
         <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Requests</th>
-        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Errors</th>
-        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Error rate</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Errors (error rate)</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -163,13 +175,13 @@
             <%= govuk_link_to provider.name, support_interface_provider_path(provider.id) %>
           </td>
           <td class="govuk-table__cell">
+            <%= provider.vendor.name.humanize %>
+          </td>
+          <td class="govuk-table__cell">
             <%= number_with_delimiter(provider.request_count) %>
           </td>
           <td class="govuk-table__cell">
-            <%= number_with_delimiter(provider.error_count) %>
-          </td>
-          <td class="govuk-table__cell">
-            <%= provider.error_rate.round(1) %>%
+            <%= number_with_delimiter(provider.error_count) %> (<%= provider.error_rate.round(1) %>%)
           </td>
         </tr>
       <% end %>


### PR DESCRIPTION
## Context

We now have this information, so show it.

## Changes proposed in this pull request

<img width="1159" alt="Screenshot 2021-10-07 at 19 28 49" src="https://user-images.githubusercontent.com/642279/136442201-08ced1b9-43b6-4992-8900-106259cb3eb0.png">

On the errors table, fold the error rate into the error count column because that would make 5 columns, and the design system doesn't support a width of one fifth.