### PR TITLE
Structured reasons for rejection support dashboard - iterate at a glance metrics

### DIFF
--- a/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
+++ b/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
@@ -17,13 +17,15 @@
         size: :reduced,
       ) %>
     </div>
-    <div class="govuk-grid-column-one-half">
-      <%= render SupportInterface::TileComponent.new(
-        count: percentage_rejected_for_reason_this_month,
-        label: number_of_rejections_out_of_total_this_month,
-        size: :reduced,
-      ) %>
-    </div>
+    <% if @recruitment_cycle_year == RecruitmentCycle.current_year %>
+      <div class="govuk-grid-column-one-half">
+        <%= render SupportInterface::TileComponent.new(
+          count: percentage_rejected_for_reason_this_month,
+          label: number_of_rejections_out_of_total_this_month,
+          size: :reduced,
+        ) %>
+      </div>
+    <% end %>
   </div>
   <% if @sub_reasons_result %>
     <%= render SupportInterface::SubReasonsForRejectionTableComponent.new(

--- a/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
+++ b/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
@@ -11,23 +11,16 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
       <%= render SupportInterface::TileComponent.new(
-        count: @percentage_rejected,
+        count: percentage_rejected_for_reason,
         label: number_of_rejections_out_of_total_rejections,
-        colour: :blue,
+        colour: 'light-blue',
         size: :reduced,
       ) %>
     </div>
-    <div class="govuk-grid-column-one-quarter">
+    <div class="govuk-grid-column-one-half">
       <%= render SupportInterface::TileComponent.new(
-        count: @total_count,
-        label: 'total',
-        size: :reduced,
-      ) %>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-      <%= render SupportInterface::TileComponent.new(
-        count: @this_month,
-        label: 'this month',
+        count: percentage_rejected_for_reason_this_month,
+        label: number_of_rejections_out_of_total_this_month,
         size: :reduced,
       ) %>
     </div>
@@ -38,8 +31,8 @@
       sub_reasons: @sub_reasons_result,
       total_all_time: @total_rejection_count,
       total_this_month: @total_rejection_count_this_month,
-      total_for_reason_all_time: @total_count,
-      total_for_reason_this_month: @this_month,
+      total_for_reason_all_time: rejection_count,
+      total_for_reason_this_month: rejection_count(:this_month),
       recruitment_cycle_year: @recruitment_cycle_year,
     ) %>
   <% end %>

--- a/app/components/support_interface/reason_for_rejection_dashboard_section_component.rb
+++ b/app/components/support_interface/reason_for_rejection_dashboard_section_component.rb
@@ -2,13 +2,10 @@ module SupportInterface
   class ReasonForRejectionDashboardSectionComponent < ViewComponent::Base
     include ViewHelper
 
-    def initialize(heading:, total_count:, this_month:, percentage_rejected:, total_rejection_count:,
-                   total_rejection_count_this_month:, reason_key:, sub_reasons_result: nil,
-                   recruitment_cycle_year: RecruitmentCycle.current_year)
+    def initialize(heading:, rejection_reasons:, total_rejection_count:, total_rejection_count_this_month:,
+                   reason_key:, sub_reasons_result: nil, recruitment_cycle_year: RecruitmentCycle.current_year)
       @heading = heading
-      @total_count = total_count
-      @this_month = this_month
-      @percentage_rejected = percentage_rejected
+      @rejection_reasons = rejection_reasons
       @total_rejection_count = total_rejection_count
       @total_rejection_count_this_month = total_rejection_count_this_month
       @reason_key = reason_key
@@ -23,8 +20,24 @@ module SupportInterface
       sub_reasons_result.slice(*sub_reason_values.map(&:to_s)) if sub_reason_values.present?
     end
 
