### PR TITLE
Stop unnecessary clock starts during deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,7 +126,3 @@ jobs:
       - name: Exit if smoke test failed
         if: steps.wait_for_smoke_test.outputs.conclusion != 'success'
         run: exit 1
-
-      - name: Start Clockwork container
-        if: always()
-        run: cf start apply-clock-${{ env.SPACE_SUFFIX || matrix.environment }}


### PR DESCRIPTION
## Context

This dates back to an experiment stopping `clock` at the start of deployments. This is no longer needed.

## Changes proposed in this pull request

Remove.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
