### PR TITLE
Reasons for rejection Support dashboard : update detailed subcategory tables

### DIFF
--- a/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
+++ b/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
@@ -40,6 +40,7 @@
       total_this_month: @total_rejection_count_this_month,
       total_for_reason_all_time: @total_count,
       total_for_reason_this_month: @this_month,
+      recruitment_cycle_year: @recruitment_cycle_year,
     ) %>
   <% end %>
 </section>

--- a/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
+++ b/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
@@ -36,7 +36,10 @@
     <%= render SupportInterface::SubReasonsForRejectionTableComponent.new(
       reason: @reason_key,
       sub_reasons: @sub_reasons_result,
-      total: @total_structured_rejection_reasons_count,
+      total_all_time: @total_rejection_count,
+      total_this_month: @total_rejection_count_this_month,
+      total_for_reason_all_time: @total_count,
+      total_for_reason_this_month: @this_month,
     ) %>
   <% end %>
 </section>

--- a/app/components/support_interface/reason_for_rejection_dashboard_section_component.rb
+++ b/app/components/support_interface/reason_for_rejection_dashboard_section_component.rb
@@ -19,7 +19,8 @@ module SupportInterface
   private
 
     def ordered_sub_reason_results(sub_reasons_result)
-      sub_reasons_result.slice(*ReasonsForRejectionCountQuery::SUBREASON_VALUES[@reason_key].map(&:to_s))
+      sub_reason_values = ReasonsForRejectionCountQuery::SUBREASON_VALUES[@reason_key]
+      sub_reasons_result.slice(*sub_reason_values.map(&:to_s)) if sub_reason_values.present?
     end
 
     def number_of_rejections_out_of_total_rejections

--- a/app/components/support_interface/reason_for_rejection_dashboard_section_component.rb
+++ b/app/components/support_interface/reason_for_rejection_dashboard_section_component.rb
@@ -2,12 +2,13 @@ module SupportInterface
   class ReasonForRejectionDashboardSectionComponent < ViewComponent::Base
     include ViewHelper
 
-    def initialize(heading:, total_count:, this_month:, percentage_rejected:, total_structured_rejection_reasons_count:, reason_key:, sub_reasons_result: nil)
+    def initialize(heading:, total_count:, this_month:, percentage_rejected:, total_rejection_count:, total_rejection_count_this_month:, reason_key:, sub_reasons_result: nil)
       @heading = heading
       @total_count = total_count
       @this_month = this_month
       @percentage_rejected = percentage_rejected
-      @total_structured_rejection_reasons_count = total_structured_rejection_reasons_count
+      @total_rejection_count = total_rejection_count
+      @total_rejection_count_this_month = total_rejection_count_this_month
       @reason_key = reason_key
       @sub_reasons_result = ordered_sub_reason_results(sub_reasons_result) if sub_reasons_result.present?
     end
@@ -19,7 +20,7 @@ module SupportInterface
     end
 
     def number_of_rejections_out_of_total_rejections
-      "#{@total_count} of #{@total_structured_rejection_reasons_count} application choices"
+      "#{@total_count} of #{@total_rejection_count} application choices"
     end
   end
 end

--- a/app/components/support_interface/reason_for_rejection_dashboard_section_component.rb
+++ b/app/components/support_interface/reason_for_rejection_dashboard_section_component.rb
@@ -2,7 +2,9 @@ module SupportInterface
   class ReasonForRejectionDashboardSectionComponent < ViewComponent::Base
     include ViewHelper
 
-    def initialize(heading:, total_count:, this_month:, percentage_rejected:, total_rejection_count:, total_rejection_count_this_month:, reason_key:, sub_reasons_result: nil)
+    def initialize(heading:, total_count:, this_month:, percentage_rejected:, total_rejection_count:,
+                   total_rejection_count_this_month:, reason_key:, sub_reasons_result: nil,
+                   recruitment_cycle_year: RecruitmentCycle.current_year)
       @heading = heading
       @total_count = total_count
       @this_month = this_month
@@ -11,6 +13,7 @@ module SupportInterface
       @total_rejection_count_this_month = total_rejection_count_this_month
       @reason_key = reason_key
       @sub_reasons_result = ordered_sub_reason_results(sub_reasons_result) if sub_reasons_result.present?
+      @recruitment_cycle_year = recruitment_cycle_year
     end
 
   private

--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
@@ -7,6 +7,7 @@
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :candidate_behaviour_y_n,
   sub_reasons_result: sub_reasons_for(:candidate_behaviour_y_n),
+  recruitment_cycle_year: recruitment_cycle_year,
 ) %>
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
@@ -18,6 +19,7 @@
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :quality_of_application_y_n,
   sub_reasons_result: sub_reasons_for(:quality_of_application_y_n),
+  recruitment_cycle_year: recruitment_cycle_year,
 ) %>
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
@@ -29,6 +31,7 @@
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :qualifications_y_n,
   sub_reasons_result: sub_reasons_for(:qualifications_y_n),
+  recruitment_cycle_year: recruitment_cycle_year,
 ) %>
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
@@ -39,6 +42,7 @@
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :performance_at_interview_y_n,
+  recruitment_cycle_year: recruitment_cycle_year,
 ) %>
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
@@ -49,6 +53,8 @@
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :course_full_y_n,
+  sub_reasons_result: sub_reasons_for(:qualifications_y_n),
+  recruitment_cycle_year: recruitment_cycle_year,
 ) %>
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
@@ -59,6 +65,7 @@
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :offered_on_another_course_y_n,
+  recruitment_cycle_year: recruitment_cycle_year,
 ) %>
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
@@ -70,6 +77,7 @@
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :honesty_and_professionalism_y_n,
   sub_reasons_result: sub_reasons_for(:honesty_and_professionalism_y_n),
+  recruitment_cycle_year: recruitment_cycle_year,
 ) %>
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
@@ -81,6 +89,7 @@
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :safeguarding_y_n,
   sub_reasons_result: sub_reasons_for(:safeguarding_y_n),
