### PR TITLE
Include interviewing state when recalculating dates

### DIFF
--- a/app/workers/recalculate_dates.rb
+++ b/app/workers/recalculate_dates.rb
@@ -4,7 +4,7 @@ class RecalculateDates
   def perform(*)
     Audited.audit_class.as_user('RecalculateDates worker') do
       ApplicationChoice
-        .where(status: :awaiting_provider_decision)
+        .where(status: %i[awaiting_provider_decision interviewing])
         .includes(:application_form)
         .find_each do |application_choice|
           SetRejectByDefault.new(application_choice).call


### PR DESCRIPTION
## Context

We introduced holidays recently and selected the task to recalculate dates. However we missed applications in the interviewing state which also needed to be amended.

## Changes proposed in this pull request

Include "interviewing" state in applications when the RBD is to be recalculated.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
