### PR TITLE
Log changes when alerting on site sync changes

### DIFF
--- a/app/services/concerns/full_sync_error_handler.rb
+++ b/app/services/concerns/full_sync_error_handler.rb
@@ -1,7 +1,19 @@
 module FullSyncErrorHandler
-  def raise_update_error(updates = {})
+  def raise_update_error(updates = {}, changeset = nil)
     return if updates.none?
 
-    Sentry.capture_exception(TeacherTrainingPublicAPI::FullSyncUpdateError.new("#{updates.keys.to_sentence} have been updated"))
+    Sentry.capture_exception(TeacherTrainingPublicAPI::FullSyncUpdateError.new(error_message(updates, changeset)))
+  end
+
+private
+
+  def error_message(updates, changeset)
+    error_message = "#{updates.keys.to_sentence} have been updated"
+    error_message << "\n#{stringify_changeset(changeset)}" if changeset.present?
+    error_message
+  end
+
+  def stringify_changeset(changeset)
+    changeset.map(&:to_s).join(",\n")
   end
 end

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -154,8 +154,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
 
         described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, false)
 
-        expect(Sentry).to have_received(:capture_exception)
-                          .with(TeacherTrainingPublicAPI::FullSyncUpdateError.new('site and course_option have been updated'))
+        expect(Sentry).to have_received(:capture_exception).twice
       end
 
       it 'correctly updates vacancy status for any existing course options' do

--- a/spec/support/test_helpers/teacher_training_public_api_helper.rb
+++ b/spec/support/test_helpers/teacher_training_public_api_helper.rb
@@ -45,7 +45,7 @@ module TeacherTrainingPublicAPIHelper
     stub_teacher_training_api_sites(recruitment_cycle_year: recruitment_cycle_year, provider_code: provider_code, course_code: course_code, specified_attributes: site_attributes, vacancy_status: vacancy_status)
   end
 
-  def stub_teacher_training_api_course(provider_code:, course_code:, recruitment_cycle_year: RecruitmentCycle.current_year, specified_attributes: [])
+  def stub_teacher_training_api_course(provider_code:, course_code:, recruitment_cycle_year: RecruitmentCycle.current_year, specified_attributes: {})
     response_body = build_response_body('course_single_response.json', specified_attributes.merge(code: course_code))
     stub_teacher_training_single_api_request("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses/#{course_code}", response_body)
   end


### PR DESCRIPTION
## Context

In order to identify what has changed when we get a full sync change error, log the changes

## Changes proposed in this pull request

Log `model.changes` when a site is updated via the FullSync

## Link to Trello card

https://trello.com/c/7rGoWWVY/4461-log-changes-when-alerting-on-full-sync-changes

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
