### PR TITLE
Add ExternalReportCandidatesExport for our monthly report

### DIFF
--- a/app/controllers/monthly_statistics_controller.rb
+++ b/app/controllers/monthly_statistics_controller.rb
@@ -1,6 +1,7 @@
 class MonthlyStatisticsController < ApplicationController
   def show
     @statistics = MonthlyStatisticsReport.last.statistics
+    @candidates_export = DataExport.where(export_type: 'external_report_candidates').order(:created_at).last
     @applications_export = DataExport.where(export_type: 'external_report_applications').order(:created_at).last
   end
 end

--- a/app/exports/external_report_candidates_export.yml
+++ b/app/exports/external_report_candidates_export.yml
@@ -1,0 +1,40 @@
+custom_columns:
+  candidates_sex:
+    type: string
+    description: The sex of the candidate
+    enum:
+      - Male
+      - Female
+      - Intersex
+      - Prefer not to say
+      - Not provided
+  area:
+    type: string
+    description: The region or country the candidates are from
+    enum:
+      - East
+      - East Midlands
+      - London
+      - North East
+      - North West
+      - Northern Ireland
+      - Scotland
+      - South East
+      - South West
+      - Wales
+      - West Midlands
+      - Yorkshire and The Humber
+      - European Economic Area
+      - Rest of the World
+  age_group:
+    type: string
+    description: The age group of the candidates
+    example: 21 and under
+  status:
+    type: string
+    description: The status of the candidates application
+    example: Recruited
+  total:
+    type: integer
+    description: The number of candidates who meet the aggregated data criteria
+    example: 1

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -76,8 +76,14 @@ class DataExport < ApplicationRecord
     external_report_applications: {
       name: 'External report applications',
       export_type: 'external_report_applications',
-      description: 'Aggregated applications choice data for the external reporting dashboard.',
+      description: 'Aggregated application choice data for the external reporting dashboard.',
       class: SupportInterface::ExternalReportApplicationsExport,
+    },
+    external_report_candidates: {
+      name: 'External report candidates',
+      export_type: 'external_report_candidates',
+      description: 'Aggregated candidate data for the external reporting dashboard.',
+      class: SupportInterface::ExternalReportCandidatesExport,
     },
     find_feedback: {
       name: 'Find feedback',
@@ -253,6 +259,7 @@ class DataExport < ApplicationRecord
     candidate_course_choice_withdrawal_survey: 'candidate_course_choice_withdrawal_survey',
     equality_and_diversity: 'equality_and_diversity',
     external_report_applications: 'external_report_applications',
+    external_report_candidates: 'external_report_candidates',
     find_feedback: 'find_feedback',
     interviews_export: 'interview_export',
     ministerial_report_applications_export: 'ministerial_report_applications_export',

--- a/app/services/support_interface/external_report_applications_export.rb
+++ b/app/services/support_interface/external_report_applications_export.rb
@@ -31,7 +31,7 @@ module SupportInterface
         end
       end
 
-      output.sort_by { |row| [row['Course type'], row['Age group'], row['Subject'], row['Provider area']] }
+      output
     end
 
   private

--- a/app/services/support_interface/external_report_candidates_export.rb
+++ b/app/services/support_interface/external_report_candidates_export.rb
@@ -13,16 +13,6 @@ module SupportInterface
         hash[sex][area][age_group][status] += count
       end
 
-      deferred_offers_counts.each do |item|
-        sex = item['sex']
-        area = item['area']
-        age_group = item['age_group']
-        status = item['status_before_deferral']
-        count = item['count']
-
-        hash[sex][area][age_group][status] += count
-      end
-
       output = []
 
       hash.each do |sex, areas|
@@ -81,15 +71,46 @@ module SupportInterface
                 f.id,
                 ac.id,
                 CASE
-                  #{equality_and_diversity_sql}
+                  WHEN f.equality_and_diversity is NULL THEN 'Not provided'
+                  WHEN f.equality_and_diversity->> 'sex' = 'intersex' then 'Intersex'
+                  WHEN f.equality_and_diversity->> 'sex' = 'male' then 'Male'
+                  WHEN f.equality_and_diversity->> 'sex' = 'female' then 'Female'
+                  WHEN f.equality_and_diversity->> 'sex' = 'Prefer not to say' then 'Prefer not to say'
                 END sex,
                 CASE
-                  #{area_sql}
+                  WHEN f.region_code = 'eastern' THEN 'East'
+                  WHEN f.region_code = 'east_midlands' THEN 'East Midlands'
+                  WHEN f.region_code = 'london' THEN 'London'
+                  WHEN f.region_code = 'north_east' THEN 'North East'
+                  WHEN f.region_code = 'north_west' THEN 'North West'
+                  WHEN f.region_code = 'northern_ireland' THEN 'Northern Ireland'
+                  WHEN f.region_code = 'scotland' THEN 'Scotland'
+                  WHEN f.region_code = 'south_east' THEN 'South East'
+                  WHEN f.region_code = 'south_west' THEN 'South West'
+                  WHEN f.region_code = 'wales' THEN 'Wales'
+                  WHEN f.region_code = 'west_midlands' THEN 'West Midlands'
+                  WHEN f.region_code = 'yorkshire_and_the_humber' THEN 'Yorkshire and The Humber'
+                  WHEN f.region_code = 'european_economic_area' THEN 'European Economic Area'
+                  WHEN f.region_code = 'rest_of_the_world' THEN 'Rest of the World'
                 END area,
                 CASE
-                  #{age_group_sql}
+                  WHEN f.date_of_birth > '#{Date.new(RecruitmentCycle.current_year - 22, 8, 31)}' THEN '21 and under'
+                  WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 23, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 22, 8, 31)}' THEN '22'
+                  WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 24, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 23, 8, 31)}' THEN '23'
+                  WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 25, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 24, 8, 31)}' THEN '24'
+                  WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 30, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 25, 8, 31)}' THEN '25 to 29'
+                  WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 35, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 30, 8, 31)}' THEN '30 to 34'
+                  WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 40, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 35, 8, 31)}' THEN '35 to 39'
+                  WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 45, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 40, 8, 31)}' THEN '40 to 44'
+                  WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 50, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 45, 8, 31)}' THEN '45 to 49'
+                  WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 55, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 50, 8, 31)}' THEN '50 to 54'
+                  WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 60, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 55, 8, 31)}' THEN '55 to 59'
+                  WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 65, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 60, 8, 31)}' THEN '60 to 64'
+                  WHEN f.date_of_birth < '#{Date.new(RecruitmentCycle.current_year - 65, 9, 1)}' THEN '65 and over'
                 END age_group,
                 CASE
