### PR TITLE
International addresses show the wrong error messages

### DIFF
--- a/app/forms/candidate_interface/contact_details_form.rb
+++ b/app/forms/candidate_interface/contact_details_form.rb
@@ -16,9 +16,9 @@ module CandidateInterface
     validates :country, presence: true, on: :address_type, if: :international?
 
     validates :address_line1, :address_line2, :address_line3, :address_line4,
-              length: { maximum: 50 }, on: :address, if: :uk?
+              length: { maximum: MAX_LENGTH }, on: :address, if: :uk?
 
-    validates :phone_number, length: { maximum: 50 }, phone_number: true, on: :base
+    validates :phone_number, length: { maximum: MAX_LENGTH }, phone_number: true, on: :base
 
     validates :postcode, postcode: true, on: :address, if: :uk?
 
@@ -84,7 +84,7 @@ module CandidateInterface
       return if address_lines.include?(nil)
 
       address_lines.each.with_index(1) do |value, index|
-        value.length > MAX_LENGTH ? errors.add("address_line#{index}".to_sym, :international_too_long) : nil
+        value.length > MAX_LENGTH ? errors.add("address_line#{index}".to_sym, :international_too_long, count: MAX_LENGTH) : nil
       end
     end
 

--- a/app/forms/candidate_interface/contact_details_form.rb
+++ b/app/forms/candidate_interface/contact_details_form.rb
@@ -81,6 +81,8 @@ module CandidateInterface
     end
 
     def address_lines_length_valid?
+      return if address_lines.include?(nil)
+
       address_lines.each.with_index(1) do |value, index|
         value.length > MAX_LENGTH ? errors.add("address_line#{index}".to_sym, :international_too_long) : nil
       end

--- a/config/locales/candidate_interface/contact_details.yml
+++ b/config/locales/candidate_interface/contact_details.yml
@@ -50,14 +50,19 @@ en:
               too_long: Phone number must be %{count} characters or fewer
             address_line1:
               blank: Enter your building and street
+              international_blank: Enter your address
               too_long: Building and street line 1 must be %{count} characters or fewer
+              international_too_long: Address line 1 must be 50 characters or fewer
             address_line2:
               too_long: Building and street line 2 must be %{count} characters or fewer
+              international_too_long: Address line 2 must be 50 characters or fewer
             address_line3:
               blank: Enter your town or city
               too_long: Town or city must be %{count} characters or fewer
+              international_too_long: Address line 3 must be 50 characters or fewer
             address_line4:
               too_long: County must be %{count} characters or fewer
+              international_too_long: Address line 4 must be 50 characters or fewer
             postcode:
               blank: Enter a postcode
               invalid: Enter a real postcode (for example, BN1 1AA)

--- a/config/locales/candidate_interface/contact_details.yml
+++ b/config/locales/candidate_interface/contact_details.yml
@@ -52,17 +52,17 @@ en:
               blank: Enter your building and street
               international_blank: Enter your address
               too_long: Building and street line 1 must be %{count} characters or fewer
-              international_too_long: Address line 1 must be 50 characters or fewer
+              international_too_long: Address line 1 must be %{count} characters or fewer
             address_line2:
               too_long: Building and street line 2 must be %{count} characters or fewer
-              international_too_long: Address line 2 must be 50 characters or fewer
+              international_too_long: Address line 2 must be %{count} characters or fewer
             address_line3:
               blank: Enter your town or city
               too_long: Town or city must be %{count} characters or fewer
-              international_too_long: Address line 3 must be 50 characters or fewer
+              international_too_long: Address line 3 must be %{count} characters or fewer
             address_line4:
               too_long: County must be %{count} characters or fewer
-              international_too_long: Address line 4 must be 50 characters or fewer
+              international_too_long: Address line 4 must be %{count} characters or fewer
             postcode:
               blank: Enter a postcode
               invalid: Enter a real postcode (for example, BN1 1AA)

--- a/spec/forms/candidate_interface/contact_details_form_spec.rb
+++ b/spec/forms/candidate_interface/contact_details_form_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
                                               address_line2: '', address_line3: '', address_line4: '')
 
         expect(contact_details.save_address(application_form)).to eq(false)
-        expect(contact_details.errors[:address_line1]).to include(I18n.t("#{error_attr}.address_line1.international_too_long"))
+        expect(contact_details.errors[:address_line1]).to include(I18n.t("#{error_attr}.address_line1.international_too_long", count: described_class::MAX_LENGTH))
       end
     end
   end

--- a/spec/forms/candidate_interface/contact_details_form_spec.rb
+++ b/spec/forms/candidate_interface/contact_details_form_spec.rb
@@ -122,21 +122,20 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
       it { is_expected.to validate_presence_of(:address_line3).on(:address) }
       it { is_expected.to validate_presence_of(:postcode).on(:address) }
       it { is_expected.not_to allow_value('MUCH WOW').for(:postcode).on(:address) }
