### PR TITLE
Update copy for the generic status 500 page to let users know when theres a problem with the service

### DIFF
--- a/service_unavailable_page/web/public/internal/index.html
+++ b/service_unavailable_page/web/public/internal/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>Sorry, there is a problem with the service - Apply for teacher training - GOV.UK</title>
+    <title>Sorry, there’s a problem with the service - Apply for teacher training - GOV.UK</title>
     <meta name="robots" content="noindex, nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
@@ -30,8 +30,8 @@
             </span>
           </a>
         </div>
-        <div class="govuk-header__product-name">    Apply for teacher training
-          <strong class="govuk-tag">Beta</strong>
+        <div class="govuk-header__product-name">
+          Apply for teacher training
         </div>
       </div>
     </header>
@@ -39,8 +39,11 @@
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-xl">Sorry, this service is unavailable</h1>
-            <p class="govuk-body">If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.</p>
+            <h1 class="govuk-heading-l">Sorry, there’s a problem with the service</h1>
+            <p class="govuk-body">Try again later.</p>
+            <p class="govuk-body">If you reached this page after submitting information then it has not been saved. You’ll need to enter it again when the service is available.</p>
+            <p class="govuk-body">If you have any questions, email us at<br>
+            <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
           </div>
         </div>
       </main>
@@ -49,6 +52,16 @@
       <div class="govuk-width-container">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+            <h2 class="govuk-heading-m">Get help</h2>
+            <div class="govuk-grid-row govuk-!-margin-bottom-5">
+              <div class=" govuk-grid-column-one-half">
+                <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Email</h2>
+                <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
+                  <li><a class="govuk-footer__link" href=" mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> </li>
+                  <li>You’ll get a response within 5 working days, or one working day for urgent requests.</li>
+                </ul>
+              </div>
+            </div>
           </div>
           <div class="govuk-footer__meta-item">
             <a class="govuk-footer__link govuk-footer__copyright-logo govuk-!-margin-bottom-1" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>


### PR DESCRIPTION
## Context
We've updated the copy of the status page we show to users when there's a 500 error to let users know when there's a problem with the service 


## Guidance to review
<img width="1061" alt="Screenshot 2021-10-15 at 15 23 34" src="https://user-images.githubusercontent.com/159200/137503241-435784dc-b650-4b25-9c5c-18c13cf5c596.png">

## Link to Trello card
https://trello.com/c/guwfGpGe/4389-update-copy-for-the-generic-status-500-page-to-let-users-know-when-theres-a-problem-with-the-service

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
