### PR TITLE
Use timeliness to parse interview time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.4'
 
+gem 'timeliness'
+
 gem 'activesupport', '~> 6.1'
 gem 'actionpack', '~> 6.1'
 gem 'actionview', '~> 6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -599,6 +599,7 @@ GEM
       httpclient (>= 2.4)
     thor (1.1.0)
     timecop (0.9.4)
+    timeliness (0.4.4)
     trailblazer-option (0.1.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -766,6 +767,7 @@ DEPENDENCIES
   strong_migrations
   super_diff
   timecop
+  timeliness
   tzinfo-data
   uk_postcode
   view_component

--- a/app/forms/provider_interface/interview_wizard.rb
+++ b/app/forms/provider_interface/interview_wizard.rb
@@ -3,8 +3,6 @@ module ProviderInterface
     include ActiveModel::Model
     include ActiveModel::Attributes
 
-    VALID_TIME_FORMAT = /^(1[0-2]|0?[1-9])([:.\s]([0-5][0-9]))?([AaPp][Mm])$/.freeze
-
     attr_accessor :time, :location, :additional_details, :provider_id, :application_choice, :provider_user,
                   :current_step, :path_history, :wizard_path_history, :action, :referer
     attr_writer :date
@@ -123,18 +121,12 @@ module ProviderInterface
       end
     end
 
-    def time_in_correct_format?
-      time.match(VALID_TIME_FORMAT)
-    end
-
     def parsed_time
-      return unless time_in_correct_format?
-
-      Time.zone.parse(time.gsub(/[ .]/, ':'))
+      Timeliness.parse(time)
     end
 
     def time_is_valid
-      return if time_in_correct_format?
+      return if parsed_time.present?
 
       errors.add(:time, :invalid)
     end

--- a/config/initializers/timeliness.rb
+++ b/config/initializers/timeliness.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# Time formats for timeliness are defined here: https://github.com/adzap/timeliness/blob/master/lib/timeliness/definitions.rb
+
 Timeliness.add_formats('time', 'h[.]?')             # Allow 12/24 hour time with no minutes e.g. 14 = 2:00pm, 5 = 5am
 Timeliness.add_formats('time', 'h_nn')              # Allow 12/24 hour format without punctuation or am/pm
 Timeliness.add_formats('time', 'h_nn_ampm')         # Allow 12 hour format without punctuation between hours and minutes

--- a/config/initializers/timeliness.rb
+++ b/config/initializers/timeliness.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Timeliness.add_formats('time', 'h[.]?')             # Allow 12/24 hour time with no minutes e.g. 14 = 2:00pm, 5 = 5am
+Timeliness.add_formats('time', 'h_nn')              # Allow 12/24 hour format without punctuation or am/pm
+Timeliness.add_formats('time', 'h_nn_ampm')         # Allow 12 hour format without punctuation between hours and minutes
+Timeliness.add_formats('time', 'h[:.]_ampm')        # Allow 12 hour format with am/pm separated by .
+Timeliness.add_formats('time', 'h[:.]?_nn_._ampm')  # Allow hours and minutes separated with : or . and with am/pm separated by .

--- a/config/locales/provider_interface/interviews.yml
+++ b/config/locales/provider_interface/interviews.yml
@@ -36,13 +36,13 @@ en:
   helpers:
     label:
       provider_interface_interview_wizard:
-        time: Time
+        time: Start time
         location: Address or online meeting details
         additional_details: Additional details
     hint:
       provider_interface_interview_wizard:
         date: No later than %{rbd_date}, after which the application will be automatically rejected - enter numbers, for example, %{example_date}
-        time: For example, 9am or 2:30pm - enter 12pm for midday
+        time: For example, 2pm or 14:30
     legend:
       provider_interface_interview_wizard:
         date: Date

--- a/spec/components/provider_interface/interview_details_component_spec.rb
+++ b/spec/components/provider_interface/interview_details_component_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ProviderInterface::InterviewDetailsComponent do
   end
 
   it 'renders the interview time' do
-    time_row = find_table_row('Time')
+    time_row = find_table_row('Start time')
     expect(time_row.text).to include('3:30pm')
   end
 
@@ -61,7 +61,7 @@ RSpec.describe ProviderInterface::InterviewDetailsComponent do
     end
 
     it 'time' do
-      time_row = find_table_row('Time')
+      time_row = find_table_row('Start time')
       expect(time_row.css('a').attr('href').value).to eq('/provider/applications/1/interviews/new#provider-interface-interview-wizard-time-field')
     end
 

--- a/spec/forms/provider_interface/interview_wizard_spec.rb
+++ b/spec/forms/provider_interface/interview_wizard_spec.rb
@@ -115,8 +115,15 @@ RSpec.describe ProviderInterface::InterviewWizard do
       end
 
       context 'checks if the time is in the correct format' do
-        let(:invalid_times) { ['noon', '1700', '12:30', '12:3pm', '1800pm', '30am', '800am', '140am', '9 am', '14pm', '6767'] }
-        let(:valid_times) { ['12:30pm', '2pm', '1.30am', '01.24AM', '09am', '9:00am', '9 00am', '9am', '9:30am', '9 30am', '9.30am'] }
+        let(:invalid_times) do
+          ['00am', '0am', '17:15am', '1715am', '20:45pm', '900a m', 'noon', '12:3pm', '1800pm', '30am', '14pm', '6767']
+        end
+        let(:valid_times) do
+          ['05:15', '16:15', '0755', '1535', '09.43', '17.26', '08 26', '18 24', '8:am', '3:pm', '615am', '745.pm',
+           '900a.m.', '1000a.m', '1200 am', '6 30am', '7 30 am', '0515pm', '05:15am', '01.15am', '5:00am', '3.', '13',
+           '12:30pm', '2pm', '1.30am', '01.24AM', '09am', '9:00am', '9 00am', '9am', '9:30am', '9 30am', '9.30am',
+           '00', '0', '06']
+        end
 
         it 'the wizard is invalid and contains the right error when time is invalid' do
           invalid_times.each do |time|

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     fill_in 'Month', with: tomorrow.month
     fill_in 'Year', with: tomorrow.year
 
-    fill_in 'Time', with: time
+    fill_in 'Start time', with: time
 
     fill_in 'Address or online meeting details', with: 'N/A'
 
@@ -198,14 +198,14 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     expect(page).to have_field('Day', with: 1.day.from_now.day)
     expect(page).to have_field('Month', with: 1.day.from_now.month)
     expect(page).to have_field('Year', with: 1.day.from_now.year)
-    expect(page).to have_field('Time', with: '12:00pm')
+    expect(page).to have_field('Start time', with: '12:00pm')
     expect(page).to have_field('Address or online meeting details', with: 'N/A')
     expect(page).to have_field('Additional details (optional)', with: '')
 
     fill_in 'Day', with: 2.days.from_now.day
     fill_in 'Month', with: 2.days.from_now.month
     fill_in 'Year', with: 2.days.from_now.year
-    fill_in 'Time', with: '10am'
+    fill_in 'Start time', with: '10am'
 
     fill_in 'Address or online meeting details', with: 'Zoom meeting'
     fill_in 'Additional details (optional)', with: 'Business casual'
@@ -216,7 +216,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   def and_i_confirm_the_interview_details
     expect(page).to have_content('Check and send new interview details')
     expect(page).to have_content("Date\n#{2.days.from_now.to_s(:govuk_date)}")
-    expect(page).to have_content("Time\n10am")
+    expect(page).to have_content("Start time\n10am")
     expect(page).to have_content("Address or online meeting details\nZoom meeting")
     expect(page).to have_content("Additional details\nBusiness casual")
 

--- a/spec/system/support_interface/validation_errors_provider_spec.rb
+++ b/spec/system/support_interface/validation_errors_provider_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature 'Validation errors Provider' do
     fill_in 'Month', with: tomorrow.month
     fill_in 'Year', with: tomorrow.year
 
-    fill_in 'Time', with: '45pm'
+    fill_in 'Start time', with: '45pm'
 
     fill_in 'Address or online meeting details', with: 'We will let you know'
 

--- a/spec/system/support_interface/validation_errors_provider_summary_spec.rb
+++ b/spec/system/support_interface/validation_errors_provider_summary_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'Validation errors provider summary' do
     fill_in 'Month', with: tomorrow.month
     fill_in 'Year', with: tomorrow.year
 
-    fill_in 'Time', with: '45pm'
+    fill_in 'Start time', with: '45pm'
 
     fill_in 'Address or online meeting details', with: 'We will let you know'
 

--- a/spec/system/wizard_cache_cleared_spec.rb
+++ b/spec/system/wizard_cache_cleared_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Clearing the wizard cache' do
     fill_in 'Month', with: tomorrow.month
     fill_in 'Year', with: tomorrow.year
 
-    fill_in 'Time', with: time
+    fill_in 'Start time', with: time
 
     fill_in 'Address or online meeting details', with: 'N/A'
 
@@ -113,7 +113,7 @@ RSpec.describe 'Clearing the wizard cache' do
     expect(page.find_field('Day').value).to be_nil
     expect(page.find_field('Month').value).to be_nil
     expect(page.find_field('Year').value).to be_nil
-    expect(page.find_field('Time').value).to be_nil
+    expect(page.find_field('Start time').value).to be_nil
     expect(page.find_field('Address or online meeting details').value).to be_empty
   end
 


### PR DESCRIPTION
## Context
There are lots of validation errors around interviews. Many of them are users inputting human readable times, which are not accepted by our strict regex (or `Time.parse`).

## Changes
Use the `timeliness` gem to parse user inputted times, and to decide if they are valid

Add more spec coverage on what is considered a valid or invalid time for interviews

Update interview time hint text and field label

## To review
Try it out in the review app – are there any ways to break this and get a time you aren't expecting

## Trello
https://trello.com/c/hWdX7GiG/4454-implement-interview-time-validations-and-text-updates