### PR TITLE
Remove cancel interviews flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -35,7 +35,6 @@ class FeatureFlag
     [:summer_recruitment_banner, 'Show a banner to indicate a shorter recruitment timeframe during summer', 'Richard Pattinson'],
     [:restructured_immigration_status, 'New model for right to work and study in the UK to be released from 2022 cycle', 'Steve Hook'],
     [:block_fraudulent_submission, 'A button used on the fraud audit page to block submissions', 'James Glenn'],
-    [:cancel_upcoming_interviews_on_decision_made, 'When we make a decision on a candidate, future interviews should be cancelled', 'Richard Pattinson'],
     [:support_user_revert_withdrawn_offer, 'Allows a support user to revert an application withdrawn by the candidate', 'James Glenn'],
     [:region_from_postcode, 'Uses an external service to find the region code for each candidate using their postcode', 'Steve Hook'],
   ].freeze

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -31,13 +31,11 @@ class MakeOffer
           SetDeclineByDefault.new(application_form: application_choice.application_form).call
         end
 
-        if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made)
-          CancelUpcomingInterviews.new(
-            actor: actor,
-            application_choice: application_choice,
-            cancellation_reason: I18n.t('interview_cancellation.reason.offer_made'),
-          ).call!
-        end
+        CancelUpcomingInterviews.new(
+          actor: actor,
+          application_choice: application_choice,
+          cancellation_reason: I18n.t('interview_cancellation.reason.offer_made'),
+        ).call!
 
         SendNewOfferEmailToCandidate.new(application_choice: application_choice).call
       end

--- a/app/services/provider_interface/decline_or_withdraw_application.rb
+++ b/app/services/provider_interface/decline_or_withdraw_application.rb
@@ -55,13 +55,11 @@ module ProviderInterface
     end
 
     def cancel_upcoming_interviews!
-      if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made)
-        CancelUpcomingInterviews.new(
-          actor: @actor,
-          application_choice: @application_choice,
-          cancellation_reason: I18n.t('interview_cancellation.reason.application_withdrawn'),
-        ).call!
-      end
+      CancelUpcomingInterviews.new(
+        actor: @actor,
+        application_choice: @application_choice,
+        cancellation_reason: I18n.t('interview_cancellation.reason.application_withdrawn'),
+      ).call!
     end
 
     def auth

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -31,9 +31,7 @@ class RejectApplication
         SetDeclineByDefault.new(application_form: @application_choice.application_form).call
       end
 
-      if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made)
-        CancelUpcomingInterviews.new(actor: @auth.actor, application_choice: @application_choice, cancellation_reason: I18n.t('interview_cancellation.reason.application_rejected')).call!
-      end
+      CancelUpcomingInterviews.new(actor: @auth.actor, application_choice: @application_choice, cancellation_reason: I18n.t('interview_cancellation.reason.application_rejected')).call!
 
       SendCandidateRejectionEmail.new(application_choice: @application_choice).call
     end

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -10,17 +10,13 @@ class WithdrawApplication
       SetDeclineByDefault.new(application_form: application_choice.application_form).call
     end
 
-    if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made)
-      number_of_cancelled_interviews = application_choice.interviews.kept.upcoming_not_today.count
+    number_of_cancelled_interviews = application_choice.interviews.kept.upcoming_not_today.count
 
-      CancelUpcomingInterviews.new(
-        actor: application_choice.candidate,
-        application_choice: application_choice,
-        cancellation_reason: I18n.t('interview_cancellation.reason.application_withdrawn'),
-      ).call!
-    else
-      number_of_cancelled_interviews = 0
-    end
+    CancelUpcomingInterviews.new(
+      actor: application_choice.candidate,
+      application_choice: application_choice,
+      cancellation_reason: I18n.t('interview_cancellation.reason.application_withdrawn'),
+    ).call!
 
     if @application_choice.application_form.ended_without_success?
       CandidateMailer.withdraw_last_application_choice(@application_choice.application_form).deliver_later

--- a/app/views/candidate_interface/decisions/accept_offer.html.erb
+++ b/app/views/candidate_interface/decisions/accept_offer.html.erb
@@ -10,11 +10,7 @@
     <%= render(CandidateInterface::OfferReviewComponent.new(course_choice: @application_choice)) %>
 
     <% if !single_application_choice? %>
