### PR TITLE
Download and compare simplecov reports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,6 +203,62 @@ jobs:
           INCLUDE_PATTERN: ${{ matrix.include-pattern }}
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern || ' ' }}
           DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
+      - name: Notify Slack channel on job failure
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: CI Deployment
+          SLACK_TITLE: Test failure
+          SLACK_MESSAGE: ${{ matrix.tests }} (feature-flags ${{ matrix.feature-flags }}) test failure on branch ${{ needs.build.outputs.GIT_BRANCH }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_COLOR: failure
+          SLACK_FOOTER: Sent from test job in build workflow
+
+  full-test-suite:
+    name: Full Test Suite
+    needs: [build]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    services:
+      redis:
+        image: redis:alpine
+        ports:
+          - 6379:6379
+      postgres:
+        image: postgres:11.10
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+        - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    defaults:
+      run:
+        working-directory: /app
+    container:
+      image: ghcr.io/dfe-digital/apply-teacher-training:${{ needs.build.outputs.IMAGE_TAG }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GH_CONTAINER_REGISTRY_TOKEN }}
+      env:
+        RAILS_ENV: test
+        DB_HOSTNAME: postgres
+        DB_USERNAME: postgres
+        DB_PASSWORD: postgres
+        REDIS_URL: redis://redis:6379/0
+        DB_PORT: 5432
+    outputs:
+        flakey_tests: ${{ steps.set_flakey_test_results_var.outputs.flakey_tests }}
+    steps:
+      - name: Setup Test Database
+        run: bundle exec rake db:setup
+      - name: Install chromedriver
+        run: apk add chromium chromium-chromedriver
+
+      - name: Run tests with feature flags on
+        run: bundle exec --verbose rspec
       - name: Read flakey test results
         id: set_flakey_test_results_var
         run: |
@@ -227,20 +283,10 @@ jobs:
         with:
           name: base-result
           path: /app/coverage/.resultset.json
-      - name: Notify Slack channel on job failure
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_USERNAME: CI Deployment
-          SLACK_TITLE: Test failure
-          SLACK_MESSAGE: ${{ matrix.tests }} (feature-flags ${{ matrix.feature-flags }}) test failure on branch ${{ needs.build.outputs.GIT_BRANCH }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_COLOR: failure
-          SLACK_FOOTER: Sent from test job in build workflow
 
   report-flakey-specs:
     name: Report on flakey specs in pull request
-    needs: [build, test]
+    needs: [build, full-test-suite]
     runs-on: ubuntu-latest
     steps:
       - name: Echo flakey test output
@@ -282,7 +328,7 @@ jobs:
 
   compare-coverage:
     name: Compare main and PR branch Simplecov coverage reports
-    needs: [build, test]
+    needs: [build, full-test-suite]
     runs-on: ubuntu-latest
     steps:
       - name: Download PR branch coverage artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -306,7 +306,7 @@ jobs:
 
       - name: Diff coverage resultsets
         id: diff-coverage-resultsets
-        uses: kzkn/simplecov-resultset-diff-action@v1
+        uses: DFE-Digital/simplecov-resultset-diff-action@v1.1.1
         with:
           base-resultset-path: base-result/.resultset.json
           head-resultset-path: head-result/.resultset.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,6 +280,38 @@ jobs:
               }
             }
 
+  compare-coverage:
+    name: Compare main and PR branch Simplecov coverage reports
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download PR branch coverage artifact
+        uses: actions/download-artifact@v2
+        id: download-head-coverage
+        with:
+          name: head-result
+          path: head-result/
+
+      - name: Download main branch coverage artifact
+        id: download-base-coverage
+        uses: dawidd6/action-download-artifact@v2
+        if: github.event_name == 'pull_request'
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          workflow: build.yml
+          workflow_conclusion: success
+          branch: main
+          name: base-result
+          path: base-result/
+
+      - name: Diff coverage resultsets
+        id: diff-coverage-resultsets
+        uses: kzkn/simplecov-resultset-diff-action@v1
+        with:
+          base-resultset-path: base-result/.resultset.json
+          head-resultset-path: head-result/.resultset.json
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   trigger-deployment:
     name: Trigger Deployment
     needs: [build, lint, test]


### PR DESCRIPTION
## Context

We would like to give a better indication of test coverage improvements on PR branch builds. For this we'll be using a Github action which diffs the `main` branch coverage report to the PR branch report.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds a build workflow step which 

- Downloads `main` branch coverage `.resultset,json`
- Downloads PR branch coverage `.resultset.json`
- Compares the two using [Simplecov resultset diff action](https://github.com/kzkn/simplecov-resultset-diff-action)

This will then produce a comment on the PR detailing test coverage changes.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

This PR build won't pass until we have a coverage report generated on the `main` branch.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/G2D7y5XO/4465-%F0%9F%8F%88-improve-testing-and-coverage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
