### PR TITLE
Ignore unpersisted deselected_provider_permissions

### DIFF
--- a/app/services/save_provider_user.rb
+++ b/app/services/save_provider_user.rb
@@ -4,7 +4,7 @@ class SaveProviderUser
   def initialize(provider_user:, provider_permissions: [], deselected_provider_permissions: [])
     @provider_user = provider_user
     @provider_permissions = provider_permissions
-    @deselected_provider_permissions = deselected_provider_permissions
+    @deselected_provider_permissions = deselected_provider_permissions.select(&:persisted?)
   end
 
   def call!

--- a/spec/services/save_provider_user_spec.rb
+++ b/spec/services/save_provider_user_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe SaveProviderUser do
       expect { described_class.new }.to raise_error(ArgumentError)
       expect { described_class.new(provider_user: ProviderUser.new) }.not_to raise_error
     end
+
+    it 'ignores unpersisted deselected permissions' do
+      persisted_permissions = create(:provider_permissions)
+      service = described_class.new(provider_user: ProviderUser.new, deselected_provider_permissions: [persisted_permissions, build(:provider_permissions)])
+
+      expect(service.deselected_provider_permissions).to eq([persisted_permissions])
+    end
   end
 
   describe '#call!' do


### PR DESCRIPTION
## Context

The Support UI can send initialized but non-persisted permissions to this service which causes the calculated list of deselected permissions to be wrong, we should ignore the non-persisted permissions in this case.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Ignore non-persisted deselected provider permissions
 
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

We think the support UI is the only place this happens but filtering in the service seems sensible.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
