### PR TITLE
VendorAPI spec helper refactoring

### DIFF
--- a/spec/support/appear_before_matcher.rb
+++ b/spec/support/appear_before_matcher.rb
@@ -1,5 +1,0 @@
-RSpec::Matchers.define :appear_before do |later_content|
-  match do |earlier_content|
-    page.body.index(earlier_content) < page.body.index(later_content)
-  end
-end

--- a/spec/support/test_helpers/course_option_helpers.rb
+++ b/spec/support/test_helpers/course_option_helpers.rb
@@ -1,20 +1,20 @@
 module CourseOptionHelpers
   def course_option_for_provider(provider:, course: nil, site: nil, study_mode: 'full_time', recruitment_cycle_year: RecruitmentCycle.current_year)
-    course ||= create(:course, :open_on_apply, provider: provider, recruitment_cycle_year: recruitment_cycle_year)
-    site ||= create(:site, provider: provider)
+    course ||= build(:course, :open_on_apply, provider: provider, recruitment_cycle_year: recruitment_cycle_year)
+    site ||= build(:site, provider: provider)
     create(:course_option, course: course, site: site, study_mode: study_mode)
   end
 
   def course_option_for_provider_code(provider_code:)
     provider = create(:provider, :with_signed_agreement, code: provider_code)
-    course = create(:course, :open_on_apply, provider: provider)
-    site = create(:site, provider: provider)
+    course = build(:course, :open_on_apply, provider: provider)
+    site = build(:site, provider: provider)
     create(:course_option, course: course, site: site)
   end
 
   def course_option_for_accredited_provider(provider:, accredited_provider:, recruitment_cycle_year: RecruitmentCycle.current_year)
-    course = create(:course, :open_on_apply, :with_provider_relationship_permissions, provider: provider, accredited_provider: accredited_provider, recruitment_cycle_year: recruitment_cycle_year)
-    site = create(:site, provider: provider)
+    course = build(:course, :open_on_apply, :with_provider_relationship_permissions, provider: provider, accredited_provider: accredited_provider, recruitment_cycle_year: recruitment_cycle_year)
+    site = build(:site, provider: provider)
     create(:course_option, course: course, site: site)
   end
 end

--- a/spec/support/vendor_api/vendor_api_spec_helpers.rb
+++ b/spec/support/vendor_api/vendor_api_spec_helpers.rb
@@ -1,4 +1,14 @@
+RSpec.shared_context 'Vendor API Spec Helpers' do
+  let(:api_token) { VendorAPIToken.create_with_random_token!(provider: currently_authenticated_provider) }
+  let(:currently_authenticated_provider) { create(:provider) }
+  let(:auth_header) { "Bearer #{api_token}" }
+end
+
 module VendorAPISpecHelpers
+  RSpec.configure do |config|
+    config.include_context 'Vendor API Spec Helpers'
+  end
+
   VALID_METADATA = {
     attribution: {
       full_name: 'Jane Smith',
@@ -34,24 +44,12 @@ module VendorAPISpecHelpers
     post url, **headers_and_params
   end
 
-  def auth_header
-    "Bearer #{api_token}"
-  end
-
-  def api_token
-    @api_token ||= VendorAPIToken.create_with_random_token!(provider: currently_authenticated_provider)
-  end
-
-  def currently_authenticated_provider
-    @currently_authenticated_provider ||= create(:provider)
-  end
-
   def create_application_choice_for_currently_authenticated_provider(attributes = {})
-    create(
-      :submitted_application_choice,
-      :with_completed_application_form,
-      { course_option: course_option_for_provider(provider: currently_authenticated_provider) }.merge(attributes),
-    )
+    course = build(:course, provider: currently_authenticated_provider)
+    course_option = build(:course_option, course: course)
+    create(:submitted_application_choice,
+           :with_completed_application_form,
+           { course_option: course_option }.merge(attributes))
   end
 
   def parsed_response


### PR DESCRIPTION
Use `let` insted of instance variables in vendor api helper.
