### PR TITLE
Update guidance on changing a course or course location

### DIFF
--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -102,7 +102,8 @@ ApplicationForm.find(_id).update!(becoming_a_teacher: 'new text', subject_knowle
 
 ### Changing a course or course location 
 
-A provider may request that a candidate be placed on an different course, or a different site.
+A provider may request that a candidate be placed on an different course, or a different site. 
+This method of updating the course option bypasses the state machine and can be applied to any course option regardless of state (e.g 'awaiting provider decision', 'interviewing' etc).
 
 - Find the course
 
@@ -125,7 +126,7 @@ new_course_option = CourseOption
     course_id: course,
     study_mode: _study_mode,
     site: { id: _site_id }
-  )
+  ).first
 ```
 
 - Find the current application choice


### PR DESCRIPTION
## Context

The support tech docs need to be updated to include the correct way to change a course and or course location in place (bypassing the state machine)

## Changes proposed in this pull request

- Update support docs 

## Guidance to review

- Make sense? 
- Are there still scenarios when we would prefer to use the old method?

## Link to Trello card

https://trello.com/c/2EucQz0o/4150-update-support-tech-docs

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
