### PR TITLE
[Revertception] Reinstate 'Ensure candidates get passed to the candidates API on state change'

### DIFF
--- a/adr/0017-application-choice-updated-at.md
+++ b/adr/0017-application-choice-updated-at.md
@@ -46,7 +46,7 @@ This solution will require that spec to be kept up to date with a variety of app
 
 As described so far, this solution only addresses changes from the ApplicationForm model that affect API responses for ApplicationChoices.
 There are other models (e.g. ApplicationQualification or ApplicationWorkExperience) for which changes to their attributes affect their associated applications.
-For these smaller models, we have added a concern PublishedInAPI which touches the application_choices whenever the model is created, updated or deleted.
+For these smaller models, we have added a concern TouchApplicationChoices which touches the application_choices whenever the model is created, updated or deleted.
 
 ## Consequences
 

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -47,7 +47,7 @@ module CandidateInterface
 
       if authentication_token&.still_valid?
         candidate = authentication_token.user
-        candidate.last_signed_in_at.nil?
+        candidate.update!(candidate_api_updated_at: Time.zone.now) if candidate.last_signed_in_at.nil?
         sign_in(candidate, scope: :candidate)
         set_user_context(candidate.id)
         authentication_token.use!

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -1,5 +1,6 @@
 class ApplicationChoice < ApplicationRecord
   include Chased
+  include TouchApplicationFormState
 
   before_create :set_initial_status
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -106,8 +106,7 @@ class ApplicationForm < ApplicationRecord
     if (form.changed & PUBLISHED_FIELDS).any?
       touch_choices
     end
-
-    candidate.update!(candidate_api_updated_at: Time.zone.now) if form.changed.include?('phase')
+    candidate.update!(candidate_api_updated_at: Time.zone.now) if form.changed.include?('phase') || created_at == updated_at
   end
 
   after_commit :geocode_address_if_required

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -1,5 +1,6 @@
 class ApplicationQualification < ApplicationRecord
-  include PublishedInAPI
+  include TouchApplicationChoices
+  include TouchApplicationFormState
 
   EXPECTED_DEGREE_DATA = %i[
     qualification_type
@@ -47,6 +48,7 @@ class ApplicationQualification < ApplicationRecord
   ].freeze
 
   belongs_to :application_form, touch: true
+  has_one :candidate, through: :application_form
 
   scope :degrees, -> { where level: 'degree' }
   scope :gcses, -> { where level: 'gcse' }

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -1,6 +1,7 @@
 class ApplicationReference < ApplicationRecord
   include Chased
-  include PublishedInAPI
+  include TouchApplicationChoices
+  include TouchApplicationFormState
 
   self.table_name = 'references'
 

--- a/app/models/application_volunteering_experience.rb
+++ b/app/models/application_volunteering_experience.rb
@@ -1,5 +1,5 @@
 class ApplicationVolunteeringExperience < ApplicationExperience
-  include PublishedInAPI
+  include TouchApplicationChoices
 
   belongs_to :application_form, touch: true
 

--- a/app/models/application_work_experience.rb
+++ b/app/models/application_work_experience.rb
@@ -1,5 +1,5 @@
 class ApplicationWorkExperience < ApplicationExperience
-  include PublishedInAPI
+  include TouchApplicationChoices
 
   belongs_to :application_form, touch: true
 

--- a/app/models/application_work_history_break.rb
+++ b/app/models/application_work_history_break.rb
@@ -1,5 +1,5 @@
 class ApplicationWorkHistoryBreak < ApplicationRecord
-  include PublishedInAPI
+  include TouchApplicationChoices
 
   belongs_to :application_form, touch: true
 

--- a/app/models/concerns/touch_application_choices.rb
+++ b/app/models/concerns/touch_application_choices.rb
@@ -1,4 +1,4 @@
-module PublishedInAPI
+module TouchApplicationChoices
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/concerns/touch_application_form_state.rb
+++ b/app/models/concerns/touch_application_form_state.rb
@@ -1,0 +1,9 @@
+module TouchApplicationFormState
+  extend ActiveSupport::Concern
+
+  included do
+    before_save do |object|
+      object.application_form.candidate.update_column(:candidate_api_updated_at, Time.zone.now) if !object.application_form.candidate.new_record? && object.application_form.created_at == object.application_form.updated_at
+    end
+  end
+end

