### PR TITLE
4407 cancel upcoming interviews when a provider makes an offer on an application

### DIFF
--- a/app/controllers/provider_interface/offer/checks_controller.rb
+++ b/app/controllers/provider_interface/offer/checks_controller.rb
@@ -7,6 +7,7 @@ module ProviderInterface
 
         @providers = available_providers
         @courses = available_courses(@wizard.provider_id)
+        @interview_cancellation_presenter = InterviewCancellationExplanationPresenter.new(@application_choice)
         @course_options = available_course_options(@wizard.course_id, @wizard.study_mode)
       end
 

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -31,6 +31,10 @@ class MakeOffer
           SetDeclineByDefault.new(application_form: application_choice.application_form).call
         end
 
+        if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made)
+          CancelUpcomingInterviews.new(actor: actor, application_choice: application_choice, cancellation_reason: 'We made you an offer.').call!
+        end
+
         SendNewOfferEmailToCandidate.new(application_choice: application_choice).call
       end
     else

--- a/app/views/provider_interface/offer/checks/new.html.erb
+++ b/app/views/provider_interface/offer/checks/new.html.erb
@@ -19,6 +19,10 @@
                                                               available_course_options: @course_options,
                                                               show_conditions_link: true) %>
 
+      <% if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made) && @interview_cancellation_presenter.render? %>
+        <p class="govuk-body"><%= @interview_cancellation_presenter.text %></p>
+      <% end %>
+
       <%= f.govuk_submit t('.submit') %>
 
       <p class="govuk-body">

--- a/spec/system/provider_interface/make_offer_cancels_upcoming_interview_spec.rb
+++ b/spec/system/provider_interface/make_offer_cancels_upcoming_interview_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider makes an offer on an application with interviews in the future' do
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+  before do
+    FeatureFlag.activate(:cancel_upcoming_interviews_on_decision_made)
+  end
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
+  let(:provider) { provider_user.providers.first }
+  let(:application_form) { build(:application_form, :minimum_info) }
+  let!(:application_choice) do
+    create(:application_choice, :awaiting_provider_decision,
+           application_form: application_form,
+           course_option: course_option)
+  end
+  let!(:interview) { create(:interview, application_choice: application_choice, date_and_time: 2.days.from_now) }
+  let(:course) do
+    build(:course, :full_time, provider: provider)
+  end
+  let(:course_option) { build(:course_option, course: course) }
+
+  scenario 'Making an offer for the requested course option cancels upcoming interviews' do
+    given_i_am_a_provider_user
+    and_i_am_permitted_to_make_decisions_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_make_an_offer_on_an_application_with_interviews
+    then_i_see_the_review_page_with_cancelling_interviews_warning_text
+
+    when_i_send_the_offer
+    then_i_see_that_the_offer_was_successfuly_made
+    and_future_interviews_are_cancelled
+  end
+
+  def given_i_am_a_provider_user
+    user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+  end
+
+  def and_i_am_permitted_to_make_decisions_for_my_provider
+    permit_make_decisions!
+  end
+
+  def and_i_sign_in_to_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def when_i_make_an_offer_on_an_application_with_interviews
+    when_i_visit_the_provider_interface
+    and_i_click_an_application_choice_awaiting_decision_with_upcoming_interviews
+    and_i_click_on_make_decision
+    then_i_see_the_decision_page
+
+    when_i_choose_to_make_an_offer
+    then_the_conditions_page_is_loaded
+    and_i_click_continue
+  end
+
+  def when_i_visit_the_provider_interface
+    visit provider_interface_applications_path
+  end
+
+  def and_i_click_an_application_choice_awaiting_decision_with_upcoming_interviews
+    click_on application_choice.application_form.full_name
+  end
+
+  def and_i_click_on_make_decision
+    click_on 'Make decision'
+  end
+
+  def then_i_see_the_decision_page
+    expect(page).to have_content('Make a decision')
+    expect(page).to have_content('Course applied for')
+  end
+
+  def when_i_choose_to_make_an_offer
+    choose 'Make an offer'
+    and_i_click_continue
+  end
+
+  def then_the_conditions_page_is_loaded
+    expect(page).to have_content('Conditions of offer')
+  end
+
+  def and_i_click_continue
+    click_on t('continue')
+  end
+
+  def then_i_see_the_review_page_with_cancelling_interviews_warning_text
+    expect(page).to have_content('Check and send offer')
+    expect(page).to have_content('The upcoming interview will be cancelled.')
+  end
+
+  def when_i_send_the_offer
+    click_on 'Send offer'
+  end
+
+  def then_i_see_that_the_offer_was_successfuly_made
+    within('.govuk-notification-banner--success') do
+      expect(page).to have_content('Offer sent')
+    end
+  end
+
+  def and_future_interviews_are_cancelled
+    expect(interview.reload.cancelled_at).not_to be(nil)
+  end
+end

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -66,12 +66,14 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     when_i_set_up_another_interview(days_in_future: 4)
     then_another_interview_has_been_created(4.days.from_now.to_s(:govuk_date))
 
-    when_i_can_make_decisions_for_my_provider
-    and_i_visit_that_application_in_the_provider_interface
-    when_i_click_make_decision
-    and_i_make_an_offer
-    then_i_should_see_the_interview_on_the_interview_tab(4.days.from_now.to_s(:govuk_date))
-    but_i_should_not_see_the_set_up_change_or_cancel_interview_controls
+    unless FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made)
+      when_i_can_make_decisions_for_my_provider
+      and_i_visit_that_application_in_the_provider_interface
+      when_i_click_make_decision
+      and_i_make_an_offer
+      then_i_should_see_the_interview_on_the_interview_tab(4.days.from_now.to_s(:govuk_date))
+      but_i_should_not_see_the_set_up_change_or_cancel_interview_controls
+    end
   end
 
   def when_i_reload_the_page


### PR DESCRIPTION
## Context

We want to cancel upcoming interviews for applications that receive an offer, so there is no confusion with upcoming interviews. This is done using a service (to cancel the interviews) and a presenter (to display text informing the provider they will be cancelling a candidates interviews).

## Link to Trello card

https://trello.com/c/x9YrzsUM/4407-cancel-upcoming-interviews-when-a-provider-makes-an-offer-on-an-application

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
