### PR TITLE
Hide low numbers in monthly reports

### DIFF
--- a/app/models/monthly_statistics/base.rb
+++ b/app/models/monthly_statistics/base.rb
@@ -33,5 +33,20 @@ module MonthlyStatistics
         awaiting_decision_count(statuses) +
         unsuccessful_count(statuses)
     end
+
+    MINIMUM_VISIBLE_VALUE = 5
+    def apply_minimum_value_rule(count)
+      count.is_a?(Numeric) && count < MINIMUM_VISIBLE_VALUE ? '0 to 4' : count
+    end
+
+    def apply_minimum_value_rule_to_rows(rows)
+      rows.map do |hash|
+        hash.transform_values { |count| apply_minimum_value_rule(count) }
+      end
+    end
+
+    def apply_minimum_value_rule_to_totals(totals)
+      totals.map { |count| apply_minimum_value_rule(count) }
+    end
   end
 end

--- a/app/models/monthly_statistics/by_age_group.rb
+++ b/app/models/monthly_statistics/by_age_group.rb
@@ -2,8 +2,8 @@ module MonthlyStatistics
   class ByAgeGroup < MonthlyStatistics::Base
     def table_data
       {
-        rows: rows,
-        column_totals: column_totals_for(rows),
+        rows: apply_minimum_value_rule_to_rows(rows),
+        column_totals: apply_minimum_value_rule_to_totals(column_totals_for(rows)),
       }
     end
 

--- a/app/models/monthly_statistics/by_area.rb
+++ b/app/models/monthly_statistics/by_area.rb
@@ -4,8 +4,8 @@ module MonthlyStatistics
 
     def table_data
       {
-        rows: rows,
-        column_totals: column_totals_for(rows),
+        rows: apply_minimum_value_rule_to_rows(rows),
+        column_totals: apply_minimum_value_rule_to_totals(column_totals_for(rows)),
       }
     end
 
@@ -33,9 +33,23 @@ module MonthlyStatistics
       _area, *statuses = rows.first.keys
 
       statuses.map do |column_name|
-        column_total = rows.inject(0) { |total, hash| total + hash[column_name] }
-        column_total
+        rows.inject(0) { |total, hash| total + hash[column_name] }
       end
+    end
+
+    MINIMUM_VISIBLE_VALUE = 5
+    def apply_minimum_value_rule(count)
+      count.is_a?(Numeric) && count < MINIMUM_VISIBLE_VALUE ? '0 to 4' : count
+    end
+
+    def apply_minimum_value_rule_to_rows(rows)
+      rows.map do |hash|
+        hash.transform_values { |count| apply_minimum_value_rule(count) }
+      end
+    end
+
+    def apply_minimum_value_rule_to_totals(totals)
+      totals.map { |count| apply_minimum_value_rule(count) }
     end
 
     def column_label_for(region_code)

--- a/app/models/monthly_statistics/by_sex.rb
+++ b/app/models/monthly_statistics/by_sex.rb
@@ -2,8 +2,8 @@ module MonthlyStatistics
   class BySex < MonthlyStatistics::Base
     def table_data
       {
-        rows: rows,
-        column_totals: column_totals_for(rows),
+        rows: apply_minimum_value_rule_to_rows(rows),
+        column_totals: apply_minimum_value_rule_to_totals(column_totals_for(rows)),
       }
     end
 

--- a/spec/models/monthly_statistics/by_age_group_spec.rb
+++ b/spec/models/monthly_statistics/by_age_group_spec.rb
@@ -4,199 +4,201 @@ RSpec.describe MonthlyStatistics::ByAgeGroup do
   subject(:statistics) { described_class.new.table_data }
 
   it "returns table data for 'by age group'" do
-    application_form_21_year_old1 = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 21, 8, 31))
-    application_form_21_year_old2 = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 21, 8, 31))
-    application_form_21_year_old3 = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 22, 9, 1))
+    5.times do
+      application_form_21_year_old1 = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 21, 8, 31))
+      application_form_21_year_old2 = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 21, 8, 31))
+      application_form_21_year_old3 = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 22, 9, 1))
 
-    application_form_22_year_old1 = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 22, 8, 31))
-    application_form_22_year_old2 = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 23, 9, 1))
+      application_form_22_year_old1 = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 22, 8, 31))
+      application_form_22_year_old2 = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 23, 9, 1))
 
