### PR TITLE
Structured reasons for rejection -  Support dashboard content changes

### DIFF
--- a/app/components/support_interface/reasons_for_rejection_search_results_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.html.erb
@@ -1,7 +1,3 @@
-<p class="govuk-body">
-  Showing application choices with rejection reason <strong><%= search_title_text %></strong>
-</p>
-
 <% @application_choices.each do |application_choice| %>
   <section class="app-summary-card govuk-!-margin-bottom-6" id="application-choice-section-<%= application_choice.id %>">
     <%= render(SummaryCardHeaderComponent.new(

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -109,7 +109,7 @@ module ViewHelper
 
     percentage = percent_of(count, total)
     precision = (percentage % 1).zero? ? 0 : 2
-    number_to_percentage(percentage, precision: precision)
+    number_to_percentage(percentage, precision: precision, strip_insignificant_zeros: true)
   end
 
   def protect_against_mistakes

--- a/app/views/support_interface/performance/reasons_for_rejection_application_choices.html.erb
+++ b/app/views/support_interface/performance/reasons_for_rejection_application_choices.html.erb
@@ -1,5 +1,16 @@
+<% search_results_component = SupportInterface::ReasonsForRejectionSearchResultsComponent.new(
+  search_attribute: params[:structured_rejection_reasons].keys.first,
+  search_value: params[:structured_rejection_reasons].values.first,
+  application_choices: @application_choices,
+) -%>
 <% content_for :context, 'Structured reasons for rejection' %>
-<% content_for :title, 'Search' %>
+<% content_for :title do %>
+  <% if @application_choices.any? -%>
+    <%= search_results_component.search_title_text %>
+  <% else -%>
+    There are no results for the selected reason for rejection.
+  <% end -%>
+<% end -%>
 
 <% content_for :before_content do %>
   <%= render SupportInterface::ReasonsForRejectionSearchBreadcrumbComponent.new(
@@ -8,10 +19,6 @@
   ) %>
 <% end %>
 
-<%= render SupportInterface::ReasonsForRejectionSearchResultsComponent.new(
-  search_attribute: params[:structured_rejection_reasons].keys.first,
-  search_value: params[:structured_rejection_reasons].values.first,
-  application_choices: @application_choices,
-) %>
+<%= render search_results_component %>
 
 <%= render(PaginatorComponent.new(scope: @application_choices)) %>

--- a/app/views/support_interface/performance/reasons_for_rejection_dashboard.html.erb
+++ b/app/views/support_interface/performance/reasons_for_rejection_dashboard.html.erb
@@ -1,4 +1,11 @@
-<% content_for :title, 'Structured reasons for rejection' %>
+<% content_for :browser_title, 'Structured reasons for rejection' %>
+<% content_for :title do %>
+  <span class="govuk-caption-l">
+    <%= RecruitmentCycle.cycle_name(@recruitment_cycle_year) %> (starts <%= @recruitment_cycle_year %>)
+    <% if @recruitment_cycle_year == RecruitmentCycle.current_year %> - current<% end %>
+  </span>
+  Structured reasons for rejection
+<% end %>
 
 <% content_for :before_content do %>
   <%= breadcrumbs({
@@ -6,6 +13,22 @@
     'Structured reasons for rejection': nil,
   }) %>
 <% end %>
+
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Understanding this report
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      The report does not include rejections made through the API.
+    </p>
+    <p class="govuk-body">
+      Since users can choose more than one reason for rejection, the percentages for all the categories will not add up to 100%.
+    </p>
+  </div>
+</details>
 
 <%= render SupportInterface::ReasonsForRejectionDashboardComponent.new(
   @reasons_for_rejection,

--- a/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
@@ -36,10 +36,6 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
       render_result([@application_choice])
     end
 
-    it 'renders the correct title' do
-      expect(@rendered_result.text).to include('Showing application choices with rejection reason Quality of application')
-    end
-
     it 'renders a link to the application form' do
       expect(@rendered_result.css("a[href='/support/applications/123']")).to be_present
     end
@@ -80,12 +76,6 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
         application_form_id: 123,
       )
       render_result([@application_choice], :qualifications_which_qualifications, :no_degree)
-    end
-
-    it 'renders the correct title' do
-      expect(@rendered_result.text).to include(
-        'Showing application choices with rejection reason Qualifications - No degree',
-      )
     end
 
     it 'highlights the search term' do

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -70,16 +70,17 @@ RSpec.feature 'Structured reasons for rejection dashboard' do
   end
 
   def then_i_should_see_reasons_for_rejection_dashboard
-    then_i_should_see_reasons_for_rejection_course_full
+    then_i_should_see_reasons_for_rejection_title_and_details
     and_i_should_see_reasons_for_rejection_candidate_behaviour
-    and_i_should_see_reasons_for_rejection_honesty_and_professionalism
-    and_i_should_see_reasons_for_rejection_offered_on_another_course
-    and_i_should_see_reasons_for_rejection_other_advice_or_feedback
-    and_i_should_see_reasons_for_rejection_performance_at_interview
-    and_i_should_see_reasons_for_rejection_qualifications
     and_i_should_see_reasons_for_rejection_quality_of_application
+    and_i_should_see_reasons_for_rejection_qualifications
+    and_i_should_see_reasons_for_rejection_course_full
+    and_i_should_see_reasons_for_rejection_offered_on_another_course
+    and_i_should_see_reasons_for_rejection_honesty_and_professionalism
+    and_i_should_see_reasons_for_rejection_performance_at_interview
     and_i_should_see_reasons_for_rejection_safeguarding_concerns
     and_i_should_see_reasons_for_rejection_cannot_sponsor_visa
+    and_i_should_see_reasons_for_rejection_other_advice_or_feedback
   end
 
   def and_i_should_see_sub_reasons_for_rejection
@@ -163,7 +164,14 @@ private
     )
   end
 
-  def then_i_should_see_reasons_for_rejection_course_full
+  def then_i_should_see_reasons_for_rejection_title_and_details
+    expect(page).to have_content('2020 to 2021 (starts 2021) - current Structured reasons for rejection')
+    expect(page).to have_content('Understanding this report')
+    expect(page).to have_content('The report does not include rejections made through the API.')
+    expect(page).to have_content('Since users can choose more than one reason for rejection, the percentages for all the categories will not add up to 100%.')
+  end
+
+  def and_i_should_see_reasons_for_rejection_course_full
     within '#course-full' do
       expect(page).to have_content('0%')
       expect(page).to have_content('0 of 5 rejections included this category')

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -289,7 +289,8 @@ private
         structured_rejection_reasons: { candidate_behaviour_y_n: 'Yes' },
       ),
     )
