### PR TITLE
Remove duplicate provider ids from associated application choices

### DIFF
--- a/spec/services/data_migrations/remove_duplicate_provider_spec.rb
+++ b/spec/services/data_migrations/remove_duplicate_provider_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe DataMigrations::RemoveDuplicateProvider do
       expect(other_course.reload.accredited_provider).not_to be_nil
     end
 
+    it 'updates application choices related to courses accredited by the duplicate self-ratified provider' do
+      current_course_option = create(:course_option, course: self_ratified_course)
+      application_choice = create(:application_choice, current_course_option: current_course_option)
+      application_choice.update!(provider_ids: [duplicate_provider.id, 1223])
+      described_class.new.change
+
+      expect(application_choice.reload.provider_ids).to eq([1223])
+    end
+
     it 'destroys the relationship between the training provider and the duplicate' do
       expect { described_class.new.change }.to change(ProviderRelationshipPermissions, :count).by(-1)
     end


### PR DESCRIPTION
## Context

We originally wrote the data migration `RemoveDuplicateProvider` in order to remove `Provider` records which were duplicates by name of existing training providers.

The problem arises from syncing from Publish where providers of the same name could exist, one acting as a training provider and the other as a ratifying provider but both being the same org.

The migration aims to remove the ratifying provider duplicate, we didn't run the migration because of end of cycle considerations and the necessity of fixing data upstream.

Since then we've included provider ids on `ApplicationChoice` records in order to increase read performance in the db.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Ensures that `ApplicationChoice#provider_ids` which include the duplicate ratifying provider id are updated to remove the relevant provider id before removing the duplicate provider record. 
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Lb5uFkix/4036-remove-9-duplicate-providers
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