-    application_form_23_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 23, 1, 1))
+      application_form_23_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 23, 1, 1))
 
-    application_form_25_to_29_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 25, 1, 1))
+      application_form_25_to_29_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 25, 1, 1))
 
-    application_form_30_to_34_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 30, 1, 1))
+      application_form_30_to_34_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 30, 1, 1))
 
-    first_application_form_40_to_44_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 44, 1, 1))
-    second_application_form_40_to_44_year_old = create(:completed_application_form,
-                                                       date_of_birth: Date.new(RecruitmentCycle.current_year - 44, 1, 1),
-                                                       phase: 'apply_2', candidate: first_application_form_40_to_44_year_old.candidate,
-                                                       previous_application_form_id: first_application_form_40_to_44_year_old.id)
+      first_application_form_40_to_44_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 44, 1, 1))
+      second_application_form_40_to_44_year_old = create(:completed_application_form,
+                                                         date_of_birth: Date.new(RecruitmentCycle.current_year - 44, 1, 1),
+                                                         phase: 'apply_2', candidate: first_application_form_40_to_44_year_old.candidate,
+                                                         previous_application_form_id: first_application_form_40_to_44_year_old.id)
 
-    deferred_application_form_from_previous_cycle_45_to_49_year_old = create(:completed_application_form,
-                                                                             date_of_birth: Date.new(RecruitmentCycle.current_year - 49, 1, 1),
-                                                                             recruitment_cycle_year: RecruitmentCycle.previous_year)
+      deferred_application_form_from_previous_cycle_45_to_49_year_old = create(:completed_application_form,
+                                                                               date_of_birth: Date.new(RecruitmentCycle.current_year - 49, 1, 1),
+                                                                               recruitment_cycle_year: RecruitmentCycle.previous_year)
 
-    offer_withdrawn_application_for_50_to_54_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 50, 1, 1))
+      offer_withdrawn_application_for_50_to_54_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 50, 1, 1))
 
-    withdrawn_application_form_55_to_59_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 55, 1, 1))
+      withdrawn_application_form_55_to_59_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 55, 1, 1))
 
-    unsuccessful_application_for_65_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 65, 8, 31))
+      unsuccessful_application_for_65_year_old = create(:completed_application_form, date_of_birth: Date.new(RecruitmentCycle.current_year - 65, 8, 31))
 
-    # check recruited takes precedence over deferred
-    create(:application_choice, :with_recruited, application_form: application_form_21_year_old1)
-    create(:application_choice, :with_deferred_offer, application_form: application_form_21_year_old1)
+      # check recruited takes precedence over deferred
+      create(:application_choice, :with_recruited, application_form: application_form_21_year_old1)
+      create(:application_choice, :with_deferred_offer, application_form: application_form_21_year_old1)
 
-    # check deferred takes precedence over pending conditions and is filtered out
-    create(:application_choice, :with_deferred_offer, application_form: application_form_21_year_old2)
-    create(:application_choice, :with_accepted_offer, application_form: application_form_21_year_old2)
+      # check deferred takes precedence over pending conditions and is filtered out
+      create(:application_choice, :with_deferred_offer, application_form: application_form_21_year_old2)
+      create(:application_choice, :with_accepted_offer, application_form: application_form_21_year_old2)
 
-    # check pending conditions takes precedence over offer
-    create(:application_choice, :with_accepted_offer, application_form: application_form_21_year_old3)
-    create(:application_choice, :with_offer, application_form: application_form_21_year_old3)
+      # check pending conditions takes precedence over offer
+      create(:application_choice, :with_accepted_offer, application_form: application_form_21_year_old3)
+      create(:application_choice, :with_offer, application_form: application_form_21_year_old3)
 
-    # check offer takes precedence over awaiting_provider_decision
-    create(:application_choice, :with_offer, application_form: application_form_22_year_old1)
-    create(:application_choice, :awaiting_provider_decision, application_form: application_form_22_year_old1)
+      # check offer takes precedence over awaiting_provider_decision
+      create(:application_choice, :with_offer, application_form: application_form_22_year_old1)
+      create(:application_choice, :awaiting_provider_decision, application_form: application_form_22_year_old1)
 
