### PR TITLE
Monthly statistics: Include 'withdrawn' and 'offer_withdrawn' in 'unsuccessful' count

### DIFF
--- a/app/models/monthly_statistics/base.rb
+++ b/app/models/monthly_statistics/base.rb
@@ -19,7 +19,11 @@ module MonthlyStatistics
     end
 
     def unsuccessful_count(statuses)
-      (statuses['declined'] || 0) + (statuses['rejected'] || 0) + (statuses['conditions_not_met'] || 0)
+      (statuses['declined'] || 0) +
+        (statuses['rejected'] || 0) +
+        (statuses['conditions_not_met'] || 0) +
+        (statuses['withdrawn'] || 0) +
+        (statuses['offer_withdrawn'] || 0)
     end
 
     def statuses_count(statuses)

--- a/spec/models/monthly_statistics/by_age_group_spec.rb
+++ b/spec/models/monthly_statistics/by_age_group_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe MonthlyStatistics::ByAgeGroup do
 
     # check awaiting_provider_decision takes precedence over unsuccessful states
     create(:application_choice, :awaiting_provider_decision, application_form: application_form_22_year_old2)
-    create(:application_choice, :with_conditions_not_met, application_form: application_form_22_year_old2)
+    create(:application_choice, :withdrawn, application_form: application_form_22_year_old2)
 
     create(:application_choice, :awaiting_provider_decision, application_form: application_form_23_year_old)
     create(:application_choice, :with_conditions_not_met, application_form: application_form_23_year_old)
@@ -59,7 +59,7 @@ RSpec.describe MonthlyStatistics::ByAgeGroup do
     create(:application_choice, :with_rejection, application_form: application_form_30_to_34_year_old)
 
     # only counts the latest application form
-    create(:application_choice, :with_rejection, application_form: first_application_form_40_to_44_year_old)
+    create(:application_choice, :with_withdrawn_offer, application_form: first_application_form_40_to_44_year_old)
     create(:application_choice, :with_recruited, application_form: second_application_form_40_to_44_year_old)
 
     # counts deferred offers from the previous cycle

--- a/spec/models/monthly_statistics/by_area_spec.rb
+++ b/spec/models/monthly_statistics/by_area_spec.rb
@@ -12,9 +12,11 @@ RSpec.describe MonthlyStatistics::ByArea do
     create_application_choice(statuses: %i[with_deferred_offer with_declined_offer], status_before_deferral: 'offer', region_code: 'london', recruitment_cycle_year: RecruitmentCycle.current_year)
     create_application_choice(statuses: %i[with_conditions_not_met], region_code: 'wales')
     create_application_choice(statuses: %i[with_offer], region_code: 'london')
+    create_application_choice(statuses: %i[with_withdrawn_offer], region_code: 'north_east')
+    create_application_choice(statuses: %i[withdrawn], region_code: 'north_east')
     create_application_choice_with_previous_application(status: :with_rejection, region_code: 'north_west')
 
-    expect(column_totals).to eq([1, 0, 3, 1, 3, 8])
+    expect(column_totals).to eq([1, 0, 3, 1, 5, 10])
     expect(totals_for('London')).to eq(
       'Recruited' => 0,
       'Conditions pending' => 0,
@@ -54,6 +56,15 @@ RSpec.describe MonthlyStatistics::ByArea do
       'Awaiting provider decisions' => 0,
       'Unsuccessful' => 1,
       'Total' => 1,
+    )
+
+    expect(totals_for('North East')).to eq(
+      'Recruited' => 0,
+      'Conditions pending' => 0,
+      'Received an offer' => 0,
+      'Awaiting provider decisions' => 0,
+      'Unsuccessful' => 2,
+      'Total' => 2,
     )
   end
 

--- a/spec/models/monthly_statistics/by_course_age_group_spec.rb
+++ b/spec/models/monthly_statistics/by_course_age_group_spec.rb
@@ -22,19 +22,19 @@ RSpec.describe MonthlyStatistics::ByCourseAgeGroup do
           'Conditions pending' => 1,
           'Received an offer' => 1,
           'Awaiting provider decisions' => 0,
