### PR TITLE
Fix issue with the 'never_signed_in' state on the CandidatesAPI

### DIFF
--- a/app/controllers/candidate_api/candidates_controller.rb
+++ b/app/controllers/candidate_api/candidates_controller.rb
@@ -104,6 +104,10 @@ module CandidateAPI
 
     def candidates
       Candidate
+      .left_outer_joins(:application_forms)
+      .where(application_forms: { recruitment_cycle_year: RecruitmentCycle.current_year })
+      .or(Candidate.where('candidates.created_at > ? ', CycleTimetable.apply_1_deadline(RecruitmentCycle.previous_year)))
+      .distinct
       .includes(application_forms: :application_choices)
       .where('candidate_api_updated_at > ?', updated_since_params)
       .order('candidates.candidate_api_updated_at DESC')


### PR DESCRIPTION
## Context

At the moment, we're not ensuring that we only send candidates who are active in the current cycle through the candidates API.

We're also ordering on via the application forms created_at rather than the candidate_api_updated_at. We should be passing the most recently updated back first.

I've also ensured that the application forms are ordered for each candidate by their created_at. So their first apply1 application will always be returned first.

## Changes proposed in this pull request

- Order the results by candidate_api_updated_at DESC rather than by application form created_at
- Ensure application forms are ordered by created_at so that their first application is the first application form in the array

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
