### PR TITLE
Fix flakey test application spec by ensuring apply1 applications are created in the past

### DIFF
--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -163,6 +163,20 @@ RSpec.describe TestApplications do
     end
   end
 
+  describe 'apply again' do
+    it 'generates 2 applications, one in the past and one current' do
+      create(:course_option, course: create(:course, :open_on_apply))
+      described_class.new.create_application(recruitment_cycle_year: RecruitmentCycle.current_year, states: %i[awaiting_provider_decision], courses_to_apply_to: Course.current_cycle, apply_again: true)
+      previous_form = ApplicationForm.first
+      new_form = ApplicationForm.last
+
+      expect(previous_form).not_to be_nil
+      expect(previous_form.created_at).to be_between(30.days.ago, 21.days.ago)
+      expect(new_form).not_to be_nil
+      expect(new_form.created_at).to be_between(20.days.ago, Time.zone.now)
+    end
+  end
+
   describe 'carried over' do
     it 'generates an application to courses from the year before' do
       create(:course_option, course: create(:course, :open_on_apply))


### PR DESCRIPTION
## Context

Test applications could previously overlap with current applications depending on the time they were set randomly in test_applications. The initialize_time method has been amended to set applicaitons further in the past if they are the apply 1 part of an apply 2 application.

## Link to Trello card

https://trello.com/c/C2mnQez6/4362-flakey-spec-generatetestapplications
## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
