### PR TITLE
Update content on email: 'feedback_received_for_application_rejected_by_default'

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -182,9 +182,11 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
-  def feedback_received_for_application_rejected_by_default(application_choice)
+  def feedback_received_for_application_rejected_by_default(application_choice, show_apply_again_guidance)
     @application_choice = RejectedApplicationChoicePresenter.new(application_choice)
     @course = @application_choice.current_course_option.course
+    @candidate_magic_link = candidate_magic_link(@application_choice.application_form.candidate)
+    @show_apply_again_guidance = show_apply_again_guidance
 
     email_for_candidate(
       @application_choice.application_form,

--- a/app/services/reject_by_default_feedback.rb
+++ b/app/services/reject_by_default_feedback.rb
@@ -28,21 +28,17 @@ class RejectByDefaultFeedback
 
   def notify_slack
     provider_name = application_choice.current_course.provider.name
-    candidate_name = application_choice.application_form.first_name
+    candidate_name = application_form.first_name
     message = ":telephone_receiver: #{provider_name} has sent feedback for #{candidate_name}’s RBD application"
-    url = Rails.application.routes.url_helpers.support_interface_application_form_url(application_choice.application_form)
+    url = Rails.application.routes.url_helpers.support_interface_application_form_url(application_form)
 
     SlackNotificationWorker.perform_async(message, url)
   end
 
+private
+
   def not_applied_again?
-    ApplicationForm
-      .where(
-        candidate_id: candidate.id,
-        recruitment_cycle_year: RecruitmentCycle.current_year,
-        previous_application_form_id: application_form.id,
-      )
-      .empty?
+    application_form.subsequent_application_form.nil?
   end
 
   def unsuccessful_application_choices?
@@ -56,7 +52,5 @@ class RejectByDefaultFeedback
     @application_form ||= application_choice.application_form
   end
 
-  def candidate
-    @candidate ||= application_choice.application_form.candidate
-  end
+  delegate :candidate, to: :application_form
 end

--- a/app/views/candidate_mailer/feedback_received_for_application_rejected_by_default.text.erb
+++ b/app/views/candidate_mailer/feedback_received_for_application_rejected_by_default.text.erb
@@ -1,9 +1,14 @@
 Dear <%= @application_form.first_name %>,
 
-# Feedback on your application
+As you know, your application for <%= @course.name_and_code %> could not progress because <%= @course.provider.name %>
+did not respond by their deadline of <%= @application_choice.rejected_at.to_s(:govuk_date) %>.
 
-Your application for <%= @course.name_and_code %> was automatically rejected on <%= @application_choice.rejected_at.to_s(:govuk_date) %>.
-
-This was because <%= @course.provider.name %> did not respond in time. They’ve now given you the following feedback:
+They’ve now given you the following feedback:
 
 <%= render 'reasons_for_rejection' %>
+
+<% if @show_apply_again_guidance %>
+  If this feedback was useful, consider using it to strengthen your application and apply again:
+
+  <%= @candidate_magic_link %>
+<% end %>

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -264,18 +264,42 @@ RSpec.describe CandidateMailer, type: :mailer do
     end
   end
 
-  describe 'feedback_received_for_application_rejected_by_default' do
-    let(:email) { mailer.feedback_received_for_application_rejected_by_default(application_choices.first) }
+  describe '.feedback_received_for_application_rejected_by_default' do
     let(:application_choices) { [build_stubbed(:application_choice, :with_rejection_by_default_and_feedback, course_option: course_option, current_course_option: course_option, rejection_reason: 'I\'m so happy')] }
 
-    it_behaves_like(
-      'a mail with subject and content',
-      'Feedback on your application for Brighthurst Technical',
-      'heading' => 'Dear Bob',
-      'provider name' => 'Brighthurst Technical College did not respond in time',
-      'name and code for course' => 'Applied Science (Psychology) (3TT5)',
-      'feedback' => 'I\'m so happy',
-    )
+    context 'candidate has been awarded a place on a course or has applied again since' do
+      let(:email) { mailer.feedback_received_for_application_rejected_by_default(application_choices.first, true) }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Feedback on your application for Brighthurst Technical',
+        'heading' => 'Dear Bob',
+        'provider name' => 'Brighthurst Technical College',
+        'name and code for course' => 'Applied Science (Psychology) (3TT5)',
+        'feedback' => 'I\'m so happy',
+      )
+
+      it 'encourages candidate to apply again' do
+        expect(email.body).to include('If this feedback was useful, consider using it to strengthen your application and apply again:')
+      end
+    end
+
+    context 'candidate did not get a place on any of their courses and has not applied again since' do
+      let(:email) { mailer.feedback_received_for_application_rejected_by_default(application_choices.first, false) }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Feedback on your application for Brighthurst Technical',
+        'heading' => 'Dear Bob',
+        'provider name' => 'Brighthurst Technical College',
+        'name and code for course' => 'Applied Science (Psychology) (3TT5)',
+        'feedback' => 'I\'m so happy',
+      )
+
+      it 'does not encourage candidate to apply again' do
+        expect(email.body).not_to include('If this feedback was useful, consider using it to strengthen your application and apply again:')
+      end
+    end
   end
 
   describe '.deferred_offer' do

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -512,8 +512,22 @@ class CandidateMailerPreview < ActionMailer::Preview
         application_form: application_form,
         course_option: course_option,
       )