+                  WHEN 'recruited' = ANY(ARRAY_AGG(ac.status_before_deferral)) THEN 'Recruited'
+                  WHEN 'pending_conditions' = ANY(ARRAY_AGG(ac.status_before_deferral)) THEN 'Conditions pending'
                   WHEN 'recruited' = ANY(ARRAY_AGG(ac.status)) THEN 'Recruited'
                   WHEN 'offer_deferred' = ANY(ARRAY_AGG(ac.status)) THEN 'offer_deferred'
                   WHEN 'pending_conditions' = ANY(ARRAY_AGG(ac.status)) THEN 'Conditions pending'
@@ -111,7 +132,7 @@ module SupportInterface
             WHERE
                 NOT c.hide_in_reporting
                 AND f.submitted_at IS NOT NULL
-                AND f.recruitment_cycle_year = #{RecruitmentCycle.current_year}
+                AND f.date_of_birth IS NOT NULL
                 AND f.region_code IN (
                   'eastern',
                   'east_midlands',
@@ -136,6 +157,9 @@ module SupportInterface
                     WHERE f.id = subsequent_application_forms.previous_application_form_id
                   )
                 )
+                AND f.recruitment_cycle_year = #{RecruitmentCycle.current_year}
+                OR f.recruitment_cycle_year = #{RecruitmentCycle.previous_year}
+                AND ac.status_before_deferral IS NOT NULL
             GROUP BY
                 c.id, ac.id, f.id
         )
@@ -153,116 +177,6 @@ module SupportInterface
             raw_data.age_group,
             raw_data.status
       SQL
