### PR TITLE
Extract reusable wizard code into modules

### DIFF
--- a/app/controllers/provider_interface/reconfirm_deferred_offers_controller.rb
+++ b/app/controllers/provider_interface/reconfirm_deferred_offers_controller.rb
@@ -17,7 +17,7 @@ module ProviderInterface
 
     def update_conditions
       @wizard = wizard_for_step('conditions')
-      if @wizard.valid?
+      if @wizard.valid_for_current_step?
         @wizard.save_state!
         redirect_to next_path
       else
@@ -33,7 +33,7 @@ module ProviderInterface
     def commit
       @wizard = wizard_for_step('check')
 
-      render :check and return unless @wizard.valid?
+      render :check and return unless @wizard.valid_for_current_step?
 
       service_class = if @wizard.conditions_met?
                         ReinstateConditionsMet

--- a/app/forms/concerns/wizard.rb
+++ b/app/forms/concerns/wizard.rb
@@ -8,6 +8,23 @@ module Wizard
     attr_reader :state_store
   end
 
+  module Initializer
+    def initialize(state_store, attrs = {})
+      @state_store = state_store
+
+      attrs = sanitize_attrs(attrs) if defined?(sanitize_attrs)
+
+      super(last_saved_state.deep_merge(attrs))
+
+      initialize_extra(attrs) if defined?(initialize_extra)
+      setup_path_history(attrs) if defined?(setup_path_history)
+    end
+  end
+
+  def self.included(klass)
+    klass.prepend(Initializer)
+  end
+
   def clear_state!
     state_store.delete
   end

--- a/app/forms/concerns/wizard.rb
+++ b/app/forms/concerns/wizard.rb
@@ -1,0 +1,37 @@
+module Wizard
+  extend ActiveSupport::Concern
+
+  include ActiveModel::Model
+
+  included do
+    attr_accessor :current_step, :action, :referer
+    attr_reader :state_store
+  end
+
+  def clear_state!
+    state_store.delete
+  end
+
+  def save_state!
+    state_store.write(state)
+  end
+
+  def valid_for_current_step?
+    valid?(current_step.to_sym)
+  end
+
+private
+
+  def last_saved_state
+    saved_state = state_store.read
+    saved_state ? JSON.parse(saved_state).with_indifferent_access : {}
+  end
+
+  def state
+    as_json(except: state_excluded_attributes).to_json
+  end
+
+  def state_excluded_attributes
+    %w[state_store errors validation_context]
+  end
+end

--- a/app/forms/concerns/wizard/path_history.rb
+++ b/app/forms/concerns/wizard/path_history.rb
@@ -1,18 +1,11 @@
 module Wizard::PathHistory
   extend ActiveSupport::Concern
 
-  module Initializer
-    def initialize(state_store, attrs = {})
-      @state_store = state_store
+  attr_accessor :wizard_path_history
 
-      super(last_saved_state.deep_merge(attrs))
-      @path_history ||= [:referer]
-      update_path_history(attrs)
-    end
-  end
-
-  def self.included(klass)
-    klass.send :prepend, Initializer
+  def setup_path_history(attrs)
+    @path_history ||= [:referer]
+    update_path_history(attrs)
   end
 
   def previous_step

--- a/app/forms/concerns/wizard/path_history.rb
+++ b/app/forms/concerns/wizard/path_history.rb
@@ -1,0 +1,33 @@
+module Wizard::PathHistory
+  extend ActiveSupport::Concern
+
+  module Initializer
+    def initialize(state_store, attrs = {})
+      @state_store = state_store
+
+      super(last_saved_state.deep_merge(attrs))
+      @path_history ||= [:referer]
+      update_path_history(attrs)
+    end
+  end
+
+  def self.included(klass)
+    klass.send :prepend, Initializer
+  end
+
+  def previous_step
+    wizard_path_history.previous_step
+  rescue WizardPathHistory::NoSuchStepError
+    :referer
+  end
+
+private
+
+  def update_path_history(attrs)
+    @wizard_path_history = WizardPathHistory.new(@path_history,
+                                                 step: attrs[:current_step].presence,
+                                                 action: attrs[:action].presence)
+    @wizard_path_history.update
+    @path_history = @wizard_path_history.path_history
+  end
+end

--- a/app/forms/provider_interface/cancel_interview_wizard.rb
+++ b/app/forms/provider_interface/cancel_interview_wizard.rb
@@ -1,8 +1,8 @@
 module ProviderInterface
   class CancelInterviewWizard
