### PR TITLE
Update referee flow

### DIFF
--- a/app/components/referee_interface/feedback_hints_component.html.erb
+++ b/app/components/referee_interface/feedback_hints_component.html.erb
@@ -1,13 +1,11 @@
 <p class="govuk-body">You could comment on things like their:</p>
 
 <ul class="govuk-list govuk-list--bullet">
-  <% if @academic %>
-    <li>academic skills</li>
-  <% end %>
   <li>communication skills</li>
   <li>reliability and professionalism</li>
-  <li>ability to work with children</li>
   <li>transferable skills</li>
+  <li>ability to work with children</li>
+  <li>academic skills</li>
 </ul>
 
 <p class="govuk-body">You can write up to 500 words. </p>

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -142,12 +142,12 @@ module RefereeInterface
       @application_form = reference.application_form
     end
 
-    def decline
+    def confirm_decline
       @application = reference.application_form
       @confirm_refuse_feedback_form = ConfirmRefuseFeedbackForm.new
     end
 
-    def confirm_decline
+    def decline
       ConfirmRefuseFeedbackForm.new.save(reference)
       redirect_to referee_interface_finish_path(token: @token_param)
     end

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -17,7 +17,7 @@ module RefereeInterface
       @relationship = reference.relationship
       @relationship_form = ReferenceRelationshipForm.build_from_reference(reference: reference)
 
-      @previous_path = previous_path(previous_path_in_flow: nil)
+      @previous_path = previous_path(previous_path_in_flow: referee_interface_refuse_feedback_path(token: @token_param))
     end
 
     def confirm_relationship
@@ -131,8 +131,7 @@ module RefereeInterface
       render :refuse_feedback and return unless @refuse_feedback_form.valid?
 
       if @refuse_feedback_form.referee_has_confirmed_they_wont_a_reference?
-        @refuse_feedback_form.save(reference)
-        redirect_to referee_interface_thank_you_path(token: @token_param)
+        redirect_to referee_interface_decline_reference_path(token: @token_param)
       else
         redirect_to referee_interface_reference_relationship_path(token: @token_param, from: 'refuse')
       end
@@ -141,6 +140,16 @@ module RefereeInterface
     def finish
       @reference_cancelled = reference.cancelled?
       @application_form = reference.application_form
+    end
+
+    def decline
+      @application = reference.application_form
+      @confirm_refuse_feedback_form = ConfirmRefuseFeedbackForm.new
+    end
+
+    def confirm_decline
+      ConfirmRefuseFeedbackForm.new.save(reference)
+      redirect_to referee_interface_finish_path(token: @token_param)
     end
 
     def thank_you; end

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -120,20 +120,22 @@ module RefereeInterface
     end
 
     def refuse_feedback
-      @refuse_feedback_form = RefuseFeedbackForm.new
+      @refuse_feedback_form = RefuseFeedbackForm.build_from_reference(reference: reference)
       @application = reference.application_form
     end
 
     def confirm_feedback_refusal
-      @refuse_feedback_form = RefuseFeedbackForm.new(choice: choice_params)
+      @refuse_feedback_form = RefuseFeedbackForm.new(refused: refused_params)
       @application = reference.application_form
 
       render :refuse_feedback and return unless @refuse_feedback_form.valid?
 
-      if @refuse_feedback_form.referee_has_confirmed_they_wont_a_reference?
-        redirect_to referee_interface_decline_reference_path(token: @token_param)
-      else
-        redirect_to referee_interface_reference_relationship_path(token: @token_param, from: 'refuse')
+      if @refuse_feedback_form.save(reference)
+        if @reference.refused
+          redirect_to referee_interface_decline_reference_path(token: @token_param)
+        else
+          redirect_to referee_interface_reference_relationship_path(token: @token_param, from: 'refuse')
+        end
       end
     end
 
@@ -218,8 +220,8 @@ module RefereeInterface
             .permit(:any_safeguarding_concerns, :safeguarding_concerns)
     end
 
-    def choice_params
-      params.dig(:referee_interface_refuse_feedback_form, :choice)
+    def refused_params
+      params.dig(:referee_interface_refuse_feedback_form, :refused)
     end
   end
 end

