### PR TITLE
Change the order of the before_actions in the References::EmailAddressController

### DIFF
--- a/app/controllers/candidate_interface/references/email_address_controller.rb
+++ b/app/controllers/candidate_interface/references/email_address_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   module References
     class EmailAddressController < BaseController
-      before_action :verify_email_is_editable, :redirect_to_review_page_unless_reference_is_editable
+      before_action :redirect_to_review_page_unless_reference_is_editable, :verify_email_is_editable
       before_action :set_edit_backlink, only: %i[edit update]
 
       def new


### PR DESCRIPTION
## Context

We've witnessed a few `undefined method 'not_requested_yet?' for nil:NilClass`. These are all originating from the `editable?` method in `ReferencesActionsPolicy`, which gets called by `:verify_email_is_editable`.

Instead we should call `:redirect_to_review_page_unless_reference_is_editable` first, which will redirect back if the reference is missing (`@reference.blank?`).

## Changes proposed in this pull request

From:
```
    class EmailAddressController < BaseController
      before_action :verify_email_is_editable, :redirect_to_review_page_unless_reference_is_editable
```
To:
```
    class EmailAddressController < BaseController
      before_action :redirect_to_review_page_unless_reference_is_editable, :verify_email_is_editable
```
## Guidance to review

Struggling to replicate this locally... so perhaps it's something deeper?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
