### PR TITLE
[450] Remove guid from yabeda metrics

### DIFF
--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -1,14 +1,12 @@
 if ENV.key?('VCAP_APPLICATION')
   vcap_config = JSON.parse(ENV['VCAP_APPLICATION'])
   app_name = vcap_config['name']
-  app_guid = vcap_config['application_id']
   org_name = vcap_config['organization_name']
   space_name = vcap_config['space_name']
   app_instance = ENV['CF_INSTANCE_INDEX']
 
   Yabeda.configure do
     default_tag :app, app_name
-    default_tag :guid, app_guid
     default_tag :exported_instance, app_instance
     default_tag :organisation, org_name
     default_tag :space, space_name


### PR DESCRIPTION
## Context
We store a really high number of prometheus time series which creates slowness and crashes

## Changes proposed in this pull request
The guid changes all the time and this creates a high cardinality problem especially for the following metrics:

* rails_db_runtime_seconds_bucket
* rails_request_duration_seconds_bucket
* rails_view_runtime_seconds_bucket

There are currently more than 50000 time series of each of these metrics.

Dropping the guid will reduce this number drastically. It has no value for monitoring.

## Guidance to review
Observe the rails_db_runtime_seconds_bucket metric for example:
https://prometheus-bat.london.cloudapps.digital/graph?g0.expr=rails_db_runtime_seconds_bucket&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h

## Link to Trello card
https://trello.com/c/Cy7Ws6t6/450-remove-guid-from-yabeda-metrics

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
