### PR TITLE
Update content in the reference request email and decline page

### DIFF
--- a/app/views/referee_interface/reference/refuse_feedback.html.erb
+++ b/app/views/referee_interface/reference/refuse_feedback.html.erb
@@ -13,9 +13,7 @@
         <%= t('page_titles.referee.refuse_feedback') %>
       </h1>
 
-      <p class="govuk-body">Teacher training courses can fill up quickly, and candidates need 2 references to apply.</p>
-
-      <p class="govuk-body"><%= @application.full_name %> will be able to submit the application quicker if you give a reference.</p>
+      <p class="govuk-body">Declining <%= @application.full_name %>’s reference request may delay their application and make it harder for them to get onto teacher training.</p>
 
       <%= f.govuk_radio_buttons_fieldset :choices, legend: { text: t('referee.refuse_feedback.choice.label', full_name: @application.full_name) } do %>
         <%= f.govuk_radio_button :choice, 'yes', label: { text: t('referee.refuse_feedback.choice.confirm') }, link_errors: true %>

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -2,27 +2,31 @@ Dear <%= @reference.name %>,
 
 <%= @candidate_name %> put us in touch with you to get a reference for their teacher training application.
 
-Please complete the reference form as soon as you can:
+# If you would like to give a reference
+
+Use this form to give your reference:
 
 <%= referee_interface_reference_relationship_url(token: @unhashed_token) %>
 
-Teacher training courses can become full at any time. The sooner <%= @candidate_name %> gets a reference, the more likely it is that they’ll get a place.
+References sent by email will not be accepted.
 
-# What’s in the reference form?
+You’ll be asked to write up to 500 words explaining whether <%= @candidate_name %> has the potential to teach. You could comment on their:
 
-You’ll be asked to:
-
-* confirm how you know <%= @candidate_name %>
-* state whether you know of any reason why they should not work with children
-* provide a reference of up to 500 words (you can talk about the candidate’s teaching potential, their reliability and professionalism, their suitability to work with children and transferable skills, for example)
+* academic skills
+* communication skills
+* reliability and professionalism
+* ability to work with children
+* transferable skills
 
 You can start, save and return to your reference at any time.
 
-The candidate will not be able to see what you write. 
+The candidate will not be able to see what you write.
 
-# If you decline to give a reference
+Teacher training courses can become full at any time. The sooner <%= @candidate_name %> gets a reference, the more likely it is that they’ll get a place.
 
-Let us know as soon as possible:
+# If you do not intend to give a reference
+
+If you cannot meet the requirements outlined above or you decline to give a reference for another reason, let us know as soon as possible:
 
 <%= referee_interface_refuse_feedback_url(token: @unhashed_token) %>
 

--- a/config/locales/referee_interface/referee_interface.yml
+++ b/config/locales/referee_interface/referee_interface.yml
@@ -2,9 +2,9 @@ en:
   referee:
     refuse_feedback:
       choice:
-        label: Are you sure you do not want to give %{full_name} a reference?
-        confirm: Yes, I’m sure
-        cancel: No, I’ve changed my mind
+        label: Can you give %{full_name} a reference?
+        confirm: No, I decline to give a reference
+        cancel: Yes, I can give a reference
     relationship_confirmation:
       legend: Is this correct?
       'yes':

--- a/spec/system/referee_interface/referee_does_not_respond_spec.rb
+++ b/spec/system/referee_interface/referee_does_not_respond_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Referee does not respond in time' do
 
     expect(current_emails.size).to be(1)
 
-    expect(current_email.text).to include('Please complete the reference form as soon as you can')
+    expect(current_email.text).to include('If you would like to give a reference')
   end
 
   def and_an_email_is_sent_to_the_candidate

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature 'Refusing to give a reference' do
   end
 
   def and_choose_that_i_do_actually_want_to_give_a_reference
-    choose 'No, I’ve changed my mind'
+    choose 'Yes, I can give a reference'
     click_button t('continue')
   end
 
@@ -50,7 +50,7 @@ RSpec.feature 'Refusing to give a reference' do
   end
 
   def and_i_confirm_that_i_wont_give_a_reference
-    choose 'Yes, I’m sure'
+    choose 'No, I decline to give a reference'
     click_button t('continue')
   end
 

--- a/spec/system/support_interface/provide_or_refuse_feedback_for_a_feedback_requested_reference_spec.rb
+++ b/spec/system/support_interface/provide_or_refuse_feedback_for_a_feedback_requested_reference_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature 'Support user can access the RefereeInterface' do
   end
 
   def then_i_see_the_refuse_feedback_page
-    expect(page).to have_content "#{@application.full_name} will be able to submit the application quicker if you give a reference"
+    expect(page).to have_content "Declining #{@application.full_name}’s reference request may delay their application and make it harder for them to get onto teacher training."
   end
 
   def when_the_candidates_reference_is_in_the_feedback_provided_state


### PR DESCRIPTION
## Context

Some referees and accidentally declining references. This PR expands/updates the content in the email and decline page to make it more clear that they are choosing to decline the reference request.

## Changes proposed in this pull request

- Email 

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/137882596-c4b692a4-74e5-444e-b587-78283ec6583f.png)|![image](https://user-images.githubusercontent.com/42515961/137882786-97b79879-4253-40c5-841a-229863042b22.png)|

- Decline page 
|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/137882352-482ccf94-5043-415e-bc37-4fdbc559e634.png)|![image](https://user-images.githubusercontent.com/42515961/137882170-81ae0631-8d1c-494f-8d60-ae938f1790a7.png)|

## Guidance to review

https://docs.google.com/document/d/1v_YHugIjejUrlmFSML7N1CCcukXTFuN8977UhEwsO2I/edit#

## Link to Trello card

https://trello.com/c/Pp01vajJ/4069-update-content-of-referee-email

https://trello.com/c/BMaxUSLH/4070-update-content-of-decline-a-reference-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
