### PR TITLE
Retain checkbox selections on references selection form

### DIFF
--- a/app/controllers/candidate_interface/references/selection_controller.rb
+++ b/app/controllers/candidate_interface/references/selection_controller.rb
@@ -6,7 +6,7 @@ module CandidateInterface
       def new
         @selection_form = CandidateInterface::Reference::SelectionForm.new(
           application_form: current_application,
-          selected: current_application.application_references.selected.pluck(:id),
+          selected: current_application.application_references.selected.pluck(:id).map(&:to_s),
         )
         @return_to = return_to_after_edit(default: candidate_interface_review_selected_references_path)
 
@@ -25,7 +25,6 @@ module CandidateInterface
           render :new and return
         else
           track_validation_error(@selection_form)
-          @selection_form.selected = current_application.application_references.selected.pluck(:id)
           render :new
         end
       end
@@ -37,7 +36,9 @@ module CandidateInterface
 
       def complete
         @references_selected = current_application.application_references.includes(:application_form).selected
-        @section_complete_form = SectionCompleteForm.new(completed: section_complete_params[:completed])
+        @section_complete_form = SectionCompleteForm.new(
+          completed: section_complete_params[:completed],
+        )
 
         if !@section_complete_form.valid?
           track_validation_error(@section_complete_form)

--- a/app/views/candidate_interface/references/selection/new.html.erb
+++ b/app/views/candidate_interface/references/selection/new.html.erb
@@ -12,7 +12,7 @@
           <% @selection_form.available_references.each do |reference| %>
             <%= f.govuk_check_box(
               :selected,
-              reference.id,
+              reference.id.to_s,
               label: { text: reference.name, size: 's' },
               hint: { text: "#{reference.referee_type.capitalize.dasherize} reference" },
             ) %>

--- a/spec/system/candidate_interface/references/candidate_selects_two_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_selects_two_references_spec.rb
@@ -24,9 +24,15 @@ RSpec.feature 'Candidate selects two references of many feedback_provided refere
     when_i_click_save_and_continue
     then_i_am_told_i_need_to_select_two_references
 
+    when_i_select_1_reference
+    and_i_click_save_and_continue
+    then_i_am_told_i_need_to_select_two_references
+    and_i_see_1_reference_selected
+
     when_i_select_3_references
     and_i_click_save_and_continue
     then_i_am_told_i_need_to_select_two_references
+    and_i_see_3_references_selected
 
     when_i_select_2_references
     and_i_click_save_and_continue
@@ -106,6 +112,40 @@ RSpec.feature 'Candidate selects two references of many feedback_provided refere
     expect_validation_error 'Select 2 references'
   end
 
+  def first_reference_checkbox
+    page.find("#candidate-interface-reference-selection-form-selected-#{@first_reference.id}-field")
+  end
+
+  def second_reference_checkbox
+    page.find("#candidate-interface-reference-selection-form-selected-#{@second_reference.id}-field")
+  end
+
+  def third_reference_checkbox
+    page.find("#candidate-interface-reference-selection-form-selected-#{@third_reference.id}-field")
+  end
+
+  def fourth_reference_checkbox
+    page.find("#candidate-interface-reference-selection-form-selected-#{@fourth_reference.id}-field")
+  end
+
+  def and_i_see_1_reference_selected
+    expect(first_reference_checkbox).to be_checked
+    expect(second_reference_checkbox).not_to be_checked
+    expect(third_reference_checkbox).not_to be_checked
+    expect(fourth_reference_checkbox).not_to be_checked
+  end
+
+  def and_i_see_3_references_selected
+    expect(first_reference_checkbox).to be_checked
+    expect(second_reference_checkbox).to be_checked
+    expect(third_reference_checkbox).to be_checked
+    expect(fourth_reference_checkbox).not_to be_checked
+  end
+
+  def when_i_select_1_reference
+    check @first_reference.name
+  end
+
   def when_i_select_3_references
     check @first_reference.name
     check @second_reference.name
@@ -115,6 +155,8 @@ RSpec.feature 'Candidate selects two references of many feedback_provided refere
   def when_i_select_2_references
     check @first_reference.name
     check @second_reference.name
+    uncheck @third_reference.name
+    uncheck @fourth_reference.name
   end
 
   def then_those_references_are_selected


### PR DESCRIPTION
## Context

When validation errors occur on the select references page any checked boxes values are not retained.

## Changes proposed in this pull request

- These were being deliberately reset it seems (when input is invalid) and were also failing to map correctly due to a type mismatch. I think I've fixed those issues and updated the relevant system spec to assert that values are retained.

## Guidance to review

- To me it seems right to retain these values rather than reset them in the event of a validation error. Does this make sense?

## Link to Trello card

https://trello.com/c/GUC9l5yg/3883-checkbox-values-are-not-retained-when-validations-occur-on-the-selected-references-page-check-if-its-still-occuring

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
