### PR TITLE
Reinstate old cookie banner class

### DIFF
--- a/app/components/utility/cookie_banners_component.html.erb
+++ b/app/components/utility/cookie_banners_component.html.erb
@@ -1,10 +1,10 @@
 <% heading_text = "Cookies on #{service_name}" %>
 <%= govuk_cookie_banner(
+  classes: 'govuk-!-display-none-print',
   html_attributes: {
     aria: {
       label: heading_text,
     },
-    class: 'govuk-!-display-none-print',
     data: {
       module: 'govuk-cookie-banner',
       qa: 'cookie-banner',


### PR DESCRIPTION
## Context
Accidentally removed in https://github.com/DFE-Digital/apply-for-teacher-training/pull/5882

## Testing
Test that the banner does not render in the pdf output for an application choice, and that the font looks correct in broswer on all other pages