### PR TITLE
Fix bug with personal details review component

### DIFF
--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -53,7 +53,7 @@ module CandidateInterface
     def date_of_birth_row
       {
         key: I18n.t('application_form.personal_details.date_of_birth.label'),
-        value: @personal_details_form.date_of_birth&.to_s(:govuk_date),
+        value: @personal_details_form.date_of_birth.is_a?(Date) ? @personal_details_form.date_of_birth.to_s(:govuk_date) : nil,
         action: (if @editable
                    {
                      href: candidate_interface_edit_name_and_dob_path(return_to_params),

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -86,6 +86,26 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter, mid_cycle: tr
         ),
       )
     end
+
+    it 'returns nil when date of birth is not present' do
+      personal_details_form = build(
+        :personal_details_form,
+        first_name: 'Max',
+        last_name: 'Caulfield',
+        day: nil,
+        month: nil,
+        year: nil,
+      )
+
+      expect(rows(personal_details_form: personal_details_form)).to include(
+        row_for(
+          :date_of_birth,
+          nil,
+          candidate_interface_edit_name_and_dob_path('return-to' => 'application-review'),
+          'personal-details-dob',
+        ),
+      )
+    end
   end
 
   context 'when presenting nationality' do


### PR DESCRIPTION
## Context

At the moment, if a candidate carries over an application form where they didn't input their date of birth, then tries to view the application from post submission, this blows up.

## Changes proposed in this pull request

- Check to see if date of birth is a date time and if not return nil

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
