### PR TITLE
[4169] - Add missing line break in our rejection emails

### DIFF
--- a/app/views/candidate_mailer/_reasons_for_rejection.text.erb
+++ b/app/views/candidate_mailer/_reasons_for_rejection.text.erb
@@ -1,7 +1,3 @@
-<% unless @application_choice.rejected_by_default? %>
-  <%= @course.provider.name %> has decided not to make you an offer to study <%= @course.name_and_code %>. They've given feedback to explain this decision.
-<% end %>
-
 <% @application_choice.rejection_reasons.each_pair do |title, reasons| %>
 
 ^ # <%=  title %>

--- a/app/views/candidate_mailer/_reasons_for_rejection_intro.text.erb
+++ b/app/views/candidate_mailer/_reasons_for_rejection_intro.text.erb
@@ -1,0 +1,5 @@
+<% unless @application_choice.rejected_by_default? %>
+
+  <%= @course.provider.name %> has decided not to make you an offer to study <%= @course.name_and_code %>. They've given feedback to explain this decision.
+
+<% end %>

--- a/app/views/candidate_mailer/application_rejected_all_applications_rejected.text.erb
+++ b/app/views/candidate_mailer/application_rejected_all_applications_rejected.text.erb
@@ -5,7 +5,7 @@ Dear <%= @application_form.first_name %>,
   <%= render 'rejected_by_default_intro' %>
 
 <% else %>
-
+  <%= render 'reasons_for_rejection_intro' %>
   <%= render 'reasons_for_rejection' %>
 
   Contact <%= @course.provider.name %> directly if you have any questions about their feedback.

--- a/app/views/candidate_mailer/application_rejected_awaiting_decision_only.text.erb
+++ b/app/views/candidate_mailer/application_rejected_awaiting_decision_only.text.erb
@@ -5,7 +5,7 @@ Dear <%= @application_form.first_name %>,
   <%= render 'rejected_by_default_intro' %>
 
 <% else %>
-
+  <%= render 'reasons_for_rejection_intro' %>
   <%= render 'reasons_for_rejection' %>
 
   Contact <%= @course.provider.name %> directly if you have any questions about their feedback.

--- a/app/views/candidate_mailer/application_rejected_offers_only.text.erb
+++ b/app/views/candidate_mailer/application_rejected_offers_only.text.erb
@@ -5,7 +5,7 @@ Dear <%= @application_form.first_name %>,
   <%= render 'rejected_by_default_intro' %>
 
 <% else %>
-
+  <%= render 'reasons_for_rejection_intro' %>
   <%= render 'reasons_for_rejection' %>
 
   Contact <%= @course.provider.name %> directly if you have any questions about their feedback.

--- a/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
@@ -7,7 +7,7 @@ Dear <%= @application_form.first_name %>,
   <%= render 'rejected_by_default_intro' %>
 
 <% else %>
-
+  <%= render 'reasons_for_rejection_intro' %>
   <%= render 'reasons_for_rejection' %>
 
   Contact <%= @course.provider.name %> directly if you have any questions about their feedback.

--- a/app/views/candidate_mailer/feedback_received_for_application_rejected_by_default.text.erb
+++ b/app/views/candidate_mailer/feedback_received_for_application_rejected_by_default.text.erb
@@ -5,6 +5,7 @@ did not respond by their deadline of <%= @application_choice.rejected_at.to_s(:g
 
 They’ve now given you the following feedback:
 
+<%= render 'reasons_for_rejection_intro' %>
 <%= render 'reasons_for_rejection' %>
 
 <% if @show_apply_again_guidance %>


### PR DESCRIPTION
## Context

We have an instance where our rejection email doesn't render correctly - there is a line break missing between the reasons for rejection _introduction_ and the reasons for rejection

## Changes proposed in this pull request

- Extract the 'reasons for rejection introduction' to a separate partial.

| Before         | After     | 
|--------------|-------------|
| <img width="868" alt="before" src="https://user-images.githubusercontent.com/5256922/144415136-172597d7-c2dd-4d86-bd4b-3bc3daf0dd96.png"> | <img width="868" alt="after" src="https://user-images.githubusercontent.com/5256922/144415048-d77edfcc-7901-4ceb-a677-3d5abdd16dd7.png"> | 

## Guidance to review
- It seems like this has something to do with `erb.text` partials not respecting line breaks for some reason. I'm not entirely sure why the propose changes fix it.

Make sense?

## Link to Trello card
https://trello.com/c/5ipsqVEp/4169-apply-missing-line-break-in-our-rejection-emails

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
