### PR TITLE
Prototype RSpec-retry and Github actions workflow for flakey tests 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Read flakey test results
         id: set_flakey_test_results_var
         run: |
-          file_text=$(cat /app/tmp/rspec-retry-flakey-tests.txt)
+          file_text=$(cat /app/tmp/rspec-retry-flakey-specs.log)
           file_text="${file_text//$'\n'/%0A}"
           echo "::set-output name=flakey_tests::$file_text"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,6 +196,7 @@ jobs:
         id: download-head-coverage
         with:
           name: head-result
+          path: head-result/
 
 #      - name: Download base coverage artifact
 #        id: download-base-coverage
@@ -207,14 +208,14 @@ jobs:
 #          workflow_conclusion: success
 #          branch: main
 #          name: base-result
-#          path: base-result/.resultset.json
+#          path: base-result/
 
       - name: Diff coverage resultsets
         id: diff-coverage-resultsets
         uses: kzkn/simplecov-resultset-diff-action@v1
         with:
-          base-resultset-path: .resultset.json
-          head-resultset-path: .resultset.json
+          base-resultset-path: head-result/.resultset.json
+          head-resultset-path: head-result/.resultset.json
           token: ${{ secrets.GITHUB_TOKEN }}
 
   report-flakey-specs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,6 @@ jobs:
         id: download-head-coverage
         with:
           name: head-result
-          path: head-result/.resultset.json
 
 #      - name: Download base coverage artifact
 #        id: download-base-coverage
@@ -214,8 +213,8 @@ jobs:
         id: diff-coverage-resultsets
         uses: kzkn/simplecov-resultset-diff-action@v1
         with:
-          base-resultset-path: ./head-result/.resultset.json
-          head-resultset-path: ./head-result/.resultset.json
+          base-resultset-path: .resultset.json
+          head-resultset-path: .resultset.json
           token: ${{ secrets.GITHUB_TOKEN }}
 
   report-flakey-specs:
@@ -235,29 +234,35 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { FLAKEY_TEST_DATA } = process.env;
+            const { FLAKEY_TEST_DATA, GITHUB_HEAD_REF } = process.env;
 
             if (FLAKEY_TEST_DATA.length) {
-              const { issue: { number: issue_number }, repo: { owner, repo }, serverUrl, ref  } = context;
+              const { issue: { number: issue_number }, repo: { owner, repo } } = context;
               let commentBody = '<h3>You have one or more flakey tests on this branch! :snowflake: :snowflake: :snowflake:</h3>';
               let dataStr, dataAry, attempts, retryCount, errorLocation, errorPath, errorMessages, errorLink;
 
-              let flakeyTestRows = FLAKEY_TEST_DATA.split("\n");
+              let branchName = GITHUB_HEAD_REF.split('/').pop();
+              let createComment = false;
+              let rows = FLAKEY_TEST_DATA.split("\n");
+              let rowsLength = rows.length;
 
-              for (var idx = 0; idx < flakeyTestRows.length; idx++) {
-                dataStr = flakeyTestRows[idx];
+              for (var idx = 0; idx < rowsLength; idx++) {
+                dataStr = rows[idx];
 
                 if (dataStr.length) {
                   dataAry = dataStr.split(',');
                   [attempts, retryCount, errorLocation, ...errorMessages] = dataAry;
 
-                  errorPath = errorLocation.replace(':', '#L');
+                  errorPath = '/' + owner + '/' + repo + '/blob/' + branchName + '/' + errorLocation.replace(':', '#L');
                   errorLink = '<a href="' + errorPath + '">' + errorLocation + '</a>';
                   commentBody += ':x: Failed ' + attempts + ' out of ' + retryCount + ' times at ' + errorLink + ': :warning: ' + errorMessages.join(' :warning: ') + '<br>';
+                  createComment = true;
                 }
               }
 
-              github.issues.createComment({ issue_number, owner, repo, body: commentBody });
+              if (createComment) {
+                github.issues.createComment({ issue_number, owner, repo, body: commentBody });
+              }
             }
 
   trigger-deployment:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,7 +275,7 @@ jobs:
 
                   errorPath = `/${owner}/${repo}/blob/${branchName}/${errorLocation.replace(':', '#L')}`;
                   errorLink = `<a href="${errorPath}">${errorLocation}</a>`;
-                  commentBody += `Failed ${attempts} out of ${retryCount} times at ${errorLink}: :x: ${errorMessages.join(' :x: ')}<br>`;
+                  commentBody += `Failed ${attempts} out of ${retryCount} times at ${errorLink}: :warning: ${errorMessages.join(' :warning: ')}<br>`;
                   createComment = true;
                 }
               }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
         DB_PORT: 5432
 
     outputs:
