### PR TITLE
Fixed export to include 'Other' structured reason

### DIFF
--- a/app/presenters/support_interface/flat_reasons_for_rejection_presenter.rb
+++ b/app/presenters/support_interface/flat_reasons_for_rejection_presenter.rb
@@ -50,7 +50,7 @@ module SupportInterface
     def self.build_top_level_reasons(structured_rejection_reasons)
       return nil if structured_rejection_reasons.blank?
 
-      structured_rejection_reasons.select { |reason, value| ReasonsForRejection::INITIAL_TOP_LEVEL_QUESTIONS.include?(reason.to_sym) && value == 'Yes' }
+      structured_rejection_reasons.select { |reason, value| (ReasonsForRejection::INITIAL_TOP_LEVEL_QUESTIONS.include?(reason.to_sym) && value == 'Yes') || reason.to_sym == ReasonsForRejection::OTHER_REASON }
           .keys
           .map { |reason| humanized_title_for_top_level_reason(reason) }
           .join(', ')
@@ -65,7 +65,11 @@ module SupportInterface
     end
 
     def self.humanized_title_for_top_level_reason(reason)
-      I18n.t("reasons_for_rejection.#{ReasonsForRejection::TOP_LEVEL_REASONS_TO_I18N_KEYS[reason]}.title")
+      if reason.to_sym == ReasonsForRejection::OTHER_REASON
+        'Other'
+      else
+        I18n.t("reasons_for_rejection.#{ReasonsForRejection::TOP_LEVEL_REASONS_TO_I18N_KEYS[reason]}.title")
+      end
     end
 
     def self.title_for_top_level_reason(reason)

--- a/spec/presenters/support_interface/flat_reasons_for_rejection_presenter_spec.rb
+++ b/spec/presenters/support_interface/flat_reasons_for_rejection_presenter_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe SupportInterface::FlatReasonsForRejectionPresenter, type: :presen
       rejection_export_line = described_class.build_top_level_reasons(application_choice.structured_rejection_reasons)
 
       expect(rejection_export_line).to eq(
-        'Something you did, Honesty and professionalism, Performance at interview, Qualifications, Quality of application, Safeguarding issues',
+        'Something you did, Honesty and professionalism, Performance at interview, Qualifications, Quality of application, Safeguarding issues, Other',
       )
     end
   end


### PR DESCRIPTION
## Context

On the Application Choice export, application choices that have been rejected with the 'Other' structured reason for rejection are appearing as though they have not been given any reasons for rejection.

## Changes proposed in this pull request

Changed the 'flat_reasons_for_rejection_presenter' and its spec to include the 'Other' structured reason.

## Guidance to review

See Trello Story

## Link to Trello card

https://trello.com/c/29IUFY8R/4509-other-structured-reason-not-appearing-in-the-application-choices-export

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
