### PR TITLE
Upload one artifact per test matrix node

### DIFF
--- a/.github/scripts/comment_on_flakey_specs.js
+++ b/.github/scripts/comment_on_flakey_specs.js
@@ -1,0 +1,35 @@
+module.exports = ({github, context}) => {
+  class FlakeySpecError extends Error {
+    constructor(message) {
+      super(message);
+      this.name = 'FlakeySpecError';
+    }
+  }
+
+  const { FLAKEY_TEST_DATA, GITHUB_HEAD_REF } = process.env;
+  if (FLAKEY_TEST_DATA.length) {
+    const { issue: { number: issue_number }, repo: { owner, repo } } = context;
+    const heading = 'You have one or more flakey tests on this branch!';
+    let commentBody = `<h2>${heading} :snowflake: :snowflake: :snowflake:</h2>`;
+    let dataStr, dataAry, attempts, retryCount, errorLocation, errorPath, errorMessages, errorLink;
+    let branchName = GITHUB_HEAD_REF.split('/').pop();
+    let createComment = false;
+    let rows = FLAKEY_TEST_DATA.split("\n");
+    let rowsLength = rows.length;
+    for (var idx = 0; idx < rowsLength; idx++) {
+      dataStr = rows[idx];
+      if (dataStr.length) {
+        dataAry = dataStr.split(',');
+        [attempts, retryCount, errorLocation, ...errorMessages] = dataAry;
+        errorPath = `/${owner}/${repo}/blob/${branchName}/${errorLocation.replace(':', '#L')}`;
+        errorLink = `<a href="${errorPath}">${errorLocation}</a>`;
+        commentBody += `Failed ${attempts} out of ${retryCount} times at ${errorLink}: :warning: ${errorMessages.toString()}<br>`;
+        createComment = true;
+      }
+    }
+    if (createComment) {
+      github.issues.createComment({ issue_number, owner, repo, body: commentBody });
+      throw new FlakeySpecError(heading);
+    }
+  }
+}

--- a/.github/scripts/simplecov_collate.rb
+++ b/.github/scripts/simplecov_collate.rb
@@ -1,0 +1,9 @@
+require 'simplecov'
+
+SimpleCov.root '/app'
+
+SimpleCov.start do
+  enable_coverage :branch
+end
+
+SimpleCov.collate Dir['*-result/.resultset.json']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,6 +220,7 @@ jobs:
         with:
           name: ${{ matrix.tests }}-head-result
           path: /app/coverage/.resultset.json
+          retention-days: 1
 
       - name: Upload main coverage report
         if: github.ref == 'refs/heads/main'
@@ -227,6 +228,8 @@ jobs:
         with:
           name: ${{ matrix.tests }}-base-result
           path: /app/coverage/.resultset.json
+          retention-days: 1
+
       - name: Notify Slack channel on job failure
         if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2
@@ -312,6 +315,7 @@ jobs:
         with:
           name: head-result
           path: coverage/.resultset.json
+          retention-days: 1
 
       - name: Upload collated main branch coverage report
         if: github.ref == 'refs/heads/main'
@@ -319,6 +323,7 @@ jobs:
         with:
           name: base-result
           path: coverage/.resultset.json
+          retention-days: 5
 
   trigger-deployment:
     name: Trigger Deployment

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,7 +304,7 @@ jobs:
         run: sudo ln -s /home/runner/work/apply-for-teacher-training/apply-for-teacher-training /app
 
       - name: Collate PR coverage results
-        run: bundle exec ruby -e "require 'simplecov'; SimpleCov.root '/app'; SimpleCov.start do enable_coverage :branch end; SimpleCov.collate Dir[\"*-result/.resultset.json\"]"
+        run: bundle exec ruby .github/scripts/simplecov_collate.rb
 
       - name: Replace compound command name with 'RSpec'
         run: sed -i 's/"RSpec-.*"/"RSpec"/' coverage/.resultset.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,6 +249,9 @@ jobs:
       - name: Echo flakey test output
         run: echo "${{ needs.test.outputs.flakey_tests }}"
 
+      - name: Checkout source
+        uses: actions/checkout@v2
+
       - name: Comment on flakey specs in pull request
         uses: actions/github-script@0.5.0
         if: github.event_name == 'pull_request' && needs.test.outputs.flakey_tests
