### PR TITLE
Add Christmas holidays to non-working days

### DIFF
--- a/app/controllers/provider_interface/content_controller.rb
+++ b/app/controllers/provider_interface/content_controller.rb
@@ -1,6 +1,7 @@
 module ProviderInterface
   class ContentController < ProviderInterfaceController
     include ContentHelper
+
     skip_before_action :authenticate_provider_user!
     skip_before_action :redirect_if_setup_required
     layout 'application'
@@ -28,7 +29,12 @@ module ProviderInterface
     def service_guidance_provider; end
 
     def dates_and_deadlines
-      render_content_page :dates_and_deadlines, with_breadcrumbs: true
+      holidays = CycleTimetable.holidays.reduce({}) do |hols, (holiday, date_range)|
+        hols[holiday] = { begins: date_range.first, ends: date_range.last }
+        hols
+      end
+
+      render_content_page :dates_and_deadlines, with_breadcrumbs: true, locals: { holidays: holidays }
     end
 
     def complaints

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -1,7 +1,10 @@
 module ContentHelper
-  def render_content_page(page_name, with_breadcrumbs: false)
+  def render_content_page(page_name, with_breadcrumbs: false, locals: {})
     raw_content = File.read("app/views/content/#{page_name}.md")
-    content_with_erb_tags_replaced = ApplicationController.renderer.render(inline: raw_content)
+    content_with_erb_tags_replaced = ApplicationController.renderer.render(
+      inline: raw_content,
+      locals: locals,
+    )
     @converted_markdown = GovukMarkdown.render(content_with_erb_tags_replaced).html_safe
     @page_name = page_name
     @with_breadcrumbs = with_breadcrumbs

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -9,6 +9,7 @@ class CycleTimetable
       apply_2_deadline: Time.zone.local(2019, 9, 18, 18),
       reject_by_default: Time.zone.local(2021, 9, 29, 23, 59, 59),
       find_closes: Time.zone.local(2019, 10, 3, 23, 59, 59),
+      holidays: {},
     },
     2020 => {
       find_opens: Time.zone.local(2019, 10, 6, 9),
@@ -18,6 +19,7 @@ class CycleTimetable
       apply_2_deadline: Time.zone.local(2020, 9, 18, 18),
       reject_by_default: Time.zone.local(2021, 9, 29, 23, 59, 59),
       find_closes: Time.zone.local(2020, 10, 3, 23, 59, 59),
+      holidays: {},
     },
     2021 => {
       find_opens: Time.zone.local(2020, 10, 6, 9),
@@ -27,6 +29,10 @@ class CycleTimetable
       apply_2_deadline: Time.zone.local(2021, 9, 21, 18),
       reject_by_default: Time.zone.local(2021, 9, 29, 23, 59, 59),
       find_closes: Time.zone.local(2021, 10, 4, 23, 59, 59),
+      holidays: {
+        christmas: Date.new(2020, 12, 20)..Date.new(2021, 1, 1),
+        easter: Date.new(2021, 4, 2)..Date.new(2021, 4, 16),
+      },
     },
     2022 => {
       find_opens: Time.zone.local(2021, 10, 5, 9),
@@ -36,6 +42,10 @@ class CycleTimetable
       apply_2_deadline: Time.zone.local(2022, 9, 21, 18), # This is a placeholder till we know the real date
       reject_by_default: Time.zone.local(2022, 9, 29, 23, 59, 59), # This is a placeholder till we know the real date
       find_closes: Time.zone.local(2022, 10, 4, 23, 59, 59), # This is a placeholder till we know the real date
+      holidays: { # Placeholders
+        christmas: Date.new(2021, 12, 21)..Date.new(2022, 1, 1),
+        easter: Date.new(2022, 4, 2)..Date.new(2022, 4, 6),
+      },
     },
     2023 => {
       find_opens: Time.zone.local(2022, 10, 5, 9), # This is a placeholder till we know the real date
@@ -45,6 +55,7 @@ class CycleTimetable
       apply_2_deadline: Time.zone.local(2023, 9, 21, 18), # This is a placeholder till we know the real date
       reject_by_default: Time.zone.local(2023, 9, 29, 23, 59, 59), # This is a placeholder till we know the real date
       find_closes: Time.zone.local(2023, 10, 4, 23, 59, 59), # This is a placeholder till we know the real date
+      holidays: {},
     },
   }.freeze
 
@@ -119,6 +130,16 @@ class CycleTimetable
 
   def self.apply_reopens(year = next_year)
     date(:apply_opens, year)