-          'Unsuccessful' => 1,
-          'Total' => 3 },
+          'Unsuccessful' => 2,
+          'Total' => 4 },
         {
           'Age group' => 'Further education',
           'Recruited' => 0,
           'Conditions pending' => 0,
           'Received an offer' => 1,
           'Awaiting provider decisions' => 0,
-          'Unsuccessful' => 1,
-          'Total' => 2,
+          'Unsuccessful' => 2,
+          'Total' => 3,
         },
       ],
-      column_totals: [1, 1, 2, 1, 3, 8],
+      column_totals: [1, 1, 2, 1, 5, 10],
     })
   end
 
@@ -47,7 +47,9 @@ RSpec.describe MonthlyStatistics::ByCourseAgeGroup do
     create(:application_choice, :with_recruited, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: create(:course_option, course: create(:course, level: 'primary')))
     create(:application_choice, :with_offer, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: create(:course_option, course: create(:course, level: 'secondary')))
     create(:application_choice, :with_conditions_not_met, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: create(:course_option, course: create(:course, level: 'secondary')))
+    create(:application_choice, :with_withdrawn_offer, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: create(:course_option, course: create(:course, level: 'secondary')))
     create(:application_choice, :with_offer, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: create(:course_option, course: create(:course, level: 'further_education')))
     create(:application_choice, :with_rejection, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: create(:course_option, course: create(:course, level: 'further_education')))
+    create(:application_choice, :withdrawn, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: create(:course_option, course: create(:course, level: 'further_education')))
   end
 end

--- a/spec/models/monthly_statistics/by_course_type_spec.rb
+++ b/spec/models/monthly_statistics/by_course_type_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe MonthlyStatistics::ByCourseType do
             'Conditions pending' => 0,
             'Received an offer' => 0,
             'Awaiting provider decisions' => 1,
-            'Unsuccessful' => 1,
-            'Total' => 3,
+            'Unsuccessful' => 2,
+            'Total' => 4,
           },
           {
             'Course type' => 'Postgraduate teaching apprenticeship',
@@ -24,8 +24,8 @@ RSpec.describe MonthlyStatistics::ByCourseType do
             'Conditions pending' => 1,
             'Received an offer' => 1,
             'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 1,
-            'Total' => 3,
+            'Unsuccessful' => 2,
+            'Total' => 4,
           },
           {
             'Course type' => 'School-centred initial teacher training (SCITT)',
@@ -56,7 +56,7 @@ RSpec.describe MonthlyStatistics::ByCourseType do
           },
 
         ],
-        column_totals: [2, 3, 4, 1, 5, 15] },
+        column_totals: [2, 3, 4, 1, 7, 17] },
     )
   end
 
@@ -70,9 +70,11 @@ RSpec.describe MonthlyStatistics::ByCourseType do
 
     # current year
     create_application_choice_for_this_cycle(status: :with_rejection, program_type: 'higher_education_programme')
+    create_application_choice_for_this_cycle(status: :withdrawn, program_type: 'higher_education_programme')
     create_application_choice_for_this_cycle(status: :awaiting_provider_decision, program_type: 'higher_education_programme')
     create_application_choice_for_this_cycle(status: :with_offer, program_type: 'pg_teaching_apprenticeship')
     create_application_choice_for_this_cycle(status: :with_conditions_not_met, program_type: 'pg_teaching_apprenticeship')
+    create_application_choice_for_this_cycle(status: :with_withdrawn_offer, program_type: 'pg_teaching_apprenticeship')
     create_application_choice_for_this_cycle(status: :with_offer, program_type: 'scitt_programme')
     create_application_choice_for_this_cycle(status: :with_rejection, program_type: 'scitt_programme')
     create_application_choice_for_this_cycle(status: :with_offer, program_type: 'school_direct_training_programme')

