### PR TITLE
Add privacy policies for chat

### DIFF
--- a/app/controllers/provider_interface/content_controller.rb
+++ b/app/controllers/provider_interface/content_controller.rb
@@ -34,7 +34,10 @@ module ProviderInterface
         hols
       end
 
-      render_content_page :dates_and_deadlines, with_breadcrumbs: true, locals: { holidays: holidays }
+      render_content_page :dates_and_deadlines,
+                          breadcrumb_title: 'service_guidance_provider',
+                          breadcrumb_path: provider_interface_service_guidance_path,
+                          locals: { holidays: holidays }
     end
 
     def complaints

--- a/app/controllers/provider_interface/content_controller.rb
+++ b/app/controllers/provider_interface/content_controller.rb
@@ -12,8 +12,12 @@ module ProviderInterface
       render_content_page :accessibility
     end
 
-    def privacy_policy
-      render_content_page :privacy_policy
+    def privacy; end
+
+    def service_privacy_notice
+      render_content_page :service_privacy_notice,
+                          breadcrumb_title: 'privacy_notices',
+                          breadcrumb_path: provider_interface_privacy_path
     end
 
     def cookies_page

--- a/app/controllers/provider_interface/content_controller.rb
+++ b/app/controllers/provider_interface/content_controller.rb
@@ -20,6 +20,12 @@ module ProviderInterface
                           breadcrumb_path: provider_interface_privacy_path
     end
 
+    def online_chat_privacy_notice
+      render_content_page :online_chat_privacy_notice,
+                          breadcrumb_title: 'privacy_notices',
+                          breadcrumb_path: provider_interface_privacy_path
+    end
+
     def cookies_page
       @application = :manage
       @cookie_ga_code = ENV.fetch('GOOGLE_ANALYTICS_MANAGE', '').gsub(/-/, '_')

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -1,5 +1,5 @@
 module ContentHelper
-  def render_content_page(page_name, with_breadcrumbs: false, locals: {})
+  def render_content_page(page_name, breadcrumb_title: nil, breadcrumb_path: nil, locals: {})
     raw_content = File.read("app/views/content/#{page_name}.md")
     content_with_erb_tags_replaced = ApplicationController.renderer.render(
       inline: raw_content,
@@ -7,7 +7,8 @@ module ContentHelper
     )
     @converted_markdown = GovukMarkdown.render(content_with_erb_tags_replaced).html_safe
     @page_name = page_name
-    @with_breadcrumbs = with_breadcrumbs
+    @breadcrumb_title = breadcrumb_title
+    @breadcrumb_path = breadcrumb_path
     render 'rendered_markdown_template'
   end
 end

