### PR TITLE
[435] Move SHA ARG down in Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
             type=registry,ref=${{ env.GEMS_NODE_MODULES_IMAGE }}:${{ env.GIT_BRANCH }}
             type=register,ref=${{ env.GEMS_NODE_MODULES_IMAGE }}:main
           build-args: |
-            VERSION=${{ env.IMAGE_TAG }}
+            SHA=${{ env.IMAGE_TAG }}
 
       - name: Notify Slack channel on job failure
         if: failure() && github.event_name == 'push'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
             type=registry,ref=${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
             type=registry,ref=${{ env.DOCKER_IMAGE }}:${{ env.GIT_BRANCH }}
             type=registry,ref=${{ env.GEMS_NODE_MODULES_IMAGE }}:${{ env.GIT_BRANCH }}
-            type=register,ref=${{ env.GEMS_NODE_MODULES_IMAGE }}:main
+            type=registry,ref=${{ env.GEMS_NODE_MODULES_IMAGE }}:main
           build-args: |
             SHA=${{ env.IMAGE_TAG }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,14 +46,12 @@ RUN bundle exec rake assets:precompile && \
 # If a existing base image name is specified Stage 1 & 2 will not be built and gems and dev packages will be used from the supplied image.
 FROM ${BASE_RUBY_IMAGE} AS production
 
-ARG VERSION
 ENV WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine \
     RAILS_ENV=production \
     GOVUK_NOTIFY_API_KEY=TestKey \
     AUTHORISED_HOSTS=127.0.0.1 \
     SECRET_KEY_BASE=TestKey \
     GOVUK_NOTIFY_CALLBACK_API_KEY=TestKey \
-    SHA=${VERSION} \
     REDIS_CACHE_URL=redis://127.0.0.1:6379
 
 RUN apk -U upgrade && \
@@ -69,7 +67,9 @@ ENV ENV="/root/.ashrc"
 COPY --from=gems-node-modules /app /app
 COPY --from=gems-node-modules /usr/local/bundle/ /usr/local/bundle/
 
-RUN echo ${VERSION} > public/check
+ARG SHA
+ENV SHA=${SHA}
+RUN echo ${SHA} > public/check
 
 # Use this for development testing
 # CMD bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0


### PR DESCRIPTION
## Context
Docker build cache not optimal causing unnecessary slow builds

## Changes proposed in this pull request
SHA now moved as low as possible in Dockerfile only for the steps which require it.

## Guidance to review
Look for CACHED in docker build

## Link to Trello card
https://trello.com/c/yB2dZdji/435-improve-docker-build-time-by-moving-the-sha-arg

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
