### PR TITLE
Update R4R word count regex to match the frontend word count pattern

### DIFF
--- a/app/forms/provider_interface/reasons_for_rejection_wizard.rb
+++ b/app/forms/provider_interface/reasons_for_rejection_wizard.rb
@@ -172,7 +172,7 @@ module ProviderInterface
     end
 
     def excessive_word_count?(value, count = 100)
-      value.present? && value.scan(/\w+/).size > count
+      value.present? && value.scan(/\S+/).size > count
     end
 
     def to_model


### PR DESCRIPTION
## Context

A provider has contacted us via support saying that they're unable to leave some R4R feedback despite being within the word count. 

The GOV.UK frontend word count matcher allows hyphens and forward flashes for a single word, where as our backend validation doesn't. This leads to this:

![image](https://user-images.githubusercontent.com/42515961/139667468-9ec680a1-99ff-439d-b608-9740dcde6ee0.png)
 
## Changes proposed in this pull request

- Use the same regex pattern on the backend that the frontend uses

## Guidance to review

This is slightly abusable, but the risk seems minimal. Will this affect the API's? I'm unsure how word count will be done by the vendors?

## Link to Trello card

https://trello.com/c/AB9k94Mh/891-problems-inputting-feedback

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