--- a/app/forms/referee_interface/confirm_refuse_feedback_form.rb
+++ b/app/forms/referee_interface/confirm_refuse_feedback_form.rb
@@ -1,0 +1,20 @@
+module RefereeInterface
+  class ConfirmRefuseFeedbackForm
+    include ActiveModel::Model
+
+    def save(reference)
+      reference.update!(feedback_status: :feedback_refused, feedback_refused_at: Time.zone.now)
+      send_slack_notification(reference)
+      SendNewRefereeRequestEmail.call(reference: reference, reason: :refused)
+    end
+
+  private
+
+    def send_slack_notification(reference)
+      message = ":sadparrot: A referee declined to give feedback for #{reference.application_form.first_name}’s application"
+      url = Rails.application.routes.url_helpers.support_interface_application_form_url(reference.application_form)
+
+      SlackNotificationWorker.perform_async(message, url)
+    end
+  end
+end

--- a/app/forms/referee_interface/refuse_feedback_form.rb
+++ b/app/forms/referee_interface/refuse_feedback_form.rb
@@ -2,12 +2,22 @@ module RefereeInterface
   class RefuseFeedbackForm
     include ActiveModel::Model
 
-    attr_accessor :choice
+    attr_accessor :refused
 
-    validates :choice, presence: true
+    validates :refused, presence: true
 
-    def referee_has_confirmed_they_wont_a_reference?
-      choice == 'yes'
+    def self.build_from_reference(reference:)
+      refused = reference.refused ? 'yes' : 'no' unless reference.refused.nil?
+
+      new(refused: refused)
+    end
+
+    def save(application_reference)
+      return false unless valid?
+
+      application_reference.update!(
+        refused: refused != 'no',
+      )
     end
   end
 end

--- a/app/forms/referee_interface/refuse_feedback_form.rb
+++ b/app/forms/referee_interface/refuse_feedback_form.rb
@@ -6,25 +6,8 @@ module RefereeInterface
 
     validates :choice, presence: true
 
-    def save(reference)
-      return false unless valid?
-
-      reference.update!(feedback_status: :feedback_refused, feedback_refused_at: Time.zone.now)
-      send_slack_notification(reference)
-      SendNewRefereeRequestEmail.call(reference: reference, reason: :refused)
-    end
-
     def referee_has_confirmed_they_wont_a_reference?
       choice == 'yes'
-    end
-
-  private
-
-    def send_slack_notification(reference)
-      message = ":sadparrot: A referee declined to give feedback for #{reference.application_form.first_name}’s application"
-      url = Rails.application.routes.url_helpers.support_interface_application_form_url(reference.application_form)
-
-      SlackNotificationWorker.perform_async(message, url)
     end
   end
 end

--- a/app/views/referee_interface/reference/confirm_decline.html.erb
+++ b/app/views/referee_interface/reference/confirm_decline.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.referee.decline'), @refuse_feedback_form&.errors&.any?) %>
+<% content_for :title, t('page_titles.referee.decline') %>
 <% content_for :before_content, govuk_back_link_to(referee_interface_refuse_feedback_path(token: @token_param)) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referee_interface/reference/decline.html.erb
+++ b/app/views/referee_interface/reference/decline.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.referee.decline'), @refuse_feedback_form&.errors&.any?) %>
+<% content_for :before_content, govuk_back_link_to(referee_interface_refuse_feedback_path(token: @token_param)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Are you sure you are unable to give <%= @application.full_name %> a reference?
+    </h1>
+    <%= form_with(
+      model: @confirm_refuse_feedback_form,
+      url: referee_interface_decline_reference_path(token: @token_param),
+      method: :patch,
+    ) do |f| %>
+      <%= f.govuk_submit 'Yes, I am unable to give a reference' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/referee_interface/reference/refuse_feedback.html.erb
+++ b/app/views/referee_interface/reference/refuse_feedback.html.erb
@@ -1,23 +1,17 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.referee.refuse_feedback'), @refuse_feedback_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.referee.refuse_feedback', full_name: @application.full_name), @refuse_feedback_form.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @refuse_feedback_form,
-      url: referee_interface_refuse_feedback_path(token: @token_param),
+      url: referee_interface_refuse_feedback_path(token: @token_param, choice: @choice),
       method: :patch,
     ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        <%= t('page_titles.referee.refuse_feedback') %>
