### PR TITLE
Structured reasons for rejection support dashboard - Re-add other reasons section

### DIFF
--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
@@ -85,6 +85,15 @@
 ) %>
 
 <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
+  heading: 'Other reasons',
+  rejection_reasons: rejection_reasons,
+  total_rejection_count: total_structured_rejection_reasons_count,
+  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
+  reason_key: :why_are_you_rejecting_this_application,
+  recruitment_cycle_year: recruitment_cycle_year,
+) %>
+
+<%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
   heading: 'Additional advice or feedback',
   rejection_reasons: rejection_reasons,
   total_rejection_count: total_structured_rejection_reasons_count,

--- a/app/components/support_interface/reasons_for_rejection_search_breadcrumb_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_breadcrumb_component.rb
@@ -30,7 +30,8 @@ module SupportInterface
   private
 
     def top_level_reason?
-      @search_attribute =~ /_y_n$/ && @search_value == 'Yes'
+      @search_attribute == ReasonsForRejection::OTHER_REASON.to_s || (
+        @search_attribute =~ /_y_n$/ && @search_value == 'Yes')
     end
   end
 end

--- a/app/components/support_interface/reasons_for_rejection_search_results_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.rb
@@ -74,6 +74,8 @@ module SupportInterface
     end
 
     def top_level_reason?(reason, value)
+      return true if other_reasons_question?(reason)
+
       ReasonsForRejection::TOP_LEVEL_REASONS_TO_I18N_KEYS.key?(reason) &&
         value == 'Yes'
     end
@@ -99,12 +101,17 @@ module SupportInterface
     end
 
     def detail_reason_for(application_choice, top_level_reason)
-      detail_questions = ReasonsForRejection::ALL_QUESTIONS[top_level_reason.to_sym]&.keys
-      return 'Yes' if detail_questions.nil?
+      detail_questions = ReasonsForRejection::ALL_QUESTIONS[top_level_reason.to_sym]&.keys || []
+      detail_questions << top_level_reason if other_reasons_question?(top_level_reason)
+      return 'Yes' if detail_questions.empty?
 
       values_as_list(
         detail_questions.map { |detail_question| application_choice.structured_rejection_reasons[detail_question.to_s] }.compact,
       )
+    end
+
+    def other_reasons_question?(question_key)
+      question_key == ReasonsForRejection::OTHER_REASON.to_s
     end
   end
 end

--- a/app/models/reasons_for_rejection.rb
+++ b/app/models/reasons_for_rejection.rb
@@ -23,6 +23,7 @@ class ReasonsForRejection
     offered_on_another_course_y_n: :offered_on_another_course,
     performance_at_interview_y_n: :interview_performance,
     interested_in_future_applications_y_n: :interested_in_future_applications,
+    why_are_you_rejecting_this_application: :why_are_you_rejecting_this_application,
     other_advice_or_feedback_y_n: :additional_advice,
     cannot_sponsor_visa_y_n: :cannot_sponsor_visa,
   }.with_indifferent_access.freeze
@@ -66,6 +67,7 @@ class ReasonsForRejection
     other_advice_or_feedback_y_n: { other_advice_or_feedback_details: nil },
   }.freeze
   INITIAL_QUESTIONS = ALL_QUESTIONS.select { |key| INITIAL_TOP_LEVEL_QUESTIONS.include?(key) }.freeze
+  OTHER_REASON = :why_are_you_rejecting_this_application
 
   attr_writer :candidate_behaviour_what_did_the_candidate_do, :quality_of_application_which_parts_needed_improvement,
               :qualifications_which_qualifications, :honesty_and_professionalism_concerns, :safeguarding_concerns

--- a/app/queries/reasons_for_rejection_applications_query.rb
+++ b/app/queries/reasons_for_rejection_applications_query.rb
@@ -22,7 +22,14 @@ private
 
   def apply_filters(application_choices)
     filters[:structured_rejection_reasons].each do |key, value|
-      jsonb_query = key =~ /_y_n$/ ? '->>:key = :value' : '->:key ? :value'
+      jsonb_query = case key
+                    when ReasonsForRejection::OTHER_REASON.to_s
+                      "->>:key != ''"
+                    when /_y_n$/
+                      '->>:key = :value'
+                    else
+                      '->:key ? :value'
+                    end
 
       application_choices = application_choices.where(
         "application_choices.structured_rejection_reasons#{jsonb_query}", { key: key, value: value }

--- a/app/queries/reasons_for_rejection_count_query.rb
+++ b/app/queries/reasons_for_rejection_count_query.rb
@@ -122,7 +122,7 @@ private
     FROM application_choices,
       jsonb_each_text(structured_rejection_reasons) AS reasons
     WHERE structured_rejection_reasons IS NOT NULL
-      AND reasons.value = 'Yes'
+      AND reasons.value != 'No'
       AND current_recruitment_cycle_year = '#{recruitment_cycle_year}'
     GROUP BY (key, time_period)
     ORDER BY count(*) DESC;

--- a/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
       course_full_y_n: result(1, 1),
       offered_on_another_course_y_n: result,
       performance_at_interview_y_n: result,
+      why_are_you_rejecting_this_application: result(2, 1),
       other_advice_or_feedback_y_n: result,
     })
   end
@@ -125,8 +126,14 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
       expect(summary_text(section)).to eq(['16.67%', '2 of 12 rejections included this category'])
     end
 
-    it 'renders other advice section' do
+    it 'renders other reasons section' do
       section = rendered_component.css('.app-section')[9]
+      expect(heading_text(section)).to eq('Other reasons')
+      expect(summary_text(section)).to eq(['16.67%', '2 of 12 rejections included this category'])
+    end
+
+    it 'renders other advice section' do
+      section = rendered_component.css('.app-section')[10]
       expect(heading_text(section)).to eq('Additional advice or feedback')
       expect(summary_text(section)).to eq(['0%', '0 of 12 rejections included this category'])
     end


### PR DESCRIPTION
## Context

The dashboard is missing a section relating to a conditional question which is a free-text field. This question is only rendered when all other top level answers are _No_. We still need to report on it.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Amends dashboard count and applications queries to handle this special-case question
- Amends components to render links and sections necessary to display the Other reasons data

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ZFfhc4vO/4460-sr4r-re-add-other-reasons-section
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