+  recruitment_cycle_year: recruitment_cycle_year,
 ) %>
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
@@ -91,6 +100,7 @@
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :cannot_sponsor_visa_y_n,
+  recruitment_cycle_year: recruitment_cycle_year,
 ) %>
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
@@ -101,4 +111,5 @@
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :other_advice_or_feedback_y_n,
+  recruitment_cycle_year: recruitment_cycle_year,
 ) %>

--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
@@ -3,7 +3,8 @@
   total_count: total_rejection_count('candidate_behaviour_y_n'),
   this_month: current_month_rejection_count('candidate_behaviour_y_n'),
   percentage_rejected: percentage_rejected_for_reason('candidate_behaviour_y_n'),
-  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
+  total_rejection_count: total_structured_rejection_reasons_count,
+  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :candidate_behaviour_y_n,
   sub_reasons_result: sub_reasons_for(:candidate_behaviour_y_n),
 ) %>
@@ -13,7 +14,8 @@
   total_count: total_rejection_count('quality_of_application_y_n'),
   this_month: current_month_rejection_count('quality_of_application_y_n'),
   percentage_rejected: percentage_rejected_for_reason('quality_of_application_y_n'),
-  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
+  total_rejection_count: total_structured_rejection_reasons_count,
+  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :quality_of_application_y_n,
   sub_reasons_result: sub_reasons_for(:quality_of_application_y_n),
 ) %>
@@ -23,7 +25,8 @@
   total_count: total_rejection_count('qualifications_y_n'),
   this_month: current_month_rejection_count('qualifications_y_n'),
   percentage_rejected: percentage_rejected_for_reason('qualifications_y_n'),
-  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
+  total_rejection_count: total_structured_rejection_reasons_count,
+  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :qualifications_y_n,
   sub_reasons_result: sub_reasons_for(:qualifications_y_n),
 ) %>
@@ -33,7 +36,8 @@
   total_count: total_rejection_count('performance_at_interview_y_n'),
   this_month: current_month_rejection_count('performance_at_interview_y_n'),
   percentage_rejected: percentage_rejected_for_reason('performance_at_interview_y_n'),
-  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
+  total_rejection_count: total_structured_rejection_reasons_count,
+  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :performance_at_interview_y_n,
 ) %>
 
@@ -42,7 +46,8 @@
   total_count: total_rejection_count('course_full_y_n'),
   this_month: current_month_rejection_count('course_full_y_n'),
   percentage_rejected: percentage_rejected_for_reason('course_full_y_n'),
-  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
+  total_rejection_count: total_structured_rejection_reasons_count,
+  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :course_full_y_n,
 ) %>
 
@@ -51,7 +56,8 @@
   total_count: total_rejection_count('offered_on_another_course_y_n'),
   this_month: current_month_rejection_count('offered_on_another_course_y_n'),
   percentage_rejected: percentage_rejected_for_reason('offered_on_another_course_y_n'),
-  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
+  total_rejection_count: total_structured_rejection_reasons_count,
+  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :offered_on_another_course_y_n,
 ) %>
 
@@ -60,7 +66,8 @@
   total_count: total_rejection_count('honesty_and_professionalism_y_n'),
   this_month: current_month_rejection_count('honesty_and_professionalism_y_n'),
   percentage_rejected: percentage_rejected_for_reason('honesty_and_professionalism_y_n'),
-  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
+  total_rejection_count: total_structured_rejection_reasons_count,
+  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :honesty_and_professionalism_y_n,
   sub_reasons_result: sub_reasons_for(:honesty_and_professionalism_y_n),
 ) %>
@@ -70,7 +77,8 @@
   total_count: total_rejection_count('safeguarding_y_n'),
   this_month: current_month_rejection_count('safeguarding_y_n'),
   percentage_rejected: percentage_rejected_for_reason('safeguarding_y_n'),
-  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
+  total_rejection_count: total_structured_rejection_reasons_count,
+  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :safeguarding_y_n,
   sub_reasons_result: sub_reasons_for(:safeguarding_y_n),
 ) %>
@@ -80,7 +88,8 @@
   total_count: total_rejection_count('cannot_sponsor_visa_y_n'),
   this_month: current_month_rejection_count('cannot_sponsor_visa_y_n'),
   percentage_rejected: percentage_rejected_for_reason('cannot_sponsor_visa_y_n'),
-  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
+  total_rejection_count: total_structured_rejection_reasons_count,
+  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :cannot_sponsor_visa_y_n,
 ) %>
 
@@ -89,6 +98,7 @@
   total_count: total_rejection_count('other_advice_or_feedback_y_n'),
   this_month: current_month_rejection_count('other_advice_or_feedback_y_n'),
   percentage_rejected: percentage_rejected_for_reason('other_advice_or_feedback_y_n'),
-  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
+  total_rejection_count: total_structured_rejection_reasons_count,
+  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :other_advice_or_feedback_y_n,
 ) %>

--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.rb
@@ -2,12 +2,14 @@ module SupportInterface
   class ReasonsForRejectionDashboardComponent < ViewComponent::Base
     include ViewHelper
 
-    attr_reader :total_structured_rejection_reasons_count, :total_structured_rejection_reasons_count_this_month
+    attr_reader :total_structured_rejection_reasons_count, :total_structured_rejection_reasons_count_this_month, :recruitment_cycle_year
 
-    def initialize(rejection_reasons, total_structured_rejection_reasons_count, total_structured_rejection_reasons_count_this_month)
+    def initialize(rejection_reasons, total_structured_rejection_reasons_count,
+                   total_structured_rejection_reasons_count_this_month, recruitment_cycle_year = RecruitmentCycle.current_year)
       @rejection_reasons = rejection_reasons
       @total_structured_rejection_reasons_count = total_structured_rejection_reasons_count
       @total_structured_rejection_reasons_count_this_month = total_structured_rejection_reasons_count_this_month
+      @recruitment_cycle_year = recruitment_cycle_year
     end
 
   private

--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.rb
@@ -2,11 +2,12 @@ module SupportInterface
   class ReasonsForRejectionDashboardComponent < ViewComponent::Base
     include ViewHelper
 
-    attr_reader :total_structured_rejection_reasons_count
+    attr_reader :total_structured_rejection_reasons_count, :total_structured_rejection_reasons_count_this_month
 
