### PR TITLE
Timestamp on API docs not ISO8601

### DIFF
--- a/app/exports/common_columns/_common_columns.yml
+++ b/app/exports/common_columns/_common_columns.yml
@@ -2,7 +2,7 @@ extract_date:
   type: string
   format: date-time
   description: Time when the report ran
-  example: 2020-11-01T00:00:00+00:00
+  example: "2020-11-01T00:00:00+00:00"
 
 candidate_id:
   type: string
@@ -30,14 +30,14 @@ phase:
     declined, or withdrawn, the user can go into "Apply 2". This means
     they can choose 1 course at a time.
   enum:
-  - apply_1
-  - apply_2
+    - apply_1
+    - apply_2
   example: apply_1
 
 provider_user_id:
-    type: int
-    description: The ID of the provider user associated to the exported record.
-    example: 22
+  type: int
+  description: The ID of the provider user associated to the exported record.
+  example: 22
 
 recruitment_cycle_year:
   type: integer
@@ -48,7 +48,7 @@ submitted_at:
   type: string
   format: date-time
   description: When the candidate submitted their application
-  example: 2020-11-01T00:00:00+00:00
+  example: "2020-11-01T00:00:00+00:00"
 
 application_state:
   type: string
@@ -118,19 +118,19 @@ age_group:
   type: string
   description: The age group of the candidates
   enum:
-     - 21 and under
-     - '22'
-     - '23'
-     - '24'
-     - 25 to 29
-     - 30 to 34
-     - 35 to 39
-     - 40 to 44
-     - 45 to 49
-     - 50 to 54
-     - 55 to 59
-     - 60 to 64
-     - 65 and over
+    - 21 and under
+    - "22"
+    - "23"
+    - "24"
+    - 25 to 29
+    - 30 to 34
+    - 35 to 39
+    - 40 to 44
+    - 45 to 49
+    - 50 to 54
+    - 55 to 59
+    - 60 to 64
+    - 65 and over
 candidate_status:
   type: string
   description: Candidates application form status


### PR DESCRIPTION
## Context

Timestamps on the data API docs were not in an ISO8601 format. This was because of the way `JSON.pretty_generate` formats a Time object. Instead, a string object needed to be passed in to get the correct format. 

## Changes proposed in this pull request
Changed `extract date` and `submitted_at` example to strings. 
Fix indentation in rest of yml file.

## Guidance to review
Visit `/data-api/`

## Link to Trello card

https://trello.com/c/VIDIqZFv/3510-api-docs-dont-render-timestamps-correctly-check-if-its-still-occuring

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