+    def rejection_count(time_period = :all_time)
+      @rejection_reasons[@reason_key]&.send(time_period) || 0
+    end
+
+    def percentage_rejected_for_reason
+      formatted_percentage(rejection_count, @total_rejection_count)
+    end
+
+    def percentage_rejected_for_reason_this_month
+      formatted_percentage(rejection_count(:this_month), @total_rejection_count_this_month)
+    end
+
     def number_of_rejections_out_of_total_rejections
-      "#{@total_count} of #{@total_rejection_count} application choices"
+      "#{rejection_count} of #{@total_rejection_count} rejections included this category"
+    end
+
+    def number_of_rejections_out_of_total_this_month
+      "#{rejection_count(:this_month)} of #{@total_rejection_count_this_month} rejections in #{Time.zone.now.strftime('%B')} included this category"
     end
   end
 end

--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
@@ -57,6 +57,7 @@
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
   heading: 'Honesty and professionalism',
+  rejection_reasons: rejection_reasons,
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :honesty_and_professionalism_y_n,

--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
@@ -1,8 +1,6 @@
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
   heading: 'Candidate behaviour',
-  total_count: total_rejection_count('candidate_behaviour_y_n'),
-  this_month: current_month_rejection_count('candidate_behaviour_y_n'),
-  percentage_rejected: percentage_rejected_for_reason('candidate_behaviour_y_n'),
+  rejection_reasons: rejection_reasons,
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :candidate_behaviour_y_n,
@@ -12,9 +10,7 @@
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
   heading: 'Quality of application',
-  total_count: total_rejection_count('quality_of_application_y_n'),
-  this_month: current_month_rejection_count('quality_of_application_y_n'),
-  percentage_rejected: percentage_rejected_for_reason('quality_of_application_y_n'),
+  rejection_reasons: rejection_reasons,
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :quality_of_application_y_n,
@@ -24,9 +20,7 @@
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
   heading: 'Qualifications',
-  total_count: total_rejection_count('qualifications_y_n'),
-  this_month: current_month_rejection_count('qualifications_y_n'),
-  percentage_rejected: percentage_rejected_for_reason('qualifications_y_n'),
+  rejection_reasons: rejection_reasons,
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :qualifications_y_n,
@@ -36,9 +30,7 @@
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
   heading: 'Performance at interview',
-  total_count: total_rejection_count('performance_at_interview_y_n'),
-  this_month: current_month_rejection_count('performance_at_interview_y_n'),
-  percentage_rejected: percentage_rejected_for_reason('performance_at_interview_y_n'),
+  rejection_reasons: rejection_reasons,
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :performance_at_interview_y_n,
@@ -47,9 +39,7 @@
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
   heading: 'Course full',
-  total_count: total_rejection_count('course_full_y_n'),
-  this_month: current_month_rejection_count('course_full_y_n'),
-  percentage_rejected: percentage_rejected_for_reason('course_full_y_n'),
+  rejection_reasons: rejection_reasons,
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :course_full_y_n,
@@ -58,9 +48,7 @@
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
   heading: 'Offered on another course',
-  total_count: total_rejection_count('offered_on_another_course_y_n'),
-  this_month: current_month_rejection_count('offered_on_another_course_y_n'),
-  percentage_rejected: percentage_rejected_for_reason('offered_on_another_course_y_n'),
+  rejection_reasons: rejection_reasons,
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :offered_on_another_course_y_n,
@@ -69,9 +57,6 @@
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
   heading: 'Honesty and professionalism',
-  total_count: total_rejection_count('honesty_and_professionalism_y_n'),
-  this_month: current_month_rejection_count('honesty_and_professionalism_y_n'),
-  percentage_rejected: percentage_rejected_for_reason('honesty_and_professionalism_y_n'),
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :honesty_and_professionalism_y_n,
@@ -81,9 +66,7 @@
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
   heading: 'Safeguarding concerns',
