### PR TITLE
Fix redirect on update science double award

### DIFF
--- a/app/controllers/candidate_interface/gcse/science/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/science/grade_controller.rb
@@ -36,9 +36,9 @@ module CandidateInterface
         return redirect_to candidate_interface_application_review_path if redirect_back_to_application_review_page?
 
         if current_qualification.failed_required_gcse?
-          candidate_interface_gcse_details_edit_grade_explanation_path(@subject)
+          redirect_to candidate_interface_gcse_details_edit_grade_explanation_path(@subject)
         else
-          candidate_interface_gcse_review_path(@subject)
+          redirect_to candidate_interface_gcse_review_path(@subject)
         end
       else
         track_validation_error(@gcse_grade_form)


### PR DESCRIPTION
## Context
EoC bug 🐛 : no redirect after updating double award science GCSE

## Changes proposed in this pull request

adding redirect

## Guidance to review

## Link to Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
