### PR TITLE
Fix slack fraud message

### DIFF
--- a/app/services/update_fraud_matches.rb
+++ b/app/services/update_fraud_matches.rb
@@ -27,8 +27,7 @@ class UpdateFraudMatches
       :female-detective: In total there #{total_match_count == 1 ? 'is' : 'are'} #{total_match_count} #{'match'.pluralize(total_match_count)} :male-detective:
     MSG
 
-    url = Rails.application.routes.url_helpers.support_interface_fraud_auditing_matches_url
-    SlackNotificationWorker.perform_async(message, url)
+    SlackNotificationWorker.perform_async(message)
   end
 
 private

--- a/spec/services/update_fraud_matches_spec.rb
+++ b/spec/services/update_fraud_matches_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe UpdateFraudMatches do
     MSG
   end
 
-  let(:expected_url) { Rails.application.routes.url_helpers.support_interface_fraud_auditing_matches_url }
-
   before do
     Timecop.freeze(Time.zone.local(2020, 8, 23, 12, 0o0, 0o0)) do
       create(:application_form, candidate: candidate1, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH', submitted_at: Time.zone.now)
@@ -69,7 +67,7 @@ RSpec.describe UpdateFraudMatches do
 
       described_class.new.save!
 
-      expect(SlackNotificationWorker).to have_received(:perform_async).with(expected_message, expected_url)
+      expect(SlackNotificationWorker).to have_received(:perform_async).with(expected_message)
     end
   end
 end


### PR DESCRIPTION
## Context

This is still sending the url through! My bad 🤦 

## Changes proposed in this pull request

- Remove double link from the slack fraud message
