### PR TITLE
Update copy for the 503 page

### DIFF
--- a/app/components/shared/service_unavailable_component.html.erb
+++ b/app/components/shared/service_unavailable_component.html.erb
@@ -2,7 +2,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= title_content %></h1>
+    <h1 class="govuk-heading-l"><%= title_content %></h1>
+    <p class="govuk-body"><%= t('service_unavailable.info', date: 'Monday 11 October 2021', time: '3pm') %></p>
     <p class="govuk-body"><%= t('service_unavailable.body') %></p>
+    <p class="govuk-body">
+      <%= t('service_unavailable.questions') %><br>
+      <a class="govuk-link" href="mailto:<%= t('service_unavailable.enquiry_email') %>"><%= t('service_unavailable.enquiry_email') %></a>
+    </p>
   </div>
 </div>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -36,6 +36,16 @@
     <%= govuk_footer(classes: 'govuk-!-display-none-print') do |footer| %>
       <%= footer.meta do %>
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        <h2 class="govuk-heading-m">Get help</h2>
+        <div class="govuk-grid-row govuk-!-margin-bottom-5">
+          <div class=" govuk-grid-column-one-half">
+            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Email</h2>
+            <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
+              <li><a class="govuk-footer__link" href=" mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> </li>
+              <li>You’ll get a response within 5 working days, or one working day for urgent requests.</li>
+            </ul>
+          </div>
+        </div>
       </div>
         <div class="govuk-footer__meta-item">
           <a class="govuk-footer__link govuk-footer__copyright-logo govuk-!-margin-bottom-1" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>

--- a/config/locales/service_unavailable.yml
+++ b/config/locales/service_unavailable.yml
@@ -1,5 +1,8 @@
 en:
   service_unavailable:
     sandbox_title: Sorry, the sandbox is unavailable
-    title: Sorry, this service is unavailable
-    body: If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.
+    title: Sorry, the service is unavailable
+    info: You’ll be able to use the service from %{time} on %{date}.
+    body: If you reached this page after submitting information then it has not been saved. You’ll need to enter it again when the service is available.
+    questions: If you have any questions, email
+    enquiry_email: becomingateacher@digital.education.gov.uk

--- a/spec/components/previews/service_unavailable_component_preview.rb
+++ b/spec/components/previews/service_unavailable_component_preview.rb
@@ -1,4 +1,6 @@
 class ServiceUnavailableComponentPreview < ViewComponent::Preview
+  layout 'layouts/error'
+
   def service_unavailable_page
     render ServiceUnavailableComponent.new
   end

--- a/spec/components/shared/service_unavailable_component_spec.rb
+++ b/spec/components/shared/service_unavailable_component_spec.rb
@@ -4,7 +4,11 @@ RSpec.describe ServiceUnavailableComponent do
   subject(:result) { render_inline(described_class.new) }
 
   it 'renders the page title' do
-    expect(result.text).to include('Sorry, this service is unavailable')
+    expect(result.text).to include('Sorry, the service is unavailable')
+  end
+
+  it 'renders details about when the page will be available again' do
+    expect(result.text).to include('You’ll be able to use the service from 3pm on Monday 11 October 2021')
   end
 
   context 'when the hosting environment is sandbox', sandbox: true do


### PR DESCRIPTION

## Context

Updates the copy for the service maintenance we show to users when there's planned downtime for service maintenance (503 page)


<img width="1173" alt="Screenshot 2021-10-18 at 13 28 06" src="https://user-images.githubusercontent.com/159200/137730396-af133250-5bbc-4143-b679-b95c1c470691.png">


## Link to Trello card
https://trello.com/c/gFFcvTjr/4390-update-copy-for-the-generic-status-503-page-to-let-users-when-theres-downtime-for-planned-maintenance

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
