### PR TITLE
Update naming on fraud auditing dashboard

### DIFF
--- a/app/views/support_interface/candidates/_candidates_navigation.html.erb
+++ b/app/views/support_interface/candidates/_candidates_navigation.html.erb
@@ -4,7 +4,7 @@
 <%= render TabNavigationComponent.new(items: [
   { name: 'Applications', url: support_interface_applications_path, current: local_assigns[:current] == 'Applications' },
   { name: 'Candidate accounts', url: support_interface_candidates_path, current: local_assigns[:current] == 'Candidates' },
-  { name: 'Fraud auditing dashboard', url: support_interface_fraud_auditing_matches_path(years: RecruitmentCycle.current_year), current: local_assigns[:current] == 'Fraud auditing dashboard' },
+  { name: 'Duplicate candidate matches', url: support_interface_fraud_auditing_matches_path(years: RecruitmentCycle.current_year), current: local_assigns[:current] == 'Duplicate candidate matches' },
 ]) %>
 
 <h2 class="govuk-visually-hidden"><%= title %></h2>

--- a/app/views/support_interface/fraud_auditing_matches/index.html.erb
+++ b/app/views/support_interface/fraud_auditing_matches/index.html.erb
@@ -1,9 +1,9 @@
-<%= render 'support_interface/candidates/candidates_navigation', title: 'Fraud auditing dashboard' %>
+<%= render 'support_interface/candidates/candidates_navigation', title: 'Duplicate candidate matches' %>
 
-<p class="govuk-body govuk-!-width-two-thirds">A Fraud match appears in this list for applications that have a postcode, name and date of birth in common, but they were created using different candidate accounts.</p>
+<p class="govuk-body govuk-!-width-two-thirds">A match appears in this list for applications that have a postcode, name and date of birth in common, but they were created using different candidate accounts.</p>
 
 <div class="govuk-body govuk-!-width-two-thirds">
-  <h4 class="govuk-heading-s">For each new Fraud match support users should:</h4>
+  <h4 class="govuk-heading-s">For each new match support users should:</h4>
   <ul class="govuk-list govuk-list--bullet">
     <li class="govuk-body govuk-!-width-two-thirds">send a notice email through the dashboard (this will send to all listed email addresses)</li>
     <li class="govuk-body govuk-!-width-two-thirds">block submission of the matched applications</li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -904,16 +904,15 @@ Rails.application.routes.draw do
       patch '/revert-withdrawal/:application_choice_id' => 'application_forms/application_choices#revert_withdrawal'
     end
 
-    get '/duplicate-candidate-matches', to: redirect('/support/fraud-auditing-dashboard')
-    get '/fraud-auditing-dashboard' => 'fraud_auditing_matches#index', as: :fraud_auditing_matches
+    get '/duplicate-candidate-matches' => 'fraud_auditing_matches#index', as: :fraud_auditing_matches
 
     patch '/fraudulent/:fraud_match_id' => 'fraud_auditing_matches#fraudulent', as: :fraud_auditing_matches_fraudulent
-    get '/fraud-auditing-dashboard/:fraud_match_id/block-submission' => 'fraud_auditing_matches#confirm_block_submission', as: :fraud_auditing_matches_confirm_block_submission
-    patch '/fraud-auditing-dashboard/:fraud_match_id/block-submission' => 'fraud_auditing_matches#block_submission'
-    get '/fraud-auditing-dashboard/:fraud_match_id/unblock-submission' => 'fraud_auditing_matches#confirm_unblock_submission', as: :fraud_auditing_matches_confirm_unblock_submission
-    patch '/fraud-auditing-dashboard/:fraud_match_id/unblock-submission' => 'fraud_auditing_matches#unblock_submission'
-    get '/fraud-auditing-dashboard/:fraud_match_id/remove-access/:candidate_id' => 'fraud_auditing_matches#confirm_remove_access', as: :fraud_auditing_matches_confirm_remove_access
-    patch '/fraud-auditing-dashboard/:fraud_match_id/remove-access/:candidate_id' => 'fraud_auditing_matches#remove_access'
+    get '/duplicate-candidate-matches/:fraud_match_id/block-submission' => 'fraud_auditing_matches#confirm_block_submission', as: :fraud_auditing_matches_confirm_block_submission
+    patch '/duplicate-candidate-matches/:fraud_match_id/block-submission' => 'fraud_auditing_matches#block_submission'
+    get '/duplicate-candidate-matches/:fraud_match_id/unblock-submission' => 'fraud_auditing_matches#confirm_unblock_submission', as: :fraud_auditing_matches_confirm_unblock_submission
+    patch '/duplicate-candidate-matches/:fraud_match_id/unblock-submission' => 'fraud_auditing_matches#unblock_submission'
+    get '/duplicate-candidate-matches/:fraud_match_id/remove-access/:candidate_id' => 'fraud_auditing_matches#confirm_remove_access', as: :fraud_auditing_matches_confirm_remove_access
+    patch '/duplicate-candidate-matches/:fraud_match_id/remove-access/:candidate_id' => 'fraud_auditing_matches#remove_access'
 
     get '/send-email/:fraud_match_id' => 'fraud_auditing_matches#send_email', as: :fraud_auditing_matches_send_email
     post '/send-email/:fraud_match_id' => 'fraud_auditing_matches#send_email'

