### PR TITLE
Account for original course options being updated

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -189,15 +189,14 @@ class ApplicationChoice < ApplicationRecord
   end
 
   def update_course_option_and_associated_fields!(new_course_option, other_fields: {}, audit_comment: nil)
-    self.current_course_option = new_course_option # provider_ids_for_access needs this
-
     attrs = {
       current_course_option: new_course_option,
-      provider_ids: provider_ids_for_access,
       current_recruitment_cycle_year: new_course_option.course.recruitment_cycle_year,
     }.merge(other_fields)
-
     attrs[:audit_comment] = audit_comment if audit_comment.present?
+
+    assign_attributes(attrs) # provider_ids_for_access needs this to be set beforehand
+    self.provider_ids = provider_ids_for_access
 
     update!(attrs)
   end


### PR DESCRIPTION
## Context

We have been using the `update_course_option_and_associated_fields!` method to update application choices if the course option is updated before an offer. However because we aren't accounting for the course option to be updated and passed in through the other fields we are not updating the `provider_ids` appropriately and this is causing issues among different providers seeing applications they shouldn't vs not seeing them at all on their feeds

## Changes proposed in this pull request

Assign all attributes before calculating the providers ids to ensure we calculate them correctly and account for course option and current course option.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
