### PR TITLE
Ensure rspec retry formatter closes the IO stream used to report flakey specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,12 +35,20 @@ require 'rspec/core/formatters/base_text_formatter'
 ENV['SERVICE_TYPE'] = 'test' # this is used for logging
 ENV['STATE_CHANGE_SLACK_URL'] = nil # ensure tests send no Slack notifications
 
+class RSpecRetryFormatter < RSpec::Core::Formatters::BaseTextFormatter
+  def close(notification)
+    super(notification)
+
+    output.close
+  end
+end
+
 RSpec.configure do |config|
   # RSpec-retry configuration, retry and log any indeterminate tests.
   config.verbose_retry = true
   config.display_try_failure_messages = true
   reporter = RSpec::Core::Reporter.new(config)
-  formatter = RSpec::Core::Formatters::BaseTextFormatter.new(File.open('tmp/rspec-retry-flakey-specs.log', 'ab'))
+  formatter = RSpecRetryFormatter.new(File.open('tmp/rspec-retry-flakey-specs.log', 'ab'))
   reporter.register_listener(formatter, 'message')
   config.retry_reporter = reporter
 


### PR DESCRIPTION
## Context

We `cat` the contents of the rspec retry log, this is [a File object passed to the relevant RSpec formatter](https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/spec/spec_helper.rb#L43).
`RSpec::Core::Formatters::BaseTextFormatter` [does not explicitly close the IO stream](https://github.com/rspec/rspec-core/blob/main/lib/rspec/core/formatters/base_text_formatter.rb#L60-L62).

We think `cat` may hang on some builds as the IO stream is not explicitly closed.

Paired with @JR-G on this
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Subclass `RSpec::Core::Formatters::BaseTextFormatter` and explicitly close the IO stream.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

We've subclassed in `spec_helper.rb`, are we bad people?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
