### PR TITLE
Fix revealing ethnic group in question

### DIFF
--- a/app/components/provider_interface/diversity_information_component.rb
+++ b/app/components/provider_interface/diversity_information_component.rb
@@ -17,7 +17,7 @@ module ProviderInterface
         rows << { key: I18n.t('equality_and_diversity.disability_status.title'), value: row_value(disability_status) }
         rows << { key: I18n.t('equality_and_diversity.disabilities.title'), value: row_value(disability_value.html_safe) } if disability_status == 'Yes'
         rows << { key: I18n.t('equality_and_diversity.ethnic_group.title'), value: row_value(equality_and_diversity['ethnic_group']) }
-        if equality_and_diversity['ethnic_background'].present?
+        if equality_and_diversity['ethnic_background'].present? && application_in_correct_state?
           rows << {
             key: I18n.t('equality_and_diversity.ethnic_background.title', group: equality_and_diversity['ethnic_group']),
             value: row_value(equality_and_diversity['ethnic_background']),

--- a/spec/components/provider_interface/diversity_information_component_spec.rb
+++ b/spec/components/provider_interface/diversity_information_component_spec.rb
@@ -164,6 +164,7 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
           expect(result.text).to include("You'll be able to view this if the candidate accepts an offer for this application.")
+          expect(result.text).not_to include('Which of the following best describes your Asian or Asian British background?')
         end
       end
 


### PR DESCRIPTION
## Context

A candidate's ethnic group is used to form the question about their ethnic background. We should not reveal this unless the application is under offer, pending conditions etc.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Check that the application is in one of the correct states before rendering the question about ethnic background.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
