### PR TITLE
Scope R4R dashboard counts to current recruitment cycle

### DIFF
--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.rb
@@ -1,8 +1,12 @@
 module SupportInterface
   class ReasonsForRejectionDashboardComponent < ViewComponent::Base
     include ViewHelper
-    def initialize(rejection_reasons)
+
+    attr_reader :total_structured_rejection_reasons_count
+
+    def initialize(rejection_reasons, total_structured_rejection_reasons_count)
       @rejection_reasons = rejection_reasons
+      @total_structured_rejection_reasons_count = total_structured_rejection_reasons_count
     end
 
   private
@@ -17,10 +21,6 @@ module SupportInterface
 
     def percentage_rejected_for_reason(reason)
       formatted_percentage(total_rejection_count(reason), total_structured_rejection_reasons_count)
-    end
-
-    def total_structured_rejection_reasons_count
-      @total_structured_rejection_reasons_count ||= ApplicationChoice.where.not(structured_rejection_reasons: nil).count
     end
 
     def sub_reasons_for(reason)

--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -25,7 +25,9 @@ module SupportInterface
     end
 
     def reasons_for_rejection_dashboard
-      @reasons_for_rejection = ReasonsForRejectionCountQuery.new.sub_reason_counts
+      query = ReasonsForRejectionCountQuery.new
+      @reasons_for_rejection = query.sub_reason_counts
+      @total_structured_rejection_reasons_count = query.total_structured_reasons_for_rejection
     end
 
     def reasons_for_rejection_application_choices

--- a/app/queries/reasons_for_rejection_count_query.rb
+++ b/app/queries/reasons_for_rejection_count_query.rb
@@ -5,7 +5,10 @@ class ReasonsForRejectionCountQuery
   Result = Struct.new(:all_time, :this_month, :sub_reasons)
 
   def total_structured_reasons_for_rejection
-    ApplicationChoice.where.not(structured_rejection_reasons: nil).count
+    ApplicationChoice
+      .where(current_recruitment_cycle_year: RecruitmentCycle.current_year)
+      .where.not(structured_rejection_reasons: nil)
+      .count
   end
 
   def reason_counts
@@ -111,6 +114,7 @@ private
       jsonb_each_text(structured_rejection_reasons) AS reasons
     WHERE structured_rejection_reasons IS NOT NULL
       AND reasons.value = 'Yes'
+      AND current_recruitment_cycle_year = '#{RecruitmentCycle.current_year}'
     GROUP BY (key, time_period)
     ORDER BY count(*) DESC;
     "
@@ -132,6 +136,7 @@ private
       jsonb_array_elements_text(reasons.value) AS sub_reasons
     WHERE structured_rejection_reasons IS NOT NULL
       AND jsonb_typeof(reasons.value) = 'array'
+      AND current_recruitment_cycle_year = '#{RecruitmentCycle.current_year}'
     GROUP BY (key, sub_reasons.value, time_period);
     "
   end

--- a/app/views/support_interface/performance/reasons_for_rejection_dashboard.html.erb
+++ b/app/views/support_interface/performance/reasons_for_rejection_dashboard.html.erb
@@ -7,4 +7,4 @@
   }) %>
 <% end %>
 
-<%= render SupportInterface::ReasonsForRejectionDashboardComponent.new(@reasons_for_rejection) %>
+<%= render SupportInterface::ReasonsForRejectionDashboardComponent.new(@reasons_for_rejection, @total_structured_rejection_reasons_count) %>


### PR DESCRIPTION
## Context

We'd like to see reasons for rejections counts for the current cycle before we start work on the next iteration of the feature.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Scopes all count queries to the current recruitment cycle.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/k3y1Qjkb/4393-scope-current-r4r-board-to-current-cycle
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
