### PR TITLE
Place coverage report and slack notification steps back in Test job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,6 +214,29 @@ jobs:
           else
             echo "No flakey tests logged"
           fi
+      - name: Upload pull request coverage report
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v2
+        with:
+          name: head-result
+          path: /app/coverage/.resultset.json
+
+      - name: Upload main coverage report
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v2
+        with:
+          name: base-result
+          path: /app/coverage/.resultset.json
+      - name: Notify Slack channel on job failure
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: CI Deployment
+          SLACK_TITLE: Test failure
+          SLACK_MESSAGE: ${{ matrix.tests }} (feature-flags ${{ matrix.feature-flags }}) test failure on branch ${{ needs.build.outputs.GIT_BRANCH }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_COLOR: failure
+          SLACK_FOOTER: Sent from test job in build workflow
 
   report-flakey-specs:
     name: Report on flakey specs in pull request
@@ -256,31 +279,6 @@ jobs:
                 github.issues.createComment({ issue_number, owner, repo, body: commentBody });
               }
             }
-
-      - name: Upload pull request coverage report
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v2
-        with:
-          name: head-result
-          path: /app/coverage/.resultset.json
-
-      - name: Upload main coverage report
-        if: github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v2
-        with:
-          name: base-result
-          path: /app/coverage/.resultset.json
-
-      - name: Notify Slack channel on job failure
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_USERNAME: CI Deployment
-          SLACK_TITLE: Test failure
-          SLACK_MESSAGE: ${{ matrix.tests }} (feature-flags ${{ matrix.feature-flags }}) test failure on branch ${{ needs.build.outputs.GIT_BRANCH }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_COLOR: failure
-          SLACK_FOOTER: Sent from test job in build workflow
 
   trigger-deployment:
     name: Trigger Deployment


### PR DESCRIPTION
## Context

These seem to have been moved into the wrong job (report flakey tests), possibly as part of a PR merge. 
Move them to the correct job (test).

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Moves the coverage report artifact uploads and slack notifications steps back under the `test` job.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

We should see a coverage artifact in this PR build.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/G2D7y5XO/4465-%F0%9F%8F%88-improve-testing-and-coverage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
