### PR TITLE
Fix flaky test setup

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,6 +3,8 @@
 Devise.setup do |config|
   require 'devise/orm/active_record'
 
+  config.secret_key = Rails.application.secret_key_base if Rails.env.test?
+
   config.case_insensitive_keys = [:email]
 
   config.strip_whitespace_keys = [:email]


### PR DESCRIPTION
## Changes proposed in this pull request
Set devise secret key manually to avoid flaky test setup

I think this value is the default anyway, but for some reason it doesn't get set when running `rake parallel:setup`

## Guidance to review
Not sure if this is going to fix it...

## Link to Trello card
https://trello.com/c/z7g2FU3L/4357-flakey-setup-devise-initializer