### PR TITLE
Add migration to fix Candidate#candidate_api_updated_at

### DIFF
--- a/app/services/data_migrations/fix_candidate_api_updated_at.rb
+++ b/app/services/data_migrations/fix_candidate_api_updated_at.rb
@@ -16,14 +16,33 @@ module DataMigrations
             group by candidates.id
           ) candidates_with_latest_application_form on candidates_with_latest_application_form.id = candidates.id',
         )
-        .select('candidates.*, candidates_with_latest_application_form.max_form_created_at')
-        .where('candidate_api_updated_at < max_form_created_at')
+        .joins(
+          "left outer join (
+            select application_forms.candidate_id candidate_id,
+              min(audits.created_at) earliest_update
+            from audits
+            inner join application_forms on application_forms.id = audits.auditable_id
+            WHERE audits.action = 'update'
+            AND audits.auditable_type = 'ApplicationForm'
+            AND audits.user_id IS NOT NULL
+            group by application_forms.candidate_id
+          ) forms_with_earliest_audit ON forms_with_earliest_audit.candidate_id = candidates.id",
+        )
+        .select('candidates.*, candidates_with_latest_application_form.max_form_created_at, forms_with_earliest_audit.earliest_update')
+        .where('candidate_api_updated_at < max_form_created_at OR candidate_api_updated_at < forms_with_earliest_audit.earliest_update')
+        .where("created_at > '2021-01-01'")
 
       candidates.find_in_batches(batch_size: 10) do |batch|
         batch.each do |candidate|
-          candidate.update!(candidate_api_updated_at: candidate.max_form_created_at)
+          candidate.update!(candidate_api_updated_at: calculate_candidate_api_updated_at(candidate))
         end
       end
+    end
+
+    private
+
+    def calculate_candidate_api_updated_at(candidate)
+      candidate.max_form_created_at
     end
   end
 end

--- a/app/services/data_migrations/fix_candidate_api_updated_at.rb
+++ b/app/services/data_migrations/fix_candidate_api_updated_at.rb
@@ -1,0 +1,28 @@
+module DataMigrations
+  class FixCandidateAPIUpdatedAt
+    TIMESTAMP = 20211208172459
+    MANUAL_RUN = false
+
+    # Ensure that all the candidates have a `candidate_api_updated_at` that is
+    # no earlier than the `created_at` of the most recent application form.
+    def change
+      candidates = Candidate
+        .joins('inner join (
+            select candidates.id id,
+              max(application_forms.created_at) max_form_created_at
+            from candidates
+            inner join application_forms on application_forms.candidate_id = candidates.id
+            group by candidates.id
+          ) candidates_with_latest_application_form on candidates_with_latest_application_form.id = candidates.id'
+        )
+        .select('candidates.*, candidates_with_latest_application_form.max_form_created_at')
+        .where('candidate_api_updated_at < max_form_created_at')
+
+      candidates.find_in_batches(batch_size: 10) do |batch|
+        batch.each do |candidate|
+          candidate.update!(candidate_api_updated_at: candidate.max_form_created_at)
+        end
+      end
+    end
+  end
+end

--- a/app/services/data_migrations/fix_candidate_api_updated_at.rb
+++ b/app/services/data_migrations/fix_candidate_api_updated_at.rb
@@ -7,13 +7,14 @@ module DataMigrations
     # no earlier than the `created_at` of the most recent application form.
     def change
       candidates = Candidate
-        .joins('inner join (
+        .joins(
+          'inner join (
             select candidates.id id,
               max(application_forms.created_at) max_form_created_at
             from candidates
             inner join application_forms on application_forms.candidate_id = candidates.id
             group by candidates.id
-          ) candidates_with_latest_application_form on candidates_with_latest_application_form.id = candidates.id'
+          ) candidates_with_latest_application_form on candidates_with_latest_application_form.id = candidates.id',
         )
         .select('candidates.*, candidates_with_latest_application_form.max_form_created_at')
         .where('candidate_api_updated_at < max_form_created_at')

--- a/app/services/data_migrations/fix_candidate_api_updated_at.rb
+++ b/app/services/data_migrations/fix_candidate_api_updated_at.rb
@@ -39,10 +39,10 @@ module DataMigrations
       end
     end
 
-    private
+  private
 
     def calculate_candidate_api_updated_at(candidate)
-      candidate.max_form_created_at
+      [candidate.max_form_created_at, candidate.earliest_update].compact.max
     end
   end
 end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::FixCandidateAPIUpdatedAt',
   'DataMigrations::BackfillCarriedOverApplicationsDegreesComplete',
   'DataMigrations::BackfillWorkHistoryStatusForCurrentCycle',
   'DataMigrations::BackfillWorkHistoryStatus',

