### PR TITLE
Monthly stats by course type - stop deferrals overwriting other counts

### DIFF
--- a/app/models/publications/monthly_statistics/by_course_type.rb
+++ b/app/models/publications/monthly_statistics/by_course_type.rb
@@ -51,7 +51,8 @@ module Publications
         group_query_for_deferred_offers.map do |item|
           program_type, status_before_deferral = item[0]
           count = item[1]
-          counts[program_type_lookup(program_type)]&.merge!({ status_before_deferral => count })
+          statuses_for_program_type = counts[program_type_lookup(program_type)] || {}
+          statuses_for_program_type[status_before_deferral] = (statuses_for_program_type[status_before_deferral] || 0) + count
         end
 
         counts

--- a/spec/models/publications/monthly_statistics/by_course_type_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_course_type_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe Publications::MonthlyStatistics::ByCourseType do
           {
             'Course type' => 'School-centred initial teacher training (SCITT)',
             'Recruited' => 0,
-            'Conditions pending' => 1,
+            'Conditions pending' => 2,
             'Received an offer' => 1,
             'Awaiting provider decisions' => 0,
             'Unsuccessful' => 1,
-            'Total' => 3,
+            'Total' => 4,
           },
           {
             'Course type' => 'School Direct (fee-paying)',
@@ -56,7 +56,7 @@ RSpec.describe Publications::MonthlyStatistics::ByCourseType do
           },
 
         ],
-        column_totals: [2, 3, 4, 1, 7, 17] },
+        column_totals: [2, 4, 4, 1, 7, 18] },
     )
   end
 
@@ -81,6 +81,7 @@ RSpec.describe Publications::MonthlyStatistics::ByCourseType do
     create_application_choice_for_this_cycle(status: :with_rejection, program_type: 'school_direct_training_programme')
     create_application_choice_for_this_cycle(status: :with_offer, program_type: 'school_direct_salaried_training_programme')
     create_application_choice_for_this_cycle(status: :with_rejection, program_type: 'school_direct_salaried_training_programme')
+    create_application_choice_for_this_cycle(status: :with_accepted_offer, program_type: 'scitt_programme')
   end
 
   def create_application_choice_for_this_cycle(status:, program_type:)


### PR DESCRIPTION
## Context

This PR attempts to fix number 2 of 5 issue that TAD have reported about monthly stats reports:

> The overall totals in “monthly-statistics-applications-by-course-type” are odd. You’re showing as having only 129 + 13 total acceptances, whereas the MR says we have 1768. The offer number looks low here too. Should it be “Received an offer but not responded” as in the previous table?

## Changes proposed in this pull request

The counts for acceptances and offers is low because we are overwriting the counts for this year with last years deferrals. We should be summing them.

## Guidance to review

- Does this make sense?
- Is there a neater way to implement the summing?

## Link to Trello card

[<!-- http://trello.com/123-example-card -->
](https://trello.com/c/5iXjyAxM/4151-respond-to-tad-qa-comments-on-the-monthly-external-report)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
