### PR TITLE
Monthly statistics reports - make dates in copy dynamic

### DIFF
--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -3,11 +3,7 @@ module Publications
     before_action :redirect_unless_published
 
     def show
-      @monthly_statistics_report = MonthlyStatisticsTimetable.current_report
-      @statistics = @monthly_statistics_report.statistics
-      @academic_year_name = RecruitmentCycle.cycle_name(CycleTimetable.next_year)
-      @current_cycle_name = RecruitmentCycle.verbose_cycle_name
-      @exports = MonthlyStatisticsTimetable.current_exports
+      @presenter = Publications::MonthlyStatisticsPresenter.new(MonthlyStatisticsTimetable.current_report)
     end
 
     def redirect_unless_published
@@ -15,3 +11,4 @@ module Publications
     end
   end
 end
+

--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -11,4 +11,3 @@ module Publications
     end
   end
 end
-

--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -3,7 +3,9 @@ module Publications
     before_action :redirect_unless_published
 
     def show
-      @presenter = Publications::MonthlyStatisticsPresenter.new(MonthlyStatisticsTimetable.current_report)
+      @presenter = Publications::MonthlyStatisticsPresenter.new(
+        MonthlyStatisticsTimetable.current_report,
+      )
     end
 
     def redirect_unless_published

--- a/app/presenters/publications/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/monthly_statistics_presenter.rb
@@ -10,15 +10,15 @@ module Publications
       report.statistics
     end
 
-    def academic_year_name
+    def next_cycle_name
       RecruitmentCycle.cycle_name(CycleTimetable.next_year)
     end
 
-    def current_cycle_name
+    def current_cycle_verbose_name
       RecruitmentCycle.verbose_cycle_name
     end
 
-    def current_recruitment_cycle_year
+    def current_year
       RecruitmentCycle.current_year
     end
 

--- a/app/presenters/publications/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/monthly_statistics_presenter.rb
@@ -29,7 +29,7 @@ module Publications
     end
 
     def current_reporting_period
-      '12 October 2021 to 22 November 2021'
+      "#{CycleTimetable.apply_opens.to_s(:govuk_date)} to #{report.created_at.to_s(:govuk_date)}"
     end
 
     def exports

--- a/app/presenters/publications/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/monthly_statistics_presenter.rb
@@ -1,0 +1,25 @@
+module Publications
+  class MonthlyStatisticsPresenter
+    attr_accessor :report
+
+    def initialize(report)
+      self.report = report
+    end
+
+    def statistics
+      report.statistics
+    end
+
+    def academic_year_name
+      RecruitmentCycle.cycle_name(CycleTimetable.next_year)
+    end
+
+    def current_cycle_name
+      RecruitmentCycle.verbose_cycle_name
+    end
+
+    def exports
+      MonthlyStatisticsTimetable.current_exports
+    end
+  end
+end

--- a/app/presenters/publications/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/monthly_statistics_presenter.rb
@@ -18,6 +18,10 @@ module Publications
       RecruitmentCycle.verbose_cycle_name
     end
 
+    def current_recruitment_cycle_year
+      RecruitmentCycle.current_year
+    end
+
     def exports
       MonthlyStatisticsTimetable.current_exports
     end

--- a/app/presenters/publications/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/monthly_statistics_presenter.rb
@@ -6,9 +6,7 @@ module Publications
       self.report = report
     end
 
-    def statistics
-      report.statistics
-    end
+    delegate :statistics, to: :report
 
     def next_cycle_name
       RecruitmentCycle.cycle_name(CycleTimetable.next_year)
@@ -18,8 +16,20 @@ module Publications
       RecruitmentCycle.verbose_cycle_name
     end
 
+    def previous_cycle_verbose_name
+      RecruitmentCycle.verbose_cycle_name(RecruitmentCycle.previous_year)
+    end
+
     def current_year
       RecruitmentCycle.current_year
