### PR TITLE
Don't use SemanticLogger in test environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ gem 'yabeda-prometheus'
 # Logging
 gem 'request_store_rails'
 gem 'request_store-sidekiq'
-gem 'rails_semantic_logger'
+gem 'rails_semantic_logger', group: %w[development production]
 
 # Background processing
 gem 'sidekiq'

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'request_store_rails'
+return unless defined? SemanticLogger
 
 class CustomLogFormatter < SemanticLogger::Formatters::Raw
   def call(log, logger)


### PR DESCRIPTION
It writes a _lot_ of log lines to STDOUT, which isn't helpful, especially in CI. If we want test logs we can still `tail -f log/test.log` as normal.

## Context

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1638920628456000