### PR TITLE
Update reinstated offer content for Notify emails

### DIFF
--- a/app/views/candidate_mailer/reinstated_offer.text.erb
+++ b/app/views/candidate_mailer/reinstated_offer.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @application_form.first_name %>,
 
-# You’re due to take up your deferred offer
+# Your deferred offer has been confirmed
 
 You have an offer from <%= @course_option.course.provider.name %> to study <%= @course_option.course.name_and_code %> in <%= @course_option.course.start_date.to_s(:month_and_year) %>. This was deferred from last year (<%= @application_choice.offer_deferred_at.to_s(:month_and_year) %>).
 

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -86,7 +86,7 @@ en:
     deferred_offer_reminder:
       subject: "Reminder of your deferred offer"
     reinstated_offer:
-      subject: "You’re due to take up your deferred offer"
+      subject: "Your deferred offer has been confirmed"
     apply_again_call_to_action:
       subject: You can still apply for teacher training
     course_unavailable_notification:

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -337,7 +337,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      'You’re due to take up your deferred offer',
+      'Your deferred offer has been confirmed',
       'heading' => 'Dear Bob',
       'provider name' => 'You have an offer from Falconholt Technical College',
       'name and code for course' => 'Forensic Science (E0FO)',
@@ -348,7 +348,7 @@ RSpec.describe CandidateMailer, type: :mailer do
     describe 'with pending conditions' do
       it_behaves_like(
         'a mail with subject and content',
-        'You’re due to take up your deferred offer',
+        'Your deferred offer has been confirmed',
         'heading' => 'Dear Bob',
         'provider name' => 'You have an offer from Falconholt Technical College',
         'name and code for course' => 'Forensic Science (E0FO)',


### PR DESCRIPTION
## Context

We received a request from Adam Silver to improve the content on when a deferred offer is due to be taken up. The current content sounds like the candidate needs to take an action. This copy makes it less like that.

## Changes proposed in this pull request

You're due to take up your deferred offer -> Your deferred offer has been confirmed.

## Guidance to review

Are we happy with this content tweak. @EmmaFrith to confirm.

## Link to Trello card

https://trello.com/c/79O96UgP 

## Things to check

Do we want to change both the title in the email and the subject line. I've changed both. This may be too much.