-    def initialize(rejection_reasons, total_structured_rejection_reasons_count)
+    def initialize(rejection_reasons, total_structured_rejection_reasons_count, total_structured_rejection_reasons_count_this_month)
       @rejection_reasons = rejection_reasons
       @total_structured_rejection_reasons_count = total_structured_rejection_reasons_count
+      @total_structured_rejection_reasons_count_this_month = total_structured_rejection_reasons_count_this_month
     end
 
   private

--- a/app/components/support_interface/sub_reasons_for_rejection_table_component.html.erb
+++ b/app/components/support_interface/sub_reasons_for_rejection_table_component.html.erb
@@ -2,9 +2,10 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header" width="40%">Reason</th>
-      <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="10%">%&nbsp;of&nbsp;<%= @total %><br>choices</th>
-      <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="25%">Total</th>
-      <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="25%">This month</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections within this category</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections this month</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections within this category this month</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -19,13 +20,20 @@
           ) %>
         </th>
         <td class="govuk-table__cell govuk-table__cell--numeric">
-          <%= sub_reason_percentage(sub_reason) %>
+          <%= sub_reason_percentage(sub_reason) %><br>
+          <%= "#{sub_reason_count(sub_reason)} of #{total_all_time}" %>
         </td>
         <td class="govuk-table__cell govuk-table__cell--numeric">
-          <%= sub_reason_result&.all_time || 0 %>
+          <%= sub_reason_percentage_of_reason(sub_reason) %><br>
+          <%= "#{sub_reason_count(sub_reason)} of #{total_for_reason}" %>
         </td>
         <td class="govuk-table__cell govuk-table__cell--numeric">
-          <%= sub_reason_result&.this_month || 0 %>
+          <%= sub_reason_percentage(sub_reason, :this_month) %><br>
+          <%= "#{sub_reason_count(sub_reason, :this_month)} of #{total_this_month}" %>
+        </td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">
+          <%= sub_reason_percentage_of_reason(sub_reason, :this_month) %><br>
+          <%= "#{sub_reason_count(sub_reason, :this_month)} of #{total_for_reason(:this_month)}" %>
         </td>
       </tr>
     <% end %>

--- a/app/components/support_interface/sub_reasons_for_rejection_table_component.html.erb
+++ b/app/components/support_interface/sub_reasons_for_rejection_table_component.html.erb
@@ -5,8 +5,8 @@
       <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections</th>
       <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections within this category</th>
       <% if recruitment_cycle_year == RecruitmentCycle.current_year %>
-        <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections this month</th>
-        <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections within this category this month</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections in <%= month_name %></th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections in <%= month_name %> within this category</th>
       <% end %>
     </tr>
   </thead>

--- a/app/components/support_interface/sub_reasons_for_rejection_table_component.html.erb
+++ b/app/components/support_interface/sub_reasons_for_rejection_table_component.html.erb
@@ -4,8 +4,10 @@
       <th scope="col" class="govuk-table__header" width="40%">Reason</th>
       <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections</th>
       <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections within this category</th>
-      <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections this month</th>
-      <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections within this category this month</th>
+      <% if recruitment_cycle_year == RecruitmentCycle.current_year %>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections this month</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections within this category this month</th>
+      <% end %>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -21,20 +23,22 @@
         </th>
         <td class="govuk-table__cell govuk-table__cell--numeric">
           <%= sub_reason_percentage(sub_reason) %><br>
-          <%= "#{sub_reason_count(sub_reason)} of #{total_all_time}" %>
+          <span class="govuk-caption-m"><%= "#{sub_reason_count(sub_reason)} of #{total_all_time}" %></span>
         </td>
         <td class="govuk-table__cell govuk-table__cell--numeric">
           <%= sub_reason_percentage_of_reason(sub_reason) %><br>
-          <%= "#{sub_reason_count(sub_reason)} of #{total_for_reason}" %>
+          <span class="govuk-caption-m"><%= "#{sub_reason_count(sub_reason)} of #{total_for_reason}" %>
         </td>
-        <td class="govuk-table__cell govuk-table__cell--numeric">
-          <%= sub_reason_percentage(sub_reason, :this_month) %><br>
-          <%= "#{sub_reason_count(sub_reason, :this_month)} of #{total_this_month}" %>
-        </td>
-        <td class="govuk-table__cell govuk-table__cell--numeric">
-          <%= sub_reason_percentage_of_reason(sub_reason, :this_month) %><br>
-          <%= "#{sub_reason_count(sub_reason, :this_month)} of #{total_for_reason(:this_month)}" %>
-        </td>
+        <% if recruitment_cycle_year == RecruitmentCycle.current_year %>
+          <td class="govuk-table__cell govuk-table__cell--numeric">
+            <%= sub_reason_percentage(sub_reason, :this_month) %><br>
+            <span class="govuk-caption-m"><%= "#{sub_reason_count(sub_reason, :this_month)} of #{total_this_month}" %>
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">
+            <%= sub_reason_percentage_of_reason(sub_reason, :this_month) %><br>
+            <span class="govuk-caption-m"><%= "#{sub_reason_count(sub_reason, :this_month)} of #{total_for_reason(:this_month)}" %></span>
+          </td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/components/support_interface/sub_reasons_for_rejection_table_component.rb
+++ b/app/components/support_interface/sub_reasons_for_rejection_table_component.rb
@@ -1,15 +1,18 @@
 module SupportInterface
   class SubReasonsForRejectionTableComponent < ViewComponent::Base
     include ViewHelper
-    attr_accessor :reason, :sub_reasons, :total_all_time, :total_this_month, :total_for_reason_all_time, :total_for_reason_this_month
+    attr_accessor :reason, :sub_reasons, :total_all_time, :total_this_month, :total_for_reason_all_time,
+                  :total_for_reason_this_month, :recruitment_cycle_year
 
-    def initialize(reason:, sub_reasons:, total_all_time:, total_this_month:, total_for_reason_all_time:, total_for_reason_this_month:)
+    def initialize(reason:, sub_reasons:, total_all_time:, total_this_month:, total_for_reason_all_time:,
+                   total_for_reason_this_month:, recruitment_cycle_year: RecruitmentCycle.current_year)
       @reason = reason
       @sub_reasons = sub_reasons
       @total_all_time = total_all_time
       @total_this_month = total_this_month
       @total_for_reason_all_time = total_for_reason_all_time
       @total_for_reason_this_month = total_for_reason_this_month