--- a/spec/components/support_interface/fraud_auditing_matches_table_component_spec.rb
+++ b/spec/components/support_interface/fraud_auditing_matches_table_component_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe SupportInterface::FraudAuditingMatchesTableComponent do
       expect(result.css('td')[5].text).to include('No')
       expect(result.css('td')[5].text).to include('Yes')
       expect(result.css('td')[6].text).to include('Block')
-      expect(result.css('td')[6].children[1].attributes['href'].value).to include("/support/fraud-auditing-dashboard/#{fraud_match1.id}/block-submission")
+      expect(result.css('td')[6].children[1].attributes['href'].value).to include("/support/duplicate-candidate-matches/#{fraud_match1.id}/block-submission")
       expect(result.css('td')[8].text).to include('No')
       expect(result.css('td')[8].text).to include('Mark as fraudulent')
     end
@@ -56,7 +56,7 @@ RSpec.describe SupportInterface::FraudAuditingMatchesTableComponent do
       expect(result.css('td')[5].text).to include('No')
       expect(result.css('td')[5].text).to include('Yes')
       expect(result.css('td')[6].text).to include('Block')
-      expect(result.css('td')[6].children[1].attributes['href'].value).to include("/support/fraud-auditing-dashboard/#{fraud_match2.id}/block-submission")
+      expect(result.css('td')[6].children[1].attributes['href'].value).to include("/support/duplicate-candidate-matches/#{fraud_match2.id}/block-submission")
       expect(result.css('td')[8].text).to include('Yes')
       expect(result.css('td')[8].text).to include('Mark as non fraudulent')
     end

--- a/spec/system/support_interface/duplicate_candidate_matches_removing_duplicate_application_spec.rb
+++ b/spec/system/support_interface/duplicate_candidate_matches_removing_duplicate_application_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-RSpec.feature 'See Fraud Auditing matches' do
+RSpec.feature 'See Duplicate candidate matches' do
   include DfESignInHelpers
   include CandidateHelper
 
-  scenario 'Support agent visits Fraud Auditing Dashboard page' do
+  scenario 'Support agent visits Duplicate candidate matches page' do
     given_i_am_a_support_user
     and_there_are_candidates_with_duplicate_applications_in_the_system
 

--- a/spec/system/support_interface/duplicate_candidate_matches_spec.rb
+++ b/spec/system/support_interface/duplicate_candidate_matches_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'See Fraud Auditing matches' do
+RSpec.feature 'See Duplicate candidate matches' do
   include DfESignInHelpers
 
   around do |example|
@@ -10,7 +10,7 @@ RSpec.feature 'See Fraud Auditing matches' do
     end
   end
 
-  scenario 'Support agent visits Fraud Auditing Dashboard page', sidekiq: true do
+  scenario 'Support agent visits Duplicate candidate matches page', sidekiq: true do
     given_i_am_a_support_user
     and_the_feature_flag_is_active
     and_i_go_to_fraud_auditing_dashboard_page


### PR DESCRIPTION
## Context

In keeping with legal advice we are updating the nomenclature to Duplicate candidate matches on the front end

## Changes proposed in this pull request

Update routes titles and removing references of fraud

## Guidance to review

Have I missed anything?

## Link to Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