-    # check awaiting_provider_decision takes precedence over unsuccessful states
-    create(:application_choice, :awaiting_provider_decision, application_form: application_form_22_year_old2)
-    create(:application_choice, :withdrawn, application_form: application_form_22_year_old2)
+      # check awaiting_provider_decision takes precedence over unsuccessful states
+      create(:application_choice, :awaiting_provider_decision, application_form: application_form_22_year_old2)
+      create(:application_choice, :withdrawn, application_form: application_form_22_year_old2)
 
-    create(:application_choice, :awaiting_provider_decision, application_form: application_form_23_year_old)
-    create(:application_choice, :with_conditions_not_met, application_form: application_form_23_year_old)
+      create(:application_choice, :awaiting_provider_decision, application_form: application_form_23_year_old)
+      create(:application_choice, :with_conditions_not_met, application_form: application_form_23_year_old)
 
-    create(:application_choice, :awaiting_provider_decision, application_form: application_form_25_to_29_year_old)
-    create(:application_choice, :with_declined_offer, application_form: application_form_25_to_29_year_old)
+      create(:application_choice, :awaiting_provider_decision, application_form: application_form_25_to_29_year_old)
+      create(:application_choice, :with_declined_offer, application_form: application_form_25_to_29_year_old)
 
-    create(:application_choice, :awaiting_provider_decision, application_form: application_form_30_to_34_year_old)
-    create(:application_choice, :with_rejection, application_form: application_form_30_to_34_year_old)
+      create(:application_choice, :awaiting_provider_decision, application_form: application_form_30_to_34_year_old)
+      create(:application_choice, :with_rejection, application_form: application_form_30_to_34_year_old)
 
-    # only counts the latest application form
-    create(:application_choice, :with_withdrawn_offer, application_form: first_application_form_40_to_44_year_old)
-    create(:application_choice, :with_recruited, application_form: second_application_form_40_to_44_year_old)
+      # only counts the latest application form
+      create(:application_choice, :with_withdrawn_offer, application_form: first_application_form_40_to_44_year_old)
+      create(:application_choice, :with_recruited, application_form: second_application_form_40_to_44_year_old)
 
-    # counts deferred offers from the previous cycle
-    create(:application_choice, :with_deferred_offer, application_form: deferred_application_form_from_previous_cycle_45_to_49_year_old)
+      # counts deferred offers from the previous cycle
+      create(:application_choice, :with_deferred_offer, application_form: deferred_application_form_from_previous_cycle_45_to_49_year_old)
 
-    create(:application_choice, :with_rejection, application_form: offer_withdrawn_application_for_50_to_54_year_old)
+      create(:application_choice, :with_rejection, application_form: offer_withdrawn_application_for_50_to_54_year_old)
 
-    create(:application_choice, :with_rejection, application_form: withdrawn_application_form_55_to_59_year_old)
+      create(:application_choice, :with_rejection, application_form: withdrawn_application_form_55_to_59_year_old)
 
