### PR TITLE
Extend 2021/2022 christmas holiday period - Yay!

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -43,7 +43,7 @@ class CycleTimetable
       reject_by_default: Time.zone.local(2022, 9, 29, 23, 59, 59), # This is a placeholder till we know the real date
       find_closes: Time.zone.local(2022, 10, 4, 23, 59, 59), # This is a placeholder till we know the real date
       holidays: { # Placeholders
-        christmas: Date.new(2021, 12, 21)..Date.new(2022, 1, 1),
+        christmas: Date.new(2021, 12, 21)..Date.new(2022, 1, 15),
         easter: Date.new(2022, 4, 2)..Date.new(2022, 4, 6),
       },
     },

--- a/spec/services/set_reject_by_default_spec.rb
+++ b/spec/services/set_reject_by_default_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SetRejectByDefault do
       ['1 Jul 2019 9:00:00 AM BST',  '30 Jul 2019 0:00:00 AM BST', 'safely within BST'],
       ['4 Jan 2019 11:00:00 PM GMT', '2 Mar 2019 0:00:00 AM GMT',  'safely within GMT'],
       ['1 Jul 2020 11:00:00 PM BST', '30 Jul 2020 0:00:00 AM BST', 'during the 20-day summer period'],
-      ['21 Nov 2021 12:00:00 PM GMT', '1 Feb 2022 0:00:00 AM GMT', 'near the Christmas holidays'],
+      ['21 Nov 2021 12:00:00 PM GMT', '11 Feb 2022 23:59:59 PM GMT', 'near the Christmas holidays'],
       ['1 Sept 2021 0:00:00 AM BST', '29 Sept 2021 23:59:59 PM BST', '7 days before the apply 1 deadline'],
       ['7 Sept 2021 0:00:00 AM BST', '29 Sept 2021 23:59:59 PM BST', '1 day before apply 1 deadline'],
       ['20 Sept 2021 0:00:00 AM BST', '29 Sep 2021 23:59:59 PM BST', '1 day before apply 2 deadline'],


### PR DESCRIPTION
## Context

Calm down, this is so we can extend RBD dates to allow for interviews to take place at the start of 2022

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Extend 2021/2022 xmas holiday period to Jan 15 2022
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

We'll run the RBD parts of RecalculateDates task to fix any imminent RBD dates based on this change.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
