### PR TITLE
Fix undefined method error on missing_qualification?

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -52,7 +52,7 @@ module CandidateInterface
 
     def section_or_gcse_incomplete?
       gcse_completed = "#{@subject}_gcse_completed"
-      (!@application_form.send(gcse_completed) || @application_form.send("#{@subject}_gcse").incomplete_gcse_information?) && !@application_qualification.missing_qualification?
+      (!@application_form.send(gcse_completed) || @application_form.send("#{@subject}_gcse")&.incomplete_gcse_information?) && !@application_qualification&.missing_qualification?
     end
 
     def qualification_row


### PR DESCRIPTION
## Context

A small number of candidates are encountering `undefined method 'missing_qualification?' for nil:NilClass`:
https://sentry.io/organizations/dfe-bat/issues/2660550362/events/?project=1765973&referrer=slack

After taking a look at these candidates it appears that they never populated their first application with GCSE information, so when they come to review the previous application after carrying over they hit the error – as a result they can't view the application at all.

## Changes proposed in this pull request

Add safe navigators to the `incomplete_gcse_information?` method.

## Guidance to review

This has only happened to 5 candidates... but is this fix a bit cheap? ... i.e. would be better to be a bit more thorough with this?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
