### PR TITLE
Prevent provider impersonation bugs by restricting sign-in, impersonation across logins

### DIFF
--- a/app/controllers/dfe_sign_in_controller.rb
+++ b/app/controllers/dfe_sign_in_controller.rb
@@ -1,13 +1,13 @@
 class DfESignInController < ActionController::Base
   protect_from_forgery except: :bypass_callback
 
+  SESSION_KEYS_TO_FORGET_WITH_EACH_LOGIN = %w[session_id impersonated_provider_user].freeze
+
   def callback
-    @target_path = session['post_dfe_sign_in_path']
-
-    reset_session # prevents session fixation attacks and impersonation bugs
-
+    change_session_id_and_drop_provider_impersonation
     DfESignInUser.begin_session!(session, request.env['omniauth.auth'])
     @dfe_sign_in_user = DfESignInUser.load_from_session(session)
+    @target_path = session['post_dfe_sign_in_path']
     @local_user = local_user
 
     if @local_user
@@ -20,7 +20,7 @@ class DfESignInController < ActionController::Base
         send_provider_sign_in_confirmation_email
       end
 
-      redirect_to @target_path || default_authenticated_path
+      redirect_to @target_path ? session.delete('post_dfe_sign_in_path') : default_authenticated_path
     else
       DfESignInUser.end_session!(session)
       render(
@@ -47,6 +47,12 @@ class DfESignInController < ActionController::Base
   end
 
 private
+
+  def change_session_id_and_drop_provider_impersonation
+    existing_values = session.to_hash # e.g. candidate/devise login, cookie consent
+    reset_session # prevents session fixation attacks and impersonation bugs
+    session.update existing_values.except(*SESSION_KEYS_TO_FORGET_WITH_EACH_LOGIN)
+  end
 
   def send_support_sign_in_confirmation_email
     return if cookies.signed[:sign_in_confirmation] == @local_user.id

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -4,6 +4,8 @@ module ProviderInterface
     skip_before_action :redirect_if_setup_required
 
     def new
+      redirect_to provider_interface_applications_path and return if impersonation?
+
       if FeatureFlag.active?('dfe_sign_in_fallback')
         render :authentication_fallback
       end
@@ -54,6 +56,12 @@ module ProviderInterface
       provider_user.update!(last_signed_in_at: Time.zone.now)
 
       redirect_to provider_interface_applications_path
+    end
+
+  private
+
+    def impersonation?
+      ProviderImpersonation.load_from_session(session)
     end
   end
 end

--- a/spec/requests/provider_interface/sessions_controller_spec.rb
+++ b/spec/requests/provider_interface/sessions_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::SessionsController do
+  let(:provider) { create(:provider, :with_signed_agreement) }
+  let(:provider_user) { create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
+
+  describe '#new' do
+    let(:support_user) { create(:support_user, dfe_sign_in_uid: 'SUPPORT_DFE_SIGN_IN_UID') }
+    let(:dfe_sign_in_user) do
+      DfESignInUser.new(
+        email_address: support_user.email_address,
+        dfe_sign_in_uid: support_user.dfe_sign_in_uid,
+        first_name: support_user.first_name,
+        last_name: support_user.last_name,
+      )
+    end
+
+    it 'redirects to applications when impersonation is active' do
+      support_user.impersonated_provider_user = provider_user
+
+      allow(DfESignInUser).to receive(:load_from_session).and_return(dfe_sign_in_user)
+      allow(SupportUser).to receive(:load_from_session).and_return(support_user)
+      get provider_interface_sign_in_path
+
+      expect(response.status).to eq(302)
+      expect(response.redirect_url).to eq(provider_interface_applications_url)
+    end
+  end
+end


### PR DESCRIPTION
## Context

As a support user, if I log in and start impersonating a provider user, but visit `/provider/sign-in`, I am able to trigger the DSI flow, which returns me to the DSI callback. This has the unintended consequence of updating real provider user details with my own, as the callback uses the active DSI session details to update the provider user.

## Changes proposed in this pull request

Make `provider_interface/sessions#new` aware of the impersonation feature and redirect support users with an active impersonation to the applications page.

UPDATE: also clear any pre-existing state within `session` at start of `DfESignInController#callback`. Impersonation details are stored within `session`.

## Guidance to review

Try the code, see the spec.

We stop accepting DSI sessions after 2 hours of inactivity (see `DfESignInUser.load_from_session`), but browsers may stay open much longer than that. If the browser stays open and we force the user to re-authenticate with DSI, previous impersonation data will still be around. This could lead to trouble, especially if the user returns to the service with a different identity from DSI. The `reset_session` commit addresses this.

BONUS: using `reset_session` may also prevent session fixation attacks, see https://guides.rubyonrails.org/security.html#session-fixation

Note: clearing `session` does not clear any other cookies, so any analytics cookies etc. should still work as expected.

## Link to Trello card

https://trello.com/c/OBX3pZ8y

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
