### PR TITLE
Nationality dropdown bug

### DIFF
--- a/app/frontend/styles/_autocomplete.scss
+++ b/app/frontend/styles/_autocomplete.scss
@@ -4,14 +4,12 @@
   font-family: $govuk-font-family;
 }
 
-.govuk-form-group--error {
-  .autocomplete__input {
-    border-color: $govuk-error-colour;
-  }
+.govuk-form-group--error > .autocomplete__input {
+  border-color: $govuk-error-colour;
+}
 
-  .autocomplete__input--focused {
-    border-color: $govuk-input-border-colour;
-  }
+.govuk-form-group--error > .autocomplete__input--focused {
+  border-color: $govuk-input-border-colour;
 }
 
 .autocomplete__dropdown-arrow-down {


### PR DESCRIPTION
## Context
Small bug on the nationality dropdown. It errors red when the grandparent element errors when it should remain black. This was because of a bug in the autocomplete css. 

## Changes proposed in this pull request
CSS now uses `>` selector instead of inheritance so that only the next nested element is shown visually in error. 
Before
<img width="953" alt="Screenshot 2021-11-29 at 17 10 12" src="https://user-images.githubusercontent.com/58793682/143913668-2d54e465-3c0e-4616-a5db-2f1266c0a071.png">

After
<img width="1035" alt="Screenshot 2021-11-29 at 17 15 04" src="https://user-images.githubusercontent.com/58793682/143913739-2f7d3b57-4b53-4d37-8e92-fcd78d7c2387.png">

## Guidance to review


## Link to Trello card

https://trello.com/c/7j5Egw10/3890-bug-nationality-dropdown-has-a-red-border-when-the-parent-fieldset-is-in-error

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