--- a/spec/services/data_migrations/fix_candidate_api_updated_at_spec.rb
+++ b/spec/services/data_migrations/fix_candidate_api_updated_at_spec.rb
@@ -5,54 +5,104 @@ RSpec.describe DataMigrations::FixCandidateAPIUpdatedAt do
     Timecop.freeze { example.run }
   end
 
-  it 'does not change valid `candidate_api_updated_at` values' do
-    valid_candidate = create(
-      :candidate,
-    )
-    create(
-      :application_form,
-      candidate: valid_candidate,
-      created_at: 3.weeks.ago,
-    )
-    create(
-      :application_form,
-      candidate: valid_candidate,
-      created_at: 2.weeks.ago,
-    )
-    valid_candidate.update(candidate_api_updated_at: 5.days.ago)
+  context 'when an associated application form has been updated', with_audited: true do
+    it 'does not change valid `candidate_api_updated_at` values' do
+      valid_candidate = create(
+        :candidate,
+      )
+      application_form = create(
+        :application_form,
+        candidate: valid_candidate,
+        created_at: 2.weeks.ago,
+      )
+      Audited.audit_class.as_user(valid_candidate) do
+        Timecop.freeze(1.week.ago) do
+          application_form.update(interview_preferences: 'Only on sunny days')
+        end
+      end
 
-    expect { described_class.new.change }.not_to(
-      change { valid_candidate.reload.candidate_api_updated_at },
-    )
+      valid_candidate.update(candidate_api_updated_at: 5.days.ago)
+
+      expect { described_class.new.change }.not_to(
+        change { valid_candidate.reload.candidate_api_updated_at },
+      )
+    end
+
+    it 'changes invalid `candidate_api_updated_at` values' do
+      invalid_candidate = create(
+        :candidate,
+      )
+      application_form = create(
+        :application_form,
+        candidate: invalid_candidate,
+        created_at: 2.weeks.ago,
+      )
+      Audited.audit_class.as_user(invalid_candidate) do
+        Timecop.freeze(1.week.ago) do
+          application_form.update(interview_preferences: 'Only on sunny days')
+        end
+      end
+
+      invalid_candidate.update(candidate_api_updated_at: 10.days.ago)
+
+      expect { described_class.new.change }.to(
+        change { invalid_candidate.reload.candidate_api_updated_at },
+      )
+      expect(invalid_candidate.candidate_api_updated_at).to be_within(1.second).of(1.week.ago)
+    end
   end
 
-  it 'does not change `candidate_api_updated_at` values for candidates with no applications' do
-    candidate_with_no_applications = create(:candidate)
-    candidate_with_no_applications.update(candidate_api_updated_at: 5.days.ago)
+  context 'when associated application forms have never been updated' do
+    it 'does not change valid `candidate_api_updated_at` values' do
+      valid_candidate = create(
+        :candidate,
+      )
+      create(
+        :application_form,
+        candidate: valid_candidate,
+        created_at: 3.weeks.ago,
+      )
+      create(
+        :application_form,
+        candidate: valid_candidate,
+        created_at: 2.weeks.ago,
+      )
+      valid_candidate.update(candidate_api_updated_at: 5.days.ago)
 
-    expect { described_class.new.change }.not_to(
-      change { candidate_with_no_applications.reload.candidate_api_updated_at },
-    )
-  end
+      expect { described_class.new.change }.not_to(
+        change { valid_candidate.reload.candidate_api_updated_at },
+      )
+    end
 
-  it 'changes invalid `candidate_api_updated_at` values' do
-    invalid_candidate = create(
-      :candidate,
-    )
-    create(
-      :application_form,
-      candidate: invalid_candidate,
-      created_at: 3.weeks.ago,
-    )
-    create(
-      :application_form,
-      candidate: invalid_candidate,
-      created_at: 2.weeks.ago,
-    )
-    invalid_candidate.update(candidate_api_updated_at: 5.weeks.ago)
+    it 'does not change `candidate_api_updated_at` values for candidates with no applications' do
+      candidate_with_no_applications = create(:candidate)
+      candidate_with_no_applications.update(candidate_api_updated_at: 5.days.ago)
 
