### PR TITLE
[4165] Add 'else' clause to call method

### DIFF
--- a/app/services/send_candidate_rejection_email.rb
+++ b/app/services/send_candidate_rejection_email.rb
@@ -8,14 +8,14 @@ class SendCandidateRejectionEmail
   end
 
   def call
-    if candidate_applications.all?(&:rejected?)
-      CandidateMailer.application_rejected_all_applications_rejected(application_choice).deliver_later
-    elsif applications_with_offer_and_awaiting_decision?
+    if applications_with_offer_and_awaiting_decision?
       CandidateMailer.application_rejected_one_offer_one_awaiting_decision(application_choice).deliver_later
     elsif applications_awaiting_decision_only?
       CandidateMailer.application_rejected_awaiting_decision_only(application_choice).deliver_later
     elsif applications_with_offers_only?
       CandidateMailer.application_rejected_offers_only(application_choice).deliver_later
+    else
+      CandidateMailer.application_rejected_all_applications_rejected(application_choice).deliver_later
     end
   end
 end

--- a/spec/services/send_candidate_rejection_email_spec.rb
+++ b/spec/services/send_candidate_rejection_email_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe SendCandidateRejectionEmail do
     let(:application_choice_with_offer) { create(:application_choice, :with_offer, application_form: application_form) }
     let(:application_choice_awaiting_decision) { create(:application_choice, status: :awaiting_provider_decision, application_form: application_form) }
     let(:application_choice_with_interview) { create(:application_choice, status: :interviewing, application_form: application_form) }
+    let(:application_choice_withdrawn) { create(:application_choice, status: :withdrawn, application_form: application_form) }
+    let(:application_choice_not_sent) { create(:application_choice, status: :application_not_sent, application_form: application_form) }
+    let(:application_choice_declined) { create(:application_choice, status: :declined, application_form: application_form) }
+    let(:application_choice_offer_withdrawn) { create(:application_choice, status: :offer_withdrawn, application_form: application_form) }
+    let(:application_choice_offer_deferred) { create(:application_choice, status: :offer_deferred, application_form: application_form) }
     let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
 
     context 'when an application choice is rejected' do
@@ -72,6 +77,62 @@ RSpec.describe SendCandidateRejectionEmail do
 
         it 'the application_rejected_offers_only email is sent to the candidate' do
           expect(CandidateMailer).to have_received(:application_rejected_offers_only).with(application_choice)
+        end
+      end
+
+      describe 'when applications are withdrawn and another is rejected' do
+        before do
+          application_choice_withdrawn
+          application_choice
+
+          allow(CandidateMailer).to receive(:application_rejected_all_applications_rejected).and_return(mail)
+          described_class.new(application_choice: application_choice).call
+        end
+
+        it 'sends the all_applications_rejected email to the candidate' do
+          expect(CandidateMailer).to have_received(:application_rejected_all_applications_rejected).with(application_choice)
+        end
+      end
+
+      describe 'when applications are declined and another is rejected' do
+        before do
+          application_choice_declined
+          application_choice
+
+          allow(CandidateMailer).to receive(:application_rejected_all_applications_rejected).and_return(mail)
+          described_class.new(application_choice: application_choice).call
+        end
+
+        it 'sends the all_applications_rejected email to the candidate' do
+          expect(CandidateMailer).to have_received(:application_rejected_all_applications_rejected).with(application_choice)
+        end
+      end
+
+      describe 'applications have had offers withdrawn and another is rejected' do
+        before do
+          application_choice_offer_withdrawn
+          application_choice
+
+          allow(CandidateMailer).to receive(:application_rejected_all_applications_rejected).and_return(mail)
+          described_class.new(application_choice: application_choice).call
+        end
+
+        it 'sends the all_applications_rejected email to the candidate' do
+          expect(CandidateMailer).to have_received(:application_rejected_all_applications_rejected).with(application_choice)
+        end
+      end
+
+      describe 'applications have had offers deferred and another is rejected' do
+        before do
+          application_choice_offer_deferred
+          application_choice
+
+          allow(CandidateMailer).to receive(:application_rejected_all_applications_rejected).and_return(mail)
+          described_class.new(application_choice: application_choice).call
+        end
+
+        it 'sends the all_applications_rejected email to the candidate' do
+          expect(CandidateMailer).to have_received(:application_rejected_all_applications_rejected).with(application_choice)
         end
       end
     end


### PR DESCRIPTION
## Context

There have been cases where candidates haven't recieved their rejection email. This is because the `call` is missing an `else` clause. 

## Changes proposed in this pull request

Make the `all_applications_rejected` email the default to account for edge cases where candidates were not receiving rejection emails.

## Guidance to review

- Are there any scenarios that have been missed in the tests.
- Do we need to add logic which sends a different default email based on whether it's before or after the end of cycle.
