### PR TITLE
Document length for Qualification.hesa_degstdt in the API

### DIFF
--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -913,14 +913,15 @@ components:
         hesa_degstdt:
           type: string
           description: Degree start date in ISO8601 format
-          format: date-time
-          example: 2019-09-18T15:33:49.216Z
+          format: date
+          example: 2019-09-18
+          maxLength: 10
           nullable: true
         hesa_degenddt:
           type: string
           description: Degree end date in ISO8601 format
-          format: date-time
-          example: 2019-09-18T15:33:49.216Z
+          format: date
+          example: 2019-09-18
           maxLength: 10
           nullable: true
     Reference:


### PR DESCRIPTION
- also update hesa_degenddt length to match example

## Context
Update documentation to include field length

## Link to Trello card

https://trello.com/c/ZhFTn81r/4343-document-maxlength-for-hesadegstdt-in-api

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