-      </h1>
-
-      <p class="govuk-body">Declining <%= @application.full_name %>’s reference request may delay their application and make it harder for them to get onto teacher training.</p>
-
-      <%= f.govuk_radio_buttons_fieldset :choices, legend: { text: t('referee.refuse_feedback.choice.label', full_name: @application.full_name) } do %>
-        <%= f.govuk_radio_button :choice, 'yes', label: { text: t('referee.refuse_feedback.choice.confirm') }, link_errors: true %>
+      <%= f.govuk_radio_buttons_fieldset :choices, legend: { text: t('referee.refuse_feedback.choice.label', full_name: @application.full_name), size: 'l' } do %>
         <%= f.govuk_radio_button :choice, 'no', label: { text: t('referee.refuse_feedback.choice.cancel') } %>
+        <%= f.govuk_radio_button :choice, 'yes', label: { text: t('referee.refuse_feedback.choice.confirm') }, link_errors: true %>
       <% end %>
 
       <%= f.govuk_submit t('continue') %>

--- a/app/views/referee_interface/reference/refuse_feedback.html.erb
+++ b/app/views/referee_interface/reference/refuse_feedback.html.erb
@@ -4,14 +4,14 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @refuse_feedback_form,
-      url: referee_interface_refuse_feedback_path(token: @token_param, choice: @choice),
+      url: referee_interface_refuse_feedback_path(token: @token_param),
       method: :patch,
     ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :choices, legend: { text: t('referee.refuse_feedback.choice.label', full_name: @application.full_name), size: 'l' } do %>
-        <%= f.govuk_radio_button :choice, 'no', label: { text: t('referee.refuse_feedback.choice.cancel') } %>
-        <%= f.govuk_radio_button :choice, 'yes', label: { text: t('referee.refuse_feedback.choice.confirm') }, link_errors: true %>
+      <%= f.govuk_radio_buttons_fieldset :refused, legend: { text: t('referee.refuse_feedback.choice.label', full_name: @application.full_name), size: 'l', tag: 'h1' } do %>
+        <%= f.govuk_radio_button :refused, :no, label: { text: t('referee.refuse_feedback.choice.cancel') }, link_errors: true %>
+        <%= f.govuk_radio_button :refused, :yes, label: { text: t('referee.refuse_feedback.choice.confirm') } %>
       <% end %>
 
       <%= f.govuk_submit t('continue') %>

--- a/app/views/referee_interface/reference/relationship.html.erb
+++ b/app/views/referee_interface/reference/relationship.html.erb
@@ -1,8 +1,6 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.referee.relationship', full_name: @application.full_name), @relationship_form.errors.any?) %>
 
