### PR TITLE
Restart journey if candidate changes qualification type to non-UK

### DIFF
--- a/app/controllers/candidate_interface/gcse/english/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/english/grade_controller.rb
@@ -26,7 +26,7 @@ module CandidateInterface
       @qualification_type = gcse_english_qualification.qualification_type
       @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path(@subject))
 
-      render view_path
+      render view_path(update_path: true)
     end
 
     def update
@@ -44,7 +44,7 @@ module CandidateInterface
         end
       else
         track_validation_error(@gcse_grade_form)
-        render view_path
+        render view_path(update_path: true)
       end
     end
 
@@ -75,17 +75,17 @@ module CandidateInterface
         ])
     end
 
-    def view_path
+    def view_path(update_path: false)
       if gcse_qualification? && application_not_submitted_yet?
-        if gcse_english_qualification.award_year.nil?
-          'candidate_interface/gcse/english/grade/multiple_gcse_new'
-        else
+        if update_path
           'candidate_interface/gcse/english/grade/multiple_gcse_edit'
+        else
+          'candidate_interface/gcse/english/grade/multiple_gcse_new'
         end
-      elsif gcse_english_qualification.award_year.nil?
-        'candidate_interface/gcse/english/grade/new'
-      else
+      elsif update_path
         'candidate_interface/gcse/english/grade/edit'
+      else
+        'candidate_interface/gcse/english/grade/new'
       end
     end
 

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -53,7 +53,8 @@ module CandidateInterface
     end
 
     def changed_qualification_type?
-      current_qualification.saved_change_to_qualification_type.present?
+      current_qualification.saved_change_to_qualification_type.present? &&
+        !@type_form.missing_qualification?
     end
 
     def next_gcse_path

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -32,10 +32,9 @@ module CandidateInterface
 
     def update
       @type_form = GcseQualificationTypeForm.new(qualification_params)
-      @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path)
 
       if @type_form.update(current_qualification)
-        redirect_to @return_to[:back_path]
+        redirect_to next_gcse_path_after_edit
       else
         track_validation_error(@type_form)
         render :edit
@@ -43,6 +42,19 @@ module CandidateInterface
     end
 
   private
+
+    def next_gcse_path_after_edit
+      @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path)
+      if changed_qualification_type?
+        next_gcse_path
+      else
+        @return_to[:back_path]
+      end
+    end
+
+    def changed_qualification_type?
+      current_qualification.saved_change_to_qualification_type.present?
+    end
 
     def next_gcse_path
       if non_uk_qualification?

--- a/app/forms/candidate_interface/gcse_enic_form.rb
+++ b/app/forms/candidate_interface/gcse_enic_form.rb
@@ -10,7 +10,7 @@ module CandidateInterface
 
     def self.build_from_qualification(qualification)
       new(
-        have_enic_reference: qualification.enic_reference?,
+        have_enic_reference: qualification.enic_reference.nil? ? nil : qualification.enic_reference?,
         enic_reference: qualification.enic_reference,
         comparable_uk_qualification: qualification.comparable_uk_qualification,
       )

--- a/app/forms/candidate_interface/gcse_qualification_type_form.rb
+++ b/app/forms/candidate_interface/gcse_qualification_type_form.rb
@@ -5,7 +5,8 @@ module CandidateInterface
     include ActiveModel::Model
 
     attr_accessor :subject, :level, :qualification_type,
-                  :other_uk_qualification_type, :non_uk_qualification_type
+                  :other_uk_qualification_type, :non_uk_qualification_type,
+                  :enic_reference, :comparable_uk_qualification
 
     validates :subject, :level, :qualification_type, presence: true
 
@@ -21,6 +22,8 @@ module CandidateInterface
         qualification_type: qualification.qualification_type,
         other_uk_qualification_type: qualification.other_uk_qualification_type,
         non_uk_qualification_type: qualification.non_uk_qualification_type,
+        enic_reference: qualification.enic_reference,
+        comparable_uk_qualification: qualification.comparable_uk_qualification,
       )
     end
 
@@ -36,6 +39,8 @@ module CandidateInterface
         qualification_type: qualification_type,
         other_uk_qualification_type: other_uk_qualification_type,
         non_uk_qualification_type: non_uk_qualification_type,
+        enic_reference: enic_reference,
+        comparable_uk_qualification: comparable_uk_qualification,
       )
     end
 
