### PR TITLE
Reduce flakey spec verbosity

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,8 +37,6 @@ ENV['STATE_CHANGE_SLACK_URL'] = nil # ensure tests send no Slack notifications
 
 RSpec.configure do |config|
   # RSpec-retry configuration, retry and log any indeterminate tests.
-  config.verbose_retry = true
-  config.display_try_failure_messages = true
   reporter = RSpec::Core::Reporter.new(config)
   formatter = RSpec::Core::Formatters::BaseTextFormatter.new(File.open('tmp/rspec-retry-flakey-specs.log', 'ab'))
   reporter.register_listener(formatter, 'message')


### PR DESCRIPTION
## Context

[RSpec-Retry](https://github.com/DFE-Digital/rspec-retry) no longer relies on verbosity settings to write flakey test output.
(See https://github.com/DFE-Digital/rspec-retry/commit/f3e42572c55e5fdde4e2e06c42ee54b74981c907)
This allows us to reduce flakey spec noise when running tests. 

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Update Gemfile.lock to point to latest rspec-retry main branch commit
- Remove verbosity settings for rspec-retry in `spec_helper.rb`

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

I tested this locally and could still produce flakey spec file output (using something flakey like `expect(rand(2)).to eq(rand(2))`)

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/G2D7y5XO/4465-%F0%9F%8F%88-improve-testing-and-coverage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
