### PR TITLE
Ensure candidates with no region are added to the ExternalReportCandidatesExport

### DIFF
--- a/app/services/support_interface/external_report_candidates_export.rb
+++ b/app/services/support_interface/external_report_candidates_export.rb
@@ -78,9 +78,12 @@ module SupportInterface
                   WHEN f.equality_and_diversity->> 'sex' = 'Prefer not to say' then 'Prefer not to say'
                 END sex,
                 CASE
+                  WHEN f.region_code = 'channel_islands' THEN 'Channel Islands'
                   WHEN f.region_code = 'eastern' THEN 'East'
                   WHEN f.region_code = 'east_midlands' THEN 'East Midlands'
+                  WHEN f.region_code = 'isle_of_man' THEN 'Isle of Man'
                   WHEN f.region_code = 'london' THEN 'London'
+                  WHEN f.region_code = 'NULL' THEN 'No region'
                   WHEN f.region_code = 'north_east' THEN 'North East'
                   WHEN f.region_code = 'north_west' THEN 'North West'
                   WHEN f.region_code = 'northern_ireland' THEN 'Northern Ireland'
@@ -92,6 +95,8 @@ module SupportInterface
                   WHEN f.region_code = 'yorkshire_and_the_humber' THEN 'Yorkshire and The Humber'
                   WHEN f.region_code = 'european_economic_area' THEN 'European Economic Area'
                   WHEN f.region_code = 'rest_of_the_world' THEN 'Rest of the World'
+                  ELSE
+                    'No region'
                 END area,
                 CASE
                   WHEN f.date_of_birth > '#{Date.new(RecruitmentCycle.current_year - 22, 8, 31)}' THEN '21 and under'
@@ -133,22 +138,6 @@ module SupportInterface
                 NOT c.hide_in_reporting
                 AND f.submitted_at IS NOT NULL
                 AND f.date_of_birth IS NOT NULL
-                AND f.region_code IN (
-                  'eastern',
-                  'east_midlands',
-                  'london',
-                  'north_east',
-                  'north_west',
-                  'northern_ireland',
-                  'scotland',
-                  'south_east',
-                  'south_west',
-                  'wales',
-                  'west_midlands',
-                  'yorkshire_and_the_humber',
-                  'european_economic_area',
-                  'rest_of_the_world'
-                )
                 AND (
                   NOT EXISTS (
                     SELECT 1
@@ -157,9 +146,11 @@ module SupportInterface
                     WHERE f.id = subsequent_application_forms.previous_application_form_id
                   )
                 )
-                AND f.recruitment_cycle_year = #{RecruitmentCycle.current_year}
-                OR f.recruitment_cycle_year = #{RecruitmentCycle.previous_year}
-                AND ac.status_before_deferral IS NOT NULL
+                AND (
+                  f.recruitment_cycle_year = #{RecruitmentCycle.current_year}
+                  OR f.recruitment_cycle_year = #{RecruitmentCycle.previous_year}
+                  AND ac.status_before_deferral IS NOT NULL
+              )
             GROUP BY
                 c.id, ac.id, f.id
         )

--- a/config/initializers/external_report_candidates.rb
+++ b/config/initializers/external_report_candidates.rb
@@ -1,11 +1,15 @@
 module ExternalReportCandidates
   AREAS = {
+    'channel_islands' => 'Channel Islands',
     'eastern' => 'East',
     'east_midlands' => 'East Midlands',
+    'isle_of_man' => 'Isle of Man',
     'london' => 'London',
+    nil => 'No region',
     'north_east' => 'North East',
     'north_west' => 'North West',
     'northern_ireland' => 'Northern Ireland',
+    'no_region' => 'No region',
     'scotland' => 'Scotland',
     'south_east' => 'South East',
     'south_west' => 'South West',

--- a/spec/services/support_interface/external_report_candidates_export_spec.rb
+++ b/spec/services/support_interface/external_report_candidates_export_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe SupportInterface::ExternalReportCandidatesExport do
     end
 
     def generate_test_data
-      region_codes = ApplicationForm.region_codes.keys.reject { |region| %w[channel_islands isle_of_man no_region].include?(region) }
+      region_codes = ApplicationForm.region_codes.keys + [nil]
       statuses = ApplicationChoice.statuses.keys.reject { |status| %w[unsubmitted cancelled application_not_sent offer_deferred].include?(status) }
       sexes = ExternalReportCandidates::SEX.keys
 


### PR DESCRIPTION
## Context

As part of the aggregated candidates export i didn't add in  rows for the applications from the Channel Islands, the Isle of Man and application forms with no region. 

It also fixes the query to ensure that the where conditions apply to deferred applications.

## Changes proposed in this pull request

- Ensure that candidates who input invalid postcodes are exposed as 'No region'
- Fix the query to ensure deferred offers still meet the rest of the where conditions

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
