### PR TITLE
Count candidates since A2 closed, not since Find opened

### DIFF
--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -233,11 +233,11 @@ private
   end
 
   def date_range_query_for_recruitment_cycle_year(cycle_year)
-    start_date = CycleTimetable.find_opens(cycle_year)
+    start_date = CycleTimetable.apply_2_deadline(cycle_year - 1).end_of_day
 
     query = "created_at >= '#{start_date}'"
 
-    end_date = CycleTimetable.find_opens(cycle_year + 1)
+    end_date = CycleTimetable.apply_2_deadline(cycle_year)
 
     if end_date
       query + " AND created_at <= '#{end_date}'"

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe PerformanceStatistics, type: :model do
       Timecop.freeze(CycleTimetable.find_opens(2020) + 1.day) do
         create_list(:candidate, 2)
       end
-      Timecop.freeze(CycleTimetable.find_opens(2021) + 1.day) do
+      Timecop.freeze(CycleTimetable.apply_2_deadline(2020) + 1.day) do
         create_list(:candidate, 3)
       end
 


### PR DESCRIPTION
Signups after A2 has closed are effectively for the new cycle, so count them as such on the Service Performance dashboard.