### PR TITLE
[4145] Reinstate semantic logger in development and add amazing_print…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN gem update --system && \
     bundler -v && \
     bundle config set no-cache 'true' && \
     bundle config set no-binstubs 'true' && \
-    bundle --retry=5 --jobs=4 --without=development --with=production && \
+    bundle --retry=5 --jobs=4 --without=development && \
     rm -rf /usr/local/bundle/cache
 
 COPY package.json yarn.lock ./

--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,7 @@ gem 'yabeda-prometheus'
 # Logging
 gem 'request_store_rails'
 gem 'request_store-sidekiq'
+gem 'rails_semantic_logger'
 
 # Background processing
 gem 'sidekiq'
@@ -133,10 +134,6 @@ gem 'colorize'
 # Performance profiling - keep this below 'pg' gem
 gem 'rack-mini-profiler', require: ['prepend_net_http_patch']
 
-group :production do
-  gem 'rails_semantic_logger'
-end
-
 # Data integration with Bigquery
 gem 'google-cloud-bigquery'
 
@@ -176,4 +173,5 @@ group :development, :test do
   gem 'pry-rails'
   gem 'bullet'
   gem 'parallel_tests'
+  gem 'amazing_print'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
+    amazing_print (1.4.0)
     anyway_config (2.1.0)
       ruby-next-core (>= 0.11.0)
     ar-sequence (0.2.0)
@@ -695,6 +696,7 @@ DEPENDENCIES
   activerecord (~> 6.1)
   activerecord-cte
   activesupport (~> 6.1)
+  amazing_print
   ar-sequence
   archive-zip
   audited!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,7 +70,13 @@ Rails.application.configure do
 
   # Logging configuration
   config.log_level = :debug
-  Rails.logger = ActiveSupport::Logger.new(STDOUT)
+  config.rails_semantic_logger.started = true
+  config.rails_semantic_logger.processing = true
+  config.rails_semantic_logger.rendered = true
+
+  config.rails_semantic_logger.format = :color
+
+  config.semantic_logger.backtrace_level = :info
 
   config.x.read_only_database_url = "postgres://localhost/bat_apply_development"
 end

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -2,50 +2,52 @@
 
 require 'request_store_rails'
 
-if Rails.env.production?
-  class CustomLogFormatter < SemanticLogger::Formatters::Raw
-    def call(log, logger)
-      super(log, logger)
-      add_service_type
-      add_job_data
-      remove_post_params
-      hash.to_json
-    end
+class CustomLogFormatter < SemanticLogger::Formatters::Raw
+  def call(log, logger)
+    super(log, logger)
+    add_service_type
+    add_job_data
+    remove_post_params
+    hash.to_json
+  end
 
-  private
+private
 
-    def add_service_type
-      hash['domain'] = HostingEnvironment.hostname
-      hash['environment'] = HostingEnvironment.environment_name
-      hash['hosting_environment'] = HostingEnvironment.environment_name
-      hash['service'] = ENV['SERVICE_TYPE']
-    end
+  def add_service_type
+    hash['domain'] = HostingEnvironment.hostname
+    hash['environment'] = HostingEnvironment.environment_name
+    hash['hosting_environment'] = HostingEnvironment.environment_name
+    hash['service'] = ENV['SERVICE_TYPE']
+  end
 
-    def add_job_data
-      hash[:job_id] = RequestStore.store[:job_id] if RequestStore.store[:job_id].present?
-      hash[:job_queue] = RequestStore.store[:job_queue] if RequestStore.store[:job_queue].present?
-      tid = Thread.current['sidekiq_tid']
-      if tid.present?
-        ctx = Sidekiq::Context.current
-        hash['tid'] = tid
-        hash['ctx'] = ctx
-      end
-    end
-
-    def remove_post_params
-      if method_is_post_or_put_or_patch? && hash.dig(:payload, :params).present?
-        hash[:payload][:params].clear
-      end
-    end
-
-    def method_is_post_or_put_or_patch?
-      hash.dig(:payload, :method).in? %w[PUT POST PATCH]
+  def add_job_data
+    hash[:job_id] = RequestStore.store[:job_id] if RequestStore.store[:job_id].present?
+    hash[:job_queue] = RequestStore.store[:job_queue] if RequestStore.store[:job_queue].present?
+    tid = Thread.current['sidekiq_tid']
+    if tid.present?
+      ctx = Sidekiq::Context.current
+      hash['tid'] = tid
+      hash['ctx'] = ctx
     end
   end
 
-  rails_config = Rails.application.config
-  log_formatter = CustomLogFormatter.new
-  Clockwork.configure { |config| config[:logger] = SemanticLogger[Clockwork] if defined?(Clockwork) }
-  SemanticLogger.add_appender(io: STDOUT, level: rails_config.log_level, formatter: log_formatter)
-  rails_config.logger.info('Application logging to STDOUT')
+  def remove_post_params
+    if method_is_post_or_put_or_patch? && hash.dig(:payload, :params).present?
+      hash[:payload][:params].clear
+    end
+  end
+
+  def method_is_post_or_put_or_patch?
+    hash.dig(:payload, :method).in? %w[PUT POST PATCH]
+  end
 end
+
+rails_config = Rails.application.config
+log_formatter = if HostingEnvironment.development?
+                  rails_config.rails_semantic_logger.format
+                else
+                  CustomLogFormatter.new
+                end
+Clockwork.configure { |config| config[:logger] = SemanticLogger[Clockwork] if defined?(Clockwork) }
+SemanticLogger.add_appender(io: STDOUT, level: rails_config.log_level, formatter: log_formatter)
+rails_config.logger.info('Application logging to STDOUT')


### PR DESCRIPTION
## Context

Giving Apply the same 'beautiful logs' treatment as Find (in [this PR](https://github.com/DFE-Digital/find-teacher-training/pull/1061)) by reinstating `rails_semantic_logger` in development and adding the `amazing_print` gem.

## Changes proposed

This PR also reverts the work done in #4674.

## Screenshot

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/50492247/143900338-314042b8-a6cc-422f-b9b7-8e25b7ec3d98.png">

## Guidance to review

- Run the app locally and marvel at the logs.
- Ensure nothing has gone missing from the logs. 