--- a/spec/models/monthly_statistics/by_primary_specialist_subject_spec.rb
+++ b/spec/models/monthly_statistics/by_primary_specialist_subject_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe MonthlyStatistics::ByPrimarySpecialistSubject do
               'Conditions pending' => 1,
               'Received an offer' => 0,
               'Awaiting provider decisions' => 0,
-              'Unsuccessful' => 0,
-              'Total' => 1,
+              'Unsuccessful' => 1,
+              'Total' => 2,
             },
             {
               'Subject' => 'Geography and History',
@@ -34,8 +34,8 @@ RSpec.describe MonthlyStatistics::ByPrimarySpecialistSubject do
               'Conditions pending' => 1,
               'Received an offer' => 0,
               'Awaiting provider decisions' => 0,
-              'Unsuccessful' => 0,
-              'Total' => 1,
+              'Unsuccessful' => 1,
+              'Total' => 2,
             },
             {
               'Subject' => 'Modern languages',
@@ -74,7 +74,7 @@ RSpec.describe MonthlyStatistics::ByPrimarySpecialistSubject do
               'Total' => 1,
             },
           ],
-          column_totals: [2, 2, 0, 2, 1, 7],
+          column_totals: [2, 2, 0, 2, 3, 9],
         },
       )
     end
@@ -97,6 +97,8 @@ RSpec.describe MonthlyStatistics::ByPrimarySpecialistSubject do
     # current year
     create(:application_choice, :with_recruited, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: primary_with_geography_and_history_course_option)
     create(:application_choice, :with_rejection, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: primary_with_modern_languages_course_option)
+    create(:application_choice, :with_withdrawn_offer, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: primary_with_mathematics_course_option)
+    create(:application_choice, :withdrawn, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: primary_with_english_course_option)
     create(:application_choice, :awaiting_provider_decision, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: primary_with_science_course_option)
     create(:application_choice, :awaiting_provider_decision, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: primary_with_pe_course_option)
   end

--- a/spec/models/monthly_statistics/by_provider_area_spec.rb
+++ b/spec/models/monthly_statistics/by_provider_area_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe MonthlyStatistics::ByProviderArea do
               'Conditions pending' => 0,
               'Received an offer' => 0,
               'Awaiting provider decisions' => 0,
-              'Unsuccessful' => 0,
-              'Total' => 1,
+              'Unsuccessful' => 2,
+              'Total' => 3,
             },
             {
               'Area' => 'North West',
@@ -92,7 +92,7 @@ RSpec.describe MonthlyStatistics::ByProviderArea do
               'Total' => 1,
             },
           ],
-          column_totals: [2, 2, 2, 0, 3, 9],
+          column_totals: [2, 2, 2, 0, 5, 11],
         },
       )
     end
@@ -111,6 +111,8 @@ RSpec.describe MonthlyStatistics::ByProviderArea do
     create_application_choice_for_this_cycle(status: :with_rejection, region_code: 'south_west')
     create_application_choice_for_this_cycle(status: :with_offer, region_code: 'west_midlands')
     create_application_choice_for_this_cycle(status: :with_conditions_not_met, region_code: 'yorkshire_and_the_humber')
+    create_application_choice_for_this_cycle(status: :withdrawn, region_code: 'north_east')
+    create_application_choice_for_this_cycle(status: :with_withdrawn_offer, region_code: 'north_east')
   end
 
   def create_application_choice_for_this_cycle(status:, region_code:)

--- a/spec/models/monthly_statistics/by_secondary_subject_spec.rb
+++ b/spec/models/monthly_statistics/by_secondary_subject_spec.rb
@@ -178,8 +178,8 @@ RSpec.describe MonthlyStatistics::BySecondarySubject do
               'Conditions pending' => 2,
               'Received an offer' => 4,
               'Awaiting provider decisions' => 0,
