### PR TITLE
Configure 'UpdateMonthlyStatisticsReport' job to run at the beginning of every month

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -34,6 +34,8 @@ class Clock
 
   every(1.day, 'Generate export for TAD', at: '23:59') { DataAPI::TADExport.run_daily }
 
+  every(1.day, 'Generate monthly statistics report', at: '00:00', if: ->(t) { t.day == 1 }) { UpdateMonthlyStatisticsReport.perform_async }
+
   every(1.day, 'MinisterialReportCandidatesExport', at: '23:59') { SupportInterface::MinisterialReportCandidatesExport.run_daily }
   every(1.day, 'MinisterialReportApplicationsExport', at: '23:59') { SupportInterface::MinisterialReportApplicationsExport.run_daily }
 

--- a/spec/workers/update_monthly_statistics_report_spec.rb
+++ b/spec/workers/update_monthly_statistics_report_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe UpdateMonthlyStatisticsReport, sidekiq: true do
+  describe '#perform' do
+    context 'it is the beginning of the month' do
+      it 'generates the monthly stats' do
+        expect(MonthlyStatisticsReport.count).to eq(0)
+
+        described_class.new.perform
+
+        expect(MonthlyStatisticsReport.count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to generate a monthly stats report at the beginning of every month

## Changes in this PR

Configure 'UpdateMonthlyStatisticsReport' job to run at the beginning of every month

## Link to Trello card

https://trello.com/c/NmjvZ359/4110-configure-updatemonthlystatisticsreport-job-to-run-at-the-beginning-of-every-month

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