-      <% if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made) %>
-        <p class="govuk-body">Your other applications will be withdrawn and any upcoming interviews will be cancelled.</p>
-      <% else %>
-        <p class="govuk-body">By accepting this offer you understand that any other applications made through Apply for teacher training will be automatically withdrawn.</p>
-      <% end %>
+      <p class="govuk-body">Your other applications will be withdrawn and any upcoming interviews will be cancelled.</p>
     <% end %>
 
     <%= form_with model: @respond_to_offer, url: candidate_interface_accept_offer_path(@application_choice) do |f| %>

--- a/app/views/candidate_interface/decisions/withdraw.html.erb
+++ b/app/views/candidate_interface/decisions/withdraw.html.erb
@@ -15,9 +15,7 @@
       <p class="govuk-body">If you withdraw this course choice (and all your other course choices) you can still apply for more courses this year.</p>
     <% end %>
 
-    <% if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made) %>
-      <p class="govuk-body">Any upcoming interviews will be cancelled when you withdraw.</p>
-    <% end %>
+    <p class="govuk-body">Any upcoming interviews will be cancelled when you withdraw.</p>
 
     <%= govuk_button_to t('decisions.withdraw.confirm'), candidate_interface_withdraw_path, warning: true %>
   </div>

--- a/app/views/provider_interface/decline_or_withdraw/edit.html.erb
+++ b/app/views/provider_interface/decline_or_withdraw/edit.html.erb
@@ -7,7 +7,7 @@
 
     <p class="govuk-body">The candidate will be told that their application has been withdrawn.</p>
 
-    <% if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made) && @interview_cancellation_presenter.render? %>
+    <% if @interview_cancellation_presenter.render? %>
       <p class="govuk-body"><%= @interview_cancellation_presenter.text %></p>
     <% end %>
 

--- a/app/views/provider_interface/offer/checks/new.html.erb
+++ b/app/views/provider_interface/offer/checks/new.html.erb
@@ -19,7 +19,7 @@
                                                               available_course_options: @course_options,
                                                               show_conditions_link: true) %>
 
-      <% if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made) && @interview_cancellation_presenter.render? %>
+      <% if @interview_cancellation_presenter.render? %>
         <p class="govuk-body"><%= @interview_cancellation_presenter.text %></p>
       <% end %>
 

--- a/app/views/provider_interface/reasons_for_rejection/check.html.erb
+++ b/app/views/provider_interface/reasons_for_rejection/check.html.erb
@@ -24,7 +24,7 @@
         ) %>
       <% end %>
 
-      <% if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made) && @interview_cancellation_presenter.render? %>
+      <% if @interview_cancellation_presenter.render? %>
         <p class="govuk-body"><%= @interview_cancellation_presenter.text %></p>
       <% end %>
 

--- a/app/views/provider_mailer/application_withdrawn.text.erb
+++ b/app/views/provider_mailer/application_withdrawn.text.erb
@@ -7,6 +7,6 @@ Dear <%= @provider_user.full_name || 'colleague' %>
 
 <%= provider_interface_application_choice_url(@application_choice) %>
 
-<% if @number_of_cancelled_interviews.positive? && FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made) %>
+<% if @number_of_cancelled_interviews.positive? %>
   <%= t('interview_cancellation.explanation.email', count: @number_of_cancelled_interviews) %>
 <% end %>

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -180,8 +180,6 @@ RSpec.describe ProviderMailer, type: :mailer do
     context 'when some interviews were cancelled' do
       let(:number_of_cancelled_interviews) { 2 }
 