-    end
-
-    def deferred_offers_counts
-      @deferred_offers_counts ||= ActiveRecord::Base
-        .connection
-        .execute(deferred_offers_query)
-        .to_a
-    end
-
-    def deferred_offers_query
-      <<-SQL
-        WITH raw_data AS (
-            SELECT
-                c.id,
-                f.id,
-                CASE
-                  WHEN ac.status_before_deferral = 'recruited' THEN 'Recruited'
-                  WHEN ac.status_before_deferral = 'pending_conditions' THEN 'Conditions pending'
-                END status_before_deferral,
-                CASE
-                  #{equality_and_diversity_sql}
-                END sex,
-                CASE
-                  #{area_sql}
-                END area,
-                CASE
-                  #{age_group_sql}
-                END age_group
-            FROM
-                application_forms f
-            LEFT JOIN
-                candidates c ON f.candidate_id = c.id
-            LEFT JOIN
-                application_choices ac ON ac.application_form_id = f.id
-            WHERE
-                NOT c.hide_in_reporting
-                AND f.recruitment_cycle_year = #{RecruitmentCycle.previous_year}
-                AND f.date_of_birth IS NOT NULL
-                AND ac.status_before_deferral IS NOT NULL
-                AND f.region_code IN (
-                  'eastern',
-                  'east_midlands',
-                  'london',
-                  'north_east',
-                  'north_west',
-                  'northern_ireland',
-                  'scotland',
-                  'south_east',
-                  'south_west',
-                  'wales',
-                  'west_midlands',
-                  'yorkshire_and_the_humber',
-                  'european_economic_area',
-                  'rest_of_the_world'
-                )
-            GROUP BY
-                c.id, f.id, ac.status_before_deferral
-        )
-        SELECT
-            raw_data.status_before_deferral,
-            raw_data.sex,
-            raw_data.area,
-            raw_data.age_group,
-            COUNT(*)
-        FROM
-            raw_data
-        GROUP BY
-            raw_data.status_before_deferral, raw_data.sex, raw_data.area, raw_data.age_group
-      SQL
-    end
-
-    def equality_and_diversity_sql
-      "WHEN f.equality_and_diversity is NULL THEN 'Not provided'
-      WHEN f.equality_and_diversity->> 'sex' = 'intersex' then 'Intersex'
-      WHEN f.equality_and_diversity->> 'sex' = 'male' then 'Male'
-      WHEN f.equality_and_diversity->> 'sex' = 'female' then 'Female'
-      WHEN f.equality_and_diversity->> 'sex' = 'Prefer not to say' then 'Prefer not to say'"
-    end
-
-    def area_sql
-      "WHEN f.region_code = 'eastern' THEN 'East'
-      WHEN f.region_code = 'east_midlands' THEN 'East Midlands'
-      WHEN f.region_code = 'london' THEN 'London'
-      WHEN f.region_code = 'north_east' THEN 'North East'
-      WHEN f.region_code = 'north_west' THEN 'North West'
-      WHEN f.region_code = 'northern_ireland' THEN 'Northern Ireland'
-      WHEN f.region_code = 'scotland' THEN 'Scotland'
-      WHEN f.region_code = 'south_east' THEN 'South East'
-      WHEN f.region_code = 'south_west' THEN 'South West'
-      WHEN f.region_code = 'wales' THEN 'Wales'
-      WHEN f.region_code = 'west_midlands' THEN 'West Midlands'
-      WHEN f.region_code = 'yorkshire_and_the_humber' THEN 'Yorkshire and The Humber'
-      WHEN f.region_code = 'european_economic_area' THEN 'European Economic Area'
-      WHEN f.region_code = 'rest_of_the_world' THEN 'Rest of the World'"
-    end
-
-    def age_group_sql
-      "WHEN f.date_of_birth > '#{Date.new(RecruitmentCycle.current_year - 22, 8, 31)}' THEN '21 and under'
-      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 23, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 22, 8, 31)}' THEN '22'
-      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 24, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 23, 8, 31)}' THEN '23'
-      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 25, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 24, 8, 31)}' THEN '24'
-      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 30, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 25, 8, 31)}' THEN '25 to 29'
-      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 35, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 30, 8, 31)}' THEN '30 to 34'
-      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 40, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 35, 8, 31)}' THEN '35 to 39'
-      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 45, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 40, 8, 31)}' THEN '40 to 44'
-      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 50, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 45, 8, 31)}' THEN '45 to 49'
-      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 55, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 50, 8, 31)}' THEN '50 to 54'
-      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 60, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 55, 8, 31)}' THEN '55 to 59'
-      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 65, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 60, 8, 31)}' THEN '60 to 64'
-      WHEN f.date_of_birth < '#{Date.new(RecruitmentCycle.current_year - 65, 9, 1)}' THEN '65 and over'"
     end
   end
 end

