### PR TITLE
TAD Export 1 - Degree class by subject & outcome

### DIFF
--- a/app/exports/tad_degree_class_export.yml
+++ b/app/exports/tad_degree_class_export.yml
@@ -1,0 +1,39 @@
+custom_columns:
+  subject:
+    type: string
+    description: The course subject
+    example: Criminology
+
+  route:
+    type: string
+    description: TBC
+    example: TBC
+
+  degree_class:
+    type: string
+    description: TBC
+    example: TBC
+
+  applications:
+    type: integer
+    description: TBC
+
+  offers_received:
+    type: integer
+    description: TBC
+
+  number_of_acceptances:
+    type: integer
+    description: TBC
+
+  number_of_declined_applications:
+    type: integer
+    description: TBC
+
+  number_of_rejected_applications:
+    type: integer
+    description: TBC
+
+  number_of_withdrawn_applications:
+    type: integer
+    description: TBC

--- a/app/exports/tad_degree_class_export.yml
+++ b/app/exports/tad_degree_class_export.yml
@@ -6,34 +6,38 @@ custom_columns:
 
   route:
     type: string
-    description: TBC
-    example: TBC
+    description: The provider type
+    enum:
+      - scitt
+      - lead_school
+      - university
+      - unknown
 
   degree_class:
     type: string
-    description: TBC
-    example: TBC
+    description: The grade awarded
+    example: Upper second-class honours (2:1)
 
   applications:
     type: integer
-    description: TBC
+    description: The number of applications for this subject, route & degree class
 
   offers_received:
     type: integer
-    description: TBC
+    description: The number of applications that have received offers for this subject, route & degree class
 
   number_of_acceptances:
     type: integer
-    description: TBC
+    description: The number of applications that have accepted offers for this subject, route & degree class
 
   number_of_declined_applications:
     type: integer
-    description: TBC
+    description: The number of applications that have declined offers for this subject, route & degree class
 
   number_of_rejected_applications:
     type: integer
-    description: TBC
+    description: The number of applications that have been rejected for this subject, route & degree class
 
   number_of_withdrawn_applications:
     type: integer
-    description: TBC
+    description: The number of applications that have been withdrawn for this subject, route & degree class

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -200,9 +200,9 @@ class DataExport < ApplicationRecord
       description: 'A list of all applications for TAD.',
       class: DataAPI::TADExport,
     },
-    tad_degree_class: {
+    tad_degree_class_by_subject_and_outcome: {
       name: 'TAD degree class by subject and outcome',
-      export_type: 'tad_degree_class',
+      export_type: 'tad_degree_class_by_subject_and_outcome',
       description: 'Report of subject by route, degree class and application status',
       class: SupportInterface::TADDegreeClassExport,
     },
@@ -291,7 +291,7 @@ class DataExport < ApplicationRecord
     submitted_application_choices: 'submitted_application_choices',
     submitted_application_choices_for_current_cycle: 'submitted_application_choices_for_current_cycle',
     tad_applications: 'tad_applications',
-    tad_degree_class: 'tad_degree_class',
+    tad_degree_class_by_subject_and_outcome: 'tad_degree_class_by_subject_and_outcome',
     tad_provider_performance: 'tad_provider_performance',
     user_permissions: 'user_permissions',
     who_ran_which_export: 'who_ran_which_export',

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -200,6 +200,12 @@ class DataExport < ApplicationRecord
       description: 'A list of all applications for TAD.',
       class: DataAPI::TADExport,
     },