-<% if @previous_path %>
-  <% content_for :before_content, govuk_back_link_to(@previous_path) %>
-<% end %>
+<% content_for :before_content, govuk_back_link_to(@previous_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -1,34 +1,26 @@
 Dear <%= @reference.name %>,
 
-<%= @candidate_name %> put us in touch with you to get a reference for their teacher training application.
+<%= @candidate_name %> is asking for a reference for their teacher training application.
 
-# If you would like to give a reference
+To give a reference you’ll need to write up to 500 words about <%= @candidate_name %>’s potential to teach.
 
-Use this form to give your reference:
+You could talk about their:
 
-<%= referee_interface_reference_relationship_url(token: @unhashed_token) %>
-
-References sent by email will not be accepted.
-
-You’ll be asked to write up to 500 words explaining whether <%= @candidate_name %> has the potential to teach. You could comment on their:
-
-* academic skills
 * communication skills
 * reliability and professionalism
-* ability to work with children
 * transferable skills
+* ability to work with children
+* academic skills
 
-You can start, save and return to your reference at any time.
+Please give your reference as soon as you can, or let us know if you cannot give one:
 
-The candidate will not be able to see what you write.
+<%= referee_interface_url(token: @unhashed_token) %>
 
-Teacher training courses can become full at any time. The sooner <%= @candidate_name %> gets a reference, the more likely it is that they’ll get a place.
+We cannot accept references sent by email.
 
-# If you do not intend to give a reference
+Teacher training places can fill up at any time. Your reference will help <%= @candidate_name %> secure a place quickly.
 
-If you cannot meet the requirements outlined above or you decline to give a reference for another reason, let us know as soon as possible:
-
-<%= referee_interface_refuse_feedback_url(token: @unhashed_token) %>
+The candidate will not be able to see what you write about them.
 
 # Get support
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,13 +171,14 @@ en:
     application_feedback_thank_you: Thank you for your feedback
     find_feedback: Help us improve this service
     referee:
-      refuse_feedback: Decline to give a reference
+      refuse_feedback: A reference for %{full_name}
       relationship: Confirm how you know %{full_name}
       safeguarding: Do you know of any reason why %{full_name} should not work with children?
       feedback: Does %{full_name} have the potential to teach?
       review: Your reference for %{full_name}
       confirmation: Your reference for %{full_name} has been submitted
       finish: Thank you
+      decline: Decline to give a reference
     providers: Courses on this service
     decisions:
       offer: Details of offer

--- a/config/locales/referee_interface/referee_interface.yml
+++ b/config/locales/referee_interface/referee_interface.yml
@@ -2,9 +2,9 @@ en:
   referee:
     refuse_feedback:
       choice:
-        label: Can you give %{full_name} a reference?
-        confirm: No, I decline to give a reference
-        cancel: Yes, I can give a reference
+        label: Can you give a reference for %{full_name}?
+        confirm: No, I am unable to give a reference
+        cancel: Yes, I can give them a reference
     relationship_confirmation:
       legend: Is this correct?
       'yes':
@@ -76,8 +76,8 @@ en:
               too_many_words: Your reference must be %{count} words or fewer
         referee_interface/refuse_feedback_form:
           attributes:
-            choice:
-              blank: Choose whether to decline this reference request
+            refused:
+              blank: Select yes if you can give a reference
         receive_reference:
           attributes:
             feedback:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -609,8 +609,8 @@ Rails.application.routes.draw do
     patch '/questionnaire' => 'reference#submit_questionnaire', as: :submit_questionnaire
     get '/finish' => 'reference#finish', as: :finish
 
-    get '/decline' => 'reference#decline', as: :decline_reference
-    patch '/decline' => 'reference#confirm_decline'
+    get '/decline' => 'reference#confirm_decline', as: :decline_reference
+    patch '/decline' => 'reference#decline'
 
     get '/thank-you' => 'reference#thank_you', as: :thank_you
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -589,7 +589,10 @@ Rails.application.routes.draw do
   end
 
   namespace :referee_interface, path: '/reference' do
-    get '/' => 'reference#relationship', as: :reference_relationship
+    get '/' => 'reference#refuse_feedback', as: :refuse_feedback
+    patch '/' => 'reference#confirm_feedback_refusal'
+
+    get '/relationship' => 'reference#relationship', as: :reference_relationship
     patch '/confirm-relationship' => 'reference#confirm_relationship', as: :confirm_relationship
 
     get '/safeguarding' => 'reference#safeguarding', as: :safeguarding
@@ -606,8 +609,8 @@ Rails.application.routes.draw do
     patch '/questionnaire' => 'reference#submit_questionnaire', as: :submit_questionnaire
     get '/finish' => 'reference#finish', as: :finish
 
-    get '/refuse-feedback' => 'reference#refuse_feedback', as: :refuse_feedback
-    patch '/refuse-feedback' => 'reference#confirm_feedback_refusal'
+    get '/decline' => 'reference#decline', as: :decline_reference
+    patch '/decline' => 'reference#confirm_decline'
 
     get '/thank-you' => 'reference#thank_you', as: :thank_you
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -613,6 +613,8 @@ Rails.application.routes.draw do
     patch '/decline' => 'reference#decline'
 
     get '/thank-you' => 'reference#thank_you', as: :thank_you
+
+    get '/refuse-feedback', to: redirect(path: '/reference')
   end
 
   namespace :vendor_api, path: 'api/v1' do

--- a/spec/components/referee_interface/feedback_hints_component_spec.rb
+++ b/spec/components/referee_interface/feedback_hints_component_spec.rb
@@ -1,23 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe RefereeInterface::FeedbackHintsComponent do
-  context 'when it is an academic reference' do
-    let(:reference) { build_stubbed(:reference, referee_type: :academic) }
+  let(:reference) { build_stubbed(:reference, referee_type: :academic) }
 
-    it 'displays the academic skills bullet point' do
-      result = render_inline(described_class.new(reference: reference))
+  it 'displays the academic skills bullet point' do
+    result = render_inline(described_class.new(reference: reference))
 
-      expect(result.text).to include('academic skills')
-    end
-  end
-
-  context 'when it is non-academic reference' do
-    let(:reference) { build_stubbed(:reference, referee_type: :school_based) }
-
-    it 'does not display that the academic skills bullet point' do
-      result = render_inline(described_class.new(reference: reference))
-
-      expect(result.text).not_to include('academic skills')
-    end
+    expect(result.text).to include('academic skills')
   end
 end

--- a/spec/forms/referee_interface/confirm_refuse_feedback_form_spec.rb
+++ b/spec/forms/referee_interface/confirm_refuse_feedback_form_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe RefereeInterface::ConfirmRefuseFeedbackForm do
+  describe '#save' do
+    let(:application_reference) { create(:reference, :feedback_requested) }
+
+    context 'when the form is valid' do
+      it 'updates the reference to feedback_refused and sets the feedback_refused_at to the current time and sends a slack message' do
+        Timecop.freeze do
+          form = described_class.new
+          form.save(application_reference)
+
+          expect(application_reference.feedback_status).to eq('feedback_refused')
+          expect(application_reference.feedback_refused_at).to eq(Time.zone.now)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/referee_interface/refuse_feedback_form_spec.rb
+++ b/spec/forms/referee_interface/refuse_feedback_form_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe RefereeInterface::RefuseFeedbackForm do
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:choice) }
+    it { is_expected.to validate_presence_of(:refused) }
 
     describe '#save' do
       let(:application_reference) { create(:reference, :feedback_requested) }