--- a/app/views/content/online_chat_privacy_notice.md
+++ b/app/views/content/online_chat_privacy_notice.md
@@ -1,0 +1,80 @@
+We are the Department for Education (DfE), 20 Great Smith Street, London SW1P 3BT. We are the data controller for your personal data.
+This privacy notice about online chat sets out:
+
+- what personal data we collect and how we use it
+- how we protect your personal data
+- how long we keep your personal data for
+- what rights you have under the lawful basis we’re relying on
+
+We use Zendesk software to store and process this data. This means that Zendesk is our data processor.
+
+### The lawful basis for processing your personal data
+
+Under the data protection legislation we need a lawful basis for processing your personal data.
+
+The lawful basis we are relying on is public interest.
+
+### The personal data we collect for online chat
+
+We use the Zendesk customer service management system to manage all our support requests, including online chat and some sources of feedback. In order for you to access tailored support via online chat, we collect your:
+
+- name
+- email address
+- IP address - and the country and city associated with it
+- browser and version information
+- device type
+
+In order for us to investigate and respond to a support request, we will also ask you for additional information such as:
+
+- your phone number
+- where you work
+- your role
+- candidate application details
+- additional information you got from the candidate
+
+Do not enter any personal data into the chat unless we ask you for it.
+
+### How we use your data
+
+We’ll use your data to help you manage teacher training applications.
+
+We’ll also analyse and consolidate data from support requests to help us understand how we can improve our services.
+
+### How we protect your data
+
+The Zendesk customer service management system is hosted in accordance with its [regional data hosting policy](https://support.zendesk.com/hc/en-us/articles/360022185194?_ga=2.9135733.1989263323.1628099773-531922291.1627980374).
+
+Zendesk is required to process and protect your personal data under strict conditions. These are stated in a written agreement between us and Zendesk, as required by the UK General Data Protection Regulation (GDPR) and UK Data Protection Act 2018 (DPA 2018).
+
+### How long we keep your data
+
+We keep your data only for as long as needed for the uses listed above.
+
+We’ll need to support some people considering applying for teacher training for many years. We’ll delete the data we hold on you 3 years after you first contact us.
+
+### Your rights
+
+Under the DPA 2018 and UK GDPR and the lawful basis of public interest, you have the right to:
+
+- find out what data we hold about you
+- be informed about how your data is being used
+- access personal data
+- have incorrect or incomplete data updated
+- object to how your data is processed
+- restrict the processing of your data in certain circumstances
+- object to direct marketing
+- object to automated decision making and profiling
+
+You can find more information about how we handle personal data in our [personal information charter](https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter).
+
+### Get help or tell us about a concern
+
+If you have any concerns or queries, email us at becomingateacher@digital.education.gov.uk.
+
+If we cannot resolve your issue, you have the right to raise it with the [Information Commissioner's Office (ICO)](https://ico.org.uk/).
+
+### Keeping this privacy policy up to date
+
+We may update this privacy notice. Any changes will apply to you and your data immediately.
+
+This privacy notice was published on 30 November 2021.

--- a/app/views/content/service_privacy_notice.md
+++ b/app/views/content/service_privacy_notice.md
@@ -1,0 +1,173 @@
+Apply for teacher training and Manage teacher training applications are run by the Department for Education (‘we’).
+
+Any information we collect when you use our services will be used and looked after by:
+
+- the Department for Education, and/or
+- the teacher training providers the candidate applies to
+
+This means we’re joint data controllers, as well as data processors, for your information (defined by data protection law).
+
+Apply for teacher training and Manage teacher training applications are new services. We’re confident that they’ve met our security standards, but we’ll continue to run security tests as we improve the service. Like with any digital service, there’s always a chance of data breaches happening.
+
+### What personal data we collect
+
+The personal data we collect will depend on whether you’re a candidate, a referee, or a staff member at a teacher training provider.
+
+#### What data we collect if you’re a candidate
+
+If you’re a candidate using Apply for teacher training, we may collect the following information about you:
+
+- name
+- address
+- date of birth
+- phone number
+- email address
+- any other information you choose to share during the application process - for example, you can choose to share equality and diversity information, or give information about your criminal record
+
+#### What data we collect if you’re a referee
+
+If you’re a referee, we got your information from a teacher training candidate. They told us:
+
+- your name
+- email address
+- how you know the candidate
+
+We may also collect:
+
+- any personal data you include in your reference
+- any information you give us if you consent to be contacted for user research
+
+#### What data we collect if you work for a training provider
+
+If you process teacher training applications, we may need to collect information about you so we can process applications, for example:
+
+- your name
+- your email address
+- your phone number
+- where you work
+- what your role is
+
+### How we use your data
+
+#### Processing applications
+
+Processing applications includes the following:
+
+- sending applications and references to training providers
+- managing communications between candidates and training providers
+- managing communications between referees and training providers
+- working out any funding candidates are entitled to
+- getting in touch if there’s a security issue concerning your data
+- getting in touch with candidates and training providers about their applications
+
+#### Building a better teacher training application process
+
+We’ll use your data to help us build a better teacher training application process.
+
+For example, we’ll look at any feedback you give us about our services so we can improve them.
+
+If you’re a candidate or you work at a teacher training provider, we may contact you to carry out user research.
+
+If you’re a referee, we’ll ask you to consent before contacting you for user research.
+
+#### Getting insight to make government policy better
+
+We might analyse your data to help us inform government policy around teacher recruitment and retention.
+
+### Using your data lawfully
+
+We need to use personal data for the purposes mentioned above. Most of these purposes are a public task (defined in data protection law).
+
+However, if we contacted you asking for a reference, this was in our legitimate interests (defined in data protection law) because we need references to process applications.
+
+If you give a reference, we use your data to meet our public task (processing applications, building a better service and improving policy). To help us do this, we’ll ask for your consent (defined in data protection law) to be contacted for user research.
+
+If you’re a candidate or a referee, we’ll also ask for your consent before using cookies to get statistics from Google Analytics.
+
+### Who we share your data with
+
+We need to share personal data for the purposes mentioned above.
+
+We do so under section 132 of the Education Act 2002, together with regulation 5 of the Education (School Teachers’ Qualifications) (England) Regulations 2003.
+
+#### Sharing data with teacher training providers
+
+We share teacher training applicant and referee data with the teacher training providers the candidate applies to.
+
+We have a data sharing agreement with providers so they can only use your data to:
+
+- process applications, which may include contacting candidates
+- get statistics for internal use
+- get in touch with you if there’s a security issue concerning your data
+
+#### Sharing candidate data with referees
+
+We’ll share candidate names with referees so the referee can identify the candidate and give a reference.
+
+We may need to share a bit more information to help the referee identify the candidate, such as how the candidate knows the referee.
+
+#### Sharing candidate data with UCAS
+
+We’ll share candidate data with UCAS.
+
+This is so UCAS can check applications across UCAS and Apply for teaching training.
+
+For example, UCAS will tell us if a candidate accepts offers on both services and we will contact the candidate if this is the case.
+
+### External organisations who process data
+
+#### Customer service systems
+
+We use a customer service management system to process some personal data, such as feedback you send us.
+
+[Zendesk are currently our preferred customer service management system](https://www.zendesk.co.uk/company/customers-partners/master-subscription-agreement/?cta=msa#confidentiality) because they use various safeguards to look after your data.
+
+#### Google
+
+We’ll ask if you agree to cookies so that we can get statistics from Google Analytics. If you consent, Google may be able to get your IP address. We use Google Analytics for statistics and will not identify you personally from these.
+
+We also use Google’s G Suite to process some personal data. For example, we’ll ask referees to send a reference via Google Forms and process the data using Google Sheets.
+
+Google processes your data according to our instructions.
+
+#### Hosting services
+
+We host our services on Microsoft Azure Cloud, which encrypts your data to prevent it being accessed by unauthorised people.
+
+### How long we keep your data
+
+We only keep your data for as long as needed for the uses listed above.
+
+We will delete your data after 7 years.
+
+### Your rights
+
+Under the Data Protection Act 2018, you have the right to find out what data we have about you. This includes the right to:
+
+- be informed about how your data is being used
+- access personal data
+- have incorrect data updated
+- have data erased
+- stop or restrict the processing of your data
+- get and reuse your data for different services
+- object to how your data is processed in certain circumstances
+
+You can find more information about how we handle personal data in our [personal information charter](https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter).
+
+### Getting help and raising a concern
+
+If you want to ask us to remove your data or get access to the data we have about you, you can email us:
+
+[becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
+
+You can also use our contact form to [get in touch with our Data Protection Officer](https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen).
+
+Once a candidate has enrolled with a teacher training provider, we will not be able to ask them to remove personal data from their systems. Please contact the provider separately.
+
+For further information or to raise a concern, visit the [Information Commissioner’s Office](https://ico.org.uk/) (ICO).
+
+### Keeping our privacy policy up to date
+
+We might need to update this privacy policy occasionally. Please review the policy now and then.
+
+This version was last updated on 30 November 2021.

--- a/app/views/layouts/_footer_meta_provider.html.erb
+++ b/app/views/layouts/_footer_meta_provider.html.erb
@@ -40,7 +40,7 @@
     <%= link_to t('layout.support_links.provider_complaints'), provider_interface_complaints_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.support_links.privacy_policy'), provider_interface_privacy_policy_path, class: 'govuk-footer__link' %>
+    <%= link_to t('layout.support_links.privacy'), provider_interface_privacy_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
     <%= link_to t('layout.support_links.roadmap'), provider_interface_roadmap_path, class: 'govuk-footer__link' %>

--- a/app/views/provider_interface/content/privacy.html.erb
+++ b/app/views/provider_interface/content/privacy.html.erb
@@ -1,0 +1,12 @@
+<%= content_for :title, t('page_titles.privacy_notices') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('page_titles.privacy_notices') %></h1>
+    <ul class="govuk-list govuk-list">
+      <li>
+        <%= govuk_link_to('Service privacy notice', provider_interface_service_privacy_notice_path) %>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/app/views/provider_interface/content/privacy.html.erb
+++ b/app/views/provider_interface/content/privacy.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= t('page_titles.privacy_notices') %></h1>
+    <h1 class="govuk-heading-l"><%= t('page_titles.privacy_notices') %></h1>
     <ul class="govuk-list govuk-list--spaced">
       <li>
         <%= govuk_link_to('Service privacy notice', provider_interface_service_privacy_notice_path) %>

--- a/app/views/provider_interface/content/privacy.html.erb
+++ b/app/views/provider_interface/content/privacy.html.erb
@@ -3,9 +3,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('page_titles.privacy_notices') %></h1>
-    <ul class="govuk-list govuk-list">
+    <ul class="govuk-list govuk-list--spaced">
       <li>
         <%= govuk_link_to('Service privacy notice', provider_interface_service_privacy_notice_path) %>
+      </li>
+      <li>
+        <%= govuk_link_to('Online chat privacy notice', provider_interface_online_chat_privacy_notice_path) %>
       </li>
     </ul>
   </div>

--- a/app/views/provider_interface/content/rendered_markdown_template.html.erb
+++ b/app/views/provider_interface/content/rendered_markdown_template.html.erb
@@ -11,7 +11,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= t("page_titles.#{@page_name}") %></h1>
+    <h1 class="govuk-heading-l"><%= t("page_titles.#{@page_name}") %></h1>
 
     <%= @converted_markdown %>
   </div>

--- a/app/views/provider_interface/content/rendered_markdown_template.html.erb
+++ b/app/views/provider_interface/content/rendered_markdown_template.html.erb
@@ -1,9 +1,9 @@
 <%= content_for :title, t("page_titles.#{@page_name}") %>
 
-<% if @with_breadcrumbs %>
+<% if @breadcrumb_title && @breadcrumb_path %>
   <% content_for :before_content do %>
     <%= breadcrumbs({
-      t('page_titles.service_guidance_provider') => provider_interface_service_guidance_path,
+      t("page_titles.#{@breadcrumb_title}") => @breadcrumb_path,
       t("page_titles.#{@page_name}") => nil,
     }) %>
   <% end %>

--- a/app/views/provider_interface/content/service_guidance_provider.html.erb
+++ b/app/views/provider_interface/content/service_guidance_provider.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= t('page_titles.service_guidance_provider') %></h1>
+    <h1 class="govuk-heading-l"><%= t('page_titles.service_guidance_provider') %></h1>
     <ul class="govuk-list govuk-list">
       <li>
         <%= govuk_link_to('Dates and deadlines', provider_interface_service_guidance_dates_and_deadlines_path) %>

--- a/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
+++ b/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
@@ -220,7 +220,7 @@
     <p class="govuk-body">Participants will not be asked to share information related to their private or family lives.</p>
 
     <h3 class="govuk-heading-m" id="section-3-3">Privacy notices</h3>
-    <p class="govuk-body">Please see the <%= govuk_link_to 'Apply for teacher training privacy policy for candidates, referees and provider staff', provider_interface_privacy_policy_path %>.</p>
+    <p class="govuk-body">Please see the <%= govuk_link_to 'Apply for teacher training privacy policy for candidates, referees and provider staff', provider_interface_service_privacy_notice_path %>.</p>
     <p class="govuk-body">DfE will make data subjects aware of how their data will be processed before data is collected through Apply for teacher training.</p>
     <p class="govuk-body">Please see DfE’s Personal Information Charter for more details on the organisation’s data storage and sharing policies.</p>
     <p class="govuk-body">By agreeing to this data sharing agreement, DfE and the provider confirm that their respective privacy policies explain the data sharing activities outlined in this agreement.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,7 @@ en:
     privacy_policy: How we look after your personal data
     privacy_notices: Privacy notices
     service_privacy_notice: Service privacy notice
+    online_chat_privacy_notice: Online chat privacy notice
     terms_candidate: Terms of use
     service_guidance_provider: How to use this service
     cookies_candidate: Cookies

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,8 @@ en:
     data_sharing_agreement: Data sharing agreement
     accessibility: Accessibility statement
     privacy_policy: How we look after your personal data
+    privacy_notices: Privacy notices
+    service_privacy_notice: Service privacy notice
     terms_candidate: Terms of use
     service_guidance_provider: How to use this service
     cookies_candidate: Cookies
@@ -277,6 +279,7 @@ en:
       candidate_complaints: Make a complaint, give feedback, or let us know if you’ve been treated unfairly
       terms_of_use: Terms of use
       privacy_policy: Privacy policy
+      privacy: Privacy
       roadmap: Roadmap
   activemodel:
     attributes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -659,6 +659,7 @@ Rails.application.routes.draw do
     get '/privacy-policy', to: redirect('provider/privacy')
     get '/privacy', to: 'content#privacy', as: :privacy
     get '/privacy/service-privacy-notice', to: 'content#service_privacy_notice', as: :service_privacy_notice
+    get '/privacy/online-chat-privacy-notice', to: 'content#online_chat_privacy_notice', as: :online_chat_privacy_notice
     get '/cookies', to: 'content#cookies_page', as: :cookies
     get '/roadmap', to: 'content#roadmap', as: :roadmap
     get '/make-a-complaint', to: 'content#complaints', as: :complaints

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -656,7 +656,9 @@ Rails.application.routes.draw do
     get '/' => 'start_page#show'
 
     get '/accessibility', to: 'content#accessibility'
-    get '/privacy-policy', to: 'content#privacy_policy', as: :privacy_policy
+    get '/privacy-policy', to: redirect('provider/privacy')
+    get '/privacy', to: 'content#privacy', as: :privacy
+    get '/privacy/service-privacy-notice', to: 'content#service_privacy_notice', as: :service_privacy_notice
     get '/cookies', to: 'content#cookies_page', as: :cookies
     get '/roadmap', to: 'content#roadmap', as: :roadmap
     get '/make-a-complaint', to: 'content#complaints', as: :complaints

--- a/spec/requests/provider_interface/content_controller_spec.rb
+++ b/spec/requests/provider_interface/content_controller_spec.rb
@@ -16,4 +16,20 @@ RSpec.describe ProviderInterface::ContentController, type: :request do
       expect(response).to have_http_status :ok
     end
   end
+
+  describe 'visit /provider/privacy' do
+    it 'returns 200' do
+      get provider_interface_privacy_path
+
+      expect(response).to have_http_status :ok
+    end
+  end
+
+  describe 'visit /provider/privacy/service-privacy-notice' do
+    it 'returns 200' do
+      get provider_interface_service_privacy_notice_path
+
+      expect(response).to have_http_status :ok
+    end
+  end
 end

--- a/spec/requests/provider_interface/content_controller_spec.rb
+++ b/spec/requests/provider_interface/content_controller_spec.rb
@@ -32,4 +32,12 @@ RSpec.describe ProviderInterface::ContentController, type: :request do
       expect(response).to have_http_status :ok
     end
   end
+
+  describe 'visit /provider/privacy/online-chat-privacy-notice' do
+    it 'returns 200' do
+      get provider_interface_online_chat_privacy_notice_path
+
+      expect(response).to have_http_status :ok
+    end
+  end
 end

--- a/spec/system/provider_interface/provider_content_spec.rb
+++ b/spec/system/provider_interface/provider_content_spec.rb
@@ -15,8 +15,11 @@ RSpec.feature 'Provider content' do
     then_i_can_see_the_cookies_page
     and_i_can_opt_in_to_tracking_website_usage
 
-    when_i_click_on_the_privacy_policy
-    then_i_can_see_the_privacy_policy
+    when_i_click_on_privacy
+    then_i_can_see_the_privacy_notices
+
+    when_i_click_on_service_privacy_notice
+    then_i_can_see_the_service_privacy_notice
 
     when_i_click_on_the_service_guidance
     then_i_can_see_the_service_guidance_provider
@@ -68,12 +71,20 @@ RSpec.feature 'Provider content' do
     expect(page).to have_content('Make a complaint about this service')
   end
 
-  def when_i_click_on_the_privacy_policy
-    within('.govuk-footer') { click_link t('layout.support_links.privacy_policy') }
+  def when_i_click_on_privacy
+    within('.govuk-footer') { click_link t('layout.support_links.privacy') }
   end
 
-  def then_i_can_see_the_privacy_policy
-    expect(page).to have_content(t('page_titles.privacy_policy'))
+  def then_i_can_see_the_privacy_notices
+    expect(page).to have_content(t('page_titles.privacy_notices'))
+  end
+
+  def when_i_click_on_service_privacy_notice
+    click_on 'Service privacy notice'
+  end
+
+  def then_i_can_see_the_service_privacy_notice
+    expect(page).to have_content(t('page_titles.service_privacy_notice'))
   end
 
   def when_i_click_on_the_service_guidance

--- a/spec/system/provider_interface/provider_content_spec.rb
+++ b/spec/system/provider_interface/provider_content_spec.rb
@@ -21,6 +21,10 @@ RSpec.feature 'Provider content' do
     when_i_click_on_service_privacy_notice
     then_i_can_see_the_service_privacy_notice
 
+    when_i_click_on_privacy
+    and_i_click_on_online_chat_privacy_notice
+    then_i_can_see_the_online_chat_privacy_notice
+
     when_i_click_on_the_service_guidance
     then_i_can_see_the_service_guidance_provider
 
@@ -85,6 +89,14 @@ RSpec.feature 'Provider content' do
 
   def then_i_can_see_the_service_privacy_notice
     expect(page).to have_content(t('page_titles.service_privacy_notice'))
+  end
+
+  def and_i_click_on_online_chat_privacy_notice
+    click_on 'Online chat privacy notice'
+  end
+
+  def then_i_can_see_the_online_chat_privacy_notice
+    expect(page).to have_content(t('page_titles.online_chat_privacy_notice'))
   end
 
   def when_i_click_on_the_service_guidance


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

https://trello.com/c/QGnTn00w/4497-adding-privacy-policies-for-chat-apply-manage

We're shaking up the privacy pages that we show for provider users - this is in preparation for the chat stuff. 

## Changes proposed in this pull request

The `Privacy policy` section in the footer has been reworded to `Privacy` with the page title `Privacy notices`. This now contains a list of privacy notices, of which we will show two. Those have both been added here. 

The content helper has also been changed to make setting out breadcrumbs more flexible, as it was previously hardcoded for the `Service Guidance` pages as that was the only spot the breadcrumbs were used - which is no longer the case. 

There are still some uncertainties around the appropriate header tagging for markdown content. Our prototype [uses header tags differently](https://ukgovernmentdfe.slack.com/archives/CPH8J9G65/p1637579401172400) which leads to some odd discrepancies. 

The key issue is that the prototype never uses the `govuk-heading-xl` class, and h1s are mapped to `govuk-heading-l` instead, with smaller headers using lower sizes. H3s and h4s end up having the `govuk-heading-s`, so there's no difference visually. 

## Guidance to review

Head to the provider interface and select the Privacy section in the footer. Poke around there!
