### PR TITLE
Add checks for completing Contact information section

### DIFF
--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -13,7 +13,10 @@ module CandidateInterface
       @application_form = current_application
       @section_complete_form = SectionCompleteForm.new(completed: application_form_params[:completed])
 
-      if @section_complete_form.save(current_application, :contact_details_completed)
+      if ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed) && !details_complete?
+        flash[:warning] = 'You cannot mark this section complete with incomplete contact details.'
+        redirect_to candidate_interface_contact_information_review_path
+      elsif @section_complete_form.save(current_application, :contact_details_completed)
         redirect_to candidate_interface_application_form_path
       else
         track_validation_error(@section_complete_form)
@@ -25,6 +28,15 @@ module CandidateInterface
 
     def application_form_params
       strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
+    end
+
+    def details_complete?
+      contact_details_form.valid?(:address) && contact_details_form.valid?(:base)
+    end
+
+    def contact_details_form
+      @contact_details_form ||=
+        CandidateInterface::ContactDetailsForm.build_from_application(@application_form)
     end
   end
 end

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -1,4 +1,7 @@
-<% content_for :title, t('page_titles.contact_information') %>
+<% content_for(
+  :title,
+  title_with_error_prefix(t('page_titles.contact_information'), @contact_details_form&.errors&.any?),
+) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_contact_information_complete_path, method: :patch do |f| %>

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_contact_details_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_contact_details_section_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate is redirected correctly' do
+  include CandidateHelper
+
+  scenario 'Candidate reviews completed application and updates contact details section' do
+    given_i_am_signed_in
+    when_i_have_completed_my_application
+    and_i_have_not_filled_in_my_address
+    and_i_review_my_application
+    then_i_should_see_all_sections_are_complete_except_contact_details
+
+    when_i_click_complete_contact_details
+    then_i_should_see_the_phone_number_form
+
+    when_i_enter_a_phone_number_and_submit
+    then_i_should_see_the_contact_information_review_page
+
+    when_i_select_section_complete_and_submit
+    then_i_should_see_a_message_saying_that_details_are_incomplete
+
+    when_i_set_my_address
+    and_i_select_section_complete_and_submit
+    then_i_should_be_redirected_to_the_application_page
+    and_i_should_see_all_sections_are_complete
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_have_completed_my_application
+    candidate_completes_application_form
+  end
+
+  def and_i_have_not_filled_in_my_address
+    current_candidate.current_application.update(
+      address_type: 'uk',
+      address_line1: nil,
+      address_line2: nil,
+      address_line3: nil,
+      address_line4: nil,
+      postcode: nil,
+      country: nil,
+      contact_details_completed: false,
+    )
+  end
+
+  def and_i_review_my_application
+    allow(LanguagesSectionPolicy).to receive(:hide?).and_return(false)
+    and_i_visit_the_application_form_page
+    when_i_click_on_check_your_answers
+  end
+
+  def then_i_should_see_all_sections_are_complete_except_contact_details
+    application_form_sections.excluding(:contact_details).each do |section|
+      expect(page).not_to have_selector "[data-qa='incomplete-#{section}']"
+    end
+    expect(page).to have_selector "[data-qa='incomplete-contact_details']"
+  end
+
+  def and_i_visit_the_application_form_page
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_check_your_answers
+    click_link 'Check and submit your application'
+  end
+
+  def when_i_click_complete_contact_details
+    click_link 'Complete your contact details'
+  end
+
+  def then_i_should_see_the_phone_number_form
+    expect(page).to have_current_path(candidate_interface_edit_phone_number_path)
+  end
+
+  def when_i_enter_a_phone_number_and_submit
+    fill_in 'Phone number', with: '0736519012'
+    click_button 'Save and continue'
+  end
+
+  def then_i_should_see_the_contact_information_review_page
+    expect(page).to have_current_path(candidate_interface_contact_information_review_path)
+  end
+
+  def when_i_select_section_complete_and_submit
+    choose t('application_form.completed_radio')
+    click_button t('continue')
+  end
+  alias_method :and_i_select_section_complete_and_submit, :when_i_select_section_complete_and_submit
+
+  def then_i_should_see_a_message_saying_that_details_are_incomplete
+    expect(page).to have_current_path(candidate_interface_contact_information_review_path)
+    expect(page).to have_content('You cannot mark this section complete with incomplete contact details.')
+  end
+
+  def when_i_set_my_address
+    when_i_click_change_address
+
+    choose 'In the UK'
+    click_button t('save_and_continue')
+    find(:css, "[autocomplete='address-line1']").fill_in with: '42 Much Wow Street'
+    fill_in t('application_form.contact_details.address_line3.label.uk'), with: 'London'
+    fill_in t('application_form.contact_details.postcode.label.uk'), with: 'SW1P 3BT'
+    click_button t('save_and_continue')
+  end
+
+  def when_i_click_change_address
+    within('[data-qa="contact-details-address"]') do
+      click_link 'Change'
+    end
+  end
+
+  def then_i_should_be_redirected_to_the_application_page
+    expect(page).to have_current_path(candidate_interface_application_form_path)
+  end
+
+  def and_i_should_see_all_sections_are_complete
+    expect(page).to have_content('Contact information Completed')
+  end
+end


### PR DESCRIPTION
## Context

At least 2 candidates have been able to submit applications without providing an address. We were able to reproduce this; there seems to be a loophole in the application review and contact details review pages that allows a candidate to do this. This PR attempts to fix the immediate problem by stopping anyone setting the `ApplicationForm#contact_information_completed` to `true` unless the contact information is valid.

## Changes proposed in this pull request

- Check that the information is valid - according to
  `ContactDetailsForm` before allowing the candidate to set the section
  to completed.
- Add a system spec to cover the case where the candidate attempts to
  submit incomplete contact details.

## Guidance to review

- Does this prevent the submission of forms without addresses?
- Could the tests be improved?

I think this bug raises wider questions about how watertight our validation is around setting sections to completed. And whether we police that at submission time. I am going to log a follow-up card to review this question and look at ways in which we can make the validation mechanisms more consistent and easier to maintain in future.

## Link to Trello card

[https://trello.com/c/OX2pxkxs/4173-investigate-users-able-to-submit-applications-without-addresses
](https://trello.com/c/OX2pxkxs/4173-investigate-users-able-to-submit-applications-without-addresses)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
