### PR TITLE
Fix award year validation

### DIFF
--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -14,7 +14,7 @@ module CandidateInterface
     validates :qualification_type, presence: true
 
     validates :award_year, presence: true
-    validate :award_year_is_at_most_one_year_in_future, if: -> { award_year }
+    validate :award_year_is_within_acceptable_range, if: -> { award_year }
     validates :subject, :grade, presence: true, if: -> { should_validate_grade? }
     validates :subject, :grade, length: { maximum: 255 }
     validates :other_uk_qualification_type, length: { maximum: 100 }
@@ -198,8 +198,8 @@ module CandidateInterface
                               OtherQualificationTypeForm::GCSE_TYPE]
     end
 
-    def award_year_is_at_most_one_year_in_future
-      errors.add(:award_year, :future) if award_year.to_i > RecruitmentCycle.next_year || award_year.to_i.zero?
+    def award_year_is_within_acceptable_range
+      errors.add(:award_year, :future) unless (100.years.ago.year..RecruitmentCycle.next_year).cover?(award_year.to_i)
     end
   end
 end

--- a/app/validators/year_validator.rb
+++ b/app/validators/year_validator.rb
@@ -5,6 +5,7 @@ class YearValidator < ActiveModel::EachValidator
     return if value.blank?
 
     record.errors.add(attribute, :invalid_year, attribute: humanize(attribute)) if outside_acceptable_age_range(value.to_i)
+    record.errors.add(attribute, :multiple_year, attribute: humanize(attribute)) if value.to_s.length > 4
     record.errors.add(attribute, :future, article: article(attribute), attribute: humanize(attribute)) if value.to_i > Time.zone.today.year && options[:future]
   end
 end

--- a/app/views/candidate_interface/gcse/year/_form.html.erb
+++ b/app/views/candidate_interface/gcse/year/_form.html.erb
@@ -2,9 +2,9 @@
 <h1 class="govuk-heading-xl"><%= year_step_title(@subject, @year_form.qualification_type) %></h1>
 
 <% if @year_form.qualification_type == 'gce_o_level' %>
-  <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, hint: { text: t('application_form.gcse.award_year.gce_o_level_hint_text') }, width: 4 %>
+  <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, hint: { text: t('application_form.gcse.award_year.gce_o_level_hint_text') }, type: :number, width: 4 %>
 <% else %>
-  <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, hint: { text: t('application_form.gcse.award_year.hint_text') }, width: 4 %>
+  <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, hint: { text: t('application_form.gcse.award_year.hint_text') }, type: :number, width: 4 %>
 <% end %>
 
 <%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/other_qualifications/details/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/_form.html.erb
@@ -2,7 +2,7 @@
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.optional_label'), size: 'm' } %>
     <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('application_form.other_qualification.institution_country.label'), size: 'm' } %>
     <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.optional_label'), size: 'm' }, width: 10 %>
-    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, width: 4 %>
+    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, type: :number, width: 4 %>
   <% elsif @form.btec? %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
     <%= tag.div(id: 'subject-autosuggest-data', data: { source: subjects }) if subjects %>
@@ -11,7 +11,7 @@
         <%= f.govuk_radio_button :grade, grade, label: { text: grade.to_s }, link_errors: i.zero? %>
       <% end %>
     <% end %>
-    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, width: 4 %>
+    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, type: :number, width: 4 %>
   <% else %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
     <%= tag.div(id: 'subject-autosuggest-data', data: { source: subjects }) if subjects %>
@@ -20,5 +20,5 @@
                            width: ['A level', 'AS level', 'GCSE'].include?(@form.qualification_type) ? 4 : 10,
                            hint: @form.grade_hint %>
     <%= tag.div(id: 'grade-autosuggest-data', data: { source: grades }) if grades %>
-    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, width: 4 %>
+    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, type: :number, width: 4 %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -450,6 +450,7 @@ en:
       too_many_course_choices: You cannot have more than 3 course choices. You must delete a choice if you want to apply to %{course_name_and_code}.
       apply_again_course_already_chosen: You cannot choose more than 1 course when you apply again. You must delete your existing choice if you want to apply to %{course_name_and_code}
       invalid_year: Enter a real %{attribute}
+      multiple_year: Enter a single %{attribute}
       invalid_date: Enter a real %{attribute}
       invalid_date_month_and_year: Enter a real %{attribute}, for example 5 2019
       future: Enter %{article} %{attribute} that is not in the future

--- a/spec/forms/candidate_interface/gcse_year_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_year_form_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CandidateInterface::GcseYearForm, type: :model do
         valid_years = (1951..1988)
 
         valid_years.each do |year|
-          form.award_year = year
+          form.award_year = year.to_s
           form.validate
 
           expect(form.errors[:award_year]).to be_empty

--- a/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
@@ -106,13 +106,21 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
     describe 'award year' do
       context 'year validations' do
         it 'allows award year to be valid for the next recruitment_cycle_year' do
-          valid_award_year = described_class.new(nil, nil, qualification_type: 'A level', award_year: RecruitmentCycle.next_year)
-          invalid_award_year = described_class.new(nil, nil, qualification_type: 'A level', award_year: RecruitmentCycle.next_year + 1)
+          valid_award_year = described_class.new(nil, nil, qualification_type: 'A level', award_year: RecruitmentCycle.next_year.to_s)
+          invalid_award_year = described_class.new(nil, nil, qualification_type: 'A level', award_year: (RecruitmentCycle.next_year + 1).to_s)
 
           valid_award_year.valid?(:details)
           invalid_award_year.valid?(:details)
 
           expect(valid_award_year.errors.full_messages_for(:award_year)).to be_empty
+          expect(invalid_award_year.errors.full_messages_for(:award_year)).not_to be_empty
+        end
+
+        it 'is not valid if the award year is before 1900' do
+          invalid_award_year = described_class.new(nil, nil, qualification_type: 'A level', award_year: '1899')
+
+          invalid_award_year.valid?(:details)
+
           expect(invalid_award_year.errors.full_messages_for(:award_year)).not_to be_empty
         end
       end

--- a/spec/support/shared_examples/year_validations.rb
+++ b/spec/support/shared_examples/year_validations.rb
@@ -23,6 +23,16 @@ RSpec.shared_examples 'year validations' do |year_field, validations|
         expect(model.errors.added?(year_field, :invalid_year, attribute: humanize(year_field))).to eq(true)
       end
     end
+
+    context 'when multiple years are submitted' do
+      let(:year) { '2020 - 2021' }
+
+      it 'returns :invalid_year error' do
+        expect(model).to be_invalid
+
+        expect(model.errors.added?(year_field, :multiple_year, attribute: humanize(year_field))).to eq(true)
+      end
+    end
   end
 
   describe 'when in the future', if: validations && validations[:future] do


### PR DESCRIPTION
## Context

When completing GCSE and other qualifications details candidates can enter multiple award years and other funky variations.

If the form does not add `type: :integer` to the award year field it is possible for candidates to enter other variants of award year e.g '2020- 2021'. The year validator was not picking up on this because it calls `#to_i` on the string which returns the first year in the string i.e. '2020'

## Changes proposed in this pull request

- Add `type: :number` to GSCE award year field and Other quals award year field
- Add additional validation to the year validator

## Guidance to review

- The GCSE and Other quals award fields should accept number input only
- Where an award year field does not accept number input only, the year validator should return an error if the candidate enters a string that contains more than a single year e.g. '2020 - 2021', '2020 / 2021', '2020 and 2021' etc

## Link to Trello card

https://trello.com/c/COchnPJ7/4057-fix-validation-for-award-year-for-gcses-a-levels-and-other-qualifications

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
