### PR TITLE
Count pending_conditions applications in monthly report

### DIFF
--- a/app/models/publications/monthly_statistics/by_status.rb
+++ b/app/models/publications/monthly_statistics/by_status.rb
@@ -55,13 +55,13 @@ module Publications
             case status
             when 'awaiting_provider_decision', 'interviewing'
               counts['Awaiting provider decisions'][phase] += count
-            when 'conditions_not_met', 'offer_deferred'
+            when 'pending_conditions'
               counts['Conditions pending'][phase] += count
             when 'offer'
               counts['Received an offer but not responded'][phase] += count
             when 'recruited'
               counts['Recruited'][phase] += count
-            when 'rejected'
+            when 'rejected', 'conditions_not_met', 'offer_withdrawn'
               counts['Application rejected'][phase] += count
             when 'withdrawn'
               counts['Withdrew an application'][phase] += count

--- a/spec/models/publications/monthly_statistics/by_status_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_status_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Publications::MonthlyStatistics::ByStatus do
               },
               {
                 'Status' => 'Conditions pending',
-                'First application' => 0,
+                'First application' => 1,
                 'Apply again' => 0,
-                'Total' => 0,
+                'Total' => 1,
               },
               {
                 'Status' => 'Received an offer but not responded',
@@ -49,12 +49,12 @@ RSpec.describe Publications::MonthlyStatistics::ByStatus do
               },
               {
                 'Status' => 'Application rejected',
-                'First application' => 2,
+                'First application' => 4,
                 'Apply again' => 1,
-                'Total' => 3,
+                'Total' => 5,
               },
             ],
-          column_totals: [4, 3, 7],
+          column_totals: [7, 3, 10],
         },
       )
     end
@@ -76,9 +76,9 @@ RSpec.describe Publications::MonthlyStatistics::ByStatus do
           },
           {
             'Status' => 'Conditions pending',
-            'First application' => 0,
+            'First application' => 1,
             'Apply again' => 0,
-            'Total' => 0,
+            'Total' => 1,
           },
           {
             'Status' => 'Received an offer but not responded',
@@ -106,12 +106,12 @@ RSpec.describe Publications::MonthlyStatistics::ByStatus do
           },
           {
             'Status' => 'Application rejected',
-            'First application' => 0,
+            'First application' => 2,
             'Apply again' => 0,
-            'Total' => 0,
+            'Total' => 2,
           },
         ],
-          column_totals: [2, 2, 4] },
+          column_totals: [5, 2, 7] },
       )
     end
   end
@@ -150,5 +150,17 @@ RSpec.describe Publications::MonthlyStatistics::ByStatus do
     candidate_four = create(:candidate)
     candidate_four_apply_one_deferred_application = create(:application_form, phase: 'apply_1', candidate: candidate_four, recruitment_cycle_year: RecruitmentCycle.previous_year)
     create(:application_choice, :with_offer, :offer_deferred, status_before_deferral: 'recruited', application_form: candidate_four_apply_one_deferred_application)
+
+    candidate_five = create(:candidate)
+    candidate_five_conditions_pending_application = create(:application_form, phase: 'apply_1', candidate: candidate_five)
+    create(:application_choice, :with_accepted_offer, application_form: candidate_five_conditions_pending_application)
+
+    candidate_six = create(:candidate)
+    candidate_six_withdrawn_application = create(:application_form, phase: 'apply_1', candidate: candidate_six)
+    create(:application_choice, :with_withdrawn_offer, application_form: candidate_six_withdrawn_application)
+
+    candidate_seven = create(:candidate)
+    candidate_seven_conditions_not_met_application = create(:application_form, phase: 'apply_1', candidate: candidate_seven)
+    create(:application_choice, :with_conditions_not_met, application_form: candidate_seven_conditions_not_met_application)
   end
 end


### PR DESCRIPTION
## Context

We're not counting these apps in the report.

## Changes proposed in this pull request

Fix the case statement missing `pending_conditions`

## Link to Trello card

https://trello.com/c/5iXjyAxM/4151-respond-to-tad-qa-comments-on-the-monthly-external-report

## Things to check

- [X] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