-    create(:application_choice, :with_rejection, application_form: unsuccessful_application_for_65_year_old)
+      create(:application_choice, :with_rejection, application_form: unsuccessful_application_for_65_year_old)
+    end
 
     expect(statistics).to eq(
       { rows:
         [
           {
             'Age group' => '21 and under',
-            'Recruited' => 1,
-            'Conditions pending' => 1,
-            'Received an offer' => 0,
-            'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 0,
-            'Total' => 2,
+            'Recruited' => 5,
+            'Conditions pending' => 5,
+            'Received an offer' => '0 to 4',
+            'Awaiting provider decisions' => '0 to 4',
+            'Unsuccessful' => '0 to 4',
+            'Total' => 10,
           },
           {
             'Age group' => '22',
-            'Recruited' => 0,
-            'Conditions pending' => 0,
-            'Received an offer' => 1,
-            'Awaiting provider decisions' => 1,
-            'Unsuccessful' => 0,
-            'Total' => 2,
+            'Recruited' => '0 to 4',
+            'Conditions pending' => '0 to 4',
+            'Received an offer' => 5,
+            'Awaiting provider decisions' => 5,
+            'Unsuccessful' => '0 to 4',
+            'Total' => 10,
           },
           {
             'Age group' => '23',
-            'Recruited' => 0,
-            'Conditions pending' => 0,
-            'Received an offer' => 0,
-            'Awaiting provider decisions' => 1,
-            'Unsuccessful' => 0,
-            'Total' => 1,
+            'Recruited' => '0 to 4',
+            'Conditions pending' => '0 to 4',
+            'Received an offer' => '0 to 4',
+            'Awaiting provider decisions' => 5,
+            'Unsuccessful' => '0 to 4',
+            'Total' => 5,
           },
           {
             'Age group' => '24',
-            'Recruited' => 0,
-            'Conditions pending' => 0,
-            'Received an offer' => 0,
-            'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 0,
-            'Total' => 0,
+            'Recruited' => '0 to 4',
+            'Conditions pending' => '0 to 4',
+            'Received an offer' => '0 to 4',
+            'Awaiting provider decisions' => '0 to 4',
+            'Unsuccessful' => '0 to 4',
+            'Total' => '0 to 4',
           },
           {
             'Age group' => '25 to 29',
-            'Recruited' => 0,
-            'Conditions pending' => 0,
-            'Received an offer' => 0,
-            'Awaiting provider decisions' => 1,
-            'Unsuccessful' => 0,
-            'Total' => 1,
+            'Recruited' => '0 to 4',
+            'Conditions pending' => '0 to 4',
+            'Received an offer' => '0 to 4',
+            'Awaiting provider decisions' => 5,
+            'Unsuccessful' => '0 to 4',
+            'Total' => 5,
           },
           {
             'Age group' => '30 to 34',
-            'Recruited' => 0,
-            'Conditions pending' => 0,
-            'Received an offer' => 0,
-            'Awaiting provider decisions' => 1,
-            'Unsuccessful' => 0,
-            'Total' => 1,
+            'Recruited' => '0 to 4',
+            'Conditions pending' => '0 to 4',
+            'Received an offer' => '0 to 4',
+            'Awaiting provider decisions' => 5,
+            'Unsuccessful' => '0 to 4',
+            'Total' => 5,
           },
           {
             'Age group' => '35 to 39',
-            'Recruited' => 0,
-            'Conditions pending' => 0,
-            'Received an offer' => 0,
-            'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 0,
-            'Total' => 0,
+            'Recruited' => '0 to 4',
+            'Conditions pending' => '0 to 4',
+            'Received an offer' => '0 to 4',
+            'Awaiting provider decisions' => '0 to 4',
+            'Unsuccessful' => '0 to 4',
+            'Total' => '0 to 4',
           },
           {
             'Age group' => '40 to 44',
-            'Recruited' => 1,
-            'Conditions pending' => 0,
-            'Received an offer' => 0,
-            'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 0,
-            'Total' => 1,
+            'Recruited' => 5,
+            'Conditions pending' => '0 to 4',
+            'Received an offer' => '0 to 4',
+            'Awaiting provider decisions' => '0 to 4',
+            'Unsuccessful' => '0 to 4',
+            'Total' => 5,
           },
           {
             'Age group' => '45 to 49',
-            'Recruited' => 0,
-            'Conditions pending' => 1,
-            'Received an offer' => 0,
-            'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 0,
-            'Total' => 1,
+            'Recruited' => '0 to 4',
+            'Conditions pending' => 5,
+            'Received an offer' => '0 to 4',
+            'Awaiting provider decisions' => '0 to 4',
+            'Unsuccessful' => '0 to 4',
+            'Total' => 5,
           },
           {
             'Age group' => '50 to 54',
-            'Recruited' => 0,
-            'Conditions pending' => 0,
-            'Received an offer' => 0,
-            'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 1,
-            'Total' => 1,
+            'Recruited' => '0 to 4',
+            'Conditions pending' => '0 to 4',
+            'Received an offer' => '0 to 4',
+            'Awaiting provider decisions' => '0 to 4',
+            'Unsuccessful' => 5,
+            'Total' => 5,
           },
           {
             'Age group' => '55 to 59',
-            'Recruited' => 0,
-            'Conditions pending' => 0,
-            'Received an offer' => 0,
-            'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 1,
-            'Total' => 1,
+            'Recruited' => '0 to 4',
+            'Conditions pending' => '0 to 4',
+            'Received an offer' => '0 to 4',
+            'Awaiting provider decisions' => '0 to 4',
+            'Unsuccessful' => 5,
+            'Total' => 5,
           },
           {
             'Age group' => '60 to 64',
-            'Recruited' => 0,
-            'Conditions pending' => 0,
-            'Received an offer' => 0,
-            'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 0,
-            'Total' => 0,
+            'Recruited' => '0 to 4',
+            'Conditions pending' => '0 to 4',
+            'Received an offer' => '0 to 4',
+            'Awaiting provider decisions' => '0 to 4',
+            'Unsuccessful' => '0 to 4',
+            'Total' => '0 to 4',
           },
           {
             'Age group' => '65 and over',
-            'Recruited' => 0,
-            'Conditions pending' => 0,
-            'Received an offer' => 0,
-            'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 1,
-            'Total' => 1,
+            'Recruited' => '0 to 4',
+            'Conditions pending' => '0 to 4',
+            'Received an offer' => '0 to 4',
+            'Awaiting provider decisions' => '0 to 4',
+            'Unsuccessful' => 5,
+            'Total' => 5,
           },
         ],
-        column_totals: [2, 2, 1, 4, 3, 12] },
+        column_totals: [10, 10, 5, 20, 15, 60] },
     )
   end
 end