--- a/app/services/support_interface/external_report_candidates_export.rb
+++ b/app/services/support_interface/external_report_candidates_export.rb
@@ -1,0 +1,268 @@
+module SupportInterface
+  class ExternalReportCandidatesExport
+    def data_for_export(*)
+      hash = create_base_hash
+
+      counts.each do |item|
+        sex = item['sex']
+        area = item['area']
+        age_group = item['age_group']
+        status = item['status']
+        count = item['count']
+
+        hash[sex][area][age_group][status] += count
+      end
+
+      deferred_offers_counts.each do |item|
+        sex = item['sex']
+        area = item['area']
+        age_group = item['age_group']
+        status = item['status_before_deferral']
+        count = item['count']
+
+        hash[sex][area][age_group][status] += count
+      end
+
+      output = []
+
+      hash.each do |sex, areas|
+        areas.each do |area, age_groups|
+          age_groups.each do |age_group, statuses|
+            statuses.each do |status, count|
+              output << {
+                'Sex' => sex,
+                'Area' => area,
+                'Age group' => age_group,
+                'Status' => status,
+                'Total' => count,
+              }
+            end
+          end
+        end
+      end
+
+      output
+    end
+
+  private
+
+    def create_base_hash
+      hash = {}
+
+      ExternalReportCandidates::SEX.each_value do |sex|
+        hash[sex] = {}
+        ExternalReportCandidates::AREAS.each_value do |area|
+          hash[sex][area] = {}
+          ExternalReportCandidates::AGE_GROUPS.each do |age_group|
+            hash[sex][area][age_group] = {}
+            ExternalReportCandidates::STATUSES.each do |status|
+              hash[sex][area][age_group][status] = 0
+            end
+          end
+        end
+      end
+
+      hash
+    end
+
+    def counts
+      @counts ||= ActiveRecord::Base
+        .connection
+        .execute(query)
+        .to_a
+        .reject { |row| row.values.include?('offer_deferred') }
+    end
+
+    def query
+      <<-SQL
+        WITH raw_data AS (
+            SELECT
+                c.id,
+                f.id,
+                ac.id,
+                CASE
+                  #{equality_and_diversity_sql}
+                END sex,
+                CASE
+                  #{area_sql}
+                END area,
+                CASE
+                  #{age_group_sql}
+                END age_group,
+                CASE
+                  WHEN 'recruited' = ANY(ARRAY_AGG(ac.status)) THEN 'Recruited'
+                  WHEN 'offer_deferred' = ANY(ARRAY_AGG(ac.status)) THEN 'offer_deferred'
+                  WHEN 'pending_conditions' = ANY(ARRAY_AGG(ac.status)) THEN 'Conditions pending'
+                  WHEN 'interviewing' = ANY(ARRAY_AGG(ac.status)) THEN 'Received an offer'
+                  WHEN 'offer' = ANY(ARRAY_AGG(ac.status)) THEN 'Received an offer'
+                  WHEN 'awaiting_provider_decision' = ANY(ARRAY_AGG(ac.status)) THEN 'Awaiting provider decisions'
+                  WHEN 'declined' = ANY(ARRAY_AGG(ac.status)) THEN 'Unsuccessful'
+                  WHEN 'rejected' = ANY(ARRAY_AGG(ac.status)) THEN 'Unsuccessful'
+                  WHEN 'conditions_not_met' = ANY(ARRAY_AGG(ac.status)) THEN 'Unsuccessful'
+                  WHEN 'offer_withdrawn' = ANY(ARRAY_AGG(ac.status)) THEN 'Unsuccessful'
+                  WHEN 'withdrawn' = ANY(ARRAY_AGG(ac.status)) THEN 'Unsuccessful'
+                END status
+            FROM
+                application_forms f
+            LEFT JOIN
+                application_choices ac ON ac.application_form_id = f.id
+            LEFT JOIN
+                candidates c ON f.candidate_id = c.id
+            WHERE
+                NOT c.hide_in_reporting
+                AND f.submitted_at IS NOT NULL
+                AND f.recruitment_cycle_year = #{RecruitmentCycle.current_year}
+                AND f.region_code IN (
+                  'eastern',
+                  'east_midlands',
+                  'london',
+                  'north_east',
+                  'north_west',
+                  'northern_ireland',
+                  'scotland',
+                  'south_east',
+                  'south_west',
+                  'wales',
+                  'west_midlands',
+                  'yorkshire_and_the_humber',
+                  'european_economic_area',
+                  'rest_of_the_world'
+                )
+                AND (
+                  NOT EXISTS (
+                    SELECT 1
+                    FROM application_forms
+                    AS subsequent_application_forms
+                    WHERE f.id = subsequent_application_forms.previous_application_form_id
+                  )
+                )
+            GROUP BY
+                c.id, ac.id, f.id
+        )
+        SELECT
+            raw_data.sex,
+            raw_data.area,
+            raw_data.age_group,
+            raw_data.status,
+            COUNT(*)
+        FROM
+            raw_data
+        GROUP BY
+            raw_data.sex,
+            raw_data.area,
+            raw_data.age_group,
+            raw_data.status
+      SQL
+    end
+
+    def deferred_offers_counts
+      @deferred_offers_counts ||= ActiveRecord::Base
+        .connection
+        .execute(deferred_offers_query)
+        .to_a
+    end
+
+    def deferred_offers_query
+      <<-SQL
+        WITH raw_data AS (
+            SELECT
+                c.id,
+                f.id,
+                CASE
+                  WHEN ac.status_before_deferral = 'recruited' THEN 'Recruited'
+                  WHEN ac.status_before_deferral = 'pending_conditions' THEN 'Conditions pending'
+                END status_before_deferral,
+                CASE
+                  #{equality_and_diversity_sql}
+                END sex,
+                CASE
+                  #{area_sql}
+                END area,
+                CASE
+                  #{age_group_sql}
+                END age_group
+            FROM
+                application_forms f
+            LEFT JOIN
+                candidates c ON f.candidate_id = c.id
+            LEFT JOIN
+                application_choices ac ON ac.application_form_id = f.id
+            WHERE
+                NOT c.hide_in_reporting
+                AND f.recruitment_cycle_year = #{RecruitmentCycle.previous_year}
+                AND f.date_of_birth IS NOT NULL
+                AND ac.status_before_deferral IS NOT NULL
+                AND f.region_code IN (
+                  'eastern',
+                  'east_midlands',
+                  'london',
+                  'north_east',
+                  'north_west',
+                  'northern_ireland',
+                  'scotland',
+                  'south_east',
+                  'south_west',
+                  'wales',
+                  'west_midlands',
+                  'yorkshire_and_the_humber',
+                  'european_economic_area',
+                  'rest_of_the_world'
+                )
+            GROUP BY
+                c.id, f.id, ac.status_before_deferral
+        )
+        SELECT
+            raw_data.status_before_deferral,
+            raw_data.sex,
+            raw_data.area,
+            raw_data.age_group,
+            COUNT(*)
+        FROM
+            raw_data
+        GROUP BY
+            raw_data.status_before_deferral, raw_data.sex, raw_data.area, raw_data.age_group
+      SQL
+    end
+
+    def equality_and_diversity_sql
+      "WHEN f.equality_and_diversity is NULL THEN 'Not provided'
+      WHEN f.equality_and_diversity->> 'sex' = 'intersex' then 'Intersex'
+      WHEN f.equality_and_diversity->> 'sex' = 'male' then 'Male'
+      WHEN f.equality_and_diversity->> 'sex' = 'female' then 'Female'
+      WHEN f.equality_and_diversity->> 'sex' = 'Prefer not to say' then 'Prefer not to say'"
+    end
+
+    def area_sql
+      "WHEN f.region_code = 'eastern' THEN 'East'
+      WHEN f.region_code = 'east_midlands' THEN 'East Midlands'
+      WHEN f.region_code = 'london' THEN 'London'
+      WHEN f.region_code = 'north_east' THEN 'North East'
+      WHEN f.region_code = 'north_west' THEN 'North West'
+      WHEN f.region_code = 'northern_ireland' THEN 'Northern Ireland'
+      WHEN f.region_code = 'scotland' THEN 'Scotland'
+      WHEN f.region_code = 'south_east' THEN 'South East'
+      WHEN f.region_code = 'south_west' THEN 'South West'
+      WHEN f.region_code = 'wales' THEN 'Wales'
+      WHEN f.region_code = 'west_midlands' THEN 'West Midlands'
+      WHEN f.region_code = 'yorkshire_and_the_humber' THEN 'Yorkshire and The Humber'
+      WHEN f.region_code = 'european_economic_area' THEN 'European Economic Area'
+      WHEN f.region_code = 'rest_of_the_world' THEN 'Rest of the World'"
+    end
+
+    def age_group_sql
+      "WHEN f.date_of_birth > '#{Date.new(RecruitmentCycle.current_year - 22, 8, 31)}' THEN '21 and under'
+      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 23, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 22, 8, 31)}' THEN '22'
+      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 24, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 23, 8, 31)}' THEN '23'
+      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 25, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 24, 8, 31)}' THEN '24'
+      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 30, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 25, 8, 31)}' THEN '25 to 29'
+      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 35, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 30, 8, 31)}' THEN '30 to 34'
+      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 40, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 35, 8, 31)}' THEN '35 to 39'
+      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 45, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 40, 8, 31)}' THEN '40 to 44'
+      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 50, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 45, 8, 31)}' THEN '45 to 49'
+      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 55, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 50, 8, 31)}' THEN '50 to 54'
+      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 60, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 55, 8, 31)}' THEN '55 to 59'
+      WHEN f.date_of_birth BETWEEN '#{Date.new(RecruitmentCycle.current_year - 65, 9, 1)}' AND '#{Date.new(RecruitmentCycle.current_year - 60, 8, 31)}' THEN '60 to 64'
+      WHEN f.date_of_birth < '#{Date.new(RecruitmentCycle.current_year - 65, 9, 1)}' THEN '65 and over'"
+    end
+  end
+end