@@ -15,15 +15,21 @@ RSpec.describe RefereeInterface::RefuseFeedbackForm do
         end
       end
 
-      context 'when the form is valid' do
-        it 'updates the reference to feedback_refused and sets the feedback_refused_at to the current time' do
-          Timecop.freeze do
-            form = described_class.new(choice: 'yes')
-            form.save(application_reference)
+      context 'when the form is valid and the reference was refused' do
+        it 'updates the reference refused status' do
+          form = described_class.new(refused: 'yes')
+          form.save(application_reference)
 
-            expect(application_reference.feedback_status).to eq('feedback_refused')
-            expect(application_reference.feedback_refused_at).to eq(Time.zone.now)
-          end
+          expect(application_reference.refused).to eq(true)
+        end
+      end
+
+      context 'when the form is valid and the reference was not refused' do
+        it 'updates the reference refused status' do
+          form = described_class.new(refused: 'no')
+          form.save(application_reference)
+
+          expect(application_reference.refused).to eq(false)
         end
       end
     end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_application_with_references_to_new_cycle_and_referee_provides_reference_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_application_with_references_to_new_cycle_and_referee_provides_reference_spec.rb
@@ -27,6 +27,7 @@ RSpec.feature 'Carry over' do
 
     when_i_sign_out_as_the_candidate
     and_i_sign_in_as_the_referee
+    and_i_select_yes_to_giving_a_reference
     then_i_am_asked_to_provide_a_reference_for_the_candidate
 
     when_i_submit_the_outstanding_reference
@@ -101,6 +102,11 @@ RSpec.feature 'Carry over' do
   def and_i_sign_in_as_the_referee
     open_email(@reference.email_address)
     click_sign_in_link(current_email)
+  end
+
+  def and_i_select_yes_to_giving_a_reference
+    choose 'Yes, I can give them a reference'
+    click_button t('continue')
   end
 
   def then_i_am_asked_to_provide_a_reference_for_the_candidate

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
     then_i_see_page_not_found
 
     when_i_click_on_the_link_within_the_email
+    and_i_select_yes_to_giving_a_reference
     then_i_am_asked_to_confirm_my_relationship_with_the_candidate
 
     when_i_click_on_save_and_continue
@@ -122,6 +123,11 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
 
   def when_i_click_on_the_link_within_the_email
     click_sign_in_link(current_email)
+  end
+
+  def and_i_select_yes_to_giving_a_reference
+    choose 'Yes, I can give them a reference'
+    click_button t('continue')
   end
 
   def then_i_am_asked_to_confirm_my_relationship_with_the_candidate

--- a/spec/system/referee_interface/referee_can_use_initial_and_chaser_sign_in_links_spec.rb
+++ b/spec/system/referee_interface/referee_can_use_initial_and_chaser_sign_in_links_spec.rb
@@ -7,13 +7,16 @@ RSpec.feature 'Referee can use sign in link in the initial and chaser email' do
     given_i_am_a_referee_of_an_submitted_application
     and_i_received_the_initial_reference_request_email
     when_i_click_on_the_link_within_the_initial_email
