### PR TITLE
Stub ProcessState state for entire test

### DIFF
--- a/spec/requests/candidate_api/get_candidates_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_spec.rb
@@ -81,6 +81,8 @@ RSpec.describe 'GET /candidate-api/candidates', type: :request do
   end
 
   it 'returns applications ordered by created_at timestamp' do
+    allow(ProcessState).to receive(:new).and_return(instance_double(ProcessState, state: :unsubmitted_not_started_form))
+
     candidate = create(:candidate)
     application_forms = create_list(
       :completed_application_form,
@@ -91,8 +93,6 @@ RSpec.describe 'GET /candidate-api/candidates', type: :request do
     get_api_request "/candidate-api/candidates?updated_since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}", token: candidate_api_token
 
     response_data = parsed_response.dig('data', 0, 'attributes', 'application_forms')
-
-    allow(ProcessState).to receive(:new).and_return(instance_double(ProcessState, state: :unsubmitted_not_started_form))
 
     expect(response_data.size).to eq(2)
 


### PR DESCRIPTION
## Context

We're testing for results ordering, though we do expect specific states. 
`ProcessState` state varies according to timestamps so stub this for the entire test.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Stub `ProcessState#state` for entire test.
 
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