--- a/app/views/monthly_statistics/show.html.erb
+++ b/app/views/monthly_statistics/show.html.erb
@@ -19,6 +19,12 @@
         </a>
       </li>
       <li>
+        <a href="#by-status" class="govuk-link app-toc__link">
+          <span class="app-toc__number">2.</span>
+          <span class="app-toc__content">By status</span>
+        </a>
+      </li>
+      <li>
        <a href="#by-age-group" class="govuk-link app-toc__link">
          <span class="app-toc__number">3.</span>
          <span class="app-toc__content">By age group</span>
@@ -93,7 +99,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l" id="applications-by-status">2. By status</h2>
+    <h2 class="govuk-heading-l" id="by-status">2. By status</h2>
     <p class='govuk-body'>Applications can be in the following states:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>Draft</li>

--- a/app/views/monthly_statistics/show.html.erb
+++ b/app/views/monthly_statistics/show.html.erb
@@ -185,8 +185,15 @@
     <p class="govuk-body">You can download all of the data on this page in CSV (comma separated values) format, which can be opened in a spreadsheet and other analysis tools.</p>
     <p class="govuk-body">The downloads include some further breakdowns of the data by combining fields, for example applicant age group and sex.</p>
     <p class="govuk-body">Something about how rounding / disclosure / etc is handled in the CSV files.</p>
