### PR TITLE
Base register API applications on course year rather than application year

### DIFF
--- a/app/queries/get_recruited_application_choices.rb
+++ b/app/queries/get_recruited_application_choices.rb
@@ -10,7 +10,8 @@ class GetRecruitedApplicationChoices
 
     application_choices
       .includes(INCLUDES)
-      .where(application_forms: { recruitment_cycle_year: recruitment_cycle_year })
+      .joins(:current_course)
+      .merge(Course.in_cycle(recruitment_cycle_year))
       .where.not(recruited_at: nil)
   end
 end

--- a/spec/queries/get_recruited_application_choices_spec.rb
+++ b/spec/queries/get_recruited_application_choices_spec.rb
@@ -78,6 +78,26 @@ RSpec.describe GetRecruitedApplicationChoices do
     expect(application_choices).to be_empty
   end
 
+  it 'returns reinstated deferred applications that have since been recruited when in the matching year' do
+    create(
+      :application_choice,
+      :with_deferred_offer,
+      application_form: build(:application_form, recruitment_cycle_year: '2021'),
+      current_course_option: course_option_for_year('2022'),
+    )
+
+    reinstated_application = create(
+      :application_choice,
+      :with_deferred_offer,
+      :with_recruited,
+      application_form: build(:application_form, recruitment_cycle_year: '2021'),
+      current_course_option: course_option_for_year('2022'),
+    )
+
+    application_choices = described_class.call(recruitment_cycle_year: '2022')
+    expect(application_choices).to contain_exactly(reinstated_application)
+  end
+
   it 'returns nothing if no applications available for year given' do
     create(
       :application_choice,

--- a/spec/queries/get_recruited_application_choices_spec.rb
+++ b/spec/queries/get_recruited_application_choices_spec.rb
@@ -1,19 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe GetRecruitedApplicationChoices do
-  include CourseOptionHelpers
-
-  it 'returns the recruited applications for the given year' do
+  it 'returns the recruited applications to courses for the given year' do
     create(
       :application_choice,
       :with_declined_by_default_offer,
       application_form: build(:application_form, recruitment_cycle_year: '2021'),
+      current_course_option: course_option_for_year('2021'),
     )
 
     recruited_application = create(
       :application_choice,
       :with_recruited,
       application_form: build(:application_form, recruitment_cycle_year: '2021'),
+      current_course_option: course_option_for_year('2021'),
     )
 
     application_choices = described_class.call(recruitment_cycle_year: '2021')
@@ -25,6 +25,7 @@ RSpec.describe GetRecruitedApplicationChoices do
       :application_choice,
       :withdrawn,
       application_form: build(:application_form, recruitment_cycle_year: '2021'),
+      current_course_option: course_option_for_year('2021'),
     )
 
     withdrawn_application = create(
@@ -32,27 +33,49 @@ RSpec.describe GetRecruitedApplicationChoices do
       :withdrawn,
       recruited_at: Time.zone.now,
       application_form: build(:application_form, recruitment_cycle_year: '2021'),
+      current_course_option: course_option_for_year('2021'),
     )
 
     application_choices = described_class.call(recruitment_cycle_year: '2021')
     expect(application_choices).to contain_exactly(withdrawn_application)
   end
 
-  it 'returns the the previously recruited then deferred applications for the given year' do
+  it 'returns the previously recruited then deferred applications for the given year when they have not been reinstated' do
     create(
       :application_choice,
       :with_deferred_offer,
       application_form: build(:application_form, recruitment_cycle_year: '2021'),
+      current_course_option: course_option_for_year('2021'),
     )
 
     deferred_application = create(
       :application_choice,
       :with_deferred_offer_previously_recruited,
       application_form: build(:application_form, recruitment_cycle_year: '2021'),
+      current_course_option: course_option_for_year('2021'),
     )
 
     application_choices = described_class.call(recruitment_cycle_year: '2021')
     expect(application_choices).to contain_exactly(deferred_application)
+  end
+
+  it 'does not return reinstated deferred applications when in the next year' do
+    create(
+      :application_choice,
+      :with_deferred_offer,
+      application_form: build(:application_form, recruitment_cycle_year: '2021'),
+      current_course_option: course_option_for_year('2022'),
+    )
+
+    create(
+      :application_choice,
+      :with_deferred_offer_previously_recruited,
+      application_form: build(:application_form, recruitment_cycle_year: '2021'),
+      current_course_option: course_option_for_year('2022'),
+    )
+
+    application_choices = described_class.call(recruitment_cycle_year: '2021')
+    expect(application_choices).to be_empty
   end
 
   it 'returns nothing if no applications available for year given' do
@@ -60,6 +83,7 @@ RSpec.describe GetRecruitedApplicationChoices do
       :application_choice,
       :with_deferred_offer_previously_recruited,
       application_form: build(:application_form, recruitment_cycle_year: '2021'),
+      current_course_option: course_option_for_year('2021'),
     )
 
     application_choices = described_class.call(recruitment_cycle_year: '2022')
@@ -72,6 +96,7 @@ RSpec.describe GetRecruitedApplicationChoices do
         :application_choice,
         :with_deferred_offer_previously_recruited,
         application_form: build(:application_form, recruitment_cycle_year: '2021'),
+        current_course_option: course_option_for_year('2021'),
       )
       deferred_application.update(updated_at: Time.zone.now + 1.day)
 
@@ -84,11 +109,17 @@ RSpec.describe GetRecruitedApplicationChoices do
         :application_choice,
         :with_deferred_offer_previously_recruited,
         application_form: build(:application_form, recruitment_cycle_year: '2021'),
+        current_course_option: course_option_for_year('2021'),
         updated_at: Time.zone.now - 1.day,
       )
 
       application_choices = described_class.call(recruitment_cycle_year: '2021', changed_since: Time.zone.now)
       expect(application_choices).to be_empty
     end
+  end
+
+  def course_option_for_year(year)
+    course = create(:course, recruitment_cycle_year: year)
+    create(:course_option, course: course)
   end
 end


### PR DESCRIPTION
## Context
If an application was deferred and then reinstated in the next year, there is a mismatch between course year and the year on the application form. Previously, we were basing the register API on application form year, but it makes more sense to base it on the course year.

## Changes proposed in this pull request
Base the application filtering on course year

## Guidance to review
Not sure about the exact behaviour here so tests might need cleaning up – comments inline

## Link to Trello card
https://trello.com/c/KWx5SEoR/4430-make-register-api-recruitment-cycle-scope-return-applications-deferred-and-reinstated-in-2022-when-2022-is-passed-not-when-2021

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