-    include ActiveModel::Model
+    include Wizard
 
-    attr_accessor :cancellation_reason, :path_history, :wizard_path_history, :current_step, :action, :referer
+    attr_accessor :cancellation_reason, :path_history, :wizard_path_history
 
     validates :cancellation_reason, presence: true, word_count: { maximum: 2000 }
 
@@ -12,14 +12,6 @@ module ProviderInterface
       super(last_saved_state.deep_merge(attrs))
       @path_history ||= [:referer]
       update_path_history(attrs)
-    end
-
-    def save_state!
-      @state_store.write(state)
-    end
-
-    def clear_state!
-      @state_store.delete
     end
 
     def previous_step
@@ -38,13 +30,5 @@ module ProviderInterface
       @path_history = @wizard_path_history.path_history
     end
 
-    def last_saved_state
-      saved_state = @state_store.read
-      saved_state ? JSON.parse(saved_state) : {}
-    end
-
-    def state
-      as_json(except: %w[state_store errors validation_context]).to_json
-    end
   end
 end

--- a/app/forms/provider_interface/cancel_interview_wizard.rb
+++ b/app/forms/provider_interface/cancel_interview_wizard.rb
@@ -1,34 +1,10 @@
 module ProviderInterface
   class CancelInterviewWizard
     include Wizard
+    include Wizard::PathHistory
 
     attr_accessor :cancellation_reason, :path_history, :wizard_path_history
 
     validates :cancellation_reason, presence: true, word_count: { maximum: 2000 }
-
-    def initialize(state_store, attrs = {})
-      @state_store = state_store
-
-      super(last_saved_state.deep_merge(attrs))
-      @path_history ||= [:referer]
-      update_path_history(attrs)
-    end
-
-    def previous_step
-      wizard_path_history.previous_step
-    rescue WizardPathHistory::NoSuchStepError
-      :referer
-    end
-
-  private
-
-    def update_path_history(attrs)
-      @wizard_path_history = WizardPathHistory.new(@path_history,
-                                                   step: attrs[:current_step].presence,
-                                                   action: attrs[:action].presence)
-      @wizard_path_history.update
-      @path_history = @wizard_path_history.path_history
-    end
-
   end
 end

--- a/app/forms/provider_interface/confirm_conditions_wizard.rb
+++ b/app/forms/provider_interface/confirm_conditions_wizard.rb
@@ -6,12 +6,6 @@ module ProviderInterface
 
     validate :all_conditions_have_a_status_selected
 
-    def initialize(state_store, attrs = {})
-      @state_store = state_store
-
-      super(last_saved_state.merge(attrs))
-    end
-
     def conditions
       duplicate_conditions = offer.conditions.map { |condition| duplicate_condition_with_id(condition) }
 

--- a/app/forms/provider_interface/confirm_conditions_wizard.rb
+++ b/app/forms/provider_interface/confirm_conditions_wizard.rb
@@ -1,6 +1,6 @@
 module ProviderInterface
   class ConfirmConditionsWizard
-    include ActiveModel::Model
+    include Wizard
 
     attr_accessor :statuses, :offer
 
@@ -28,14 +28,6 @@ module ProviderInterface
       conditions.any?(&:unmet?)
     end
 
-    def save_state!
-      @state_store.write(state)
-    end
-
-    def clear_state!
-      @state_store.delete
-    end
-
   private
 
     def duplicate_condition_with_id(condition)
@@ -60,17 +52,6 @@ module ProviderInterface
           errors.add(field_name, error.message)
         end
       end
-    end
-
-    def last_saved_state
-      saved_state = @state_store.read
-      saved_state ? JSON.parse(saved_state) : {}
-    end
-
-    def state
-      as_json(
-        except: %w[state_store errors validation_context],
-      ).to_json
     end
 
     def create_method(name, &block)

--- a/app/forms/provider_interface/edit_user_permissions_wizard.rb
+++ b/app/forms/provider_interface/edit_user_permissions_wizard.rb
@@ -4,12 +4,6 @@ module ProviderInterface
 
     attr_accessor :permissions
 
-    def initialize(state_store, attrs = {})
-      @state_store = state_store
-
-      super(last_saved_state.deep_merge(attrs))
-    end
-
     def self.from_model(store, provider_permissions)
       wizard = new(store)
 

