### PR TITLE
Fix for monthly stats - stop overwriting totals with deferrals numbers

### DIFF
--- a/app/models/publications/monthly_statistics/by_primary_specialist_subject.rb
+++ b/app/models/publications/monthly_statistics/by_primary_specialist_subject.rb
@@ -55,7 +55,8 @@ module Publications
           subject, status = item[0]
           count = item[1]
 
-          counts[subject_lookup(subject)].merge!({ status => count })
+          statuses_for_subject = counts[subject_lookup(subject)] || {}
+          statuses_for_subject[status] = (statuses_for_subject[status] || 0) + count
         end
 
         counts

--- a/app/models/publications/monthly_statistics/by_provider_area.rb
+++ b/app/models/publications/monthly_statistics/by_provider_area.rb
@@ -55,7 +55,8 @@ module Publications
         group_query_for_deferred_offers.map do |item|
           region_code, status = item[0]
           count = item[1]
-          counts[region_code_lookup(region_code)]&.merge!({ status => count })
+          statuses_for_region_code = counts[region_code_lookup(region_code)] || {}
+          statuses_for_region_code[status] = (statuses_for_region_code[status] || 0) + count
         end
 
         counts

--- a/app/models/publications/monthly_statistics/by_secondary_subject.rb
+++ b/app/models/publications/monthly_statistics/by_secondary_subject.rb
@@ -98,7 +98,8 @@ module Publications
           if MODERN_FOREIGN_LANGUAGES.include?(subject)
             languages_counter << { status => count }
           else
-            counts[subject]&.merge!({ status => count })
+            statuses_for_subject = counts[subject] || {}
+            statuses_for_subject[status] = (statuses_for_subject[status] || 0) + count
           end
         end
 

--- a/spec/models/publications/monthly_statistics/by_primary_specialist_subject_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_primary_specialist_subject_spec.rb
@@ -66,15 +66,15 @@ RSpec.describe Publications::MonthlyStatistics::ByPrimarySpecialistSubject do
             },
             {
               'Subject' => 'No specialist subject',
-              'Recruited' => 1,
+              'Recruited' => 2,
               'Conditions pending' => 0,
               'Received an offer' => 0,
               'Awaiting provider decisions' => 0,
               'Unsuccessful' => 0,
-              'Total' => 1,
+              'Total' => 2,
             },
           ],
-          column_totals: [2, 2, 0, 2, 3, 9],
+          column_totals: [3, 2, 0, 2, 3, 10],
         },
       )
     end
@@ -95,6 +95,7 @@ RSpec.describe Publications::MonthlyStatistics::ByPrimarySpecialistSubject do
     create(:application_choice, :with_offer, :offer_deferred, status_before_deferral: 'pending_conditions', current_recruitment_cycle_year: RecruitmentCycle.previous_year, course_option: primary_with_mathematics_course_option)
 
     # current year
+    create(:application_choice, :with_recruited, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: primary_course_option)
     create(:application_choice, :with_recruited, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: primary_with_geography_and_history_course_option)
     create(:application_choice, :with_rejection, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: primary_with_modern_languages_course_option)
     create(:application_choice, :with_withdrawn_offer, current_recruitment_cycle_year: RecruitmentCycle.current_year, course_option: primary_with_mathematics_course_option)

--- a/spec/models/publications/monthly_statistics/by_provider_area_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_provider_area_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe Publications::MonthlyStatistics::ByProviderArea do
             {
               'Area' => 'East Midlands',
               'Recruited' => 0,
-              'Conditions pending' => 1,
+              'Conditions pending' => 2,
               'Received an offer' => 0,
               'Awaiting provider decisions' => 0,
               'Unsuccessful' => 0,
-              'Total' => 1,
+              'Total' => 2,
             },
             {
               'Area' => 'London',
@@ -92,7 +92,7 @@ RSpec.describe Publications::MonthlyStatistics::ByProviderArea do
               'Total' => 1,
             },
           ],
-          column_totals: [2, 2, 2, 0, 5, 11],
+          column_totals: [2, 3, 2, 0, 5, 12],
         },
       )
     end
@@ -106,6 +106,7 @@ RSpec.describe Publications::MonthlyStatistics::ByProviderArea do
     create_application_choice_for_last_cycle(status_before_deferral: 'recruited', region_code: 'north_east')
 
     # current year
+    create_application_choice_for_this_cycle(status: 'pending_conditions', region_code: 'east_midlands')
     create_application_choice_for_this_cycle(status: :with_rejection, region_code: 'north_west')
     create_application_choice_for_this_cycle(status: :with_offer, region_code: 'south_east')
     create_application_choice_for_this_cycle(status: :with_rejection, region_code: 'south_west')

--- a/spec/models/publications/monthly_statistics/by_secondary_subject_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_secondary_subject_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe Publications::MonthlyStatistics::BySecondarySubject do
           rows: [
             {
               'Subject' => 'Art and design',
-              'Recruited' => 1,
+              'Recruited' => 2,
               'Conditions pending' => 0,
               'Received an offer' => 0,
               'Awaiting provider decisions' => 0,
               'Unsuccessful' => 0,
-              'Total' => 1,
+              'Total' => 2,
             },
             {
               'Subject' => 'Science',
@@ -254,7 +254,7 @@ RSpec.describe Publications::MonthlyStatistics::BySecondarySubject do
               'Total' => 1,
             },
           ],
-          column_totals: [5, 9, 12, 1, 11, 38],
+          column_totals: [6, 9, 12, 1, 11, 39],
         },
       )
     end
@@ -278,6 +278,7 @@ RSpec.describe Publications::MonthlyStatistics::BySecondarySubject do
     create_application_choice_for_last_cycle(status_before_deferral: 'recruited', subject: 'Science')
 
     # current year
+    create_application_choice_for_this_cycle(status: 'recruited', subject: 'Art and design')
     create_application_choice_for_this_cycle(status: :with_offer, subject: 'Computing')
     create_application_choice_for_this_cycle(status: :with_conditions_not_met, subject: 'Dance')
     create_application_choice_for_this_cycle(status: :with_offer, subject: 'Design and technology')


### PR DESCRIPTION
## Context

After testing monthly statistics it became clear that the totals for certain statuses (`recruited` and `pending_conditions`) are much lower than they should be. This appears to be because the tallying logic is overwriting the deferral counts over this year's counts.

## Changes proposed in this pull request

- [x] Update specs to ensure that they reproduce this bug
- [x] Increment counts rather than overwriting

## Guidance to review

- Does this make sense?
- Could the tallying code be improved?
- Do the test additions cover this sufficiently?

## Link to Trello card

[[<!-- http://trello.com/123-example-card -->](https://trello.com/c/5iXjyAxM/4151-respond-to-tad-qa-comments-on-the-monthly-external-report)](https://trello.com/c/5iXjyAxM/4151-respond-to-tad-qa-comments-on-the-monthly-external-report)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
