### PR TITLE
Make sure we can `respond_to` headers before attempting to retrieve t…

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -6,8 +6,11 @@ class ApplicationMailer < Mail::Notify::Mailer
     # re-raised and we will not be notified via Sentry, and the job will not retry.
     #
     # @see https://github.com/rails/rails/issues/39018
-    email = Email.find(headers['email-log-id'].to_s)
-    email.update!(delivery_status: 'notify_error')
+    if respond_to?(:headers)
+      email = Email.find(headers['email-log-id'].to_s)
+      email.update!(delivery_status: 'notify_error')
+    end
+
     raise
   end
 


### PR DESCRIPTION
…he `email-log-id`

## Context

When rescuing Notify rate limit errors, we were getting the following error: https://sentry.io/organizations/dfe-bat/issues/2406532495/?environment=production&project=1765973&query=is%3Aunresolved

This is because `headers` does not exist as a class method 

## Changes proposed in this pull request

Only retrieve and update email_id from headers when headers exist.

## Link to Trello card

https://trello.com/c/tMkYjDkA/4353-fix-notify-email-callbacks-errors

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