--- a/app/forms/provider_interface/edit_user_permissions_wizard.rb
+++ b/app/forms/provider_interface/edit_user_permissions_wizard.rb
@@ -1,6 +1,6 @@
 module ProviderInterface
   class EditUserPermissionsWizard
-    include ActiveModel::Model
+    include Wizard
 
     attr_accessor :permissions
 
@@ -18,25 +18,6 @@ module ProviderInterface
       end
 
       wizard
-    end
-
-    def save_state!
-      @state_store.write(state)
-    end
-
-    def clear_state!
-      @state_store.delete
-    end
-
-  private
-
-    def last_saved_state
-      saved_state = @state_store.read
-      saved_state ? JSON.parse(saved_state) : {}
-    end
-
-    def state
-      as_json(except: %w[state_store errors validation_context]).to_json
     end
   end
 end

--- a/app/forms/provider_interface/interview_wizard.rb
+++ b/app/forms/provider_interface/interview_wizard.rb
@@ -1,12 +1,12 @@
 module ProviderInterface
   class InterviewWizard
-    include ActiveModel::Model
+    include Wizard
     include ActiveModel::Attributes
 
     VALID_TIME_FORMAT = /^(1[0-2]|0?[1-9])([:.\s]([0-5][0-9]))?([AaPp][Mm])$/.freeze
 
     attr_accessor :time, :location, :additional_details, :provider_id, :application_choice, :provider_user,
-                  :current_step, :path_history, :wizard_path_history, :action, :referer
+                  :path_history, :wizard_path_history
     attr_writer :date
 
     attribute 'date(3i)', :string
@@ -63,20 +63,12 @@ module ProviderInterface
       end
     end
 
-    def save_state!
-      @state_store.write(state)
-    end
-
     def update_path_history(attrs)
       @wizard_path_history = WizardPathHistory.new(@path_history,
                                                    step: attrs[:current_step].presence,
                                                    action: attrs[:action].presence)
       @wizard_path_history.update
       @path_history = @wizard_path_history.path_history
-    end
-
-    def clear_state!
-      @state_store.delete
     end
 
     def self.from_model(store, interview, step = 'input', action = nil)
@@ -143,13 +135,8 @@ module ProviderInterface
       @_application_providers ||= application_choice.associated_providers
     end
 
-    def last_saved_state
-      saved_state = @state_store.read
-      saved_state ? JSON.parse(saved_state) : {}
-    end
-
-    def state
-      as_json(except: %w[state_store errors validation_context _application_providers _multiple_application_providers]).to_json
+    def state_excluded_attributes
+      %w[state_store errors validation_context _application_providers _multiple_application_providers]
     end
   end
 end

--- a/app/forms/provider_interface/invite_user_wizard.rb
+++ b/app/forms/provider_interface/invite_user_wizard.rb
@@ -1,9 +1,8 @@
 module ProviderInterface
   class InviteUserWizard
-    include ActiveModel::Model
+    include Wizard
 
     attr_accessor :first_name, :last_name, :email_address, :provider, :permissions, :checking_answers
-    attr_writer :current_step
 
     validates :first_name, presence: true
     validates :last_name, presence: true
@@ -41,24 +40,7 @@ module ProviderInterface
       end
     end
 
-    def save_state!
-      @state_store.write(state)
-    end
-
-    def clear_state!
-      @state_store.delete
-    end
-
   private
-
-    def last_saved_state
-      saved_state = @state_store.read
-      saved_state ? JSON.parse(saved_state) : {}
-    end
-
-    def state
-      as_json(except: %w[state_store errors validation_context]).to_json
-    end
 
     def email_not_already_used_for_provider
       return unless provider.provider_users.exists?(email_address: email_address.downcase)

--- a/app/forms/provider_interface/invite_user_wizard.rb
+++ b/app/forms/provider_interface/invite_user_wizard.rb
@@ -10,11 +10,7 @@ module ProviderInterface
     validates :email_address, presence: true, valid_for_notify: true
     validate :email_not_already_used_for_provider, if: -> { email_address.present? }
 
-    def initialize(state_store, attrs = {})
-      @state_store = state_store
-
-      super(last_saved_state.merge(attrs))
-
+    def initialize_extra(_attrs)
       self.checking_answers = false if current_step == :check
     end
 

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -1,6 +1,7 @@
 module ProviderInterface
   class OfferWizard
     include Wizard
