### PR TITLE
Update TAD export weekly method to use new name

### DIFF
--- a/app/services/support_interface/applications_by_subject_route_and_degree_grade_export.rb
+++ b/app/services/support_interface/applications_by_subject_route_and_degree_grade_export.rb
@@ -12,7 +12,7 @@ module SupportInterface
     def self.run_weekly
       data_export = DataExport.create!(
         name: 'Weekly export of the applications export grouped by subject, route and degree grade',
-        export_type: :tad_degree_class,
+        export_type: :applications_by_subject_route_and_degree_grade,
       )
       DataExporter.perform_async(SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport, data_export.id)
     end


### PR DESCRIPTION
## Context

The name of the TAD export was updated in this [PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/5993/commits/5977fff22048135f0ed26dd98585120d21c983fa) but was missed from the method that it used to run this export as part of the weekly job

## Changes proposed in this pull request

Update the `export_type` value to use the correct name.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
