### PR TITLE
Prevent award_year from being set before start_year on the application_qualification factory

### DIFF
--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -57,6 +57,10 @@ private
     return if gcse.blank?
 
     qualification = ApplicationQualificationDecorator.new(gcse)
-    "#{qualification.qualification_type.humanize} #{qualification.subject.capitalize}, #{qualification.grade_details.join(' ')}, #{qualification.start_year}-#{qualification.award_year}"
+    if qualification.start_year.present?
+      "#{qualification.qualification_type.humanize} #{qualification.subject.capitalize}, #{qualification.grade_details.join(' ')}, #{qualification.start_year}-#{qualification.award_year}"
+    else
+      "#{qualification.qualification_type.humanize} #{qualification.subject.capitalize}, #{qualification.grade_details.join(' ')}, #{qualification.award_year}"
+    end
   end
 end

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -8,7 +8,17 @@ RSpec.describe ApplicationChoiceExportDecorator do
 
       summary = described_class.new(application_choice).gcse_qualifications_summary
 
-      expect(summary).to match(/^Gcse Maths, [ABCD], \d{4}-\d{4},Gcse English, [ABCD], \d{4}-\d{4},Gcse Science, [ABCD], \d{4}-\d{4}$/)
+      expect(summary).to match(/^Gcse Maths, [ABCD], \d{4},Gcse English, [ABCD], \d{4},Gcse Science, [ABCD], \d{4}$/)
+    end
+
+    it 'returns the gcse start year if present' do
+      application_form = create(:application_form)
+      application_choice = create(:application_choice, application_form: application_form)
+      create(:application_qualification, qualification_type: :gcse, level: :gcse, start_year: '2005', award_year: '2006', subject: :maths, application_form: application_form)
+
+      summary = described_class.new(application_choice).gcse_qualifications_summary
+
+      expect(summary).to match(/^Gcse Maths, [ABCD], \d{4}-\d{4}$/)
     end
 
     it 'does not include gcses in other subjects' do

--- a/spec/factories/application_qualification.rb
+++ b/spec/factories/application_qualification.rb
@@ -6,8 +6,7 @@ FactoryBot.define do
     subject { Faker::Educator.subject }
     grade { %w[A B].sample }
     predicted_grade { %w[true false].sample }
-    start_year { Time.zone.today.year }
-    award_year { Faker::Date.between(from: 60.years.ago, to: 3.years.from_now).year }
+    award_year { Faker::Date.between(from: 10.years.ago, to: 1.year.ago).year }
     institution_name { Faker::University.name }
     institution_country { Faker::Address.country_code }
     equivalency_details { Faker::Lorem.paragraph_by_chars(number: 200) }
@@ -18,6 +17,7 @@ FactoryBot.define do
       subject { %w[maths english science].sample }
       grade { %w[A B C].sample }
       predicted_grade { false }
+      award_year { Faker::Date.between(from: 10.years.ago, to: 8.years.ago).year }
 
       trait :non_uk do
         qualification_type { 'non_uk' }
@@ -32,6 +32,7 @@ FactoryBot.define do
         qualification_type { 'missing' }
         grade { nil }
         predicted_grade { nil }
+        award_year { nil }
         currently_completing_qualification { true }
         not_completed_explanation { 'I will be taking an equivalency test in a few weeks' }
       end
@@ -40,6 +41,7 @@ FactoryBot.define do
         qualification_type { 'missing' }
         grade { nil }
         predicted_grade { nil }
+        award_year { nil }
         currently_completing_qualification { false }
         missing_explanation { 'I have 10 years experience teaching English Language' }
       end
@@ -57,6 +59,8 @@ FactoryBot.define do
       subject { Hesa::Subject.all.sample.name }
       institution_name { Hesa::Institution.all.sample.name }
       grade { Hesa::Grade.all.sample.description }
+      start_year { Faker::Date.between(from: 5.years.ago, to: 3.years.ago).year }
+      award_year { Faker::Date.between(from: 2.years.ago, to: 1.year.ago).year }
 
       after(:build) do |degree, _evaluator|
         degree.qualification_type_hesa_code = Hesa::DegreeType.find_by_name(degree.qualification_type)&.hesa_code
@@ -75,6 +79,7 @@ FactoryBot.define do
       grade { %w[pass merit distinction].sample }
       predicted_grade { false }
       institution_country { 'GB' }
+      award_year { Faker::Date.between(from: 7.years.ago, to: 6.years.ago).year }
 
       trait :non_uk do
         level { 'other' }


### PR DESCRIPTION
## Context

On the `application_qualification` factory the `start_year` was set as the current year and the `award_year` was being given a range – which could result in it being set as 60 years ago. As a result test data sometimes produced results that would have an award year before the start year.

## Changes proposed in this pull request

Update the factory to have a dynamic start year that all other year values work from, to try and produce more of a chronological qualification journey.

![image](https://user-images.githubusercontent.com/47917431/144095599-c0e189f3-6f29-4611-92ef-d065c1d7eebd.png)

## Guidance to review

Went with this approach for the following reasons:
- award years wouldn't be set in the future
- each candidate would have a different set of year values 
- the time between the different qualification types wouldn't be too farfetched 

## Link to Trello card

https://trello.com/c/fZJFYuSC

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
