### PR TITLE
Fix insufficient privilege errors during deploys

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -35,11 +35,8 @@ resource "cloudfoundry_app" "web_app" {
       route = routes.value.id
     }
   }
-  dynamic "service_binding" {
-    for_each = local.app_service_bindings
-    content {
-      service_instance = service_binding.value.id
-    }
+  service_binding {
+    service_instance = cloudfoundry_user_provided_service.logging.id
   }
 }
 
@@ -55,11 +52,8 @@ resource "cloudfoundry_app" "clock" {
   timeout              = 180
   environment          = local.clock_app_env_variables
   docker_credentials   = var.docker_credentials
-  dynamic "service_binding" {
-    for_each = local.app_service_bindings
-    content {
-      service_instance = service_binding.value.id
-    }
+  service_binding {
+    service_instance = cloudfoundry_user_provided_service.logging.id
   }
 }
 
@@ -76,11 +70,8 @@ resource "cloudfoundry_app" "worker" {
   timeout              = 180
   environment          = local.worker_app_env_variables
   docker_credentials   = var.docker_credentials
-  dynamic "service_binding" {
-    for_each = local.app_service_bindings
-    content {
-      service_instance = service_binding.value.id
-    }
+  service_binding {
+    service_instance = cloudfoundry_user_provided_service.logging.id
   }
 }
 
@@ -97,11 +88,8 @@ resource "cloudfoundry_app" "worker_secondary" {
   timeout              = 180
   environment          = local.worker_app_env_variables
   docker_credentials   = var.docker_credentials
-  dynamic "service_binding" {
-    for_each = local.app_service_bindings
-    content {
-      service_instance = service_binding.value.id
-    }
+  service_binding {
+    service_instance = cloudfoundry_user_provided_service.logging.id
   }
 }
 
@@ -144,6 +132,11 @@ resource "cloudfoundry_service_instance" "postgres" {
     create = "60m"
     update = "60m"
   }
+}
+
+resource "cloudfoundry_service_key" "postgres" {
+  name = "postgres-${var.app_environment}"
+  service_instance = cloudfoundry_service_instance.postgres.id
 }
 
 resource "cloudfoundry_service_instance" "redis" {

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -67,8 +67,6 @@ locals {
   allkeys_lru_maxmemory_policy = {
     maxmemory_policy = "allkeys-lru"
   }
-  app_service_bindings = [cloudfoundry_service_instance.postgres, cloudfoundry_service_instance.redis,
-  cloudfoundry_service_instance.redis_cache, cloudfoundry_user_provided_service.logging]
   service_gov_uk_host_names = {
     qa        = "qa"
     staging   = "staging"
@@ -89,6 +87,7 @@ locals {
   cloudfoundry_route.web_app_education_gov_uk_route, cloudfoundry_route.web_app_internal_route, cloudfoundry_route.web_app_assets_service_gov_uk_route]
   app_environment_variables = merge(var.app_environment_variables,
     {
+      DATABASE_URL        = cloudfoundry_service_key.postgres.credentials.uri
       BLAZER_DATABASE_URL = cloudfoundry_service_key.postgres-readonly-key.credentials.uri
       REDIS_URL           = cloudfoundry_service_key.worker_redis_key.credentials.uri
       REDIS_CACHE_URL     = cloudfoundry_service_key.cache_redis_key.credentials.uri


### PR DESCRIPTION
## Context

![image](https://user-images.githubusercontent.com/107591/138726357-5889c00f-c662-4a53-bdc2-3891c1a7bfb1.png)

These errors occur because database credentials are rotated with every deploy as part of dynamic service key binding. This PR creates a persistent 'postgres' service key, the credentials of which are exposed to Rails instances via DATABASE_URL env var.

This PR also removes the dynamic re-binding of redis instances, which is not needed as we have already switched to our self-managed service keys for both Redis instances.

## Changes proposed in this pull request

Create a long-lived, terraform-managed read/writ 'postgres' service key for each environment and expose the credentials to the app via a `DATABASE_URL` environment variable.

Remove automatic service binding of redis instances, as we already manage the relevant service keys via terraform and expose them through environment variables.

## Guidance to review

Removing the dynamic service binding loops simplifies the terraform codebase and also makes deployments faster (automatic re-binding seems to take a while).

We are already using the terraform-managed service key approach for Redis instances and Blazer.

The presence and values of `DATABASE_URL` trumps all other database configuration in Rails apps. Have preserved the existing env vars within `docker-compose.yml` and `config/database.yml` to avoid breaking the running of tests, as `DATABASE_URL` will also overwrite the database name.

## Link to Trello card

https://trello.com/c/YxKa69ka

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
