### PR TITLE
Exclude semantic logger from :test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,6 @@ gem 'yabeda-prometheus'
 # Logging
 gem 'request_store_rails'
 gem 'request_store-sidekiq'
-gem 'rails_semantic_logger'
 
 # Background processing
 gem 'sidekiq'
@@ -174,4 +173,8 @@ group :development, :test do
   gem 'bullet'
   gem 'parallel_tests'
   gem 'amazing_print'
+end
+
+group :development, :production do
+  gem 'rails_semantic_logger'
 end

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -70,6 +70,10 @@ module HostingEnvironment
     environment_name == 'production'
   end
 
+  def self.test?
+    environment_name == 'test'
+  end
+
   def self.sandbox_mode?
     ENV.fetch('SANDBOX', 'false') == 'true'
   end

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -2,52 +2,54 @@
 
 require 'request_store_rails'
 
-class CustomLogFormatter < SemanticLogger::Formatters::Raw
-  def call(log, logger)
-    super(log, logger)
-    add_service_type
-    add_job_data
-    remove_post_params
-    hash.to_json
-  end
+unless HostingEnvironment.test?
+  class CustomLogFormatter < SemanticLogger::Formatters::Raw
+    def call(log, logger)
+      super(log, logger)
+      add_service_type
+      add_job_data
+      remove_post_params
+      hash.to_json
+    end
 
-private
+  private
 
-  def add_service_type
-    hash['domain'] = HostingEnvironment.hostname
-    hash['environment'] = HostingEnvironment.environment_name
-    hash['hosting_environment'] = HostingEnvironment.environment_name
-    hash['service'] = ENV['SERVICE_TYPE']
-  end
+    def add_service_type
+      hash['domain'] = HostingEnvironment.hostname
+      hash['environment'] = HostingEnvironment.environment_name
+      hash['hosting_environment'] = HostingEnvironment.environment_name
+      hash['service'] = ENV['SERVICE_TYPE']
+    end
 
-  def add_job_data
-    hash[:job_id] = RequestStore.store[:job_id] if RequestStore.store[:job_id].present?
-    hash[:job_queue] = RequestStore.store[:job_queue] if RequestStore.store[:job_queue].present?
-    tid = Thread.current['sidekiq_tid']
-    if tid.present?
-      ctx = Sidekiq::Context.current
-      hash['tid'] = tid
-      hash['ctx'] = ctx
+    def add_job_data
+      hash[:job_id] = RequestStore.store[:job_id] if RequestStore.store[:job_id].present?
+      hash[:job_queue] = RequestStore.store[:job_queue] if RequestStore.store[:job_queue].present?
+      tid = Thread.current['sidekiq_tid']
+      if tid.present?
+        ctx = Sidekiq::Context.current
+        hash['tid'] = tid
+        hash['ctx'] = ctx
+      end
+    end
+
+    def remove_post_params
+      if method_is_post_or_put_or_patch? && hash.dig(:payload, :params).present?
+        hash[:payload][:params].clear
+      end
+    end
+
+    def method_is_post_or_put_or_patch?
+      hash.dig(:payload, :method).in? %w[PUT POST PATCH]
     end
   end
 
-  def remove_post_params
-    if method_is_post_or_put_or_patch? && hash.dig(:payload, :params).present?
-      hash[:payload][:params].clear
-    end
-  end
-
-  def method_is_post_or_put_or_patch?
-    hash.dig(:payload, :method).in? %w[PUT POST PATCH]
-  end
+  rails_config = Rails.application.config
+  log_formatter = if HostingEnvironment.development?
+                    rails_config.rails_semantic_logger.format
+                  else
+                    CustomLogFormatter.new
+                  end
+  Clockwork.configure { |config| config[:logger] = SemanticLogger[Clockwork] if defined?(Clockwork) }
+  SemanticLogger.add_appender(io: STDOUT, level: rails_config.log_level, formatter: log_formatter)
+  rails_config.logger.info('Application logging to STDOUT')
 end
-
-rails_config = Rails.application.config
-log_formatter = if HostingEnvironment.development?
-                  rails_config.rails_semantic_logger.format
-                else
-                  CustomLogFormatter.new
-                end
-Clockwork.configure { |config| config[:logger] = SemanticLogger[Clockwork] if defined?(Clockwork) }
-SemanticLogger.add_appender(io: STDOUT, level: rails_config.log_level, formatter: log_formatter)
-rails_config.logger.info('Application logging to STDOUT')


### PR DESCRIPTION
-Move the semantic logger gem to a new development and production group

- Execute CustomLogFormatter unless test env, in line with the gem file

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
