### PR TITLE
Remove duplicated copy from 'Why do you want to teach' review page

### DIFF
--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -20,15 +20,6 @@
         </blockquote>
       <% end %>
     <% end %>
-  <% else %>
-    <p class="govuk-body govuk-!-font-weight-bold">This section is important to your application. Before continuing:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>proofread your answer carefully for spelling and grammar</li>
-      <li>ask someone you trust for their opinion</li>
-      <li>ensure this piece of writing is all your own work – plagiarism will be penalised</li>
-    </ul>
-    <p class="govuk-body govuk-!-font-weight-bold">You’ll be able to review it again before you submit your
-      application.</p>
   <% end %>
 
   <%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: @application_form)) %>


### PR DESCRIPTION
## Context

The 'Why you want to teach' section has some repeated content on the review page. 

## Changes proposed in this pull request

Remove the top chunk of text, as it is repeated in the hint text below. 

## Link to Trello card

https://trello.com/c/YTouDnoy/3864-repeated-information-on-personal-section-review-next-sprint

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