+    <% if @candidates_export.present? %>
+      <p class='govuk-body'>
+        <%= govuk_link_to 'Applicants by status, age group, sex, area (CSV)', download_support_interface_data_export_path(@candidates_export.id), type: 'text/csv' %>
+      </p>
+    <% end %>
     <% if @applications_export.present? %>
-      <%= govuk_link_to 'Applications by course type, age group, subject, provider area (CSV)', download_support_interface_data_export_path(@applications_export.id), type: 'text/csv', class: 'govuk-body' %>
+      <p class='govuk-body'>
+        <%= govuk_link_to 'Applications by course type, age group, subject, provider area (CSV)', download_support_interface_data_export_path(@applications_export.id), type: 'text/csv' %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/support_interface/data_exports/view_export_information.html.erb
+++ b/app/views/support_interface/data_exports/view_export_information.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
     <p class="govuk-body"><%= @data_export.fetch(:description) %></p>
-    <% if @data_export.fetch(:export_type) == 'external_report_applications' %>
+    <% if %w[external_report_applications external_report_candidates].include?(@data_export.fetch(:export_type)) %>
       <p class="govuk-body">This export is generated at midnight on the first of each month. Please use the latest copy in the history tab.</p>
     <% else %>
       <%= govuk_button_to 'Generate new export', support_interface_data_exports_path(export_type_id: params[:data_export_type]) %>

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -62,4 +62,12 @@ class Clock
     )
     DataExporter.perform_async(SupportInterface::ExternalReportApplicationsExport, export.id, {})
   end
+
+  every(1.day, 'Generate candidates export for the External Report', at: '00:00', if: ->(t) { t.day == 1 }) do
+    export = DataExport.create!(
+      name: 'External report candidates',
+      export_type: :external_report_candidates,
+    )
+    DataExporter.perform_async(SupportInterface::ExternalReportCandidatesExport, export.id, {})
+  end
 end

