### PR TITLE
Add mark as fraudulent ability to Fraud Audit Dashboard

### DIFF
--- a/app/components/support_interface/fraud_auditing_matches_table_component.html.erb
+++ b/app/components/support_interface/fraud_auditing_matches_table_component.html.erb
@@ -39,7 +39,18 @@
         </td>
 
         <td class="govuk-table__cell">
-          <%= table_row[:fraudulent] %>
+          <%= table_row[:fraudulent] %><br><br>
+          <% if table_row[:match].fraudulent? %>
+            <%= govuk_link_to support_interface_fraud_auditing_matches_fraudulent_path(table_row[:match].id) do %>
+              <%= 'Mark as non fraudulent' %>
+              <span class="govuk-visually-hidden"> <%= table_row[:match].last_name %></span>
+            <% end %>
+          <% else %>
+            <%= govuk_link_to support_interface_fraud_auditing_matches_fraudulent_path(table_row[:match].id) do %>
+              <%= 'Mark as fraudulent' %>
+              <span class="govuk-visually-hidden"> <%= table_row[:match].last_name %></span>
+            <% end %>
+          <% end %>
         </td>
 
         <td class="govuk-table__cell">

--- a/app/components/support_interface/fraud_auditing_matches_table_component.rb
+++ b/app/components/support_interface/fraud_auditing_matches_table_component.rb
@@ -11,6 +11,7 @@ module SupportInterface
     def table_rows
       matches.map do |match|
         {
+          match: match,
           first_names: match.candidates.map { |candidate| candidate.application_forms.first.first_name },
           last_name: match.last_name,
           fraudulent: marked_as_fraudulent?(match),

--- a/app/controllers/support_interface/fraud_auditing_matches_controller.rb
+++ b/app/controllers/support_interface/fraud_auditing_matches_controller.rb
@@ -1,7 +1,21 @@
 module SupportInterface
   class FraudAuditingMatchesController < SupportInterfaceController
     def index
-      @matches = FraudMatch.where(recruitment_cycle_year: RecruitmentCycle.current_year).all
+      @matches = FraudMatch.where(recruitment_cycle_year: RecruitmentCycle.current_year).all.sort_by(&:created_at)
+    end
+
+    def fraudulent
+      fraud_match = FraudMatch.find(params[:id])
+
+      if fraud_match.fraudulent?
+        fraud_match.update!(fraudulent: false)
+        flash[:success] = 'Match marked as non fraudulent'
+      else
+        fraud_match.update!(fraudulent: true)
+        flash[:success] = 'Match marked as fraudulent'
+      end
+
+      redirect_to support_interface_fraud_auditing_matches_path
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -913,6 +913,8 @@ Rails.application.routes.draw do
 
     get '/duplicate-candidate-matches', to: redirect('/support/fraud-auditing-dashboard')
     get '/fraud-auditing-dashboard' => 'fraud_auditing_matches#index', as: :fraud_auditing_matches
+    get '/fraudulent/:id' => 'fraud_auditing_matches#fraudulent', as: :fraud_auditing_matches_fraudulent
+    patch '/fraudulent/:id' => 'fraud_auditing_matches#fraudulent'
 
     get '/application_choices/:application_choice_id' => redirect('/application-choices/%{application_choice_id}')
     get '/application-choices/:application_choice_id' => 'application_choices#show', as: :application_choice

--- a/spec/components/support_interface/fraud_auditing_matches_table_component_spec.rb
+++ b/spec/components/support_interface/fraud_auditing_matches_table_component_spec.rb
@@ -1,12 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::FraudAuditingMatchesTableComponent do
-  let(:fraud_match) { create(:fraud_match) }
+  let(:fraud_match1) { create(:fraud_match) }
+  let(:fraud_match2) { create(:fraud_match, fraudulent: true) }
 
   before do
     Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
-      create(:application_form, candidate: fraud_match.candidates.first, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH', submitted_at: Time.zone.now)
-      create(:application_form, candidate: fraud_match.candidates.second, first_name: 'Joffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH')
+      create(:application_form, candidate: fraud_match1.candidates.first, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH', submitted_at: Time.zone.now)
+      create(:application_form, candidate: fraud_match1.candidates.second, first_name: 'Joffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH')
+
+      create(:application_form, candidate: fraud_match2.candidates.first, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH', submitted_at: Time.zone.now)
+      create(:application_form, candidate: fraud_match2.candidates.second, first_name: 'Joffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH')
     end
   end
 
@@ -16,19 +20,41 @@ RSpec.describe SupportInterface::FraudAuditingMatchesTableComponent do
     expect(result.css('td')[0]).to eq(nil)
   end
 
-  it 'renders a single row for a fraud match' do
-    result = render_inline(described_class.new(matches: [fraud_match]))
+  context 'fraud match has been marked non fraudulent' do
+    it 'renders a single row for a fraud match' do
+      result = render_inline(described_class.new(matches: [fraud_match1]))
 
-    expect(result.css('td')[0].text).to include('Thompson')
-    expect(result.css('td')[1].text).to include('Jeffrey')
-    expect(result.css('td')[1].text).to include('Joffrey')
-    expect(result.css('td')[2].text).to include(fraud_match.candidates.first.email_address)
-    expect(result.css('td')[2].text).to include(fraud_match.candidates.second.email_address)
-    expect(result.css('td')[3].text).to include('')
-    expect(result.css('td')[4].text).to include('')
-    expect(result.css('td')[5].text).to include('No')
-    expect(result.css('td')[6].text).to include('No')
-    expect(result.css('td')[6].text).to include('Yes')
-    expect(result.css('td')[7].text).to include('')
+      expect(result.css('td')[0].text).to include('Thompson')
+      expect(result.css('td')[1].text).to include('Jeffrey')
+      expect(result.css('td')[1].text).to include('Joffrey')
+      expect(result.css('td')[2].text).to include(fraud_match1.candidates.first.email_address)
+      expect(result.css('td')[2].text).to include(fraud_match1.candidates.second.email_address)
+      expect(result.css('td')[3].text).to include('')
+      expect(result.css('td')[4].text).to include('')
+      expect(result.css('td')[5].text).to include('No')
+      expect(result.css('td')[5].text).to include('Mark as fraudulent')
+      expect(result.css('td')[6].text).to include('No')
+      expect(result.css('td')[6].text).to include('Yes')
+      expect(result.css('td')[7].text).to include('')
+    end
+  end
+
+  context 'fraud match has been marked fraudulent' do
+    it 'renders a single row for a fraud match' do
+      result = render_inline(described_class.new(matches: [fraud_match2]))
+
+      expect(result.css('td')[0].text).to include('Thompson')
+      expect(result.css('td')[1].text).to include('Jeffrey')
+      expect(result.css('td')[1].text).to include('Joffrey')
+      expect(result.css('td')[2].text).to include(fraud_match2.candidates.first.email_address)
+      expect(result.css('td')[2].text).to include(fraud_match2.candidates.second.email_address)
+      expect(result.css('td')[3].text).to include('')
+      expect(result.css('td')[4].text).to include('')
+      expect(result.css('td')[5].text).to include('Yes')
+      expect(result.css('td')[5].text).to include('Mark as non fraudulent')
+      expect(result.css('td')[6].text).to include('No')
+      expect(result.css('td')[6].text).to include('Yes')
+      expect(result.css('td')[7].text).to include('')
+    end
   end
 end

--- a/spec/system/support_interface/fraud_auditing_dashboard_spec.rb
+++ b/spec/system/support_interface/fraud_auditing_dashboard_spec.rb
@@ -12,6 +12,12 @@ RSpec.feature 'See Fraud Auditing matches' do
     and_the_update_fraud_matches_worker_has_run
     and_i_go_to_fraud_auditing_dashboard_page
     then_i_should_see_list_of_fraud_auditing_matches
+
+    when_i_mark_a_match_as_fradulent
+    then_i_see_that_the_match_is_marked_as_fraudulent
+
+    when_i_mark_a_match_as_non_fradulent
+    then_i_see_that_the_match_is_marked_as_non_fraudulent
   end
 
   def given_i_am_a_support_user
@@ -63,6 +69,7 @@ RSpec.feature 'See Fraud Auditing matches' do
 
     within 'td:eq(6)' do
       expect(page).to have_content 'No'
+      expect(page).to have_link 'Mark as fraudulent'
     end
 
     within 'td:eq(7)' do
@@ -72,6 +79,32 @@ RSpec.feature 'See Fraud Auditing matches' do
 
     within 'td:eq(8)' do
       expect(page).to have_content ''
+    end
+  end
+
+  def when_i_mark_a_match_as_fradulent
+    within 'td:eq(6)' do
+      click_link 'Mark as fraudulent'
+    end
+  end
+
+  def then_i_see_that_the_match_is_marked_as_fraudulent
+    within 'td:eq(6)' do
+      expect(page).to have_content 'Yes'
+      expect(page).to have_link 'Mark as non fraudulent'
+    end
+  end
+
+  def when_i_mark_a_match_as_non_fradulent
+    within 'td:eq(6)' do
+      click_link 'Mark as non fraudulent'
+    end
+  end
+
+  def then_i_see_that_the_match_is_marked_as_non_fraudulent
+    within 'td:eq(6)' do
+      expect(page).to have_content 'No'
+      expect(page).to have_link 'Mark as fraudulent'
     end
   end
 end


### PR DESCRIPTION
## Context

In order to give support users the ability to mark matches as fraudulent
or not. This will also allow future work around filtering.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
<img width="1176" alt="image" src="https://user-images.githubusercontent.com/62567622/136579789-13d8972a-b6eb-4262-a187-aef326a610ca.png">


<img width="1176" alt="image" src="https://user-images.githubusercontent.com/62567622/136579653-35109692-a9b2-4e63-9f68-53d1e6e5c294.png">


<img width="1176" alt="image" src="https://user-images.githubusercontent.com/62567622/136579619-27f4db0f-f5a2-4ec1-9b00-d72520c91f7f.png">

## Link to Trello card
https://trello.com/c/RbVGxEOd/4029-fraud-add-mark-as-fraudulent-button-to-the-fraud-audit-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
