### PR TITLE
Update Submitted Application Choices csv export to be cycle specific

### DIFF
--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -62,6 +62,7 @@ module SupportInterface
 
     def relevant_applications
       ApplicationForm
+        .current_cycle
         .includes(
           :candidate,
           application_choices: %i[course provider audits],

--- a/spec/services/support_interface/application_choices_export_spec.rb
+++ b/spec/services/support_interface/application_choices_export_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe SupportInterface::ApplicationChoicesExport, with_audited: true do
     it 'returns submitted application choices with timings' do
       unsubmitted_form = create(:application_form)
       create(:application_choice, status: :unsubmitted, application_form: unsubmitted_form)
+      previous_cycle_application_form = create(:completed_application_form, application_choices_count: 3)
+      previous_cycle_application_form.update!(recruitment_cycle_year: RecruitmentCycle.previous_year)
       submitted_form = create(:completed_application_form, application_choices_count: 2)
 
       choices = described_class.new.application_choices


### PR DESCRIPTION
## Context

Update report to only retrieve application choices for current cycle

## Link to Trello card

https://trello.com/c/B1cZGTK8/4125-enable-downloading-of-current-cycle-only-for-submitted-application-choices-csv-export-in-support

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
