### PR TITLE
Update TAD reports following feedback

### DIFF
--- a/app/exports/applications_by_subject_route_and_degree_grade_export.yml
+++ b/app/exports/applications_by_subject_route_and_degree_grade_export.yml
@@ -13,10 +13,10 @@ custom_columns:
       - university
       - unknown
 
-  degree_class:
+  grade_hesa_code:
     type: string
-    description: The grade awarded
-    example: Upper second-class honours (2:1)
+    description: The HESA code for the awarded degree grade
+    example: 1
 
   applications:
     type: integer

--- a/app/services/support_interface/applications_by_subject_route_and_degree_grade_export.rb
+++ b/app/services/support_interface/applications_by_subject_route_and_degree_grade_export.rb
@@ -26,7 +26,7 @@ module SupportInterface
         {
           subject: subject,
           route: choice.route,
-          degree_class: choice.degree_class,
+          grade_hesa_code: choice.grade_hesa_code,
           applications: 0,
           offers_received: 0,
           number_of_acceptances: 0,
@@ -76,12 +76,12 @@ module SupportInterface
     end
 
     def grouping_key(hash)
-      hash[:subject].to_s + hash[:route].to_s + hash[:degree_class].to_s
+      hash[:subject].to_s + hash[:route].to_s + hash[:grade_hesa_code].to_s
     end
 
     def choices_with_courses_and_subjects
       ApplicationChoice
-        .select('application_choices.id as id, application_choices.status as status, providers.provider_type as route, application_qualifications.grade as degree_class, application_form.id as application_form_id, application_form.phase as phase, courses.name as course_name, courses.level as course_level, ARRAY_AGG(subjects.name) as subject_names, ARRAY_AGG(subjects.code) as subject_codes, (CASE WHEN a2_latest_application_forms.candidate_id IS NOT NULL THEN true ELSE false END) AS is_latest_a2_app')
+        .select('application_choices.id as id, application_choices.status as status, providers.provider_type as route, application_qualifications.grade_hesa_code as grade_hesa_code, application_form.id as application_form_id, application_form.phase as phase, courses.name as course_name, courses.level as course_level, ARRAY_AGG(subjects.name) as subject_names, ARRAY_AGG(subjects.code) as subject_codes, (CASE WHEN a2_latest_application_forms.candidate_id IS NOT NULL THEN true ELSE false END) AS is_latest_a2_app')
         .joins(application_form: :application_qualifications)
         .joins(course_option: { course: :provider })
         .joins(course_option: { course: :subjects })
@@ -89,7 +89,7 @@ module SupportInterface
         .where(application_form: { recruitment_cycle_year: RecruitmentCycle.current_year })
         .where(application_form: { application_qualifications: { level: 'degree' } })
         .where.not(application_form: { submitted_at: nil })
-        .group('application_choices.id', 'application_form.id', 'a2_latest_application_forms.candidate_id', 'courses.name', 'courses.level', 'status', 'providers.provider_type', 'subjects.name', 'subjects.code', 'application_qualifications.grade')
+        .group('application_choices.id', 'application_form.id', 'a2_latest_application_forms.candidate_id', 'courses.name', 'courses.level', 'status', 'providers.provider_type', 'subjects.name', 'subjects.code', 'application_qualifications.grade_hesa_code')
     end
   end
 end

--- a/spec/requests/data_api/applications_by_subject_route_and_degree_grade_export_spec.rb
+++ b/spec/requests/data_api/applications_by_subject_route_and_degree_grade_export_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe 'GET /data-api/applications-by-subject-route-and-degree-grade/lat
     get_api_request '/data-api/applications-by-subject-route-and-degree-grade/latest', token: tad_api_token
 
     expect(response).to have_http_status(:success)
-    expect(response.body).to start_with('subject,route,degree_class,applications,offers_received,number_of_acceptances,number_of_declined_applications,number_of_rejected_applications,number_of_withdrawn_applications')
+    expect(response.body).to start_with('subject,route,grade_hesa_code,applications,offers_received,number_of_acceptances,number_of_declined_applications,number_of_rejected_applications,number_of_withdrawn_applications')
   end
 end

--- a/spec/services/support_interface/applications_by_subject_route_and_degree_grade_export_spec.rb
+++ b/spec/services/support_interface/applications_by_subject_route_and_degree_grade_export_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport 
     it 'correctly breaks down subject choice by route' do
       drama = create(:subject, code: '13')
       first_application_form = create(:completed_application_form)
-      create(:application_qualification, level: 'degree', grade: 'Upper second-class honours (2:1)', application_form: first_application_form)
+      create(:application_qualification, level: 'degree', grade_hesa_code: '2', application_form: first_application_form)
       scitt_provider = create(:provider, provider_type: 'scitt')
       first_course = create(:course, provider: scitt_provider, subjects: [drama])
       first_course_option = create(:course_option, course: first_course)
@@ -13,7 +13,7 @@ RSpec.describe SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport 
       create(:application_choice, :with_declined_offer, course_option: first_course_option, application_form: first_application_form)
 
       second_application_form = create(:completed_application_form)
-      create(:application_qualification, level: 'degree', grade: 'Upper second-class honours (2:1)', application_form: second_application_form)
+      create(:application_qualification, level: 'degree', grade_hesa_code: '2', application_form: second_application_form)
       lead_school_provider = create(:provider, provider_type: 'lead_school')
       second_course = create(:course, provider: lead_school_provider, subjects: [drama])
       second_course_option = create(:course_option, course: second_course)
@@ -26,7 +26,7 @@ RSpec.describe SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport 
         {
           subject: :drama,
           route: 'scitt',
-          degree_class: 'Upper second-class honours (2:1)',
+          grade_hesa_code: '2',
           applications: 1,
           offers_received: 0,
           number_of_acceptances: 0,
@@ -37,7 +37,7 @@ RSpec.describe SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport 
         {
           subject: :drama,
           route: 'lead_school',
-          degree_class: 'Upper second-class honours (2:1)',
+          grade_hesa_code: '2',
           applications: 1,
           offers_received: 0,
           number_of_acceptances: 0,
@@ -78,9 +78,9 @@ RSpec.describe SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport 
         first_apply_2_application = create(:completed_application_form, candidate: candidate, phase: 'apply_2', application_choices: [first_apply_2_application_choice])
         latest_application = create(:completed_application_form, candidate: candidate, phase: 'apply_2', application_choices: [latest_application_choice])
 
-        create(:application_qualification, level: 'degree', grade: 'Upper second-class honours (2:1)', application_form: first_application)
-        create(:application_qualification, level: 'degree', grade: 'Upper second-class honours (2:1)', application_form: first_apply_2_application)
-        create(:application_qualification, level: 'degree', grade: 'Upper second-class honours (2:1)', application_form: latest_application)
+        create(:application_qualification, level: 'degree', grade_hesa_code: '2', application_form: first_application)
+        create(:application_qualification, level: 'degree', grade_hesa_code: '2', application_form: first_apply_2_application)
+        create(:application_qualification, level: 'degree', grade_hesa_code: '2', application_form: latest_application)
 
         data = described_class.new.call
 
@@ -88,7 +88,7 @@ RSpec.describe SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport 
           {
             subject: :classics,
             route: 'scitt',
-            degree_class: 'Upper second-class honours (2:1)',
+            grade_hesa_code: '2',
             applications: 1,
             offers_received: 0,
             number_of_acceptances: 0,
@@ -99,7 +99,7 @@ RSpec.describe SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport 
           {
             subject: :other,
             route: 'scitt',
-            degree_class: 'Upper second-class honours (2:1)',
+            grade_hesa_code: '2',
             applications: 1,
             offers_received: 1,
             number_of_acceptances: 0,
@@ -110,7 +110,7 @@ RSpec.describe SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport 
           {
             subject: :physical_education,
             route: 'scitt',
-            degree_class: 'Upper second-class honours (2:1)',
+            grade_hesa_code: '2',
             applications: 1,
             offers_received: 0,
             number_of_acceptances: 0,
@@ -124,7 +124,7 @@ RSpec.describe SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport 
           {
             subject: :music,
             route: 'scitt',
-            degree_class: 'Upper second-class honours (2:1)',
+            grade_hesa_code: '2',
             applications: 1,
             offers_received: 1,
             number_of_acceptances: 1,
@@ -138,7 +138,7 @@ RSpec.describe SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport 
           {
             subject: :design_and_technology,
             route: 'scitt',
-            degree_class: 'Upper second-class honours (2:1)',
+            grade_hesa_code: '2',
             applications: 1,
             offers_received: 0,
             number_of_acceptances: 0,


### PR DESCRIPTION
## Context

Updates to recently created TAD reports following initial feedback

## Changes proposed in this pull request

On `applications_by_subject_route_and_degree_grade_export` use `grade_hesa_code` instead of `grade` (which returns a free-text string)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
