### PR TITLE
Monthly statistics by sex report to count candidates

### DIFF
--- a/app/models/publications/monthly_statistics/by_sex.rb
+++ b/app/models/publications/monthly_statistics/by_sex.rb
@@ -46,40 +46,89 @@ module Publications
         }
 
         group_query_excluding_deferred_offers.map do |item|
-          sex, status = item[0]
-          count = item[1]
-          counts[sex]&.merge!({ status => count })
+          counts[item['sex']]&.merge!({ item['status'] => item['count'] })
         end
 
         group_query_for_deferred_offers.map do |item|
-          sex, status = item[0]
-          count = item[1]
-          counts[sex]&.merge!({ status => count })
+          counts[item['sex']]&.merge!({ item['status_before_deferral'] => item['count'] })
         end
 
         counts
       end
 
       def group_query_for_deferred_offers
-        group_query(recruitment_cycle_year: RecruitmentCycle.previous_year)
-          .where(status: :offer_deferred)
-          .count
+        group_query(
+          cycle: RecruitmentCycle.previous_year,
+          status_attribute: :status_before_deferral,
+        )
       end
 
       def group_query_excluding_deferred_offers
-        group_query(recruitment_cycle_year: RecruitmentCycle.current_year)
-          .where.not(status: :offer_deferred)
-          .count
+        group_query
       end
 
-      def group_query(recruitment_cycle_year: RecruitmentCycle.current_year)
-        ApplicationChoice
-          .joins(:application_form)
-          .where(application_forms: { recruitment_cycle_year: recruitment_cycle_year })
-          .where.not(
-            application_forms: ApplicationForm.select(:previous_application_form_id).where.not(previous_application_form_id: nil),
-          )
-          .group("application_forms.equality_and_diversity->'sex'", 'status')
+      def group_query(
+        cycle: RecruitmentCycle.current_year,
+        status_attribute: :status
+      )
+        without_subsequent_applications_query =
+          "AND (
+            NOT EXISTS (
+              SELECT 1
+              FROM application_forms
+              AS subsequent_application_forms
+              WHERE application_forms.id = subsequent_application_forms.previous_application_form_id
+            )
+          )"
+        with_statuses =
+          if status_attribute.to_s == 'status_before_deferral'
+            "AND application_choices.status = 'offer_deferred'"
+          else
+            "AND NOT application_choices.status = 'offer_deferred'"
+          end
+
+        query = "SELECT
+          COUNT(application_choices_with_minimum_statuses.id),
+          application_choices_with_minimum_statuses.#{status_attribute},
+          sex
+        FROM (
+          SELECT application_choices.id as id,
+            application_choices.status_before_deferral as status_before_deferral,
+            application_choices.status as status,
+            application_forms.equality_and_diversity->>'sex' as sex,
+            ROW_NUMBER() OVER (
+              PARTITION BY application_forms.id
+              ORDER BY
+              CASE application_choices.#{status_attribute}
+              WHEN 'offer_deferred' THEN 0
+              WHEN 'recruited' THEN 1
+              WHEN 'pending_conditions' THEN 2
+              WHEN 'conditions_not_met' THEN 2
+              WHEN 'offer' THEN 3
+              WHEN 'awaiting_provider_decision' THEN 4
+              WHEN 'interviewing' THEN 4
+              WHEN 'declined' THEN 5
+              WHEN 'offer_withdrawn' THEN 6
+              WHEN 'withdrawn' THEN 7
+              WHEN 'cancelled' THEN 7
+              WHEN 'rejected' THEN 7
+              ELSE 8
+              END
+            ) AS row_number
+          FROM application_forms
+          INNER JOIN application_choices
+            ON application_choices.application_form_id = application_forms.id
+          WHERE application_forms.recruitment_cycle_year = #{cycle}
+            #{without_subsequent_applications_query}
+            #{with_statuses}
+          ) AS application_choices_with_minimum_statuses
+        WHERE application_choices_with_minimum_statuses.row_number = 1
+        GROUP BY sex, #{status_attribute}"
+
+        ActiveRecord::Base
+          .connection
+          .execute(query)
+          .to_a
       end
     end
   end

--- a/app/models/publications/monthly_statistics/by_sex.rb
+++ b/app/models/publications/monthly_statistics/by_sex.rb
@@ -81,7 +81,7 @@ module Publications
             )
           )"
         with_statuses =
