### PR TITLE
Adjust widths of At a Glance and Details table components

### DIFF
--- a/app/components/support_interface/sub_reasons_for_rejection_table_component.html.erb
+++ b/app/components/support_interface/sub_reasons_for_rejection_table_component.html.erb
@@ -1,46 +1,50 @@
-<table class="govuk-table govuk-!-margin-top-2">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header" width="30%">Reason</th>
-      <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="17.5%">Percentage of all rejections</th>
-      <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="17.5%">Percentage of all rejections within this category</th>
-      <% if recruitment_cycle_year == RecruitmentCycle.current_year %>
-        <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="17.5%">Percentage of all rejections in <%= month_name %></th>
-        <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="17.5%">Percentage of all rejections in <%= month_name %> within this category</th>
-      <% end %>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% sub_reasons.each do |sub_reason, sub_reason_result| %>
-      <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header">
-          <%= govuk_link_to(
-            sub_reason_label(sub_reason),
-            support_interface_reasons_for_rejection_application_choices_path(
-              "structured_rejection_reasons[#{sub_reason_key}]": sub_reason,
-              recruitment_cycle_year: recruitment_cycle_year,
-            ),
-          ) %>
-        </th>
-        <td class="govuk-table__cell govuk-table__cell--numeric">
-          <%= sub_reason_percentage(sub_reason) %><br>
-          <span class="govuk-caption-m"><%= "#{sub_reason_count(sub_reason)} of #{total_all_time}" %></span>
-        </td>
-        <td class="govuk-table__cell govuk-table__cell--numeric">
-          <%= sub_reason_percentage_of_reason(sub_reason) %><br>
-          <span class="govuk-caption-m"><%= "#{sub_reason_count(sub_reason)} of #{total_for_reason}" %>
-        </td>
-        <% if recruitment_cycle_year == RecruitmentCycle.current_year %>
-          <td class="govuk-table__cell govuk-table__cell--numeric">
-            <%= sub_reason_percentage(sub_reason, :this_month) %><br>
-            <span class="govuk-caption-m"><%= "#{sub_reason_count(sub_reason, :this_month)} of #{total_this_month}" %>
-          </td>
-          <td class="govuk-table__cell govuk-table__cell--numeric">
-            <%= sub_reason_percentage_of_reason(sub_reason, :this_month) %><br>
-            <span class="govuk-caption-m"><%= "#{sub_reason_count(sub_reason, :this_month)} of #{total_for_reason(:this_month)}" %></span>
-          </td>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-<%= RecruitmentCycle.current_year == recruitment_cycle_year ? 'full' : 'two-thirds' %>">
+    <table class="govuk-table govuk-!-margin-top-5">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header" width="30%">Reason</th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="17.5%">Percentage of all rejections</th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="17.5%">Percentage of all rejections within this category</th>
+          <% if recruitment_cycle_year == RecruitmentCycle.current_year %>
+            <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="17.5%">Percentage of all rejections in <%= month_name %></th>
+            <th scope="col" class="govuk-table__header govuk-table__header--numeric" width="17.5%">Percentage of all rejections in <%= month_name %> within this category</th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% sub_reasons.each do |sub_reason, sub_reason_result| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">
+              <%= govuk_link_to(
+                sub_reason_label(sub_reason),
+                support_interface_reasons_for_rejection_application_choices_path(
+                  "structured_rejection_reasons[#{sub_reason_key}]": sub_reason,
+                  recruitment_cycle_year: recruitment_cycle_year,
+                ),
+              ) %>
+            </th>
+            <td class="govuk-table__cell govuk-table__cell--numeric">
+              <%= sub_reason_percentage(sub_reason) %><br>
+              <span class="govuk-caption-m"><%= "#{sub_reason_count(sub_reason)} of #{total_all_time}" %></span>
+            </td>
+            <td class="govuk-table__cell govuk-table__cell--numeric">
+              <%= sub_reason_percentage_of_reason(sub_reason) %><br>
+              <span class="govuk-caption-m"><%= "#{sub_reason_count(sub_reason)} of #{total_for_reason}" %>
+            </td>
+            <% if recruitment_cycle_year == RecruitmentCycle.current_year %>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                <%= sub_reason_percentage(sub_reason, :this_month) %><br>
+                <span class="govuk-caption-m"><%= "#{sub_reason_count(sub_reason, :this_month)} of #{total_this_month}" %>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                <%= sub_reason_percentage_of_reason(sub_reason, :this_month) %><br>
+                <span class="govuk-caption-m"><%= "#{sub_reason_count(sub_reason, :this_month)} of #{total_for_reason(:this_month)}" %></span>
+              </td>
+            <% end %>
+          </tr>
         <% end %>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/support_interface/performance/reasons_for_rejection_dashboard.html.erb
+++ b/app/views/support_interface/performance/reasons_for_rejection_dashboard.html.erb
@@ -35,7 +35,7 @@
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-<%= RecruitmentCycle.current_year == @recruitment_cycle_year ? 'full-width' : 'two-thirds' %>">
+  <div class="govuk-grid-column-full">
     <%= render SupportInterface::ReasonsForRejectionDashboardComponent.new(
       @reasons_for_rejection,
       @total_structured_rejection_reasons_count,


### PR DESCRIPTION
## Context

Design tweaks from iterating the SR4R performance dashboard.

The _At A Glance_ outer container should always be full width
The section details table should vary from two-thirds to full width depending on recruitment cycle as we display fewer columns for past cycles.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Amend outer container widths to match design prototype.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
