### PR TITLE
Use 'adviser' instead of 'advisor'

### DIFF
--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -24,7 +24,7 @@
         <li>if you decline all of your offers, or do not respond in time, you can still apply for courses that start this academic year</li>
       </ul>
 
-      <p class="govuk-body">If you need help, you can speak to our <%= govuk_link_to 'teacher training advisers', t('get_into_teaching.url_get_an_advisor') %>.</p>
+      <p class="govuk-body">If you need help, you can speak to our <%= govuk_link_to 'teacher training advisers', t('get_into_teaching.url_get_an_adviser') %>.</p>
 
       <%= f.govuk_radio_buttons_fieldset :response, legend: { text: t('decisions.response.legend'), size: 'm' } do %>
         <% if @application_choice.unconditional_offer? %>

--- a/app/views/candidate_interface/personal_details/immigration_right_to_work/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/immigration_right_to_work/_shared_form.html.erb
@@ -3,7 +3,7 @@
 <%= f.govuk_radio_buttons_fieldset(
   :immigration_right_to_work,
   legend: { text: t('page_titles.immigration_right_to_work'), size: 'l' },
-  hint: { text: "To get help with student visas and your immigration status, speak to a #{govuk_link_to 'teacher training advisor', t('get_into_teaching.url_get_an_advisor')}.".html_safe },
+  hint: { text: "To get help with student visas and your immigration status, speak to a #{govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser')}.".html_safe },
 ) do %>
   <%= f.govuk_radio_button :immigration_right_to_work, true, label: { text: 'Yes' }, link_errors: true %>
   <%= f.govuk_radio_button :immigration_right_to_work, false, label: { text: 'Not yet' } %>

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
@@ -6,7 +6,7 @@
 
 <p class="govuk-body">
   To get help with student visas and your immigration status, speak to a
-  <%= govuk_link_to 'teacher training advisor', t('get_into_teaching.url_get_an_advisor') %>.
+  <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser') %>.
 </p>
 
 <h2 class="govuk-heading-m">Getting a visa through your training provider</h2>

--- a/app/views/candidate_interface/personal_statement/_form.html.erb
+++ b/app/views/candidate_interface/personal_statement/_form.html.erb
@@ -16,7 +16,7 @@
 </ul>
 
 <%= govuk_inset_text do %>
-  <p class="govuk-body"><%= govuk_link_to 'Find out if you’re eligible for a teacher training adviser', t('get_into_teaching.url_get_an_advisor') %> to get advice on your application from an experienced teacher.</p>
+  <p class="govuk-body"><%= govuk_link_to 'Find out if you’re eligible for a teacher training adviser', t('get_into_teaching.url_get_an_adviser') %> to get advice on your application from an experienced teacher.</p>
 <% end %>
 
 <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('application_form.personal_statement.becoming_a_teacher.label'), size: 'm' }, rows: 20, max_words: 600 %>

--- a/app/views/candidate_interface/shared/_support.html.erb
+++ b/app/views/candidate_interface/shared/_support.html.erb
@@ -10,7 +10,7 @@
 
   <h3 class="govuk-heading-s govuk-!-font-size-16 govuk-!-margin-bottom-1"><%= t('layout.support.online_chat') %></h3>
   <ul class="govuk-list govuk-!-font-size-16">
-    <li><%= govuk_link_to t('layout.support.talk_to_advisor'), t('get_into_teaching.url_online_chat') %></li>
+    <li><%= govuk_link_to t('layout.support.talk_to_adviser'), t('get_into_teaching.url_online_chat') %></li>
     <li><%= t('get_into_teaching.opening_times') %></li>
   </ul>
 </aside>

--- a/app/views/layouts/_footer_meta_candidate.html.erb
+++ b/app/views/layouts/_footer_meta_candidate.html.erb
@@ -11,7 +11,7 @@
   <div class="govuk-grid-column-one-half">
     <h2 class="govuk-heading-s govuk-!-margin-bottom-1"><%= t('layout.support.online_chat') %></h2>
     <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
-      <li><%= link_to t('layout.support.talk_to_advisor'), t('get_into_teaching.url_online_chat'), class: 'govuk-footer__link' %></li>
+      <li><%= link_to t('layout.support.talk_to_adviser'), t('get_into_teaching.url_online_chat'), class: 'govuk-footer__link' %></li>
       <li><%= t('get_into_teaching.opening_times') %></li>
     </ul>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,7 +29,7 @@ en:
     opening_times: "Monday to Friday, 8:30am to 5:30pm (except public\u00A0holidays)"
     url: https://getintoteaching.education.gov.uk
     url_applying: https://getintoteaching.education.gov.uk/steps-to-become-a-teacher#step-5
-    url_get_an_advisor: https://adviser-getintoteaching.education.gov.uk
+    url_get_an_adviser: https://adviser-getintoteaching.education.gov.uk
     url_international_candidates: https://getintoteaching.education.gov.uk/international-candidates
     url_training_with_a_disability: https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#training-to-teach-if-you-have-a-disability
     url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
@@ -269,7 +269,7 @@ en:
       title: Get help
       telephone: Telephone
       online_chat: Online chat
-      talk_to_advisor: Talk to an adviser online
+      talk_to_adviser: Talk to an adviser online
       response_time: You’ll get a response within 5 working days, or one working day for urgent requests.
       provider_service_guidance: How to use this service
     support_links:


### PR DESCRIPTION
Both spelling variants are commonly used, but we should use 'adviser' for consistency with the [Get an adviser service](https://adviser-getintoteaching.education.gov.uk) itself.