-          if status_attribute.to_s == 'status_before_deferral'
+          if status_attribute == :status_before_deferral
             "AND application_choices.status = 'offer_deferred'"
           else
             "AND NOT application_choices.status = 'offer_deferred'"

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -301,6 +301,26 @@
       "note": ""
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "c438240efdd424f557a29170dd2cc4c44c0acf6ff324e686019ee3ca7035ad26",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/publications/monthly_statistics/by_sex.rb",
+      "line": 130,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ActiveRecord::Base.connection.execute(\"SELECT\\n          COUNT(application_choices_with_minimum_statuses.id),\\n          application_choices_with_minimum_statuses.#{status_attribute},\\n          sex\\n        FROM (\\n          SELECT application_choices.id as id,\\n            application_choices.status_before_deferral as status_before_deferral,\\n            application_choices.status as status,\\n            application_forms.equality_and_diversity->>'sex' as sex,\\n            ROW_NUMBER() OVER (\\n              PARTITION BY application_forms.id\\n              ORDER BY\\n              CASE application_choices.#{status_attribute}\\n              WHEN 'offer_deferred' THEN 0\\n              WHEN 'recruited' THEN 1\\n              WHEN 'pending_conditions' THEN 2\\n              WHEN 'conditions_not_met' THEN 2\\n              WHEN 'offer' THEN 3\\n              WHEN 'awaiting_provider_decision' THEN 4\\n              WHEN 'interviewing' THEN 4\\n              WHEN 'declined' THEN 5\\n              WHEN 'offer_withdrawn' THEN 6\\n              WHEN 'withdrawn' THEN 7\\n              WHEN 'cancelled' THEN 7\\n              WHEN 'rejected' THEN 7\\n              ELSE 8\\n              END\\n            ) AS row_number\\n          FROM application_forms\\n          INNER JOIN application_choices\\n            ON application_choices.application_form_id = application_forms.id\\n          WHERE application_forms.recruitment_cycle_year = #{cycle}\\n            #{\"AND (\\n            NOT EXISTS (\\n              SELECT 1\\n              FROM application_forms\\n              AS subsequent_application_forms\\n              WHERE application_forms.id = subsequent_application_forms.previous_application_form_id\\n            )\\n          )\"}\\n            #{(\"AND application_choices.status = 'offer_deferred'\" or \"AND NOT application_choices.status = 'offer_deferred'\")}\\n          ) AS application_choices_with_minimum_statuses\\n        WHERE application_choices_with_minimum_statuses.row_number = 1\\n        GROUP BY sex, #{status_attribute}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Publications::MonthlyStatistics::BySex",
+        "method": "group_query"
+      },
+      "user_input": "status_attribute",
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
       "warning_type": "Dangerous Send",
       "warning_code": 23,
       "fingerprint": "db94836510b6f2c59eddb567e3cce707e5a8960d9f886491c639d1f631810278",
@@ -402,6 +422,6 @@
       "note": ""
     }
   ],
-  "updated": "2021-11-19 16:08:35 +0000",
+  "updated": "2021-11-26 13:32:23 +0000",
   "brakeman_version": "5.1.2"
 }

--- a/spec/models/publications/monthly_statistics/by_sex_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_sex_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Publications::MonthlyStatistics::BySex do
       create_application_choice(status: :awaiting_provider_decision, sex: 'Prefer not to say')
       create_application_choice(status: :with_recruited, sex: 'Prefer not to say')
       create_application_choice(status: :with_offer, sex: 'intersex')
-      create_application_choice(status: :with_deferred_offer, sex: 'male', recruitment_cycle_year: RecruitmentCycle.previous_year)
-      create_application_choice(status: :with_deferred_offer, sex: 'female', recruitment_cycle_year: RecruitmentCycle.current_year)
+      create_application_choice(status: :with_deferred_offer, sex: 'male', status_before_deferral: 'offer', recruitment_cycle_year: RecruitmentCycle.previous_year)
+      create_application_choice(status: :with_deferred_offer, sex: 'female', status_before_deferral: 'offer', recruitment_cycle_year: RecruitmentCycle.current_year)
       create_application_choice(status: :with_conditions_not_met, sex: 'intersex')
       create_application_choice(status: :with_offer, sex: 'female')
       create_application_choice(status: :with_withdrawn_offer, sex: 'female')
@@ -66,11 +66,13 @@ RSpec.describe Publications::MonthlyStatistics::BySex do
     status:,
     sex:,
     recruitment_cycle_year: RecruitmentCycle.current_year,
