### PR TITLE
Ensure we only use matches from the current cycle in the fraud slack messages

### DIFF
--- a/app/services/update_fraud_matches.rb
+++ b/app/services/update_fraud_matches.rb
@@ -21,9 +21,10 @@ class UpdateFraudMatches
     end
 
     message = <<~MSG
-      :face_with_monocle: There’s #{new_match_count} new fraud #{'match'.pluralize(new_match_count)} today :face_with_monocle:
+      \n#{Rails.application.routes.url_helpers.support_interface_fraud_auditing_matches_url}
+      :face_with_monocle: There #{new_match_count == 1 ? 'is' : 'are'} #{new_match_count} new fraud #{'match'.pluralize(new_match_count)} today :face_with_monocle:
       :gavel: #{fraudulent_match_count} #{'match'.pluralize(fraudulent_match_count)} #{fraudulent_match_count == 1 ? 'has' : 'have'} been marked as fraudulent :gavel:
-      :female-detective: In total there’s #{FraudMatch.count} #{'match'.pluralize(FraudMatch.count)} :male-detective:
+      :female-detective: In total there #{total_match_count == 1 ? 'is' : 'are'} #{total_match_count} #{'match'.pluralize(total_match_count)} :male-detective:
     MSG
 
     url = Rails.application.routes.url_helpers.support_interface_fraud_auditing_matches_url
@@ -33,10 +34,14 @@ class UpdateFraudMatches
 private
 
   def new_match_count
-    FraudMatch.where('created_at > ?', 1.day.ago).count
+    @new_match_count ||= FraudMatch.where('created_at > ?', 1.day.ago).count
   end
 
   def fraudulent_match_count
-    FraudMatch.where(fraudulent: true).count
+    @fraudulent_match_count ||= FraudMatch.where(recruitment_cycle_year: CycleTimetable.current_year, fraudulent: true).count
+  end
+
+  def total_match_count
+    @total_match_count ||= FraudMatch.where(recruitment_cycle_year: CycleTimetable.current_year).count
   end
 end

--- a/spec/services/update_fraud_matches_spec.rb
+++ b/spec/services/update_fraud_matches_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe UpdateFraudMatches do
   let(:candidate2) { create(:candidate, email_address: 'exemplar2@example.com') }
   let(:expected_message) do
     <<~MSG
-      :face_with_monocle: There’s 1 new fraud match today :face_with_monocle:
+      \n#{Rails.application.routes.url_helpers.support_interface_fraud_auditing_matches_url}
+      :face_with_monocle: There is 1 new fraud match today :face_with_monocle:
       :gavel: 1 match has been marked as fraudulent :gavel:
-      :female-detective: In total there’s 2 matches :male-detective:
+      :female-detective: In total there are 2 matches :male-detective:
     MSG
   end
 


### PR DESCRIPTION
## Context

We should only be using matches from the current recruitment cycle for our fraud UI updates. This also fixes up some poor grammar.

## Changes proposed in this pull request

- Scope the fraud count to the current cycles fraud matches

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
