### PR TITLE
change API maxLength for withdraw offer and reject application

### DIFF
--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -6,7 +6,7 @@ class RejectApplication
   attr_accessor :rejection_reason, :structured_rejection_reasons
 
   validate :at_least_one_rejection_reason_format
-  validates_length_of :rejection_reason, maximum: 10240
+  validates_length_of :rejection_reason, maximum: 65535
 
   def initialize(actor:, application_choice:, rejection_reason: nil, structured_rejection_reasons: nil)
     @auth = ProviderAuthorisation.new(actor: actor)

--- a/app/services/withdraw_offer.rb
+++ b/app/services/withdraw_offer.rb
@@ -5,7 +5,7 @@ class WithdrawOffer
   attr_accessor :offer_withdrawal_reason
 
   validates_presence_of :offer_withdrawal_reason
-  validates_length_of :offer_withdrawal_reason, maximum: 255
+  validates_length_of :offer_withdrawal_reason, maximum: 65535
 
   def initialize(actor:, application_choice:, offer_withdrawal_reason: nil)
     @auth = ProviderAuthorisation.new(actor: actor)


### PR DESCRIPTION
## Context

Change max length of withdraw offer reason to be consistent with the documentation. This means the that the rejection reason field length must also increase, to avoid permitting a too long rejection reason and have it fail at the reject application validator. 

## Link to Trello card

https://trello.com/c/VrVptF7j/4363-increase-character-limit-for-offer-withdrawal-reason-in-the-api

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