--- a/spec/models/monthly_statistics/by_area_spec.rb
+++ b/spec/models/monthly_statistics/by_area_spec.rb
@@ -4,18 +4,20 @@ RSpec.describe MonthlyStatistics::ByArea do
   subject(:statistics) { described_class.new.table_data }
 
   it "returns table data for 'by area'" do
-    create_application_choice(statuses: %i[with_rejection], region_code: 'london')
-    create_application_choice(statuses: %i[awaiting_provider_decision], region_code: 'south_east')
-    create_application_choice(statuses: %i[with_recruited], region_code: 'south_east')
-    create_application_choice(statuses: %i[with_offer], region_code: 'wales')
-    create_application_choice(statuses: %i[with_deferred_offer with_rejection], status_before_deferral: 'offer', region_code: 'west_midlands', recruitment_cycle_year: RecruitmentCycle.previous_year)
-    create_application_choice(statuses: %i[with_deferred_offer with_declined_offer], status_before_deferral: 'offer', region_code: 'london', recruitment_cycle_year: RecruitmentCycle.current_year)
-    create_application_choice(statuses: %i[with_conditions_not_met], region_code: 'wales')
-    create_application_choice(statuses: %i[with_offer], region_code: 'london')
-    create_application_choice(statuses: %i[with_withdrawn_offer], region_code: 'north_east')
-    create_application_choice(statuses: %i[withdrawn], region_code: 'north_east')
-    create_application_choice(statuses: %i[with_rejection], region_code: nil)
-    create_application_choice_with_previous_application(status: :with_rejection, region_code: 'north_west')
+    5.times do
+      create_application_choice(statuses: %i[with_rejection], region_code: 'london')
+      create_application_choice(statuses: %i[awaiting_provider_decision], region_code: 'south_east')
+      create_application_choice(statuses: %i[with_recruited], region_code: 'south_east')
+      create_application_choice(statuses: %i[with_offer], region_code: 'wales')
+      create_application_choice(statuses: %i[with_deferred_offer with_rejection], status_before_deferral: 'offer', region_code: 'west_midlands', recruitment_cycle_year: RecruitmentCycle.previous_year)
+      create_application_choice(statuses: %i[with_deferred_offer with_declined_offer], status_before_deferral: 'offer', region_code: 'london', recruitment_cycle_year: RecruitmentCycle.current_year)
+      create_application_choice(statuses: %i[with_conditions_not_met], region_code: 'wales')
+      create_application_choice(statuses: %i[with_offer], region_code: 'london')
+      create_application_choice(statuses: %i[with_withdrawn_offer], region_code: 'north_east')
+      create_application_choice(statuses: %i[withdrawn], region_code: 'north_east')
+      create_application_choice(statuses: %i[with_rejection], region_code: nil)
+      create_application_choice_with_previous_application(status: :with_rejection, region_code: 'north_west')
+    end
 
     expect(region_titles).to eq(
       [
@@ -38,64 +40,64 @@ RSpec.describe MonthlyStatistics::ByArea do
         'Rest of the World',
       ],
     )
