### PR TITLE
Deprecate working with children

### DIFF
--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+## 13th October
+
+Documentation:
+
+Mark `working_with_children` as deprecated and nullable. This field can contain `null` values as we no longer collect this information.
+
 ## 10th October
 
 Adds the attribute `application_url`, this is the URL of the application details in 'Manage teacher training applications'.

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -1075,7 +1075,6 @@ components:
       - end_date
       - role
       - description
-      - working_with_children
       - commitment
       properties:
         id:
@@ -1110,7 +1109,9 @@ components:
           example: I lead, develop and enhance the literacy teaching practice of others...
         working_with_children:
           type: boolean
-          description: Did this position involve working in a school or with children?
+          nullable: true
+          deprecated: true
+          description: 'Did this position involve working in a school or with children? DEPRECATED: this field will be null for new applications as Apply no longer collects this information.'
           example: true
         commitment:
           nullable: true


### PR DESCRIPTION
We aren't collecting this information anymore, allow `null` values to be returned in the API and mark as deprecated

