### PR TITLE
Add one time degree export for User Research

### DIFF
--- a/app/exports/one_time_degree_export.yml
+++ b/app/exports/one_time_degree_export.yml
@@ -1,0 +1,55 @@
+common_columns:
+  - phase
+
+custom_columns:
+  email_address:
+    type: string
+    description: A candidates email address
+    example: joe@bloggs.com
+  name:
+    type: string
+    description: A candidates full name
+    example: Joe Bloggs
+    phone_number:
+      type: string
+      description: A candidates phone number
+      example: '01234 567890'
+  qualification_type:
+    type: string
+    description: The specific type of qualification at a given level
+    example: BSc Computer Science
+    type: string
+  subject:
+    type: string
+    description: The qualification subject
+    example: Chemistry
+  grade:
+    type: string
+    description: The qualification grade
+    example: First class honours
+  start_year:
+    type: integer
+    description: The year the qualification was started
+    example: 1999
+  award_year:
+    type: integer
+    description: The year the qualification was awarded
+    example: 1999
+  predicted_grade:
+    type: boolean
+    description: Whether or not the provided grade is predicted
+  international_degree:
+    type: boolean
+    description: Whether or not this is an international degree. Note that this only applies to qualifications entered via the Degree flow - candidates sometimes enter degrees in the 'A levels and other qualifications' section.
+  institution_name:
+    type: string
+    description: Name of the awarding institution
+    example: Loughborough Grammar School
+  institution_country:
+    type: string
+    description: Country of the awarding institution
+    example: FR
+  application_status:
+    type: string
+    description: The overall status of the candidates application
+    example: ended_without_success

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -198,6 +198,12 @@ class DataExport < ApplicationRecord
       description: 'A list of candidates with breaks in their work history.',
       class: SupportInterface::WorkHistoryBreakExport,
     },
+    one_time_degree_export: {
+      name: 'One time degree export',
+      export_type: 'work_history_break',
+      description: 'A one time export for UR purposes',
+      class: SupportInterface::OneTimeDegreeExport,
+    },
   }.freeze
 
   belongs_to :initiator, polymorphic: true, optional: true

--- a/app/services/support_interface/one_time_degree_export.rb
+++ b/app/services/support_interface/one_time_degree_export.rb
@@ -1,0 +1,38 @@
+module SupportInterface
+  class OneTimeDegreeExport
+    def data_for_export
+      degrees.includes(application_form: :application_choices).find_each(batch_size: 100).map do |degree|
+        candidate = degree.application_form.candidate
+        application_form = degree.application_form
+
+        {
+          email_address: candidate.email_address,
+          name: application_form.full_name,
+          phone_number: application_form.phone_number,
+          phase: application_form.phase,
+          qualification_type: degree.qualification_type,
+          subject: degree.subject,
+          grade: degree.grade,
+          predicted_grade: degree.predicted_grade,
+          start_year: degree.start_year,
+          award_year: degree.award_year,
+          international: degree.international,
+          institution_name: degree.institution_name,
+          institution_country: degree.institution_country,
+          application_status: ProcessState.new(application_form).state,
+        }
+      end
+    end
+
+  private
+
+    def degrees
+      ApplicationQualification
+      .joins(application_form: :candidate)
+      .where(level: 'degree')
+      .where.not(candidates: { hide_in_reporting: true }, application_forms: { submitted_at: nil })
+      .where(application_forms: { recruitment_cycle_year: 2021 })
+      .order('candidates.id')
+    end
+  end
+end


### PR DESCRIPTION
## Context

Adding this in as a one time export as trying to determine an application forms status via the ProcessState abstraction is a nightmare via SQL.

## Changes proposed in this pull request

- One time export for UR on candidates degrees 

## Guidance to review

This will be pulled out as soon as i've run it once.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
