### PR TITLE
Fail on flakey specs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,6 +277,7 @@ jobs:
               }
               if (createComment) {
                 github.issues.createComment({ issue_number, owner, repo, body: commentBody });
+                throw 'You have one or more flakey tests on this branch';
               }
             }
 


### PR DESCRIPTION
## Context

We add a comment to PRs containing indeterminate tests but because of the retry mechanism we use to determine these flakey specs, the test suite passes.
We think it would be better to report _and_ have the build fail.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Throw an error if we are reporting on flakey specs.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

The test suite was made to fail on `spec/lib/flakey_spec.rb` in this commit https://github.com/DFE-Digital/apply-for-teacher-training/pull/6129/commits/493323ca202ddb9a49fa5c577ab87df0758c10df (removed from this PR)
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/G2D7y5XO/4465-%F0%9F%8F%88-improve-testing-and-coverage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