-      flaky_tests: ${{ steps.set_flaky_test_results_var.outputs.flaky_tests }}
+      flakey_tests: ${{ steps.set_flakey_test_results_var.outputs.flakey_tests }}
 
     steps:
       - name: Setup Parallel Database
@@ -180,10 +180,11 @@ jobs:
           DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
 
       - name: Read flakey test results
-        id: set_flaky_test_results_var
+        id: set_flakey_test_results_var
         run: |
           file_text=$(cat rspec-retry-flakey-tests.txt)
-          echo ::set-output name=flaky_tests::$file_text
+          file_text="${file_text//$'\n'/%0A}"
+          echo "::set-output name=flakey_tests::$file_text"
 
   report-flakey-specs:
     name: Report on flakey specs in pull request
@@ -191,13 +192,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Echo flakey test output
-        run: echo ${{ needs.test.outputs.flaky_tests }}
+        run: echo "${{ needs.test.outputs.flakey_tests }}"
 
       - name: Comment on flakey specs in pull request
         uses: actions/github-script@0.3.0
         if: github.event_name == 'pull_request'
         env:
-          COMMENT_BODY: ${{ needs.test.outputs.flaky_tests }}
+          COMMENT_BODY: |
+            :snowflake: **You have a flakey test on this branch!** :snowflake:
+            ${{ needs.test.outputs.flakey_tests }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,25 +113,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tests: [ unit_shared, unit_candidate-provider, unit_support-referee-api, integration_shared, integration_provider, integration_candidate ]
-        feature-flags: [on, off]
+        tests: [ unit_shared ]
+        feature-flags: [on]
         include:
           - tests: unit_shared
-            include-pattern: spec/.*/*_spec.rb
-            exclude-pattern: spec/.*(candidate_interface|provider_interface|support_interface|referee_interface|system|.*api.*).*/*_spec.rb
-          - tests: unit_candidate-provider
-            include-pattern: spec/.*(candidate_interface|provider_interface).*/*_spec.rb
-            exclude-pattern: spec/system/.*/*_spec.rb
-          - tests: unit_support-referee-api
-            include-pattern: spec/.*(support_interface|referee_interface|.*api.*).*/*_spec.rb
-            exclude-pattern: spec/system/.*/*_spec.rb
-          - tests: integration_shared
-            include-pattern: spec/system/.*/*_spec.rb
-            exclude-pattern: spec/system/.*(provider_interface|candidate_interface).*/*_spec.rb
-          - tests: integration_provider
-            include-pattern: spec/system/provider_interface/.*/*_spec.rb
-          - tests: integration_candidate
-            include-pattern: spec/system/candidate_interface/.*/*_spec.rb
+            include-pattern: spec/lib/flaky_spec.rb
     services:
       redis:
         image: redis:alpine
@@ -173,7 +159,7 @@ jobs:
         run: apk add chromium chromium-chromedriver
 
       - name: ${{ matrix.tests }} tests with feature flags ${{ matrix.feature-flags }}
-        run: bundle exec --verbose parallel_rspec --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}"
+        run: bundle exec --verbose rspec ./spec/lib/flaky_spec.rb
         env:
           INCLUDE_PATTERN: ${{ matrix.include-pattern }}
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern || ' ' }}
@@ -195,19 +181,37 @@ jobs:
         run: echo "${{ needs.test.outputs.flakey_tests }}"
 
       - name: Comment on flakey specs in pull request
-        uses: actions/github-script@0.3.0
+        uses: actions/github-script@0.5.0
         if: github.event_name == 'pull_request'
         env:
