### PR TITLE
4381 update apidoc with latest hesa info

### DIFF
--- a/app/views/api_docs/vendor_api_docs/pages/home.md
+++ b/app/views/api_docs/vendor_api_docs/pages/home.md
@@ -43,7 +43,7 @@ Codes appear in three contexts:
 
 - All dates in the API specification are intended to be [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) compliant
 - Nationality is expressed as an [ISO 3166-2](https://www.iso.org/iso-3166-country-codes.html) country code
-- Demographic data required for HESA reporting uses [HESA codes for the 2020/21 Initial Teacher Training return](https://www.hesa.ac.uk/collection/c20053). When the HESA codes for the next cycle are released, we will update the documentation to reflect these.
+- Demographic data required for HESA reporting uses [HESA codes for the 2021/22 Initial Teacher Training return](https://www.hesa.ac.uk/collection/c21053). When the HESA codes for the next cycle are released, we will update the documentation to reflect these
 
 Where it is not possible to structure data strictly — for example, in the case of GCSE subjects, where candidates need to be able to enter subjects our sources might not include — we encourage candidates to enter values from an [autocomplete field](https://designnotes.blog.gov.uk/2017/04/20/were-building-an-autocomplete/).
 


### PR DESCRIPTION
## Context

Update content of the API docs to refer to the correct HESA documentation for the current cycle. 

## Link to Trello card

https://trello.com/c/seoy64Ob/4381-update-api-documentation-to-confirm-that-demographic-data-required-for-hesa-reporting-uses-hesa-codes-for-the-2021-22-initial-te

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
