### PR TITLE
Add an optional essential cookies row for chat widget cookie

### DIFF
--- a/app/views/content/cookies.html.erb
+++ b/app/views/content/cookies.html.erb
@@ -51,6 +51,19 @@
           6 months
         </td>
       </tr>
+      <% if request.path == '/provider/cookies' -%>
+      <tr>
+        <td class="govuk-table__cell">
+          __zlcmid
+        </td>
+        <td class="govuk-table__cell">
+          Store customer ID for chat widget authentication
+        </td>
+        <td class="govuk-table__cell">
+          365 days
+        </td>
+      </tr>
+      <% end -%>
       </tbody>
     </table>
 


### PR DESCRIPTION
## Context

The provider interface sets a cookie for the chat widget which should be documented on the `/provider/cookies` page.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Add a conditional row to the provider cookies page documenting the chat widget cookie.
<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/142015069-be65ea4f-8341-4dc9-8e77-e4cfcce54f22.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/TCd0GBaP/4505-update-cookie-policy-to-let-users-know-what-cookies-are-in-place-when-using-zendesk-webchat
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
