### PR TITLE
Update the report status mapping

### DIFF
--- a/app/services/support_interface/ministerial_report_candidates_export.rb
+++ b/app/services/support_interface/ministerial_report_candidates_export.rb
@@ -47,8 +47,8 @@ module SupportInterface
     def determine_states(application)
       choice_statuses = application.application_choices.map(&:status)
 
-      if choice_statuses.any? { |choice_status| ApplicationStateChange::SUCCESSFUL_STATES.include? choice_status.to_sym }
-        MinisterialReport::CANDIDATES_REPORT_STATUS_MAPPING[:recruited]
+      if choice_statuses.any? { |choice_status| %w[pending_conditions offer_deferred recruited].include? choice_status }
+        MinisterialReport::CANDIDATES_REPORT_STATUS_MAPPING[:pending_conditions]
       elsif choice_statuses.any? { |choice_status| %w[offer conditions_not_met].include? choice_status }
         MinisterialReport::CANDIDATES_REPORT_STATUS_MAPPING[:offer]
       elsif choice_statuses.any? { |choice_status| %w[awaiting_provider_decision interviewing].include? choice_status }


### PR DESCRIPTION
## Context

The candidates ministerial report was displaying identical figures for the `candidates_holding _offers` and `candidates_that_have_accepted_offers` columns.

<img src="https://user-images.githubusercontent.com/47917431/138915867-22d5c360-7e60-448e-8640-becfb231ce4d.png" width="60%">  

This was because `ApplicationStateChange::SUCCESSFUL_STATES` was being used to map states, which included both `pending_conditions` and `offer`, when these actually needed to be mapped separately.

## Changes proposed in this pull request

Remove:
 `ApplicationStateChange::SUCCESSFUL_STATES.include?` 
and replace with
`%w[pending_conditions offer_deferred recruited].include?`

## Guidance to review


## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
