### PR TITLE
Make sure the 'course by age group' monthly stats calculation considers deferred offers

### DIFF
--- a/spec/models/monthly_statistics/by_course_age_group_spec.rb
+++ b/spec/models/monthly_statistics/by_course_age_group_spec.rb
@@ -4,50 +4,50 @@ RSpec.describe MonthlyStatistics::ByCourseAgeGroup do
   subject(:statistics) { described_class.new.table_data }
 
   it "returns table data for 'by course age group'" do
-    create_application_choice(status: :with_rejection, course_level: 'primary')
-    create_application_choice(status: :awaiting_provider_decision, course_level: 'primary')
-    create_application_choice(status: :with_recruited, course_level: 'primary')
-    create_application_choice(status: :with_offer, course_level: 'secondary')
-    create_application_choice(status: :with_conditions_not_met, course_level: 'secondary')
-    create_application_choice(status: :with_offer, course_level: 'further_education')
-    create_application_choice(status: :with_rejection, course_level: 'further_education')
+    setup_test_data
 
-    expect(statistics).to eq(
-      { rows:
-        [
-          {
-            'Age group' => 'Primary',
-            'Recruited' => 1,
-            'Conditions pending' => 0,
-            'Received an offer' => 0,
-            'Awaiting provider decisions' => 1,
-            'Unsuccessful' => 1,
-            'Total' => 3,
-          },
-          {
-            'Age group' => 'Secondary',
-            'Recruited' => 0,
-            'Conditions pending' => 0,
-            'Received an offer' => 1,
-            'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 1,
-            'Total' => 2,
-          },
-          {
-            'Age group' => 'Further education',
-            'Recruited' => 0,
-            'Conditions pending' => 0,
-            'Received an offer' => 1,
-            'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 1,
-            'Total' => 2,
-          },
-        ],
-        column_totals: [1, 0, 2, 1, 3, 7] },
-    )
+    expect(statistics).to eq({
+      rows: [
+        {
+          'Age group' => 'Primary',
+          'Recruited' => 1,
+          'Conditions pending' => 0,
+          'Received an offer' => 0,
+          'Awaiting provider decisions' => 1,
+          'Unsuccessful' => 1,
+          'Total' => 3,
+        },
+        { 'Age group' => 'Secondary',
+          'Recruited' => 0,
+          'Conditions pending' => 1,
+          'Received an offer' => 1,
+          'Awaiting provider decisions' => 0,
+          'Unsuccessful' => 1,
+          'Total' => 3 },
+        {
+          'Age group' => 'Further education',
+          'Recruited' => 0,
+          'Conditions pending' => 0,
+          'Received an offer' => 1,
+          'Awaiting provider decisions' => 0,
+          'Unsuccessful' => 1,
+          'Total' => 2,
+        },
+      ],
+      column_totals: [1, 1, 2, 1, 3, 8],
+    })
   end
 
-  def create_application_choice(status:, course_level:)
-    create(:application_choice, status, course_option: create(:course_option, course: create(:course, level: course_level)))
+  def setup_test_data
+    create(:application_choice, :with_offer, :offer_deferred, status_before_deferral: 'recruited', current_recruitment_cycle_year: RecruitmentCycle.previous_year, course_option: create(:course_option, course: create(:course, level: 'primary')))
+    create(:application_choice, :with_offer, :offer_deferred, status_before_deferral: 'pending_conditions', current_recruitment_cycle_year: RecruitmentCycle.previous_year, course_option: create(:course_option, course: create(:course, level: 'secondary')))
+
+    create(:application_choice, :with_rejection, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: create(:course_option, course: create(:course, level: 'primary')))
+    create(:application_choice, :awaiting_provider_decision, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: create(:course_option, course: create(:course, level: 'primary')))
+    create(:application_choice, :with_recruited, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: create(:course_option, course: create(:course, level: 'primary')))
+    create(:application_choice, :with_offer, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: create(:course_option, course: create(:course, level: 'secondary')))
+    create(:application_choice, :with_conditions_not_met, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: create(:course_option, course: create(:course, level: 'secondary')))
+    create(:application_choice, :with_offer, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: create(:course_option, course: create(:course, level: 'further_education')))
+    create(:application_choice, :with_rejection, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: create(:course_option, course: create(:course, level: 'further_education')))
   end
 end


### PR DESCRIPTION
## Context

When I originally created this table for the 'monthly stats' page, I forgot to include deferred offers from the previous cycle, and remove deferred offers from the current cycle from consideration 

## Changes proposed in this pull request

- Fix the table calculation and update spec
 
## Guidance to review

Make sense?

## Link to Trello card
https://trello.com/c/Y8WnsHo9/4072-monthly-stats-by-course-age-group-defect-and-refactor

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