+    show_apply_again_guidance = false
 
-    CandidateMailer.feedback_received_for_application_rejected_by_default(application_choice)
+    CandidateMailer.feedback_received_for_application_rejected_by_default(application_choice, show_apply_again_guidance)
+  end
+
+  def feedback_received_for_application_rejected_by_default_apply_again
+    application_choice =
+      FactoryBot.build(
+        :application_choice,
+        :with_structured_rejection_reasons,
+        application_form: application_form,
+        course_option: course_option,
+      )
+    show_apply_again_guidance = true
+
+    CandidateMailer.feedback_received_for_application_rejected_by_default(application_choice, show_apply_again_guidance)
   end
 
   def reference_received

--- a/spec/services/reject_by_default_feedback_spec.rb
+++ b/spec/services/reject_by_default_feedback_spec.rb
@@ -52,6 +52,47 @@ RSpec.describe RejectByDefaultFeedback, sidekiq: true do
     expect(CandidateMailer.deliveries.count).to be 1
   end
 
+  context 'candidate did not get a place on any of their courses and has not applied again since' do
+    it "requests mailer to display 'apply again' guidance" do
+      show_apply_again_guidance = true
+      mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+
+      allow(CandidateMailer).to receive(:feedback_received_for_application_rejected_by_default).and_return(mailer)
+
+      service.save
+
+      expect(CandidateMailer).to have_received(:feedback_received_for_application_rejected_by_default).with(application_choice, show_apply_again_guidance)
+    end
+  end
+
+  context 'candidate did get a place on one of their courses' do
+    it "does not request mailer to display 'apply again' guidance" do
+      show_apply_again_guidance = false
+      mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+
+      create(:application_choice, :with_offer, application_form: application_choice.application_form)
+      allow(CandidateMailer).to receive(:feedback_received_for_application_rejected_by_default).and_return(mailer)
+
+      service.save
+
+      expect(CandidateMailer).to have_received(:feedback_received_for_application_rejected_by_default).with(application_choice, show_apply_again_guidance)
+    end
+  end
+
+  context 'candidate did not get a place on any of their courses but has applied again since' do
+    it "does not request mailer to display 'apply again' guidance" do
+      show_apply_again_guidance = false
+      mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+
+      create(:application_form, :minimum_info, phase: 'apply_2', previous_application_form_id: application_choice.application_form.id, candidate_id: application_choice.application_form.candidate_id)
+      allow(CandidateMailer).to receive(:feedback_received_for_application_rejected_by_default).and_return(mailer)
+
+      service.save
+
+      expect(CandidateMailer).to have_received(:feedback_received_for_application_rejected_by_default).with(application_choice, show_apply_again_guidance)
+    end
+  end
+
   it 'sends a Slack notification' do
     allow(SlackNotificationWorker).to receive(:perform_async)
     service.save


### PR DESCRIPTION
## Context

This email needs some new content. We've moved away from the term 'automatic rejection' in our other RBD emails, so want to do the same here. 

## Changes proposed in this pull request

- Update copy 
- Display additional copy encouraging to apply again depending of whether the candidate has another successful application choice or has already applied again since. 

### Without apply again copy 
<img width="249" alt="feedback_received_for_application_rejected_by_default" src="https://user-images.githubusercontent.com/5256922/140088935-fa689c47-deb3-4a92-a879-6bf48433cd3d.png">

### With apply again copy 
<img width="221" alt="feedback_received_for_application_rejected_by_default_apply_again" src="https://user-images.githubusercontent.com/5256922/140088982-2034c9f7-ff11-4d4e-a5ac-360919617e1c.png">

## Guidance to review

To review the changes visit: 

- `/rails/mailers/candidate_mailer/feedback_received_for_application_rejected_by_default`
- `/rails/mailers/candidate_mailer/feedback_received_for_application_rejected_by_default_apply_again` - additional copy appears if all the candidate's application choices are unsuccessful and they have not applied again since 

## Link to Trello card
https://trello.com/c/O3AwXQG3/4098-update-content-on-email-feedbackreceivedforapplicationrejectedbydefault


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
