### PR TITLE
Remove "app-start-page" as it's no longer used

### DIFF
--- a/app/frontend/styles/_header.scss
+++ b/app/frontend/styles/_header.scss
@@ -44,10 +44,3 @@
     }
   }
 }
-
-.app-start-page {
-  .app-header.app-header--full-border,
-  .govuk-header__container {
-    border-bottom-color: transparent;
-  }
-}

--- a/app/frontend/styles/_phase-banner.scss
+++ b/app/frontend/styles/_phase-banner.scss
@@ -3,24 +3,3 @@
     border-bottom: 0;
   }
 }
-
-.app-start-page {
-  .app-phase-banner {
-    background-color: $govuk-brand-colour;
-    margin-top: -(govuk-spacing(2));
-  }
-
-  .govuk-phase-banner {
-    border-bottom-color: govuk-colour("light-blue");
-  }
-
-  .govuk-phase-banner__text,
-  .govuk-phase-banner__text .govuk-link {
-    color: govuk-colour("white");
-  }
-
-  .govuk-phase-banner .govuk-tag {
-    background: govuk-colour("white");
-    color: $govuk-brand-colour;
-  }
-}

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -1,5 +1,3 @@
-<%= content_for :body_class, 'app-start-page' %>
-
 <div class="govuk-width-container">
   <main id="main-content" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" role="main">
     <div class="govuk-grid-row">


### PR DESCRIPTION
## Context

This class was adding a style to the beta banner which we no longer need in the new design

## Changes proposed in this pull request

Remove `app-start-page` and any associated styles

## Guidance to review

Did I miss anything?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
