### PR TITLE
Ensure only courses only show on dropdown/radios if they're open for applications

### DIFF
--- a/app/forms/candidate_interface/pick_course_form.rb
+++ b/app/forms/candidate_interface/pick_course_form.rb
@@ -8,12 +8,12 @@ module CandidateInterface
     DropdownOption = Struct.new(:id, :name)
 
     def radio_available_courses
-      @radio_available_courses ||= courses_for_current_cycle.exposed_in_find.order(:name).includes(:course_options)
+      @radio_available_courses ||= available_courses
     end
 
     def dropdown_available_courses
       @dropdown_available_courses ||= begin
-        courses = courses_for_current_cycle.exposed_in_find.includes(:accredited_provider, :course_options)
+        courses = available_courses
 
         courses_with_unambiguous_names = courses.map do |course|
           name = unique_name_for(course) || course.name_and_code
@@ -64,7 +64,7 @@ module CandidateInterface
     end
 
     def available_courses
-      @available_courses ||= courses_for_current_cycle.exposed_in_find.includes(:accredited_provider, :course_options)
+      @available_courses ||= courses_for_current_cycle.exposed_in_find.open_for_applications.includes(:accredited_provider, :course_options).order(:name)
     end
 
     def courses_with_names

--- a/app/forms/candidate_interface/pick_provider_form.rb
+++ b/app/forms/candidate_interface/pick_provider_form.rb
@@ -6,7 +6,12 @@ module CandidateInterface
     validates :provider_id, presence: true
 
     def available_providers
-      @available_providers ||= Provider.joins(:courses).where(courses: { recruitment_cycle_year: RecruitmentCycle.current_year, exposed_in_find: true }).order(:name).distinct
+      @available_providers ||= Provider
+      .joins(:courses)
+      .where(courses: { recruitment_cycle_year: RecruitmentCycle.current_year, exposed_in_find: true })
+      .where('courses.applications_open_from <= ?', Time.zone.today)
+      .order(:name)
+      .distinct
     end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -12,6 +12,7 @@ class Course < ApplicationRecord
 
   scope :open_on_apply, -> { exposed_in_find.where(open_on_apply: true) }
   scope :exposed_in_find, -> { where(exposed_in_find: true) }
+  scope :open_for_applications, -> { where('courses.applications_open_from <= ?', Time.zone.today) }
   scope :current_cycle, -> { where(recruitment_cycle_year: RecruitmentCycle.current_year) }
   scope :previous_cycle, -> { where(recruitment_cycle_year: RecruitmentCycle.previous_year) }
   scope :in_cycle, ->(year) { where(recruitment_cycle_year: year) }

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     description { 'PGCE with QTS full time' }
     course_length { 'OneYear' }
     start_date { Faker::Date.between(from: 1.month.from_now, to: 1.year.from_now) }
+    applications_open_from { CycleTimetable.apply_opens }
     age_range { '4 to 8' }
     withdrawn { false }
     program_type { 'scitt_programme' }

--- a/spec/forms/candidate_interface/pick_course_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_course_form_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe CandidateInterface::PickCourseForm do
       provider = create(:provider, name: 'School with courses')
 
       create(:course, exposed_in_find: false, open_on_apply: true, name: 'Course not shown in Find', provider: provider)
-      create(:course, exposed_in_find: true, open_on_apply: false, name: 'Course not open on apply', provider: provider)
+      create(:course, exposed_in_find: true, open_on_apply: true, name: 'Course that is not accepting applications', applications_open_from: Time.zone.tomorrow, provider: provider)
       create(:course, exposed_in_find: true, open_on_apply: true, name: 'Course you can apply to', provider: provider)
       create(:course, exposed_in_find: true, open_on_apply: true, name: 'Course from another cycle', provider: provider, recruitment_cycle_year: 2016)
       create(:course, exposed_in_find: true, open_on_apply: true, name: 'Course from other provider')
 
       form = described_class.new(provider_id: provider.id)
 
-      expect(form.radio_available_courses.map(&:name)).to eql(['Course not open on apply', 'Course you can apply to'])
+      expect(form.radio_available_courses.map(&:name)).to eql(['Course you can apply to'])
     end
   end
 
@@ -40,6 +40,18 @@ RSpec.describe CandidateInterface::PickCourseForm do
       form = described_class.new(provider_id: provider.id)
 
       expect(form.dropdown_available_courses.map(&:name)).to eql(['This cycle (A)'])
+    end
+
+    it 'only shows courses which are open for applications' do
+      provider = create(:provider)
+      course = create(:course, :open_on_apply, name: 'Course is open for applications', code: 'A', provider: provider)
+      create(:course, :open_on_apply, name: 'Course is not open for applications', provider: provider, applications_open_from: Time.zone.tomorrow)
+
+      create(:course_option, course: course)
+
+      form = described_class.new(provider_id: provider.id)
+
+      expect(form.dropdown_available_courses.map(&:name)).to eql(['Course is open for applications (A)'])
     end
 
     context 'with no ambiguous courses' do

--- a/spec/forms/candidate_interface/pick_provider_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_provider_form_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::PickProviderForm do
   describe '#available_providers' do
-    it 'returns providers with a course exposed in find in the current cycle' do
+    it 'returns providers with a course exposed in find in the current cycle which are open to applications' do
       create(:provider, name: 'School without courses')
       create(:course, open_on_apply: true, exposed_in_find: false, provider: create(:provider, name: 'School with disabled courses'))
-      create(:course, open_on_apply: true, exposed_in_find: true, provider: create(:provider, name: 'School with courses'))
+      create(:course, open_on_apply: true, exposed_in_find: true, applications_open_from: Time.zone.today, provider: create(:provider, name: 'School with courses'))
+      create(:course, open_on_apply: true, exposed_in_find: true, applications_open_from: Time.zone.tomorrow, provider: create(:provider, name: 'School with courses but not open for applications'))
       create(:course, open_on_apply: true, exposed_in_find: true, recruitment_cycle_year: RecruitmentCycle.previous_year)
 
       form = described_class.new({})


### PR DESCRIPTION
## Context

Publish gives providers the option to accept applications for a course from a specific date. Currently, we don't have the concept of courses opening on a specific date. In order to do this we're going to need to pull the date in as part of our sync.

This PR follows on from #5970 and ensures that only courses which are open for applications show in the dropdown/radio buttons on the pick course page.

It also ensures that only providers which have an open course, in the current cycle, which is open for applications show in the pick provider dropdown.

## Changes proposed in this pull request

- Update the pick provider dropdown to only have providers where a course is open for applications
- Update the pick course form/radio buttons to only have courses which are open for applications

## Link to Trello card

https://trello.com/b/dcWOMFyp/user-support-ticket-tracker

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
