### PR TITLE
Only display current Provider Performance tad data

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -177,7 +177,7 @@ class DataExport < ApplicationRecord
     tad_provider_performance: {
       name: 'TAD provider performance',
       export_type: 'tad_provider_performance',
-      description: 'A list of all application/offered/accepted counts for all courses in Apply.',
+      description: 'A list of all application/offered/accepted counts for all courses in Apply belonging to the current recruitment cycle.',
       class: SupportInterface::TADProviderStatsExport,
     },
     user_permissions: {

--- a/app/services/support_interface/tad_provider_stats_export.rb
+++ b/app/services/support_interface/tad_provider_stats_export.rb
@@ -27,7 +27,7 @@ module SupportInterface
   private
 
     def courses
-      Course.includes(:provider)
+      Course.includes(:provider).current_cycle
     end
 
     def choice_statuses(course)

--- a/spec/services/support_interface/tad_provider_stats_export_spec.rb
+++ b/spec/services/support_interface/tad_provider_stats_export_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe SupportInterface::TADProviderStatsExport do
       course_option_for_provider(provider: provider_one, course: create(:course, :open_on_apply, name: 'Biology', provider: provider_one))
       course_option_for_provider(provider: provider_two, course: create(:course, :open_on_apply, name: 'Science book', provider: provider_two))
       course_option_for_provider(provider: provider_two, course: create(:course, :open_on_apply, name: 'French I took', provider: provider_two))
-
+      course_option_for_provider(provider: provider_two, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      course_option_for_provider(provider: provider_two, recruitment_cycle_year: RecruitmentCycle.previous_year)
       # we get a row per course
       expect(exported_rows.count).to eq(4)
 


### PR DESCRIPTION
## Context
On review of which exports need to be cycle-aware it was concluded that only the current cycle data is needed for this export, not the all-time data.
## Link to Trello card

https://trello.com/c/BIHcvKmM/4191-enable-downloading-of-current-cycle-only-for-tad-provider-performance-csv-export-in-support

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
