### PR TITLE
Fix the Science GCSE controller error

### DIFF
--- a/app/controllers/candidate_interface/gcse/science/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/science/grade_controller.rb
@@ -53,10 +53,10 @@ module CandidateInterface
         'candidate_interface/gcse/science/grade/awards_new'
       elsif gcse_qualification?
         'candidate_interface/gcse/science/grade/awards_edit'
-      elsif current_qualification.award_year.nil?
-        'candidate_interface/gcse/science/grade/new'
       elsif update_path
         'candidate_interface/gcse/science/grade/edit'
+      else
+        'candidate_interface/gcse/science/grade/new'
       end
     end
 

--- a/app/controllers/candidate_interface/gcse/science/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/science/grade_controller.rb
@@ -25,7 +25,7 @@ module CandidateInterface
       @qualification_type = current_qualification.qualification_type
       @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path(@subject))
 
-      render view_path
+      render view_path(update_path: true)
     end
 
     def update
@@ -42,20 +42,20 @@ module CandidateInterface
         end
       else
         track_validation_error(@gcse_grade_form)
-        render view_path
+        render view_path(update_path: true)
       end
     end
 
   private
 
-    def view_path
+    def view_path(update_path: false)
       if gcse_qualification? && current_qualification.award_year.nil?
         'candidate_interface/gcse/science/grade/awards_new'
       elsif gcse_qualification?
         'candidate_interface/gcse/science/grade/awards_edit'
       elsif current_qualification.award_year.nil?
         'candidate_interface/gcse/science/grade/new'
-      else
+      elsif update_path
         'candidate_interface/gcse/science/grade/edit'
       end
     end

--- a/app/views/candidate_interface/gcse/science/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/science/grade/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(grade_step_title(@subject, @qualification_type), @gcse_grade_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(@return_to[:back_link]) %>
+<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_international_science_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_international_science_qualification_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate entering GCSE Science details' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their Science GCSE award' do
+    given_i_am_signed_in
+    and_i_wish_to_apply_to_a_course_that_requires_gcse_science
+    and_i_visit_the_site
+
+    and_i_click_on_the_science_gcse_link
+    then_i_see_the_add_gcse_science_page
+
+    when_i_select_a_non_uk_qualification
+    and_i_click_save_and_continue
+    and_i_select_the_country_i_studied_in
+    and_i_click_save_and_continue
+    then_i_see_the_add_enic_reference_page
+
+    when_i_fill_in_my_enic_reference_and_choose_an_equivalency
+    and_i_click_save_and_continue
+    then_i_see_the_add_grade_page
+
+    when_i_choose_other
+    and_i_fill_in_my_grade
+    and_i_click_save_and_continue
+    then_i_see_qualification_year_page
+
+    when_i_fill_in_the_year
+    and_i_click_save_and_continue
+    then_i_see_the_review_page_with_new_details
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_wish_to_apply_to_a_course_that_requires_gcse_science
+    course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Science')
+    course_option = create(:course_option, course: course)
+    current_candidate.current_application.application_choices << create(:application_choice, course_option: course_option)
+  end
+
+  def and_i_click_on_the_science_gcse_link
+    click_on 'Science GCSE or equivalent'
+  end
+
+  def then_i_see_the_add_gcse_science_page
+    expect(page).to have_content 'What type of qualification in science do you have?'
+  end
+
+  def when_i_select_a_non_uk_qualification
+    choose('Non-UK qualification')
+    within '#candidate-interface-gcse-qualification-type-form-qualification-type-non-uk-conditional' do
+      fill_in 'Qualification name', with: 'Diploma'
+    end
+  end
+
+  def and_i_click_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def and_i_select_the_country_i_studied_in
+    select 'Abu Dhabi'
+  end
+
+  def then_i_see_the_add_enic_reference_page
+    expect(page).to have_current_path candidate_interface_gcse_details_new_enic_path('science')
+  end
+
+  def when_i_fill_in_my_enic_reference_and_choose_an_equivalency
+    choose 'Yes'
+    fill_in 'candidate-interface-gcse-enic-form-enic-reference-field', with: '12345'
+    choose 'GCSE (grades A*-C / 9-4)'
+  end
+
+  def then_i_see_the_add_grade_page
+    expect(page).to have_current_path candidate_interface_new_gcse_science_grade_path
+  end
+
+  def when_i_choose_other
+    choose 'Other'
+  end
+
+  def and_i_fill_in_my_grade
+    fill_in 'Grade', with: 'A'
+  end
+
+  def when_i_fill_in_the_year
+    fill_in 'Enter year', with: '1990'
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def then_i_see_qualification_year_page
+    expect(page).to have_content t('gcse_edit_year.page_title', subject: 'science', qualification_type: 'qualification')
+  end
+
+  def then_i_see_the_review_page_with_new_details
+    expect(page).to have_content 'Science GCSE or equivalent'
+
+    expect(page).to have_content 'Diploma'
+    expect(page).to have_content 'Abu Dhabi'
+    expect(page).to have_content '12345'
+    expect(page).to have_content 'GCSE (grades A*-C / 9-4)'
+    expect(page).to have_content 'A'
+    expect(page).to have_content '1990'
+  end
+end


### PR DESCRIPTION
## Context

The science GCSE controller was causing sentry errors: https://sentry.io/organizations/dfe-bat/issues/2694951556/?project=1765973&referrer=slack

This is because the path to the view page was being conditionally rendered but when international candidates hit the `new` action they would fall through all the conditionals and reach the final else statement, which would render the `edit` page & would also require the `@return_to` variable to be passed in (which isn't set within the `new` action).

## Changes proposed in this pull request

Added a condition if it's `edit` or `update` action that's being called.

Updated existing spec.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/EoA7mlGq/

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