-          COMMENT_BODY: |
-            :snowflake: **You have a flakey test on this branch!** :snowflake:
+          FLAKEY_TEST_DATA: |
             ${{ needs.test.outputs.flakey_tests }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            const { COMMENT_BODY } = process.env;
-            if (COMMENT_BODY.length) {
-              github.issues.createComment({ issue_number, owner, repo, body: COMMENT_BODY });
+            const { FLAKEY_TEST_DATA } = process.env;
+
+            if (FLAKEY_TEST_DATA.length) {
+              const { issue: { number: issue_number }, repo: { owner, repo }, serverUrl  } = context;
+              let commentBody = '<h3>You have one or more flakey tests on this branch! :snowflake: :snowflake: :snowflake:</h3>';
+              let dataStr, dataAry, attempts, retryCount, errorLocation, errorPath, errorMessages, errorLink;
+
+              let flakeyTestRows = FLAKEY_TEST_DATA.split("\n");
+
+              for (var idx = 0; idx < flakeyTestRows.length; idx++) {
+                dataStr = flakeyTestRows[idx];
+
+                if (dataStr.length) {
+                  dataAry = dataStr.split(',');
+                  [attempts, retryCount, errorLocation, ...errorMessages] = dataAry;
+
+                  errorPath = errorLocation.replace(':', '#L');
+                  errorLink = '<a href="' + errorPath + '">' + errorLocation + '</a>';
+                  commentBody += ':x: Failed ' + attempts + ' out of ' + retryCount + ' times at ' + errorLink + ': :warning: ' + errorMessages.join(' :warning: ') + '<br>';
+                }
+              }
+
+              github.issues.createComment({ issue_number, owner, repo, body: commentBody });
             }
 
   trigger-deployment:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,11 +182,7 @@ jobs:
       - name: Read flakey test results
         id: set_flaky_test_results_var
         run: |
-          input_file="rspec-retry-flakey-tests.txt"
-          while read line
-          do
-            file_text="${file_text}\n${line}"
-          done < "$input_file"
+          file_text=$(cat rspec-retry-flakey-tests.txt)
           echo ::set-output name=flaky_tests::$file_text
 
   report-flakey-specs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,6 +175,17 @@ jobs:
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern || ' ' }}
           DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
 
+      - name: Report on flakey tests
+        id: set_flaky_test_results_var
+        run: |
+          input_file="rspec-retry-flakey-tests.txt"
+          while read line
+          do
+            file_text=$line
+          done < "$input_file"
+          echo ::set-output name=flaky_tests::$file_text
+      - run: echo ${{ steps.set_flaky_test_results_var.outputs.flaky_tests }}
+
   trigger-deployment:
     name: Trigger Deployment
     needs: [build, test]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,7 @@ jobs:
         id: set_flaky_test_results_var
         run: |
           file_text=$(cat rspec-retry-flakey-tests.txt)
-          echo ::set-output name=flaky_tests::$file_text
+          echo ::set-output name=flaky_tests::"$file_text"
 
   report-flakey-specs:
     name: Report on flakey specs in pull request

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,7 @@ jobs:
         run: ${{ env.COMMAND }}
         env:
           COMMAND: ${{ matrix.command }}
+
   test:
     name: Tests
     needs: [build]
@@ -113,11 +114,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tests: [ unit_shared ]
-        feature-flags: [on]
+        tests: [ unit_shared, unit_candidate-provider, unit_support-referee-api, integration_shared, integration_provider, integration_candidate ]
+        feature-flags: [on, off]
         include:
           - tests: unit_shared
-            include-pattern: spec/lib/flaky_spec.rb
+            include-pattern: spec/.*/*_spec.rb
+            exclude-pattern: spec/.*(candidate_interface|provider_interface|support_interface|referee_interface|system|.*api.*).*/*_spec.rb
+          - tests: unit_candidate-provider
+            include-pattern: spec/.*(candidate_interface|provider_interface).*/*_spec.rb
+            exclude-pattern: spec/system/.*/*_spec.rb
+          - tests: unit_support-referee-api
+            include-pattern: spec/.*(support_interface|referee_interface|.*api.*).*/*_spec.rb
+            exclude-pattern: spec/system/.*/*_spec.rb
+          - tests: integration_shared
+            include-pattern: spec/system/.*/*_spec.rb
+            exclude-pattern: spec/system/.*(provider_interface|candidate_interface).*/*_spec.rb
+          - tests: integration_provider
+            include-pattern: spec/system/provider_interface/.*/*_spec.rb
+          - tests: integration_candidate
+            include-pattern: spec/system/candidate_interface/.*/*_spec.rb
     services:
       redis:
         image: redis:alpine
