### PR TITLE
Add support service for updating application_choice course 

### DIFF
--- a/app/services/support_interface/change_application_choice_course_option.rb
+++ b/app/services/support_interface/change_application_choice_course_option.rb
@@ -1,0 +1,37 @@
+module SupportInterface
+  class ChangeApplicationChoiceCourseOption
+    attr_reader :application_choice, :provider_id, :course_code, :study_mode, :site_code, :audit_comment
+
+    def initialize(application_choice_id:,
+                   provider_id:,
+                   course_code:,
+                   study_mode:,
+                   site_code:,
+                   audit_comment:)
+      @application_choice = ApplicationChoice.find(application_choice_id)
+      @provider_id = provider_id
+      @course_code = course_code
+      @site_code = site_code
+      @study_mode = study_mode
+      @audit_comment = audit_comment
+    end
+
+    def call
+      application_choice.update_course_option_and_associated_fields!(course_option,
+                                                                     other_fields: { course_option: course_option },
+                                                                     audit_comment: audit_comment)
+    end
+
+  private
+
+    def course_option
+      course.course_options.joins(:site).find_by!(site: { code: site_code }, study_mode: study_mode)
+    end
+
+    def course
+      Course.find_by!(code: course_code,
+                      provider_id: provider_id,
+                      recruitment_cycle_year: RecruitmentCycle.current_year)
+    end
+  end
+end

--- a/app/services/support_interface/change_application_choice_course_option.rb
+++ b/app/services/support_interface/change_application_choice_course_option.rb
@@ -1,5 +1,7 @@
 module SupportInterface
   class ChangeApplicationChoiceCourseOption
+    VALID_STATES = ApplicationStateChange::DECISION_PENDING_STATUSES
+
     attr_reader :application_choice, :provider_id, :course_code, :study_mode, :site_code, :audit_comment
 
     def initialize(application_choice_id:,
@@ -17,12 +19,20 @@ module SupportInterface
     end
 
     def call
+      check_application_state!
+
       application_choice.update_course_option_and_associated_fields!(course_option,
                                                                      other_fields: { course_option: course_option },
                                                                      audit_comment: audit_comment)
     end
 
   private
+
+    def check_application_state!
+      return if VALID_STATES.include?(application_choice.status.to_sym)
+
+      raise "Changing the course option of application choices in the #{application_choice.status} state is not allowed"
+    end
 
     def course_option
       course.course_options.joins(:site).find_by!(site: { code: site_code }, study_mode: study_mode)

--- a/spec/services/support_interface/change_application_choice_course_option_spec.rb
+++ b/spec/services/support_interface/change_application_choice_course_option_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
+  describe '#call' do
+    let!(:application_choice) { create(:application_choice) }
+    let!(:course_option) { create(:course_option, study_mode: :full_time) }
+    let(:other_provider) { create(:provider) }
+    let(:audit_comment) { 'Zendesk ticket 2 - update course' }
+    let(:other_site) { create(:site) }
+
+    it 'sets the course_option of the specified site of a course' do
+      expect {
+        described_class.new(application_choice_id: application_choice.id,
+                            provider_id: course_option.course.provider_id,
+                            course_code: course_option.course.code,
+                            study_mode: course_option.study_mode,
+                            site_code: course_option.site.code,
+                            audit_comment: '').call
+      }.to(change { application_choice.reload.course_option })
+
+      expect(application_choice.course_option).to eq(course_option)
+    end
+
+    it 'creates an audit entry', with_audited: true do
+      expect {
+        described_class.new(application_choice_id: application_choice.id,
+                            provider_id: course_option.course.provider_id,
+                            course_code: course_option.course.code,
+                            study_mode: course_option.study_mode,
+                            site_code: course_option.site.code,
+                            audit_comment: audit_comment).call
+      }.to change { Audited::Audit.count }.by(1)
+
+      expect(Audited::Audit.last.comment).to eq(audit_comment)
+    end
+
+    it 'raises a RecordNotFound error if the course does not exist for the provided provider_id' do
+      expect {
+        described_class.new(application_choice_id: application_choice.id,
+                            provider_id: other_provider.id,
+                            course_code: course_option.course.code,
+                            study_mode: course_option.study_mode,
+                            site_code: course_option.site.code,
+                            audit_comment: audit_comment).call
+      }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find Course/)
+    end
+
+    it 'raises a RecordNotFound error if the site does not exist for the provided course' do
+      expect {
+        described_class.new(application_choice_id: application_choice.id,
+                            provider_id: course_option.course.provider_id,
+                            course_code: course_option.course.code,
+                            study_mode: course_option.study_mode,
+                            site_code: other_site.code,
+                            audit_comment: audit_comment).call
+      }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find CourseOption/)
+    end
+
+    it 'raises a RecordNotFound error if the site does not exist for the provided study_mode' do
+      expect {
+        described_class.new(application_choice_id: application_choice.id,
+                            provider_id: course_option.course.provider_id,
+                            course_code: course_option.course.code,
+                            study_mode: :part_time,
+                            site_code: course_option.site.code,
+                            audit_comment: audit_comment).call
+      }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find CourseOption/)
+    end
+  end
+end

--- a/spec/services/support_interface/change_application_choice_course_option_spec.rb
+++ b/spec/services/support_interface/change_application_choice_course_option_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
   describe '#call' do
-    let!(:application_choice) { create(:application_choice) }
+    let!(:application_choice) { create(:application_choice, :interviewing) }
     let!(:course_option) { create(:course_option, study_mode: :full_time) }
     let(:other_provider) { create(:provider) }
     let(:audit_comment) { 'Zendesk ticket 2 - update course' }
@@ -65,6 +65,21 @@ RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
                             site_code: course_option.site.code,
                             audit_comment: audit_comment).call
       }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find CourseOption/)
+    end
+
+    context 'application choice status check' do
+      let!(:application_choice) { create(:application_choice, :offer) }
+
+      it 'raises an error if the application is not in a decision pending state' do
+        expect {
+          described_class.new(application_choice_id: application_choice.id,
+                              provider_id: course_option.course.provider_id,
+                              course_code: course_option.course.code,
+                              study_mode: :part_time,
+                              site_code: course_option.site.code,
+                              audit_comment: audit_comment).call
+        }.to raise_error(RuntimeError, "Changing the course option of application choices in the #{application_choice.status} state is not allowed")
+      end
     end
   end
 end


### PR DESCRIPTION
## Context
 
Service that partially automates changing a candidate's application course to a course at a specified location. 

This should make dealing with a number of pending support requests easier until we get around to implementing the ability to make this change via the interface.

Related tickets:
https://trello.com/c/fQw6S0zm/948-course-correction-zake-ahmed

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
