### PR TITLE
Create data migration to fix formatting of qualification award years

### DIFF
--- a/app/services/data_migrations/fix_qualification_award_year.rb
+++ b/app/services/data_migrations/fix_qualification_award_year.rb
@@ -1,0 +1,48 @@
+module DataMigrations
+  class FixQualificationAwardYear
+    TIMESTAMP = 20211014091914
+    MANUAL_RUN = false
+
+    def change
+      ApplicationQualification
+        .includes(:application_form)
+        .where(application_form: { recruitment_cycle_year: RecruitmentCycle.current_year })
+        .where(level: %i[gcse other])
+        .where('length(award_year) > 4')
+        .find_each do |qualification|
+        year_to_update_to = nil
+
+        if award_year_matches_pattern_one?(qualification)
+          year_to_update_to = qualification.award_year.split.last
+        end
+
+        if award_year_matches_pattern_two?(qualification)
+          year_to_update_to = qualification.award_year.split('/').last
+        end
+
+        if award_year_matches_pattern_three?(qualification)
+          first_year, last_year = qualification.award_year.split('/')
+          year_to_update_to = first_year[0..1] + last_year
+        end
+
+        if year_to_update_to
+          qualification.update(award_year: year_to_update_to, audit_comment: 'Fixing award year formatting')
+        end
+      end
+    end
+
+  private
+
+    def award_year_matches_pattern_one?(qualification)
+      /\A\d{4} (-|and|\/) \d{4}\z/.match?(qualification.award_year)
+    end
+
+    def award_year_matches_pattern_two?(qualification)
+      /\A\d{4}\/\d{4}\z/.match?(qualification.award_year)
+    end
+
+    def award_year_matches_pattern_three?(qualification)
+      /\A\d{4}\/\d{2}\z/.match?(qualification.award_year)
+    end
+  end
+end

--- a/spec/services/data_migrations/fix_qualification_award_year_spec.rb
+++ b/spec/services/data_migrations/fix_qualification_award_year_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::FixQualificationAwardYear do
+  let(:application_form) { create(:application_form, :minimum_info, recruitment_cycle_year: RecruitmentCycle.current_year) }
+
+  context "when qualification award year has the pattern 'YYYY - YYYY'" do
+    it 'updates the application qualification with the second year' do
+      gcse_qualification = create(:gcse_qualification, award_year: '2020 - 2021', application_form: application_form)
+      other_qualification = create(:other_qualification, award_year: '2020 - 2021', application_form: application_form)
+
+      described_class.new.change
+      gcse_qualification.reload
+      other_qualification.reload
+
+      expect(gcse_qualification.award_year).to eq('2021')
+      expect(other_qualification.award_year).to eq('2021')
+    end
+  end
+
+  context "when qualification award year has the pattern 'YYYY / YYYY'" do
+    it 'updates the application qualification with the second year' do
+      gcse_qualification = create(:gcse_qualification, award_year: '2020 / 2021', application_form: application_form)
+      other_qualification = create(:other_qualification, award_year: '2020 / 2021', application_form: application_form)
+
+      described_class.new.change
+      gcse_qualification.reload
+      other_qualification.reload
+
+      expect(gcse_qualification.award_year).to eq('2021')
+      expect(other_qualification.award_year).to eq('2021')
+    end
+  end
+
+  context "when qualification award year has the pattern 'YYYY/YYYY'" do
+    it 'updates the application qualification with the second year' do
+      gcse_qualification = create(:gcse_qualification, award_year: '2020/2021', application_form: application_form)
+      other_qualification = create(:other_qualification, award_year: '2020/2021', application_form: application_form)
+
+      described_class.new.change
+      gcse_qualification.reload
+      other_qualification.reload
+
+      expect(gcse_qualification.award_year).to eq('2021')
+      expect(other_qualification.award_year).to eq('2021')
+    end
+  end
+
+  context "when qualification award year has the pattern 'YYYY/YY'" do
+    it 'updates the application qualification with the correctly formatted second year' do
+      gcse_qualification = create(:gcse_qualification, award_year: '2020/21', application_form: application_form)
+      other_qualification = create(:other_qualification, award_year: '2020/21', application_form: application_form)
+
+      described_class.new.change
+      gcse_qualification.reload
+      other_qualification.reload
+
+      expect(gcse_qualification.award_year).to eq('2021')
+      expect(other_qualification.award_year).to eq('2021')
+    end
+  end
+
+  context "when qualification award year has the pattern 'YYYY and YYYY'" do
+    it 'updates the application qualification with the second year' do
+      gcse_qualification = create(:gcse_qualification, award_year: '2020 and 2021', application_form: application_form)
+      other_qualification = create(:other_qualification, award_year: '2020 and 2021', application_form: application_form)
+
+      described_class.new.change
+      gcse_qualification.reload
+      other_qualification.reload
+
+      expect(gcse_qualification.award_year).to eq('2021')
+      expect(other_qualification.award_year).to eq('2021')
+    end
+  end
+
+  context "when qualification award year has the correct pattern i.e. 'YEAR'" do
+    it 'leaves the award year untouched' do
+      gcse_qualification = create(:gcse_qualification, award_year: '2020', application_form: application_form)
+      other_qualification = create(:gcse_qualification, award_year: '2020', application_form: application_form)
+
+      described_class.new.change
+      gcse_qualification.reload
+      other_qualification.reload
+
+      expect(gcse_qualification.award_year).to eq('2020')
+      expect(other_qualification.award_year).to eq('2020')
+    end
+  end
+end


### PR DESCRIPTION
## Context

[Until recently](https://github.com/DFE-Digital/apply-for-teacher-training/pull/5835) candidates where able to enter variants of award years e.g '2002 / 2003' rather than a single year i.e '2003'


## Changes proposed in this pull request

This is a followup PR to fix the data for award years that have a pattern that does not match `YYYY`

## Guidance to review

- Make sense?
- Note this does not fix all the issues, any remaining will need to be done manually

## Link to Trello card

https://trello.com/c/COchnPJ7/4057-fix-validation-for-award-year-for-gcses-a-levels-and-other-qualifications

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
