### PR TITLE
Add additional logic to the `by_age_group` query for `withdrawn` and `offer_withdrawn` statuses

### DIFF
--- a/app/models/monthly_statistics/by_age_group.rb
+++ b/app/models/monthly_statistics/by_age_group.rb
@@ -173,14 +173,16 @@ module MonthlyStatistics
                 c.id,
                 f.id,
                 CASE
-                  WHEN 'recruited' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['0', 'recruited']
-                  WHEN 'offer_deferred' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['1', 'offer_deferred']
-                  WHEN 'pending_conditions' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['2', 'pending_conditions']
-                  WHEN 'offer' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['3', 'offer']
-                  WHEN 'awaiting_provider_decision' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['4', 'awaiting_provider_decision']
-                  WHEN 'declined' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['5', 'declined']
-                  WHEN 'rejected' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['6', 'rejected']
-                  WHEN 'conditions_not_met' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['7', 'conditions_not_met']
+                  WHEN 'recruited' = ANY(ARRAY_AGG(ch.status)) THEN 'recruited'
+                  WHEN 'offer_deferred' = ANY(ARRAY_AGG(ch.status)) THEN 'offer_deferred'
+                  WHEN 'pending_conditions' = ANY(ARRAY_AGG(ch.status)) THEN 'pending_conditions'
+                  WHEN 'offer' = ANY(ARRAY_AGG(ch.status)) THEN 'offer'
+                  WHEN 'awaiting_provider_decision' = ANY(ARRAY_AGG(ch.status)) THEN 'awaiting_provider_decision'
+                  WHEN 'declined' = ANY(ARRAY_AGG(ch.status)) THEN 'declined'
+                  WHEN 'rejected' = ANY(ARRAY_AGG(ch.status)) THEN 'rejected'
+                  WHEN 'conditions_not_met' = ANY(ARRAY_AGG(ch.status)) THEN 'conditions_not_met'
+                  WHEN 'offer_withdrawn' = ANY(ARRAY_AGG(ch.status)) THEN 'offer_withdrawn'
+                  WHEN 'withdrawn' = ANY(ARRAY_AGG(ch.status)) THEN 'withdrawn'
                 END status,
                 CASE
                   #{age_group_sql}
@@ -207,7 +209,7 @@ module MonthlyStatistics
                 c.id, f.id, age_group
         )
         SELECT
-            raw_data.status[2],
+            raw_data.status,
             raw_data.age_group,
             COUNT(*)
         FROM
@@ -215,7 +217,7 @@ module MonthlyStatistics
         GROUP BY
             raw_data.status, raw_data.age_group
         ORDER BY
-            raw_data.status[1]
+            raw_data.status
       SQL
     end
 

--- a/spec/models/monthly_statistics/by_age_group_spec.rb
+++ b/spec/models/monthly_statistics/by_age_group_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe MonthlyStatistics::ByAgeGroup do
                                                                              date_of_birth: Date.new(RecruitmentCycle.current_year - 49, 1, 1),
                                                                              recruitment_cycle_year: RecruitmentCycle.previous_year)
 
+    offer_withdrawn_application_for_50_to_54_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 50, 1, 1))
+
+    withdrawn_application_form_55_to_59_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 55, 1, 1))
+
     unsuccessful_application_for_65_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 65, 8, 31))
 
     # check recruited takes precedence over deferred
@@ -64,6 +68,10 @@ RSpec.describe MonthlyStatistics::ByAgeGroup do
 
     # counts deferred offers from the previous cycle
     create(:application_choice, :with_deferred_offer, application_form: deferred_application_form_from_previous_cycle_45_to_49_year_old)
+
+    create(:application_choice, :with_rejection, application_form: offer_withdrawn_application_for_50_to_54_year_old)
+
+    create(:application_choice, :with_rejection, application_form: withdrawn_application_form_55_to_59_year_old)
 
     create(:application_choice, :with_rejection, application_form: unsuccessful_application_for_65_year_old)
 
@@ -157,8 +165,8 @@ RSpec.describe MonthlyStatistics::ByAgeGroup do
             'Conditions pending' => 0,
             'Received an offer' => 0,
             'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 0,
-            'Total' => 0,
+            'Unsuccessful' => 1,
+            'Total' => 1,
           },
           {
             'Age group' => '55 to 59',
@@ -166,8 +174,8 @@ RSpec.describe MonthlyStatistics::ByAgeGroup do
             'Conditions pending' => 0,
             'Received an offer' => 0,
             'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 0,
-            'Total' => 0,
+            'Unsuccessful' => 1,
+            'Total' => 1,
           },
           {
             'Age group' => '60 to 64',
@@ -188,7 +196,7 @@ RSpec.describe MonthlyStatistics::ByAgeGroup do
             'Total' => 1,
           },
         ],
-        column_totals: [2, 2, 1, 4, 1, 10] },
+        column_totals: [2, 2, 1, 4, 3, 12] },
     )
   end
 end


### PR DESCRIPTION
## Context

This currently isn't counting the withdrawn and offer withdrawn statuses. They should be included in the unsuccessful count.

## Changes proposed in this pull request

- Update the query to include withdrawn and offer withdrawn statuses

## Link to Trello card

https://trello.com/c/M4CJttMk/4109-include-withdrawn-and-withdrawn-offer-in-unsuccessful-count-all-monthly-stats-tables

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
