### PR TITLE
update API doc content to reflect UCAS closure

### DIFF
--- a/app/views/api_docs/vendor_api_docs/pages/home.md
+++ b/app/views/api_docs/vendor_api_docs/pages/home.md
@@ -1,6 +1,6 @@
 This is API documentation for the Department for Education (DfE)’s new Apply for teacher training service.
 
-Apply is replacing the online UCAS application form for postgraduate teacher training. All vendors of student record systems (SRS) and some training providers will need to make changes to integrate with Apply.
+Apply has replaced the online UCAS teacher training service for postgraduate initial teacher training in England. All vendors of student record systems (SRS) and some training providers will need to make changes to integrate with Apply.
 
 ## What this API is for
 


### PR DESCRIPTION
## Context

Apply has replaced the online UCAS application form for postgraduate teacher training. All vendors of student record systems (SRS) and some training providers will need to make changes to integrate with Apply. This should be reflected in the API documentation.

## Link to Trello card

https://trello.com/c/UpdkgZSs/4369-update-api-documentation-to-reflect-the-fact-that-apply-has-replaced-ucas

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
