### PR TITLE
Offers back link error when referer path is set

### DIFF
--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -31,7 +31,9 @@ module ProviderInterface
       end
     end
 
-    def edit; end
+    def edit
+      redirect_to provider_interface_application_choice_offer_path(@application_choice)
+    end
 
     def show
       @wizard = OfferWizard.build_from_application_choice(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -708,8 +708,8 @@ Rails.application.routes.draw do
 
       resource :decision, only: %i[new create], as: :application_choice_decision
 
-      resource :offers, only: %i[new create show update], as: :application_choice_offer
-      resource :offers, only: %i[new], as: :application_choice_offer_referer
+      resource :offers, only: %i[new edit create show update], as: :application_choice_offer
+      resource :offers, only: %i[new edit], as: :application_choice_offer_referer
 
       namespace :offer, as: :application_choice_offer do
         resource :providers, only: %i[new create edit update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -709,6 +709,7 @@ Rails.application.routes.draw do
       resource :decision, only: %i[new create], as: :application_choice_decision
 
       resource :offers, only: %i[new create show update], as: :application_choice_offer
+      resource :offers, only: %i[new], as: :application_choice_offer_referer
 
       namespace :offer, as: :application_choice_offer do
         resource :providers, only: %i[new create edit update]

--- a/spec/requests/provider_interface/offers_controller_spec.rb
+++ b/spec/requests/provider_interface/offers_controller_spec.rb
@@ -74,6 +74,32 @@ RSpec.describe ProviderInterface::OffersController, type: :request do
     end
   end
 
+  describe 'if application choice is in the offer state' do
+    let!(:application_choice) do
+      create(:application_choice, :offer,
+             application_form: application_form,
+             course_option: course_option)
+    end
+
+    context 'GET edit' do
+      it 'responds with 302 end redirects to the offer page' do
+        get edit_provider_interface_application_choice_offer_path(application_choice)
+
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(provider_interface_application_choice_offer_url(application_choice))
+      end
+
+      context 'aliased referer path' do
+        it 'responds with 302 and redirects to the application page' do
+          get edit_provider_interface_application_choice_offer_referer_path(application_choice)
+
+          expect(response.status).to eq(302)
+          expect(response.redirect_url).to eq(provider_interface_application_choice_offer_url(application_choice))
+        end
+      end
+    end
+  end
+
   describe 'if application choice is not in an offered state' do
     let!(:application_choice) do
       create(:application_choice, :awaiting_provider_decision,

--- a/spec/requests/provider_interface/offers_controller_spec.rb
+++ b/spec/requests/provider_interface/offers_controller_spec.rb
@@ -48,10 +48,20 @@ RSpec.describe ProviderInterface::OffersController, type: :request do
     end
 
     context 'GET new' do
-      it 'responds with 302' do
+      it 'responds with 302 and redirects to the application page' do
         get new_provider_interface_application_choice_offer_path(application_choice)
 
         expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(provider_interface_application_choice_url(application_choice))
+      end
+
+      context 'aliased referer path' do
+        it 'responds with 302 and redirects to the application page' do
+          get new_provider_interface_application_choice_offer_referer_path(application_choice)
+
+          expect(response.status).to eq(302)
+          expect(response.redirect_url).to eq(provider_interface_application_choice_url(application_choice))
+        end
       end
     end
 


### PR DESCRIPTION
## Context
Resolve issue with generated `referer` path caused by Offer flow having dedicated entry points.

## Changes proposed in this pull request

Alias referer path for new and edit offer to redirect to beginning of new and edit offer flows.

## Link to Trello card

https://trello.com/c/bb8ecKNv/4504-offers-back-link-error-when-refere-path-is-set

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
