### PR TITLE
Fix Manage reference feedback column width

### DIFF
--- a/app/components/utility/summary_list_component.html.erb
+++ b/app/components/utility/summary_list_component.html.erb
@@ -4,7 +4,7 @@
       <% summary_list_row.key { row[:key] } %>
       <% summary_list_row.value { value(row) } %>
 
-      <% Array.wrap(row[:action] || row[:actions] || { href: '' }).each do |action| %>
+      <% Array.wrap(actions(row)).each do |action| %>
         <% summary_list_row.action(classes: 'govuk-!-display-none-print', **action) %>
       <% end %>
     <% end %>

--- a/app/components/utility/summary_list_component.rb
+++ b/app/components/utility/summary_list_component.rb
@@ -22,6 +22,14 @@ class SummaryListComponent < ViewComponent::Base
     end
   end
 
+  def actions(row)
+    defined_action = row[:action] || row[:actions]
+
+    return defined_action if defined_action.present?
+
+    { href: '' } if any_rows_with_actions?
+  end
+
   def html_attributes(row)
     row[:html_attributes] || {}
   end
@@ -47,5 +55,9 @@ private
 
   def format_list_as_paragraphs(list)
     safe_join(list.map { |s| tag.p(class: 'govuk-body') { ERB::Util.html_escape(s) } })
+  end
+
+  def any_rows_with_actions?
+    rows.any? { |row| (row[:action] || row[:actions]).present? }
   end
 end

--- a/spec/components/utility/summary_list_component_spec.rb
+++ b/spec/components/utility/summary_list_component_spec.rb
@@ -175,4 +175,47 @@ RSpec.describe SummaryListComponent do
     expect(links[1].text).to eq 'Remove this chef'
     expect(links[1].attr('href')).to eq '#remove'
   end
+
+  it 'does not include action dd tags when none of the rows have actions' do
+    rows = [
+      {
+        key: 'Role',
+        value: 'Chef de partie',
+      },
+      {
+        key: 'Name',
+        value: 'Bob the builder',
+      },
+    ]
+
+    result = render_inline(described_class.new(rows: rows))
+
+    expect(result.css('.govuk-summary-list__actions')).to be_empty
+  end
+
+  it 'includes action dd tags when at least one of the rows has actions' do
+    rows = [
+      {
+        key: 'Role',
+        value: 'Chef de partie',
+        action: {
+          href: '/some/url',
+          visually_hidden_text: 'role',
+        },
+      },
+      {
+        key: 'Name',
+        value: 'Bob the builder',
+      },
+    ]
+
+    result = render_inline(described_class.new(rows: rows))
+
+    actions = result.css('.govuk-summary-list__actions')
+
+    expect(actions[0].text).to eq 'Change role'
+    expect(actions[0].css('a').first.attr('href')).to eq '/some/url'
+
+    expect(actions[1].text).to be_blank
+  end
 end


### PR DESCRIPTION
## Context
The feedback column for references in Manage is very narrow and hard to read

## Changes proposed in this pull request
Update the summary list component to only render the action `dd` when there are any actions given to the component. If there are no actions, then it's safe to never render the action column

## Guidance to review
Have I missed anything?

## Link to Trello card
https://trello.com/c/6iTuMUdV/4426-references-section-in-manage-columns-too-narrow

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