+    include Wizard::PathHistory
 
     STEPS = { make_offer: %i[select_option conditions check],
               change_offer: %i[select_option providers courses study_modes locations conditions check] }.freeze
@@ -8,7 +9,7 @@ module ProviderInterface
 
     attr_accessor :provider_id, :course_id, :course_option_id, :study_mode,
                   :standard_conditions, :further_condition_attrs, :decision,
-                  :path_history, :wizard_path_history,
+                  :path_history,
                   :provider_user_id, :application_choice_id
 
     validates :decision, presence: true, on: %i[select_option]
@@ -18,14 +19,6 @@ module ProviderInterface
     validate :further_conditions_valid, on: %i[conditions]
     validate :max_conditions_length, on: %i[conditions]
     validate :course_option_details, if: :course_option_id, on: :save
-
-    def initialize(state_store, attrs = {})
-      @state_store = state_store
-      attrs = sanitize_parameters(attrs)
-
-      super(last_saved_state.merge(attrs))
-      update_path_history(attrs)
-    end
 
     def self.build_from_application_choice(state_store, application_choice, options = {})
       course_option = application_choice.current_course_option
@@ -69,8 +62,6 @@ module ProviderInterface
 
       next_step
     end
-
-    delegate :previous_step, to: :wizard_path_history
 
     def further_condition_models
       @_further_condition_models ||= further_condition_attrs.map do |index, params|
@@ -193,14 +184,6 @@ module ProviderInterface
       %w[state_store errors validation_context query_service wizard_path_history _further_condition_models]
     end
 
-    def update_path_history(attrs)
-      @wizard_path_history = WizardPathHistory.new(path_history,
-                                                   step: attrs[:current_step].presence,
-                                                   action: attrs[:action].presence)
-      @wizard_path_history.update
-      @path_history = @wizard_path_history.path_history
-    end
-
     def further_conditions_valid
       further_condition_models.map(&:valid?).all?
 
@@ -220,7 +203,7 @@ module ProviderInterface
       errors.add(:base, :exceeded_max_conditions, count: OfferValidations::MAX_CONDITIONS_COUNT)
     end
 
-    def sanitize_parameters(attrs)
+    def sanitize_attrs(attrs)
       if !last_saved_state.empty? && attrs[:course_id].present? && last_saved_state['course_id'] != attrs[:course_id]
         attrs.merge!(study_mode: nil, course_option_id: nil)
       end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -45,7 +45,7 @@ module ProviderInterface
     end
 
     def conditions
-      @conditions = (standard_conditions + further_condition_models.map(&:text)).reject(&:blank?)
+      @conditions = (standard_conditions + further_condition_models.map(&:text).uniq).reject(&:blank?)
     end
 
     def conditions_to_render

--- a/app/forms/provider_interface/organisation_permissions_setup_wizard.rb
+++ b/app/forms/provider_interface/organisation_permissions_setup_wizard.rb
@@ -1,17 +1,17 @@
 module ProviderInterface
   class OrganisationPermissionsSetupWizard
-    include ActiveModel::Model
+    include Wizard
     include ProviderRelationshipPermissionsParamsHelper
 
-    attr_accessor :relationship_ids, :current_relationship_id, :current_step, :checking_answers
-    attr_writer :state_store, :provider_relationship_attrs
+    attr_accessor :relationship_ids, :current_relationship_id, :checking_answers
+    attr_writer :provider_relationship_attrs
 
     def initialize(state_store, attrs = {})
       @state_store = state_store
 
       super(last_saved_state.deep_merge(attrs))
 
-      self.checking_answers = false if current_step == :check
+      checking_answers = false if current_step == :check
     end
 
     def current_relationship
@@ -30,14 +30,6 @@ module ProviderInterface
       return [:check] if checking_answers
 
       [:relationship, previous_relationship_id] if previous_relationship_id.present?
-    end
-
-    def save_state!
-      @state_store.write(state)
-    end
-
-    def clear_state!
-      @state_store.delete
     end
 
     def relationships
@@ -66,20 +58,6 @@ module ProviderInterface
 
     def provider_relationship_attrs
       @provider_relationship_attrs.presence || {}
-    end
-
-    def state
-      as_json(except: %w[state_store errors validation_context]).to_json
-    end
-
-    def last_saved_state
-      state = @state_store.read
-
-      if state
-        JSON.parse(state).with_indifferent_access
-      else
-        {}
-      end
     end
 
     def assign_wizard_attrs_to_relationship(relationship)

