### PR TITLE
Fix default selection bug on degree grade page

### DIFF
--- a/app/forms/candidate_interface/degree_grade_form.rb
+++ b/app/forms/candidate_interface/degree_grade_form.rb
@@ -40,6 +40,8 @@ module CandidateInterface
   private
 
     def assign_form_values_with_hesa_data_if_available
+      return if degree.grade.blank?
+
       if degree.grade_hesa_code.present?
         hesa_grade = Hesa::Grade.find_by_hesa_code(degree.grade_hesa_code)
         if hesa_grade.visual_grouping == :other

--- a/spec/forms/candidate_interface/degree_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_grade_form_spec.rb
@@ -60,5 +60,17 @@ RSpec.describe CandidateInterface::DegreeGradeForm, type: :model do
         expect(degree_form.other_grade).to eq 'gold medal'
       end
     end
+
+    context 'when the database degree has no grade info' do
+      it 'sets no form values' do
+        degree = build_stubbed(:degree_qualification, grade: nil)
+        degree_form = described_class.new(degree: degree)
+
+        degree_form.assign_form_values
+
+        expect(degree_form.grade).to eq nil
+        expect(degree_form.other_grade).to eq nil
+      end
+    end
   end
 end


### PR DESCRIPTION



## Context
When adding a new degree, 'Other' is automatically selected on the grade
page.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Update logic in DegreeGradeForm so that nothing is selected if no grade
is persisted.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Add a new degree in the review app. Nothing should be selected when viewing the grade page. Any submitted value should be persisted and selected when returning to this page.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/psiz9Z2i
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
