### PR TITLE
Update nomenclature on duplicate candidate match slack alert

### DIFF
--- a/app/services/update_fraud_matches.rb
+++ b/app/services/update_fraud_matches.rb
@@ -22,7 +22,7 @@ class UpdateFraudMatches
 
     message = <<~MSG
       \n#{Rails.application.routes.url_helpers.support_interface_fraud_auditing_matches_url}
-      :face_with_monocle: There #{new_match_count == 1 ? 'is' : 'are'} #{new_match_count} new fraud #{'match'.pluralize(new_match_count)} today :face_with_monocle:
+      :face_with_monocle: There #{new_match_count == 1 ? 'is' : 'are'} #{new_match_count} new duplicate candidate #{'match'.pluralize(new_match_count)} today :face_with_monocle:
       :gavel: #{fraudulent_match_count} #{'match'.pluralize(fraudulent_match_count)} #{fraudulent_match_count == 1 ? 'has' : 'have'} been marked as fraudulent :gavel:
       :female-detective: In total there #{total_match_count == 1 ? 'is' : 'are'} #{total_match_count} #{'match'.pluralize(total_match_count)} :male-detective:
     MSG

--- a/spec/services/update_fraud_matches_spec.rb
+++ b/spec/services/update_fraud_matches_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe UpdateFraudMatches do
   let(:expected_message) do
     <<~MSG
       \n#{Rails.application.routes.url_helpers.support_interface_fraud_auditing_matches_url}
-      :face_with_monocle: There is 1 new fraud match today :face_with_monocle:
+      :face_with_monocle: There is 1 new duplicate candidate match today :face_with_monocle:
       :gavel: 1 match has been marked as fraudulent :gavel:
       :female-detective: In total there are 2 matches :male-detective:
     MSG

--- a/spec/system/support_interface/duplicate_candidate_matches_removing_duplicate_application_spec.rb
+++ b/spec/system/support_interface/duplicate_candidate_matches_removing_duplicate_application_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'See Duplicate candidate matches' do
     given_i_am_a_support_user
     and_there_are_candidates_with_duplicate_applications_in_the_system
 
-    when_i_go_to_fraud_auditing_dashboard_page
+    when_i_go_to_duplicate_candidate_matches_page
     and_i_click_to_remove_access_from_the_second_candidate
     then_i_see_the_confirm_remove_access_page
 
@@ -17,7 +17,7 @@ RSpec.feature 'See Duplicate candidate matches' do
 
     when_i_check_confirm_that_i_have_read_the_guidance
     and_i_click_continue
-    then_i_see_the_fraud_auditing_dashboard
+    then_i_see_the_duplicate_candidate_matches
     and_that_candidate_two_has_had_their_email_updated_to_the_correct_value
   end
 
@@ -35,7 +35,7 @@ RSpec.feature 'See Duplicate candidate matches' do
     @fraud_match = create(:fraud_match, candidates: [@candidate_one, @candidate_two])
   end
 
-  def when_i_go_to_fraud_auditing_dashboard_page
+  def when_i_go_to_duplicate_candidate_matches_page
     visit support_interface_fraud_auditing_matches_path
   end
 
@@ -60,7 +60,7 @@ RSpec.feature 'See Duplicate candidate matches' do
     check 'I have read the guidance'
   end
 
-  def then_i_see_the_fraud_auditing_dashboard
+  def then_i_see_the_duplicate_candidate_matches
     expect(page).to have_current_path support_interface_fraud_auditing_matches_path
   end
 

--- a/spec/system/support_interface/duplicate_candidate_matches_spec.rb
+++ b/spec/system/support_interface/duplicate_candidate_matches_spec.rb
@@ -13,12 +13,12 @@ RSpec.feature 'See Duplicate candidate matches' do
   scenario 'Support agent visits Duplicate candidate matches page', sidekiq: true do
     given_i_am_a_support_user
     and_the_feature_flag_is_active
-    and_i_go_to_fraud_auditing_dashboard_page
+    and_i_go_to_duplicate_candidate_matches_page
     then_i_should_see_a_message_declaring_that_there_are_no_matches
 
     when_there_are_candidates_with_duplicate_applications_in_the_system
     and_the_update_fraud_matches_worker_has_run
-    and_i_go_to_fraud_auditing_dashboard_page
+    and_i_go_to_duplicate_candidate_matches_page
     then_i_should_see_list_of_fraud_auditing_matches
 
     when_i_mark_a_match_as_fraudulent
@@ -74,7 +74,7 @@ RSpec.feature 'See Duplicate candidate matches' do
     UpdateFraudMatchesWorker.perform_async
   end
 
-  def and_i_go_to_fraud_auditing_dashboard_page
+  def and_i_go_to_duplicate_candidate_matches_page
     visit support_interface_fraud_auditing_matches_path
   end
 


### PR DESCRIPTION
## Context

Copy on slack alert needs to be updated to not make reference to fraud matches

## Changes proposed in this pull request

Change to copy.

## Guidance to review

:shipit: 

## Link to Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
