### PR TITLE
Touch application form and choices when course changes

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -18,6 +18,9 @@ class Course < ApplicationRecord
   scope :in_cycle, ->(year) { where(recruitment_cycle_year: year) }
 
   scope :with_course_options, -> { left_outer_joins(:course_options).where.not(course_options: { id: nil }) }
+
+  after_update :touch_application_choices_and_forms
+
   CODE_LENGTH = 4
 
   # This enum is copied verbatim from Find to maintain consistency
@@ -161,5 +164,14 @@ class Course < ApplicationRecord
       open_on_apply: true,
       opened_on_apply_at: Time.zone.now,
     )
+  end
+
+private
+
+  def touch_application_choices_and_forms
+    ActiveRecord::Base.transaction do
+      application_choices.touch_all
+      ApplicationForm.where(application_choices: application_choices).touch_all
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,8 @@ Timecop.safe_mode = true
 
 Faker::Config.locale = 'en-GB'
 
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                           .with(TeacherTrainingPublicAPI::FullSyncUpdateError.new('course_option have been updated'))
       end
 
-      it 'touches related application choices and forms' do
+      it 'touches related application choices and forms', with_audited: true do
         stub_teacher_training_api_course_with_site(provider_code: 'ABC',
                                                    course_code: 'ABC1',
                                                    course_attributes: [{ accredited_body_code: nil, study_mode: 'full_time' }],
@@ -208,6 +208,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
           described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, false)
         }.to change { course_option.application_choices.first.updated_at }
          .and change { course_option.application_choices.first.application_form.updated_at }
+         .and(not_change { Audited::Audit.count })
       end
 
       it 'correctly updates withdrawn attribute for an existing course' do


### PR DESCRIPTION
## Context

When we update course details in publish, and we sync those details through the TTAPI, those will be updated in Apply. However those changes don't make their way to the Vendor API responses as application choices are not touched. 

## Changes proposed in this pull request

When course details are updated, we touch application forms as well as choices in the TTAPI sync

## Link to Trello card

https://trello.com/c/g9PUXgZZ/4463-touch-application-form-and-choices-when-course-changes

## Things to check

- [X] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
