### PR TITLE
Give example Support user set up interviews permissions

### DIFF
--- a/app/lib/create_example_provider_users_with_permissions.rb
+++ b/app/lib/create_example_provider_users_with_permissions.rb
@@ -15,6 +15,7 @@ class CreateExampleProviderUsersWithPermissions
     }, %w[1JA 1JB 24J], {
       manage_users: true,
       manage_organisations: true,
+      set_up_interviews: true,
       view_safeguarding_information: true,
       make_decisions: true,
     })


### PR DESCRIPTION
This user used to have permission when it was wrapped up inside make_decisions, so this just reinstates that logic and makes it easier to test in review apps