-      before { FeatureFlag.activate(:cancel_upcoming_interviews_on_decision_made) }
-
       it_behaves_like('a mail with subject and content',
                       'Harry Potter (123A) withdrew their application',
                       'provider name' => 'Dear Johny English',

--- a/spec/services/make_offer_spec.rb
+++ b/spec/services/make_offer_spec.rb
@@ -78,20 +78,14 @@ RSpec.describe MakeOffer do
         expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
       end
 
-      context 'when the feature flag is on' do
-        before do
-          FeatureFlag.activate(:cancel_upcoming_interviews_on_decision_made)
-        end
+      it 'then calls the cancel upcoming interview services' do
+        cancel_upcoming_interviews = instance_double(CancelUpcomingInterviews, call!: true)
 
-        it 'then calls the cancel upcoming interview services' do
-          cancel_upcoming_interviews = instance_double(CancelUpcomingInterviews, call!: true)
-
-          allow(CancelUpcomingInterviews)
-            .to receive(:new).with(actor: provider_user, application_choice: application_choice, cancellation_reason: 'We made you an offer.')
-               .and_return(cancel_upcoming_interviews)
-          make_offer.save!
-          expect(cancel_upcoming_interviews).to have_received(:call!)
-        end
+        allow(CancelUpcomingInterviews)
+          .to receive(:new).with(actor: provider_user, application_choice: application_choice, cancellation_reason: 'We made you an offer.')
+             .and_return(cancel_upcoming_interviews)
+        make_offer.save!
+        expect(cancel_upcoming_interviews).to have_received(:call!)
       end
     end
 

--- a/spec/services/provider_interface/decline_or_withdraw_application_spec.rb
+++ b/spec/services/provider_interface/decline_or_withdraw_application_spec.rb
@@ -58,26 +58,22 @@ RSpec.describe ProviderInterface::DeclineOrWithdrawApplication do
       expect(email_service).to have_received(:call)
     end
 
-    context 'when the cancel_upcoming_interviews_on_decision_made feature flag is on' do
-      before { FeatureFlag.activate(:cancel_upcoming_interviews_on_decision_made) }
+    it 'calls the CancelUpcomingInterviewsService' do
+      application_choice = create(:application_choice, :awaiting_provider_decision)
+      provider = application_choice.course_option.provider
+      permitted_user = create(:provider_user, :with_make_decisions, providers: [provider])
+      cancel_service = instance_double(CancelUpcomingInterviews, call!: true)
+      allow(CancelUpcomingInterviews).to receive(:new)
+                                           .with(
+                                             actor: permitted_user,
+                                             application_choice: application_choice,
+                                             cancellation_reason: 'You withdrew your application.',
+                                           )
+                                           .and_return(cancel_service)
 
-      it 'calls the CancelUpcomingInterviewsService' do
-        application_choice = create(:application_choice, :awaiting_provider_decision)
-        provider = application_choice.course_option.provider
-        permitted_user = create(:provider_user, :with_make_decisions, providers: [provider])
-        cancel_service = instance_double(CancelUpcomingInterviews, call!: true)
-        allow(CancelUpcomingInterviews).to receive(:new)
-                                             .with(
-                                               actor: permitted_user,
-                                               application_choice: application_choice,
-                                               cancellation_reason: 'You withdrew your application.',
-                                             )
-                                             .and_return(cancel_service)
+      described_class.new(application_choice: application_choice, actor: permitted_user).save!
 
-        described_class.new(application_choice: application_choice, actor: permitted_user).save!
-
-        expect(cancel_service).to have_received(:call!)
-      end
+      expect(cancel_service).to have_received(:call!)
     end
   end
 end

--- a/spec/services/reject_application_spec.rb
+++ b/spec/services/reject_application_spec.rb
@@ -78,20 +78,14 @@ RSpec.describe RejectApplication do
       expect(service.save).to be false
     end
 
-    context 'when the cancel upcoming feature flag is enabled' do
-      before do
-        FeatureFlag.activate(:cancel_upcoming_interviews_on_decision_made)
-      end
+    it 'calls the CancelUpcomingInterviews service' do
+      cancel_upcoming_interviews = instance_double(CancelUpcomingInterviews, call!: true)
 
-      it 'calls the CancelUpcomingInterviews service' do
-        cancel_upcoming_interviews = instance_double(CancelUpcomingInterviews, call!: true)
-
-        allow(CancelUpcomingInterviews)
-          .to receive(:new).with(actor: provider_user, application_choice: application_choice, cancellation_reason: 'Your application was unsuccessful.')
-                           .and_return(cancel_upcoming_interviews)
-        service.save
-        expect(cancel_upcoming_interviews).to have_received(:call!)
-      end
+      allow(CancelUpcomingInterviews)
+        .to receive(:new).with(actor: provider_user, application_choice: application_choice, cancellation_reason: 'Your application was unsuccessful.')
+                         .and_return(cancel_upcoming_interviews)
+      service.save
+      expect(cancel_upcoming_interviews).to have_received(:call!)
     end
   end
 end

--- a/spec/services/withdraw_application_spec.rb
+++ b/spec/services/withdraw_application_spec.rb
@@ -22,24 +22,20 @@ RSpec.describe WithdrawApplication do
       expect(SetDeclineByDefault).to have_received(:new).with(application_form: withdrawing_application.application_form)
     end
 
-    context 'when the cancel interviews feature flag is on' do
-      before { FeatureFlag.activate(:cancel_upcoming_interviews_on_decision_made) }
+    it 'cancels upcoming interviews for the withdrawn application' do
+      cancel_service = instance_double(CancelUpcomingInterviews, call!: true)
+      withdrawing_application = create(:application_choice, status: :interviewing)
+      allow(CancelUpcomingInterviews).to receive(:new)
+                                           .with(
+                                             actor: withdrawing_application.candidate,
+                                             application_choice: withdrawing_application,
+                                             cancellation_reason: 'You withdrew your application.',
+                                           )
+                                           .and_return(cancel_service)
 
-      it 'cancels upcoming interviews for the withdrawn application' do
-        cancel_service = instance_double(CancelUpcomingInterviews, call!: true)
-        withdrawing_application = create(:application_choice, status: :interviewing)
-        allow(CancelUpcomingInterviews).to receive(:new)
-                                             .with(
-                                               actor: withdrawing_application.candidate,
-                                               application_choice: withdrawing_application,
-                                               cancellation_reason: 'You withdrew your application.',
-                                             )
-                                             .and_return(cancel_service)
+      described_class.new(application_choice: withdrawing_application).save!
 
-        described_class.new(application_choice: withdrawing_application).save!
-
-        expect(cancel_service).to have_received(:call!)
-      end
+      expect(cancel_service).to have_received(:call!)
     end
 
     it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
@@ -105,11 +105,7 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def and_i_confirm_the_acceptance
-    if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made)
-      expect(page).to have_content 'Your other applications will be withdrawn and any upcoming interviews will be cancelled.'
-    else
-      expect(page).to have_content 'By accepting this offer you understand that any other applications made through Apply for teacher training will be automatically withdrawn.'
-    end
+    expect(page).to have_content 'Your other applications will be withdrawn and any upcoming interviews will be cancelled.'
     click_button 'Accept offer'
   end
 

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_spec.rb
@@ -75,10 +75,7 @@ RSpec.feature 'A candidate withdraws her application' do
 
   def then_i_see_a_confirmation_page
     expect(page).to have_content('Are you sure you want to withdraw this course choice?')
