### PR TITLE
change invite/delete user to add/remove

### DIFF
--- a/app/components/provider_interface/provider_user_permissions_form_component.rb
+++ b/app/components/provider_interface/provider_user_permissions_form_component.rb
@@ -25,7 +25,7 @@ module ProviderInterface
     end
 
     def caption_text
-      prefix = user_name || 'Invite user'
+      prefix = user_name || 'Add user'
       "#{prefix} - #{provider.name}"
     end
 

--- a/app/controllers/provider_interface/user_invitation/review_controller.rb
+++ b/app/controllers/provider_interface/user_invitation/review_controller.rb
@@ -28,7 +28,7 @@ module ProviderInterface
         if service.call
           @wizard.clear_state!
 
-          flash[:success] = 'User invited'
+          flash[:success] = 'User added'
           redirect_to provider_interface_organisation_settings_organisation_users_path(@provider)
         else
           track_validation_error(@wizard)

--- a/app/controllers/provider_interface/users_controller.rb
+++ b/app/controllers/provider_interface/users_controller.rb
@@ -17,7 +17,7 @@ module ProviderInterface
     def destroy
       RemoveUserFromProvider.new(current_provider_user: current_provider_user, provider: @provider, user_to_remove: @provider_user).call!
 
-      flash[:success] = 'User deleted'
+      flash[:success] = 'User removed'
       redirect_to provider_interface_organisation_settings_organisation_users_path(@provider)
     end
 

--- a/app/views/content/service_guidance_provider.md
+++ b/app/views/content/service_guidance_provider.md
@@ -102,7 +102,7 @@ The permissions feature allows you to control:
 
 * who can make decisions about applications
 * who can view sensitive information disclosed by the candidate (in the safeguarding or equality and diversity sections of the application)
-* who can invite other users, and set their permissions
+* who can add other users, and set their permissions
 
 #### For example, you may wish to:
 
@@ -117,8 +117,8 @@ Everyone on your team who uses the Manage service will be able to view all appli
 The ‘Manage users’ permission allows you to:
 
 * set permissions for team members
-* invite new users
-* delete users
+* add new users
+* remove Users
 
 #### ‘Manage users’ for training providers who are already part of our pilot
 

--- a/app/views/provider_interface/user_invitation/personal_details/new.html.erb
+++ b/app/views/provider_interface/user_invitation/personal_details/new.html.erb
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">Invite user - <%= @provider.name %></span>
+        <span class="govuk-caption-l">Add user - <%= @provider.name %></span>
         <%= t('page_titles.provider.personal_details') %>
       </h1>
 

--- a/app/views/provider_interface/user_invitation/review/check.html.erb
+++ b/app/views/provider_interface/user_invitation/review/check.html.erb
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l"><%= "Invite user - #{@provider.name}" %></span>
+        <span class="govuk-caption-l"><%= "Add user - #{@provider.name}" %></span>
         <%= t('page_titles.provider.check_user_invitation_permissions') %>
       </h1>
 
@@ -26,7 +26,7 @@
         change_path: new_provider_interface_organisation_settings_organisation_user_invitation_permissions_path(@provider, checking_answers: true),
       ) %>
 
-      <%= f.govuk_submit 'Invite user' %>
+      <%= f.govuk_submit 'Add user' %>
     <% end %>
 
     <p class="govuk-body">

--- a/app/views/provider_interface/users/confirm_destroy.html.erb
+++ b/app/views/provider_interface/users/confirm_destroy.html.erb
@@ -7,7 +7,7 @@
     <span class="govuk-caption-l"><%= @provider_user.full_name %></span>
     <h1 class="govuk-heading-l"><%= t('page_titles.provider.confirm_delete_user', provider_name: @provider.name) %></h1>
 
-    <%= govuk_button_to 'Delete user', provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user), method: :delete, class: 'govuk-button--warning' %>
+    <%= govuk_button_to 'Remove User', provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user), method: :delete, class: 'govuk-button--warning' %>
 
     <p class="govuk-body">
       <%= govuk_link_to t('cancel'), provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user) %>

--- a/app/views/provider_interface/users/index.html.erb
+++ b/app/views/provider_interface/users/index.html.erb
@@ -13,7 +13,7 @@
     <h1 class="govuk-heading-l"><%= t('page_titles.provider.users') %></h1>
 
     <% if @current_user_can_manage_users %>
-      <%= govuk_button_link_to 'Invite user', new_provider_interface_organisation_settings_organisation_user_invitation_personal_details_path(@provider) %>
+      <%= govuk_button_link_to 'Add user', new_provider_interface_organisation_settings_organisation_user_invitation_personal_details_path(@provider) %>
     <% end %>
 
     <% @provider.provider_users.order(:first_name, :last_name).each do |user| %>

