### PR TITLE
Fixup `rake setup_local_dev_data`

### DIFF
--- a/app/lib/create_example_provider_users_with_permissions.rb
+++ b/app/lib/create_example_provider_users_with_permissions.rb
@@ -12,7 +12,7 @@ class CreateExampleProviderUsersWithPermissions
       email_address: 'support@example.com',
       first_name: 'Susan',
       last_name: 'Upport',
-    }, %w[1JA 1JB 24J], {
+    }, %w[1JA 24J], {
       manage_users: true,
       manage_organisations: true,
       set_up_interviews: true,
@@ -42,7 +42,7 @@ class CreateExampleProviderUsersWithPermissions
     })
 
     ProviderRelationshipPermissions.find_or_create_by(
-      training_provider: Provider.find_by_code('1JB'),
+      training_provider: Provider.find_by_code('1JA'),
       ratifying_provider: Provider.find_by_code('24P'),
     ).update(
       training_provider_can_make_decisions: true,
@@ -50,34 +50,6 @@ class CreateExampleProviderUsersWithPermissions
       training_provider_can_view_diversity_information: true,
       setup_at: Time.zone.now,
     )
-
-    # cannot_view__no_org_level_perm__with_manage_orgs__training_provider
-    admin_1jb1 = create_provider_user({
-      dfe_sign_in_uid: 'dev-1JB-admin-1',
-      email_address: '1JB-admin-1@example.com',
-      first_name: '1JB',
-      last_name: 'Admin 1',
-    }, %w[1JB], {
-      manage_organisations: true,
-      view_safeguarding_information: true,
-    })
-
-    ProviderAgreement.create!(
-      provider: Provider.find_by_code('1JB'),
-      provider_user: admin_1jb1,
-      agreement_type: :data_sharing_agreement,
-      accept_agreement: true,
-    )
-
-    create_provider_user({
-      dfe_sign_in_uid: 'dev-1JB-admin-2',
-      email_address: '1JB-admin-2@example.com',
-      first_name: '1JB',
-      last_name: 'Admin 2',
-    }, %w[1JB], {
-      manage_organisations: true,
-      view_safeguarding_information: true,
-    })
 
     create_provider_user({
       dfe_sign_in_uid: 'dev-1JA-admin',
@@ -100,7 +72,7 @@ class CreateExampleProviderUsersWithPermissions
     })
 
     ProviderRelationshipPermissions.find_or_create_by(
-      training_provider: Provider.find_by_code('1JB'),
+      training_provider: Provider.find_by_code('1JA'),
       ratifying_provider: Provider.find_by_code('D39'),
     ).update(
       training_provider_can_make_decisions: true,
@@ -116,16 +88,6 @@ class CreateExampleProviderUsersWithPermissions
       accept_agreement: true,
     )
 
-    # cannot_view__no_org_level_perm__without_manage_orgs__without_setup__training_provider
-    create_provider_user({
-      dfe_sign_in_uid: 'dev-1JB-user',
-      email_address: '1JB-user@example.com',
-      first_name: '1JB',
-      last_name: 'User',
-    }, %w[1JB], {
-      view_safeguarding_information: true,
-    })
-
     # can_view__with_org_level_perm__with_user_level__ratifying_provider
     user_s72 = create_provider_user({
       dfe_sign_in_uid: 'dev-S72',
@@ -137,7 +99,7 @@ class CreateExampleProviderUsersWithPermissions
     })
 
     ProviderRelationshipPermissions.find_or_create_by(
-      training_provider: Provider.find_by_code('1JB'),
+      training_provider: Provider.find_by_code('1JA'),
       ratifying_provider: Provider.find_by_code('S72'),
     ).update(
       ratifying_provider_can_make_decisions: true,

--- a/app/lib/create_persona_users.rb
+++ b/app/lib/create_persona_users.rb
@@ -41,7 +41,7 @@ class CreatePersonaUsers
   end
 
   def self.create_personas_with_multiple_providers
-    providers = Provider.where(code: %w[1JA 1JB 24J]).all
+    providers = Provider.where(code: %w[1JA 24J]).all
 
     create_provider_user(
       providers,

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -1,5 +1,5 @@
 desc 'Set up your local development environment with data from the Teacher training public API'
-task setup_local_dev_data: %i[environment copy_feature_flags_from_production sync_dev_providers_and_open_courses update_vendors] do
+task setup_local_dev_data: %i[environment copy_feature_flags_from_production sync_dev_providers_and_open_courses] do
   puts 'Creating a support & provider user with DfE Sign-in UID `dev-support` and email `support@example.com`...'
   SupportUser.create!(
     dfe_sign_in_uid: 'dev-support',
@@ -26,7 +26,7 @@ desc 'Sync some pilot-enabled providers and open all their courses'
 task sync_dev_providers_and_open_courses: :environment do
   puts 'Syncing data from TTAPI...'
 
-  provider_codes = %w[1JA 24J 24P D39 S72 1JB 4T7 1N1 Y50 L34 D86 K60 H72]
+  provider_codes = %w[1JA 24J 24P D39 S72 4T7 1N1 Y50 L34 D86 K60 H72 W53]
   provider_codes.each do |code|
     provider_from_api = TeacherTrainingPublicAPI::Provider
         .where(year: RecruitmentCycle.current_year)


### PR DESCRIPTION
## Context

`rake setup_local_dev_data` has been failing for a while. There seem to be a few different issues:

- Provider `1JB` is no longer returned by the TTAPI.
- Provider `W53` is a dependency but wasn't being listed.
- The `update_vendors` task now requires an argument so fails when
  called from `setup_local_dev_data`.

## Changes proposed in this pull request

- [x] I've done a quick and dirty fix here to get the script working again but we may need to revisit. I'm not sure what coverage we are missing now that `1JB` has just been removed.
- [x] I've dropped `update_vendors` just to get it running. We may need to reinstate this.

## Guidance to review

- Do we need a new provider to replace `City Learning Trust (1JB)`?
- Does it make sense to include `W53`?

## Link to Trello card

https://trello.com/c/ZI92JqRw/4130-fix-test-data-generation-rake-task

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
