### PR TITLE
Fix application export by correctly rendering GCSE constituent grades

### DIFF
--- a/app/components/shared/gcse_qualification_cards_component.rb
+++ b/app/components/shared/gcse_qualification_cards_component.rb
@@ -56,42 +56,7 @@ class GcseQualificationCardsComponent < ViewComponent::Base
   end
 
   def grade_details(qualification)
-    case qualification.subject
-    when ApplicationQualification::SCIENCE_TRIPLE_AWARD
-      grades = qualification.constituent_grades
-      [
-        "#{grades['biology']['grade']} (Biology)",
-        "#{grades['chemistry']['grade']} (Chemistry)",
-        "#{grades['physics']['grade']} (Physics)",
-      ]
-    when ApplicationQualification::SCIENCE_DOUBLE_AWARD
-      ["#{qualification.grade} (Double award)"]
-    when ApplicationQualification::SCIENCE_SINGLE_AWARD
-      ["#{qualification.grade} (Single award)"]
-    when ->(_n) { qualification.constituent_grades }
-      present_constituent_grades(qualification)
-    else
-      [qualification.grade]
-    end
-  end
-
-  def present_constituent_grades(qualification)
-    grades = qualification.constituent_grades
-    grades.map do |k, v,|
-      grade = v['grade']
-      case k
-      when 'english_single_award'
-        "#{grade} (English Single award)"
-      when 'english_double_award'
-        "#{grade} (English Double award)"
-      when 'english_studies_single_award'
-        "#{grade} (English Studies Single award)"
-      when 'english_studies_double_award'
-        "#{grade} (English Studies Double award)"
-      else
-        "#{grade} (#{k.humanize.titleize})"
-      end
-    end
+    ApplicationQualificationDecorator.new(qualification).grade_details
   end
 
   def editable?

--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -56,6 +56,7 @@ private
   def summary_for_gcse(gcse)
     return if gcse.blank?
 
-    "#{gcse.qualification_type.humanize} #{gcse.subject.capitalize}, #{gcse.grade}, #{gcse.start_year}-#{gcse.award_year}"
+    qualification = ApplicationQualificationDecorator.new(gcse)
+    "#{qualification.qualification_type.humanize} #{qualification.subject.capitalize}, #{qualification.grade_details.join(' ')}, #{qualification.start_year}-#{qualification.award_year}"
   end
 end

--- a/app/decorators/application_qualification_decorator.rb
+++ b/app/decorators/application_qualification_decorator.rb
@@ -1,0 +1,44 @@
+class ApplicationQualificationDecorator < SimpleDelegator
+  attr_reader :qualification
+
+  ENGLISH_AWARDS = { english_single_award: 'English Single award',
+                     english_double_award: 'English Double award',
+                     english_studies_single_award: 'English Studies Single award',
+                     english_studies_double_award: 'English Studies Double award' }.freeze
+
+  def initialize(qualification)
+    @qualification = qualification
+    super(qualification)
+  end
+
+  def grade_details
+    case qualification.subject
+    when ApplicationQualification::SCIENCE_TRIPLE_AWARD
+      grades = qualification.constituent_grades
+      [
+        "#{grades['biology']['grade']} (Biology)",
+        "#{grades['chemistry']['grade']} (Chemistry)",
+        "#{grades['physics']['grade']} (Physics)",
+      ]
+    when ApplicationQualification::SCIENCE_DOUBLE_AWARD
+      ["#{qualification.grade} (Double award)"]
+    when ApplicationQualification::SCIENCE_SINGLE_AWARD
+      ["#{qualification.grade} (Single award)"]
+    when ->(_n) { qualification.constituent_grades }
+      present_constituent_grades
+    else
+      [qualification.grade]
+    end
+  end
+
+private
+
+  def present_constituent_grades
+    grades = qualification.constituent_grades
+    grades.map do |award, details|
+      return "#{details['grade']} (#{ENGLISH_AWARDS[award]})" if ENGLISH_AWARDS.include?(award)
+
+      "#{details['grade']} (#{award.humanize.titleize})"
+    end
+  end
+end

--- a/spec/decorators/application_qualification_decorator_spec.rb
+++ b/spec/decorators/application_qualification_decorator_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+RSpec.describe ApplicationQualificationDecorator do
+  describe '#grade_details' do
+    describe 'rendering multiple English GCSEs' do
+      let(:application_qualification) do
+        create(:gcse_qualification, subject: 'english', constituent_grades: { english_language: { grade: 'E' }, english_literature: { grade: 'E' }, 'Cockney Rhyming Slang': { grade: 'A*' } }, award_year: 2006)
+      end
+
+      it 'renders grades for multiple English GCSEs' do
+        grade_details = described_class.new(application_qualification).grade_details
+
+        expect(grade_details).to include 'E (English Language)'
+        expect(grade_details).to include 'E (English Literature)'
+        expect(grade_details).to include 'A* (Cockney Rhyming Slang)'
+      end
+    end
+
+    describe 'rendering multiple Science GCSEs' do
+      science_triple_awards = {
+        biology: { grade: 'A' },
+        chemistry: { grade: 'B' },
+        physics: { grade: 'C' },
+      }
+
+      let(:application_qualification) do
+        create(:gcse_qualification,
+               subject: 'science triple award',
+               constituent_grades: science_triple_awards,
+               award_year: 2006)
+      end
+
+      it 'renders grades for multiple English GCSEs' do
+        grade_details = described_class.new(application_qualification).grade_details
+
+        expect(grade_details).to include 'A (Biology)'
+        expect(grade_details).to include 'B (Chemistry)'
+        expect(grade_details).to include 'C (Physics)'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

There is missing information when exporting application data due to constituent grades not being mapped to the export.

## Guidance to review

Create a candidate that has multiple GCSE grades on one subject, eg. English, and then export the application export for the provider they have applied to. All grades should be rendered as part of the export.

## Link to Trello card
https://trello.com/c/7jBLANyT/4552-bug-gcse-grades-missing-from-application-export-for-qualifications-with-constituent-grades

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