+      @recruitment_cycle_year = recruitment_cycle_year
     end
 
     def reason_label

--- a/app/components/support_interface/sub_reasons_for_rejection_table_component.rb
+++ b/app/components/support_interface/sub_reasons_for_rejection_table_component.rb
@@ -1,12 +1,15 @@
 module SupportInterface
   class SubReasonsForRejectionTableComponent < ViewComponent::Base
     include ViewHelper
-    attr_accessor :reason, :sub_reasons, :total
+    attr_accessor :reason, :sub_reasons, :total_all_time, :total_this_month, :total_for_reason_all_time, :total_for_reason_this_month
 
-    def initialize(reason:, sub_reasons:, total:)
+    def initialize(reason:, sub_reasons:, total_all_time:, total_this_month:, total_for_reason_all_time:, total_for_reason_this_month:)
       @reason = reason
       @sub_reasons = sub_reasons
-      @total = total
+      @total_all_time = total_all_time
+      @total_this_month = total_this_month
+      @total_for_reason_all_time = total_for_reason_all_time
+      @total_for_reason_this_month = total_for_reason_this_month
     end
 
     def reason_label
@@ -21,9 +24,25 @@ module SupportInterface
       I18n.t("reasons_for_rejection.#{ReasonsForRejection::TOP_LEVEL_REASONS_TO_I18N_KEYS[reason]}.#{sub_reason}")
     end
 
-    def sub_reason_percentage(sub_reason_key)
+    def sub_reason_percentage_of_reason(sub_reason_key, time_period = :all_time)
+      formatted_percentage(sub_reason_count(sub_reason_key, time_period) || 0, total_for_reason(time_period))
+    end
+
+    def sub_reason_percentage(sub_reason_key, time_period = :all_time)
+      formatted_percentage(sub_reason_count(sub_reason_key, time_period) || 0, total(time_period))
+    end
+
+    def sub_reason_count(sub_reason_key, time_period = :all_time)
       sub_reason_result = sub_reasons[sub_reason_key]
-      formatted_percentage(sub_reason_result&.all_time || 0, total)
+      sub_reason_result&.send(time_period)
+    end
+
+    def total_for_reason(time_period = :all_time)
+      send(:"total_for_reason_#{time_period}")
+    end
+
+    def total(time_period)
+      send(:"total_#{time_period}")
     end
   end
 end

--- a/app/components/support_interface/sub_reasons_for_rejection_table_component.rb
+++ b/app/components/support_interface/sub_reasons_for_rejection_table_component.rb
@@ -47,5 +47,9 @@ module SupportInterface
     def total(time_period)
       send(:"total_#{time_period}")
     end
+
+    def month_name
+      Time.zone.today.strftime('%B')
+    end
   end
 end

--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -31,6 +31,7 @@ module SupportInterface
       @reasons_for_rejection = query.sub_reason_counts
       @total_structured_rejection_reasons_count = query.total_structured_reasons_for_rejection
       @total_structured_rejection_reasons_count_this_month = query.total_structured_reasons_for_rejection(time_period: :this_month)
+      @recruitment_cycle_year = year_param.to_i
     end
 
     def reasons_for_rejection_application_choices

--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -30,6 +30,7 @@ module SupportInterface
       query = ReasonsForRejectionCountQuery.new(year_param)
       @reasons_for_rejection = query.sub_reason_counts
       @total_structured_rejection_reasons_count = query.total_structured_reasons_for_rejection
+      @total_structured_rejection_reasons_count_this_month = query.total_structured_reasons_for_rejection(time_period: :this_month)
     end
 
     def reasons_for_rejection_application_choices

--- a/app/queries/reasons_for_rejection_count_query.rb
+++ b/app/queries/reasons_for_rejection_count_query.rb
@@ -10,11 +10,14 @@ class ReasonsForRejectionCountQuery
     @recruitment_cycle_year = recruitment_cycle_year
   end
 
-  def total_structured_reasons_for_rejection
-    ApplicationChoice
+  def total_structured_reasons_for_rejection(time_period: nil)
+    scope = ApplicationChoice
       .where(current_recruitment_cycle_year: recruitment_cycle_year)
       .where.not(structured_rejection_reasons: nil)
-      .count
+
+    scope = scope.where(['rejected_at > ?', Time.zone.now.beginning_of_month]) if time_period == :this_month
+
+    scope.count
   end
 
   def reason_counts

--- a/app/views/support_interface/performance/reasons_for_rejection_dashboard.html.erb
+++ b/app/views/support_interface/performance/reasons_for_rejection_dashboard.html.erb
@@ -7,4 +7,10 @@
   }) %>
 <% end %>
 
-<%= render SupportInterface::ReasonsForRejectionDashboardComponent.new(@reasons_for_rejection, @total_structured_rejection_reasons_count) %>
+<%= @reasons_for_rejection %>
+
+<%= render SupportInterface::ReasonsForRejectionDashboardComponent.new(
+  @reasons_for_rejection,
+  @total_structured_rejection_reasons_count,
+  @total_structured_rejection_reasons_count_this_month,
+) %>

--- a/app/views/support_interface/performance/reasons_for_rejection_dashboard.html.erb
+++ b/app/views/support_interface/performance/reasons_for_rejection_dashboard.html.erb
@@ -7,10 +7,9 @@
   }) %>
 <% end %>
 
-<%= @reasons_for_rejection %>
-
 <%= render SupportInterface::ReasonsForRejectionDashboardComponent.new(
   @reasons_for_rejection,
   @total_structured_rejection_reasons_count,
   @total_structured_rejection_reasons_count_this_month,
+  @recruitment_cycle_year,
 ) %>

