### PR TITLE
TAD Export 2 ApplicationsByDemographicDomicileAndDegreeClassExport

### DIFF
--- a/app/controllers/data_api/tad_data_exports_controller.rb
+++ b/app/controllers/data_api/tad_data_exports_controller.rb
@@ -71,6 +71,16 @@ module DataAPI
       serve_export(data_export)
     end
 
+    def applications_by_demographic_domicile_and_degree_class
+      all = DataExport
+        .where(export_type: :applications_by_demographic_domicile_and_degree_class)
+        .where.not(completed_at: nil)
+
+      data_export = all.last
+
+      serve_export(data_export)
+    end
+
   private
 
     def serve_export(export)

--- a/app/exports/applications_by_demographic_domicile_and_degree_class_export.yml
+++ b/app/exports/applications_by_demographic_domicile_and_degree_class_export.yml
@@ -1,0 +1,51 @@
+common_columns:
+  age_group:
+    type: string
+    description: The applicant age group
+    example: Under 25
+
+  sex:
+    type: string
+    description: The applicant sex
+    example: Female
+
+  ethnicity:
+    type: string
+    description: The applicant ethnicity
+    example: Mixed - White and Asian
+
+  disability:
+    type: string
+    description: The applicant disability status
+    example: Multiple disabilities
+
+custom_columns:
+  degree_class:
+    type: string
+    description: The applicant degree grade
+    example: Pass
+
+  domicile:
+    type: string
+    description: The applicant domicile
+    example: UK
+
+  adjusted_applications:
+    type: integer
+    description: The number of applications that have received offers for this subject
+
+  adjusted_offers:
+    type: integer
+    description: The number of applications that have accepted offers for this subject
+
+  pending_conditions:
+    type: integer
+    description: The number of applications that have declined offers for this subject
+
+  recruited:
+    type: integer
+    description: The number of applications that have been rejected for this subject
+
+  total:
+    type: integer
+    description: The total number of applications

--- a/app/exports/applications_by_demographic_domicile_and_degree_class_export.yml
+++ b/app/exports/applications_by_demographic_domicile_and_degree_class_export.yml
@@ -1,25 +1,15 @@
 common_columns:
+- sex
+- ethnicity
+- disability
+- total
+
+custom_columns:
   age_group:
     type: string
     description: The applicant age group
     example: Under 25
 
-  sex:
-    type: string
-    description: The applicant sex
-    example: Female
-
-  ethnicity:
-    type: string
-    description: The applicant ethnicity
-    example: Mixed - White and Asian
-
-  disability:
-    type: string
-    description: The applicant disability status
-    example: Multiple disabilities
-
-custom_columns:
   degree_class:
     type: string
     description: The applicant degree grade
@@ -45,7 +35,3 @@ custom_columns:
   recruited:
     type: integer
     description: The number of applications that have been rejected for this subject
-
-  total:
-    type: integer
-    description: The total number of applications

--- a/app/exports/applications_by_demographic_domicile_and_degree_class_export.yml
+++ b/app/exports/applications_by_demographic_domicile_and_degree_class_export.yml
@@ -5,7 +5,7 @@ common_columns:
 - total
 
 custom_columns:
-  age_group:
+  custom_age_group:
     type: string
     description: The applicant age group
     example: Under 25

--- a/app/lib/data_api_specification.rb
+++ b/app/lib/data_api_specification.rb
@@ -15,12 +15,14 @@ class DataAPISpecification
     applications_dataset = DataSetDocumentation.for(SupportInterface::MinisterialReportApplicationsExport)
     candidates_dataset = DataSetDocumentation.for(SupportInterface::MinisterialReportCandidatesExport)
     applications_by_subject_route_grade_dataset = DataSetDocumentation.for(SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport)
+    applications_by_demographic_domicile_and_degree_class_dataset = DataSetDocumentation.for(SupportInterface::ApplicationsByDemographicDomicileAndDegreeClassExport)
 
     openapi['components']['schemas']['TADExport']['properties'] = tad_dataset
     openapi['components']['schemas']['TADSubjectDomicileNationalityExport']['properties'] = tad_subject_domicile_nationality_dataset
     openapi['components']['schemas']['ApplicationsExport']['properties'] = applications_dataset
     openapi['components']['schemas']['CandidatesExport']['properties'] = candidates_dataset
     openapi['components']['schemas']['ApplicationsBySubjectRouteAndDegreeGradeExport']['properties'] = applications_by_subject_route_grade_dataset
+    openapi['components']['schemas']['ApplicationsByDemographicDomicileAndDegreeClassExport']['properties'] = applications_by_demographic_domicile_and_degree_class_dataset
 
     openapi
   end

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -278,6 +278,12 @@ class DataExport < ApplicationRecord
       description: 'Report of subjects, candidate nationality, domicile and application status for TAD.',
       class: DataAPI::TADSubjectDomicileNationalityExport,
     },
