### PR TITLE
Revert add Other reasons to SR4R support dashboard

### DIFF
--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
@@ -85,15 +85,6 @@
 ) %>
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
-  heading: 'Other reasons',
-  total_count: total_rejection_count('other_reasons_y_n'),
-  this_month: current_month_rejection_count('other_reasons_n'),
-  percentage_rejected: percentage_rejected_for_reason('other_reasons_y_n'),
-  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
-  reason_key: :other_reasons_y_n,
-) %>
-
-<%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
   heading: 'Additional advice or feedback',
   total_count: total_rejection_count('other_advice_or_feedback_y_n'),
   this_month: current_month_rejection_count('other_advice_or_feedback_y_n'),


### PR DESCRIPTION
## Context

We added a section to report on 'Other reasons' (the _Why are you rejecting this application?_ text field) in https://github.com/DFE-Digital/apply-for-teacher-training/pull/5942
This doesn't work as expected, the link to the details page currently raises an error.
Some additional thought needed as to how the queries are modified to accurately display this data as it doesn't follow the same Yes/No top level format of other questions.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Remove 'Other reasons' section from dashboard.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

- Visit support dashboard for SR4R, any recruitment cycle.
- 'Other reasons'  section should no longer be visible.
  
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
