### PR TITLE
Amend SR4R details caption and 'Understanding this report' paragraph.

### DIFF
--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.rb
@@ -13,6 +13,12 @@ module SupportInterface
       @recruitment_cycle_year = recruitment_cycle_year
     end
 
+    def self.recruitment_cycle_context(recruitment_cycle_year = RecruitmentCycle.current_year)
+      text = %(#{RecruitmentCycle.cycle_name(recruitment_cycle_year)} (starts #{recruitment_cycle_year}))
+      text += ' - current' if recruitment_cycle_year == RecruitmentCycle.current_year
+      text
+    end
+
   private
 
     def sub_reasons_for(reason)

--- a/app/components/support_interface/reasons_for_rejection_search_breadcrumb_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_breadcrumb_component.rb
@@ -2,15 +2,16 @@ module SupportInterface
   class ReasonsForRejectionSearchBreadcrumbComponent < ViewComponent::Base
     include ViewHelper
 
-    def initialize(search_attribute:, search_value:)
+    def initialize(search_attribute:, search_value:, recruitment_cycle_year: RecruitmentCycle.current_year)
       @search_attribute = search_attribute
       @search_value = search_value
+      @recruitment_cycle_year = recruitment_cycle_year
     end
 
     def breadcrumb_items
       breadcrumb_items = {
         Performance: support_interface_performance_path,
-        'Structured reasons for rejection': support_interface_reasons_for_rejection_dashboard_path,
+        'Structured reasons for rejection': support_interface_reasons_for_rejection_dashboard_path(year: @recruitment_cycle_year),
       }
       if top_level_reason?
         i18n_key = ReasonsForRejection::TOP_LEVEL_REASONS_TO_I18N_KEYS[@search_attribute].to_s
@@ -20,6 +21,7 @@ module SupportInterface
         i18n_key = ReasonsForRejection::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
         breadcrumb_items[dashboard_title(i18n_key)] = support_interface_reasons_for_rejection_application_choices_path(
           "structured_rejection_reasons[#{top_level_reason}]" => 'Yes',
+          'recruitment_cycle_year' => @recruitment_cycle_year,
         )
         breadcrumb_items[t("reasons_for_rejection.#{i18n_key}.#{@search_value}")] = nil
       end

--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -36,6 +36,7 @@ module SupportInterface
 
     def reasons_for_rejection_application_choices
       @application_choices = ReasonsForRejectionApplicationsQuery.new(params).call
+      @recruitment_cycle_year = params.fetch(:recruitment_cycle_year, RecruitmentCycle.current_year).to_i
     end
 
     def unavailable_choices

--- a/app/views/support_interface/performance/reasons_for_rejection_application_choices.html.erb
+++ b/app/views/support_interface/performance/reasons_for_rejection_application_choices.html.erb
@@ -3,7 +3,7 @@
   search_value: params[:structured_rejection_reasons].values.first,
   application_choices: @application_choices,
 ) -%>
-<% content_for :context, 'Structured reasons for rejection' %>
+<% content_for :context, SupportInterface::ReasonsForRejectionDashboardComponent.recruitment_cycle_context(@recruitment_cycle_year) %>
 <% content_for :title, search_results_component.search_title_text %>
 
 <% content_for :before_content do %>

--- a/app/views/support_interface/performance/reasons_for_rejection_application_choices.html.erb
+++ b/app/views/support_interface/performance/reasons_for_rejection_application_choices.html.erb
@@ -10,6 +10,7 @@
   <%= render SupportInterface::ReasonsForRejectionSearchBreadcrumbComponent.new(
     search_attribute: params[:structured_rejection_reasons].keys.first,
     search_value: params[:structured_rejection_reasons].values.first,
+    recruitment_cycle_year: @recruitment_cycle_year,
   ) %>
 <% end %>
 

--- a/app/views/support_interface/performance/reasons_for_rejection_dashboard.html.erb
+++ b/app/views/support_interface/performance/reasons_for_rejection_dashboard.html.erb
@@ -1,8 +1,7 @@
 <% content_for :browser_title, 'Structured reasons for rejection' %>
 <% content_for :title do %>
   <span class="govuk-caption-l">
-    <%= RecruitmentCycle.cycle_name(@recruitment_cycle_year) %> (starts <%= @recruitment_cycle_year %>)
-    <% if @recruitment_cycle_year == RecruitmentCycle.current_year %> - current<% end %>
+    <%= SupportInterface::ReasonsForRejectionDashboardComponent.recruitment_cycle_context(@recruitment_cycle_year) %>
   </span>
   Structured reasons for rejection
 <% end %>
@@ -16,21 +15,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <details class="govuk-details" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          Understanding this report
-        </span>
-      </summary>
-      <div class="govuk-details__text">
-        <p class="govuk-body">
-          The report does not include rejections made through the API.
-        </p>
-        <p class="govuk-body">
-          Since users can choose more than one reason for rejection, the percentages for all the categories will not add up to 100%.
-        </p>
-      </div>
-    </details>
+    <p class="govuk-body">
+      The report does not include rejections made through the API.
+    </p>
+    <p class="govuk-body">
+      Since users can choose more than one reason for rejection, the percentages for all the categories will not add up to 100%.
+    </p>
   </div>
 </div>
 