--- a/app/forms/provider_interface/organisation_permissions_setup_wizard.rb
+++ b/app/forms/provider_interface/organisation_permissions_setup_wizard.rb
@@ -6,12 +6,8 @@ module ProviderInterface
     attr_accessor :relationship_ids, :current_relationship_id, :checking_answers
     attr_writer :provider_relationship_attrs
 
-    def initialize(state_store, attrs = {})
-      @state_store = state_store
-
-      super(last_saved_state.deep_merge(attrs))
-
-      checking_answers = false if current_step == :check
+    def initialize_extra(_attrs)
+      self.checking_answers = false if current_step == :check
     end
 
     def current_relationship

--- a/app/forms/provider_interface/reasons_for_rejection_wizard.rb
+++ b/app/forms/provider_interface/reasons_for_rejection_wizard.rb
@@ -68,17 +68,14 @@ module ProviderInterface
                   :cannot_sponsor_visa_y_n, :cannot_sponsor_visa_details,
                   :other_advice_or_feedback_y_n, :other_advice_or_feedback_details, :why_are_you_rejecting_this_application
 
-    def initialize(state_store, attrs = {})
-      @state_store = state_store
+    def initialize_extra(_attrs)
+      @checking_answers = true if current_step == 'check'
+    end
 
+    def sanitize_attrs(attrs)
       remove_empty_strings_from_array_attributes!(attrs)
       clean_child_values_on_deselected_answers!(attrs)
-
-      super(last_saved_state.deep_merge(attrs))
-
-      # Once we get to the check answers page, this will be true for the rest of
-      # the session
-      @checking_answers = true if current_step == 'check'
+      attrs
     end
 
     def reason_not_captured_by_initial_questions?

--- a/app/forms/provider_interface/reconfirm_deferred_offer_wizard.rb
+++ b/app/forms/provider_interface/reconfirm_deferred_offer_wizard.rb
@@ -13,12 +13,6 @@ module ProviderInterface
     validates :conditions_status, presence: true, on: %i[conditions check]
     validates :course_option_id, presence: true, on: %i[check]
 
-    def initialize(state_store, attrs = {})
-      @state_store = state_store
-
-      super(last_saved_state.deep_merge(attrs))
-    end
-
     def application_choice
       @application_choice ||= ApplicationChoice.find(application_choice_id)
     end

--- a/app/forms/provider_interface/reconfirm_deferred_offer_wizard.rb
+++ b/app/forms/provider_interface/reconfirm_deferred_offer_wizard.rb
@@ -1,24 +1,17 @@
 module ProviderInterface
   class ReconfirmDeferredOfferWizard
-    include ActiveModel::Model
+    include Wizard
 
     STEPS = %w[new conditions check].freeze
 
-    attr_accessor :current_step, :application_choice_id, :conditions_status, :course_option_id
-    attr_writer :state_store
+    attr_accessor :application_choice_id, :conditions_status, :course_option_id
 
     validates :application_choice_id, :current_step, presence: true
 
-    validate :validate_step,
-             :validate_application_choice,
-             :course_option_still_available
+    validate :validate_step, :validate_application_choice, :course_option_still_available
 
     validates :conditions_status, presence: true, on: %i[conditions check]
     validates :course_option_id, presence: true, on: %i[check]
-
-    def valid?
-      super(current_step&.to_sym)
-    end
 
     def initialize(state_store, attrs = {})
       @state_store = state_store
@@ -104,28 +97,10 @@ module ProviderInterface
       end
     end
 
-    def save_state!
-      @state_store.write(state)
-    end
-
-    def clear_state!
-      @state_store.delete
-    end
-
   private
 
-    def state
-      as_json(except: %w[state_store errors validation_context application_choice course_option_in_new_cycle current_step]).to_json
-    end
-
-    def last_saved_state
-      state = @state_store.read
-
-      if state
-        JSON.parse(state)
-      else
-        {}
-      end
+    def state_excluded_attributes
+      %w[state_store errors validation_context application_choice course_option_in_new_cycle current_step]
     end
 
     def deferred_offer_data

