### PR TITLE
Update country to country or territory on the GCSE flow

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -227,7 +227,7 @@ module CandidateInterface
       return nil unless application_qualification.qualification_type == 'non_uk'
 
       {
-        key: 'Country',
+        key: 'Country or territory',
         value: COUNTRIES_AND_TERRITORIES[application_qualification.institution_country],
         action: {
           href: candidate_interface_gcse_details_edit_institution_country_path(change_path_params),

--- a/config/locales/candidate_interface/gcse_details.yml
+++ b/config/locales/candidate_interface/gcse_details.yml
@@ -51,7 +51,7 @@ en:
   gcse_edit_year:
     page_title: When was your %{subject} %{qualification_type} awarded?
   gcse_edit_institution_country:
-    page_title: In which country did you study for your %{subject} qualification?
+    page_title: In which country or territory did you study for your %{subject} qualification?
   gcse_edit_enic:
     page_title: How your %{subject} qualification compares to a UK qualification
   gcse_summary:


### PR DESCRIPTION
## Context

We're now using country and territory, but the content needs to be updated in a couple of places on the GCSE flow.

## Changes proposed in this pull request

- Use country or territory when a candidate adds a GCSE

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