-    previous_application_form: nil
+    previous_application_form: nil,
+    status_before_deferral: nil
   )
     create(
       :application_choice,
       status,
+      status_before_deferral: status_before_deferral,
       application_form: create(
         :application_form,
         previous_application_form: previous_application_form,

--- a/spec/models/publications/monthly_statistics/by_sex_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_sex_spec.rb
@@ -5,17 +5,54 @@ RSpec.describe Publications::MonthlyStatistics::BySex do
 
   it "returns table data for 'by course age group'" do
     5.times do
-      create_application_choice(status: :with_rejection, sex: 'female')
-      create_application_choice(status: :awaiting_provider_decision, sex: 'Prefer not to say')
-      create_application_choice(status: :with_recruited, sex: 'Prefer not to say')
-      create_application_choice(status: :with_offer, sex: 'intersex')
-      create_application_choice(status: :with_deferred_offer, sex: 'male', status_before_deferral: 'offer', recruitment_cycle_year: RecruitmentCycle.previous_year)
-      create_application_choice(status: :with_deferred_offer, sex: 'female', status_before_deferral: 'offer', recruitment_cycle_year: RecruitmentCycle.current_year)
-      create_application_choice(status: :with_conditions_not_met, sex: 'intersex')
-      create_application_choice(status: :with_offer, sex: 'female')
-      create_application_choice(status: :with_withdrawn_offer, sex: 'female')
-      create_application_choice(status: :withdrawn, sex: 'male')
-      create_application_choice_with_previous_application(status: :with_rejection, sex: 'male')
+      create_application_choice(
+        statuses: %i[with_rejection with_rejection],
+        sex: 'female',
+      )
+      create_application_choice(
+        statuses: %i[awaiting_provider_decision],
+        sex: 'Prefer not to say',
+      )
+      create_application_choice(
+        statuses: %i[awaiting_provider_decision with_rejection with_recruited],
+        sex: 'Prefer not to say',
+      )
+      create_application_choice(
+        statuses: %i[awaiting_provider_decision with_rejection with_offer],
+        sex: 'intersex',
+      )
+      create_application_choice(
+        statuses: %i[with_deferred_offer],
+        sex: 'male',
+        status_before_deferral: 'offer',
+        recruitment_cycle_year: RecruitmentCycle.previous_year,
+      )
+      create_application_choice(
+        statuses: %i[with_deferred_offer],
+        sex: 'female',
+        status_before_deferral: 'offer',
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+      )
+      create_application_choice(
+        statuses: %i[with_conditions_not_met],
+        sex: 'intersex',
+      )
+      create_application_choice(
+        statuses: %i[with_offer],
+        sex: 'female',
+      )
+      create_application_choice(
+        statuses: %i[with_withdrawn_offer],
+        sex: 'female',
+      )
+      create_application_choice(
+        statuses: %i[withdrawn],
+        sex: 'male',
+      )
+      create_application_choice_with_previous_application(
+        status: :with_rejection,
+        sex: 'male',
+      )
     end
 
     expect(statistics).to eq(
@@ -63,23 +100,28 @@ RSpec.describe Publications::MonthlyStatistics::BySex do
   end
 
   def create_application_choice(
-    status:,
+    statuses:,
     sex:,
     recruitment_cycle_year: RecruitmentCycle.current_year,
     previous_application_form: nil,
     status_before_deferral: nil
   )
-    create(
-      :application_choice,
-      status,
-      status_before_deferral: status_before_deferral,
-      application_form: create(
-        :application_form,
-        previous_application_form: previous_application_form,
-        recruitment_cycle_year: recruitment_cycle_year,
-        equality_and_diversity: { 'sex' => sex },
-      ),
+    application_form = create(
+      :application_form,
+      previous_application_form: previous_application_form,
+      recruitment_cycle_year: recruitment_cycle_year,
+      equality_and_diversity: { 'sex' => sex },
     )
+    statuses.each do |status|
+      create(
+        :application_choice,
+        status,
+        application_form: application_form,
+        status_before_deferral: status_before_deferral,
+      )
+    end
+
+    application_form
   end
 
   def create_application_choice_with_previous_application(
@@ -87,16 +129,16 @@ RSpec.describe Publications::MonthlyStatistics::BySex do
     sex:,
     recruitment_cycle_year: RecruitmentCycle.current_year
   )
-    previous_application_choice = create_application_choice(
-      status: status,
+    previous_application_form = create_application_choice(
+      statuses: [status],
       sex: sex,
       recruitment_cycle_year: recruitment_cycle_year,
     )
     create_application_choice(
-      status: status,
+      statuses: [status],
       sex: sex,
       recruitment_cycle_year: recruitment_cycle_year,
-      previous_application_form: previous_application_choice.application_form,
+      previous_application_form: previous_application_form,
     )
   end
 end


### PR DESCRIPTION
## Context

This report was counting applications (application choices) but should be counting candidates, though for the purpose of these monthly stats we've taken candidate to mean application forms (sex is an attribute of forms rather than candidates).

## Changes proposed in this pull request

- Change the query to count application forms using the existing method of determining the overall status of the application from multiple application choice statuses.
- Update the specs to cover multiple choices per form.

## Guidance to review

- Does this meet the requirement more correctly?
- Are the specs sufficient here?

## Link to Trello card

[<!-- http://trello.com/123-example-card -->
](https://trello.com/c/5iXjyAxM/4151-respond-to-tad-qa-comments-on-the-monthly-external-report)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