+  end
+
+  def self.holidays
+    # do not support the cycle switcher via #date as:
+    #
+    # a) fake schedules do not deal with timespans long enough for holidays
+    # b) looking up SiteSetting.cycle_schedule requires a database, which we
+    # don’t want (or necessarily have, in builds) at boot time when the
+    # business_time initializer calls this code
+    real_schedule_for(current_year).fetch(:holidays)
   end
 
   def self.apply_1_deadline_first_reminder

--- a/app/views/content/dates_and_deadlines.md
+++ b/app/views/content/dates_and_deadlines.md
@@ -1,9 +1,9 @@
 | **Date and time** | **What happens** |
 | --- | --- |
-| 12 October 2021 at 9am | Start of recruitment cycle - candidates can apply for courses. |
-| 21 December 2021 to 1 January 2022 | This period is not counted as working days when calculating time to make a decision. |
-| 2 April to 6 April 2022 | This period is not counted as working days when calculating time to make a decision. |
+| <%= CycleTimetable.apply_opens.to_s(:govuk_date_and_time) %> | Start of recruitment cycle - candidates can apply for courses. |
+| <%= holidays[:christmas][:begins].to_s(:govuk_date) %> to <%= holidays[:christmas][:ends].to_s(:govuk_date) %> | This period is not counted as working days when calculating time to make a decision. |
+| <%= holidays[:easter][:begins].to_s(:day_and_month) %> to <%= holidays[:easter][:ends].to_s(:govuk_date) %> | This period is not counted as working days when calculating time to make a decision. |
 | 1 July 2022 | Time to make a decision is reduced from 40 working days to 20 working days. |
-| 7 September 2022 at 6pm | Candidates can no longer apply for courses, unless they have already applied within this recruitment cycle. |
-| 21 September 2022 at 6pm | Candidates can no longer apply for courses. |
-| 4 October 2022 at 11:59pm | End of recruitment cycle - applications awaiting decisions are automatically rejected. |
+| <%= CycleTimetable.apply_1_deadline.to_s(:govuk_date_and_time) %> | Candidates can no longer apply for courses, unless they have already applied within this recruitment cycle. |
+| <%= CycleTimetable.apply_2_deadline.to_s(:govuk_date_and_time) %> | Candidates can no longer apply for courses. |
+| <%= CycleTimetable.reject_by_default.to_s(:govuk_date_and_time) %> | End of recruitment cycle - applications awaiting decisions are automatically rejected. |

--- a/config/initializers/business_time.rb
+++ b/config/initializers/business_time.rb
@@ -2,14 +2,10 @@ Holidays.between(Date.civil(2019, 1, 1), 2.years.from_now, :gb_eng, :observed).m
   BusinessTime::Config.holidays << holiday[:date]
 end
 
-UCAS_COVID_DATE_FREEZE = (Date.new(2020, 3, 23)..Date.new(2020, 5, 28)).freeze
-UCAS_WINTER_HOLIDAY_2020 = (Date.new(2020, 12, 20)..Date.new(2021, 1, 1)).freeze
-UCAS_SPRING_HOLIDAY_2021 = (Date.new(2021, 4, 2)..Date.new(2021, 4, 16)).freeze
-
-UCAS_HOLIDAYS = UCAS_COVID_DATE_FREEZE.to_a + UCAS_WINTER_HOLIDAY_2020.to_a + UCAS_SPRING_HOLIDAY_2021.to_a
-
-UCAS_HOLIDAYS.each do |date|
-  BusinessTime::Config.holidays << date
+Rails.application.reloader.to_prepare do # req'd when autoloading in initializer
+  CycleTimetable.holidays.each_value do |date_range|
+    BusinessTime::Config.holidays += date_range.to_a
+  end
 end
 
 BusinessTime::Config.beginning_of_workday = '0:00 am'

--- a/spec/services/set_reject_by_default_spec.rb
+++ b/spec/services/set_reject_by_default_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SetRejectByDefault do
       ['1 Jul 2019 9:00:00 AM BST',  '30 Jul 2019 0:00:00 AM BST', 'safely within BST'],
       ['4 Jan 2019 11:00:00 PM GMT', '2 Mar 2019 0:00:00 AM GMT',  'safely within GMT'],
       ['1 Jul 2020 11:00:00 PM BST', '30 Jul 2020 0:00:00 AM BST', 'during the 20-day summer period'],
