### PR TITLE
Improve StateTransitionError messaging in the API

### DIFF
--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -79,7 +79,7 @@ module VendorAPI
       render status: :unprocessable_entity, json: {
         errors: [
           error: 'StateTransitionError',
-          message: 'The application is not ready for that action',
+          message: I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition'),
         ],
       }
     rescue ProviderAuthorisation::NotAuthorisedError => e

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -437,7 +437,7 @@ en:
         application_choice:
           attributes:
             status:
-              invalid_transition: The application is not ready for that action
+              invalid_transition: It's not possible to perform this action while the application is in its current state
         provider_agreement:
           attributes:
             accept_agreement:

--- a/spec/requests/vendor_api/post_conditions_met_spec.rb
+++ b/spec/requests/vendor_api/post_conditions_met_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-conditio
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-    expect(error_response['message']).to eq 'The application is not ready for that action'
+    expect(error_response['message']).to eq "It's not possible to perform this action while the application is in its current state"
   end
 
   it 'returns not found error when the application was not found' do

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-      expect(error_response['message']).to eq 'The application is not ready for that action'
+      expect(error_response['message']).to eq "It's not possible to perform this action while the application is in its current state"
     end
 
     it 'returns a not found error if the application cannot be found' do

--- a/spec/requests/vendor_api/post_reject_application_spec.rb
+++ b/spec/requests/vendor_api/post_reject_application_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-    expect(error_response['message']).to eq 'The application is not ready for that action'
+    expect(error_response['message']).to eq "It's not possible to perform this action while the application is in its current state"
   end
 
   it 'returns an error when a proper reason is not provided' do


### PR DESCRIPTION
## Context

Change the generic state transition message to `It's not possible to perform this action while the application is in its current state.`. Further investigation will take place from the design team as having more specific errors requires substantially more work. This is because the workflow gem does not expose the state and event when throwing an exception, nor does it allow us to modify the posted message.

## Link to Trello card

https://trello.com/c/kKH8D6vU/4247-improve-statetransitionerror-messaging-in-the-api
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
