### PR TITLE
[410] Increase timeout on build workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,6 @@ jobs:
   prepare-matrix:
     name: Prepare Environment Matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 15
     outputs:
       environments: ${{ steps.select-environments.outputs.environments }}
     steps:
@@ -40,6 +39,10 @@ jobs:
 
       - uses: DFE-Digital/github-actions/turnstyle@master
         name: Wait for other inprogress deployment runs
+        initial-wait-seconds: 12
+        poll-interval-seconds: 20
+        abort-after-seconds: 3600
+        same-branch-only: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Context
Build failures such as:
https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/1380012029

## Changes proposed in this pull request
It happens to wait more than 15m for other deployments to finish. We
increase it to 1h using the action native abort-after-seconds.
Other options added to improve reliability.

## Guidance to review
Same set-up as teaching vacancies etc

## Link to Trello card

https://trello.com/c/9wPb9a6R/410-increase-turnstyle-timeout

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
