### PR TITLE
Speed up the region code backfill task before running on production

### DIFF
--- a/lib/tasks/region_code_backfill.rake
+++ b/lib/tasks/region_code_backfill.rake
@@ -12,9 +12,9 @@ task region_code_backfill: :environment do
     .where(region_code: nil)
     .where.not(postcode: nil)
     .find_in_batches(batch_size: RegionCodeBackfill::BATCH_SIZE) do |batch|
-    batch.each do |application_form|
-      LookupAreaByPostcodeWorker.perform_at(next_batch_time, application_form.id)
+      batch.each do |application_form|
+        LookupAreaByPostcodeWorker.perform_at(next_batch_time, application_form.id)
+      end
       next_batch_time += RegionCodeBackfill::INTERVAL_BETWEEN_BATCHES
     end
-  end
 end


### PR DESCRIPTION
## Context

There was a logic error in the original code that would have caused each
application to be processed as a single batch with a 5 second gap
between each application. This would take more than 24 hours to backfill
the production DB rather than spreading it out over about an hour as
intended.

## Changes proposed in this pull request

Process 50 applications per 5 seconds rather than 1 per 5 seconds.

## Guidance to review

- Does the logic make sense?

## Link to Trello card

n/a

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
