### PR TITLE
Banner to notify providers of the Christmas non working period

### DIFF
--- a/app/components/provider_interface/key_dates_banner.html.erb
+++ b/app/components/provider_interface/key_dates_banner.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= govuk_notification_banner(title_text: t('key_dates_banner.title')) do |notification_banner| %>
+      <% notification_banner.heading(text: t('key_dates_banner.christmas_header', non_working_days_period: non_working_days_period)) %>
+      <p class="govuk-body"><%= t('key_dates_banner.christmas_body') %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/components/provider_interface/key_dates_banner.rb
+++ b/app/components/provider_interface/key_dates_banner.rb
@@ -1,0 +1,19 @@
+class ProviderInterface::KeyDatesBanner < ViewComponent::Base
+  def render?
+    render_deadline_banner?
+  end
+
+  def non_working_days_period
+    "#{christmas_period.first.to_s(:govuk_date)} to #{christmas_period.last.to_s(:govuk_date)}"
+  end
+
+private
+
+  def render_deadline_banner?
+    CycleTimetable.show_non_working_days_deadline_banner?
+  end
+
+  def christmas_period
+    CycleTimetable.holidays[:christmas]
+  end
+end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -92,6 +92,12 @@ class CycleTimetable
       (application_form.phase == 'apply_2' || (application_form.phase == 'apply_1' && application_form.ended_without_success?))
   end
 
+  def self.show_non_working_days_deadline_banner?
+    if holidays[:christmas].present?
+      Time.zone.now.between?(20.business_days.after(apply_opens).end_of_day, holidays[:christmas].last)
+    end
+  end
+
   def self.apply_1_deadline(year = current_year)
     date(:apply_1_deadline, year)
   end

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -1,5 +1,6 @@
 <% content_for :browser_title, "Applications (#{@application_choices.total_count})" %>
 
+<%= render ProviderInterface::KeyDatesBanner.new %>
 <%= render ServiceInformationBanner.new(namespace: :provider) %>
 <%= render ProviderInterface::SummerRecruitmentBanner.new %>
 

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -1,5 +1,6 @@
 <div class="govuk-width-container">
   <main id="main-content" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" role="main">
+    <%= render ProviderInterface::KeyDatesBanner.new %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Sign in to manage teacher training applications</h1>

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -1,13 +1,15 @@
 <div class="govuk-width-container">
   <main id="main-content" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" role="main">
     <%= render ProviderInterface::KeyDatesBanner.new %>
+    <%= render ServiceInformationBanner.new(namespace: :provider) %>
+    <%= render ProviderInterface::SummerRecruitmentBanner.new %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Sign in to manage teacher training applications</h1>
         <p class="govuk-body">If you do not have access to this service, ask a colleague to add you.</p>
         <p class="govuk-body">
         If your organisation has not been set up to use the service, email <br>
-          <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
+          <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.
         </p>
         <%= govuk_start_button(
           text: 'Sign in',

--- a/config/locales/key_dates_banner.yml
+++ b/config/locales/key_dates_banner.yml
@@ -1,0 +1,5 @@
+en:
+  key_dates_banner:
+    title: Important
+    christmas_header: '%{non_working_days_period} do not count as working days'
+    christmas_body: The Christmas period will not be included when calculating dates for applications to be automatically rejected.

--- a/spec/components/provider_interface/key_dates_banner_spec.rb
+++ b/spec/components/provider_interface/key_dates_banner_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::KeyDatesBanner do
+  subject(:result) { render_inline(described_class.new) }
+
+  let(:christmas_period) { "#{CycleTimetable.holidays[:christmas].first.to_s(:govuk_date)} to #{CycleTimetable.holidays[:christmas].last.to_s(:govuk_date)}" }
+
+  it 'renders the banner title' do
+    expect(result.text).to include('Important')
+  end
+
+  describe 'rendering the banner content' do
+    around do |example|
+      Timecop.freeze(time) { example.run }
+    end
+
+    context 'up to 20 days after the cycle opens' do
+      let(:time) { 10.business_days.after(CycleTimetable.apply_opens).end_of_day }
+
+      it 'does renders the non working period content' do
+        expect(result.text).not_to include(t('key_dates_banner.christmas_header', non_working_days_period: christmas_period))
+        expect(result.text).not_to include(t('key_dates_banner.christmas_body'))
+      end
+    end
+
+    context '20 days, or more, after the cycle opens' do
+      let(:time) { 20.business_days.after(CycleTimetable.apply_opens).end_of_day }
+
+      it 'renders the non working period content' do
+        expect(result.text).to include(t('key_dates_banner.christmas_header', non_working_days_period: christmas_period))
+        expect(result.text).to include(t('key_dates_banner.christmas_body'))
+      end
+    end
+
+    context 'after the end of the christmas period' do
+      let(:time) { 1.business_days.after(CycleTimetable.holidays[:christmas].last).end_of_day }
+
+      it 'does renders the non working period content' do
+        expect(result.text).not_to include(t('key_dates_banner.christmas_header', non_working_days_period: christmas_period))
+        expect(result.text).not_to include(t('key_dates_banner.christmas_body'))
+      end
+    end
+  end
+end

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe CycleTimetable do
   let(:one_hour_after_find_closes) { described_class.find_closes(2020) + 1.hour }
   let(:one_hour_after_find_opens) { described_class.find_opens(2020) + 1.hour }
   let(:three_days_before_find_reopens) { described_class.find_reopens(2020) - 3.days }
+  let(:twenty_days_after_2021_cycle_opens) { 20.business_days.after(described_class.apply_opens(2021)).end_of_day }
 
   describe '.current_year' do
     it 'is 2020 if we are in the middle of the 2020 cycle' do
@@ -98,6 +99,20 @@ RSpec.describe CycleTimetable do
 
       Timecop.travel(one_hour_after_apply2_deadline) do
         expect(described_class.show_apply_2_deadline_banner?(unsuccessful_application_form)).to be false
+      end
+    end
+  end
+
+  describe '.show_non_working_days_deadline_banner?' do
+    it 'returns false if before the 20 day period' do
+      Timecop.travel(one_hour_after_2021_cycle_opens) do
+        expect(described_class.show_non_working_days_deadline_banner?).to be false
+      end
+    end
+
+    it 'returns true if after the 20 day period' do
+      Timecop.travel(twenty_days_after_2021_cycle_opens) do
+        expect(described_class.show_non_working_days_deadline_banner?).to be true
       end
     end
   end


### PR DESCRIPTION
## Context

21 Dec to 1 Jan are treated as non-working days (as most schools are off). We want to remind providers through an in-service banner.

This PR adds a generic banner component that can be reused in the future for any date related banner requirements.

## Changes proposed in this pull request

- Add a new `KeyDatesBanner`
![image](https://user-images.githubusercontent.com/47917431/143915413-60ac5294-fa75-4a1a-9365-e1a66f42d19f.png)

## Guidance to review

- Refactor `SummerRecruitmentBanner` to also cover the logic for this instead?
- Have I got the right styling for the banner?
- I'm not a fan of this:
    ```
    if holidays[:christmas]&.first
      Time.zone.now.between?(20.business_days.after(apply_opens).end_of_day, holidays[:christmas]&.first)
    end
   ```
  as I've written prod code in order to pass a test, but this is because it's been decided not to use fake schedules for the holiday period (which is what is used for testing purposes).

## Link to Trello card

https://trello.com/c/r2UQ6XYx

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