+    applications_by_demographic_domicile_and_degree_class: {
+      name: 'TAD applications by demographic, domicile and degree class',
+      export_type: 'applications_by_demographic_domicile_and_degree_class',
+      description: 'A list of all application/offered/accepted counts broken down by age group, sex, ethnicity and degree in Apply belonging to the current recruitment cycle.',
+      class: SupportInterface::ApplicationsByDemographicDomicileAndDegreeClassExport,
+    },
     user_permissions: {
       name: 'User permissions changes',
       export_type: 'user_permissions',
@@ -335,6 +341,7 @@ class DataExport < ApplicationRecord
   enum export_type: {
     active_provider_user_permissions: 'active_provider_user_permissions',
     active_provider_users: 'active_provider_users',
+    applications_by_demographic_domicile_and_degree_class: 'applications_by_demographic_domicile_and_degree_class',
     applications_by_subject_route_and_degree_grade: 'applications_by_subject_route_and_degree_grade',
     application_references: 'application_references',
     application_timings: 'application_timings',

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -54,6 +54,7 @@ class Clock
     DataAPI::TADSubjectDomicileNationalityExport.run_weekly
   end
   every(7.days, 'ApplicationsBySubjectRouteAndDegreeGradeExport', at: 'Sunday 23:59') { SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport.run_weekly }
+  every(7.days, 'ApplicationsByDemographicDomicileAndDegreeClassExport', at: 'Sunday 23:59') { SupportInterface::ApplicationsByDemographicDomicileAndDegreeClassExport.run_weekly }
 
   every(1.day, 'VendorIntegrationStatsWorker', at: '09:00', if: ->(t) { t.weekday? }) do
     VendorIntegrationStatsWorker.perform_async('tribal')

--- a/config/data-api.yml
+++ b/config/data-api.yml
@@ -97,6 +97,17 @@ paths:
             text/csv:
               schema:
                 "$ref": "#/components/schemas/ApplicationsBySubjectRouteAndDegreeGradeExport"
+  "/applications-by-demographic-domicile-and-degree-class/latest":
+    get:
+      summary: Get the tad applications by demographic, domicile and degree class
+      description: This endpoint returns a CSV consisting of the latest TAD applications by demographic, domicile and degree class. Reports are generated daily
+      responses:
+        '200':
+          description: The CSV of the latest report
+          content:
+            text/csv:
+              schema:
+                "$ref": "#/components/schemas/ApplicationsByDemographicDomicileAndDegreeClassExport"
 components:
   schemas:
     TADExport:
@@ -112,6 +123,9 @@ components:
       type: object
       properties: # this is automatically populated from the CSV definition by DataAPISpecification
     ApplicationsBySubjectRouteAndDegreeGradeExport:
+      type: object
+      properties: # this is automatically populated from the CSV definition by DataAPISpecification
+    ApplicationsByDemographicDomicileAndDegreeClassExport:
       type: object
       properties: # this is automatically populated from the CSV definition by DataAPISpecification
     TADDataExportList:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -834,6 +834,7 @@ Rails.application.routes.draw do
     get '/tad-data-exports/latest' => 'tad_data_exports#latest'
     get '/applications-by-subject-route-and-degree-grade/latest' => 'tad_data_exports#applications_by_subject_route_and_degree_grade'
     get '/applications-by-subject-domicile-and-nationality/latest' => 'tad_data_exports#subject_domicile_nationality_latest'
+    get '/applications-by-demographic-domicile-and-degree-class/latest' => 'tad_data_exports#applications_by_demographic_domicile_and_degree_class'
     get '/ministerial-report/candidates/latest' => 'tad_data_exports#candidates'
     get '/ministerial-report/applications/latest' => 'tad_data_exports#applications'
     get '/tad-data-exports' => 'tad_data_exports#index'

--- a/spec/requests/data_api/applications_by_demographic_domicile_and_degree_class_export_spec.rb
+++ b/spec/requests/data_api/applications_by_demographic_domicile_and_degree_class_export_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /data-api/tad-data-exports/applications-by-demographic-domicile-and-degree-grade/latest', type: :request, sidekiq: true do
+  include DataAPISpecHelper
+
+  it_behaves_like 'a TAD API endpoint', '/latest'
+
+  it 'returns the latest tad age and hesa export' do
+    first_application_form = create(:completed_application_form, :with_equality_and_diversity_data)
+    create(:application_qualification, level: 'degree', grade: 'Upper second-class honours (2:1)', application_form: first_application_form)
+    create(:application_choice, :with_declined_offer, application_form: first_application_form)
+
+    data_export = DataExport.create!(
+      name: 'Weekly export of the TAD applications by demographic, domicile and degree class',
+      export_type: :applications_by_demographic_domicile_and_degree_class,
+    )
+
+    DataExporter.perform_async(SupportInterface::ApplicationsByDemographicDomicileAndDegreeClassExport, data_export.id)
+
+    get_api_request '/data-api/applications-by-demographic-domicile-and-degree-class/latest', token: tad_api_token
+
+    expect(response).to have_http_status(:success)
+    expect(response.body).to start_with('age_group,sex,ethnicity,disability,degree_class,domicile,adjusted_applications,adjusted_offers,pending_conditions,recruited,total')
+  end
+end

--- a/spec/services/support_interface/applications_by_demographic_domicile_and_degree_class_export_spec.rb
+++ b/spec/services/support_interface/applications_by_demographic_domicile_and_degree_class_export_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationsByDemographicDomicileAndDegreeClassExport do
+  describe '#call' do
+    before do
+      create(:completed_application_form,
+             date_of_birth: '1999-09-05',
+             country: 'GB',
+             equality_and_diversity: {
+               'sex' => 'male',
+               'hesa_sex' => '1',
+               'disabilities' => ['Learning difficulty', 'Social or communication impairment', 'Blind'],
+               'ethnic_group' => 'Another ethnic group',
+               'hesa_ethnicity' => '50',
+               'ethnic_background' => 'Arab',
+               'hesa_disabilities' => %w[51 53 58],
+             },
+             application_choices: [
+               create(:application_choice, status: :pending_conditions),
+             ],
+             application_qualifications: [
+               create(:application_qualification, level: 'degree', grade: 'Lower second-class honours (2:2)'),
+             ])
+    end
+
+    it 'returns counts for a single application' do
+      result = described_class.new.data_for_export
+
+      expect(result).to match_array([
+        {
+          age_group: 'Under 25',
+          sex: 'Male',
+          ethnicity: '50',
+          disability: 'Two or more impairments and/or disabling medical conditions',
+          degree_class: 'Lower second-class honours (2:2)',
+          domicile: 'UK',
+          adjusted_applications: 0,
+          adjusted_offers: 0,
+          pending_conditions: 1,
+          recruited: 0,
+          total: 1,
+        },
+      ])
+    end
+
+    it 'returns combined and distinct counts for a multiple applications' do
+      create(:completed_application_form,
+             date_of_birth: '1986-09-05',
+             country: 'DE',
+             equality_and_diversity: {
+               'sex' => 'female',
+               'hesa_sex' => '2',
+               'disabilities' => ['Blind'],
+               'ethnic_group' => 'Another ethnic group',
+               'hesa_ethnicity' => '90',
+               'ethnic_background' => 'Not known',
+               'hesa_disabilities' => ['58'],
+             },
+             application_choices: [
+               create(:application_choice, status: :rejected),
+             ],
+             application_qualifications: [
+               create(:application_qualification, level: 'degree', grade: 'Upper second-class honours (2:1)'),
+             ])
+      create(:completed_application_form,
+             date_of_birth: '1986-09-20',
+             country: 'DE',
+             equality_and_diversity: {
+               'sex' => 'female',
+               'hesa_sex' => '2',
+               'disabilities' => ['Blind'],
+               'ethnic_group' => 'Another ethnic group',
+               'hesa_ethnicity' => '90',
+               'ethnic_background' => 'Not known',
+               'hesa_disabilities' => ['58'],
+             },
+             application_choices: [
+               create(:application_choice, status: :recruited),
+             ],
+             application_qualifications: [
+               create(:application_qualification, level: 'degree', grade: 'Upper second-class honours (2:1)'),
+             ])
+      result = described_class.new.data_for_export
+
+      expect(result).to match_array([
+        {
+          age_group: 'Under 25',
+          sex: 'Male',
+          ethnicity: '50',
+          disability: 'Two or more impairments and/or disabling medical conditions',
+          degree_class: 'Lower second-class honours (2:2)',
+          domicile: 'UK',
+          adjusted_applications: 0,
+          adjusted_offers: 0,
+          pending_conditions: 1,
+          recruited: 0,
+          total: 1,
+        },
+        {
+          age_group: '35 to 39',
+          sex: 'Female',
+          ethnicity: '90',
+          disability: '58',
+          degree_class: 'Upper second-class honours (2:1)',
+          domicile: 'EU',
+          adjusted_applications: 1,
+          adjusted_offers: 0,
+          pending_conditions: 0,
+          recruited: 1,
+          total: 2,
+        },
+      ])
+    end
+  end
+end

--- a/spec/services/support_interface/applications_by_demographic_domicile_and_degree_class_export_spec.rb
+++ b/spec/services/support_interface/applications_by_demographic_domicile_and_degree_class_export_spec.rb
@@ -19,11 +19,12 @@ RSpec.describe SupportInterface::ApplicationsByDemographicDomicileAndDegreeClass
                create(:application_choice, status: :pending_conditions),
              ],
              application_qualifications: [
+               create(:application_qualification, level: 'degree', grade: 'Pass'),
                create(:application_qualification, level: 'degree', grade: 'Lower second-class honours (2:2)'),
              ])
     end
 
-    it 'returns counts for a single application' do
+    it 'returns counts for a single application with highest degree grade' do
       result = described_class.new.data_for_export
 
       expect(result).to match_array([


### PR DESCRIPTION
## Context
This one of the data exports requested by TAD, should contain break down of application choices by age group, sex, ethnicity, disability, domicile, degree class.

## Changes proposed in this pull request

This PR adds the export to the Support interface and exposes it on the data API

## Guidance to review

Let me know if this looks okay

## Link to Trello card

https://trello.com/c/BbRYwaRr/4085-tad-export-2-age-ed-domicile-degree-class-and-hesa-data-by-outcome

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