+    and_i_select_yes_to_giving_a_reference
     then_i_am_asked_to_confirm_my_relationship_with_the_candidate
 
     given_i_received_the_chaser_reference_request_email
     when_i_click_on_the_link_within_the_chaser_email
+    and_i_select_yes_to_giving_a_reference
     then_i_am_asked_to_confirm_my_relationship_with_the_candidate
 
     when_i_click_on_the_link_within_the_initial_email
+    and_i_select_yes_to_giving_a_reference
     then_i_am_asked_to_confirm_my_relationship_with_the_candidate
   end
 
@@ -30,6 +33,11 @@ RSpec.feature 'Referee can use sign in link in the initial and chaser email' do
     open_email(@reference.email_address)
 
     click_sign_in_link(current_emails.first)
+  end
+
+  def and_i_select_yes_to_giving_a_reference
+    choose 'Yes, I can give them a reference'
+    click_button t('continue')
   end
 
   def then_i_am_asked_to_confirm_my_relationship_with_the_candidate

--- a/spec/system/referee_interface/referee_does_not_respond_spec.rb
+++ b/spec/system/referee_interface/referee_does_not_respond_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Referee does not respond in time' do
 
     expect(current_emails.size).to be(1)
 
-    expect(current_email.text).to include('If you would like to give a reference')
+    expect(current_email.text).to include('Please give your reference as soon as you can')
   end
 
   def and_an_email_is_sent_to_the_candidate

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -8,15 +8,15 @@ RSpec.feature 'Refusing to give a reference' do
     and_i_received_the_initial_reference_request_email
     then_i_receive_an_email_with_a_reference_request
 
-    when_i_click_the_refuse_reference_link_in_the_email
-    and_choose_that_i_do_actually_want_to_give_a_reference
-    then_i_see_the_reference_relationship_page
+    when_i_click_the_reference_link
+    then_i_see_the_give_a_reference_page
 
-    when_i_click_on_the_backlink
+    when_i_select_no_to_giving_a_reference
+    then_i_see_the_confirmation_page
     and_i_confirm_that_i_wont_give_a_reference
     and_a_slack_notification_is_sent
     then_an_email_is_sent_to_the_candidate
-    and_i_should_see_the_thank_you_page
+    then_i_should_see_the_thank_you_page
   end
 
   def given_i_am_a_referee_of_an_application
@@ -32,26 +32,25 @@ RSpec.feature 'Refusing to give a reference' do
     open_email('terri@example.com')
   end
 
-  def when_i_click_the_refuse_reference_link_in_the_email
-    current_email.click_link(refuse_feedback_url)
+  def when_i_click_the_reference_link
+    current_email.click_link(give_feedback_url)
   end
 
-  def and_choose_that_i_do_actually_want_to_give_a_reference
-    choose 'Yes, I can give a reference'
+  def then_i_see_the_give_a_reference_page
+    expect(page).to have_content("Can you give a reference for #{@application.full_name}?")
+  end
+
+  def when_i_select_no_to_giving_a_reference
+    choose 'No, I am unable to give a reference'
     click_button t('continue')
   end
 
-  def then_i_see_the_reference_relationship_page
-    expect(page).to have_content("Confirm how you know #{@application.full_name}")
-  end
-
-  def when_i_click_on_the_backlink
-    click_link 'Back'
+  def and_i_see_the_confirmation_page
+    expect(page).to have_content("Are you sure you are unable to give #{@application.full_name} a reference?")
   end
 
   def and_i_confirm_that_i_wont_give_a_reference
-    choose 'No, I decline to give a reference'
-    click_button t('continue')
+    click_button t('Yes, I am unable to give a reference')
   end
 
   def and_a_slack_notification_is_sent
@@ -64,14 +63,14 @@ RSpec.feature 'Refusing to give a reference' do
     expect(current_email.subject).to have_content('Terri Tudor has declined your reference request')
   end
 
-  def and_i_should_see_the_thank_you_page
+  def then_i_should_see_the_thank_you_page
     expect(page).to have_content('Thank you')
   end
 
 private
 