@@ -258,31 +261,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { FLAKEY_TEST_DATA, GITHUB_HEAD_REF } = process.env;
-            if (FLAKEY_TEST_DATA.length) {
-              const { issue: { number: issue_number }, repo: { owner, repo } } = context;
-              let commentBody = '<h2>You have one or more flakey tests on this branch! :snowflake: :snowflake: :snowflake:</h2>';
-              let dataStr, dataAry, attempts, retryCount, errorLocation, errorPath, errorMessages, errorLink;
-              let branchName = GITHUB_HEAD_REF.split('/').pop();
-              let createComment = false;
-              let rows = FLAKEY_TEST_DATA.split("\n");
-              let rowsLength = rows.length;
-              for (var idx = 0; idx < rowsLength; idx++) {
-                dataStr = rows[idx];
-                if (dataStr.length) {
-                  dataAry = dataStr.split(',');
-                  [attempts, retryCount, errorLocation, ...errorMessages] = dataAry;
-                  errorPath = `/${owner}/${repo}/blob/${branchName}/${errorLocation.replace(':', '#L')}`;
-                  errorLink = `<a href="${errorPath}">${errorLocation}</a>`;
-                  commentBody += `Failed ${attempts} out of ${retryCount} times at ${errorLink}: :warning: ${errorMessages.toString()}<br>`;
-                  createComment = true;
-                }
-              }
-              if (createComment) {
-                github.issues.createComment({ issue_number, owner, repo, body: commentBody });
-                throw 'You have one or more flakey tests on this branch';
-              }
-            }
+            const script = require('/home/runner/work/apply-for-teacher-training/apply-for-teacher-training/.github/scripts/comment_on_flakey_specs.js')
+            script({github, context})
 
   collate-coverage:
     name: Collate test coverage reports

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,14 +286,32 @@ jobs:
     needs: [build, test]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby (installs .ruby-version, runs bundle install)
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
       - name: Download PR branch coverage artifact
         uses: actions/download-artifact@v2
         id: download-head-coverage
-        with:
-          path: head-result/
 
-      - name: List coverage results
-        run: ls -la head-result/
+      - name: List downloaded coverage report artifacts
+        run: ls -la *-head-result/.resultset.json
+
+      - name: Symlink source checkout directory to /app
+        run: sudo ln -s /home/runner/work/apply-for-teacher-training/apply-for-teacher-training /app
+
+      - name: Collate coverage results
+        run:  bundle exec ruby -e "require 'simplecov'; SimpleCov.root '/app'; SimpleCov.collate Dir[\"*-head-result/.resultset.json\"]"
+
+      - name: Replace compound command name with 'RSpec'
+        run: sed -i 's/"RSpec-.*"/"RSpec"/' coverage/.resultset.json
+
+      - name: Output collated results
+        run: cat coverage/.resultset.json
 
   trigger-deployment:
     name: Trigger Deployment

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,12 +281,12 @@ jobs:
               }
             }
 
-  download-coverage:
-    name: Download PR branch Simplecov coverage reports
+  collate-coverage:
+    name: Collate test coverage reports
     needs: [build, test]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR branch
+      - name: Checkout
         uses: actions/checkout@v2
 
       - name: Set up Ruby (installs .ruby-version, runs bundle install)
@@ -294,24 +294,31 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Download PR branch coverage artifact
+      - name: Download all coverage artifacts
         uses: actions/download-artifact@v2
-        id: download-head-coverage
-
-      - name: List downloaded coverage report artifacts
-        run: ls -la *-head-result/.resultset.json
 
       - name: Symlink source checkout directory to /app
         run: sudo ln -s /home/runner/work/apply-for-teacher-training/apply-for-teacher-training /app
 
-      - name: Collate coverage results
-        run:  bundle exec ruby -e "require 'simplecov'; SimpleCov.root '/app'; SimpleCov.collate Dir[\"*-head-result/.resultset.json\"]"
+      - name: Collate PR coverage results
+        run: bundle exec ruby -e "require 'simplecov'; SimpleCov.root '/app'; SimpleCov.start do enable_coverage :branch end; SimpleCov.collate Dir[\"*-result/.resultset.json\"]"
 
       - name: Replace compound command name with 'RSpec'
         run: sed -i 's/"RSpec-.*"/"RSpec"/' coverage/.resultset.json
 
