### PR TITLE
Add migration for new refused column

### DIFF
--- a/db/migrate/20211117220532_add_refused_to_references.rb
+++ b/db/migrate/20211117220532_add_refused_to_references.rb
@@ -1,0 +1,5 @@
+class AddRefusedToReferences < ActiveRecord::Migration[6.1]
+  def change
+    add_column :references, :refused, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_12_082940) do
+ActiveRecord::Schema.define(version: 2021_11_17_220532) do
 
   create_sequence "qualifications_public_id_seq", start: 120000
 
@@ -658,6 +658,7 @@ ActiveRecord::Schema.define(version: 2021_11_12_082940) do
     t.datetime "cancelled_at_end_of_cycle_at"
     t.boolean "duplicate", default: false
     t.boolean "selected", default: false
+    t.boolean "refused"
     t.index ["application_form_id", "email_address"], name: "index_references_on_application_form_id_and_email_address", unique: true
     t.index ["application_form_id"], name: "index_references_on_application_form_id"
     t.index ["feedback_status"], name: "index_references_on_feedback_status"


### PR DESCRIPTION
## Context

As part of the new referee flow we need to retain their choice when the select to either provide or refuse a reference.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Addded ```refused``` to the references table

## Link to Trello card

https://trello.com/c/KULV4Maf

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
