### PR TITLE
Flakey spec fix : GET candidate api candidates

### DIFF
--- a/spec/requests/candidate_api/get_candidates_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_spec.rb
@@ -92,6 +92,8 @@ RSpec.describe 'GET /candidate-api/candidates', type: :request do
 
     response_data = parsed_response.dig('data', 0, 'attributes', 'application_forms')
 
+    allow(ProcessState).to receive(:new).and_return(instance_double(ProcessState, state: :unsubmitted_not_started_form))
+
     expect(response_data.size).to eq(2)
 
     expect(response_data.first['id']).to eq(application_forms.first.id)

--- a/spec/support/candidate_api/candidate_api_spec_helper.rb
+++ b/spec/support/candidate_api/candidate_api_spec_helper.rb
@@ -10,7 +10,7 @@ module CandidateAPISpecHelper
   end
 
   def candidate_api_token
-    @candidate_api_token ||= ServiceAPIUser.candidate_user.create_magic_link_token!
+    @candidate_api_token = ServiceAPIUser.candidate_user.create_magic_link_token!
   end
 
   def parsed_response


### PR DESCRIPTION
## Context

Two different flakey test failures seem to be occurring with this spec.
The bearer token can't be found and `ProcessState` returns an unexpected state.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

1. Don't memoize `@candidate_api_token` - this seems to fix the error 
```
GET /candidate-api/candidates returns applications ordered by created_at timestamp

Failure/Error: @authenticating_token.user_id == ServiceAPIUser.find_by(authorized_api: self.class.name.deconstantize).id

NoMethodError:
  undefined method `user_id' for nil:NilClass
```

2. Stub `ProcessState#state` for the commonly failing spec, it's not what is under test and seems to be vulnerable to comparing two timestamps which are within a second of one another but not identical to the second value.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/cTg2N8kM/4472-flakey-spec-get-candidate-api-candidates

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