--- a/app/models/english_proficiency.rb
+++ b/app/models/english_proficiency.rb
@@ -1,5 +1,5 @@
 class EnglishProficiency < ApplicationRecord
-  include PublishedInAPI
+  include TouchApplicationChoices
 
   audited associated_with: :application_form
 

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -61,6 +61,10 @@ FactoryBot.define do
       withdrawn_at { Time.zone.now }
     end
 
+    trait :unsubmitted do
+      status { :unsubmitted }
+    end
+
     trait :dbd do
       with_offer
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -25,6 +25,29 @@ RSpec.describe ApplicationForm do
         .not_to(change { application_form.application_choices.first.updated_at })
     end
 
+    it 'updates the candidates `candidate_api_updated_at` when phase is updated' do
+      application_form = create(:completed_application_form)
+
+      expect { application_form.update(phase: 'apply_2') }
+        .to(change { application_form.candidate.candidate_api_updated_at })
+    end
+
+    it 'updates the candidates `candidate_api_updated_at` on the first update' do
+      application_form = create(:application_form)
+
+      expect { application_form.update(first_name: 'David') }
+        .to(change { application_form.candidate.candidate_api_updated_at })
+    end
+
+    it 'does not update the candidates `candidate_api_updated_at` on subsequent updates' do
+      application_form = create(:application_form)
+
+      application_form.update(first_name: 'Divad')
+
+      expect { application_form.update(first_name: 'David') }
+        .not_to(change { application_form.candidate.candidate_api_updated_at })
+    end
+
     context 'when the form belongs to a previous recruitment cycle' do
       it 'throws an exception rather than touch an application choice' do
         application_form = create(
@@ -58,13 +81,6 @@ RSpec.describe ApplicationForm do
               .not_to raise_error
           end
         end
-      end
-
-      it 'updates the candidates `candidate_api_updated_at` when phase is updated' do
-        application_form = create(:completed_application_form)
-
-        expect { application_form.update(phase: 'apply_2') }
-          .to(change { application_form.candidate.candidate_api_updated_at })
       end
     end
   end

--- a/spec/models/concerns/touch_application_form_state_spec.rb
+++ b/spec/models/concerns/touch_application_form_state_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe TouchApplicationFormState do
+  describe 'before_save' do
+    context 'application choice is created and the application form has not been updated' do
+      it 'updates the candidate_api_updated_at' do
+        application_form = create(:application_form)
+
+        expect { create(:application_choice, :unsubmitted, application_form: application_form) }
+          .to(change { application_form.candidate.candidate_api_updated_at })
+      end
+    end
+
+    context 'application choice is created and the application form has been updated' do
+      it 'does not update the candidate_api_updated_at' do
+        application_form = create(:application_form, created_at: 1.day.ago)
+
+        expect { create(:application_choice, :unsubmitted, application_form: application_form) }
+          .not_to(change { application_form.candidate.candidate_api_updated_at })
+      end
+    end
+
+    context 'application qualification is created and the application form has not been updated' do
+      it 'updates the candidate_api_updated_at' do
+        application_form = create(:application_form)
+
+        expect { create(:application_qualification, application_form: application_form) }
+          .to(change { application_form.candidate.candidate_api_updated_at })
+      end
+    end
+
+    context 'application qualification is created and the application form has been updated' do
+      it 'does not update the candidate_api_updated_at' do
+        application_form = create(:application_form, created_at: 1.day.ago)
+
+        expect { create(:application_qualification, application_form: application_form) }
+          .not_to(change { application_form.candidate.candidate_api_updated_at })
+      end
+    end
+
+    context 'reference is created and the application form has been updated' do
+      it 'updates the candidate_api_updated_at' do
+        application_form = create(:application_form)
+
+        expect { create(:reference, application_form: application_form) }
+          .to(change { application_form.candidate.candidate_api_updated_at })
+      end
+    end
+
+    context 'reference is created and the application form has not been updated' do
+      it 'does not update the candidate_api_updated_at' do
+        application_form = create(:application_form, created_at: 1.day.ago)
+
+        expect { create(:reference, application_form: application_form) }
+          .not_to(change { application_form.candidate.candidate_api_updated_at })
+      end
+    end
+  end
+end

--- a/spec/presenters/register_api/single_application_presenter_spec.rb
+++ b/spec/presenters/register_api/single_application_presenter_spec.rb
@@ -627,7 +627,7 @@ RSpec.describe RegisterAPI::SingleApplicationPresenter do
     end
 
     it 'doesn’t depend on any fields that don’t cause a touch' do
-      (ApplicationForm.attribute_names - %w[id] - ApplicationForm::PUBLISHED_FIELDS).each do |field|
+      (ApplicationForm.attribute_names - %w[id created_at updated_at] - ApplicationForm::PUBLISHED_FIELDS).each do |field|
         allow(non_uk_application_form).to receive(field).and_call_original
         allow(application_choice.application_form).to receive(field).and_call_original
       end
@@ -635,7 +635,7 @@ RSpec.describe RegisterAPI::SingleApplicationPresenter do
       described_class.new(application_choice).as_json
       described_class.new(non_uk_application_choice).as_json
 
-      (ApplicationForm.attribute_names - %w[id] - ApplicationForm::PUBLISHED_FIELDS).each do |field|
+      (ApplicationForm.attribute_names - %w[id created_at updated_at] - ApplicationForm::PUBLISHED_FIELDS).each do |field|
         expect(non_uk_application_form).not_to have_received(field)
         expect(application_choice.application_form).not_to have_received(field)
       end

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -1114,7 +1114,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     end
 
     it 'doesn’t depend on any fields that don’t cause a touch' do
-      (ApplicationForm.attribute_names - %w[id] - ApplicationForm::PUBLISHED_FIELDS).each do |field|
+      (ApplicationForm.attribute_names - %w[id created_at updated_at] - ApplicationForm::PUBLISHED_FIELDS).each do |field|
         allow(non_uk_application_form).to receive(field).and_call_original
         allow(application_choice.application_form).to receive(field).and_call_original
       end
@@ -1122,7 +1122,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       described_class.new(application_choice).as_json
       described_class.new(non_uk_application_choice).as_json
 
-      (ApplicationForm.attribute_names - %w[id] - ApplicationForm::PUBLISHED_FIELDS).each do |field|
+      (ApplicationForm.attribute_names - %w[id created_at updated_at] - ApplicationForm::PUBLISHED_FIELDS).each do |field|
         expect(non_uk_application_form).not_to have_received(field)
         expect(application_choice.application_form).not_to have_received(field)
       end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -18,17 +18,17 @@ module CandidateHelper
     references_selected
   ].freeze
 