-
-    if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made)
-      expect(page).to have_content('Any upcoming interviews will be cancelled when you withdraw.')
-    end
+    expect(page).to have_content('Any upcoming interviews will be cancelled when you withdraw.')
   end
 
   def when_i_click_to_confirm_withdrawal

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_with_upcoming_interviews_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_with_upcoming_interviews_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 RSpec.feature 'A candidate withdraws with upcoming interviews' do
   include CandidateHelper
 
-  before { FeatureFlag.activate(:cancel_upcoming_interviews_on_decision_made) }
-
   scenario 'successful withdrawal' do
     given_i_am_signed_in_as_a_candidate
     and_i_have_an_application_choice_with_an_upcoming_interview

--- a/spec/system/provider_interface/make_offer_cancels_upcoming_interview_spec.rb
+++ b/spec/system/provider_interface/make_offer_cancels_upcoming_interview_spec.rb
@@ -3,9 +3,6 @@ require 'rails_helper'
 RSpec.feature 'Provider makes an offer on an application with interviews in the future' do
   include DfESignInHelpers
   include ProviderUserPermissionsHelper
-  before do
-    FeatureFlag.activate(:cancel_upcoming_interviews_on_decision_made)
-  end
 
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
   let(:provider) { provider_user.providers.first }
@@ -30,7 +27,7 @@ RSpec.feature 'Provider makes an offer on an application with interviews in the 
     then_i_see_the_review_page_with_cancelling_interviews_warning_text
 
     when_i_send_the_offer
-    then_i_see_that_the_offer_was_successfuly_made
+    then_i_see_that_the_offer_was_successfully_made
     and_future_interviews_are_cancelled
   end
 
@@ -96,7 +93,7 @@ RSpec.feature 'Provider makes an offer on an application with interviews in the 
     click_on 'Send offer'
   end
 
-  def then_i_see_that_the_offer_was_successfuly_made
+  def then_i_see_that_the_offer_was_successfully_made
     within('.govuk-notification-banner--success') do
       expect(page).to have_content('Offer sent')
     end

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -65,41 +65,6 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
     when_i_set_up_another_interview(days_in_future: 4)
     then_another_interview_has_been_created(4.days.from_now.to_s(:govuk_date))
