### PR TITLE
Cookie banner component does not render if cookies set

### DIFF
--- a/app/components/utility/cookie_banners_component.rb
+++ b/app/components/utility/cookie_banners_component.rb
@@ -4,13 +4,14 @@ class CookieBannersComponent < ViewComponent::Base
   CANDIDATE_INTERFACE = 'candidate_interface'.freeze
   PROVIDER_INTERFACE = 'provider_interface'.freeze
 
-  def initialize(current_namespace:, request_path:)
+  def initialize(current_namespace:, request_path:, current_cookies: nil)
     @current_namespace = current_namespace
     @request_path = request_path
+    @current_cookies = current_cookies
   end
 
   def render?
-    valid_page? && valid_namespace?
+    valid_page? && valid_namespace? && cookies_have_not_been_set?
   end
 
   def service_name_short
@@ -35,9 +36,13 @@ private
     current_namespace.eql?(CANDIDATE_INTERFACE) || current_namespace.eql?(PROVIDER_INTERFACE)
   end
 
+  def cookies_have_not_been_set?
+    current_cookies.blank?
+  end
+
   def url_helpers
     Rails.application.routes.url_helpers
   end
 
-  attr_reader :current_namespace, :request_path
+  attr_reader :current_namespace, :request_path, :current_cookies
 end

--- a/app/components/utility/cookie_banners_component.rb
+++ b/app/components/utility/cookie_banners_component.rb
@@ -3,11 +3,12 @@ class CookieBannersComponent < ViewComponent::Base
 
   CANDIDATE_INTERFACE = 'candidate_interface'.freeze
   PROVIDER_INTERFACE = 'provider_interface'.freeze
+  RELEVANT_COOKIES = %w[consented-to-apply-cookies consented-to-manage-cookies].freeze
 
-  def initialize(current_namespace:, request_path:, current_cookies: nil)
+  def initialize(current_namespace:, request_path:, cookies: nil)
     @current_namespace = current_namespace
     @request_path = request_path
-    @current_cookies = current_cookies
+    @cookies = cookies
   end
 
   def render?
@@ -37,12 +38,14 @@ private
   end
 
   def cookies_have_not_been_set?
-    current_cookies.blank?
+    return true if cookies.blank?
+
+    cookies.to_h.keys.none? { |c| RELEVANT_COOKIES.include?(c) }
   end
 
   def url_helpers
     Rails.application.routes.url_helpers
   end
 
-  attr_reader :current_namespace, :request_path, :current_cookies
+  attr_reader :current_namespace, :request_path, :cookies
 end

--- a/app/frontend/packs/cookies/cookie-banners.js
+++ b/app/frontend/packs/cookies/cookie-banners.js
@@ -23,9 +23,6 @@ class CookieBanners {
     if (!checkConsentedToCookieExists(this.service)) {
       this.showCookieMessage()
       this.bindEvents()
-    } else {
-      // TODO: Remove this once this is hidden server side
-      this.hideModule(this.$cookieBannerModule)
     }
   }
 

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -44,7 +44,7 @@
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 
-    <%= render CookieBannersComponent.new(current_namespace: try(:current_namespace), request_path: request.path, current_cookies: cookies['consented-to-apply-cookies']) %>
+    <%= render CookieBannersComponent.new(current_namespace: try(:current_namespace), request_path: request.path, cookies: cookies) %>
 
     <%= govuk_skip_link %>
 

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -44,7 +44,7 @@
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 
-    <%= render CookieBannersComponent.new(current_namespace: try(:current_namespace), request_path: request.path) %>
+    <%= render CookieBannersComponent.new(current_namespace: try(:current_namespace), request_path: request.path, current_cookies: cookies['consented-to-apply-cookies']) %>
 
     <%= govuk_skip_link %>
 

--- a/spec/components/utility/cookie_banners_component_spec.rb
+++ b/spec/components/utility/cookie_banners_component_spec.rb
@@ -24,6 +24,20 @@ RSpec.describe CookieBannersComponent, type: :component do
 
       expect(result.to_html).to be_blank
     end
+
+    it "renders when 'current_cookies' are not set" do
+      component = described_class.new(current_namespace: 'candidate_interface', request_path: '/', current_cookies: nil)
+      result = render_inline(component)
+
+      expect(result.to_html).not_to be_blank
+    end
+
+    it "does not render when 'current_cookies' are set" do
+      component = described_class.new(current_namespace: 'candidate_interface', request_path: '/', current_cookies: 'yes')
+      result = render_inline(component)
+
+      expect(result.to_html).to be_blank
+    end
   end
 
   describe '#service_name_short' do

--- a/spec/components/utility/cookie_banners_component_spec.rb
+++ b/spec/components/utility/cookie_banners_component_spec.rb
@@ -25,15 +25,15 @@ RSpec.describe CookieBannersComponent, type: :component do
       expect(result.to_html).to be_blank
     end
 
-    it "renders when 'current_cookies' are not set" do
-      component = described_class.new(current_namespace: 'candidate_interface', request_path: '/', current_cookies: nil)
+    it "renders when 'cookies' are not set" do
+      component = described_class.new(current_namespace: 'candidate_interface', request_path: '/', cookies: nil)
       result = render_inline(component)
 
       expect(result.to_html).not_to be_blank
     end
 
-    it "does not render when 'current_cookies' are set" do
-      component = described_class.new(current_namespace: 'candidate_interface', request_path: '/', current_cookies: 'yes')
+    it "does not render when 'cookies' are set" do
+      component = described_class.new(current_namespace: 'candidate_interface', request_path: '/', cookies: { 'consented-to-apply-cookies' => 'yes' })
       result = render_inline(component)
 
       expect(result.to_html).to be_blank


### PR DESCRIPTION
## Context
App was relying on JS to hide cookie banner component if cookies have been set. However, this was bad on a slow connection as the component could be seen very briefly until JS kicked in. 

## Changes proposed in this pull request
Cookie banner component now checks whether `consented-to-apply-cookies` or `consented-to-manage-cookies` have been set. If they have not, and the key-value pair does not exist, the banner will appear for the user.
JS to hide banner removed

## Guidance to review
Visit any valid page, and check mark up in elements tab of chrome dev tools. Check that cookie banner component html is not rendered and there is no css hiding elements. Toggle cookie in application tab. 
check fallback banner still works by toggling js

## Link to Trello card

https://trello.com/c/hz1fd2K5/3775-%F0%9F%8D%AA-apply-dont-render-cookie-banner-component-if-cookies-have-been-set-server-side-medium-term-priority

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
