### PR TITLE
Freeze start time of tests

### DIFF
--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -4,7 +4,7 @@ require 'sidekiq'
 
 RSpec.describe Clockwork, clockwork: true do
   around do |example|
-    Timecop.freeze(Time.zone.now) do
+    Timecop.freeze(Time.zone.now.change(hour: 0, min: 0, sec: 0)) do
       example.run
     end
   end
@@ -17,11 +17,11 @@ RSpec.describe Clockwork, clockwork: true do
     describe 'worker schedule' do
       it 'runs the job every hour' do
         start_time = Time.zone.now
-        end_time = Time.zone.now + 3.hours + 1.minute
+        end_time = Time.zone.now + 3.hours
         Clockwork::Test.run(
           start_time: start_time,
           end_time: end_time,
-          tick_speed: 1.minute,
+          tick_speed: 30.seconds,
           file: './config/clock.rb',
         )
         expect(Clockwork::Test.times_run(worker[:task])).to eq 3


### PR DESCRIPTION
## Context

[A previous attempt to fix this didn't work but did cause the test to fail with a different actual value](https://github.com/DFE-Digital/apply-for-teacher-training/pull/5788).

There's an inconsistent test around the number of jobs run which seems to vary depending on the time the test is run.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This commit freezes the test run at the start of the current hour as the job count is based on hourly jobs at 5-15 mins past the hour.
The tick frequency of the clockwork test class in this spec is also increased so that we always call the clock schedule twice a minute, this should prevent us _just missing_ the next tick. (ie belt and braces)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Eb4WFzug/4399-flakey-test-clockwork-spec
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