--- a/config/initializers/external_report_candidates.rb
+++ b/config/initializers/external_report_candidates.rb
@@ -1,0 +1,50 @@
+module ExternalReportCandidates
+  AREAS = {
+    'eastern' => 'East',
+    'east_midlands' => 'East Midlands',
+    'london' => 'London',
+    'north_east' => 'North East',
+    'north_west' => 'North West',
+    'northern_ireland' => 'Northern Ireland',
+    'scotland' => 'Scotland',
+    'south_east' => 'South East',
+    'south_west' => 'South West',
+    'wales' => 'Wales',
+    'west_midlands' => 'West Midlands',
+    'yorkshire_and_the_humber' => 'Yorkshire and The Humber',
+    'european_economic_area' => 'European Economic Area',
+    'rest_of_the_world' => 'Rest of the World',
+  }.freeze
+
+  AGE_GROUPS = [
+    '21 and under',
+    '22',
+    '23',
+    '24',
+    '25 to 29',
+    '30 to 34',
+    '35 to 39',
+    '40 to 44',
+    '45 to 49',
+    '50 to 54',
+    '55 to 59',
+    '60 to 64',
+    '65 and over',
+  ].freeze
+
+  SEX = {
+    'male' => 'Male',
+    'female' => 'Female',
+    'intersex' => 'Intersex',
+    'Prefer not to say' => 'Prefer not to say',
+    nil => 'Not provided',
+  }.freeze
+
+  STATUSES = [
+    'Recruited',
+    'Conditions pending',
+    'Received an offer',
+    'Awaiting provider decisions',
+    'Unsuccessful',
+  ].freeze
+end

--- a/spec/services/support_interface/external_report_applications_export_spec.rb
+++ b/spec/services/support_interface/external_report_applications_export_spec.rb
@@ -8,9 +8,12 @@ RSpec.describe SupportInterface::ExternalReportApplicationsExport do
       generate_test_data
       hash = add_test_data_to_hash(hash)
       expected_output = remove_key_from_hash(hash).sort
-      output = described_class.new.data_for_export
+      output = described_class.new.data_for_export.sort
 
-      expect(output).to eq(expected_output)
+      expected_output_with_empty_rows_removed = expected_output.reject { |row| row['Total'].zero? }
+      output_with_empty_rows_removed = output.reject { |row| row['Total'].zero? }
+
+      expect(output_with_empty_rows_removed).to eq(expected_output_with_empty_rows_removed)
     end
 
   private

