### PR TITLE
Add flakey test report comments to pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,8 @@ jobs:
         DB_PASSWORD: postgres
         REDIS_URL: redis://redis:6379/0
         DB_PORT: 5432
+    outputs:
+        flakey_tests: ${{ steps.set_flakey_test_results_var.outputs.flakey_tests }}
     steps:
       - name: Setup Parallel Database
         run: bundle exec rake parallel:setup
@@ -174,6 +176,54 @@ jobs:
           INCLUDE_PATTERN: ${{ matrix.include-pattern }}
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern || ' ' }}
           DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
+      - name: Read flakey test results
+        id: set_flakey_test_results_var
+        run: |
+          file_text=$(cat /app/tmp/rspec-retry-flakey-specs.log)
+          file_text="${file_text//$'\n'/%0A}"
+          echo "::set-output name=flakey_tests::$file_text"
+
+  report-flakey-specs:
+    name: Report on flakey specs in pull request
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo flakey test output
+        run: echo "${{ needs.test.outputs.flakey_tests }}"
+
+      - name: Comment on flakey specs in pull request
+        uses: actions/github-script@0.5.0
+        if: github.event_name == 'pull_request'
+        env:
+          FLAKEY_TEST_DATA: |
+            ${{ needs.test.outputs.flakey_tests }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { FLAKEY_TEST_DATA, GITHUB_HEAD_REF } = process.env;
+            if (FLAKEY_TEST_DATA.length) {
+              const { issue: { number: issue_number }, repo: { owner, repo } } = context;
+              let commentBody = '<h2>You have one or more flakey tests on this branch! :snowflake: :snowflake: :snowflake:</h2>';
+              let dataStr, dataAry, attempts, retryCount, errorLocation, errorPath, errorMessages, errorLink;
+              let branchName = GITHUB_HEAD_REF.split('/').pop();
+              let createComment = false;
+              let rows = FLAKEY_TEST_DATA.split("\n");
+              let rowsLength = rows.length;
+              for (var idx = 0; idx < rowsLength; idx++) {
+                dataStr = rows[idx];
+                if (dataStr.length) {
+                  dataAry = dataStr.split(',');
+                  [attempts, retryCount, errorLocation, ...errorMessages] = dataAry;
+                  errorPath = `/${owner}/${repo}/blob/${branchName}/${errorLocation.replace(':', '#L')}`;
+                  errorLink = `<a href="${errorPath}">${errorLocation}</a>`;
+                  commentBody += `Failed ${attempts} out of ${retryCount} times at ${errorLink}: :warning: ${errorMessages.join(' :warning: ')}<br>`;
+                  createComment = true;
+                }
+              }
+              if (createComment) {
+                github.issues.createComment({ issue_number, owner, repo, body: commentBody });
+              }
+            }
 
   trigger-deployment:
     name: Trigger Deployment

--- a/Gemfile
+++ b/Gemfile
@@ -163,6 +163,7 @@ group :test do
   gem 'deepsort'
   gem 'ruby-jmeter'
   gem 'super_diff'
+  gem 'rspec-retry', git: 'https://github.com/DFE-Digital/rspec-retry.git', branch: 'main'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,14 @@ GIT
     audited (4.10.0)
       activerecord (>= 4.2, < 6.2)
 
+GIT
+  remote: https://github.com/DFE-Digital/rspec-retry.git
+  revision: c43713cbe66311cf44ebe5d56e57c422cfe14340
+  branch: main
+  specs:
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -747,6 +755,7 @@ DEPENDENCIES
   request_store_rails
   rouge
   rspec-rails
+  rspec-retry!
   rspec_junit_formatter
   rubocop
   rubocop-rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,11 +26,25 @@ end
 require 'sidekiq/testing'
 require 'clockwork/test'
 require 'audited-rspec'
+require 'rspec/retry'
+require 'rspec/core/formatters/base_text_formatter'
 
 ENV['SERVICE_TYPE'] = 'test' # this is used for logging
 ENV['STATE_CHANGE_SLACK_URL'] = nil # ensure tests send no Slack notifications
 
 RSpec.configure do |config|
+  # RSpec-retry configuration, retry and log any indeterminate tests.
+  config.verbose_retry = true
+  config.display_try_failure_messages = true
+  reporter = RSpec::Core::Reporter.new(config)
+  formatter = RSpec::Core::Formatters::BaseTextFormatter.new(File.open('tmp/rspec-retry-flakey-specs.log', 'ab'))
+  reporter.register_listener(formatter, 'message')
+  config.retry_reporter = reporter
+
+  config.around do |ex|
+    ex.run_with_retry retry: 3
+  end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
## Context

We sometimes encounter indeterminate or flakey specs in our builds and tracking these is currently a manual process.
We'd like to make these flakey specs more visible to both PR author and reviewer.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Add the test dependency rspec-retry and configure it to run up to 3 times for failing specs
- If a spec fails then passes in the 3 retries, it is deemed flakey and logged to `tmp/rspec-retry-flakey-specs.log`
- Github workflow reads the file contents into a variable and creates a PR comment where appropriate.
- PR comment contains a link to the offending failing test(s)

eg. 

![image](https://user-images.githubusercontent.com/93511/142000082-ae97235f-0023-4993-b694-a8f60b348595.png)

Paired with @JR-G on rspec-retry fork.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/G2D7y5XO/4465-%F0%9F%8F%88-improve-testing-and-coverage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