@@ -159,7 +174,7 @@ jobs:
         run: apk add chromium chromium-chromedriver
 
       - name: ${{ matrix.tests }} tests with feature flags ${{ matrix.feature-flags }}
-        run: bundle exec --verbose rspec ./spec/lib/flaky_spec.rb
+        run: bundle exec --verbose parallel_rspec --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}"
         env:
           INCLUDE_PATTERN: ${{ matrix.include-pattern }}
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern || ' ' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
           input_file="rspec-retry-flakey-tests.txt"
           while read line
           do
-            file_text=$line
+            file_text="${file_text}\n${line}"
           done < "$input_file"
           echo ::set-output name=flaky_tests::$file_text
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
 
             if (FLAKEY_TEST_DATA.length) {
               const { issue: { number: issue_number }, repo: { owner, repo } } = context;
-              let commentBody = '<h2>:snowflake: :snowflake: :snowflake: You have one or more flakey tests on this branch! :snowflake: :snowflake: :snowflake:</h2>';
+              let commentBody = '<h2>You have one or more flakey tests on this branch! :snowflake: :snowflake: :snowflake:</h2>';
               let dataStr, dataAry, attempts, retryCount, errorLocation, errorPath, errorMessages, errorLink;
 
               let branchName = GITHUB_HEAD_REF.split('/').pop();
@@ -275,7 +275,7 @@ jobs:
 
                   errorPath = `/${owner}/${repo}/blob/${branchName}/${errorLocation.replace(':', '#L')}`;
                   errorLink = `<a href="${errorPath}">${errorLocation}</a>`;
-                  commentBody += `:x: Failed ${attempts} out of ${retryCount} times at ${errorLink}: :warning: ${errorMessages.join(' :warning: ')}<br>`;
+                  commentBody += `Failed ${attempts} out of ${retryCount} times at ${errorLink}: :x: ${errorMessages.join(' :x: ')}<br>`;
                   createComment = true;
                 }
               }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,7 @@ jobs:
         id: set_flaky_test_results_var
         run: |
           file_text=$(cat rspec-retry-flakey-tests.txt)
-          echo ::set-output name=flaky_tests::"$file_text"
+          echo ::set-output name=flaky_tests::$file_text
 
   report-flakey-specs:
     name: Report on flakey specs in pull request

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Read flakey test results
         id: set_flakey_test_results_var
         run: |
-          file_text=$(cat rspec-retry-flakey-tests.txt)
+          file_text=$(cat /app/tmp/rspec-retry-flakey-tests.txt)
           file_text="${file_text//$'\n'/%0A}"
           echo "::set-output name=flakey_tests::$file_text"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,10 @@ jobs:
         DB_PASSWORD: postgres
         REDIS_URL: redis://redis:6379/0
         DB_PORT: 5432
+
+    outputs:
+      flaky_tests: ${{ steps.set_flaky_test_results_var.outputs.flaky_tests }}
+
     steps:
       - name: Setup Parallel Database
         run: bundle exec rake parallel:setup
@@ -175,7 +179,7 @@ jobs:
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern || ' ' }}
           DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
 
-      - name: Report on flakey tests
+      - name: Read flakey test results
         id: set_flaky_test_results_var
         run: |
           input_file="rspec-retry-flakey-tests.txt"
@@ -184,7 +188,28 @@ jobs:
             file_text=$line
           done < "$input_file"
           echo ::set-output name=flaky_tests::$file_text
