### PR TITLE
Improve candidates_export_spec performance

### DIFF
--- a/spec/services/support_interface/external_report_candidates_export_spec.rb
+++ b/spec/services/support_interface/external_report_candidates_export_spec.rb
@@ -42,41 +42,27 @@ RSpec.describe SupportInterface::ExternalReportCandidatesExport do
     def generate_test_data
       region_codes = ApplicationForm.region_codes.keys + [nil]
       statuses = ApplicationChoice.statuses.keys.reject { |status| %w[unsubmitted cancelled application_not_sent offer_deferred].include?(status) }
-      sexes = ExternalReportCandidates::SEX.keys
-
-      20.times do
-        date_of_birth = rand(Time.zone.now - 75.years..Time.zone.now - 20.years)
-        region_code = region_codes.sample
-        status = statuses.sample
-        sex = sexes.sample
-
-        rand(1..7).times do
-          application_form = if sex.nil?
-                               create(:application_form, equality_and_diversity: nil, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code)
-                             else
-                               create(:application_form, :with_equality_and_diversity_data, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code)
-                             end
-
-          create(:application_choice, status: status, application_form: application_form)
-          create(:application_choice, :with_rejection, application_form: application_form)
-        end
-      end
 
       5.times do
         date_of_birth = rand(Time.zone.now - 75.years..Time.zone.now - 20.years)
         region_code = region_codes.sample
+        status = statuses.sample
+
+        create(:application_choice, status: status, application_form: create(:application_form, equality_and_diversity: nil, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code))
+        create(:application_choice, status: status, application_form: create(:application_form, :with_equality_and_diversity_data, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code))
+      end
+
+      2.times do
+        date_of_birth = rand(Time.zone.now - 75.years..Time.zone.now - 20.years)
+        region_code = region_codes.sample
         status = %w[pending_conditions recruited].sample
-        sex = sexes.sample
 
-        rand(1..7).times do
-          application_form = if sex.nil?
-                               create(:application_form, equality_and_diversity: nil, recruitment_cycle_year: RecruitmentCycle.previous_year, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code)
-                             else
-                               create(:application_form, :with_equality_and_diversity_data, recruitment_cycle_year: RecruitmentCycle.previous_year, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code)
-                             end
-
-          create(:application_choice, :with_deferred_offer, status_before_deferral: status, application_form: application_form)
-        end
+        create(:application_choice, :with_deferred_offer, status_before_deferral: status, application_form: create(
+          :application_form, equality_and_diversity: nil, recruitment_cycle_year: RecruitmentCycle.previous_year, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code
+        ))
+        create(:application_choice, :with_deferred_offer, status_before_deferral: status, application_form: create(
+          :application_form, :with_equality_and_diversity_data, recruitment_cycle_year: RecruitmentCycle.previous_year, submitted_at: Time.zone.now, date_of_birth: date_of_birth, region_code: region_code
+        ))
       end
     end
 


### PR DESCRIPTION
## Context

rspec-retry highlighted a flakey test that was taking a long time to run.

Running the spec would take upwards of 20 seconds:
![image](https://user-images.githubusercontent.com/47917431/143883330-2228c666-e2f3-4886-83f2-e34ddc35bb26.png)
This is now taking 2-3 seconds to run:
![image](https://user-images.githubusercontent.com/47917431/143883384-71b88cc6-b386-451c-a8bb-968df6d15585.png)

## Changes proposed in this pull request

- Reduce the number of iterations performed in the `times` loops
- Remove the `rand(1..7)` loop and instead specify the different application objects required

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