-      - name: Output collated results
-        run: cat coverage/.resultset.json
+      - name: Upload collated pull request coverage report
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v2
+        with:
+          name: head-result
+          path: coverage/.resultset.json
+
+      - name: Upload collated main branch coverage report
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v2
+        with:
+          name: base-result
+          path: coverage/.resultset.json
 
   trigger-deployment:
     name: Trigger Deployment

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -305,6 +305,23 @@ jobs:
           path: coverage/.resultset.json
           retention-days: 5
 
+      - name: Delete test matrix coverage artifacts
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: |
+            unit_shared-base-result
+            unit_candidate-provider-base-result
+            unit_support-referee-api-base-result
+            integration_shared-base-result
+            integration_provider-base-result
+            integration_candidate-base-result
+            unit_shared-head-result
+            unit_candidate-provider-head-result
+            unit_support-referee-api-head-result
+            integration_shared-head-result
+            integration_provider-head-result
+            integration_candidate-head-result
+
   trigger-deployment:
     name: Trigger Deployment
     needs: [build, lint, test]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,14 +218,14 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v2
         with:
-          name: head-result
+          name: ${{ matrix.tests }}-head-result
           path: /app/coverage/.resultset.json
 
       - name: Upload main coverage report
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v2
         with:
-          name: base-result
+          name: ${{ matrix.tests }}-base-result
           path: /app/coverage/.resultset.json
       - name: Notify Slack channel on job failure
         if: failure() && github.event_name == 'push'
@@ -280,6 +280,20 @@ jobs:
                 throw 'You have one or more flakey tests on this branch';
               }
             }
+
+  download-coverage:
+    name: Download PR branch Simplecov coverage reports
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download PR branch coverage artifact
+        uses: actions/download-artifact@v2
+        id: download-head-coverage
+        with:
+          path: head-result/
+
+      - name: List coverage results
+        run: ls -la head-result/
 
   trigger-deployment:
     name: Trigger Deployment

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'securerandom'
 require 'simplecov'
 require 'simplecov-cobertura'
 SimpleCov.formatters = [
@@ -20,7 +21,10 @@ SimpleCov.formatters = [
   SimpleCov::Formatter::CoberturaFormatter,
 ]
 
-SimpleCov.command_name('RSpec')
+# Give each coverage report a unique ID if we are running parallel tests
+if ENV['TEST_ENV_NUMBER']
+  SimpleCov.command_name("RSpec-#{SecureRandom.hex(4)}")
+end
 
 SimpleCov.start 'rails' do
   enable_coverage :branch

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,8 @@ SimpleCov.formatters = [
 # Give each coverage report a unique ID if we are running parallel tests
 if ENV['TEST_ENV_NUMBER']
   SimpleCov.command_name("RSpec-#{SecureRandom.hex(4)}")
+else
+  SimpleCov.command_name('RSpec')
 end
 
 SimpleCov.start 'rails' do


### PR DESCRIPTION
## Context

We attempted to generate a coverage report from one large test run but this has the side-effect of making PRs look like there are outstanding checks and doesn't really fit well with our PR workflow.

It would be more efficient to use the coverage reports from the parallel test matrix and SimpleCov provides a way to collate multiple test coverage outputs into one.
 
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Upload a coverage `.resultset.json` artifact per test matrix job
- Download these in a separate job after all tests have run
- Collate the reports into one `.resultset.json` file
- Upload the collated report, the naming and retention of these differs depending on whether this is a PR branch or main branch build

## TODO

A follow up PR will be needed to compare main branch coverage with PR branch coverage, POC here: https://github.com/DFE-Digital/apply-for-teacher-training/pull/6036

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Sorry about the lengthy PR summary below, it took a while in draft to make this workflow run as expected.

This PR should produce a bunch of artifacts, the important one being the `head-result` artifact which contains the collated coverage report for the branch.

Do we need coverage reports for both feature flag on and off? We could half the number of artifacts and speed up collation if not.

Unrelated flakey spec failures on this PR addressed here https://github.com/DFE-Digital/apply-for-teacher-training/pull/6151

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/G2D7y5XO/4465-%F0%9F%8F%88-improve-testing-and-coverage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
