### PR TITLE
Add applications_open_from to the CourseSync

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -63,6 +63,7 @@ module TeacherTrainingPublicAPI
       course.description = course_from_api.summary
       course.start_date = course_from_api.start_date
       course.course_length = course_from_api.course_length
+      course.applications_open_from = course_from_api.applications_open_from
       course.recruitment_cycle_year = recruitment_cycle_year
       course.exposed_in_find = course_from_api.findable
       course.funding_type = course_from_api.funding_type

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
       open_on_apply { true }
       exposed_in_find { true }
       opened_on_apply_at { 2.months.ago }
+      applications_open_from { 2.months.ago }
     end
 
     trait :with_accredited_provider do

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
             summary: 'PGCE with QTS full time',
             start_date: '2021-09-01',
             course_length: 'OneYear',
+            applications_open_from: CycleTimetable.apply_opens,
             age_minimum: 4,
             age_maximum: 8,
           }],
@@ -56,6 +57,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
         expect(course_option.course.description).to eq 'PGCE with QTS full time'
         expect(course_option.course.start_date).to eq Time.zone.local(2021, 9, 1)
         expect(course_option.course.course_length).to eq 'OneYear'
+        expect(course_option.course.applications_open_from).to eq CycleTimetable.apply_opens
         expect(course_option.course.age_range).to eq '4 to 8'
         expect(course_option.site.name).to eq 'Main site'
         expect(course_option.site.address_line1).to eq 'Gorse SCITT'


### PR DESCRIPTION
## Context

Publish gives providers the option to accept applications for a course from a specific date. Currently, we don't have the concept of courses opening on a specific date. In order to do this we're going to need to pull the date in as part of our Sync.

## Changes proposed in this pull request

- Add applications_open_from to the SyncCourse service.

## Link to Trello card

https://trello.com/c/3uctdX3W/889-application-open-date-error-2bt-course-v978

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
