### PR TITLE
Structured rejection reasons support dashboard : Link to details page with recruitment cycle year

### DIFF
--- a/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
+++ b/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
@@ -4,6 +4,7 @@
       @heading,
       support_interface_reasons_for_rejection_application_choices_path(
         "structured_rejection_reasons[#{@reason_key}]" => 'Yes',
+        'recruitment_cycle_year' => @recruitment_cycle_year,
       ),
     ) %>
   </h2>

--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
@@ -53,7 +53,6 @@
   total_rejection_count: total_structured_rejection_reasons_count,
   total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
   reason_key: :course_full_y_n,
-  sub_reasons_result: sub_reasons_for(:qualifications_y_n),
   recruitment_cycle_year: recruitment_cycle_year,
 ) %>
 

--- a/app/components/support_interface/sub_reasons_for_rejection_table_component.html.erb
+++ b/app/components/support_interface/sub_reasons_for_rejection_table_component.html.erb
@@ -18,6 +18,7 @@
             sub_reason_label(sub_reason),
             support_interface_reasons_for_rejection_application_choices_path(
               "structured_rejection_reasons[#{sub_reason_key}]": sub_reason,
+              recruitment_cycle_year: recruitment_cycle_year,
             ),
           ) %>
         </th>

--- a/app/components/support_interface/sub_reasons_for_rejection_table_component.rb
+++ b/app/components/support_interface/sub_reasons_for_rejection_table_component.rb
@@ -1,6 +1,7 @@
 module SupportInterface
   class SubReasonsForRejectionTableComponent < ViewComponent::Base
     include ViewHelper
+
     attr_accessor :reason, :sub_reasons, :total_all_time, :total_this_month, :total_for_reason_all_time,
                   :total_for_reason_this_month, :recruitment_cycle_year
 

--- a/app/queries/reasons_for_rejection_applications_query.rb
+++ b/app/queries/reasons_for_rejection_applications_query.rb
@@ -1,14 +1,16 @@
 class ReasonsForRejectionApplicationsQuery
   attr_accessor :filters
+  attr_reader :recruitment_cycle_year
 
   def initialize(filters)
-    self.filters = filters
+    @filters = filters
+    @recruitment_cycle_year = filters.fetch(:recruitment_cycle_year, RecruitmentCycle.current_year)
   end
 
   def call
     application_choices = ApplicationChoice
-      .where
-      .not(structured_rejection_reasons: nil)
+      .where(current_recruitment_cycle_year: recruitment_cycle_year)
+      .where.not(structured_rejection_reasons: nil)
       .order(created_at: :desc)
       .page(filters[:page])
       .per(30)
@@ -20,13 +22,11 @@ private
 
   def apply_filters(application_choices)
     filters[:structured_rejection_reasons].each do |key, value|
-      application_choices = if key =~ /_y_n$/
-                              application_choices.where('application_choices.structured_rejection_reasons->>:key = :value',
-                                                        { key: key, value: value })
-                            else
-                              application_choices.where('application_choices.structured_rejection_reasons->:key ? :value',
-                                                        { key: key, value: value })
-                            end
+      jsonb_query = key =~ /_y_n$/ ? '->>:key = :value' : '->:key ? :value'
+
+      application_choices = application_choices.where(
+        "application_choices.structured_rejection_reasons#{jsonb_query}", { key: key, value: value }
+      )
     end
 
     application_choices

--- a/spec/queries/reasons_for_rejection_applications_query_spec.rb
+++ b/spec/queries/reasons_for_rejection_applications_query_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ReasonsForRejectionApplicationsQuery do
+  describe '#call' do
+    let!(:application_choice) { create(:application_choice, :with_structured_rejection_reasons) }
+    let!(:application_choice_without_sr4r) { create(:application_choice) }
+    let!(:application_choice_from_previous_year) do
+      create(:application_choice, :with_structured_rejection_reasons, current_recruitment_cycle_year: RecruitmentCycle.previous_year)
+    end
+    let(:filter_params) do
+      {
+        structured_rejection_reasons: { 'candidate_behaviour_y_n' => 'Yes' },
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+      }
+    end
+
+    subject(:query) { described_class.new(filter_params) }
+
+    it 'filters by rejection reason key and recruitment cycle' do
+      expect(query.call).to eq([application_choice])
+    end
+  end
+end

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -287,6 +287,7 @@ private
     expect(page).to have_current_path(
       support_interface_reasons_for_rejection_application_choices_path(
         structured_rejection_reasons: { candidate_behaviour_y_n: 'Yes' },
+        recruitment_cycle_year: RecruitmentCycle.current_year,
       ),
     )
     expect(page).to have_content('Showing application choices with rejection reason Something you did')
@@ -328,6 +329,7 @@ private
     expect(page).to have_current_path(
       support_interface_reasons_for_rejection_application_choices_path(
         structured_rejection_reasons: { candidate_behaviour_what_did_the_candidate_do: 'didnt_attend_interview' },
+        recruitment_cycle_year: RecruitmentCycle.current_year,
       ),
     )
 


### PR DESCRIPTION
## Context

We recently added the ability to see rejection reasons for the current and previous recruitment cycle years.
The links to the applications search for the rejection reasons do not retain/query based on the recruitment cycle which makes the details from the search results look incompatible with the dashboard.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Amend the rejection reasons applications search to query using recruitment cycle year.
- Pass recruitment cycle year down through the various components so that links to the details/search page contain the recruitment cycle year. 
- 
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

The links should include the recruitment cycle year param when navigating from dashboard to details.

The test coverage is poor/non-existant for some of these components, this should improve in https://github.com/DFE-Digital/apply-for-teacher-training/pull/5960
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/4EctJm9k/4458-sr4r-support-dashboard-reason-details-page-doesnt-retain-recruitment-cycle-year
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
