### PR TITLE
Fix flakey spec for applications by demog, domicile & degree export API

### DIFF
--- a/spec/requests/data_api/applications_by_demographic_domicile_and_degree_class_export_spec.rb
+++ b/spec/requests/data_api/applications_by_demographic_domicile_and_degree_class_export_spec.rb
@@ -6,7 +6,18 @@ RSpec.describe 'GET /data-api/tad-data-exports/applications-by-demographic-domic
   it_behaves_like 'a TAD API endpoint', '/latest'
 
   it 'returns the latest tad age and hesa export' do
-    first_application_form = create(:completed_application_form, :with_equality_and_diversity_data)
+    first_application_form = create(
+      :completed_application_form,
+      equality_and_diversity: {
+        'sex' => 'male',
+        'hesa_sex' => '1',
+        'disabilities' => ['Learning difficulty', 'Social or communication impairment', 'Blind'],
+        'ethnic_group' => 'Another ethnic group',
+        'hesa_ethnicity' => '50',
+        'ethnic_background' => 'Arab',
+        'hesa_disabilities' => %w[51 53 58],
+      },
+    )
     create(:application_qualification, level: 'degree', grade: 'Upper second-class honours (2:1)', application_form: first_application_form)
     create(:application_choice, :with_declined_offer, application_form: first_application_form)
 


### PR DESCRIPTION
## Context

Spec is flakey due to using E&D trait on application form factory. This 
can result in a random population of the data with nil or [] which means 
that the export data is not generated

## Changes proposed in this pull request
stubbing out E&D data manually to prevent this

## Guidance to review
🚢 ?

## Link to Trello card

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
