### PR TITLE
Re-enable Simplecov in CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,6 +175,20 @@ jobs:
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern || ' ' }}
           DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
 
+      - name: Upload pull request coverage report
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v2
+        with:
+          name: head-result
+          path: /app/coverage/.resultset.json
+
+      - name: Upload main coverage report
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v2
+        with:
+          name: base-result
+          path: /app/coverage/.resultset.json
+
   trigger-deployment:
     name: Trigger Deployment
     needs: [build, test]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,8 +19,9 @@ SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   SimpleCov::Formatter::CoberturaFormatter,
 ]
-unless ENV['TEST_ENV_NUMBER']
-  SimpleCov.start 'rails'
+
+SimpleCov.start 'rails' do
+  enable_coverage :branch
 end
 
 require 'sidekiq/testing'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,8 @@ SimpleCov.formatters = [
   SimpleCov::Formatter::CoberturaFormatter,
 ]
 
+SimpleCov.command_name('RSpec')
+
 SimpleCov.start 'rails' do
   enable_coverage :branch
 end


### PR DESCRIPTION
## Context

[We disabled Simplecov coverage report generation when we implemented parallel tests](https://github.com/DFE-Digital/apply-for-teacher-training/commit/1d6b74e1dc171384f3901437d29c12aea18ebc29), this was done to reduce noise.
We would like to report on test coverage on a PR basis, comparing the branch coverage to `main`. 
We will then report the difference using [Simplecov resultset diff action](https://github.com/kzkn/simplecov-resultset-diff-action).
See prototype PR https://github.com/DFE-Digital/apply-for-teacher-training/pull/5992#issuecomment-966346778 

As an initial step we need to start generating the coverage reports on CI builds and uploading the artifacts for `main` branch builds and PR branch builds. These can then be compared (to be implemented in a subsequent PR)

<!-- Why are you making this change? What might surprise someone about it? -->

\cc @malcolmbaig 

## Changes proposed in this pull request

- Re-enable Simplecov, enable branch reporting feature in Simplecov
- Upload `main` branch `coverage/.resultset.json` artifacts on `main` branch builds.
- Upload PR branch `coverage/.resultset.json` artifacts on PR branch builds.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

This PR branch should produce an artifact (**head-result**) which should be a zip file containing a valid `.resultset.json` file from Simplecov.

### TODO: 

Simplecov needs additional config to work properly with parallel tests, this PR is dealing with basic plumbing initially.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/G2D7y5XO/4465-%F0%9F%8F%88-improve-testing-and-coverage

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
