### PR TITLE
remove reference to UCAS for current cycle courses

### DIFF
--- a/app/components/support_interface/course_details_component.rb
+++ b/app/components/support_interface/course_details_component.rb
@@ -80,7 +80,7 @@ module SupportInterface
         },
         {
           key: 'Apply status',
-          value: course.open_on_apply? ? govuk_tag(text: 'Open on Apply & UCAS', colour: 'green') : govuk_tag(text: 'Open on UCAS only', colour: 'blue'),
+          value: course.open_on_apply? ? govuk_tag(text: open_on_apply_message(course), colour: 'green') : govuk_tag(text: 'Not open on Apply', colour: 'blue'),
           action: {
             href: candidate_interface_apply_from_find_path(providerCode: course.provider.code, courseCode: course.code),
             text: 'Start page on Apply',
@@ -96,6 +96,10 @@ module SupportInterface
       end
 
       rows
+    end
+
+    def open_on_apply_message(course)
+      course.recruitment_cycle_year > 2021 ? 'Open on Apply' : 'Open on Apply & UCAS'
     end
   end
 end

--- a/app/components/support_interface/provider_courses_table_component.rb
+++ b/app/components/support_interface/provider_courses_table_component.rb
@@ -35,9 +35,9 @@ module SupportInterface
 
     def status_tag(course)
       if course.open_on_apply?
-        govuk_tag(text: 'Open on Apply & UCAS', colour: 'green')
+        govuk_tag(text: open_on_apply_message(course), colour: 'green')
       elsif course.exposed_in_find?
-        govuk_tag(text: 'Open on UCAS only', colour: 'blue')
+        govuk_tag(text: 'Not open on Apply', colour: 'blue')
       else
         govuk_tag(text: 'Hidden in Find', colour: 'grey')
       end
@@ -50,6 +50,10 @@ module SupportInterface
           support_interface_provider_path(provider),
         )
       end
+    end
+
+    def open_on_apply_message(course)
+      course.recruitment_cycle_year > 2021 ? 'Open on Apply' : 'Open on Apply & UCAS'
     end
   end
 end

--- a/spec/components/support_interface/course_details_component_spec.rb
+++ b/spec/components/support_interface/course_details_component_spec.rb
@@ -28,6 +28,24 @@ RSpec.describe SupportInterface::CourseDetailsComponent do
     }.not_to raise_error
   end
 
+  describe '#opened_on_apply_message' do
+    it 'shows Open on Apply when course in current cycle' do
+      course = create(:course, :open_on_apply, recruitment_cycle_year: RecruitmentCycle.current_year, open_on_apply: true)
+      result = render_inline(
+        described_class.new(course: course),
+      )
+      expect(result.text).to include('Open on Apply')
+    end
+
+    it 'shows Open on Apply & UCAS when course in previous cycle or earlier' do
+      course = create(:course, :open_on_apply, recruitment_cycle_year: 2021)
+      result = render_inline(
+        described_class.new(course: course),
+      )
+      expect(result.text).to include('Open on Apply & UCAS')
+    end
+  end
+
   describe 'showing Opened on Apply at' do
     it 'shows the date when the course is open' do
       course = create(:course, :open_on_apply)


### PR DESCRIPTION
## Context

As ucas has been deprecated for courses in the current cycle we should remove references to courses being open on UCAS

## Link to Trello card

https://trello.com/c/amXBLpQc/4354-change-open-on-ucas-and-apply-label-to-open-on-apply

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
