### PR TITLE
Allow DSI fallback to work for providers without DSI UIDs

### DIFF
--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -25,7 +25,7 @@ module ProviderInterface
 
       provider_user = ProviderUser.find_by(email_address: params.dig(:provider_user, :email_address).downcase.strip)
 
-      if provider_user && provider_user.dfe_sign_in_uid.present?
+      if provider_user
         magic_link_token = provider_user.create_magic_link_token!
         ProviderMailer.fallback_sign_in_email(provider_user, magic_link_token).deliver_later
       end

--- a/spec/system/provider_interface/authentication_fallback_spec.rb
+++ b/spec/system/provider_interface/authentication_fallback_spec.rb
@@ -6,14 +6,7 @@ RSpec.describe 'A provider authenticates via the fallback mechanism' do
   scenario 'signing in successfully' do
     FeatureFlag.activate('dfe_sign_in_fallback')
 
-    given_i_am_registered_as_a_provider_user_without_a_dsi_uid
-    when_i_visit_the_provider_interface_applications_path
-    then_i_am_redirected_to_the_provider_sign_in_path
-
-    when_i_provide_my_email_address
-    then_i_do_not_receive_an_email_with_a_signin_link
-
-    when_i_get_a_dsi_uid
+    given_i_am_registered_as_a_provider_user
     when_i_visit_the_provider_interface_applications_path
     then_i_am_redirected_to_the_provider_sign_in_path
 
@@ -30,13 +23,9 @@ RSpec.describe 'A provider authenticates via the fallback mechanism' do
     then_i_am_not_signed_in
   end
 
-  def given_i_am_registered_as_a_provider_user_without_a_dsi_uid
+  def given_i_am_registered_as_a_provider_user
     @email = 'provider@example.com'
     @provider_user = create(:provider_user, email_address: @email, dfe_sign_in_uid: nil, first_name: 'Michael')
-  end
-
-  def when_i_get_a_dsi_uid
-    @provider_user.update(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
   end
 
   def when_i_visit_the_provider_interface_applications_path


### PR DESCRIPTION
## Context

We have 899 provider users in the database without DSI UIDs. If DSI goes down everyone will be able to log in because of an earlier decision — reasons unknown — to forbid provider users to log in unless they have a DSI UID set. Reverse that decision and permit logins by anyone with an email in the database.
