### PR TITLE
Rename prod target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ sandbox:
 	$(eval APP_NAME_SUFFIX=sandbox)
 	$(eval AZURE_SUBSCRIPTION=s121-findpostgraduateteachertraining-production)
 
-prod:
+production:
 	$(if $(CONFIRM_PRODUCTION), , $(error Production can only run with CONFIRM_PRODUCTION))
 	$(eval APP_ENV=production)
 	$(eval APP_NAME_SUFFIX=prod)


### PR DESCRIPTION

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

This commit renames the target prod to production so that envirionment names become more standardised.

## Changes proposed in this pull request

Renames the prod target to production in the Makefile

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/oio959xP/442-apply-use-makefile-to-run-terraform-in-deploy-workflow

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