-  total_count: total_rejection_count('safeguarding_y_n'),
-  this_month: current_month_rejection_count('safeguarding_y_n'),
-  percentage_rejected: percentage_rejected_for_reason('safeguarding_y_n'),
+  rejection_reasons: rejection_reasons,
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :safeguarding_y_n,
@@ -93,9 +76,7 @@
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
   heading: 'Cannot sponsor visa',
-  total_count: total_rejection_count('cannot_sponsor_visa_y_n'),
-  this_month: current_month_rejection_count('cannot_sponsor_visa_y_n'),
-  percentage_rejected: percentage_rejected_for_reason('cannot_sponsor_visa_y_n'),
+  rejection_reasons: rejection_reasons,
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :cannot_sponsor_visa_y_n,
@@ -104,9 +85,7 @@
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
   heading: 'Additional advice or feedback',
-  total_count: total_rejection_count('other_advice_or_feedback_y_n'),
-  this_month: current_month_rejection_count('other_advice_or_feedback_y_n'),
-  percentage_rejected: percentage_rejected_for_reason('other_advice_or_feedback_y_n'),
+  rejection_reasons: rejection_reasons,
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :other_advice_or_feedback_y_n,

--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
@@ -53,7 +53,6 @@
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :course_full_y_n,
-  sub_reasons_result: sub_reasons_for(:qualifications_y_n),
   recruitment_cycle_year: recruitment_cycle_year,
 ) %>
 

--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.rb
@@ -2,7 +2,8 @@ module SupportInterface
   class ReasonsForRejectionDashboardComponent < ViewComponent::Base
     include ViewHelper
 
-    attr_reader :total_structured_rejection_reasons_count, :total_structured_rejection_reasons_count_this_month, :recruitment_cycle_year
+    attr_reader :total_structured_rejection_reasons_count, :total_structured_rejection_reasons_count_this_month,
+                :recruitment_cycle_year, :rejection_reasons
 
     def initialize(rejection_reasons, total_structured_rejection_reasons_count,
                    total_structured_rejection_reasons_count_this_month, recruitment_cycle_year = RecruitmentCycle.current_year)
@@ -14,24 +15,8 @@ module SupportInterface
 
   private
 
-    def current_month_rejection_count(reason)
-      @rejection_reasons[reason]&.this_month || 0
-    end
-
-    def total_rejection_count(reason)
-      @rejection_reasons[reason]&.all_time || 0
-    end
-
-    def percentage_rejected_for_reason(reason)
-      formatted_percentage(total_rejection_count(reason), total_structured_rejection_reasons_count)
-    end
-
     def sub_reasons_for(reason)
       @rejection_reasons[reason]&.sub_reasons || {}
-    end
-
-    def previous_rejection_count(reason)
-      total_rejection_count(reason) - current_month_rejection_count(reason)
     end
   end
 end

--- a/app/components/support_interface/sub_reasons_for_rejection_table_component.html.erb
+++ b/app/components/support_interface/sub_reasons_for_rejection_table_component.html.erb
@@ -1,12 +1,12 @@
 <table class="govuk-table govuk-!-margin-top-2">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header" width="40%">Reason</th>
-      <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections</th>
-      <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections within this category</th>
+      <th scope="col" class="govuk-table__header" width="30%">Reason</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="17.5%">Percentage of all rejections</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="17.5%">Percentage of all rejections within this category</th>
       <% if recruitment_cycle_year == RecruitmentCycle.current_year %>
-        <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections in <%= month_name %></th>
-        <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="20%">Percentage of all rejections in <%= month_name %> within this category</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="17.5%">Percentage of all rejections in <%= month_name %></th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="17.5%">Percentage of all rejections in <%= month_name %> within this category</th>
       <% end %>
     </tr>
   </thead>

--- a/app/frontend/styles/_card.scss
+++ b/app/frontend/styles/_card.scss
@@ -11,6 +11,11 @@
   color: govuk-colour("white");
 }
 