--- a/spec/forms/concerns/wizard/path_history_spec.rb
+++ b/spec/forms/concerns/wizard/path_history_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe Wizard::PathHistory do
+  let(:wizard) do
+    Class.new do
+      include Wizard
+      include Wizard::PathHistory
+    end
+  end
+  let(:attrs) { {} }
+  let(:store) { instance_double(WizardStateStores::RedisStore, read: nil) }
+
+  subject(:model) { WizardClass.new(store, attrs) }
+
+  before do
+    stub_const('WizardClass', wizard)
+  end
+
+  describe '#previous_step' do
+    let(:wizard_path_history) { WizardPathHistory.new([:previous_step], step: :current_step) }
+
+    context 'when there is a previous step' do
+      it 'returns the previous step stored on the wizard_path_history' do
+        allow(WizardPathHistory).to receive(:new).and_return(wizard_path_history)
+
+        expect(model.previous_step).to eq(:previous_step)
+      end
+    end
+
+    context 'when there is no previous step' do
+      let(:wizard_path_history) { WizardPathHistory.new([]) }
+
+      it 'returns the referer' do
+        allow(WizardPathHistory).to receive(:new).and_return(wizard_path_history)
+
+        expect(model.previous_step).to eq(:referer)
+      end
+    end
+  end
+
+  describe '#setup_path_history' do
+    let(:attrs) { { current_step: :check } }
+
+    it 'updates the wizard path history' do
+      expect(model.wizard_path_history.path_history).to eq(%i[referer check])
+    end
+  end
+end

--- a/spec/forms/concerns/wizard_spec.rb
+++ b/spec/forms/concerns/wizard_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe Wizard do
+  let(:wizard) { Class.new { include Wizard } }
+  let(:attrs) { {} }
+  let(:store) { instance_double(WizardStateStores::RedisStore, read: nil) }
+
+  subject(:model) { WizardClass.new(store, attrs) }
+
+  before do
+    stub_const('WizardClass', wizard)
+  end
+
+  describe 'attributes' do
+    it 'has a set of predefined attributes' do
+      expect(model).to respond_to(:current_step)
+      expect(model).to respond_to(:action)
+      expect(model).to respond_to(:referer)
+      expect(model).to respond_to(:state_store)
+    end
+  end
+
+  describe '#initialize_extra' do
+    let(:wizard) do
+      Class.new do
+        include Wizard
+        attr_accessor :checking_answers
+
+        def initialize_extra(_attrs)
+          @checking_answers = true if current_step.eql?(:check)
+        end
+      end
+    end
+    let(:attrs) { { current_step: :check } }
+
+    it 'runs additional actions as part of the initializer' do
+      expect(model.checking_answers).to be true
+    end
+  end
+
+  describe '#sanitize_attrs' do
+    let(:wizard) do
+      Class.new do
+        include Wizard
+        attr_accessor :value1, :value2
+
+        def sanitize_attrs(attrs)
+          attrs[:value1] = :test if attrs[:value2].nil?
+          attrs
+        end
+      end
+    end
+    let(:attrs) { { value1: 'some_value' } }
+
+    it 'runs any required attribute sanitisation' do
+      expect(model.value1).to eq(:test)
+    end
+  end
+
+  describe '#clear_state!' do
+    it 'deletes the state store' do
+      allow(store).to receive(:delete)
+
+      model.clear_state!
+
+      expect(store).to have_received(:delete)
+    end
+  end
+
+  describe '#save_state!' do
+    let(:wizard) do
+      Class.new do
+        attr_accessor :value1, :value2
+        include Wizard
+      end
+    end
+    let(:attrs) { { value1: 'field1', value2: 'field2' } }
+
+    it 'saves the state store' do
+      allow(store).to receive(:write)
+
+      model.save_state!
+
+      expect(store).to have_received(:write).with(attrs.to_json)
+    end
+  end
+
+  describe '#valid_for_current_step?' do
+    let(:wizard) do
+      Class.new do
+        include Wizard
+
+        validates :referer, presence: true, on: :step_1
+        validates :action, presence: true, on: :step_2
+      end
+    end
+    let(:attrs) { { current_step: :step_1 } }
+
+    it 'checks the wizard validity for the current step' do
+      expect(model.valid_for_current_step?).to eq(false)
+
+      expect(model.errors[:referer]).to contain_exactly("can't be blank")
+      expect(model.errors[:action]).to be_empty
+    end
+  end
+end

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -134,21 +134,6 @@ RSpec.describe ProviderInterface::OfferWizard do
       expect(wizard.further_condition_attrs).to eq({ '0' => { 'text' => 'Be cool', 'condition_id' => expected_condition_id } })
     end
 
