### PR TITLE
Remove feature flags from the db when they are removed from the application

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@
 
 ## Things to check
 
+- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
 - [ ] This code does not rely on migrations in the same Pull Request
 - [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
 - [ ] API release notes have been updated if necessary

--- a/app/services/data_migrations/remove_obsolete_feature_flags.rb
+++ b/app/services/data_migrations/remove_obsolete_feature_flags.rb
@@ -1,0 +1,16 @@
+module DataMigrations
+  class RemoveObsoleteFeatureFlags
+    TIMESTAMP = 20211109203505
+    MANUAL_RUN = false
+
+    def change
+      Feature.where.not(name: feature_names).map(&:destroy)
+    end
+
+  private
+
+    def feature_names
+      FeatureFlag::FEATURES.map(&:first)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -31,6 +31,7 @@ DATA_MIGRATION_SERVICES = [
   'DataMigrations::TrimQualificationDegreeTypes',
   'DataMigrations::BackfillExportType',
   'DataMigrations::FixLatLongFlipFlops',
+  'DataMigrations::RemoveObsoleteFeatureFlags',
 ].freeze
 
 def data_migrations

--- a/spec/factories/feature.rb
+++ b/spec/factories/feature.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :feature do
-    name { 'feature_x' }
+    name { Faker::Lorem.unique.words(number: 3).join('_') }
   end
 end

--- a/spec/services/data_migrations/remove_obsolete_feature_flags_spec.rb
+++ b/spec/services/data_migrations/remove_obsolete_feature_flags_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveObsoleteFeatureFlags do
+  let(:obsolete_feature_count) { 10 }
+  let!(:obsolete_features) { create_list(:feature, obsolete_feature_count) }
+  let!(:features) { FeatureFlag::FEATURES.map { |feature| create(:feature, name: feature.first) } }
+
+  it 'deletes any obsolete features from the database' do
+    expect(Feature.count).to eq(features.length + obsolete_feature_count)
+
+    described_class.new.change
+
+    expect(Feature.count).to eq(features.length)
+  end
+end

--- a/spec/services/data_migrations/remove_obsolete_feature_flags_spec.rb
+++ b/spec/services/data_migrations/remove_obsolete_feature_flags_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe DataMigrations::RemoveObsoleteFeatureFlags do
   let(:obsolete_feature_count) { 10 }
   let!(:obsolete_features) { create_list(:feature, obsolete_feature_count) }
-  let!(:features) { FeatureFlag::FEATURES.map { |feature| create(:feature, name: feature.first) } }
+  let!(:features) { FeatureFlag::FEATURES.map { |feature| Feature.find_or_create_by(name: feature.first) } }
 
   it 'deletes any obsolete features from the database' do
     expect(Feature.count).to eq(features.length + obsolete_feature_count)

--- a/spec/workers/detect_invariants_daily_check_spec.rb
+++ b/spec/workers/detect_invariants_daily_check_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe DetectInvariantsDailyCheck do
 
     it 'detects obsolete feature flags' do
       obsolete_features = create_list(:feature, 5)
-      FeatureFlag::FEATURES.map { |feature| create(:feature, name: feature.first) }
+      FeatureFlag::FEATURES.map { |feature| Feature.find_or_create_by(name: feature.first) }
 
       described_class.new.perform
 

--- a/spec/workers/detect_invariants_daily_check_spec.rb
+++ b/spec/workers/detect_invariants_daily_check_spec.rb
@@ -155,5 +155,18 @@ RSpec.describe DetectInvariantsDailyCheck do
         ),
       )
     end
+
+    it 'detects obsolete feature flags' do
+      obsolete_features = create_list(:feature, 5)
+      FeatureFlag::FEATURES.map { |feature| create(:feature, name: feature.first) }
+
+      described_class.new.perform
+
+      message = 'The following obsolete feature flags have yet to be deleted from the database: '  \
+                "#{obsolete_features.map(&:name).to_sentence}"
+
+      expect(Sentry).to have_received(:capture_exception)
+                    .with(described_class::ObsoleteFeatureFlags.new(message))
+    end
   end
 end


### PR DESCRIPTION
## Context
Ensure any obsolete feature flags are also removed from the database, include invariant daily check to ensure no deature flags are left behind in the future and update PR docs to include note to developers.

## Link to Trello card

https://trello.com/c/WDB1Km8S/4427-remove-feature-flags-from-the-db-when-they-are-removed-from-the-application

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