-      - run: echo ${{ steps.set_flaky_test_results_var.outputs.flaky_tests }}
+
+  report-flakey-specs:
+    name: Report on flakey specs in pull request
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo flakey test output
+        run: echo ${{ needs.test.outputs.flaky_tests }}
+
+      - name: Comment on flakey specs in pull request
+        uses: actions/github-script@0.3.0
+        if: github.event_name == 'pull_request'
+        env:
+          COMMENT_BODY: ${{ needs.test.outputs.flaky_tests }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
+            const { COMMENT_BODY } = process.env;
+            if (COMMENT_BODY.length) {
+              github.issues.createComment({ issue_number, owner, repo, body: COMMENT_BODY });
+            }
 
   trigger-deployment:
     name: Trigger Deployment
@@ -198,3 +223,4 @@ jobs:
           workflow: Deploy
           token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
           inputs: '{"qa": "true", "staging": "true", "research": "true", "sha": "${{ needs.build.outputs.IMAGE_TAG }}"}'
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,7 +238,7 @@ jobs:
 
             if (FLAKEY_TEST_DATA.length) {
               const { issue: { number: issue_number }, repo: { owner, repo } } = context;
-              let commentBody = '<h3>You have one or more flakey tests on this branch! :snowflake: :snowflake: :snowflake:</h3>';
+              let commentBody = '<h2>:snowflake: :snowflake: :snowflake: You have one or more flakey tests on this branch! :snowflake: :snowflake: :snowflake:</h2>';
               let dataStr, dataAry, attempts, retryCount, errorLocation, errorPath, errorMessages, errorLink;
 
               let branchName = GITHUB_HEAD_REF.split('/').pop();
@@ -253,9 +253,9 @@ jobs:
                   dataAry = dataStr.split(',');
                   [attempts, retryCount, errorLocation, ...errorMessages] = dataAry;
 
-                  errorPath = '/' + owner + '/' + repo + '/blob/' + branchName + '/' + errorLocation.replace(':', '#L');
-                  errorLink = '<a href="' + errorPath + '">' + errorLocation + '</a>';
-                  commentBody += ':x: Failed ' + attempts + ' out of ' + retryCount + ' times at ' + errorLink + ': :warning: ' + errorMessages.join(' :warning: ') + '<br>';
+                  errorPath = `/${owner}/${repo}/blob/${branchName}/${errorLocation.replace(':', '#L')}`;
+                  errorLink = `<a href="${errorPath}">${errorLocation}</a>`;
+                  commentBody += `:x: Failed ${attempts} out of ${retryCount} times at ${errorLink}: :warning: ${errorMessages.join(' :warning: ')}<br>`;
                   createComment = true;
                 }
               }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,12 +165,58 @@ jobs:
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern || ' ' }}
           DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
 
+      - name: Upload PR coverage report
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v2
+        with:
+          name: head-result
+          path: /app/coverage/.resultset.json
+
+      - name: Upload base coverage report
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v2
+        with:
+          name: base-result
+          path: /app/coverage/.resultset.json
+
       - name: Read flakey test results
         id: set_flakey_test_results_var
         run: |
           file_text=$(cat rspec-retry-flakey-tests.txt)
           file_text="${file_text//$'\n'/%0A}"
           echo "::set-output name=flakey_tests::$file_text"
+
+  compare-coverage:
+    name: Compare base and branch coverage reports
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download PR coverage artifact
+        uses: actions/download-artifact@v2
+        id: download-head-coverage
+        with:
+          name: head-result
+          path: head-result/.resultset.json
+
+#      - name: Download base coverage artifact
+#        id: download-base-coverage
+#        uses: dawidd6/action-download-artifact@v2
+#        if: github.event_name == 'pull_request'
+#        with:
+#          github_token: ${{secrets.GITHUB_TOKEN}}
+#          workflow: build.yml
+#          workflow_conclusion: success
+#          branch: main
+#          name: base-result
+#          path: base-result/.resultset.json
+
+      - name: Diff coverage resultsets
+        id: diff-coverage-resultsets
+        uses: kzkn/simplecov-resultset-diff-action@v1
+        with:
+          base-resultset-path: ./head-result/.resultset.json
+          head-resultset-path: ./head-result/.resultset.json
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   report-flakey-specs:
     name: Report on flakey specs in pull request
