### PR TITLE
Add an additional step to the dominant subject logic

### DIFF
--- a/app/services/support_interface/ministerial_report_applications_export.rb
+++ b/app/services/support_interface/ministerial_report_applications_export.rb
@@ -21,7 +21,9 @@ module SupportInterface
     def add_choice_to_report(choice, report)
       return report if choice.phase == 'apply_2' && !choice.is_latest_a2_app
 
-      subject = MinisterialReport.determine_dominant_course_subject_for_report(choice.course_name, choice.course_level, choice.subject_names.zip(choice.subject_codes).to_h)
+      subject_names_and_codes = choice.subject_names.zip(choice.subject_codes)
+
+      subject = MinisterialReport.determine_dominant_course_subject_for_report(choice.course_name, choice.course_level, subject_names_and_codes.to_h)
 
       MinisterialReport::APPLICATIONS_REPORT_STATUS_MAPPING[choice.status.to_sym].each do |mapped_status|
         report[:stem][mapped_status] += 1 if MinisterialReport::STEM_SUBJECTS.include? subject
@@ -68,6 +70,7 @@ module SupportInterface
         .where(application_form: { recruitment_cycle_year: RecruitmentCycle.current_year })
         .where.not(application_form: { submitted_at: nil })
         .group('application_choices.id, application_choices.status, application_form.id, application_form.phase, courses.name, courses.level, a2_latest_application_forms.candidate_id')
+        .order('subject_names, subject_codes')
     end
   end
 end

--- a/config/initializers/ministerial_report.rb
+++ b/config/initializers/ministerial_report.rb
@@ -204,6 +204,13 @@ module MinisterialReport
       end
     end
 
+    # is it a PE course
+    if !subject
+      subject = subject_names.find do |subject_name|
+        subject_name.to_s.downcase == 'physical education' && course_name.downcase.include?('pe')
+      end
+    end
+
     # take the first subject value if unable to match above
     if !subject
       subject = subject_names.first

--- a/config/initializers/ministerial_report.rb
+++ b/config/initializers/ministerial_report.rb
@@ -204,6 +204,11 @@ module MinisterialReport
       end
     end
 
+    # take the first subject value if unable to match above
+    if !subject
+      subject = subject_names.first
+    end
+
     subject_code_for_report = subject_names_and_codes[subject]
 
     SUBJECT_CODE_MAPPINGS[subject_code_for_report].presence || course_level.downcase.to_sym

--- a/spec/services/support_interface/ministerial_report_applications_export_spec.rb
+++ b/spec/services/support_interface/ministerial_report_applications_export_spec.rb
@@ -177,6 +177,39 @@ RSpec.describe SupportInterface::MinisterialReportApplicationsExport do
           },
         )
       end
+
+      it 'can match a physical education subject when the course is titled PE' do
+        application_form = create(:completed_application_form)
+        course = create(:course, name: 'PE with EBacc', level: 'secondary', subjects: [create(:subject, name: 'Biology', code: 'C1'), create(:subject, name: 'Physical education', code: 'C6')])
+        course_option = create(:course_option, course: course)
+        create(:application_choice, :with_accepted_offer, course_option: course_option, application_form: application_form)
+
+        data = described_class.new.call
+
+        expect(data).to include(
+          {
+            subject: :physical_education,
+            applications: 1,
+            offer_received: 1,
+            accepted: 1,
+            application_declined: 0,
+            application_rejected: 0,
+            application_withdrawn: 0,
+          },
+        )
+
+        expect(data).not_to include(
+          {
+            subject: :biology,
+            applications: 1,
+            offer_received: 1,
+            accepted: 1,
+            application_declined: 0,
+            application_rejected: 0,
+            application_withdrawn: 0,
+          },
+        )
+      end
     end
   end
 end

--- a/spec/services/support_interface/ministerial_report_applications_export_spec.rb
+++ b/spec/services/support_interface/ministerial_report_applications_export_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe SupportInterface::MinisterialReportApplicationsExport do
         )
       end
 
-      it 'defaults the subject to a subtotal when it cannot find the dominant subject' do
+      it 'takes the first subject in the array when it cannot find the dominant subject' do
         application_form = create(:completed_application_form)
         course = create(:course, name: 'Nonsense course', level: 'secondary', subjects: [create(:subject, name: 'Business studies', code: '08'), create(:subject, name: 'History', code: 'V1')])
         course_option = create(:course_option, course: course)
@@ -157,18 +157,6 @@ RSpec.describe SupportInterface::MinisterialReportApplicationsExport do
 
         expect(data).to include(
           {
-            subject: :secondary,
-            applications: 1,
-            offer_received: 1,
-            accepted: 1,
-            application_declined: 0,
-            application_rejected: 0,
-            application_withdrawn: 0,
-          },
-        )
-
-        expect(data).not_to include(
-          {
             subject: :business_studies,
             applications: 1,
             offer_received: 1,
@@ -177,9 +165,7 @@ RSpec.describe SupportInterface::MinisterialReportApplicationsExport do
             application_rejected: 0,
             application_withdrawn: 0,
           },
-        )
-
-        expect(data).not_to include(
+        ).or include(
           {
             subject: :history,
             applications: 1,


### PR DESCRIPTION
## Context

For the ministerial report exports we are required to assign a dominant subject for courses that have multiple subjects associated. The logic for this has multiple steps due to the various edge cases, the final fallback – if unable to map – is to just add the count to a subtotal row. 

Following on from further discussions we've decided to amend the approach to have an additional step, before reaching this point, that will just take whatever the first subject is and set the subject value to that.

These four courses (and the associated subjects) were the ones falling through to the subtotal logic:
`["Food and Nutrition", "Secondary", {"Primary"=>"00", "Design and technology"=>"DT"}]`
`[“Humanities", "Secondary", {"History"=>"V1", "Geography"=>"F8"}]`
`["Modern Languages 11-16", "Secondary", {"Spanish"=>"22", "French"=>"15"}]`
`["PE with EBacc", "Secondary", {"Biology"=>"C1", "Communication and media studies"=>"P3", "Physical education"=>"C6"}]
`

## Changes proposed in this pull request

This has been added to the `MinisterialReport.determine_dominant_course_subject_for_report` method:
```
    if !subject
      subject = subject_names.first
    end
```

And this has been added
```
    if !subject
      subject = subject_names.find do |subject_name|
        subject_name.to_s.downcase == 'physical education' && course_name.downcase.include?('pe')
      end
    end
```
To deal with this edge case:
`["PE with EBacc", "Secondary", {"Biology"=>"C1", "Communication and media studies"=>"P3", "Physical education"=>"C6"}]
`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
