### PR TITLE
Update content in request a referee journey

### DIFF
--- a/app/views/candidate_interface/references/candidate_name/new.html.erb
+++ b/app/views/candidate_interface/references/candidate_name/new.html.erb
@@ -14,7 +14,7 @@
       </h1>
 
       <p class="govuk-body">
-        Tell the referee who the reference is for.
+        This is so your referee knows who is requesting the reference.
       </p>
 
       <%= f.govuk_text_field :first_name, label: { text: t('application_form.references.candidate_name.first_name.label'), size: 'm' }, hint: { text: t('application_form.references.candidate_name.first_name.hint_text') } %>

--- a/config/locales/candidate_interface/references.yml
+++ b/config/locales/candidate_interface/references.yml
@@ -28,10 +28,10 @@ en:
           character: 'For example, ‘They are the head coach for my athletics club. I’ve known them for 5 years’.'
       candidate_name:
         first_name:
-          label: First name
+          label: Your first name
           hint_text: Or given names
         last_name:
-          label: Last name
+          label: Your last name
           hint_text: Or family name
       unsubmitted:
         label: Are you ready to send a reference request to %{reference_name}?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,7 +153,7 @@ en:
     references_type: What kind of referee do you want to add?
     references_relationship: How do you know this referee and how long have you known them?
     references_unsubmitted_review: Check your answers before sending your request
-    references_candidate_name: What is your name?
+    references_candidate_name: What’s your name?
     references_send_request: Are you ready to send a reference request?
     references_retry_request: Retry reference request
     references_cancel_request: Are you sure you want to cancel this reference request?

--- a/spec/system/candidate_interface/references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_requests_a_reference_spec.rb
@@ -101,7 +101,7 @@ RSpec.feature 'Candidate requests a reference' do
   end
 
   def then_i_am_prompted_for_my_name
-    expect(page).to have_content('What is your name?')
+    expect(page).to have_content(t('application_form.references.candidate_name.first_name.label'))
   end
 
   def when_i_continue_without_entering_my_name
@@ -114,8 +114,8 @@ RSpec.feature 'Candidate requests a reference' do
   end
 
   def when_i_enter_my_name
-    fill_in 'First name', with: 'Topsy'
-    fill_in 'Last name', with: 'Turvey'
+    fill_in t('application_form.references.candidate_name.first_name.label'), with: 'Topsy'
+    fill_in t('application_form.references.candidate_name.last_name.label'), with: 'Turvey'
     click_button t('save_and_continue')
   end
 


### PR DESCRIPTION
## Context

We're doing this to make it really clear that we're asking for the candidate name, not the referee name - as some people have accidentally put the referee name in these fields.

## Changes proposed in this pull request

- Update copy 

## Link to Trello card

https://trello.com/c/KpYgZdlN/4104-dev-update-content-in-request-a-referee-journey

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