@@ -192,7 +238,7 @@ jobs:
             const { FLAKEY_TEST_DATA } = process.env;
 
             if (FLAKEY_TEST_DATA.length) {
-              const { issue: { number: issue_number }, repo: { owner, repo }, serverUrl  } = context;
+              const { issue: { number: issue_number }, repo: { owner, repo }, serverUrl, ref  } = context;
               let commentBody = '<h3>You have one or more flakey tests on this branch! :snowflake: :snowflake: :snowflake:</h3>';
               let dataStr, dataAry, attempts, retryCount, errorLocation, errorPath, errorMessages, errorLink;
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,6 +210,10 @@ jobs:
           name: head-result
           path: base-result/
 
+      - name: Cat base-result path
+        run: |
+          cat base-result/.resultset.json
+
       - name: Diff coverage resultsets
         id: diff-coverage-resultsets
         uses: kzkn/simplecov-resultset-diff-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,23 +198,23 @@ jobs:
           name: head-result
           path: head-result/
 
-#      - name: Download base coverage artifact
-#        id: download-base-coverage
-#        uses: dawidd6/action-download-artifact@v2
-#        if: github.event_name == 'pull_request'
-#        with:
-#          github_token: ${{secrets.GITHUB_TOKEN}}
-#          workflow: build.yml
-#          workflow_conclusion: success
-#          branch: main
-#          name: base-result
-#          path: base-result/
+      - name: Download base coverage artifact
+        id: download-base-coverage
+        uses: dawidd6/action-download-artifact@v2
+        if: github.event_name == 'pull_request'
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          workflow: build.yml
+          workflow_conclusion: success
+          branch: re-enable-simplecov-in-ci-builds
+          name: head-result
+          path: base-result/
 
       - name: Diff coverage resultsets
         id: diff-coverage-resultsets
         uses: kzkn/simplecov-resultset-diff-action@v1
         with:
-          base-resultset-path: head-result/.resultset.json
+          base-resultset-path: base-result/.resultset.json
           head-resultset-path: head-result/.resultset.json
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Gemfile
+++ b/Gemfile
@@ -163,7 +163,7 @@ group :test do
   gem 'deepsort'
   gem 'ruby-jmeter'
   gem 'super_diff'
-  gem 'rspec-retry', git: 'https://github.com/JR-G/rspec-retry.git'
+  gem 'rspec-retry', git: 'https://github.com/JR-G/rspec-retry.git', branch: 'tidy-flakey-test-reporting'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -163,7 +163,7 @@ group :test do
   gem 'deepsort'
   gem 'ruby-jmeter'
   gem 'super_diff'
-  gem 'rspec-retry', git: 'https://github.com/JR-G/rspec-retry.git', branch: 'tidy-flakey-test-reporting'
+  gem 'rspec-retry', git: 'https://github.com/JR-G/rspec-retry.git'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -163,6 +163,7 @@ group :test do
   gem 'deepsort'
   gem 'ruby-jmeter'
   gem 'super_diff'
+  gem 'rspec-retry', git: 'https://github.com/JR-G/rspec-retry.git'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,13 @@ GIT
     audited (4.10.0)
       activerecord (>= 4.2, < 6.2)
 
+GIT
+  remote: https://github.com/JR-G/rspec-retry.git
+  revision: bf34a465657ab7d518bacbaacb73f58f03f4e735
+  specs:
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -747,6 +754,7 @@ DEPENDENCIES
   request_store_rails
   rouge
   rspec-rails
+  rspec-retry!
   rspec_junit_formatter
   rubocop
   rubocop-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,8 @@ GIT
 
 GIT
   remote: https://github.com/JR-G/rspec-retry.git
-  revision: bf34a465657ab7d518bacbaacb73f58f03f4e735
+  revision: de3267d1524f57afd88f9797de3acf9986418ae4
+  branch: tidy-flakey-test-reporting
   specs:
     rspec-retry (0.6.2)
       rspec-core (> 3.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/JR-G/rspec-retry.git
-  revision: de3267d1524f57afd88f9797de3acf9986418ae4
-  branch: tidy-flakey-test-reporting
+  revision: c43713cbe66311cf44ebe5d56e57c422cfe14340
   specs:
     rspec-retry (0.6.2)
       rspec-core (> 3.3)

--- a/spec/lib/flaky_spec.rb
+++ b/spec/lib/flaky_spec.rb
@@ -1,7 +1,12 @@
 require 'rails_helper'
 
+# rubocop:disable Style/ClassVars
 RSpec.describe 'A flaky spec' do
-  it 'randomly succeeds', retry: 3 do
-    expect(rand(2)).to eq(1)
+  @@fail = true
+  after { @@fail = false }
+
+  it 'eventually succeeds', retry: 3 do
+    expect(@@fail).to be false
   end
 end
+# rubocop:enable Style/ClassVars

--- a/spec/lib/flaky_spec.rb
+++ b/spec/lib/flaky_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe 'A flaky spec' do
+  it 'randomly succeeds', retry: 3 do
+    expect(rand(2)).to eq(1)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,9 +19,7 @@ SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   SimpleCov::Formatter::CoberturaFormatter,
 ]
-unless ENV['TEST_ENV_NUMBER']
-  SimpleCov.start 'rails'
-end
+SimpleCov.start 'rails'
 
 require 'sidekiq/testing'
 require 'clockwork/test'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,7 +41,7 @@ RSpec.configure do |config|
   config.verbose_retry = true
   config.display_try_failure_messages = true
   reporter = RSpec::Core::Reporter.new(config)
-  reporter.register_listener(RSpec::Core::Formatters::BaseTextFormatter.new(File.open('rspec-retry-flakey-tests.txt', 'wb')), 'message')
+  reporter.register_listener(RSpec::Core::Formatters::BaseTextFormatter.new(File.open('tmp/rspec-retry-flakey-tests.txt', 'wb')), 'message')
   config.retry_reporter = reporter
 
   config.around do |ex|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,9 @@ SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   SimpleCov::Formatter::CoberturaFormatter,
 ]
