### PR TITLE
Fix the external report exports

### DIFF
--- a/app/services/support_interface/external_report_candidates_export.rb
+++ b/app/services/support_interface/external_report_candidates_export.rb
@@ -69,7 +69,6 @@ module SupportInterface
             SELECT
                 c.id,
                 f.id,
-                ac.id,
                 CASE
                   WHEN f.equality_and_diversity is NULL THEN 'Not provided'
                   WHEN f.equality_and_diversity->> 'sex' = 'intersex' then 'Intersex'
@@ -152,7 +151,7 @@ module SupportInterface
                   AND ac.status_before_deferral IS NOT NULL
               )
             GROUP BY
-                c.id, ac.id, f.id
+                c.id, f.id
         )
         SELECT
             raw_data.sex,

--- a/spec/services/support_interface/external_report_candidates_export_spec.rb
+++ b/spec/services/support_interface/external_report_candidates_export_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe SupportInterface::ExternalReportCandidatesExport do
                              end
 
           create(:application_choice, status: status, application_form: application_form)
+          create(:application_choice, :with_rejection, application_form: application_form)
         end
       end
 


### PR DESCRIPTION
## Context

Currently, there are some bugs in the external report exports. On the candidates export, all application choices are being counted due to an error in the grouping clause

On the applications export, we're currently not filtering out deferred offers and adding the ones from last year. Additionally it should only be for submitted applications

## Changes proposed in this pull request

- Ensure application forms are only being counted once in the candidates export
- Ensure that deferrals are being counted correctly and only count submitted applications in the applications export

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
