### PR TITLE
Remove `courses_open_on_apply` email, spec and preview

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -124,12 +124,6 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
-  def courses_open_on_apply(provider_user)
-    @current_recruitment_cycle_year = RecruitmentCycle.current_year
-
-    notify_email(to: provider_user.email_address)
-  end
-
   def organisation_permissions_set_up(provider_user, provider, permissions)
     @provider_user = provider_user
     @recipient_organisation = provider

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -20,8 +20,6 @@ en:
       subject: "Respond to %{candidate_name}’s (%{support_reference}) application"
     application_withdrawn:
       subject: "%{candidate_name} (%{support_reference}) withdrew their application"
-    courses_open_on_apply:
-      subject: Your courses are live on Apply and you have access to Manage
     confirm_sign_in:
       subject: New sign in to Manage teacher training applications
     organisation_permissions_set_up:

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -58,12 +58,6 @@ class ProviderMailerPreview < ActionMailer::Preview
     )
   end
 
-  def courses_open_on_apply
-    ProviderMailer.courses_open_on_apply(
-      FactoryBot.build_stubbed(:provider_user),
-    )
-  end
-
   def unconditional_offer_accepted
     ProviderMailer.unconditional_offer_accepted(provider_user, application_choice)
   end

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -199,14 +199,6 @@ RSpec.describe ProviderMailer, type: :mailer do
                     'course name and code' => 'Computer Science (6IND)')
   end
 
-  describe '.courses_open_on_apply' do
-    let(:email) { described_class.courses_open_on_apply(provider_user) }
-
-    it_behaves_like('a mail with subject and content',
-                    I18n.t!('provider_mailer.courses_open_on_apply.subject'),
-                    'recruitment_cycle_year' => RecruitmentCycle.current_year)
-  end
-
   describe 'organisation_permissions_set_up' do
     let(:training_provider) { build_stubbed(:provider, name: 'University of Purley') }
     let(:ratifying_provider) { build_stubbed(:provider, name: 'University of Croydon') }

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -43,7 +43,6 @@ RSpec.feature 'Docs' do
       candidate_mailer-new_cycle_has_started
       candidate_mailer-fraud_match_email
       candidate_mailer-find_has_opened
-      provider_mailer-courses_open_on_apply
       candidate_mailer-unconditional_offer_accepted
       candidate_mailer-conditions_statuses_changed
       provider_mailer-unconditional_offer_accepted


### PR DESCRIPTION
## Context
Remove no longer used `ProviderMailer#courses_open_on_apply`

## Link to Trello card
https://trello.com/c/XfUI5U7i/4507-remove-no-longer-used-providermailercoursesopenonapply

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