--- a/app/views/provider_interface/users/show.html.erb
+++ b/app/views/provider_interface/users/show.html.erb
@@ -15,7 +15,7 @@
 
       <% if @current_user_can_manage_users %>
         <p class="govuk-body">
-          <%= govuk_link_to 'Delete user', confirm_destroy_provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user) %>
+          <%= govuk_link_to 'Remove User', confirm_destroy_provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user) %>
         </p>
       <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -217,7 +217,7 @@ en:
       your_user_permissions: Your user permissions
       user_permissions: User permissions
       check_user_permissions: Check and save user permissions
-      check_user_invitation_permissions: Check permissions and invite user
+      check_user_invitation_permissions: Check permissions and add user
       email_notifications: Your email notifications
       organisation_settings: Organisation settings
       organisation_permissions: Organisation permissions

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -12,7 +12,7 @@ The following set of permissions are used across the app.
 
 - Manage Users
 
-  Enables a provider user to invite or delete users and set their permissions.
+  Enables a provider user to invite or remove Users and set their permissions.
 
 - Manage Organisations
 

--- a/spec/components/provider_interface/provider_user_permissions_form_component_spec.rb
+++ b/spec/components/provider_interface/provider_user_permissions_form_component_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ProviderInterface::ProviderUserPermissionsFormComponent do
     end
 
     it 'renders the correct caption as a span within a legend for the form' do
-      expect(render.css('legend > h1 > span').text).to include("Invite user - #{provider.name}")
+      expect(render.css('legend > h1 > span').text).to include("Add user - #{provider.name}")
     end
   end
 
@@ -81,7 +81,7 @@ RSpec.describe ProviderInterface::ProviderUserPermissionsFormComponent do
     end
 
     it 'renders the correct caption as a span for the form' do
-      expect(render.css('h1 > span').text).to include("Invite user - #{provider.name}")
+      expect(render.css('h1 > span').text).to include("Add user - #{provider.name}")
     end
   end
 

--- a/spec/system/provider_interface/invite_user_spec.rb
+++ b/spec/system/provider_interface/invite_user_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature 'Provider user invitation' do
   end
 
   def then_i_cannot_see_the_invite_user_button
-    expect(page).not_to have_link('Invite user')
+    expect(page).not_to have_link('Add user')
   end
 
   def given_i_can_manage_users
@@ -71,11 +71,11 @@ RSpec.feature 'Provider user invitation' do
   end
 
   def then_i_can_see_the_invite_user_button
-    expect(page).to have_link('Invite user')
+    expect(page).to have_link('Add user')
   end
 
   def when_i_click_on_invite_user
-    click_on 'Invite user'
+    click_on 'Add user'
   end
 
   def then_i_see_a_personal_details_form
@@ -112,7 +112,7 @@ RSpec.feature 'Provider user invitation' do
   end
 
   def then_i_see_a_check_page
-    expect(page).to have_selector('h1', text: 'Check permissions and invite user')
+    expect(page).to have_selector('h1', text: 'Check permissions and add user')
   end
 
   def and_i_see_the_specified_personal_details
@@ -150,7 +150,7 @@ RSpec.feature 'Provider user invitation' do
   end
 
   def then_i_see_a_success_message
-    expect(page).to have_content('User invited')
+    expect(page).to have_content('User added')
   end
 
   def and_the_new_user_appears_in_the_user_list

--- a/spec/system/provider_interface/remove_provider_user_spec.rb
+++ b/spec/system/provider_interface/remove_provider_user_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Organisation users' do
   end
 
   def and_i_click_delete_user
-    click_on 'Delete user'
+    click_on 'Remove User'
   end
 
   def and_i_confirm_i_want_to_delete_this_user
@@ -64,7 +64,7 @@ RSpec.describe 'Organisation users' do
   end
 
   def then_i_see_the_success_message
-    expect(page).to have_content('User deleted')
+    expect(page).to have_content('User removed')
   end
 
   def and_the_user_no_longer_belongs_to_the_provider
@@ -73,6 +73,6 @@ RSpec.describe 'Organisation users' do
   end
 
   def then_i_cannot_see_a_link_to_delete_the_user
-    expect(page).not_to have_link('Delete user')
+    expect(page).not_to have_link('Remove User')
   end
 end


### PR DESCRIPTION
## Context

In order to keep messaging consistent throughout the application we are deprecating invite/delete messaging in favour of add/ remove.

## Guidance to review

Check that the banners read the new messages correctly.

## Link to Trello card

https://trello.com/c/8iOeOIVi/4322-change-invite-and-delete-user-terms-in-service-to-add-user-and-remove-user
## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
