### PR TITLE
Add robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,2 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Google somehow crawled our mailer previews on QA — the page lacks a `noindex` directive because we don't control the HTML. Tell Google not to crawl anything at all so this doesn't happen again.