--- a/spec/services/support_interface/external_report_candidates_export_spec.rb
+++ b/spec/services/support_interface/external_report_candidates_export_spec.rb
@@ -1,0 +1,143 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ExternalReportCandidatesExport do
+  describe '#data_for_export' do
+    it 'generates the full report with the correct totals' do
+      hash = create_base_hash_with_key
+
+      generate_test_data
+      hash = add_test_data_to_hash(hash)
+      expected_output = hash.values.sort
+      output = described_class.new.data_for_export.sort
+
+      expected_output_with_empty_rows_removed = expected_output.reject { |row| row['Total'].zero? }
+      output_with_empty_rows_removed = output.reject { |row| row['Total'].zero? }
+
+      expect(output_with_empty_rows_removed).to eq(expected_output_with_empty_rows_removed)
+    end
+
+  private
+
+    def create_base_hash_with_key
+      hash = {}
+
+      ExternalReportCandidates::SEX.each_value do |sex|
+        ExternalReportCandidates::AREAS.each_value do |area|
+          ExternalReportCandidates::AGE_GROUPS.each do |age_group|
+            ExternalReportCandidates::STATUSES.each do |status|
+              hash[construct_key(sex, area, age_group, status)] = {
+                'Sex' => sex,
+                'Area' => area,
+                'Age group' => age_group,
+                'Status' => status,
+                'Total' => 0,
+              }
+            end
+          end
+        end
+      end
+
+      hash
+    end
+
+    def generate_test_data
+      region_codes = ApplicationForm.region_codes.keys.reject { |region| %w[channel_islands isle_of_man no_region].include?(region) }
+      statuses = ApplicationChoice.statuses.keys.reject { |status| %w[unsubmitted cancelled application_not_sent offer_deferred].include?(status) }
+      sexes = ExternalReportCandidates::SEX.keys
+
+      20.times do
+        date_of_birth = rand(Time.zone.now - 75.years..Time.zone.now - 20.years)
+        region_code = region_codes.sample
+        status = statuses.sample
+        sex = sexes.sample
+
+        application_form = if sex.nil?
+                             create(:application_form, equality_and_diversity: nil, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code)
+                           else
+                             create(:application_form, :with_equality_and_diversity_data, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code)
+                           end
+
+        create(:application_choice, status: status, application_form: application_form)
+      end
+
+      5.times do
+        date_of_birth = rand(Time.zone.now - 75.years..Time.zone.now - 20.years)
+        region_code = region_codes.sample
+        status = %w[pending_conditions recruited].sample
+        sex = sexes.sample
+
+        application_form = if sex.nil?
+                             create(:application_form, equality_and_diversity: nil, recruitment_cycle_year: RecruitmentCycle.previous_year, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code)
+                           else
+                             create(:application_form, :with_equality_and_diversity_data, recruitment_cycle_year: RecruitmentCycle.previous_year, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code)
+                           end
+
+        create(:application_choice, :with_deferred_offer, status_before_deferral: status, application_form: application_form)
+      end
+    end
+
+    def add_test_data_to_hash(hash)
+      ApplicationForm.all.each do |application_form|
+        states = application_form.application_choices.map(&:status)
+        states = application_form.application_choices.map(&:status_before_deferral) if states.include?('offer_deferred')
+
+        hash[construct_key(
+          ExternalReportCandidates::SEX[application_form.equality_and_diversity&.dig('sex')],
+          ExternalReportCandidates::AREAS[application_form.region_code],
+          map_age_group(application_form.date_of_birth),
+          map_status(states),
+        )]['Total'] += 1
+      end
+
+      hash
+    end
+
+    def construct_key(sex, area, age_group, status)
+      "#{sex},#{area},#{age_group},#{status}"
+    end
+
+    def map_age_group(date_of_birth)
+      if date_of_birth > Date.new(RecruitmentCycle.current_year - 22, 8, 31)
+        '21 and under'
+      elsif date_of_birth.between?(Date.new(RecruitmentCycle.current_year - 23, 9, 1), Date.new(RecruitmentCycle.current_year - 22, 8, 31))
+        '22'
+      elsif date_of_birth.between?(Date.new(RecruitmentCycle.current_year - 24, 9, 1), Date.new(RecruitmentCycle.current_year - 23, 8, 31))
+        '23'
+      elsif date_of_birth.between?(Date.new(RecruitmentCycle.current_year - 25, 9, 1), Date.new(RecruitmentCycle.current_year - 24, 8, 31))
+        '24'
+      elsif date_of_birth.between?(Date.new(RecruitmentCycle.current_year - 30, 9, 1), Date.new(RecruitmentCycle.current_year - 25, 8, 31))
+        '25 to 29'
+      elsif date_of_birth.between?(Date.new(RecruitmentCycle.current_year - 35, 9, 1), Date.new(RecruitmentCycle.current_year - 30, 8, 31))
+        '30 to 34'
+      elsif date_of_birth.between?(Date.new(RecruitmentCycle.current_year - 40, 9, 1), Date.new(RecruitmentCycle.current_year - 35, 8, 31))
+        '35 to 39'
+      elsif date_of_birth.between?(Date.new(RecruitmentCycle.current_year - 45, 9, 1), Date.new(RecruitmentCycle.current_year - 40, 8, 31))
+        '40 to 44'
+      elsif date_of_birth.between?(Date.new(RecruitmentCycle.current_year - 50, 9, 1), Date.new(RecruitmentCycle.current_year - 45, 8, 31))
+        '45 to 49'
+      elsif date_of_birth.between?(Date.new(RecruitmentCycle.current_year - 55, 9, 1), Date.new(RecruitmentCycle.current_year - 50, 8, 31))
+        '50 to 54'
+      elsif date_of_birth.between?(Date.new(RecruitmentCycle.current_year - 60, 9, 1), Date.new(RecruitmentCycle.current_year - 55, 8, 31))
+        '55 to 59'
+      elsif date_of_birth.between?(Date.new(RecruitmentCycle.current_year - 65, 9, 1), Date.new(RecruitmentCycle.current_year - 60, 8, 31))
+        '60 to 64'
+      elsif date_of_birth < Date.new(RecruitmentCycle.current_year - 65, 9, 1)
+        '65 and over'
+      end
+    end
+
+    def map_status(states)
+      if states.include?('recruited')
+        'Recruited'
+      elsif states.include?('pending_conditions')
+        'Conditions pending'
+      elsif states.include?('offer') || states.include?('interviewing')
+        'Received an offer'
+      elsif states.include?('awaiting_provider_decision')
+        'Awaiting provider decisions'
+      elsif states.include?('conditions_not_met') || states.include?('rejected') || states.include?('declined') || states.include?('withdrawn') || states.include?('offer_withdrawn')
+        'Unsuccessful'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We need to provide CSVs of aggregated data for our external reporting.

This PR follows the pattern established in #5957 and adds in the functionality to download a CSV with aggregated data for sex, region, age and status for a candidates application

## Changes proposed in this pull request

-Adds in the export and some constants in an initialiser 
- Builds an export with the above aggregated data
- Ensure the export is run at midnight on the first of each month
- Add a download link to the monthly report page

## Guidance to review

Review per commit.

The ENUM warning can be ignored as it's a new value.

## Link to Trello card

https://trello.com/c/QBQYZSKh/3964-generate-monthly-stats-download-the-data-section

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