+
+      it { is_expected.to validate_length_of(:address_line1).is_at_most(50).on(:address) }
+      it { is_expected.to validate_length_of(:address_line2).is_at_most(50).on(:address) }
+      it { is_expected.to validate_length_of(:address_line3).is_at_most(50).on(:address) }
+      it { is_expected.to validate_length_of(:address_line4).is_at_most(50).on(:address) }
     end
 
     context 'for an international address' do
       subject(:form) { described_class.new(address_type: 'international') }
 
-      it { is_expected.to validate_presence_of(:address_line1).on(:address) }
       it { is_expected.not_to validate_presence_of(:address_line3).on(:address) }
       it { is_expected.not_to validate_presence_of(:postcode).on(:address) }
       it { is_expected.to allow_value('MUCH WOW').for(:postcode).on(:address) }
     end
-
-    it { is_expected.to validate_length_of(:address_line1).is_at_most(50).on(:address) }
-    it { is_expected.to validate_length_of(:address_line2).is_at_most(50).on(:address) }
-    it { is_expected.to validate_length_of(:address_line3).is_at_most(50).on(:address) }
-    it { is_expected.to validate_length_of(:address_line4).is_at_most(50).on(:address) }
 
     it { is_expected.to allow_value('SW1P 3BT').for(:postcode).on(:address) }
 
@@ -149,7 +148,7 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
     let(:error_attr) { 'activemodel.errors.models.candidate_interface/contact_details_form.attributes' }
     let(:application_form) { build(:application_form) }
 
-    context 'international address blank' do
+    context 'international address presence' do
       it 'is invalid' do
         contact_details = described_class.new(address_type: 'international', address_line1: '')
 
@@ -158,9 +157,10 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
       end
     end
 
-    context 'international address too long' do
+    context 'international address maximum length' do
       it 'is invalid' do
-        contact_details = described_class.new(address_type: 'international', address_line1: SecureRandom.alphanumeric(51))
+        contact_details = described_class.new(address_type: 'international', address_line1: SecureRandom.alphanumeric(51),
+                                              address_line2: '', address_line3: '', address_line4: '')
 
         expect(contact_details.save_address(application_form)).to eq(false)
         expect(contact_details.errors[:address_line1]).to include(I18n.t("#{error_attr}.address_line1.international_too_long"))

--- a/spec/forms/candidate_interface/contact_details_form_spec.rb
+++ b/spec/forms/candidate_interface/contact_details_form_spec.rb
@@ -144,4 +144,27 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
     it { is_expected.not_to allow_value('07700 WUT WUT').for(:phone_number).on(:base) }
     it { is_expected.to validate_length_of(:phone_number).is_at_most(50).on(:base) }
   end
+
+  describe 'custom validations' do
+    let(:error_attr) { 'activemodel.errors.models.candidate_interface/contact_details_form.attributes' }
+    let(:application_form) { build(:application_form) }
+
+    context 'international address blank' do
+      it 'is invalid' do
+        contact_details = described_class.new(address_type: 'international', address_line1: '')
+
+        expect(contact_details.save_address(application_form)).to eq(false)
+        expect(contact_details.errors[:address_line1]).to include(I18n.t("#{error_attr}.address_line1.international_blank"))
+      end
+    end
+
+    context 'international address too long' do
+      it 'is invalid' do
+        contact_details = described_class.new(address_type: 'international', address_line1: SecureRandom.alphanumeric(51))
+
+        expect(contact_details.save_address(application_form)).to eq(false)
+        expect(contact_details.errors[:address_line1]).to include(I18n.t("#{error_attr}.address_line1.international_too_long"))
+      end
+    end
+  end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'Entering their contact information' do
     when_i_select_outside_the_uk
     and_i_incorrectly_fill_in_my_international_address
     and_i_submit_my_address
-    then_i_should_see_validation_errors_for_address_line1
+    then_i_should_see_validation_errors_for_address_line1_for_my_international_address
 
     when_i_fill_in_an_international_address
     and_i_submit_my_address
@@ -174,6 +174,10 @@ RSpec.feature 'Entering their contact information' do
 
   def then_i_should_see_validation_errors_for_address_line1
     expect(page).to have_content t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.address_line1.blank')
+  end
+
+  def then_i_should_see_validation_errors_for_address_line1_for_my_international_address
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.address_line1.international_blank')
   end
 
   def when_i_fill_in_an_international_address


### PR DESCRIPTION
## Context

If validations are triggered on submission of course details form, the error messages for both international and uk form fields is identical. This is incorrect because the field labels are different despite the attributes being the same.
## Changes proposed in this pull request
* For the international address I've added custom validations to allow different error messaging to be rendered as shown below for both blank and length. 

Before: 

<img width="920" alt="Screenshot 2021-11-23 at 18 07 12" src="https://user-images.githubusercontent.com/58793682/143080252-0d23528d-f856-472e-8e08-8d76276a62d8.png">

After:
<img width="982" alt="Screenshot 2021-11-23 at 18 08 20" src="https://user-images.githubusercontent.com/58793682/143080350-4b473170-1e01-4a15-8826-c41d689bfdec.png">

## Guidance to review
Trigger validations on `/candidate/application/contact-information/address/edit` (or new) endpoint

## Link to Trello card
https://trello.com/c/iqMeSjy0/3571-international-addresses-show-the-wrong-error-messages-if-left-empty-next-sprint-check)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
