### PR TITLE
Allows support users to amend deferred applications

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -135,7 +135,7 @@ class ApplicationForm < ApplicationRecord
     return unless application_choices.any?
 
     if recruitment_cycle_year < RecruitmentCycle.current_year && \
-       !RequestStore.store[:allow_unsafe_application_choice_touches] && !deferred?
+       !RequestStore.store[:allow_unsafe_application_choice_touches] && !deferred_from_last_cycle?
       raise 'Tried to mark an application choice from a previous cycle as changed'
     end
 
@@ -479,7 +479,9 @@ private
     RecruitmentCycle.current_year >= recruitment_cycle_year
   end
 
-  def deferred?
+  def deferred_from_last_cycle?
+    return false if recruitment_cycle_year != RecruitmentCycle.previous_year
+
     application_choices.pluck(:status).join == 'offer_deferred'
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -135,7 +135,7 @@ class ApplicationForm < ApplicationRecord
     return unless application_choices.any?
 
     if recruitment_cycle_year < RecruitmentCycle.current_year && \
-       !RequestStore.store[:allow_unsafe_application_choice_touches]
+       !RequestStore.store[:allow_unsafe_application_choice_touches] && !deferred?
       raise 'Tried to mark an application choice from a previous cycle as changed'
     end
 
@@ -477,5 +477,9 @@ private
 
   def previous_recruitment_cycle?
     RecruitmentCycle.current_year >= recruitment_cycle_year
+  end
+
+  def deferred?
+    application_choices.pluck(:status).join == 'offer_deferred'
   end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe ApplicationForm do
           .to raise_error('Tried to mark an application choice from a previous cycle as changed')
       end
 
-      it 'does not throw an exception and touches an application choice when offer is deferred' do
+      it 'does not throw an exception and touches an application choice when offer is deferred from last cycle' do
         application_form = create(
           :completed_application_form,
           recruitment_cycle_year: RecruitmentCycle.previous_year,
@@ -71,6 +71,19 @@ RSpec.describe ApplicationForm do
 
         expect { application_form.update(address_line1: '123 Fake Street') }
           .not_to raise_error
+      end
+
+      it 'throws an exception when offer is deferred unless from last cycle' do
+        application_form = create(
+          :completed_application_form,
+          recruitment_cycle_year: RecruitmentCycle.previous_year - 1,
+          application_choices_count: 1,
+        )
+
+        application_form.application_choices.update(status: 'offer_deferred')
+
+        expect { application_form.update(address_line1: '123 Fake Street') }
+          .to raise_error('Tried to mark an application choice from a previous cycle as changed')
       end
 
       it 'does nothing when there are no application choices' do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -60,6 +60,19 @@ RSpec.describe ApplicationForm do
           .to raise_error('Tried to mark an application choice from a previous cycle as changed')
       end
 
+      it 'does not throw an exception and touches an application choice when offer is deferred' do
+        application_form = create(
+          :completed_application_form,
+          recruitment_cycle_year: RecruitmentCycle.previous_year,
+          application_choices_count: 1,
+        )
+
+        application_form.application_choices.update(status: 'offer_deferred')
+
+        expect { application_form.update(address_line1: '123 Fake Street') }
+          .not_to raise_error
+      end
+
       it 'does nothing when there are no application choices' do
         application_form = create(:completed_application_form, recruitment_cycle_year: RecruitmentCycle.previous_year, application_choices_count: 0)
 


### PR DESCRIPTION
## Context
Support was unable to amend contact details of a candidate who applied last cycle but deferred their application. This was because we prevent any updates of the application form from a previous cycle. 

## Changes proposed in this pull request
If the application choice status is offer deferred and the application is from a previous cycle then their details can now be amended without an error being raised

## Guidance to review
Try to amend a candidate's details who applied last recruitment cycle and deferred their application

## Link to Trello card

https://trello.com/c/WrZA7T1Z/4172-allow-support-users-to-amend-deferred-applications

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