-SimpleCov.start 'rails'
+SimpleCov.start 'rails' do
+  enable_coverage :branch
+end
 
 require 'sidekiq/testing'
 require 'clockwork/test'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,21 @@ require 'audited-rspec'
 ENV['SERVICE_TYPE'] = 'test' # this is used for logging
 ENV['STATE_CHANGE_SLACK_URL'] = nil # ensure tests send no Slack notifications
 
+require 'rspec/retry'
+require 'rspec/core/formatters/base_text_formatter'
+
 RSpec.configure do |config|
+  # RSpec retry config
+  config.verbose_retry = true
+  config.display_try_failure_messages = true
+  reporter = RSpec::Core::Reporter.new(config)
+  reporter.register_listener(RSpec::Core::Formatters::BaseTextFormatter.new(File.open('rspec-retry-flakey-tests.txt', 'wb')), 'message')
+  config.retry_reporter = reporter
+
+  config.around do |ex|
+    ex.run_with_retry retry: 3
+  end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,12 +37,12 @@ require 'rspec/retry'
 require 'rspec/core/formatters/base_text_formatter'
 
 RSpec.configure do |config|
-  # RSpec retry config
+  reporter = RSpec::Core::Reporter.new(config)
+  formatter = RSpec::Core::Formatters::BaseTextFormatter.new(File.open('tmp/rspec-retry-flakey-specs.log', 'wb'))
+  reporter.register_listener(formatter, 'message')
+  config.retry_reporter = reporter
   config.verbose_retry = true
   config.display_try_failure_messages = true
-  reporter = RSpec::Core::Reporter.new(config)
-  reporter.register_listener(RSpec::Core::Formatters::BaseTextFormatter.new(File.open('tmp/rspec-retry-flakey-tests.txt', 'wb')), 'message')
-  config.retry_reporter = reporter
 
   config.around do |ex|
     ex.run_with_retry retry: 3

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,9 @@ SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   SimpleCov::Formatter::CoberturaFormatter,
 ]
+
+SimpleCov.command_name('RSpec')
+
 SimpleCov.start 'rails' do
   enable_coverage :branch
 end


### PR DESCRIPTION
## Context

Proof of concept for flakey test workflow reporting

- Run tests (generates flakey test report)
- Set job variable from contents of flakey test report file
- Read job variable and comment on PR if flakey test var is not empty

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/93511/141319066-36efaba6-fa35-4257-b7c8-f635dc8ded81.png)


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
