### PR TITLE
Avoid writing a blank output for flakey test data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,8 +183,13 @@ jobs:
         id: set_flakey_test_results_var
         run: |
           file_text=$(cat /app/tmp/rspec-retry-flakey-specs.log)
-          file_text="${file_text//$'\n'/%0A}"
-          echo "::set-output name=flakey_tests::$file_text"
+          if [ ! -z "$file_text" ]
+          then
+            file_text="${file_text//$'\n'/%0A}"
+            echo "::set-output name=flakey_tests::$file_text"
+          else
+            echo "No flakey tests logged"
+          fi
 
   report-flakey-specs:
     name: Report on flakey specs in pull request

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
 
       - name: Comment on flakey specs in pull request
         uses: actions/github-script@0.5.0
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && needs.test.outputs.flakey_tests
         env:
           FLAKEY_TEST_DATA: |
             ${{ needs.test.outputs.flakey_tests }}


### PR DESCRIPTION
## Context

We run tests in parallel so if the given test run didn't log any flakey tests don't assign to the workflow job/step output variable.

This should prevent a race condition with various parallel test runs overwriting the variable containing flakey test data.

This won't solve two test runs logging flakey simultaneously, will tackle this in a separate PR. This PR attempts to solve the more common race condition.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Don't assign the test job output variable for flakey test data
- Don't run the Report flakey specs job if there's no flakey test data

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/G2D7y5XO/4465-%F0%9F%8F%88-improve-testing-and-coverage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