-    context 'when options are passed in' do
-      let(:options) do
-        {
-          current_step: 'my_step',
-          decision: 'my_decision',
-        }
-      end
-
-      it 'merges them into the initializing hash' do
-        expect(wizard).to be_valid
-        expect(wizard.current_step).to eq('my_step')
-        expect(wizard.decision).to eq('my_decision')
-      end
-    end
-
     context 'when there is no offer present' do
       let(:application_choice) { create(:application_choice) }
 
@@ -350,10 +335,6 @@ RSpec.describe ProviderInterface::OfferWizard do
         end
       end
     end
-  end
-
-  describe '#previous_step' do
-    it { is_expected.to delegate_method(:previous_step).to(:wizard_path_history) }
   end
 
   describe '#conditions' do

--- a/spec/forms/provider_interface/organisation_permissions_setup_wizard_spec.rb
+++ b/spec/forms/provider_interface/organisation_permissions_setup_wizard_spec.rb
@@ -4,11 +4,7 @@ RSpec.describe ProviderInterface::OrganisationPermissionsSetupWizard do
   let(:store) { instance_double(WizardStateStores::RedisStore) }
   let(:relationships) { create_list(:provider_relationship_permissions, 3).shuffle }
   let(:relationship_ids) { relationships.pluck(:id) }
-  let(:wizard_attrs) do
-    {
-      relationship_ids: relationship_ids,
-    }
-  end
+  let(:wizard_attrs) { { relationship_ids: relationship_ids } }
 
   let(:wizard) do
     described_class.new(

--- a/spec/forms/provider_interface/reconfirm_deferred_offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/reconfirm_deferred_offer_wizard_spec.rb
@@ -213,38 +213,4 @@ RSpec.describe ProviderInterface::ReconfirmDeferredOfferWizard do
       expect(wizard.previous_step).to eq(:conditions)
     end
   end
-
-  describe 'initializer' do
-    it 'deserializes state' do
-      state_store = state_store_for(application_choice_id: application_choice.id)
-      wizard = described_class.new(state_store, current_step: 'new')
-      expect(wizard.application_choice_id).to eq application_choice.id
-    end
-  end
-
-  describe '#save_state!' do
-    it 'serializes state to state store' do
-      state_store = state_store_for(application_choice_id: application_choice.id)
-      wizard = described_class.new(state_store)
-      wizard.course_option_id = 99
-
-      wizard.save_state!
-
-      expect(JSON.parse(state_store.read).symbolize_keys).to eq({
-        application_choice_id: application_choice.id,
-        course_option_id: 99,
-      })
-    end
-  end
-
-  describe '#clear_state!' do
-    it 'purges all state' do
-      state_store = state_store_for(application_choice_id: application_choice.id)
-      wizard = described_class.new(state_store)
-
-      wizard.clear_state!
-
-      expect(state_store.read).to be_nil
-    end
-  end
 end

--- a/spec/forms/provider_interface/reconfirm_deferred_offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/reconfirm_deferred_offer_wizard_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ProviderInterface::ReconfirmDeferredOfferWizard do
 
       it 'requires confirmed status of conditions' do
         this_state = state_store_for(application_choice_id: application_choice.id)
-        expect(wizard_for(this_state)).not_to be_valid
+        expect(wizard_for(this_state)).not_to be_valid_for_current_step
 
         this_state = state_store_for(
           application_choice_id: application_choice.id,
@@ -89,7 +89,7 @@ RSpec.describe ProviderInterface::ReconfirmDeferredOfferWizard do
           application_choice_id: application_choice.id,
           conditions_status: 'met',
         )
-        expect(wizard_for(this_state)).not_to be_valid
+        expect(wizard_for(this_state)).not_to be_valid_for_current_step
 
         this_state = state_store_for(
           application_choice_id: application_choice.id,


### PR DESCRIPTION
## Context
Extract existing reusable wizard code into modules


## Changes proposed in this pull request
- Introduces Wizard module
- Introduces Wizard::PathHistory module that extends Wizard functionality to include saving the path history and enable utilising to identify back button link path


## Link to Trello card

https://trello.com/c/dgnvsXQ4/4416-extract-reusable-code-into-modules-base-wizard-path-history

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
