### PR TITLE
Fix Flaky `ApplicationFormSpec`

### DIFF
--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -170,9 +170,11 @@ FactoryBot.define do
       end
 
       after(:create) do |application_form, evaluator|
-        application_form.application_choices << build_list(:application_choice, evaluator.application_choices_count, status: 'unsubmitted')
-        application_form.application_choices << build_list(:submitted_application_choice, evaluator.submitted_application_choices_count, application_form: application_form)
-        application_form.application_references << build_list(:reference, evaluator.references_count, evaluator.references_state, selected: evaluator.references_selected)
+        application_form.class.with_unsafe_application_choice_touches do
+          application_form.application_choices << build_list(:application_choice, evaluator.application_choices_count, status: 'unsubmitted')
+          application_form.application_choices << build_list(:submitted_application_choice, evaluator.submitted_application_choices_count, application_form: application_form)
+          application_form.application_references << build_list(:reference, evaluator.references_count, evaluator.references_state, selected: evaluator.references_selected)
+        end
 
         if evaluator.full_work_history
           current_year = Time.zone.today.year

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe ApplicationForm do
           :completed_application_form,
           recruitment_cycle_year: RecruitmentCycle.previous_year,
           application_choices_count: 1,
-          references_count: 0,
         )
 
         expect { application_form.update(first_name: 'Maria') }


### PR DESCRIPTION
## Context

There appears to be a race condition in the `ApplicationForm` Factory which happens adding application choices using `:application_choices_count` and setting `:recruitment_cycle_year` to the previous year.
Presumably the callback chain triggered by touching the application choices sometimes gets into a state where we're deemed to have changed an application from the previous cycle.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Wraps updates to application choices and references in a `with_unsafe_application_choice_touches` block in the `ApplicationForm` factory.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/daSE9rjr/4365-flakey-spec-applicationform

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
