### PR TITLE
Monthly Stats by area - populate No region counts and reorder results

### DIFF
--- a/config/locales/candidate_interface/application_form.yml
+++ b/config/locales/candidate_interface/application_form.yml
@@ -6,19 +6,24 @@ en:
     reviewed_radio: I have reviewed this section
     incomplete_radio: No, I’ll come back to it later
     region_codes:
+      channel_islands: Channel Islands
       east_midlands: East Midlands
       eastern: Eastern
+      isle_of_man: Isle of Man
       london: London
       no_region: No region
       no_region_specified: No region specified
       north_east: North East
       north_west: North West
+      northern_ireland: Northern Ireland
       scotland: Scotland
       south_east: South East
       south_west: South West
       wales: Wales
       west_midlands: West Midlands
       yorkshire_and_the_humber: Yorkshire and the Humber
+      european_economic_area: European Economic Area
+      rest_of_the_world: Rest of the World
 
   activemodel:
     errors:

--- a/spec/models/monthly_statistics/by_area_spec.rb
+++ b/spec/models/monthly_statistics/by_area_spec.rb
@@ -14,9 +14,31 @@ RSpec.describe MonthlyStatistics::ByArea do
     create_application_choice(statuses: %i[with_offer], region_code: 'london')
     create_application_choice(statuses: %i[with_withdrawn_offer], region_code: 'north_east')
     create_application_choice(statuses: %i[withdrawn], region_code: 'north_east')
+    create_application_choice(statuses: %i[with_rejection], region_code: nil)
     create_application_choice_with_previous_application(status: :with_rejection, region_code: 'north_west')
 
-    expect(column_totals).to eq([1, 0, 3, 1, 5, 10])
+    expect(region_titles).to eq(
+      [
+        'Channel Islands',
+        'East Midlands',
+        'Eastern',
+        'Isle of Man',
+        'London',
+        'No region',
+        'North East',
+        'North West',
+        'Northern Ireland',
+        'Scotland',
+        'South East',
+        'South West',
+        'Wales',
+        'West Midlands',
+        'Yorkshire and the Humber',
+        'European Economic Area',
+        'Rest of the World',
+      ],
+    )
+    expect(column_totals).to eq([1, 0, 3, 1, 6, 11])
     expect(totals_for('London')).to eq(
       'Recruited' => 0,
       'Conditions pending' => 0,
@@ -66,6 +88,15 @@ RSpec.describe MonthlyStatistics::ByArea do
       'Unsuccessful' => 2,
       'Total' => 2,
     )
+
+    expect(totals_for('No region')).to eq(
+      'Recruited' => 0,
+      'Conditions pending' => 0,
+      'Received an offer' => 0,
+      'Awaiting provider decisions' => 0,
+      'Unsuccessful' => 1,
+      'Total' => 1,
+    )
   end
 
   def create_application_choice(
@@ -107,6 +138,10 @@ RSpec.describe MonthlyStatistics::ByArea do
       recruitment_cycle_year: recruitment_cycle_year,
       previous_application_form: previous_application_choice.application_form,
     )
+  end
+
+  def region_titles
+    statistics[:rows].map { |row| row.values.first }
   end
 
   def column_totals


### PR DESCRIPTION
## Context

This PR makes a couple of minor changes to the monthly statistics by area table that came up in product review. See comments on Trello card for context.

## Changes proposed in this pull request

- The 'No region' region (for applications in which the region is not specified or not derivable from the address) is now counted. Applications without regions were previously ignored.
- EEA and Rest of the World should appear at the bottom of the list of regions.

## Guidance to review

- Can be manually tested by re-running `UpdateMonthlyStatisticsReport.new.perform` in Rails console.
- Do the tests cover this new behaviour?

## Link to Trello card

https://trello.com/c/57VZEAIc/3965-generate-monthly-stats-derive-the-area-from-candidates-contact-address

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