-  def refuse_feedback_url
-    matches = current_email.body.match(/(http:\/\/localhost:3000\/reference\/refuse-feedback\?token=[\w-]{20})/)
+  def give_feedback_url
+    matches = current_email.body.match(/(http:\/\/localhost:3000\/reference\/give-feedback\?token=[\w-]{20})/)
     matches&.captures&.first
   end
 end

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Refusing to give a reference' do
     then_i_see_the_give_a_reference_page
 
     when_i_select_no_to_giving_a_reference
-    then_i_see_the_confirmation_page
+    and_i_see_the_confirmation_page
     and_i_confirm_that_i_wont_give_a_reference
     and_a_slack_notification_is_sent
     then_an_email_is_sent_to_the_candidate
@@ -50,7 +50,7 @@ RSpec.feature 'Refusing to give a reference' do
   end
 
   def and_i_confirm_that_i_wont_give_a_reference
-    click_button t('Yes, I am unable to give a reference')
+    click_button 'Yes, I am unable to give a reference'
   end
 
   def and_a_slack_notification_is_sent
@@ -70,7 +70,7 @@ RSpec.feature 'Refusing to give a reference' do
 private
 
   def give_feedback_url
-    matches = current_email.body.match(/(http:\/\/localhost:3000\/reference\/give-feedback\?token=[\w-]{20})/)
+    matches = current_email.body.match(/(http:\/\/localhost:3000\/reference\?token=[\w-]{20})/)
     matches&.captures&.first
   end
 end

--- a/spec/system/referee_interface/referee_tries_to_submit_incomplete_reference_spec.rb
+++ b/spec/system/referee_interface/referee_tries_to_submit_incomplete_reference_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'Stop submission of incomplete references', with_audited: true do
     given_i_am_a_referee_of_an_application
     and_i_received_the_initial_reference_request_email
     when_i_click_on_the_link_within_the_initial_email
+    and_i_select_yes_to_giving_a_reference
     and_i_confirm_my_relationship_with_the_candidate
     and_i_manually_skip_ahead_to_the_review_page
     then_i_cannot_submit_the_reference
@@ -29,6 +30,11 @@ RSpec.feature 'Stop submission of incomplete references', with_audited: true do
     open_email(@reference.email_address)
 
     click_sign_in_link(current_emails.first)
+  end
+
+  def and_i_select_yes_to_giving_a_reference
+    choose 'Yes, I can give them a reference'
+    click_button t('continue')
   end
 
   def and_i_confirm_my_relationship_with_the_candidate

--- a/spec/system/support_interface/provide_or_refuse_feedback_for_a_feedback_requested_reference_spec.rb
+++ b/spec/system/support_interface/provide_or_refuse_feedback_for_a_feedback_requested_reference_spec.rb
@@ -13,7 +13,8 @@ RSpec.feature 'Support user can access the RefereeInterface' do
 
     when_i_visit_the_application_form_page
     and_click_the_refuse_feedback_link
-    then_i_see_the_refuse_feedback_page
+    and_i_decline_to_give_a_reference
+    then_i_confirm_i_dont_want_to_give_a_reference
 
     when_the_candidates_reference_is_in_the_feedback_provided_state
     and_i_visit_the_application_form_page
@@ -45,8 +46,13 @@ RSpec.feature 'Support user can access the RefereeInterface' do
     click_link 'decline to give a reference'
   end
 
-  def then_i_see_the_refuse_feedback_page
-    expect(page).to have_content "Declining #{@application.full_name}’s reference request may delay their application and make it harder for them to get onto teacher training."
+  def and_i_decline_to_give_a_reference
+    choose 'No, I am unable to give a reference'
+    click_button t('continue')
+  end
+
+  def then_i_confirm_i_dont_want_to_give_a_reference
+    click_button 'Yes, I am unable to give a reference'
   end
 
   def when_the_candidates_reference_is_in_the_feedback_provided_state


### PR DESCRIPTION
## Context

We’ve found that some referees mistakenly click the second link (decline) instead of the first link.

We've reviewed the journey, and simplified it so that the email contains only a single link, and the referees are asked whether or not they can give a reference within the web interface instead.

## Changes proposed in this pull request

- Email content has been updated to just have 1 link
- Link goes to a new page asking if you can give a reference
- First page of referee flow links back to first question
- Choosing not to give a reference goes to a confirmation page with a back link

## Guidance to review

https://apply-beta-prototype.herokuapp.com/reference

## Link to Trello card

https://trello.com/c/KULV4Maf/

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
