### PR TITLE
Only alert on full sync errors on production

### DIFF
--- a/app/services/concerns/full_sync_error_handler.rb
+++ b/app/services/concerns/full_sync_error_handler.rb
@@ -1,6 +1,6 @@
 module FullSyncErrorHandler
   def raise_update_error(updates = {}, changeset = nil)
-    return if updates.none?
+    return unless updates.any? && HostingEnvironment.production?
 
     Sentry.capture_exception(TeacherTrainingPublicAPI::FullSyncUpdateError.new(error_message(updates, changeset)))
   end

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -152,9 +152,11 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
           }],
         )
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, false)
+        ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'production' do
+          described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, false)
 
-        expect(Sentry).to have_received(:capture_exception).twice
+          expect(Sentry).to have_received(:capture_exception).twice
+        end
       end
 
       it 'correctly updates vacancy status for any existing course options' do
@@ -186,10 +188,13 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
         expect(CourseOption.count).to eq 1
         CourseOption.first.update!(vacancy_status: 'no_vacancies')
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, false)
+        ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'production' do
+          described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, false)
 
-        expect(Sentry).to have_received(:capture_exception)
-                          .with(TeacherTrainingPublicAPI::FullSyncUpdateError.new('course_option have been updated'))
+          expect(Sentry)
+            .to have_received(:capture_exception)
+            .with(TeacherTrainingPublicAPI::FullSyncUpdateError.new('course_option have been updated'))
+        end
       end
 
       context 'when course details are updated' do
@@ -335,10 +340,13 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, sidekiq: true do
                                                    course_attributes: [{ accredited_body_code: 'DEF', study_mode: 'full_time' }],
                                                    site_code: 'A')
 
-        described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, false)
+        ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'production' do
+          described_class.new.perform(existing_provider.id, stubbed_recruitment_cycle_year, false)
 
-        expect(Sentry).to have_received(:capture_exception)
-                          .with(TeacherTrainingPublicAPI::FullSyncUpdateError.new('provider_relationship_permission and courses have been updated'))
+          expect(Sentry)
+            .to have_received(:capture_exception)
+            .with(TeacherTrainingPublicAPI::FullSyncUpdateError.new('provider_relationship_permission and courses have been updated'))
+        end
       end
 
       it 'does not create provider relationships for self ratifying providers' do

--- a/spec/services/teacher_training_public_api/sync_provider_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_provider_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe TeacherTrainingPublicAPI::SyncProvider, sidekiq: true do
         allow(Sentry).to receive(:capture_exception)
       end
 
+      around do |example|
+        ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'production' do
+          example.run
+        end
+      end
+
       it 'raises a FullSync error' do
         described_class.new(
           provider_from_api: provider_from_api,

--- a/spec/services/teacher_training_public_api/sync_sites_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_sites_spec.rb
@@ -170,6 +170,12 @@ RSpec.describe TeacherTrainingPublicAPI::SyncSites, sidekiq: true do
       allow(Sentry).to receive(:capture_exception)
     end
 
+    around do |example|
+      ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'production' do
+        example.run
+      end
+    end
+
     it 'raises a FullSync error' do
       described_class.new.perform(provider.id,
                                   RecruitmentCycle.current_year,


### PR DESCRIPTION
## Context

We are receiving Full sync errors on other environments which is adding unnecessary noise to our slack channel, and making it hard to determine real alerts around records being updated vs test data which can go out of sync regularly

## Changes proposed in this pull request

Add a check to only raise the full sync error if the environment is production

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
