### PR TITLE
Do not show duplicate applications in providers/applications support …

### DIFF
--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -17,6 +17,7 @@ module SupportInterface
           :candidate,
           application_choices: { course_option: { course: :provider } },
         )
+        .distinct
         .order(updated_at: :desc)
         .page(applied_filters[:page] || 1).per(30)
 

--- a/spec/models/support_interface/applications_filter_spec.rb
+++ b/spec/models/support_interface/applications_filter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SupportInterface::ApplicationsFilter do
   def verify_filtered_applications_for_params(expected_applications, params:)
     applications = ApplicationForm.all
     filter = described_class.new(params: params)
-    expect(filter.filter_records(applications)).to match_array expected_applications
+    expect(filter.filter_records(applications)).to match_array(expected_applications)
   end
 
   describe '#filter_records' do
@@ -32,6 +32,21 @@ RSpec.describe SupportInterface::ApplicationsFilter do
         [expected_form],
         params: {
           application_choice_id: application_choice_with_offer.id,
+        },
+      )
+    end
+
+    it 'returns an application form with multiple application choices once' do
+      course_option = create(:course_option, course: application_choice_with_offer.course)
+      application_choice = create(:application_choice,
+                                  application_form: application_choice_with_offer.application_form,
+                                  course_option: course_option,
+                                  provider_ids: application_choice_with_offer.provider_ids)
+
+      verify_filtered_applications_for_params(
+        [application_choice.application_form],
+        params: {
+          provider_id: application_choice_with_offer.provider_ids.first,
         },
       )
     end


### PR DESCRIPTION
…view

## Context
Multiple applications are appearing in the support console applications in the provider section if a candidate submits an applications to multiple courses for the same provider

## Link to Trello card

https://trello.com/c/PdPdxLqE/4356-do-not-show-duplicate-applications-in-providers-applications-support-view

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
