### PR TITLE
Add character limit for attribution_meta properties

### DIFF
--- a/app/models/vendor_api/attribution_meta.rb
+++ b/app/models/vendor_api/attribution_meta.rb
@@ -5,6 +5,8 @@ module VendorAPI
     attr_accessor :full_name, :email, :user_id
 
     validates :full_name, :email, :user_id, presence: true
+    validates :full_name, length: { maximum: 120 }
+    validates :email, :user_id, length: { maximum: 100 }
 
     def initialize(attrs = {})
       @full_name = attrs[:full_name]

--- a/spec/models/vendor_api/attribution_meta_spec.rb
+++ b/spec/models/vendor_api/attribution_meta_spec.rb
@@ -6,4 +6,8 @@ RSpec.describe VendorAPI::AttributionMeta do
   it { is_expected.to validate_presence_of :full_name }
   it { is_expected.to validate_presence_of :email }
   it { is_expected.to validate_presence_of :user_id }
+
+  it { is_expected.to validate_length_of(:full_name).is_at_most(120) }
+  it { is_expected.to validate_length_of(:email).is_at_most(100) }
+  it { is_expected.to validate_length_of(:user_id).is_at_most(100) }
 end


### PR DESCRIPTION
## Context
Implements character limits on the fields for the Attribution object:

```
Attribution.properties.full_name.maxLength   120
Attribution.properties.email.maxLength       100
Attribution.properties.user_id.maxLength     100
```

The attribution object fields map to the `VendorApiUser` equivalent fields and there are currently no entries in either sandbox or production the limits mentioned above.

## Link to Trello card
https://trello.com/c/srBXguM6/4344-restrict-field-lengths-in-api-attribution-object

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
