### PR TITLE
Correctly add no print class to cookies external container

### DIFF
--- a/app/components/utility/cookie_banners_component.html.erb
+++ b/app/components/utility/cookie_banners_component.html.erb
@@ -4,7 +4,7 @@
     aria: {
       label: heading_text,
     },
-    classes: 'govuk-!-display-none-print',
+    class: 'govuk-!-display-none-print',
     data: {
       module: 'govuk-cookie-banner',
       qa: 'cookie-banner',


### PR DESCRIPTION
## Context

When downloading candidate applications, providers are seeing the cookie banner rendered in the PDF. This correctly updates `classes` to `class` to ensure that the `govuk-!-display-none-print` class is correctly added to the appropriate `class` html attribute, preventing the banner from being printed.

## Guidance to review

Login as a provider
Open any application
Click on the `Download application (PDF) link`
The cookies banner should not be printed as part of the downloaded PDF

## Before
<img width="863" alt="Screenshot 2021-10-18 at 15 46 40" src="https://user-images.githubusercontent.com/159200/137754404-895d6247-631e-4429-a53e-7ac48ccbdbed.png">

## After
<img width="857" alt="Screenshot 2021-10-18 at 15 46 33" src="https://user-images.githubusercontent.com/159200/137754378-dc02ede0-a1be-469f-99f7-528f3f910d1b.png">


## Link to Trello card

https://trello.com/c/w1Sm0Moi/4396-cookie-banner-appearing-in-pdf-downloads-of-candidate-applications

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
