### PR TITLE
Post each section of slack integration vendor message separately if e…

### DIFF
--- a/spec/workers/vendor_integration_stats_worker_spec.rb
+++ b/spec/workers/vendor_integration_stats_worker_spec.rb
@@ -3,22 +3,40 @@ require 'rails_helper'
 RSpec.describe VendorIntegrationStatsWorker do
   describe '#perform' do
     let(:worker) { described_class.new }
+    let(:messages) { ['test'] }
 
     before do
       double = instance_double(VendorIntegrationStatsWorker::SlackReport)
-      allow(double).to receive(:generate).and_return('test')
+      allow(double).to receive(:generate).and_return(messages)
       allow(VendorIntegrationStatsWorker::SlackReport).to receive(:new).and_return(double)
     end
 
-    it 'determines the environment variable for webhook url from the vendor name' do
-      slack_request = stub_request(:post, 'https://example.com/webhook')
-        .to_return(status: 200, headers: {})
+    context 'posting the request successfully' do
+      it 'determines the environment variable for webhook url from the vendor name' do
+        slack_request = stub_request(:post, 'https://example.com/webhook')
+          .to_return(status: 200, headers: {})
 
-      ClimateControl.modify TRIBAL_INTEGRATION_STATS_SLACK_URL: 'https://example.com/webhook' do
-        worker.perform('tribal')
+        ClimateControl.modify TRIBAL_INTEGRATION_STATS_SLACK_URL: 'https://example.com/webhook' do
+          worker.perform('tribal')
+        end
+
+        expect(slack_request).to have_been_made
       end
 
-      expect(slack_request).to have_been_made
+      context 'when the request is too long' do
+        let(:messages) { ['test' * 300, 'this' * 400, 'string' * 500] }
+
+        it 'posts each section separately' do
+          slack_request = stub_request(:post, 'https://example.com/webhook')
+            .to_return(status: 200, headers: {})
+
+          ClimateControl.modify TRIBAL_INTEGRATION_STATS_SLACK_URL: 'https://example.com/webhook' do
+            worker.perform('tribal')
+          end
+
+          expect(slack_request).to have_been_made.times(messages.count)
+        end
+      end
     end
 
     it 'does not send a Slack notification if the environment variable is empty' do
@@ -77,7 +95,7 @@ RSpec.describe VendorIntegrationStatsWorker do
       end
 
       it 'generates a text-based report for sending to Slack' do
-        report = slack_report.generate
+        report = slack_report.generate.join('\n')
         expect(report).to include('```')
         expect(report).to include('Tribal')
         expect(report).to include('Never connected via API')
@@ -101,11 +119,10 @@ RSpec.describe VendorIntegrationStatsWorker do
       end
 
       it 'renders the error rate correctly' do
-        report = slack_report.generate
+        report = slack_report.generate.join("\n")
 
         expect(report).to include("Hogwards                                          \t                 50.00%\n")
         expect(report).to include("Durmstrang                                        \t                 18.18%\n")
-        expect(report).to include("Uagadou                                           \t                       \n")
       end
     end
   end


### PR DESCRIPTION
…ntire message is over 4K character limit.

## Context

The problem with the Slack report formatting were caused because we were exceeding the 4K allowed message character limit, which resulted in Slack spltting the message in multiple posts and breaking the report.

As it's unlikely to reach 4K chars for each section of the report, if the total length of the message exceeds that length I simply post each section separately.

https://ukgovernmentdfe.slack.com/archives/CQA59PB98/p1634230236106900


## Link to Trello card

https://trello.com/c/mAd1SbH0/4386-investigate-issue-with-vendor-slack-report-formatting

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