@@ -58,12 +63,16 @@ module CandidateInterface
           currently_completing_qualification: nil,
           not_completed_explanation: nil,
           missing_explanation: nil,
+          enic_reference: nil,
+          comparable_uk_qualification: nil,
         )
       else
         qualification.update!(
           qualification_type: qualification_type,
           other_uk_qualification_type: other_uk_qualification_type,
           non_uk_qualification_type: non_uk_qualification_type,
+          enic_reference: enic_reference,
+          comparable_uk_qualification: comparable_uk_qualification,
           currently_completing_qualification: nil,
           not_completed_explanation: nil,
           missing_explanation: nil,
@@ -94,6 +103,8 @@ module CandidateInterface
     def reset_non_uk_qualification_type
       if qualification_type != NON_UK_QUALIFICATION_TYPE
         @non_uk_qualification_type = nil
+        @enic_reference = nil
+        @comparable_uk_qualification = nil
       end
     end
   end

--- a/spec/forms/candidate_interface/gcse_qualification_type_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_qualification_type_form_spec.rb
@@ -100,6 +100,8 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
 
         expect(qualification.reload.qualification_type).to eq 'gcse'
         expect(qualification.non_uk_qualification_type).to eq nil
+        expect(qualification.enic_reference).to eq nil
+        expect(qualification.comparable_uk_qualification).to eq nil
       end
     end
 

--- a/spec/system/candidate_interface/entering_details/candidate_changing_gcse_to_international_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_changing_gcse_to_international_qualification_spec.rb
@@ -146,7 +146,6 @@ RSpec.feature 'Candidate changing UK GCSE to international qualification' do
   def then_i_see_the_review_page_with_new_details
     expect(page).to have_content 'Maths GCSE or equivalent'
 
-    save_and_open_page
     expect(page).to have_content 'Baccalauréat Général'
     expect(page).to have_content '100%'
     expect(page).to have_content '2000'

--- a/spec/system/candidate_interface/entering_details/candidate_changing_gcse_to_international_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_changing_gcse_to_international_qualification_spec.rb
@@ -1,0 +1,154 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate changing UK GCSE to international qualification' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their maths GCSE details and then update them' do
+    given_i_am_signed_in
+
+    when_i_visit_the_candidate_application_page
+    and_i_click_on_the_maths_gcse_link
+    then_i_see_the_add_gcse_maths_page
+
+    when_i_select_gcse_option
+    and_i_click_save_and_continue
+    then_i_see_add_grade_page
+
+    when_i_fill_in_the_grade
+    and_i_click_save_and_continue
+    then_i_see_add_year_page
+
+    when_i_fill_in_the_year
+    and_i_click_save_and_continue
+    then_i_see_the_review_page_with_correct_details
+
+    when_i_click_to_change_qualification_type
+    then_i_see_the_gcse_option_selected
+
+    when_i_select_an_international_qualification_type
+    and_i_click_save_and_continue
+    then_i_see_the_select_country_page
+
+    when_i_select_a_country
+    and_i_click_save_and_continue
+    then_i_see_the_add_enic_reference_page
+
+    when_i_fill_in_my_enic_reference_and_choose_an_equivalency
+    and_i_click_save_and_continue
+    then_i_see_add_new_grade_page
+
+    when_i_fill_in_a_new_grade
+    and_i_click_save_and_continue
+    then_i_see_qualification_year_page
+
+    when_i_enter_a_different_qualification_year
+    and_i_click_save_and_continue
+    then_i_see_the_review_page_with_new_details
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_click_on_the_maths_gcse_link
+    click_on 'Maths GCSE or equivalent'
+  end
+
+  def when_i_select_gcse_option
+    choose('GCSE')
+  end
+
+  def and_i_click_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def when_i_visit_the_candidate_application_page
+    visit '/candidate/application'
+  end
+
+  def then_i_see_the_add_gcse_maths_page
+    expect(page).to have_content 'What type of qualification in maths do you have?'
+  end
+
+  def then_i_see_the_review_page_with_correct_details
+    expect(page).to have_content 'Maths GCSE or equivalent'
+
+    expect(page).to have_content 'GCSE'
+    expect(page).to have_content 'A'
+    expect(page).to have_content '1990'
+  end
+
+  def then_i_see_add_grade_page
+    expect(page).to have_content t('gcse_edit_grade.page_title', subject: 'maths', qualification_type: 'GCSE')
+  end
+
+  def then_i_see_add_new_grade_page
+    expect(page).to have_content t('gcse_edit_grade.page_title', subject: 'maths', qualification_type: 'qualification')
+  end
+
+  def then_i_see_add_year_page
+    expect(page).to have_content t('gcse_edit_year.page_title', subject: 'maths', qualification_type: 'GCSE')
+  end
+
+  def when_i_fill_in_the_grade
+    fill_in 'Please specify your grade', with: 'A'
+  end
+
+  def when_i_fill_in_the_year
+    fill_in 'Enter year', with: '1990'
+  end
+
+  def then_i_see_the_gcse_option_selected
+    expect(find_field('GCSE')).to be_checked
+  end
+
+  def when_i_click_to_change_qualification_type
+    find_link('Change', href: candidate_interface_gcse_details_edit_type_path(subject: 'maths')).click
+  end
+
+  def when_i_select_an_international_qualification_type
+    choose('Non-UK qualification')
+    within '#candidate-interface-gcse-qualification-type-form-qualification-type-non-uk-conditional' do
+      fill_in 'Qualification name', with: 'Baccalauréat Général'
+    end
+  end
+
+  def then_i_see_the_select_country_page
+    expect(page).to have_content t('gcse_edit_institution_country.page_title', subject: 'Maths')
+  end
+
+  def when_i_select_a_country
+    select 'France'
+  end
+
+  def then_i_see_the_add_enic_reference_page
+    expect(page).to have_current_path candidate_interface_gcse_details_new_enic_path('maths')
+  end
+
+  def when_i_fill_in_my_enic_reference_and_choose_an_equivalency
+    fill_in 'candidate-interface-gcse-enic-form-enic-reference-field', with: '12345'
+    choose 'GCSE (grades A*-C / 9-4)'
+  end
+
+  def when_i_fill_in_a_new_grade
+    choose 'Other'
+    fill_in 'Grade', with: '100%'
+  end
+
+  def then_i_see_qualification_year_page
+    expect(page).to have_content t('gcse_edit_year.page_title', subject: 'maths', qualification_type: 'qualification')
+  end
+
+  def when_i_enter_a_different_qualification_year
+    fill_in 'Enter year', with: '2000'
+  end
+
+  def then_i_see_the_review_page_with_new_details
+    expect(page).to have_content 'Maths GCSE or equivalent'
+
+    save_and_open_page
+    expect(page).to have_content 'Baccalauréat Général'
+    expect(page).to have_content '100%'
+    expect(page).to have_content '2000'
+  end
+end

--- a/spec/system/candidate_interface/entering_details/candidate_changing_gcse_to_international_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_changing_gcse_to_international_qualification_spec.rb
@@ -126,6 +126,7 @@ RSpec.feature 'Candidate changing UK GCSE to international qualification' do
   end
 
   def when_i_fill_in_my_enic_reference_and_choose_an_equivalency
+    choose 'Yes'
     fill_in 'candidate-interface-gcse-enic-form-enic-reference-field', with: '12345'
     choose 'GCSE (grades A*-C / 9-4)'
   end

--- a/spec/system/candidate_interface/entering_details/candidate_changing_their_gcse_type_from_completed_to_missing_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_changing_their_gcse_type_from_completed_to_missing_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Candidate changing their GCSE type' do
     when_i_change_my_qualification_type
     when_i_select_gcse_option
     and_i_click_save_and_continue
-    then_i_see_the_review_page_with_empty_details
+    then_i_see_add_grade_page
   end
 
   def given_i_am_signed_in

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
@@ -34,16 +34,11 @@ RSpec.feature 'Candidate entering GCSE details' do
 
     when_i_select_a_different_qualification_type
     and_i_click_save_and_continue
-    then_i_see_the_review_page_with_updated_qualification_type
-
-    when_i_click_to_change_grade
-    then_i_see_the_gcse_grade_entered
+    then_i_see_the_grade_page
+    and_i_see_the_gcse_grade_entered
 
     when_i_enter_a_different_qualification_grade
     and_i_click_save_and_continue
-    then_i_see_the_review_page_with_updated_grade
-
-    when_i_click_to_change_year
     then_i_see_the_gcse_year_entered
 
     when_i_enter_a_different_qualification_year
@@ -69,18 +64,12 @@ RSpec.feature 'Candidate entering GCSE details' do
     create_and_sign_in_candidate
   end
 
-  def given_i_am_not_signed_in; end
-
   def and_i_click_on_the_maths_gcse_link
     click_on 'Maths GCSE or equivalent'
   end
 
   def when_i_select_gcse_option
     choose('GCSE')
-  end
-
-  def when_i_select_gce_option
-    choose('O Level')
   end
 
   def and_i_click_save_and_continue
@@ -93,10 +82,6 @@ RSpec.feature 'Candidate entering GCSE details' do
     visit '/candidate/application'
   end
 
-  def then_the_maths_gcse_should_be_incomplete
-    expect(page).to have_content 'Maths GCSE or equivalent Incomplete'
-  end
-
   def then_i_see_the_add_gcse_maths_page
     expect(page).to have_content 'What type of qualification in maths do you have?'
   end
@@ -107,14 +92,6 @@ RSpec.feature 'Candidate entering GCSE details' do
     expect(page).to have_content 'GCSE'
     expect(page).to have_content 'A'
     expect(page).to have_content '1990'
-  end
-
-  def then_i_see_the_review_page_with_updated_qualification_type
-    expect(page).to have_content 'Scottish National 5'
-  end
-
-  def then_i_see_the_review_page_with_updated_grade
-    expect(page).to have_content 'BB'
   end
 
   def then_i_see_the_review_page_with_updated_year
@@ -145,7 +122,11 @@ RSpec.feature 'Candidate entering GCSE details' do
     expect(find_field('GCSE')).to be_checked
   end
 
-  def then_i_see_the_gcse_grade_entered
+  def then_i_see_the_grade_page
+    expect(page).to have_content t('gcse_edit_grade.page_title', subject: 'maths', qualification_type: 'Scottish National 5')
+  end
+
+  def and_i_see_the_gcse_grade_entered
     expect(page).to have_selector("input[value='A']")
   end
 
@@ -163,14 +144,6 @@ RSpec.feature 'Candidate entering GCSE details' do
 
   def when_i_click_to_change_qualification_type
     find_link('Change', href: candidate_interface_gcse_details_edit_type_path(subject: 'maths')).click
-  end
-
-  def when_i_click_to_change_year
-    click_change_link('year')
-  end
-
-  def when_i_click_to_change_grade
-    click_change_link('grade')
   end
 
   def when_i_enter_a_different_qualification_grade

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
@@ -17,8 +17,10 @@ RSpec.feature 'Candidate is redirected correctly' do
     then_i_should_be_redirected_to_the_application_review_page
 
     when_i_update_english_gcse_qualification
-    then_i_should_be_redirected_to_the_application_review_page
-    and_i_should_see_my_updated_gcse_qualification
+    then_i_should_see_the_gcse_country_form
+
+    when_i_navigate_back_to_the_gcse_review_page
+    then_i_should_see_my_updated_gcse_qualification
 
     # GCSE English equivalent country
     when_i_click_change_english_gcse_country
@@ -289,7 +291,7 @@ RSpec.feature 'Candidate is redirected correctly' do
   end
 
   def then_i_should_see_the_gcse_country_form
-    expect(page).to have_current_path(candidate_interface_gcse_details_edit_institution_country_path(subject: 'english', 'return-to' => 'application-review'))
+    expect(page).to have_content t('gcse_edit_institution_country.page_title', subject: 'English')
   end
 
   def then_i_should_see_the_gcse_enic_statement_form
@@ -451,7 +453,11 @@ RSpec.feature 'Candidate is redirected correctly' do
     click_button t('save_and_continue')
   end
 
-  def and_i_should_see_my_updated_gcse_qualification
+  def when_i_navigate_back_to_the_gcse_review_page
+    visit candidate_interface_application_review_path
+  end
+
+  def then_i_should_see_my_updated_gcse_qualification
     within('[data-qa="gcse-english-qualification"]') do
       expect(page).to have_content('School Certificate English')
     end


### PR DESCRIPTION
## Context

If a candidate switches the qualification type of a GCSE to non-UK they are not taken through the international qualification journey so that they fill in country, ENIC equivalence details etc.

## Changes proposed in this pull request

If a candidate switches the qualification type of a GCSE to non-UK they should be redirected to the next page in the international qualification journey as though they were entering a new qualification rather than redirected back to the review page.

## Guidance to review

- Is the system spec sufficient for this?
- Are there other cases like this for which we need to direct the candidate to fill in the full details for a qualification after changing the type?

## Link to Trello card

https://trello.com/c/e1FX465h/3896-defect-changing-a-maths-gcse-to-a-non-uk-qualification

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
