### PR TITLE
add cancel_upcoming_interviews_on_decision_made feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -35,6 +35,7 @@ class FeatureFlag
     [:summer_recruitment_banner, 'Show a banner to indicate a shorter recruitment timeframe during summer', 'Richard Pattinson'],
     [:restructured_immigration_status, 'New model for right to work and study in the UK to be released from 2022 cycle', 'Steve Hook'],
     [:block_fraudulent_submission, 'A button used on the fraud audit page to block submissions', 'James Glenn'],
+    [:cancel_upcoming_interviews_on_decision_made, 'When we make a decision on a candidate, future interviews should be cancelled', 'Richard Pattinson'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day


### PR DESCRIPTION
## Context

We are doing some work to cancel upcoming interviews when decisions are made on an application. This work will not all be done in one go, so will will put it behind a feature flag

## Link to Trello card

https://trello.com/c/yXwpEt6J/4404-add-feature-flag-for-cancelling-upcoming-interviews-when-decisions-made

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
