### PR TITLE
add presenter to display interview cancellation explanation text

### DIFF
--- a/app/presenters/provider_interface/interview_cancellation_explanation_presenter.rb
+++ b/app/presenters/provider_interface/interview_cancellation_explanation_presenter.rb
@@ -1,0 +1,23 @@
+module ProviderInterface
+  class InterviewCancellationExplanationPresenter
+    attr_reader :application_choice
+
+    def initialize(application_choice)
+      @application_choice = application_choice
+    end
+
+    def render?
+      number_of_interviews_to_be_cancelled.positive?
+    end
+
+    def text
+      I18n.t(:interview_cancellation_explanation, count: number_of_interviews_to_be_cancelled)
+    end
+
+  private
+
+    def number_of_interviews_to_be_cancelled
+      application_choice.interviews.kept.upcoming_not_today.count
+    end
+  end
+end

--- a/config/locales/components/shared.yml
+++ b/config/locales/components/shared.yml
@@ -4,3 +4,8 @@ en:
     vocation: Why do you want to become a teacher?
     subject_knowledge: What do you know about the subject you want to teach?
     further_information: Further information
+
+  interview_cancellation_explanation:
+    one: 'The upcoming interview will be cancelled.'
+    other: 'Upcoming interviews will be cancelled.'
+

--- a/spec/presenters/provider_interface/interview_cancellation_explanation_presenter_spec.rb
+++ b/spec/presenters/provider_interface/interview_cancellation_explanation_presenter_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::InterviewCancellationExplanationPresenter do
+  let(:application_choice) { create(:application_choice) }
+
+  describe 'text' do
+    context 'when there is one interview in the future' do
+      let!(:interview) { create(:interview, date_and_time: 1.day.from_now, application_choice: application_choice) }
+
+      it 'returns the single interview message' do
+        expect(described_class.new(application_choice).text).to eq('The upcoming interview will be cancelled.')
+      end
+    end
+
+    context 'when there are two or more interviews in the future' do
+      let!(:interview) { create(:interview, date_and_time: 3.days.from_now, application_choice: application_choice) }
+      let!(:interview_two) { create(:interview, date_and_time: 2.days.from_now, application_choice: application_choice) }
+
+      it 'returns the multiple interviews message' do
+        expect(described_class.new(application_choice).text).to eq('Upcoming interviews will be cancelled.')
+      end
+    end
+  end
+
+  describe 'render?' do
+    context 'when there is a future interview' do
+      let!(:interview) { create(:interview, date_and_time: 1.day.from_now, application_choice: application_choice) }
+
+      it 'returns true' do
+        expect(described_class.new(application_choice).render?).to eq(true)
+      end
+    end
+
+    context 'when there are no future interviews' do
+      it 'returns false' do
+        expect(described_class.new(application_choice).render?).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We need a presenter to handle the differing text requirements of a single application interview, vs muliple, vs no interviews to cancel.

## Link to Trello card

4409-add-a-component-to-display-interview-cancellation-explanation-in-provider-interface
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
