### PR TITLE
Prepare to publish Monthly report

### DIFF
--- a/app/components/candidate_interface/monthly_statistics_table_component.html.erb
+++ b/app/components/candidate_interface/monthly_statistics_table_component.html.erb
@@ -16,7 +16,7 @@
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><%= name_for(row) %></th>
             <% data_from(row).map do |_status, count| %>
-              <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="<%= sort_value(count) %>"><%= count %></td>
+              <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="<%= sort_value(count) %>"><%= number_with_delimiter(count) %></td>
             <% end %>
           </tr>
         <% end %>
@@ -26,7 +26,7 @@
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Total</th>
         <% totals.map do |total| %>
-          <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= total %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= number_with_delimiter(total) %></td>
         <% end %>
       </tr>
       </tfoot>

--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -1,11 +1,17 @@
 module Publications
   class MonthlyStatisticsController < ApplicationController
+    before_action :redirect_unless_published
+
     def show
       @monthly_statistics_report = MonthlyStatisticsTimetable.current_report
       @statistics = @monthly_statistics_report.statistics
       @academic_year_name = RecruitmentCycle.cycle_name(CycleTimetable.next_year)
       @current_cycle_name = RecruitmentCycle.verbose_cycle_name
       @exports = MonthlyStatisticsTimetable.current_exports
+    end
+
+    def redirect_unless_published
+      redirect_to root_path unless FeatureFlag.active?(:publish_monthly_statistics)
     end
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -37,6 +37,7 @@ class FeatureFlag
     [:block_fraudulent_submission, 'A button used on the fraud audit page to block submissions', 'James Glenn'],
     [:support_user_revert_withdrawn_offer, 'Allows a support user to revert an application withdrawn by the candidate', 'James Glenn'],
     [:region_from_postcode, 'Uses an external service to find the region code for each candidate using their postcode', 'Steve Hook'],
+    [:publish_monthly_statistics, 'Publish monthly statistics at publications/monthly-statistics', 'Duncan Brown'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -82,13 +82,6 @@
           <span class="app-toc__content">Provider region</span>
         </a>
       </li>
-
-      <li>
-        <a href="#download-the-data" class="govuk-link app-toc__link">
-          <span class="app-toc__number">13.</span>
-          <span class="app-toc__content">Download the data</span>
-        </a>
-      </li>
     </ol>
   </div>
 </div>
@@ -233,19 +226,3 @@
 </div>
 
 <%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 12.1: Candidates by provider region of England', statistics: @statistics['by_provider_area']) %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="download-the-data">13. Download the data</h2>
-    <p class="govuk-body">You can download all of the data on this page in CSV (comma separated values) format, which can be opened in a spreadsheet and other analysis tools.</p>
-    <p class="govuk-body">The downloads include some further breakdowns of the data by combining fields - for example applicant age group and sex.</p>
-    <p class="govuk-body">In cases where the data counts fewer than 5 candidates or applications in a particular category
-      (for example, if age, sex and region are combined), data is marked ‘0 to 4’. This is to prevent anyone being identifiable by a data count.</p>
-
-    <% @exports.each do |export| %>
-      <p class='govuk-body'>
-        <%= govuk_link_to t("#{export.export_type}.label"), download_support_interface_data_export_path(export.id), type: 'text/csv' %>
-      </p>
-    <% end %>
-  </div>
-</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1163,11 +1163,8 @@ Rails.application.routes.draw do
   get '/check', to: 'healthcheck#show'
   get '/check/version', to: 'healthcheck#version'
 
-  if HostingEnvironment.test_environment?
-
-    namespace :publications, path: '/publications' do
-      get '/monthly-statistics' => 'monthly_statistics#show', as: :monthly_report
-    end
+  namespace :publications, path: '/publications' do
+    get '/monthly-statistics' => 'monthly_statistics#show', as: :monthly_report
   end
 
   mount Yabeda::Prometheus::Exporter => '/metrics'

--- a/lib/tasks/monthly_report.rake
+++ b/lib/tasks/monthly_report.rake
@@ -1,0 +1,14 @@
+desc "Import monthly report CSVs from monthly_report.csv"
+task import_monthly_report_csvs: :environment do
+  filename = './monthly_report.csv'
+
+  File.foreach(filename) do |json|
+    data = JSON.parse(json)
+    support_user = SupportUser.find_by(id: 'duncan.brown@digital.education.gov.uk').presence || SupportUser.last
+
+    data.merge!(initiator_type: 'SupportUser', initiator_id: support_user.id, completed_at: Time.zone.now)
+
+    puts DataExport.create!(data).inspect
+  end
+end
+

--- a/lib/tasks/monthly_report.rake
+++ b/lib/tasks/monthly_report.rake
@@ -1,14 +1,22 @@
-desc "Import monthly report CSVs from monthly_report.csv"
-task import_monthly_report_csvs: :environment do
-  filename = './monthly_report.csv'
+desc 'Import monthly report'
+task import_monthly_report: :environment do
+  json = File.read('monthly_report.json')
 
-  File.foreach(filename) do |json|
-    data = JSON.parse(json)
+  raise 'monthly_report.json not found!' if json.blank?
+
+  statistics = JSON.parse(json)
+  Publications::MonthlyStatistics::MonthlyStatisticsReport.create!(statistics: statistics)
+
+  puts 'Monthly report import complete!'
+
+  File.foreach('monthly_report_tables.csv') do |json_from_file|
+    data = JSON.parse(json_from_file)
     support_user = SupportUser.find_by(id: 'duncan.brown@digital.education.gov.uk').presence || SupportUser.last
 
     data.merge!(initiator_type: 'SupportUser', initiator_id: support_user.id, completed_at: Time.zone.now)
 
     puts DataExport.create!(data).inspect
   end
-end
 
+  puts 'CSV import complete!'
+end

--- a/spec/system/monthly_statistics/monthly_statistics_page_spec.rb
+++ b/spec/system/monthly_statistics/monthly_statistics_page_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Monthly statistics page' do
   before do
     allow(MonthlyStatisticsTimetable).to receive(:generate_monthly_statistics?).and_return true
+    FeatureFlag.activate('publish_monthly_statistics')
     create_application_choices
     create_monthly_stats_report
   end


### PR DESCRIPTION
## Context

We need to publish the report, but keep it hidden on production. Add a temporary feature flag. We also need to import the numbers we've created using the apply database from the correct date. To this end add a rake task which can import monthly report numbers from a file. (The routine for exporting is on another branch, which we'll PR in due course).

## Changes proposed in this pull request

- add feature flag for publishing the report
- remove stats download from the report because the links went to password-protected support pages
- add import rake task

## Guidance to review

🚢 

## Link to Trello card

https://trello.com/c/5iXjyAxM/4151-respond-to-tad-qa-comments-on-the-monthly-external-report