-
-    unless FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made)
-      when_i_can_make_decisions_for_my_provider
-      and_i_visit_that_application_in_the_provider_interface
-      when_i_click_make_decision
-      and_i_make_an_offer
-      then_i_should_see_the_interview_on_the_interview_tab(4.days.from_now.to_s(:govuk_date))
-      but_i_should_not_see_the_set_up_change_or_cancel_interview_controls
-    end
-  end
-
-  def when_i_reload_the_page
-    visit current_path
-  end
-
-  def when_i_click_make_decision
-    click_link 'Make decision'
-  end
-
-  def and_i_make_an_offer
-    choose 'Make an offer'
-    click_button 'Continue'
-    click_button 'Continue' # conditions page
-    click_button 'Send offer'
-  end
-
-  def then_i_should_see_the_interview_on_the_interview_tab(date)
-    click_link 'Interviews'
-    and_an_interview_has_been_created(date)
-  end
-
-  def but_i_should_not_see_the_set_up_change_or_cancel_interview_controls
-    expect(page).not_to have_button('Set up interview')
-    expect(page).not_to have_link('Cancel interview')
-    expect(page).not_to have_link('Change interview')
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -110,10 +75,6 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     provider_user_exists_in_apply_database
   end
 
-  def when_i_can_make_decisions_for_my_provider
-    permit_make_decisions!
-  end
-
   def and_i_am_permitted_to_set_up_interviews_for_my_provider
     permit_set_up_interviews!
   end
@@ -122,15 +83,8 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     visit provider_interface_application_choice_path(application_choice)
   end
 
-  alias_method :and_i_visit_that_application_in_the_provider_interface, :when_i_visit_that_application_in_the_provider_interface
-
   def and_i_click_set_up_an_interview
     click_on 'Set up interview'
-  end
-
-  def i_can_set_up_an_interview
-    visit new_provider_interface_application_choice_interview_path(application_choice, date_and_time: 1.month.from_now)
-    expect(page).to have_content('Interview successfully created')
   end
 
   def when_i_set_up_another_interview(days_in_future:)
@@ -189,7 +143,6 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     end
   end
 
-  alias_method :and_another_interview_has_been_created, :and_an_interview_has_been_created
   alias_method :then_another_interview_has_been_created, :and_an_interview_has_been_created
 
   def when_i_change_the_interview_details

--- a/spec/system/provider_interface/reject_an_application_cancels_upcoming_interviews_spec.rb
+++ b/spec/system/provider_interface/reject_an_application_cancels_upcoming_interviews_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe 'Reject an application with interviews' do
   include ProviderUserPermissionsHelper
   include CourseOptionHelpers
 
-  before do
-    FeatureFlag.activate(:cancel_upcoming_interviews_on_decision_made)
-  end
-
   scenario 'giving reasons for rejection' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider

--- a/spec/system/provider_interface/withdraw_an_application_at_candidates_request_spec.rb
+++ b/spec/system/provider_interface/withdraw_an_application_at_candidates_request_spec.rb
@@ -13,19 +13,13 @@ RSpec.describe "withdrawing an application at the candidate's request", type: :f
 
     when_i_visit_a_submitted_application
     and_i_click_a_link_to_withdraw_at_candidates_request
-
-    if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made)
-      then_i_see_the_interview_cancellation_explanation
-    end
+    then_i_see_the_interview_cancellation_explanation
 
     when_i_confirm_the_withdrawal
     then_i_see_a_message_confirming_that_the_application_has_been_withdrawn
     and_i_can_no_longer_see_the_withdraw_at_candidates_request_link
     and_the_candidate_receives_an_email_about_the_withdrawal
-
-    if FeatureFlag.active?(:cancel_upcoming_interviews_on_decision_made)
-      and_the_interview_has_been_cancelled
-    end
+    and_the_interview_has_been_cancelled
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in


### PR DESCRIPTION
## Context
We've finished all the work that's behind this feature flag, so let's remove it

## Changes proposed in this pull request
Remove all conditional code around cancelling interviews when decisions are made

Remove the feature flag from the list

## Link to Trello card
https://trello.com/c/dpEcFKGO/4434-remove-feature-flag-for-cancelling-interviews

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
