### PR TITLE
cancel upcoming interviews on rejection

### DIFF
--- a/app/controllers/provider_interface/reasons_for_rejection_controller.rb
+++ b/app/controllers/provider_interface/reasons_for_rejection_controller.rb
@@ -49,7 +49,7 @@ module ProviderInterface
                         else
                           provider_interface_reasons_for_rejection_initial_questions_path(@application_choice)
                         end
-
+      @interview_cancellation_presenter = InterviewCancellationExplanationPresenter.new(@application_choice)
       @wizard.save_state!
     end
 
@@ -71,6 +71,7 @@ module ProviderInterface
         flash[:success] = success_message
         redirect_to provider_interface_application_choice_feedback_path(@application_choice)
       else
+        @interview_cancellation_presenter = InterviewCancellationExplanationPresenter.new(@application_choice)
         @wizard.errors.merge!(service.errors)
         track_validation_error(@wizard)
         render :check

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -31,6 +31,10 @@ class RejectApplication
         SetDeclineByDefault.new(application_form: @application_choice.application_form).call
       end
 
+      if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made)
+        CancelUpcomingInterviews.new(actor: @auth.actor, application_choice: @application_choice, cancellation_reason: I18n.t('interview_cancellation.reason.application_rejected')).call!
+      end
+
       SendCandidateRejectionEmail.new(application_choice: @application_choice).call
     end
 

--- a/app/views/provider_interface/reasons_for_rejection/check.html.erb
+++ b/app/views/provider_interface/reasons_for_rejection/check.html.erb
@@ -24,6 +24,10 @@
         ) %>
       <% end %>
 
+      <% if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made) && @interview_cancellation_presenter.render? %>
+        <p class="govuk-body"><%= @interview_cancellation_presenter.text %></p>
+      <% end %>
+
       <% if @application_choice.rejected_by_default? %>
         <%= f.govuk_submit 'Send feedback' %>
       <% else %>

--- a/config/locales/interview_cancellation.yml
+++ b/config/locales/interview_cancellation.yml
@@ -2,6 +2,7 @@ en:
   interview_cancellation:
     reason:
       application_withdrawn: You withdrew your application.
+      application_rejected: Your application was unsuccessful.
       offer_made: We made you an offer.
     explanation:
       email:

--- a/spec/services/reject_application_spec.rb
+++ b/spec/services/reject_application_spec.rb
@@ -77,5 +77,21 @@ RSpec.describe RejectApplication do
 
       expect(service.save).to be false
     end
+
+    context 'when the cancel upcoming feature flag is enabled' do
+      before do
+        FeatureFlag.activate(:cancel_upcoming_interviews_on_decision_made)
+      end
+
+      it 'calls the CancelUpcomingInterviews service' do
+        cancel_upcoming_interviews = instance_double(CancelUpcomingInterviews, call!: true)
+
+        allow(CancelUpcomingInterviews)
+          .to receive(:new).with(actor: provider_user, application_choice: application_choice, cancellation_reason: 'Your application was unsuccessful.')
+                           .and_return(cancel_upcoming_interviews)
+        service.save
+        expect(cancel_upcoming_interviews).to have_received(:call!)
+      end
+    end
   end
 end

--- a/spec/system/provider_interface/reject_an_application_cancels_upcoming_interviews_spec.rb
+++ b/spec/system/provider_interface/reject_an_application_cancels_upcoming_interviews_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe 'Reject an application with interviews' do
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+  include CourseOptionHelpers
+
+  before do
+    FeatureFlag.activate(:cancel_upcoming_interviews_on_decision_made)
+  end
+
+  scenario 'giving reasons for rejection' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_permitted_to_see_applications_for_my_provider
+    and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
+    and_my_organisation_has_received_an_application_with_an_upcoming_interview
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_respond_to_an_application
+    and_i_choose_to_reject_it
+
+    then_i_give_reasons_why_i_am_rejecting_the_application
+    and_the_cancellation_of_interviews_message_is_shown
+    and_i_submit_the_reasons_for_rejection
+    and_the_interview_is_cancelled
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_am_permitted_to_see_applications_for_my_provider
+    provider_user_exists_in_apply_database
+  end
+
+  def and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
+    permit_make_decisions!
+  end
+
+  def and_my_organisation_has_received_an_application_with_an_upcoming_interview
+    course_option = course_option_for_provider_code(provider_code: 'ABC')
+    @application_choice = create(:application_choice, :awaiting_provider_decision, course_option: course_option)
+    @interview = create(:interview, application_choice: @application_choice, date_and_time: 2.days.from_now)
+  end
+
+  def when_i_respond_to_an_application
+    visit provider_interface_application_choice_path(@application_choice)
+    click_on 'Make decision'
+  end
+
+  def and_i_choose_to_reject_it
+    choose 'Reject application'
+    click_on t('continue')
+  end
+
+  def then_i_give_reasons_why_i_am_rejecting_the_application
+    expect(page).to have_link('Back', href: new_provider_interface_application_choice_decision_path(@application_choice))
+
+    choose 'reasons-for-rejection-candidate-behaviour-y-n-no-field'
+
+    choose 'reasons-for-rejection-quality-of-application-y-n-no-field'
+
+    choose 'reasons-for-rejection-qualifications-y-n-yes-field'
+    check 'reasons-for-rejection-qualifications-which-qualifications-no-maths-gcse-field'
+    check 'reasons-for-rejection-qualifications-which-qualifications-no-degree-field'
+
+    choose 'reasons-for-rejection-performance-at-interview-y-n-no-field'
+
+    choose 'reasons-for-rejection-course-full-y-n-no-field'
+
+    choose 'reasons-for-rejection-offered-on-another-course-y-n-no-field'
+
+    choose 'reasons-for-rejection-honesty-and-professionalism-y-n-yes-field'
+    check 'reasons-for-rejection-honesty-and-professionalism-concerns-information-false-or-inaccurate-field'
+    fill_in 'reasons-for-rejection-honesty-and-professionalism-concerns-information-false-or-inaccurate-details-field', with: 'We doubt claims about your golf handicap'
+    check 'reasons-for-rejection-honesty-and-professionalism-concerns-references-field'
+    fill_in 'reasons-for-rejection-honesty-and-professionalism-concerns-references-details-field', with: 'We cannot accept references from your mum'
+
+    choose 'reasons-for-rejection-safeguarding-y-n-yes-field'
+    check 'reasons-for-rejection-safeguarding-concerns-vetting-disclosed-information-field'
+    fill_in 'reasons-for-rejection-safeguarding-concerns-vetting-disclosed-information-details-field', with: 'You abducted Jenny, now Matrix is coming to find her'
+
+    choose 'reasons-for-rejection-cannot-sponsor-visa-y-n-no-field'
+
+    click_on t('continue')
+  end
+
+  def and_the_cancellation_of_interviews_message_is_shown
+    expect(page).to have_content('The upcoming interview will be cancelled.')
+  end
+
+  def and_i_submit_the_reasons_for_rejection
+    click_on 'Send feedback and reject application'
+  end
+
+  def and_the_interview_is_cancelled
+    expect(@interview.reload.cancelled_at).not_to be nil
+  end
+end


### PR DESCRIPTION
## Context

When an application is rejected, interviews coming up in the future should be cancelled. This is done by calling the CancelUpcomingInterviews service. Additionally a message should be shown to the provider on the check rejection page, done by using a presenter.

## Guidance to review

Reject an application and check that future interviews are cancelled

## Link to Trello card

https://trello.com/c/GJ6ot8Rb/4408-cancel-upcoming-interviews-when-a-provider-rejects-an-application

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