+    tad_degree_class: {
+      name: 'TAD degree class by subject and outcome',
+      export_type: 'tad_degree_class',
+      description: 'TBC',
+      class: SupportInterface::TADDegreeClassExport,
+    },
     tad_provider_performance: {
       name: 'TAD provider performance',
       export_type: 'tad_provider_performance',
@@ -285,6 +291,7 @@ class DataExport < ApplicationRecord
     submitted_application_choices: 'submitted_application_choices',
     submitted_application_choices_for_current_cycle: 'submitted_application_choices_for_current_cycle',
     tad_applications: 'tad_applications',
+    tad_degree_class: 'tad_degree_class',
     tad_provider_performance: 'tad_provider_performance',
     user_permissions: 'user_permissions',
     who_ran_which_export: 'who_ran_which_export',

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -203,7 +203,7 @@ class DataExport < ApplicationRecord
     tad_degree_class: {
       name: 'TAD degree class by subject and outcome',
       export_type: 'tad_degree_class',
-      description: 'TBC',
+      description: 'Report of subject by route, degree class and application status',
       class: SupportInterface::TADDegreeClassExport,
     },
     tad_provider_performance: {

--- a/app/services/support_interface/tad_degree_class_export.rb
+++ b/app/services/support_interface/tad_degree_class_export.rb
@@ -1,4 +1,83 @@
 module SupportInterface
   class TADDegreeClassExport
+    def call(*)
+      report = choices_with_courses_and_subjects.find_each(batch_size: 100).map do |choice|
+        next if choice.phase == 'apply_2' && !choice.is_latest_a2_app
+
+        subject = MinisterialReport.determine_dominant_course_subject_for_report(choice.course_name, choice.course_level, choice.subject_names.zip(choice.subject_codes).to_h)
+
+        {
+          subject: subject,
+          route: choice.route,
+          degree_class: choice.degree_class,
+          applications: 0,
+          offers_received: 0,
+          number_of_acceptances: 0,
+          number_of_declined_applications: 0,
+          number_of_rejected_applications: 0,
+          number_of_withdrawn_applications: 0,
+          course_name: choice.course_name,
+          course_level: choice.course_level,
+          subject_names: choice.subject_names,
+          subject_codes: choice.subject_codes,
+          status: choice.status,
+        }
+      end
+
+      report = sort_and_group_by_subject_route_and_grade(report)
+
+      report.map do |key, ary|
+        ary.each do |hash|
+          MinisterialReport::DEGREE_CLASS_REPORT_STATUS_MAPPING[hash[:status].to_sym].each do |mapped_status|
+            report[key].first[mapped_status] += 1
+          end
+        end
+      end
+
+      report = report.values.flatten.each do |row|
+        row.delete(:course_name)
+        row.delete(:course_level)
+        row.delete(:subject_names)
+        row.delete(:subject_codes)
+        row.delete(:status)
+      end
+
+      report.reject! do |row|
+        row[:applications].zero? &&
+          row[:offers_received].zero? &&
+          row[:number_of_acceptances].zero? &&
+          row[:number_of_declined_applications].zero? &&
+          row[:number_of_rejected_applications].zero? &&
+          row[:number_of_withdrawn_applications].zero?
+      end
+
+      report
+    end
+
+    alias data_for_export call
+
+  private
+
+    def sort_and_group_by_subject_route_and_grade(report)
+      report = report.compact.uniq.flatten.sort_by { |row| row[:subject] }
+      report.group_by { |hash| grouping_key(hash) }
+    end
+
+    def grouping_key(hash)
+      hash[:subject].to_s + hash[:route].to_s + hash[:degree_class].to_s
+    end
+
+    def choices_with_courses_and_subjects
+      ApplicationChoice
+        .select('application_choices.id as id, application_choices.status as status, providers.provider_type as route, application_qualifications.grade as degree_class, application_form.id as application_form_id, application_form.phase as phase, courses.name as course_name, courses.level as course_level, ARRAY_AGG(subjects.name) as subject_names, ARRAY_AGG(subjects.code) as subject_codes, (CASE WHEN a2_latest_application_forms.candidate_id IS NOT NULL THEN true ELSE false END) AS is_latest_a2_app')
+        .joins(application_form: :application_qualifications)
+        .joins(course_option: { course: :provider })
+        .joins(course_option: { course: :subjects })
+        .joins("LEFT JOIN (SELECT candidate_id, MAX(created_at) as created FROM application_forms WHERE phase = 'apply_2' GROUP BY candidate_id) a2_latest_application_forms ON application_form.created_at = a2_latest_application_forms.created AND application_form.candidate_id = a2_latest_application_forms.candidate_id")
+        .where(application_form: { recruitment_cycle_year: RecruitmentCycle.current_year })
+        .where(application_form: { application_qualifications: { level: 'degree' } })
+        .where.not(application_form: { submitted_at: nil })
+        .group('application_choices.id', 'application_form.id', 'a2_latest_application_forms.candidate_id', 'courses.name', 'courses.level', 'status', 'providers.provider_type', 'subjects.name', 'subjects.code', 'application_qualifications.grade')
+    end
   end
 end

--- a/app/services/support_interface/tad_degree_class_export.rb
+++ b/app/services/support_interface/tad_degree_class_export.rb
@@ -1,0 +1,4 @@
+module SupportInterface
+  class TADDegreeClassExport
+  end
+end

--- a/app/services/support_interface/tad_degree_class_export.rb
+++ b/app/services/support_interface/tad_degree_class_export.rb
@@ -1,5 +1,13 @@
 module SupportInterface
   class TADDegreeClassExport
+    def self.run_weekly
+      data_export = DataExport.create!(
+        name: 'Weekly export of the TAD degree class export',
+        export_type: :tad_degree_class,
+      )
+      DataExporter.perform_async(SupportInterface::TADDegreeClassExport, data_export.id)
+    end
+
     def call(*)
       report = choices_with_courses_and_subjects.find_each(batch_size: 100).map do |choice|
         next if choice.phase == 'apply_2' && !choice.is_latest_a2_app

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -53,6 +53,7 @@ class Clock
   every(7.days, 'TADSubjectsExport', at: 'Sunday 23:59') do
     DataAPI::TADSubjectsExport.run_weekly
   end
+  every(7.days, 'TADDegreeClassExport', at: 'Sunday 23:59') { SupportInterface::TADDegreeClassExport.run_weekly }
 
   every(1.day, 'VendorIntegrationStatsWorker', at: '09:00', if: ->(t) { t.weekday? }) do
     VendorIntegrationStatsWorker.perform_async('tribal')

--- a/config/initializers/ministerial_report.rb
+++ b/config/initializers/ministerial_report.rb
@@ -24,6 +24,28 @@ module MinisterialReport
     secondary
   ].freeze
 
+  NON_TOTAL_SUBJECTS = %i[
+    art_and_design
+    biology
+    business_studies
+    chemistry
+    classics
+    computing
+    design_and_technology
+    drama
+    english
+    geography
+    history
+    mathematics
+    modern_foreign_languages
+    music
+    other
+    physical_education
+    physics
+    religious_education
+    primary
+  ].freeze
+
   STEM_SUBJECTS = %i[
     mathematics
     biology
@@ -143,6 +165,23 @@ module MinisterialReport
     declined: %i[candidates declined_candidates],
     recruited: %i[candidates candidates_holding_offers candidates_that_have_accepted_offers],
     withdrawn: %i[candidates],
+  }.freeze
+
+  DEGREE_CLASS_REPORT_STATUS_MAPPING = {
+    unsubmitted: %i[applications],
+    application_not_sent: %i[applications],
+    awaiting_provider_decision: %i[applications],
+    offer: %i[applications offers_received],
+    pending_conditions: %i[applications offers_received number_of_acceptances],
+    rejected: %i[applications number_of_rejected_applications],
+    cancelled: %i[applications number_of_declined_applications],
+    offer_deferred: %i[applications offers_received number_of_acceptances],
+    interviewing: %i[applications],
+    offer_withdrawn: %i[applications number_of_withdrawn_applications],
+    conditions_not_met: %i[applications offers_received],
+    declined: %i[applications number_of_declined_applications],
+    recruited: %i[applications offers_received number_of_acceptances],
+    withdrawn: %i[applications],
   }.freeze
 
   def self.determine_dominant_course_subject_for_report(course_name, course_level, subject_names_and_codes)

--- a/spec/services/support_interface/tad_degree_class_export_spec.rb
+++ b/spec/services/support_interface/tad_degree_class_export_spec.rb
@@ -1,0 +1,153 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::TADDegreeClassExport do
+  describe '#call' do
+    it 'correctly breaks down subject choice by route' do
+      drama = create(:subject, code: '13')
+      first_application_form = create(:completed_application_form)
+      create(:application_qualification, level: 'degree', grade: 'Upper second-class honours (2:1)', application_form: first_application_form)
+      scitt_provider = create(:provider, provider_type: 'scitt')
+      first_course = create(:course, provider: scitt_provider, subjects: [drama])
+      first_course_option = create(:course_option, course: first_course)
+
+      create(:application_choice, :with_declined_offer, course_option: first_course_option, application_form: first_application_form)
+
+      second_application_form = create(:completed_application_form)
+      create(:application_qualification, level: 'degree', grade: 'Upper second-class honours (2:1)', application_form: second_application_form)
+      lead_school_provider = create(:provider, provider_type: 'lead_school')
+      second_course = create(:course, provider: lead_school_provider, subjects: [drama])
+      second_course_option = create(:course_option, course: second_course)
+
+      create(:application_choice, :with_declined_offer, course_option: second_course_option, application_form: second_application_form)
+
+      data = described_class.new.call
+
+      expect(data).to include(
+        {
+          subject: :drama,
+          route: 'scitt',
+          degree_class: 'Upper second-class honours (2:1)',
+          applications: 1,
+          offers_received: 0,
+          number_of_acceptances: 0,
+          number_of_declined_applications: 1,
+          number_of_rejected_applications: 0,
+          number_of_withdrawn_applications: 0,
+        },
+        {
+          subject: :drama,
+          route: 'lead_school',
+          degree_class: 'Upper second-class honours (2:1)',
+          applications: 1,
+          offers_received: 0,
+          number_of_acceptances: 0,
+          number_of_declined_applications: 1,
+          number_of_rejected_applications: 0,
+          number_of_withdrawn_applications: 0,
+        },
+      )
+    end
+
+    context 'when the candidate has an apply again application' do
+      it 'only includes the latest apply again application' do
+        candidate = create(:candidate)
+        provider = create(:provider, provider_type: 'scitt')
+
+        first_course = create(:course, provider: provider, subjects: [create(:subject, code: 'Q8')])
+        first_course_option = create(:course_option, course: first_course)
+
+        second_course = create(:course, provider: provider, subjects: [create(:subject, code: 'P1')])
+        second_course_option = create(:course_option, course: second_course)
+
+        third_course = create(:course, provider: provider, subjects: [create(:subject, code: '12')])
+        third_course_option = create(:course_option, course: third_course)
+
+        first_application_choice = create(:application_choice, :with_declined_offer, course_option: first_course_option, candidate: candidate)
+        second_application_choice = create(:application_choice, :with_conditions_not_met, course_option: second_course_option, candidate: candidate)
+        third_application_choice = create(:application_choice, :with_withdrawn_offer, course_option: third_course_option, candidate: candidate)
+
+        first_apply_2_course = create(:course, provider: provider, subjects: [create(:subject, code: 'DT')])
+        first_apply_2_course_option = create(:course_option, course: first_apply_2_course)
+        first_apply_2_application_choice = create(:application_choice, :with_declined_offer, course_option: first_apply_2_course_option, candidate: candidate)
+
+        latest_course = create(:course, provider: provider, subjects: [create(:subject, code: 'W3')])
+        latest_course_option = create(:course_option, course: latest_course)
+        latest_application_choice = create(:application_choice, :with_accepted_offer, course_option: latest_course_option, candidate: candidate)
+
+        first_application = create(:completed_application_form, candidate: candidate, phase: 'apply_1', application_choices: [first_application_choice, second_application_choice, third_application_choice])
+        first_apply_2_application = create(:completed_application_form, candidate: candidate, phase: 'apply_2', application_choices: [first_apply_2_application_choice])
+        latest_application = create(:completed_application_form, candidate: candidate, phase: 'apply_2', application_choices: [latest_application_choice])
+
+        create(:application_qualification, level: 'degree', grade: 'Upper second-class honours (2:1)', application_form: first_application)
+        create(:application_qualification, level: 'degree', grade: 'Upper second-class honours (2:1)', application_form: first_apply_2_application)
+        create(:application_qualification, level: 'degree', grade: 'Upper second-class honours (2:1)', application_form: latest_application)
+
+        data = described_class.new.call
+
+        expect(data).to include(
+          {
+            subject: :classics,
+            route: 'scitt',
+            degree_class: 'Upper second-class honours (2:1)',
+            applications: 1,
+            offers_received: 0,
+            number_of_acceptances: 0,
+            number_of_declined_applications: 1,
+            number_of_rejected_applications: 0,
+            number_of_withdrawn_applications: 0,
+          },
+          {
+            subject: :other,
+            route: 'scitt',
+            degree_class: 'Upper second-class honours (2:1)',
+            applications: 1,
+            offers_received: 1,
+            number_of_acceptances: 0,
+            number_of_declined_applications: 0,
+            number_of_rejected_applications: 0,
+            number_of_withdrawn_applications: 0,
+          },
+          {
+            subject: :physical_education,
+            route: 'scitt',
+            degree_class: 'Upper second-class honours (2:1)',
+            applications: 1,
+            offers_received: 0,
+            number_of_acceptances: 0,
+            number_of_declined_applications: 0,
+            number_of_rejected_applications: 0,
+            number_of_withdrawn_applications: 1,
+          },
+        )
+
+        expect(data).to include(
+          {
+            subject: :music,
+            route: 'scitt',
+            degree_class: 'Upper second-class honours (2:1)',
+            applications: 1,
+            offers_received: 1,
+            number_of_acceptances: 1,
+            number_of_declined_applications: 0,
+            number_of_rejected_applications: 0,
+            number_of_withdrawn_applications: 0,
+          },
+        )
+
+        expect(data).not_to include(
+          {
+            subject: :design_and_technology,
+            route: 'scitt',
+            degree_class: 'Upper second-class honours (2:1)',
+            applications: 1,
+            offers_received: 0,
+            number_of_acceptances: 0,
+            number_of_declined_applications: 0,
+            number_of_rejected_applications: 0,
+            number_of_withdrawn_applications: 1,
+          },
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

TAD require an export that will breakdown a candidates choice of subject by their degree grade and the route (type of provider).

This is similar to the application export built in [#5617](https://github.com/DFE-Digital/apply-for-teacher-training/pull/5617).

## Changes proposed in this pull request

Adds a new export to the data directory. This will also be scheduled to run on a job once a week.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/hJ6FoPJ0

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