-  def create_and_sign_in_candidate
-    login_as(current_candidate)
+  def create_and_sign_in_candidate(candidate: current_candidate)
+    login_as(candidate)
   end
 
   def application_form_sections
     APPLICATION_FORM_SECTIONS
   end
 
-  def candidate_completes_application_form(with_referees: true, international: false)
+  def candidate_completes_application_form(with_referees: true, international: false, candidate: current_candidate)
     given_courses_exist
-    create_and_sign_in_candidate
+    create_and_sign_in_candidate(candidate: candidate)
     visit candidate_interface_application_form_path
 
     click_link 'Choose your courses'
@@ -44,6 +44,14 @@ module CandidateHelper
 
     candidate_fills_in_restructured_work_experience
     candidate_fills_in_restructured_work_experience_break
+
+    if with_referees
+      candidate_provides_two_referees
+      receive_references
+      Timecop.travel(5.minutes.from_now) do
+        select_references_and_complete_section
+      end
+    end
 
     click_link t('page_titles.volunteering.short')
 
@@ -85,12 +93,6 @@ module CandidateHelper
       click_button 'Continue'
       choose 'Yes, I have completed this section'
       click_button 'Continue'
-    end
-
-    if with_referees
-      candidate_provides_two_referees
-      receive_references
-      select_references_and_complete_section
     end
 
     @application = ApplicationForm.last