+.app-card--light-blue {
+  background: govuk-tint(govuk-colour("light-blue"), 73.5);
+  color: govuk-tint(govuk-colour("dark-blue"), 5);
+}
+
 .app-card--green {
   background: govuk-colour("green");
   color: govuk-colour("white");

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -104,7 +104,8 @@ module ViewHelper
   end
 
   def formatted_percentage(count, total)
-    return '-' if total.zero?
+    return '-' if total.zero? && count.positive?
+    return '0%' if total.zero?
 
     percentage = percent_of(count, total)
     precision = (percentage % 1).zero? ? 0 : 2

--- a/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
   end
 
   def summary_text(section)
-    section.css('.app-card--blue').text.split("\n").reject(&:blank?).map(&:strip)
+    section.css('.app-card--light-blue').text.split("\n").reject(&:blank?).map(&:strip)
   end
 
   def details_text(section, row_index)
@@ -68,7 +68,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
     it 'renders detailed candidate behaviour section' do
       section = rendered_component.css('.app-section')[0]
       expect(heading_text(section)).to eq('Candidate behaviour')
-      expect(summary_text(section)).to eq(['25%', '3 of 12 application choices'])
+      expect(summary_text(section)).to eq(['25%', '3 of 12 rejections included this category'])
       expect(details_text(section, 1)).to eq(['Didn’t reply to our interview offer', '8.33%', '1 of 12', '33.33%', '1 of 3', '0%', '0 of 9', '0%', '0 of 1'])
       expect(details_text(section, 2)).to eq(['Didn’t attend interview', '16.67%', '2 of 12', '66.67%', '2 of 3', '11.11%', '1 of 9', '100%', '1 of 1'])
     end
@@ -76,13 +76,13 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
     it 'renders quality of application section' do
       section = rendered_component.css('.app-section')[1]
       expect(heading_text(section)).to eq('Quality of application')
-      expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
+      expect(summary_text(section)).to eq(['0%', '0 of 12 rejections included this category'])
     end
 
     it 'renders qualifications section' do
       section = rendered_component.css('.app-section')[2]
       expect(heading_text(section)).to eq('Qualifications')
-      expect(summary_text(section)).to eq(['33.33%', '4 of 12 application choices'])
+      expect(summary_text(section)).to eq(['33.33%', '4 of 12 rejections included this category'])
       expect(details_text(section, 1)).to eq(['No Maths GCSE grade 4 (C) or above, or valid equivalent', '0%', '0 of 12', '0%', '0 of 4', '0%', '0 of 9', '0%', '0 of 2'])
       expect(details_text(section, 2)).to eq(['No English GCSE grade 4 (C) or above, or valid equivalent', '16.67%', '2 of 12', '50%', '2 of 4', '11.11%', '1 of 9', '50%', '1 of 2'])
       expect(details_text(section, 3)).to eq(['No Science GCSE grade 4 (C) or above, or valid equivalent (for primary applicants)', '8.33%', '1 of 12', '25%', '1 of 4', '11.11%', '1 of 9', '50%', '1 of 2'])
@@ -91,38 +91,38 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
     it 'renders interview section' do
       section = rendered_component.css('.app-section')[3]
       expect(heading_text(section)).to eq('Performance at interview')
-      expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
+      expect(summary_text(section)).to eq(['0%', '0 of 12 rejections included this category'])
     end
 
     it 'renders course full section' do
       section = rendered_component.css('.app-section')[4]
       expect(heading_text(section)).to eq('Course full')
-      expect(summary_text(section)).to eq(['8.33%', '1 of 12 application choices'])
+      expect(summary_text(section)).to eq(['8.33%', '1 of 12 rejections included this category'])
     end
 
     it 'renders alternative course section' do
       section = rendered_component.css('.app-section')[5]
       expect(heading_text(section)).to eq('Offered on another course')
-      expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
+      expect(summary_text(section)).to eq(['0%', '0 of 12 rejections included this category'])
     end
 
     it 'renders honesty and professionalism section' do
       section = rendered_component.css('.app-section')[6]
       expect(heading_text(section)).to eq('Honesty and professionalism')
-      expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
+      expect(summary_text(section)).to eq(['0%', '0 of 12 rejections included this category'])
     end
 
     it 'renders safeguarding section' do
       section = rendered_component.css('.app-section')[7]
       expect(heading_text(section)).to eq('Safeguarding concerns')
-      expect(summary_text(section)).to eq(['8.33%', '1 of 12 application choices'])
+      expect(summary_text(section)).to eq(['8.33%', '1 of 12 rejections included this category'])
       expect(details_text(section, 2)).to eq(['Information revealed by our vetting process makes the candidate unsuitable to work with children', '8.33%', '1 of 12', '100%', '1 of 1', '11.11%', '1 of 9', '100%', '1 of 1'])
     end
 
     it 'renders visa section' do
       section = rendered_component.css('.app-section')[8]
       expect(heading_text(section)).to eq('Cannot sponsor visa')
-      expect(summary_text(section)).to eq(['16.67%', '2 of 12 application choices'])
+      expect(summary_text(section)).to eq(['16.67%', '2 of 12 rejections included this category'])
     end
 
     it 'renders other advice section' do

--- a/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
@@ -128,7 +128,18 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
     it 'renders other advice section' do
       section = rendered_component.css('.app-section')[9]
       expect(heading_text(section)).to eq('Additional advice or feedback')
-      expect(summary_text(section)).to eq(['0%', '0 of 12 application choices'])
+      expect(summary_text(section)).to eq(['0%', '0 of 12 rejections included this category'])
+    end
+
+    context 'for a previous recruitment cycle' do
+      subject(:component) do
+        described_class.new(rejection_reasons, 12, 9, RecruitmentCycle.previous_year)
+      end
+
+      it 'only renders the all time glance metrics' do
+        section = rendered_component.css('.app-section')[0]
+        expect(section.css('.app-card').text.gsub(/\s+/, ' ').strip).to eq('25% 3 of 12 rejections included this category')
+      end
     end
   end
 end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -182,6 +182,10 @@ RSpec.describe ViewHelper, type: :helper do
       expect(helper.formatted_percentage(0, 24)).to eq '0%'
     end
 
+    it 'returns the correct value for a zero percentage of a zero total' do
+      expect(helper.formatted_percentage(0, 0)).to eq '0%'
+    end
+
     it 'handles NaN' do
       expect(helper.formatted_percentage(1, 0)).to eq '-'
     end

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -166,81 +166,74 @@ private
   def then_i_should_see_reasons_for_rejection_course_full
     within '#course-full' do
       expect(page).to have_content('0%')
-      expect(page).to have_content('0 of 5 application choices')
-      expect(page).to have_content('0 total')
-      expect(page).to have_content('0 this month')
+      expect(page).to have_content('0 of 5 rejections included this category')
+      expect(page).to have_content('0 of 2 rejections in December included this category')
     end
   end
 
   def and_i_should_see_reasons_for_rejection_candidate_behaviour
     within '#candidate-behaviour' do
       expect(page).to have_content('100%')
-      expect(page).to have_content('5 of 5 application choices')
-      expect(page).to have_content('5 total')
-      expect(page).to have_content('2 this month')
+      expect(page).to have_content('5 of 5 rejections included this category')
+      expect(page).to have_content('2 of 2 rejections in December included this category')
     end
   end
 
   def and_i_should_see_reasons_for_rejection_honesty_and_professionalism
     within '#honesty-and-professionalism' do
       expect(page).to have_content('0%')
-      expect(page).to have_content('0 of 5 application choices')
-      expect(page).to have_content('0 total')
-      expect(page).to have_content('0 this month')
+      expect(page).to have_content('0 of 5 rejections included this category')
+      expect(page).to have_content('0 of 2 rejections in December included this category')
     end
   end
 
   def and_i_should_see_reasons_for_rejection_offered_on_another_course
     within '#offered-on-another-course' do
       expect(page).to have_content('0%')
-      expect(page).to have_content('0 of 5 application choices')
-      expect(page).to have_content('0 total')
-      expect(page).to have_content('0 this month')
+      expect(page).to have_content('0 of 5 rejections included this category')
+      expect(page).to have_content('0 of 2 rejections in December included this category')
     end
   end
 
   def and_i_should_see_reasons_for_rejection_performance_at_interview
     within '#performance-at-interview' do
       expect(page).to have_content('0%')
-      expect(page).to have_content('0 of 5 application choices')
-      expect(page).to have_content('0 total')
-      expect(page).to have_content('0 this month')
+      expect(page).to have_content('0 of 5 rejections included this category')
+      expect(page).to have_content('0 of 2 rejections in December included this category')
     end
   end
 
   def and_i_should_see_reasons_for_rejection_qualifications
     within '#qualifications' do
       expect(page).to have_content('60%')
-      expect(page).to have_content('3 of 5 application choices')
-      expect(page).to have_content('3 total')
-      expect(page).to have_content('1 this month')
+      expect(page).to have_content('3 of 5 rejections included this category')
+      expect(page).to have_content('50%')
+      expect(page).to have_content('1 of 2 rejections in December included this category')
     end
   end
 
   def and_i_should_see_reasons_for_rejection_quality_of_application
     within '#quality-of-application' do
       expect(page).to have_content('0%')
-      expect(page).to have_content('0 of 5 application choices')
-      expect(page).to have_content('0 total')
-      expect(page).to have_content('0 this month')
+      expect(page).to have_content('0 of 5 rejections included this category')
+      expect(page).to have_content('0 of 2 rejections in December included this category')
     end
   end
 
   def and_i_should_see_reasons_for_rejection_safeguarding_concerns
     within '#safeguarding-concerns' do
       expect(page).to have_content('40%')
-      expect(page).to have_content('2 of 5 application choices')
-      expect(page).to have_content('2 total')
-      expect(page).to have_content('1 this month')
+      expect(page).to have_content('2 of 5 rejections included this category')
+      expect(page).to have_content('50%')
+      expect(page).to have_content('1 of 2 rejections in December included this category')
     end
   end
 
   def and_i_should_see_reasons_for_rejection_other_advice_or_feedback
     within '#additional-advice-or-feedback' do
       expect(page).to have_content('0%')
-      expect(page).to have_content('0 of 5 application choices')
-      expect(page).to have_content('0 total')
-      expect(page).to have_content('0 this month')
+      expect(page).to have_content('0 of 5 rejections included this category')
+      expect(page).to have_content('0 of 2 rejections in December included this category')
     end
   end
 
@@ -273,9 +266,8 @@ private
   def and_i_should_see_reasons_for_rejection_cannot_sponsor_visa
     within '#cannot-sponsor-visa' do
       expect(page).to have_content('0%')
-      expect(page).to have_content('0 of 5 application choices')
-      expect(page).to have_content('0 total')
-      expect(page).to have_content('0 this month')
+      expect(page).to have_content('0 of 5 rejections included this category')
+      expect(page).to have_content('0 of 2 rejections in December included this category')
     end
   end
 


### PR DESCRIPTION
## Context

We're iterating the design and stats shown on the structured reasons for rejection support dashboard.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Amend the 'At a glance' metrics for each section on the dashboard.

![image](https://user-images.githubusercontent.com/93511/139254834-1dbd01ac-4583-4ece-8972-8604e5de9473.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

This PR is based off https://github.com/DFE-Digital/apply-for-teacher-training/pull/5939 the last 3 commits deal with the 'At a glance' stats. 

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/GrSXN6hU/4412-sr4r-support-dashboard-iterate-at-a-glance-metrics
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
