### PR TITLE
Standardise csv names

### DIFF
--- a/app/controllers/provider_interface/application_data_export_controller.rb
+++ b/app/controllers/provider_interface/application_data_export_controller.rb
@@ -1,6 +1,7 @@
 module ProviderInterface
   class ApplicationDataExportController < ProviderInterfaceController
     include StreamableDataExport
+    include CSVNameHelper
 
     BATCH_SIZE = 300
 
@@ -41,7 +42,7 @@ module ProviderInterface
           .find_each(batch_size: BATCH_SIZE)
 
         self.response_body = streamable_response(
-          filename: csv_filename,
+          filename: csv_filename(export_name: 'application-data', cycle_years: cycle_years, providers: providers),
           export_headings: ApplicationDataExport.export_row(export_data.first).keys,
           export_data: export_data,
           item_yielder: proc { |item| ApplicationDataExport.export_row(item).values },
@@ -55,10 +56,6 @@ module ProviderInterface
 
     def application_data_export_params
       params.require(:provider_interface_application_data_export_form).permit(:application_status_choice, statuses: [], provider_ids: [], recruitment_cycle_years: [])
-    end
-
-    def csv_filename
-      "#{Time.zone.now}.applications-export.csv"
     end
 
     def redirect_to_hesa_export_unless_feature_enabled

--- a/app/controllers/provider_interface/reports/hesa_exports_controller.rb
+++ b/app/controllers/provider_interface/reports/hesa_exports_controller.rb
@@ -2,6 +2,7 @@ module ProviderInterface
   module Reports
     class HesaExportsController < ProviderInterfaceController
       include StreamableDataExport
+      include CSVNameHelper
 
       def show
         year = params[:year]
@@ -9,7 +10,7 @@ module ProviderInterface
           format.csv do
             hesa_data_export = HesaDataExport.new(actor: current_provider_user, recruitment_cycle_year: year)
             self.response_body = streamable_response(
-              filename: csv_filename(year),
+              filename: csv_filename(export_name: 'hesa-data', cycle_years: [year], providers: current_provider_user.providers),
               export_headings: hesa_data_export.export_row(hesa_data_export.export_data.first).keys,
               export_data: hesa_data_export.export_data,
               item_yielder: proc { |item| hesa_data_export.export_row(item).values },
@@ -19,12 +20,6 @@ module ProviderInterface
       end
 
       def index; end
-
-    private
-
-      def csv_filename(year)
-        "#{Time.zone.now}.#{year}.applications-export.csv"
-      end
     end
   end
 end

--- a/app/controllers/provider_interface/reports/status_of_active_applications_controller.rb
+++ b/app/controllers/provider_interface/reports/status_of_active_applications_controller.rb
@@ -1,12 +1,14 @@
 module ProviderInterface
   module Reports
     class StatusOfActiveApplicationsController < ProviderInterfaceController
+      include CSVNameHelper
+
       def show
         @provider = current_user.providers.find(provider_id)
         respond_to do |format|
           format.csv do
             csv_data = ProviderInterface::StatusOfActiveApplicationsExport.new(provider: @provider).call
-            send_data csv_data, disposition: 'attachment', filename: csv_filename(@provider)
+            send_data csv_data, disposition: 'attachment', filename: csv_filename(export_name: 'status-of-active-applications', cycle_years: [RecruitmentCycle.current_year], providers: [@provider])
           end
           format.html do
             @active_application_status_data = ActiveApplicationStatusesByProvider.new(@provider).call
@@ -18,10 +20,6 @@ module ProviderInterface
 
       def provider_id
         params.permit(:provider_id)[:provider_id]
-      end
-
-      def csv_filename(provider)
-        "Status of active applications - #{provider.name} - #{RecruitmentCycle.cycle_name} - #{Time.zone.now.strftime('%F-%H_%M_%S')}.csv"
       end
     end
   end

--- a/app/helpers/csv_name_helper.rb
+++ b/app/helpers/csv_name_helper.rb
@@ -1,0 +1,23 @@
+module CSVNameHelper
+  def csv_filename(export_name:, cycle_years:, providers:)
+    "#{export_name}_#{year_range(cycle_years)}_#{provider_string(providers)}_#{Time.zone.now.strftime('%Y-%m-%d_%k-%M-%S')}.csv"
+  end
+
+private
+
+  def year_range(cycle_years)
+    sorted_cycle_years = cycle_years.sort - [0]
+    integer_cycle_years = sorted_cycle_years.map(&:to_i)
+    "#{integer_cycle_years.first - 1}-to-#{sorted_cycle_years.last}"
+  end
+
+  def provider_string(providers)
+    providers.one? ? sanitized_provider_name(providers.first.name) : 'multiple-providers'
+  end
+
+  def sanitized_provider_name(name)
+    name = name.gsub(/\s/, '-') # replace spaces with dashes
+    name = name.gsub(/[^[:alnum:]-]/, '') # strip punctuation, except dashes
+    name.downcase
+  end
+end

--- a/spec/helpers/csv_name_helper_spec.rb
+++ b/spec/helpers/csv_name_helper_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe CSVNameHelper, type: :helper do
+  around do |example|
+    Timecop.freeze(2020, 6, 1, 12) do
+      example.run
+    end
+  end
+
+  let(:export_name) { 'extremely-cool-data' }
+  let(:cycle_years) { [0, 2000] }
+  let(:providers) { [create(:provider, name: 'Mars University')] }
+
+  describe '#csv_filename' do
+    context 'a report based on a single provider' do
+      it 'returns a string with the provider name' do
+        result = csv_filename(export_name: export_name, cycle_years: cycle_years, providers: providers)
+        expect(result).to eq('extremely-cool-data_1999-to-2000_mars-university_2020-06-01_12-00-00.csv')
+      end
+    end
+
+    context 'a report based on a multiple providers' do
+      let(:providers) { create_list(:provider, 3) }
+
+      it 'returns a string with multiple providers' do
+        result = csv_filename(export_name: export_name, cycle_years: cycle_years, providers: providers)
+        expect(result).to eq('extremely-cool-data_1999-to-2000_multiple-providers_2020-06-01_12-00-00.csv')
+      end
+    end
+
+    context 'a report spanning multiple recruitment cycles' do
+      let(:cycle_years) { [2000, 2005] }
+
+      it 'returns a string with the full range of years' do
+        result = csv_filename(export_name: export_name, cycle_years: cycle_years, providers: providers)
+        expect(result).to eq('extremely-cool-data_1999-to-2005_mars-university_2020-06-01_12-00-00.csv')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes proposed in this pull request
https://trello.com/c/PXP4BsEb/4323-standardise-csv-names-in-manage
<!-- If there are UI changes, please include Before and After screenshots. -->
Adding a csv naming helper, which improves consistency. 
There's still a bit of inconsistency based on what string is being passed in, maybe that could be put into the locales? 
The way different export controllers get the relevant year range is a bit inconsistent, so the helper is quite blunt in how it handles it - as long as you give it the recruitment cycle year/s, it works out a good date range string.

Does it need more tests? The helper has tests, and the controllers are all pretty much doing the same thing as before!

## Guidance to review

Logging in as a provider, head to the reports section. Try downloading each of the different available reports, and check the name of the downloaded file (and that it's a csv)

![image](https://user-images.githubusercontent.com/25597009/140103201-ff7c4b1a-5f92-4953-9c49-bef3043f15e5.png)

![image](https://user-images.githubusercontent.com/25597009/140103418-4a73e523-cda1-40d3-9cc2-589ea0c1c018.png)


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