-      ['21 Nov 2020 12:00:00 PM GMT', '2 Feb 2021 0:00:00 AM GMT', 'near the UCAS winter break'],
+      ['21 Nov 2021 12:00:00 PM GMT', '1 Feb 2022 0:00:00 AM GMT', 'near the Christmas holidays'],
       ['1 Sept 2021 0:00:00 AM BST', '29 Sept 2021 23:59:59 PM BST', '7 days before the apply 1 deadline'],
       ['7 Sept 2021 0:00:00 AM BST', '29 Sept 2021 23:59:59 PM BST', '1 day before apply 1 deadline'],
       ['20 Sept 2021 0:00:00 AM BST', '29 Sep 2021 23:59:59 PM BST', '1 day before apply 2 deadline'],

--- a/spec/services/time_limit_calculator_spec.rb
+++ b/spec/services/time_limit_calculator_spec.rb
@@ -91,62 +91,30 @@ RSpec.describe TimeLimitCalculator do
   end
 
   describe 'configured reject_by_default limits' do
-    context 'before 2020-07-01' do
-      it 'applies the 40 day rule' do
-        calculator = described_class.new(
-          rule: :reject_by_default,
-          effective_date: Time.zone.local(2020, 6, 15),
-        )
-        expect(calculator.call).to eq(
-          days: 40,
-          time_in_future: Time.zone.local(2020, 8, 10).end_of_day,
-          time_in_past: Time.zone.local(2020, 2, 11).end_of_day,
-        )
-      end
-    end
-
-    context 'after 2020-07-01' do
-      it 'applies the 20 day rule' do
-        calculator = described_class.new(
-          rule: :reject_by_default,
-          effective_date: Time.zone.local(RecruitmentCycle.current_year, 7, 6),
-        )
-        expect(calculator.call).to eq(
-          days: 20,
-          time_in_future: Time.zone.local(RecruitmentCycle.current_year, 8, 3).end_of_day,
-          time_in_past: Time.zone.local(RecruitmentCycle.current_year, 6, 8).end_of_day,
-        )
-      end
+    it 'applies the 20 day rule' do
+      calculator = described_class.new(
+        rule: :reject_by_default,
+        effective_date: Time.zone.local(RecruitmentCycle.current_year, 7, 6),
+      )
+      expect(calculator.call).to eq(
+        days: 20,
+        time_in_future: Time.zone.local(RecruitmentCycle.current_year, 8, 3).end_of_day,
+        time_in_past: Time.zone.local(RecruitmentCycle.current_year, 6, 8).end_of_day,
+      )
     end
   end
 
   describe 'configured chase_provider_before_rbd limits' do
-    context 'before 2020-07-01' do
-      it 'applies the 40 day rule' do
-        calculator = described_class.new(
-          rule: :chase_provider_before_rbd,
-          effective_date: Time.zone.local(2020, 6, 15),
-        )
-        expect(calculator.call).to eq(
-          days: 20,
-          time_in_future: Time.zone.local(2020, 7, 13).end_of_day,
-          time_in_past: Time.zone.local(2020, 3, 10).end_of_day,
-        )
-      end
-    end
-
-    context 'after 2020-07-01' do
-      it 'applies the 20 day rule' do
-        calculator = described_class.new(
-          rule: :chase_provider_before_rbd,
-          effective_date: Time.zone.local(RecruitmentCycle.current_year, 7, 6),
-        )
-        expect(calculator.call).to eq(
-          days: 10,
-          time_in_future: Time.zone.local(RecruitmentCycle.current_year, 7, 20).end_of_day,
-          time_in_past: Time.zone.local(RecruitmentCycle.current_year, 6, 22).end_of_day,
-        )
-      end
+    it 'applies the 20 day rule' do
+      calculator = described_class.new(
+        rule: :chase_provider_before_rbd,
+        effective_date: Time.zone.local(RecruitmentCycle.current_year, 7, 6),
+      )
+      expect(calculator.call).to eq(
+        days: 10,
+        time_in_future: Time.zone.local(RecruitmentCycle.current_year, 7, 20).end_of_day,
+        time_in_past: Time.zone.local(RecruitmentCycle.current_year, 6, 22).end_of_day,
+      )
     end
   end
 end


### PR DESCRIPTION
## Context

- We haven't set Christmas holidays for this year so RBD is being counted during the period we say it won't be
- The published docs are inconsistent because they don't look at the Cycle Timetable for their dates

## Changes proposed in this pull request

instead of the docs having strings in and the working days initializer having constants, make them both depend on CycleTimetable.

## Guidance to review

Anything to trip us up expressing holidays like this?

## Link to Trello card

https://trello.com/c/TwuW6biK/4135-add-christmas-holidays-to-non-working-days

## Things to check

- [X] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
