### PR TITLE
Stop logging POST/PUT/PATCH params

### DIFF
--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -8,6 +8,7 @@ if Rails.env.production?
       super(log, logger)
       add_service_type
       add_job_data
+      remove_post_params
       hash.to_json
     end
 
@@ -29,6 +30,16 @@ if Rails.env.production?
         hash['tid'] = tid
         hash['ctx'] = ctx
       end
+    end
+
+    def remove_post_params
+      if method_is_post_or_put_or_patch? && hash.dig(:payload, :params).present?
+        hash[:payload][:params].clear
+      end
+    end
+
+    def method_is_post_or_put_or_patch?
+      hash.dig(:payload, :method).in? %w[PUT POST PATCH]
     end
   end
 


### PR DESCRIPTION
## Context

POST/PUT/PATCH params often contain PII information, which we would like to omit from our logs.

We used to do this, anyway, but we started logging these params with our switch to `semantic_logger`.

## Changes proposed in this pull request

Stop logging these params.

## Guidance to review

You can verify these params are not included using various forms on the service.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
