### PR TITLE
Add recruitment cycle year and submitted at to the candidates API

### DIFF
--- a/app/controllers/candidate_api/candidates_controller.rb
+++ b/app/controllers/candidate_api/candidates_controller.rb
@@ -84,17 +84,19 @@ module CandidateAPI
           id: candidate.public_id,
           type: 'candidate',
           attributes: {
-            created_at: candidate.created_at,
+            created_at: candidate.created_at.iso8601,
             updated_at: candidate.candidate_api_updated_at,
             email_address: candidate.email_address,
             application_forms:
               candidate.application_forms.order(:created_at).map do |application|
                 {
                   id: application.id,
-                  created_at: application.created_at,
-                  updated_at: application.updated_at,
+                  created_at: application.created_at.iso8601,
+                  updated_at: application.updated_at.iso8601,
                   application_status: ProcessState.new(application).state,
                   application_phase: application.phase,
+                  recruitment_cycle_year: application.recruitment_cycle_year,
+                  submitted_at: application.submitted_at.iso8601,
                 }
               end,
           },

--- a/config/candidate-api.yml
+++ b/config/candidate-api.yml
@@ -130,6 +130,8 @@ components:
         - created_at
         - application_status
         - application_phase
+        - recruitment_cycle_year
+        - submitted_at
       properties:
         id:
           type: integer
@@ -170,6 +172,16 @@ components:
             - apply_1
             - apply_2
           example: apply_1
+        recruitment_cycle_year:
+          type: integer
+          description: The recruitment cycle that the application form was created in
+          example: 2022
+        submitted_at:
+          type: string
+          nullable: true
+          format: date-time
+          description: Time of last change
+          example: 2021-05-20T12:34:00Z
     UnauthorizedResponse:
       type: object
       required:

--- a/spec/requests/candidate_api/get_candidates_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_spec.rb
@@ -98,9 +98,13 @@ RSpec.describe 'GET /candidate-api/candidates', type: :request do
     expect(response_data.first['id']).to eq(application_forms.second.id)
     expect(response_data.first['application_phase']).to eq(application_forms.second.phase)
     expect(response_data.first['application_status']).to eq(ProcessState.new(application_forms.second).state.to_s)
+    expect(response_data.first['recruitment_cycle_year']).to eq(application_forms.second.recruitment_cycle_year)
+    expect(response_data.first['submitted_at']).to eq(application_forms.second.submitted_at.iso8601)
     expect(response_data.second['id']).to eq(application_forms.first.id)
     expect(response_data.second['application_phase']).to eq(application_forms.first.phase)
     expect(response_data.second['application_status']).to eq(ProcessState.new(application_forms.first).state.to_s)
+    expect(response_data.first['recruitment_cycle_year']).to eq(application_forms.second.recruitment_cycle_year)
+    expect(response_data.first['submitted_at']).to eq(application_forms.second.submitted_at.iso8601)
   end
 
   it 'returns the correct page and the default page items' do


### PR DESCRIPTION
## Context

GIT have requested that we add the application forms recruitment cycle year and submitted_at so they can bring their reporting in line with our methodology.

## Changes proposed in this pull request

- Add the two values to the API response
- Update the docs 
- Update the specs

## Guidance to review

I can't imagine updating the datetimes to iso8601 would cause any issues. Wdyt?

## Link to Trello card

https://trello.com/c/yU5wWcsm/4134-add-recruitment-cycle-year-and-submitted-at-the-candidates-api

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