-    expect { described_class.new.change }.to(
-      change { invalid_candidate.reload.candidate_api_updated_at }.to(2.weeks.ago),
-    )
+      expect { described_class.new.change }.not_to(
+        change { candidate_with_no_applications.reload.candidate_api_updated_at },
+      )
+    end
+
+    it 'changes invalid `candidate_api_updated_at` values' do
+      invalid_candidate = create(
+        :candidate,
+      )
+      create(
+        :application_form,
+        candidate: invalid_candidate,
+        created_at: 3.weeks.ago,
+      )
+      create(
+        :application_form,
+        candidate: invalid_candidate,
+        created_at: 2.weeks.ago,
+      )
+      invalid_candidate.update(candidate_api_updated_at: 5.weeks.ago)
+
+      expect { described_class.new.change }.to(
+        change { invalid_candidate.reload.candidate_api_updated_at },
+      )
+      expect(invalid_candidate.candidate_api_updated_at).to be_within(1.second).of(2.weeks.ago)
+    end
   end
 end

--- a/spec/services/data_migrations/fix_candidate_api_updated_at_spec.rb
+++ b/spec/services/data_migrations/fix_candidate_api_updated_at_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::FixCandidateAPIUpdatedAt do
+  around do |example|
+    Timecop.freeze { example.run }
+  end
+
+  it 'does not change valid `candidate_api_updated_at` values' do
+    valid_candidate = create(
+      :candidate,
+      candidate_api_updated_at: 5.days.ago,
+    )
+    create(
+      :application_form,
+      candidate: valid_candidate,
+      created_at: 3.weeks.ago,
+    )
+    create(
+      :application_form,
+      candidate: valid_candidate,
+      created_at: 2.weeks.ago,
+    )
+    valid_candidate.update(candidate_api_updated_at: 5.days.ago)
+
+    expect { described_class.new.change }.not_to(
+      change { valid_candidate.reload.candidate_api_updated_at },
+    )
+  end
+
+  it 'does not change `candidate_api_updated_at` values for candidates with no applications' do
+    candidate_with_no_applications = create(:candidate)
+    candidate_with_no_applications.update(candidate_api_updated_at: 5.days.ago)
+
+    expect { described_class.new.change }.not_to(
+      change { candidate_with_no_applications.reload.candidate_api_updated_at },
+    )
+  end
+
+  it 'changes invalid `candidate_api_updated_at` values' do
+    invalid_candidate = create(
+      :candidate,
+    )
+    create(
+      :application_form,
+      candidate: invalid_candidate,
+      created_at: 3.weeks.ago,
+    )
+    create(
+      :application_form,
+      candidate: invalid_candidate,
+      created_at: 2.weeks.ago,
+    )
+    invalid_candidate.update(candidate_api_updated_at: 5.weeks.ago)
+
+    expect { described_class.new.change }.to(
+      change { invalid_candidate.reload.candidate_api_updated_at }.to(2.weeks.ago),
+    )
+  end
+end

--- a/spec/services/data_migrations/fix_candidate_api_updated_at_spec.rb
+++ b/spec/services/data_migrations/fix_candidate_api_updated_at_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe DataMigrations::FixCandidateAPIUpdatedAt do
   it 'does not change valid `candidate_api_updated_at` values' do
     valid_candidate = create(
       :candidate,
-      candidate_api_updated_at: 5.days.ago,
     )
     create(
       :application_form,


### PR DESCRIPTION
## Context

Services that use the Candidate API sharing rely on the `Candidate#candidate_api_updated_at` attribute to indicate when a significant change has happened to a candidate necessitating a data refresh. The attribute is not always updated correctly, in particular for some carried over applications `candidate_api_updated_at` has not been updated at the time of carry over.

It looks like this is a significant problem on production:

```
irb(main):018:0> Candidate.select('distinct(candidates.id)').joins(:application_forms).where("(application_forms.created_at - candidates.
candidate_api_updated_at) > '1 days'").count
=> 2683
```

## Changes proposed in this pull request

There is now code to set `candidate_api_updated_at` when a new application form is created (or first updated). See https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/app/models/application_form.rb#L129

However this code was introduced on 19th October so applications carried over before this date may still be wrong. The original backfill for the this field sets the value to `Candidate.created_at` which for carried over applications is going to be unhelpful.

This PR adds a data migration that ensures that all the candidates have a `candidate_api_updated_at` that is no earlier than the `created_at` of the most recent application form.

## Guidance to review

- Does it make sense to try to ensure that all the candidates have a `candidate_api_updated_at` that is no earlier than the `created_at` of the most recent application form?
- Are there any unintended side-effects here?
- Are the tests adequate?

## Link to Trello card

[<!-- http://trello.com/123-example-card -->
](https://trello.com/c/f00SH2Mz/4184-candidate-api-does-not-correctly-populate-updatedat-when-an-application-is-carried-over)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