-    expect(page).to have_content('Showing application choices with rejection reason Something you did')
+    expect(page).to have_css('span.govuk-caption-l', text: 'Structured reasons for rejection')
+    expect(page).to have_css('h1', text: 'Something you did')
     [
       @application_choice1,
       @application_choice2,
@@ -331,7 +332,8 @@ private
       ),
     )
 
-    expect(page).to have_content('Showing application choices with rejection reason Something you did - Didn’t attend interview')
+    expect(page).to have_css('span.govuk-caption-l', text: 'Structured reasons for rejection')
+    expect(page).to have_css('h1', text: 'Something you did - Didn’t attend interview')
 
     [
       @application_choice1,


### PR DESCRIPTION
## Context

We're iterating the design of support dashboard pages for structured reasons for rejection.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Amends title of SR4R dashboard
- Amends title of SR4R dashboard details page to show reason / sub reason
- Amends percentages to drop extraneous zeros after decimal place.
- Adds explanatory section on dashboard about percentage totals

![image](https://user-images.githubusercontent.com/93511/139706213-c0854f15-8d4a-4d79-b5df-59fb1f73f7d9.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Based on https://github.com/DFE-Digital/apply-for-teacher-training/pull/5960 so the last 3 commits are actual content & design changes for this story

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/zDXarBg7/4449-sr4r-dashboard-content-changes
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