--- a/spec/system/candidate_api/candidate_api_application_state_change_triggers_update_spec.rb
+++ b/spec/system/candidate_api/candidate_api_application_state_change_triggers_update_spec.rb
@@ -1,0 +1,188 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate API application status change' do
+  include SignInHelper
+  include CandidateHelper
+
+  around do |example|
+    Timecop.freeze(mid_cycle) do
+      example.run
+    end
+  end
+
+  scenario 'candidate_api_updated_at is updated when each state transition occurs' do
+    given_the_pilot_is_open
+
+    when_i_sign_up
+    then_my_application_status_is_never_signed_in
+    and_my_candidate_api_updated_at_has_been_updated
+
+    when_i_sign_in
+    then_my_application_status_is_unsubmitted_not_started_form
+    and_my_sign_in_updates_my_candidate_api_updated_at
+
+    when_i_complete_a_field_on_my_application_form
+    then_my_application_status_is_unsubmitted_in_progress
+    and_my_first_update_updates_my_candidate_api_updated_at
+
+    when_i_submit_my_application
+    then_my_application_status_is_awaiting_provider_decisions
+    and_my_submission_updates_my_candidate_api_updated_at
+
+    when_i_receive_a_rejection
+    then_my_application_status_is_ended_without_success
+    and_the_rejection_updates_my_candidate_api_updated_at
+
+    when_i_receive_an_offer_with_conditions
+    then_my_application_status_is_awaiting_candidate_response
+    and_the_offer_updates_my_candidate_api_updated_at
+
+    when_i_accept_my_offer
+    then_my_application_status_is_pending_conditions
+    and_my_acceptance_updates_my_candidate_api_updated_at
+
+    when_i_meet_my_conditions
+    then_my_application_status_is_recruited
+    and_me_being_recruited_updates_my_candidate_api_updated_at
+
+    when_i_defer
+    then_my_application_status_is_offer_deferred
+    and_the_deferal_updates_my_candidate_api_updated_at
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def when_i_sign_up
+    @email = "#{SecureRandom.hex}@example.com"
+    visit candidate_interface_sign_up_path
+    check t('authentication.sign_up.accept_terms_checkbox')
+    fill_in t('authentication.sign_up.email_address.label'), with: @email
+    click_on t('continue')
+  end
+
+  def then_my_application_status_is_never_signed_in
+    @candidate = Candidate.last
+    expect(ProcessState.new(@candidate.application_forms.last).state).to eq :never_signed_in
+  end
+
+  def and_my_candidate_api_updated_at_has_been_updated
+    expect(@candidate.candidate_api_updated_at).to eq(Time.zone.now)
+  end
+
+  def when_i_sign_in
+    Timecop.freeze(Time.zone.now + 1.minute) do
+      open_email(@email)
+      click_magic_link_in_email
+      confirm_sign_in
+    end
+  end
+
+  def then_my_application_status_is_unsubmitted_not_started_form
+    expect(ProcessState.new(@candidate.reload.application_forms.last).state).to eq :unsubmitted_not_started_form
+  end
+
+  def and_my_sign_in_updates_my_candidate_api_updated_at
+    expect(@candidate.candidate_api_updated_at).to eq Time.zone.now + 1.minute
+  end
+
+  def when_i_complete_a_field_on_my_application_form
+    Timecop.freeze(Time.zone.now + 10.minutes) do
+      candidate_completes_application_form(candidate: @candidate)
+    end
+  end
+
+  def then_my_application_status_is_unsubmitted_in_progress
+    expect(ProcessState.new(@candidate.reload.application_forms.last).state).to eq :unsubmitted_in_progress
+  end
+
+  def and_my_first_update_updates_my_candidate_api_updated_at
+    expect(@candidate.candidate_api_updated_at).to eq Time.zone.now + 10.minutes
+  end
+
+  def when_i_submit_my_application
+    Timecop.freeze(Time.zone.now + 20.minutes) do
+      candidate_submits_application
+    end
+  end
+
+  def then_my_application_status_is_awaiting_provider_decisions
+    expect(ProcessState.new(@candidate.reload.application_forms.last).state).to eq :awaiting_provider_decisions
+  end
+
+  def and_my_submission_updates_my_candidate_api_updated_at
+    expect(@candidate.candidate_api_updated_at).to eq Time.zone.now + 20.minutes
+  end
+
+  def when_i_receive_a_rejection
+    Timecop.freeze(Time.zone.now + 30.minutes) do
+      ApplicationStateChange.new(@candidate.application_choices.first).reject!
+    end
+  end
+
+  def then_my_application_status_is_ended_without_success
+    expect(ProcessState.new(@candidate.reload.application_forms.last).state).to eq :ended_without_success
+  end
+
+  def and_the_rejection_updates_my_candidate_api_updated_at
+    expect(@candidate.candidate_api_updated_at).to eq Time.zone.now + 30.minutes
+  end
+
+  def when_i_receive_an_offer_with_conditions
+    Timecop.freeze(Time.zone.now + 40.minutes) do
+      @candidate.application_choices.first.update!(status: 'awaiting_provider_decision', offer: create(:offer))
+      ApplicationStateChange.new(@candidate.application_choices.first).make_offer!
+    end
+  end
+
+  def then_my_application_status_is_awaiting_candidate_response
+    expect(ProcessState.new(@candidate.reload.application_forms.last).state).to eq :awaiting_candidate_response
+  end
+
+  def and_the_offer_updates_my_candidate_api_updated_at
+    expect(@candidate.candidate_api_updated_at).to eq Time.zone.now + 40.minutes
+  end
+
+  def when_i_accept_my_offer
+    Timecop.freeze(Time.zone.now + 50.minutes) do
+      ApplicationStateChange.new(@candidate.application_choices.first).accept!
+    end
+  end
+
+  def then_my_application_status_is_pending_conditions
+    expect(ProcessState.new(@candidate.reload.application_forms.last).state).to eq :pending_conditions
+  end
+
+  def and_my_acceptance_updates_my_candidate_api_updated_at
+    expect(@candidate.candidate_api_updated_at).to eq Time.zone.now + 50.minutes
+  end
+
+  def when_i_meet_my_conditions
+    Timecop.freeze(Time.zone.now + 60.minutes) do
+      ApplicationStateChange.new(@candidate.application_choices.first).confirm_conditions_met!
+    end
+  end
+
+  def then_my_application_status_is_recruited
+    expect(ProcessState.new(@candidate.reload.application_forms.last).state).to eq :recruited
+  end
+
+  def and_me_being_recruited_updates_my_candidate_api_updated_at
+    expect(@candidate.candidate_api_updated_at).to eq Time.zone.now + 60.minutes
+  end
+
+  def when_i_defer
+    Timecop.freeze(Time.zone.now + 70.minutes) do
+      ApplicationStateChange.new(@candidate.application_choices.first).defer_offer!
+    end
+  end
+
+  def then_my_application_status_is_offer_deferred
+    expect(ProcessState.new(@candidate.reload.application_forms.last).state).to eq :offer_deferred
+  end
+
+  def and_the_deferal_updates_my_candidate_api_updated_at
+    expect(@candidate.candidate_api_updated_at).to eq Time.zone.now + 70.minutes
+  end
+end


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-teacher-training#5853

## Context

**This was reverted due to a deadlock issue which has hopefully been resolved by this PR #5905**

At the moment, we're not capturing and updating the `candidates_api_updated_at` when an application form transitions between `never_signed_in`, `unsubmitted_not_started_form` and `unsubmitted_in_progress`.

This PR addresses that and adds in a system spec to ensure we're testing that this update occurs when it should.

## Changes proposed in this pull request

- Update candidate_api_updated at is touched when the candidate is created, first signs in and first starts completing their application form
- Ensure the unsubmitted_not_started_form & :unsubmitted_in_progress states are captured if a candidate adds a course first

## Guidance to review

The system spec isn't great. It should really follow the whole user flow, but i don't really have time to do it right now.
I'll card something up for the backlog to do it.

## Link to Trello card

https://trello.com/c/UdPsG0rO/4028-investigate-state-changes-not-being-passed-through-the-candidates-api

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