--- a/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
@@ -20,23 +20,23 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
   let(:rejection_reasons) do
     ActiveSupport::HashWithIndifferentAccess.new({
       candidate_behaviour_y_n: result(3, 1, {
-        didnt_reply_to_interview_offer: result(1, 0),
-        didnt_attend_interview: result(2, 1),
-        other: result,
+        'didnt_reply_to_interview_offer' => result(1, 0),
+        'didnt_attend_interview' => result(2, 1),
+        'other' => result,
       }),
       qualifications_y_n: result(4, 2, {
-        no_maths_gcse: result,
-        no_english_gcse: result(2, 1),
-        no_science_gcse: result(1, 1),
-        no_degree: result(1, 0),
-        other: result,
+        'no_maths_gcse' => result,
+        'no_english_gcse' => result(2, 1),
+        'no_science_gcse' => result(1, 1),
+        'no_degree' => result(1, 0),
+        'other' => result,
       }),
       quality_of_application_y_n: result,
       honesty_and_professionalism_y_n: result,
       safeguarding_y_n: result(1, 1, {
-        candidate_disclosed_information: result,
-        vetting_disclosed_information: result(1, 1),
-        other: result,
+        'candidate_disclosed_information' => result,
+        'vetting_disclosed_information' => result(1, 1),
+        'other' => result,
       }),
       cannot_sponsor_visa_y_n: result(2, 0),
       course_full_y_n: result(1, 1),
@@ -65,40 +65,22 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
       end
     end
 
-    it 'renders course full section' do
-      section = rendered_component.css('.app-section')[0]
-      expect(heading_text(section)).to eq('Course full')
-      expect(summary_text(section)).to eq(['8.33%', '1 of 12 application choices'])
-    end
-
     it 'renders detailed candidate behaviour section' do
-      section = rendered_component.css('.app-section')[1]
+      section = rendered_component.css('.app-section')[0]
       expect(heading_text(section)).to eq('Candidate behaviour')
       expect(summary_text(section)).to eq(['25%', '3 of 12 application choices'])
       expect(details_text(section, 1)).to eq(['Didn’t reply to our interview offer', '8.33%', '1 of 12', '33.33%', '1 of 3', '0%', '0 of 9', '0%', '0 of 1'])
       expect(details_text(section, 2)).to eq(['Didn’t attend interview', '16.67%', '2 of 12', '66.67%', '2 of 3', '11.11%', '1 of 9', '100%', '1 of 1'])
     end
 
-    it 'renders honesty and professionalism section' do
-      section = rendered_component.css('.app-section')[2]
-      expect(heading_text(section)).to eq('Honesty and professionalism')
-      expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
-    end
-
-    it 'renders alternative course section' do
-      section = rendered_component.css('.app-section')[3]
-      expect(heading_text(section)).to eq('Offered on another course')
-      expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
-    end
-
-    it 'renders interview section' do
-      section = rendered_component.css('.app-section')[4]
-      expect(heading_text(section)).to eq('Performance at interview')
+    it 'renders quality of application section' do
+      section = rendered_component.css('.app-section')[1]
+      expect(heading_text(section)).to eq('Quality of application')
       expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
     end
 
     it 'renders qualifications section' do
-      section = rendered_component.css('.app-section')[5]
+      section = rendered_component.css('.app-section')[2]
       expect(heading_text(section)).to eq('Qualifications')
       expect(summary_text(section)).to eq(['33.33%', '4 of 12 application choices'])
       expect(details_text(section, 1)).to eq(['No Maths GCSE grade 4 (C) or above, or valid equivalent', '0%', '0 of 12', '0%', '0 of 4', '0%', '0 of 9', '0%', '0 of 2'])
@@ -106,9 +88,27 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
       expect(details_text(section, 3)).to eq(['No Science GCSE grade 4 (C) or above, or valid equivalent (for primary applicants)', '8.33%', '1 of 12', '25%', '1 of 4', '11.11%', '1 of 9', '50%', '1 of 2'])
     end
 
-    it 'renders quality of application section' do
+    it 'renders interview section' do
+      section = rendered_component.css('.app-section')[3]
+      expect(heading_text(section)).to eq('Performance at interview')
+      expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
+    end
+
+    it 'renders course full section' do
+      section = rendered_component.css('.app-section')[4]
+      expect(heading_text(section)).to eq('Course full')
+      expect(summary_text(section)).to eq(['8.33%', '1 of 12 application choices'])
+    end
+
+    it 'renders alternative course section' do
+      section = rendered_component.css('.app-section')[5]
+      expect(heading_text(section)).to eq('Offered on another course')
+      expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
+    end
+
+    it 'renders honesty and professionalism section' do
       section = rendered_component.css('.app-section')[6]
-      expect(heading_text(section)).to eq('Quality of application')
+      expect(heading_text(section)).to eq('Honesty and professionalism')
       expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
     end
 
@@ -127,7 +127,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
 
     it 'renders other advice section' do
       section = rendered_component.css('.app-section')[9]
-      expect(heading_text(section)).to eq('Other advice or feedback')
+      expect(heading_text(section)).to eq('Additional advice or feedback')
       expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
     end
   end

--- a/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
@@ -54,13 +54,15 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
     let(:rendered_component) { render_inline(component) }
 
     it 'renders table headings' do
-      header_row = rendered_component.css('.govuk-table__row').first
-      header_row_text = header_row.text.split("\n").reject(&:blank?).map(&:strip)
-      expect(header_row_text[0]).to eq('Reason')
-      expect(header_row_text[1]).to eq('Percentage of all rejections')
-      expect(header_row_text[2]).to eq('Percentage of all rejections within this category')
-      expect(header_row_text[3]).to eq('Percentage of all rejections this month')
-      expect(header_row_text[4]).to eq('Percentage of all rejections within this category this month')
+      Timecop.freeze(RecruitmentCycle.current_year, 9, 1) do
+        header_row = rendered_component.css('.govuk-table__row').first
+        header_row_text = header_row.text.split("\n").reject(&:blank?).map(&:strip)
+        expect(header_row_text[0]).to eq('Reason')
+        expect(header_row_text[1]).to eq('Percentage of all rejections')
+        expect(header_row_text[2]).to eq('Percentage of all rejections within this category')
+        expect(header_row_text[3]).to eq('Percentage of all rejections in September')
+        expect(header_row_text[4]).to eq('Percentage of all rejections in September within this category')
+      end
     end
 
     it 'renders course full section' do

--- a/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
+  def result(all_time_count = 0, this_month_count = 0, subreasons = nil)
+    ReasonsForRejectionCountQuery::Result.new(all_time_count, this_month_count, subreasons)
+  end
+
+  def heading_text(section)
+    section.css('.govuk-heading-m').text.strip
+  end
+
+  def summary_text(section)
+    section.css('.app-card--blue').text.split("\n").reject(&:blank?).map(&:strip)
+  end
+
+  def details_text(section, row_index)
+    section.css('tr')[row_index].text.split("\n").reject(&:blank?).map(&:strip)
+  end
+
+  let(:rejection_reasons) do
+    ActiveSupport::HashWithIndifferentAccess.new({
+      candidate_behaviour_y_n: result(3, 1, {
+        didnt_reply_to_interview_offer: result(1, 0),
+        didnt_attend_interview: result(2, 1),
+        other: result,
+      }),
+      qualifications_y_n: result(4, 2, {
+        no_maths_gcse: result,
+        no_english_gcse: result(2, 1),
+        no_science_gcse: result(1, 1),
+        no_degree: result(1, 0),
+        other: result,
+      }),
+      quality_of_application_y_n: result,
+      honesty_and_professionalism_y_n: result,
+      safeguarding_y_n: result(1, 1, {
+        candidate_disclosed_information: result,
+        vetting_disclosed_information: result(1, 1),
+        other: result,
+      }),
+      cannot_sponsor_visa_y_n: result(2, 0),
+      course_full_y_n: result(1, 1),
+      offered_on_another_course_y_n: result,
+      performance_at_interview_y_n: result,
+      other_advice_or_feedback_y_n: result,
+    })
+  end
+
+  subject(:component) do
+    described_class.new(rejection_reasons, 12, 9)
+  end
+
+  describe 'rendered component' do
+    let(:rendered_component) { render_inline(component) }
+
+    it 'renders table headings' do
+      header_row = rendered_component.css('.govuk-table__row').first
+      header_row_text = header_row.text.split("\n").reject(&:blank?).map(&:strip)
+      expect(header_row_text[0]).to eq('Reason')
+      expect(header_row_text[1]).to eq('Percentage of all rejections')
+      expect(header_row_text[2]).to eq('Percentage of all rejections within this category')
+      expect(header_row_text[3]).to eq('Percentage of all rejections this month')
+      expect(header_row_text[4]).to eq('Percentage of all rejections within this category this month')
+    end
+
+    it 'renders course full section' do
+      section = rendered_component.css('.app-section')[0]
+      expect(heading_text(section)).to eq('Course full')
+      expect(summary_text(section)).to eq(['8.33%', '1 of 12 application choices'])
+    end
+
+    it 'renders detailed candidate behaviour section' do
+      section = rendered_component.css('.app-section')[1]
+      expect(heading_text(section)).to eq('Candidate behaviour')
+      expect(summary_text(section)).to eq(['25%', '3 of 12 application choices'])
+      expect(details_text(section, 1)).to eq(['Didn’t reply to our interview offer', '8.33%', '1 of 12', '33.33%', '1 of 3', '0%', '0 of 9', '0%', '0 of 1'])
+      expect(details_text(section, 2)).to eq(['Didn’t attend interview', '16.67%', '2 of 12', '66.67%', '2 of 3', '11.11%', '1 of 9', '100%', '1 of 1'])
+    end
+
+    it 'renders honesty and professionalism section' do
+      section = rendered_component.css('.app-section')[2]
+      expect(heading_text(section)).to eq('Honesty and professionalism')
+      expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
+    end
+
+    it 'renders alternative course section' do
+      section = rendered_component.css('.app-section')[3]
+      expect(heading_text(section)).to eq('Offered on another course')
+      expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
+    end
+
+    it 'renders interview section' do
+      section = rendered_component.css('.app-section')[4]
+      expect(heading_text(section)).to eq('Performance at interview')
+      expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
+    end
+
+    it 'renders qualifications section' do
+      section = rendered_component.css('.app-section')[5]
+      expect(heading_text(section)).to eq('Qualifications')
+      expect(summary_text(section)).to eq(['33.33%', '4 of 12 application choices'])
+      expect(details_text(section, 1)).to eq(['No Maths GCSE grade 4 (C) or above, or valid equivalent', '0%', '0 of 12', '0%', '0 of 4', '0%', '0 of 9', '0%', '0 of 2'])
+      expect(details_text(section, 2)).to eq(['No English GCSE grade 4 (C) or above, or valid equivalent', '16.67%', '2 of 12', '50%', '2 of 4', '11.11%', '1 of 9', '50%', '1 of 2'])
+      expect(details_text(section, 3)).to eq(['No Science GCSE grade 4 (C) or above, or valid equivalent (for primary applicants)', '8.33%', '1 of 12', '25%', '1 of 4', '11.11%', '1 of 9', '50%', '1 of 2'])
+    end
+
+    it 'renders quality of application section' do
+      section = rendered_component.css('.app-section')[6]
+      expect(heading_text(section)).to eq('Quality of application')
+      expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
+    end
+
+    it 'renders safeguarding section' do
+      section = rendered_component.css('.app-section')[7]
+      expect(heading_text(section)).to eq('Safeguarding concerns')
+      expect(summary_text(section)).to eq(['8.33%', '1 of 12 application choices'])
+      expect(details_text(section, 2)).to eq(['Information revealed by our vetting process makes the candidate unsuitable to work with children', '8.33%', '1 of 12', '100%', '1 of 1', '11.11%', '1 of 9', '100%', '1 of 1'])
+    end
+
+    it 'renders visa section' do
+      section = rendered_component.css('.app-section')[8]
+      expect(heading_text(section)).to eq('Cannot sponsor visa')
+      expect(summary_text(section)).to eq(['16.67%', '2 of 12 application choices'])
+    end
+
+    it 'renders other advice section' do
+      section = rendered_component.css('.app-section')[9]
+      expect(heading_text(section)).to eq('Other advice or feedback')
+      expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
+    end
+  end
+end

--- a/spec/components/support_interface/sub_reasons_for_rejection_table_component_spec.rb
+++ b/spec/components/support_interface/sub_reasons_for_rejection_table_component_spec.rb
@@ -41,4 +41,67 @@ RSpec.describe SupportInterface::SubReasonsForRejectionTableComponent do
       expect(component.sub_reason_count('didnt_attend_interview', :this_month)).to eq(2)
     end
   end
+
+  describe 'rendering for current recruitment cycle' do
+    subject(:rendered_component) do
+      render_inline(
+        described_class.new(
+          reason: 'candidate_behaviour_y_n',
+          sub_reasons: { 'didnt_attend_interview' => ReasonsForRejectionCountQuery::Result.new(3, 2, {}) },
+          total_all_time: 100,
+          total_this_month: 20,
+          total_for_reason_all_time: 25,
+          total_for_reason_this_month: 15,
+        ),
+      )
+    end
+
+    it 'shows all time and current month percentages and totals' do
+      table_headings = rendered_component.css('thead th')
+      expect(table_headings.size).to eq(5)
+      expect(table_headings[0].text.strip).to eq('Reason')
+      expect(table_headings[1].text.strip).to eq('Percentage of all rejections')
+      expect(table_headings[2].text.strip).to eq('Percentage of all rejections within this category')
+      expect(table_headings[3].text.strip).to eq('Percentage of all rejections this month')
+      expect(table_headings[4].text.strip).to eq('Percentage of all rejections within this category this month')
+
+      table_cells = rendered_component.css('tbody td')
+      expect(rendered_component.css('tbody th').text.strip).to eq('Didn’t attend interview')
+      expect(table_cells.size).to eq(4)
+      expect(table_cells[0].text.strip).to start_with('3%')
+      expect(table_cells[1].text.strip).to start_with('12%')
+      expect(table_cells[2].text.strip).to start_with('10%')
+      expect(table_cells[3].text.strip).to start_with('13.33%')
+    end
+  end
+
+  describe 'rendering for a past recruitment cycle' do
+    subject(:rendered_component) do
+      render_inline(
+        described_class.new(
+          reason: 'candidate_behaviour_y_n',
+          sub_reasons: { 'didnt_attend_interview' => ReasonsForRejectionCountQuery::Result.new(3, 2, {}) },
+          total_all_time: 100,
+          total_this_month: 20,
+          total_for_reason_all_time: 25,
+          total_for_reason_this_month: 15,
+          recruitment_cycle_year: RecruitmentCycle.previous_year,
+        ),
+      )
+    end
+
+    it 'only shows all time percentages and totals' do
+      table_headings = rendered_component.css('thead th')
+      expect(table_headings.size).to eq(3)
+      expect(table_headings[0].text.strip).to eq('Reason')
+      expect(table_headings[1].text.strip).to eq('Percentage of all rejections')
+      expect(table_headings[2].text.strip).to eq('Percentage of all rejections within this category')
+
+      table_cells = rendered_component.css('tbody td')
+      expect(rendered_component.css('tbody th').text.strip).to eq('Didn’t attend interview')
+      expect(table_cells.size).to eq(2)
+      expect(table_cells[0].text.strip).to start_with('3%')
+      expect(table_cells[1].text.strip).to start_with('12%')
+    end
+  end
 end

--- a/spec/components/support_interface/sub_reasons_for_rejection_table_component_spec.rb
+++ b/spec/components/support_interface/sub_reasons_for_rejection_table_component_spec.rb
@@ -57,21 +57,23 @@ RSpec.describe SupportInterface::SubReasonsForRejectionTableComponent do
     end
 
     it 'shows all time and current month percentages and totals' do
-      table_headings = rendered_component.css('thead th')
-      expect(table_headings.size).to eq(5)
-      expect(table_headings[0].text.strip).to eq('Reason')
-      expect(table_headings[1].text.strip).to eq('Percentage of all rejections')
-      expect(table_headings[2].text.strip).to eq('Percentage of all rejections within this category')
-      expect(table_headings[3].text.strip).to eq('Percentage of all rejections this month')
-      expect(table_headings[4].text.strip).to eq('Percentage of all rejections within this category this month')
+      Timecop.freeze(RecruitmentCycle.current_year, 9, 1) do
+        table_headings = rendered_component.css('thead th')
+        expect(table_headings.size).to eq(5)
+        expect(table_headings[0].text.strip).to eq('Reason')
+        expect(table_headings[1].text.strip).to eq('Percentage of all rejections')
+        expect(table_headings[2].text.strip).to eq('Percentage of all rejections within this category')
+        expect(table_headings[3].text.strip).to eq('Percentage of all rejections in September')
+        expect(table_headings[4].text.strip).to eq('Percentage of all rejections in September within this category')
 
-      table_cells = rendered_component.css('tbody td')
-      expect(rendered_component.css('tbody th').text.strip).to eq('Didn’t attend interview')
-      expect(table_cells.size).to eq(4)
-      expect(table_cells[0].text.strip).to start_with('3%')
-      expect(table_cells[1].text.strip).to start_with('12%')
-      expect(table_cells[2].text.strip).to start_with('10%')
-      expect(table_cells[3].text.strip).to start_with('13.33%')
+        table_cells = rendered_component.css('tbody td')
+        expect(rendered_component.css('tbody th').text.strip).to eq('Didn’t attend interview')
+        expect(table_cells.size).to eq(4)
+        expect(table_cells[0].text.strip).to start_with('3%')
+        expect(table_cells[1].text.strip).to start_with('12%')
+        expect(table_cells[2].text.strip).to start_with('10%')
+        expect(table_cells[3].text.strip).to start_with('13.33%')
+      end
     end
   end
 

--- a/spec/components/support_interface/sub_reasons_for_rejection_table_component_spec.rb
+++ b/spec/components/support_interface/sub_reasons_for_rejection_table_component_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::SubReasonsForRejectionTableComponent do
+  subject(:component) do
+    described_class.new(
+      reason: 'candidate_behaviour_y_n',
+      sub_reasons: { 'didnt_attend_interview' => ReasonsForRejectionCountQuery::Result.new(3, 2, {}) },
+      total_all_time: 100,
+      total_this_month: 20,
+      total_for_reason_all_time: 25,
+      total_for_reason_this_month: 15,
+    )
+  end
+
+  describe '#sub_reason_percentage_of_reason' do
+    it 'returns a formatted percentage of occurances of the subreason for a reason' do
+      expect(component.sub_reason_percentage_of_reason('didnt_attend_interview')).to eq('12%')
+    end
+
+    it 'returns a formatted percentage of occurances of the subreason for a reason for the current month' do
+      expect(component.sub_reason_percentage_of_reason('didnt_attend_interview', :this_month)).to eq('13.33%')
+    end
+  end
+
+  describe '#sub_reason_percentage' do
+    it 'returns a formatted percentage of occurances of the subreason for all rejections' do
+      expect(component.sub_reason_percentage('didnt_attend_interview')).to eq('3%')
+    end
+
+    it 'returns a formatted percentage of occurances of the subreason for rejections this month' do
+      expect(component.sub_reason_percentage('didnt_attend_interview', :this_month)).to eq('10%')
+    end
+  end
+
+  describe '#sub_reason_count' do
+    it 'returns the occurance count for the sub reason' do
+      expect(component.sub_reason_count('didnt_attend_interview')).to eq(3)
+    end
+
+    it 'returns the occurance count for the sub reason for this month' do
+      expect(component.sub_reason_count('didnt_attend_interview', :this_month)).to eq(2)
+    end
+  end
+end

--- a/spec/queries/reasons_for_rejection_count_query_spec.rb
+++ b/spec/queries/reasons_for_rejection_count_query_spec.rb
@@ -128,4 +128,14 @@ RSpec.describe ReasonsForRejectionCountQuery do
       expect(counts[:quality_of_application_y_n].sub_reasons[:personal_statement]).to eq(described_class::Result.new(2, 1, nil))
     end
   end
+
+  describe '#total_structured_reasons_for_rejection' do
+    it 'returns the count of all applications with structured reasons for rejection' do
+      expect(described_class.new.total_structured_reasons_for_rejection).to eq(3)
+    end
+
+    it 'returns the count of applications with structured reasons for rejection for this month' do
+      expect(described_class.new.total_structured_reasons_for_rejection(time_period: :this_month)).to eq(2)
+    end
+  end
 end

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -246,27 +246,27 @@ private
 
   def and_i_should_see_sub_reasons_for_rejection_due_to_qualifications
     within '#qualifications' do
-      expect(page).to have_content('No Maths GCSE grade 4 (C) or above, or valid equivalent 40% 2 1')
-      expect(page).to have_content('No English GCSE grade 4 (C) or above, or valid equivalent 20% 1 0')
-      expect(page).to have_content('Other 20% 1 0')
-      expect(page).to have_content('No degree 40% 2 1')
-      expect(page).to have_content('No Science GCSE grade 4 (C) or above, or valid equivalent (for primary applicants) 0% 0 0')
+      expect(page).to have_content('No Maths GCSE grade 4 (C) or above, or valid equivalent 40% 2 of 5 66.67% 2 of 3 50% 1 of 2 100% 1 of 1')
+      expect(page).to have_content('No English GCSE grade 4 (C) or above, or valid equivalent 20% 1 of 5 33.33% 1 of 3 0% 0 of 2 0% 0 of 1')
+      expect(page).to have_content('Other 20% 1 of 5 33.33% 1 of 3 0% 0 of 2 0% 0 of 1')
+      expect(page).to have_content('No degree 40% 2 of 5 66.67% 2 of 3 50% 1 of 2 100% 1 of 1')
+      expect(page).to have_content('No Science GCSE grade 4 (C) or above, or valid equivalent (for primary applicants) 0% 0 of 5 0% 0 of 3 0% 0 of 2 0% 0 of 1')
     end
   end
 
   def and_i_should_see_sub_reasons_for_rejection_due_to_safeguarding
     within '#safeguarding-concerns' do
-      expect(page).to have_content('Information disclosed by candidate makes them unsuitable to work with children 0% 0 0')
-      expect(page).to have_content('Information revealed by our vetting process makes the candidate unsuitable to work with children 0% 0 0')
-      expect(page).to have_content('Other 40% 2 1')
+      expect(page).to have_content('Information disclosed by candidate makes them unsuitable to work with children 0% 0 of 5 0% 0 of 2 0% 0 of 2 0% 0 of 1')
+      expect(page).to have_content('Information revealed by our vetting process makes the candidate unsuitable to work with children 0% 0 of 5 0% 0 of 2 0% 0 of 2 0% 0 of 1')
+      expect(page).to have_content('Other 40% 2 of 5 100% 2 of 2 50% 1 of 2 100% 1 of 1')
     end
   end
 
   def and_i_should_see_sub_reasons_for_rejection_due_to_candidate_behaviour
     within '#candidate-behaviour' do
-      expect(page).to have_content('Didn’t reply to our interview offer 40% 2 1')
-      expect(page).to have_content('Didn’t attend interview 20% 1 0')
-      expect(page).to have_content('Other 0% 0 0')
+      expect(page).to have_content('Didn’t reply to our interview offer 40% 2 of 5 40% 2 of 5 50% 1 of 2 50% 1 of 2')
+      expect(page).to have_content('Didn’t attend interview 20% 1 of 5 20% 1 of 5 0% 0 of 2 0% 0 of 2')
+      expect(page).to have_content('Other 0% 0 of 5 0% 0 of 5 0% 0 of 2 0% 0 of 2')
     end
   end
 


### PR DESCRIPTION
## Context

We're iterating what we display on the structured reasons for rejection support dashboard.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Amends the design of the dashboard components to display percentages and counts for sub reasons.

#### Not in scope for this PR:

- At a glance metrics changes (see https://trello.com/c/GrSXN6hU/4412-sr4r-support-dashboard-iterate-at-a-glance-metrics)
- Formatting percentages
- Content changes

#### Current recruitment cycle

![image](https://user-images.githubusercontent.com/93511/138909560-31fde326-3ccb-4bf1-aa35-40c4d9e84b98.png)


#### Previous recruitment cycle

![image](https://user-images.githubusercontent.com/93511/138907592-49d2d3f8-46e6-4d07-a0f8-e042334db799.png)


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

I considered merging the section and details table component, I'm not sure we need 3 levels of componentry when we get little re-use and most of the arguments are passed through.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/hziTWoDC/4413-sr4r-support-dashboard-update-detailed-subcategory-tables
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
