### PR TITLE
Ensure that we pass 0 to 4 for protected characteristics in the monthly report exports

### DIFF
--- a/app/services/support_interface/external_report_candidates_export.rb
+++ b/app/services/support_interface/external_report_candidates_export.rb
@@ -24,7 +24,7 @@ module SupportInterface
                 'Area' => area,
                 'Age group' => age_group,
                 'Status' => status,
-                'Total' => count,
+                'Total' => count >= 5 ? count : '0 to 4',
               }
             end
           end

--- a/spec/services/support_interface/external_report_candidates_export_spec.rb
+++ b/spec/services/support_interface/external_report_candidates_export_spec.rb
@@ -7,13 +7,12 @@ RSpec.describe SupportInterface::ExternalReportCandidatesExport do
 
       generate_test_data
       hash = add_test_data_to_hash(hash)
-      expected_output = hash.values.sort
       output = described_class.new.data_for_export.sort
+      expected_output = hash.values.sort.each do |row|
+        row['Total'] = '0 to 4' if row['Total'] <= 4
+      end
 
-      expected_output_with_empty_rows_removed = expected_output.reject { |row| row['Total'].zero? }
-      output_with_empty_rows_removed = output.reject { |row| row['Total'].zero? }
-
-      expect(output_with_empty_rows_removed).to eq(expected_output_with_empty_rows_removed)
+      expect(output).to eq(expected_output)
     end
 
   private
@@ -51,13 +50,15 @@ RSpec.describe SupportInterface::ExternalReportCandidatesExport do
         status = statuses.sample
         sex = sexes.sample
 
-        application_form = if sex.nil?
-                             create(:application_form, equality_and_diversity: nil, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code)
-                           else
-                             create(:application_form, :with_equality_and_diversity_data, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code)
-                           end
+        rand(1..7).times do
+          application_form = if sex.nil?
+                               create(:application_form, equality_and_diversity: nil, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code)
+                             else
+                               create(:application_form, :with_equality_and_diversity_data, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code)
+                             end
 
-        create(:application_choice, status: status, application_form: application_form)
+          create(:application_choice, status: status, application_form: application_form)
+        end
       end
 
       5.times do
@@ -66,13 +67,15 @@ RSpec.describe SupportInterface::ExternalReportCandidatesExport do
         status = %w[pending_conditions recruited].sample
         sex = sexes.sample
 
-        application_form = if sex.nil?
-                             create(:application_form, equality_and_diversity: nil, recruitment_cycle_year: RecruitmentCycle.previous_year, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code)
-                           else
-                             create(:application_form, :with_equality_and_diversity_data, recruitment_cycle_year: RecruitmentCycle.previous_year, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code)
-                           end
+        rand(1..7).times do
+          application_form = if sex.nil?
+                               create(:application_form, equality_and_diversity: nil, recruitment_cycle_year: RecruitmentCycle.previous_year, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code)
+                             else
+                               create(:application_form, :with_equality_and_diversity_data, recruitment_cycle_year: RecruitmentCycle.previous_year, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code)
+                             end
 
-        create(:application_choice, :with_deferred_offer, status_before_deferral: status, application_form: application_form)
+          create(:application_choice, :with_deferred_offer, status_before_deferral: status, application_form: application_form)
+        end
       end
     end
 


### PR DESCRIPTION
## Context

In the ExternalReportCandidatesExport we pass down a granular breakdown of candidates applications based on some protected characteristics (age, region and sex). If there are 4 or less applicants who meet the criteria, we should update the cell to '0 to 4' to ensure applicants anonymity.

## Changes proposed in this pull request

- Update the export to use 0-4 for the total when less than 5 applicants meet the criteria
- Update the specs to capture this behaviour change

## Guidance to review

Running the test without rejecting empty totals actually runs quicker by about a second.

The test is now taking about 6 seconds which isn't ideal, but i can't think of a better way. Open to suggestions!

## Link to Trello card

https://trello.com/c/uySLhP7e/4133-update-the-aggregated-export-tables-for-the-monthly-reports-to-use-0-to-4-if-5-candidates-meet-the-criteria

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
