### PR TITLE
Make work history uneditable for support interface

### DIFF
--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -35,7 +35,7 @@
 
 <% if @application_form.feature_restructured_work_history %>
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.work_experience') %></h2>
-  <%= render(RestructuredWorkHistory::ReviewComponent.new(application_form: @application_form)) %>
+  <%= render(RestructuredWorkHistory::ReviewComponent.new(application_form: @application_form, editable: false)) %>
 <% else %>
   <h3 class="govuk-heading-m"><%= t('page_titles.work_history') %></h3>
   <%= render(WorkHistoryComponent.new(application_form: @application_form)) %>


### PR DESCRIPTION
## Context

https://trello.com/c/4dL8MESI/4335-change-delete-links-on-work-experience-do-not-work-in-support

## Changes proposed in this pull request

Changed the support interface application work history section to no longer be editable. 

## Guidance to review

### Before
![image](https://user-images.githubusercontent.com/25597009/137354868-fa5ca0c6-491b-4f5a-bed9-4f94b470ecd2.png)

### After

![image](https://user-images.githubusercontent.com/25597009/137354944-71a15209-47ec-43f2-9aa0-750bae41d8c6.png)