-              'Unsuccessful' => 3,
-              'Total' => 10,
+              'Unsuccessful' => 4,
+              'Total' => 11,
             },
             {
               'Subject' => 'Music',
@@ -241,8 +241,8 @@ RSpec.describe MonthlyStatistics::BySecondarySubject do
               'Conditions pending' => 0,
               'Received an offer' => 1,
               'Awaiting provider decisions' => 0,
-              'Unsuccessful' => 0,
-              'Total' => 1,
+              'Unsuccessful' => 1,
+              'Total' => 2,
             },
             {
               'Subject' => 'Further education',
@@ -254,7 +254,7 @@ RSpec.describe MonthlyStatistics::BySecondarySubject do
               'Total' => 1,
             },
           ],
-          column_totals: [5, 9, 12, 1, 9, 36],
+          column_totals: [5, 9, 12, 1, 11, 38],
         },
       )
     end
@@ -289,6 +289,7 @@ RSpec.describe MonthlyStatistics::BySecondarySubject do
     create_application_choice_for_this_cycle(status: :with_offer, subject: 'Mathematics')
     create_application_choice_for_this_cycle(status: :with_rejection, subject: 'French')
     create_application_choice_for_this_cycle(status: :with_offer, subject: 'German')
+    create_application_choice_for_this_cycle(status: :withdrawn, subject: 'German')
     create_application_choice_for_this_cycle(status: :with_rejection, subject: 'Mandarin')
     create_application_choice_for_this_cycle(status: :with_offer, subject: 'Spanish')
     create_application_choice_for_this_cycle(status: :with_offer, subject: 'Japanese')
@@ -300,6 +301,7 @@ RSpec.describe MonthlyStatistics::BySecondarySubject do
     create_application_choice_for_this_cycle(status: :with_offer, subject: 'Psychology')
     create_application_choice_for_this_cycle(status: :with_rejection, subject: 'Religious education')
     create_application_choice_for_this_cycle(status: :with_offer, subject: 'Social sciences')
+    create_application_choice_for_this_cycle(status: :withdrawn, subject: 'Social sciences')
   end
 
   def create_application_choice_for_this_cycle(status:, subject:)

--- a/spec/models/monthly_statistics/by_sex_spec.rb
+++ b/spec/models/monthly_statistics/by_sex_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe MonthlyStatistics::BySex do
     create_application_choice(status: :with_deferred_offer, sex: 'female', recruitment_cycle_year: RecruitmentCycle.current_year)
     create_application_choice(status: :with_conditions_not_met, sex: 'intersex')
     create_application_choice(status: :with_offer, sex: 'female')
+    create_application_choice(status: :with_withdrawn_offer, sex: 'female')
+    create_application_choice(status: :withdrawn, sex: 'male')
     create_application_choice_with_previous_application(status: :with_rejection, sex: 'male')
 
     expect(statistics).to eq(
@@ -23,8 +25,8 @@ RSpec.describe MonthlyStatistics::BySex do
             'Conditions pending' => 0,
             'Received an offer' => 1,
             'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 1,
-            'Total' => 2,
+            'Unsuccessful' => 2,
+            'Total' => 3,
           },
           {
             'Sex' => 'Male',
@@ -32,8 +34,8 @@ RSpec.describe MonthlyStatistics::BySex do
             'Conditions pending' => 0,
             'Received an offer' => 1,
             'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 1,
-            'Total' => 2,
+            'Unsuccessful' => 2,
+            'Total' => 3,
           },
           {
             'Sex' => 'Intersex',
@@ -54,7 +56,7 @@ RSpec.describe MonthlyStatistics::BySex do
             'Total' => 2,
           },
         ],
-        column_totals: [1, 0, 3, 1, 3, 8] },
+        column_totals: [1, 0, 3, 1, 5, 10] },
     )
   end
 


### PR DESCRIPTION
## Context

When the monthly stats tables were created, 'withdrawn' and 'withdrawn offer' application choices were not included in the 'unsuccessful' count

## Changes proposed in this pull request

- Include 'withdrawn' and 'withdrawn offer' application choices in the unsuccessful count 

## Link to Trello card
https://trello.com/c/M4CJttMk/4109-include-withdrawn-and-withdrawn-offer-in-unsuccessful-count-all-monthly-stats-tables

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