+    end
+
+    def previous_year
+      RecruitmentCycle.previous_year
+    end
+
+    def current_reporting_period
+      '12 October 2021 to 22 November 2021'
     end
 
     def exports

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -1,10 +1,10 @@
-<%= content_for :title, t('page_titles.monthly_statistics', academic_year_name: @academic_year_name) %>
+<%= content_for :title, t('page_titles.monthly_statistics', academic_year_name: @presenter.academic_year_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl">Statistics</span>
     <h1 class="govuk-heading-xl">
-      Initial teacher training applications for courses starting in the <%= @academic_year_name %> academic year
+      Initial teacher training applications for courses starting in the <%= @presenter.academic_year_name %> academic year
     </h1>
 
     <h2 class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1 govuk-!-margin-top-5">Contents</h2>
@@ -90,8 +90,8 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l" id="introduction">1. Introduction</h2>
 
-    <p class="govuk-body">These statistics cover applications for courses in England starting in the <%= @academic_year_name %> academic year.</p>
-    <p class="govuk-body">Applications for courses starting in the <%= @academic_year_name %> academic year are submitted
+    <p class="govuk-body">These statistics cover applications for courses in England starting in the <%= @presenter.academic_year_name %> academic year.</p>
+    <p class="govuk-body">Applications for courses starting in the <%= @presenter.academic_year_name %> academic year are submitted
       in the October 2021 to September 2022 recruitment cycle (ITT2022) or deferred from the previous cycle for a 2022 to 2023 course start date.</p>
     <p class="govuk-body">Teacher training applications made directly to providers or Teach First are not included. Undergraduate teacher training is also not included.</p>
 
@@ -132,7 +132,7 @@
   </div>
 </div>
 
-<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 2.1: Candidates by most “advanced” application status', statistics: @statistics['candidates_by_status']) %>
+<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 2.1: Candidates by most “advanced” application status', statistics: @presenter.statistics['candidates_by_status']) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -146,14 +146,14 @@
   </div>
 </div>
 
-<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 3.1: Applications by status', statistics: @statistics['applications_by_status']) %>
+<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 3.1: Applications by status', statistics: @presenter.statistics['applications_by_status']) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l govuk-!-padding-top-4" id="by-age-group">4. Candidate age group</h2>
     <p class="govuk-body">Candidate age is calculated from the date of birth they provide when applying.</p>
     <p class="govuk-body">Ages are calculated as of 1 August <%= RecruitmentCycle.current_year %>, just before courses start for the
-      <%= @academic_year_name %> academic year. Courses usually start in September, but sometimes in January.</p>
+      <%= @presenter.academic_year_name %> academic year. Courses usually start in September, but sometimes in January.</p>
     <p class="govuk-body">This data therefore reflects the likely age of a candidate at the point of starting
        a course, rather than their age when they apply.</p>
     <p class="govuk-body">This table counts all candidates by their age group.</p>
@@ -164,7 +164,7 @@
   </div>
 </div>
 
-<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 4.1: Candidates by age group', statistics: @statistics['by_age_group']) %>
+<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 4.1: Candidates by age group', statistics: @presenter.statistics['by_age_group']) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -177,7 +177,7 @@
   </div>
 </div>
 
-<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 5.1: Applications by sex', statistics: @statistics['by_sex']) %>
+<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 5.1: Applications by sex', statistics: @presenter.statistics['by_sex']) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -194,7 +194,7 @@
   </div>
 </div>
 
-<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 6.1: Candidates by UK region or country, or other area', statistics: @statistics['by_area']) %>
+<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 6.1: Candidates by UK region or country, or other area', statistics: @presenter.statistics['by_area']) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -206,7 +206,7 @@
   </div>
 </div>
 
-<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 7.1: Applications by course phase', statistics: @statistics['by_course_age_group']) %>
+<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 7.1: Applications by course phase', statistics: @presenter.statistics['by_course_age_group']) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -218,7 +218,7 @@
   </div>
 </div>
 
-<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 8.1: Applications by route', statistics: @statistics['by_course_type']) %>
+<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 8.1: Applications by route', statistics: @presenter.statistics['by_course_type']) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -230,7 +230,7 @@
   </div>
 </div>
 
-<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 9.1: Applications by primary specialist subject', statistics: @statistics['by_primary_specialist_subject']) %>
+<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 9.1: Applications by primary specialist subject', statistics: @presenter.statistics['by_primary_specialist_subject']) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -248,7 +248,7 @@
   </div>
 </div>
 
-<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 10.1: Applications by secondary subject', statistics: @statistics['by_secondary_subject']) %>
+<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 10.1: Applications by secondary subject', statistics: @presenter.statistics['by_secondary_subject']) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -264,7 +264,7 @@
   </div>
 </div>
 
-<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 11.1: Candidates by provider region of England', statistics: @statistics['by_provider_area']) %>
+<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 11.1: Candidates by provider region of England', statistics: @presenter.statistics['by_provider_area']) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -91,12 +91,13 @@
     <h2 class="govuk-heading-l" id="introduction">1. Introduction</h2>
 
     <p class="govuk-body">These statistics cover applications for courses in England starting in the <%= @presenter.next_cycle_name %> academic year.</p>
+
     <p class="govuk-body">Applications for courses starting in the <%= @presenter.next_cycle_name %> academic year are submitted
     in the <%= @presenter.current_cycle_verbose_name %> recruitment cycle (ITT<%= @presenter.current_year %>) or deferred from the previous cycle for a <%= @presenter.next_cycle_name %> course start date.</p>
     <p class="govuk-body">Teacher training applications made directly to providers or Teach First are not included. Undergraduate teacher training is also not included.</p>
 
-    <p class="govuk-body">These statistics collect data from 12 October 2021 to 22 November 2021
-      (ITT2022) and include deferred applications from the October 2021 to September 2022 recruitment cycle (ITT2021).</p>
+    <p class="govuk-body">These statistics collect data from <%= @presenter.current_reporting_period %>
+      (ITT<%= @presenter.current_year %>) and include deferred applications from the <%= @presenter.previous_cycle_verbose_name %> recruitment cycle (ITT<%= @presenter.previous_year %>).</p>
     <p class="govuk-body">There will be monthly updates throughout the recruitment cycle.</p>
 
     <h2 class="govuk-heading-l" id="by-candidate-status">2. Candidate status</h2>

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -1,10 +1,10 @@
-<%= content_for :title, t('page_titles.monthly_statistics', academic_year_name: @presenter.academic_year_name) %>
+<%= content_for :title, t('page_titles.monthly_statistics', academic_year_name: @presenter.next_cycle_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl">Statistics</span>
     <h1 class="govuk-heading-xl">
-      Initial teacher training applications for courses starting in the <%= @presenter.academic_year_name %> academic year
+      Initial teacher training applications for courses starting in the <%= @presenter.next_cycle_name %> academic year
     </h1>
 
     <h2 class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1 govuk-!-margin-top-5">Contents</h2>
@@ -90,9 +90,9 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l" id="introduction">1. Introduction</h2>
 
-    <p class="govuk-body">These statistics cover applications for courses in England starting in the <%= @presenter.academic_year_name %> academic year.</p>
-    <p class="govuk-body">Applications for courses starting in the <%= @presenter.academic_year_name %> academic year are submitted
-    in the <%= @presenter.current_cycle_name %> recruitment cycle (ITT<%= @presenter.current_recruitment_cycle_year %>) or deferred from the previous cycle for a <%= @presenter.academic_year_name %> course start date.</p>
+    <p class="govuk-body">These statistics cover applications for courses in England starting in the <%= @presenter.next_cycle_name %> academic year.</p>
+    <p class="govuk-body">Applications for courses starting in the <%= @presenter.next_cycle_name %> academic year are submitted
+    in the <%= @presenter.current_cycle_verbose_name %> recruitment cycle (ITT<%= @presenter.current_year %>) or deferred from the previous cycle for a <%= @presenter.next_cycle_name %> course start date.</p>
     <p class="govuk-body">Teacher training applications made directly to providers or Teach First are not included. Undergraduate teacher training is also not included.</p>
 
     <p class="govuk-body">These statistics collect data from 12 October 2021 to 22 November 2021
@@ -153,7 +153,7 @@
     <h2 class="govuk-heading-l govuk-!-padding-top-4" id="by-age-group">4. Candidate age group</h2>
     <p class="govuk-body">Candidate age is calculated from the date of birth they provide when applying.</p>
     <p class="govuk-body">Ages are calculated as of 1 August <%= RecruitmentCycle.current_year %>, just before courses start for the
-      <%= @presenter.academic_year_name %> academic year. Courses usually start in September, but sometimes in January.</p>
+      <%= @presenter.next_cycle_name %> academic year. Courses usually start in September, but sometimes in January.</p>
     <p class="govuk-body">This data therefore reflects the likely age of a candidate at the point of starting
        a course, rather than their age when they apply.</p>
     <p class="govuk-body">This table counts all candidates by their age group.</p>

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -92,7 +92,7 @@
 
     <p class="govuk-body">These statistics cover applications for courses in England starting in the <%= @presenter.academic_year_name %> academic year.</p>
     <p class="govuk-body">Applications for courses starting in the <%= @presenter.academic_year_name %> academic year are submitted
-      in the October 2021 to September 2022 recruitment cycle (ITT2022) or deferred from the previous cycle for a 2022 to 2023 course start date.</p>
+    in the <%= @presenter.current_cycle_name %> recruitment cycle (ITT<%= @presenter.current_recruitment_cycle_year %>) or deferred from the previous cycle for a <%= @presenter.academic_year_name %> course start date.</p>
     <p class="govuk-body">Teacher training applications made directly to providers or Teach First are not included. Undergraduate teacher training is also not included.</p>
 
     <p class="govuk-body">These statistics collect data from 12 October 2021 to 22 November 2021

--- a/spec/presenters/publications/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/monthly_statistics_presenter_spec.rb
@@ -6,23 +6,42 @@ RSpec.describe Publications::MonthlyStatisticsPresenter do
   end
 
   let(:report) { double }
+
   subject(:presenter) { described_class.new(report) }
 
   describe '#next_cycle_name' do
     it 'returns the years for the start and end of the next academic year' do
-      expect(subject.next_cycle_name).to eq('2022 to 2023')
+      expect(presenter.next_cycle_name).to eq('2022 to 2023')
     end
   end
 
   describe '#current_cycle_verbose_name' do
     it 'returns the months and years for the start and end of the current recruitment cycle' do
-      expect(subject.current_cycle_verbose_name).to eq('October 2021 to September 2022')
+      expect(presenter.current_cycle_verbose_name).to eq('October 2021 to September 2022')
+    end
+  end
+
+  describe '#previous_cycle_verbose_name' do
+    it 'returns the months and years for the start and end of the last recruitment cycle' do
+      expect(presenter.previous_cycle_verbose_name).to eq('October 2020 to September 2021')
     end
   end
 
   describe '#current_year' do
     it 'returns the year for the current recruitment cycle' do
-      expect(subject.current_year).to eq(2022)
+      expect(presenter.current_year).to eq(2022)
+    end
+  end
+
+  describe '#previous_year' do
+    it 'returns the year for the last recruitment cycle' do
+      expect(presenter.previous_year).to eq(2021)
+    end
+  end
+
+  describe '#current_reporting_period' do
+    it 'returns the date range for the current reporting period' do
+      expect(presenter.current_reporting_period).to eq(:foo)
     end
   end
 end

--- a/spec/presenters/publications/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/monthly_statistics_presenter_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Publications::MonthlyStatisticsPresenter do
+  around do |example|
+    Timecop.freeze(Date.new(2021, 12, 1)) { example.run }
+  end
+
+  let(:report) { double }
+  subject(:presenter) { described_class.new(report) }
+
+  describe '#academic_year_name' do
+    it 'returns the years for the start and end of the next academic year' do
+      expect(subject.academic_year_name).to eq('2022 to 2023')
+    end
+  end
+
+  describe '#current_cycle_name' do
+    it 'returns the months and years for the start and end of the current recruitment cycle' do
+      expect(subject.current_cycle_name).to eq('October 2021 to September 2022')
+    end
+  end
+
+  describe '#current_recruitment_cycle_year' do
+    it 'returns the year for the current recruitment cycle' do
+      expect(subject.current_recruitment_cycle_year).to eq(2022)
+    end
+  end
+end

--- a/spec/presenters/publications/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/monthly_statistics_presenter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Publications::MonthlyStatisticsPresenter do
     Timecop.freeze(Date.new(2021, 12, 1)) { example.run }
   end
 
-  let(:report) do 
+  let(:report) do
     instance_double(
       Publications::MonthlyStatistics::MonthlyStatisticsReport,
       created_at: Date.new(2021, 11, 23),

--- a/spec/presenters/publications/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/monthly_statistics_presenter_spec.rb
@@ -8,21 +8,21 @@ RSpec.describe Publications::MonthlyStatisticsPresenter do
   let(:report) { double }
   subject(:presenter) { described_class.new(report) }
 
-  describe '#academic_year_name' do
+  describe '#next_cycle_name' do
     it 'returns the years for the start and end of the next academic year' do
-      expect(subject.academic_year_name).to eq('2022 to 2023')
+      expect(subject.next_cycle_name).to eq('2022 to 2023')
     end
   end
 
-  describe '#current_cycle_name' do
+  describe '#current_cycle_verbose_name' do
     it 'returns the months and years for the start and end of the current recruitment cycle' do
-      expect(subject.current_cycle_name).to eq('October 2021 to September 2022')
+      expect(subject.current_cycle_verbose_name).to eq('October 2021 to September 2022')
     end
   end
 
-  describe '#current_recruitment_cycle_year' do
+  describe '#current_year' do
     it 'returns the year for the current recruitment cycle' do
-      expect(subject.current_recruitment_cycle_year).to eq(2022)
+      expect(subject.current_year).to eq(2022)
     end
   end
 end

--- a/spec/presenters/publications/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/monthly_statistics_presenter_spec.rb
@@ -5,7 +5,12 @@ RSpec.describe Publications::MonthlyStatisticsPresenter do
     Timecop.freeze(Date.new(2021, 12, 1)) { example.run }
   end
 
-  let(:report) { double }
+  let(:report) do 
+    instance_double(
+      Publications::MonthlyStatistics::MonthlyStatisticsReport,
+      created_at: Date.new(2021, 11, 23),
+    )
+  end
 
   subject(:presenter) { described_class.new(report) }
 
@@ -41,7 +46,7 @@ RSpec.describe Publications::MonthlyStatisticsPresenter do
 
   describe '#current_reporting_period' do
     it 'returns the date range for the current reporting period' do
-      expect(presenter.current_reporting_period).to eq(:foo)
+      expect(presenter.current_reporting_period).to eq('12 October 2021 to 23 November 2021')
     end
   end
 end


### PR DESCRIPTION
## Context

There are several hard-coded dates in the copy for the monthly statistics report. These need to be replaced with helper methods that return dates appropriate to the current date.

## Changes proposed in this pull request

- [x] Extract a `MonthlyStatisticsPresenter` to encapsulate any helper methods needed (and reduce the number of variables passed from controller to view template).
- [x] Replace hard-coded dates in Introduction.
- [x] Replace hard-coded dates in Preamble for section 4.
- [ ] Replace hard-coded dates and counts in Footnotes. (I think this needs some alternate copy ready for next year, without the references to UCAS).

## Guidance to review

- Anything missing?

## Link to Trello card

https://trello.com/c/wehZ0e0y/4189-monthly-report-make-dates-in-copy-dynamic

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
