### PR TITLE
Redirect to start of edit user permissions flow if wizard store is empty

### DIFF
--- a/app/controllers/provider_interface/user_permissions_controller.rb
+++ b/app/controllers/provider_interface/user_permissions_controller.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class UserPermissionsController < UsersController
+    before_action :redirect_to_edit_if_store_cleared, only: %i[check]
+
     def edit
       @previous_page_path = previous_page_path
       provider_permissions = @provider_user.provider_permissions.find_by!(provider: @provider)
@@ -53,6 +55,12 @@ module ProviderInterface
       ProviderPermissions::VALID_PERMISSIONS.each do |permission|
         provider_permissions.send("#{permission}=", wizard.permissions.include?(permission.to_s))
       end
+    end
+
+    def redirect_to_edit_if_store_cleared
+      return if edit_user_permissions_store.read.present?
+
+      redirect_to edit_provider_interface_organisation_settings_organisation_user_permissions_path(@provider, @provider_user)
     end
   end
 end

--- a/spec/requests/provider_interface/user_permissions_controller_spec.rb
+++ b/spec/requests/provider_interface/user_permissions_controller_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe ProviderInterface::UserPermissionsController do
     expect(response.status).to eq(200)
   end
 
+  it 'redirects back to the edit user permissions page when the wizard store is empty' do
+    get check_provider_interface_organisation_settings_organisation_user_permissions_path(provider, managing_user)
+
+    expect(response.status).to eq(302)
+    expect(response.redirect_url).to eq(edit_provider_interface_organisation_settings_organisation_user_permissions_url(provider, managing_user))
+  end
+
   context 'when a user does not have manage orgs permissions' do
     let(:managing_user) { create(:provider_user, :with_manage_organisations, providers: [provider]) }
     let(:provider_user) { create(:provider_user, providers: [provider]) }


### PR DESCRIPTION
## Context

Instead of erroring, redirect to the start of the  user permissions edit flow, when a user presees back after updating user permissions.


## Changes proposed in this pull request

Check if the wizard store is empty, and if it is redirect to the beginning of the flow.


## Guidance to review

1. Edit another user's permissions and click save (https://qa.apply-for-teacher-training.service.gov.uk/provider/organisation-settings/organisations/4036/users/140/permissions/edit)
2. Observe that they are saved and updated correctly
3. Press the browser back button to return to the flow
4. You should be at the beginning of the edit user permissions flow

## Link to Trello card
https://trello.com/c/0aXt3AFa/4341-clicking-back-after-editing-and-saving-provider-user-permissions-results-in-500-error

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