-    expect(column_totals).to eq([1, 0, 3, 1, 6, 11])
+    expect(column_totals).to eq([5, '0 to 4', 15, 5, 30, 55])
     expect(totals_for('London')).to eq(
-      'Recruited' => 0,
-      'Conditions pending' => 0,
-      'Received an offer' => 1,
-      'Awaiting provider decisions' => 0,
-      'Unsuccessful' => 1,
-      'Total' => 2,
+      'Recruited' => '0 to 4',
+      'Conditions pending' => '0 to 4',
+      'Received an offer' => 5,
+      'Awaiting provider decisions' => '0 to 4',
+      'Unsuccessful' => 5,
+      'Total' => 10,
     )
     expect(totals_for('South East')).to eq(
-      'Recruited' => 1,
-      'Conditions pending' => 0,
-      'Received an offer' => 0,
-      'Awaiting provider decisions' => 1,
-      'Unsuccessful' => 0,
-      'Total' => 2,
+      'Recruited' => 5,
+      'Conditions pending' => '0 to 4',
+      'Received an offer' => '0 to 4',
+      'Awaiting provider decisions' => 5,
+      'Unsuccessful' => '0 to 4',
+      'Total' => 10,
     )
     expect(totals_for('Wales')).to eq(
-      'Recruited' => 0,
-      'Conditions pending' => 0,
-      'Received an offer' => 1,
-      'Awaiting provider decisions' => 0,
-      'Unsuccessful' => 1,
-      'Total' => 2,
+      'Recruited' => '0 to 4',
+      'Conditions pending' => '0 to 4',
+      'Received an offer' => 5,
+      'Awaiting provider decisions' => '0 to 4',
+      'Unsuccessful' => 5,
+      'Total' => 10,
     )
     expect(totals_for('West Midlands')).to eq(
-      'Recruited' => 0,
-      'Conditions pending' => 0,
-      'Received an offer' => 1,
-      'Awaiting provider decisions' => 0,
-      'Unsuccessful' => 0,
-      'Total' => 1,
+      'Recruited' => '0 to 4',
+      'Conditions pending' => '0 to 4',
+      'Received an offer' => 5,
+      'Awaiting provider decisions' => '0 to 4',
+      'Unsuccessful' => '0 to 4',
+      'Total' => 5,
     )
     expect(totals_for('North West')).to eq(
-      'Recruited' => 0,
-      'Conditions pending' => 0,
-      'Received an offer' => 0,
-      'Awaiting provider decisions' => 0,
-      'Unsuccessful' => 1,
-      'Total' => 1,
+      'Recruited' => '0 to 4',
+      'Conditions pending' => '0 to 4',
+      'Received an offer' => '0 to 4',
+      'Awaiting provider decisions' => '0 to 4',
+      'Unsuccessful' => 5,
+      'Total' => 5,
     )
 
     expect(totals_for('North East')).to eq(
-      'Recruited' => 0,
-      'Conditions pending' => 0,
-      'Received an offer' => 0,
-      'Awaiting provider decisions' => 0,
-      'Unsuccessful' => 2,
-      'Total' => 2,
+      'Recruited' => '0 to 4',
+      'Conditions pending' => '0 to 4',
+      'Received an offer' => '0 to 4',
+      'Awaiting provider decisions' => '0 to 4',
+      'Unsuccessful' => 10,
+      'Total' => 10,
     )
 
     expect(totals_for('No region')).to eq(
-      'Recruited' => 0,
-      'Conditions pending' => 0,
-      'Received an offer' => 0,
-      'Awaiting provider decisions' => 0,
-      'Unsuccessful' => 1,
-      'Total' => 1,
+      'Recruited' => '0 to 4',
+      'Conditions pending' => '0 to 4',
+      'Received an offer' => '0 to 4',
+      'Awaiting provider decisions' => '0 to 4',
+      'Unsuccessful' => 5,
+      'Total' => 5,
     )
   end
 

--- a/spec/models/monthly_statistics/by_sex_spec.rb
+++ b/spec/models/monthly_statistics/by_sex_spec.rb
@@ -4,59 +4,61 @@ RSpec.describe MonthlyStatistics::BySex do
   subject(:statistics) { described_class.new.table_data }
 
   it "returns table data for 'by course age group'" do
