### PR TITLE
Don't retry flakey specs whilst in a local environment

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,13 +37,15 @@ ENV['STATE_CHANGE_SLACK_URL'] = nil # ensure tests send no Slack notifications
 
 RSpec.configure do |config|
   # RSpec-retry configuration, retry and log any indeterminate tests.
-  reporter = RSpec::Core::Reporter.new(config)
-  formatter = RSpec::Core::Formatters::BaseTextFormatter.new(File.open('tmp/rspec-retry-flakey-specs.log', 'ab'))
-  reporter.register_listener(formatter, 'message')
-  config.retry_reporter = reporter
+  if ENV['CI']
+    reporter = RSpec::Core::Reporter.new(config)
+    formatter = RSpec::Core::Formatters::BaseTextFormatter.new(File.open('tmp/rspec-retry-flakey-specs.log', 'ab'))
+    reporter.register_listener(formatter, 'message')
+    config.retry_reporter = reporter
 
-  config.around do |ex|
-    ex.run_with_retry retry: 3
+    config.around do |ex|
+      ex.run_with_retry retry: 3
+    end
   end
 
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
## Context

We don't need `rspec-retry` to run locally. This changes the config to only retry failing specs whilst inside a PR build

## Changes proposed in this pull request

Wrap the `rspec-retry` config around a conditional that checks for the CI environment variable.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