--- a/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
@@ -149,4 +149,18 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
       end
     end
   end
+
+  describe '.recruitment_cycle_context' do
+    it 'formats a string for the current recruitment cycle' do
+      year = RecruitmentCycle.current_year
+      expected = %(#{RecruitmentCycle.cycle_name(year)} (starts #{year}) - current)
+      expect(described_class.recruitment_cycle_context(year)).to eq(expected)
+    end
+
+    it 'formats a string for a previous recruitment cycle' do
+      year = RecruitmentCycle.previous_year
+      expected = %(#{RecruitmentCycle.cycle_name(year)} (starts #{year}))
+      expect(described_class.recruitment_cycle_context(year)).to eq(expected)
+    end
+  end
 end

--- a/spec/components/support_interface/reasons_for_rejection_search_breadcrumb_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_search_breadcrumb_component_spec.rb
@@ -1,14 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::ReasonsForRejectionSearchBreadcrumbComponent do
+  include Rails.application.routes.url_helpers
+
   def render_result(
     search_attribute = :quality_of_application_y_n,
-    search_value = 'Yes'
+    search_value = 'Yes',
+    recruitment_cycle_year = RecruitmentCycle.current_year
   )
     @rendered_result ||= render_inline(
       described_class.new(
         search_attribute: search_attribute,
         search_value: search_value,
+        recruitment_cycle_year: recruitment_cycle_year,
       ),
     )
   end
@@ -32,8 +36,40 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchBreadcrumbComponent do
       expect(@rendered_result.text).to include('No degree')
     end
 
+    it 'renders the link back to the dashboard' do
+      dashboard_path = support_interface_reasons_for_rejection_dashboard_path(year: RecruitmentCycle.current_year)
+
+      expect(@rendered_result.css("a[href='#{dashboard_path}']")).to be_present
+    end
+
     it 'renders the link back to qualifications' do
-      expect(@rendered_result.css("a[href='/support/performance/reasons-for-rejection/application-choices?structured_rejection_reasons%5Bqualifications_y_n%5D=Yes']")).to be_present
+      subreason_path = support_interface_reasons_for_rejection_application_choices_path(
+        'structured_rejection_reasons[qualifications_y_n]' => 'Yes',
+        'recruitment_cycle_year' => RecruitmentCycle.current_year,
+      )
+
+      expect(@rendered_result.css("a[href='#{subreason_path}']")).to be_present
+    end
+  end
+
+  context 'for a previous recruitment cycle' do
+    before do
+      render_result(:qualifications_which_qualifications, :no_degree, RecruitmentCycle.previous_year)
+    end
+
+    it 'renders the link back to the dashboard including the correct year param' do
+      dashboard_path = support_interface_reasons_for_rejection_dashboard_path(year: RecruitmentCycle.previous_year)
+
+      expect(@rendered_result.css("a[href='#{dashboard_path}']")).to be_present
+    end
+
+    it 'renders the link back to qualifications including the correct recruitment cycle year' do
+      subreason_path = support_interface_reasons_for_rejection_application_choices_path(
+        'structured_rejection_reasons[qualifications_y_n]' => 'Yes',
+        'recruitment_cycle_year' => RecruitmentCycle.previous_year,
+      )
+
+      expect(@rendered_result.css("a[href='#{subreason_path}']")).to be_present
     end
   end
 end

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -166,7 +166,6 @@ private
 
   def then_i_should_see_reasons_for_rejection_title_and_details
     expect(page).to have_content('2020 to 2021 (starts 2021) - current Structured reasons for rejection')
-    expect(page).to have_content('Understanding this report')
     expect(page).to have_content('The report does not include rejections made through the API.')
     expect(page).to have_content('Since users can choose more than one reason for rejection, the percentages for all the categories will not add up to 100%.')
   end
@@ -290,7 +289,7 @@ private
         recruitment_cycle_year: RecruitmentCycle.current_year,
       ),
     )
-    expect(page).to have_css('span.govuk-caption-l', text: 'Structured reasons for rejection')
+    expect(page).to have_css('span.govuk-caption-l', text: '2020 to 2021 (starts 2021) - current')
     expect(page).to have_css('h1', text: 'Candidate behaviour')
     [
       @application_choice1,
@@ -334,7 +333,7 @@ private
       ),
     )
 
-    expect(page).to have_css('span.govuk-caption-l', text: 'Structured reasons for rejection')
+    expect(page).to have_css('span.govuk-caption-l', text: '2020 to 2021 (starts 2021) - current')
     expect(page).to have_css('h1', text: 'Candidate behaviour - Didn’t attend interview')
 
     [


### PR DESCRIPTION
## Context

A couple of things were spotted in Dev/Design review to bring this dashboard up to date with design prototype
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Add a common method to format the caption text on dashboard and search results pages
- Render _Understanding this report_ paragraphs as plain paras rather than expandable details container.

#### Dashboard
![image](https://user-images.githubusercontent.com/93511/141115646-7514eab2-d0f8-42d5-aeb0-ab655382a60e.png)

#### Details page
![image](https://user-images.githubusercontent.com/93511/141115697-700538f9-2b6b-4156-8651-9c4e9a759ba1.png)


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