-    create_application_choice(status: :with_rejection, sex: 'female')
-    create_application_choice(status: :awaiting_provider_decision, sex: 'Prefer not to say')
-    create_application_choice(status: :with_recruited, sex: 'Prefer not to say')
-    create_application_choice(status: :with_offer, sex: 'intersex')
-    create_application_choice(status: :with_deferred_offer, sex: 'male', recruitment_cycle_year: RecruitmentCycle.previous_year)
-    create_application_choice(status: :with_deferred_offer, sex: 'female', recruitment_cycle_year: RecruitmentCycle.current_year)
-    create_application_choice(status: :with_conditions_not_met, sex: 'intersex')
-    create_application_choice(status: :with_offer, sex: 'female')
-    create_application_choice(status: :with_withdrawn_offer, sex: 'female')
-    create_application_choice(status: :withdrawn, sex: 'male')
-    create_application_choice_with_previous_application(status: :with_rejection, sex: 'male')
+    5.times do
+      create_application_choice(status: :with_rejection, sex: 'female')
+      create_application_choice(status: :awaiting_provider_decision, sex: 'Prefer not to say')
+      create_application_choice(status: :with_recruited, sex: 'Prefer not to say')
+      create_application_choice(status: :with_offer, sex: 'intersex')
+      create_application_choice(status: :with_deferred_offer, sex: 'male', recruitment_cycle_year: RecruitmentCycle.previous_year)
+      create_application_choice(status: :with_deferred_offer, sex: 'female', recruitment_cycle_year: RecruitmentCycle.current_year)
+      create_application_choice(status: :with_conditions_not_met, sex: 'intersex')
+      create_application_choice(status: :with_offer, sex: 'female')
+      create_application_choice(status: :with_withdrawn_offer, sex: 'female')
+      create_application_choice(status: :withdrawn, sex: 'male')
+      create_application_choice_with_previous_application(status: :with_rejection, sex: 'male')
+    end
 
     expect(statistics).to eq(
       { rows:
         [
           {
             'Sex' => 'Female',
-            'Recruited' => 0,
-            'Conditions pending' => 0,
-            'Received an offer' => 1,
-            'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 2,
-            'Total' => 3,
+            'Recruited' => '0 to 4',
+            'Conditions pending' => '0 to 4',
+            'Received an offer' => 5,
+            'Awaiting provider decisions' => '0 to 4',
+            'Unsuccessful' => 10,
+            'Total' => 15,
           },
           {
             'Sex' => 'Male',
-            'Recruited' => 0,
-            'Conditions pending' => 0,
-            'Received an offer' => 1,
-            'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 2,
-            'Total' => 3,
+            'Recruited' => '0 to 4',
+            'Conditions pending' => '0 to 4',
+            'Received an offer' => 5,
+            'Awaiting provider decisions' => '0 to 4',
+            'Unsuccessful' => 10,
+            'Total' => 15,
           },
           {
             'Sex' => 'Intersex',
-            'Recruited' => 0,
-            'Conditions pending' => 0,
-            'Received an offer' => 1,
-            'Awaiting provider decisions' => 0,
-            'Unsuccessful' => 1,
-            'Total' => 2,
+            'Recruited' => '0 to 4',
+            'Conditions pending' => '0 to 4',
+            'Received an offer' => 5,
+            'Awaiting provider decisions' => '0 to 4',
+            'Unsuccessful' => 5,
+            'Total' => 10,
           },
           {
             'Sex' => 'Prefer not to say',
-            'Recruited' => 1,
-            'Conditions pending' => 0,
-            'Received an offer' => 0,
-            'Awaiting provider decisions' => 1,
-            'Unsuccessful' => 0,
-            'Total' => 2,
+            'Recruited' => 5,
+            'Conditions pending' => '0 to 4',
+            'Received an offer' => '0 to 4',
+            'Awaiting provider decisions' => 5,
+            'Unsuccessful' => '0 to 4',
+            'Total' => 10,
           },
         ],
-        column_totals: [1, 0, 3, 1, 5, 10] },
+        column_totals: [5, '0 to 4', 15, 5, 25, 50] },
     )
   end
 


### PR DESCRIPTION
## Context

We need to hide exact numbers in monthly stats if the number is less than 5.

## Changes proposed in this pull request

Modify the counts for `ByArea` monthly stats report to hide exact numbers less than 5 behind a _0 to 4_ label.

- Totals are calculated before fuzzing the low numbers
- `#table_data` now returns a mixture of string (`0 to 4`) values and
  actual numbers.

## Guidance to review

This is just an initial sketch to get an idea of whether this approach meets the requirement.

## Link to Trello card

[[<!-- http://trello.com/123-example-card -->
](https://trello.com/c/XbjTikS2/j)](https://trello.com/c/XbjTikS2/4131-update-age-sex-and-candidate-region-tables-on-the-monthly-statistics-page-to-use-0-to-4-if-5-candidates-meet-the-criteria)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
