### PR TITLE
Implement versioning in the api

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -125,7 +125,7 @@ module SupportInterface
 
     def vendor_api_row
       if visible_over_vendor_api?
-        application_json = AllowedCrossNamespaceUsage::VendorAPIApplicationPresenter.new(application_choice).as_json
+        application_json = AllowedCrossNamespaceUsage::VendorAPIApplicationPresenter.new(AllowedCrossNamespaceUsage::VENDOR_API_VERSION, application_choice).as_json
         {
           key: 'Vendor API',
           value: govuk_details(summary_text: 'See this application as it appears over the Vendor API') do

--- a/app/controllers/concerns/versioning.rb
+++ b/app/controllers/concerns/versioning.rb
@@ -1,5 +1,6 @@
 module Versioning
   extend ActiveSupport::Concern
+  include VersioningHelpers
 
   included do
     before_action :check_version
@@ -31,9 +32,5 @@ private
 
   def version_number
     @version_number ||= version_param.scan(/1\.?\d*/).first
-  end
-
-  def minor_version(version)
-    (version.scan(/1\.(\d+)/).flatten.first.to_i || 0)
   end
 end

--- a/app/controllers/concerns/versioning.rb
+++ b/app/controllers/concerns/versioning.rb
@@ -2,35 +2,13 @@ module Versioning
   extend ActiveSupport::Concern
   include VersioningHelpers
 
-  included do
-    before_action :check_version
-  end
-
 private
 
   def version_param
     params[:api_version]
   end
 
-  def check_version
-    if minor_version(version_number) < minor_version(self.class::VERSION)
-      render status: :unprocessable_entity, json: {
-        errors: [
-          error: 'InvalidVersionError',
-          message: "Not available in version #{version_param}",
-        ],
-      }
-    elsif minor_version(version_number) > minor_version(VendorAPI::VERSION)
-      render status: :unprocessable_entity, json: {
-        errors: [
-          error: 'NonExistentVersionError',
-          message: "Version #{version_param} does not exist",
-        ],
-      }
-    end
-  end
-
   def version_number
-    @version_number ||= version_param.scan(/1\.?\d*/).first
+    @version_number = extract_version(version_param)
   end
 end

--- a/app/controllers/concerns/versioning.rb
+++ b/app/controllers/concerns/versioning.rb
@@ -1,0 +1,35 @@
+module Versioning
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :check_version
+  end
+
+private
+
+  def version_param
+    params[:api_version]
+  end
+
+  def check_version
+    if version_number.to_f < self.class::VERSION.to_f
+      render status: :unprocessable_entity, json: {
+        errors: [
+          error: 'InvalidVersionError',
+          message: "Not available in version #{version_param}",
+        ],
+      }
+    elsif version_number.to_f > VendorAPI::VERSION.to_f
+      render status: :unprocessable_entity, json: {
+        errors: [
+          error: 'NonExistentVersionError',
+          message: "Version #{version_param} does not exist",
+        ],
+      }
+    end
+  end
+
+  def version_number
+    @version_number ||= version_param.scan(/1\.?\d*/).first
+  end
+end

--- a/app/controllers/concerns/versioning.rb
+++ b/app/controllers/concerns/versioning.rb
@@ -12,14 +12,14 @@ private
   end
 
   def check_version
-    if version_number.to_f < self.class::VERSION.to_f
+    if minor_version(version_number) < minor_version(self.class::VERSION)
       render status: :unprocessable_entity, json: {
         errors: [
           error: 'InvalidVersionError',
           message: "Not available in version #{version_param}",
         ],
       }
-    elsif version_number.to_f > VendorAPI::VERSION.to_f
+    elsif minor_version(version_number) > minor_version(VendorAPI::VERSION)
       render status: :unprocessable_entity, json: {
         errors: [
           error: 'NonExistentVersionError',
@@ -31,5 +31,9 @@ private
 
   def version_number
     @version_number ||= version_param.scan(/1\.?\d*/).first
+  end
+
+  def minor_version(version)
+    (version.scan(/1\.(\d+)/).flatten.first.to_i || 0)
   end
 end

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -1,7 +1,5 @@
 module VendorAPI
   class ApplicationsController < VendorAPIController
-    include Versioning
-
     VERSION = '1.0'.freeze
 
     def index

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -1,5 +1,9 @@
 module VendorAPI
   class ApplicationsController < VendorAPIController
+    include Versioning
+
+    VERSION = '1.0'.freeze
+
     def index
       render json: serialized_application_choices_data
     end

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -9,14 +9,14 @@ module VendorAPI
     def show
       application_choice = application_choices_visible_to_provider.find(params[:application_id])
 
-      render json: %({"data":#{ApplicationPresenter.new(application_choice).serialized_json}})
+      render json: %({"data":#{ApplicationPresenter.new(version_number, application_choice).serialized_json}})
     end
 
   private
 
     def serialized_application_choices_data
       json_data = get_application_choices_for_provider_since(since: since_param).map do |application_choice|
-        ApplicationPresenter.new(application_choice).serialized_json
+        ApplicationPresenter.new(version_number, application_choice).serialized_json
       end
 
       %({"data":[#{json_data.join(',')}]})

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -1,7 +1,5 @@
 module VendorAPI
   class ApplicationsController < VendorAPIController
-    VERSION = '1.0'.freeze
-
     def index
       render json: serialized_application_choices_data
     end

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -1,5 +1,7 @@
 module VendorAPI
   class DecisionsController < VendorAPIController
+    VERSION = '1.0'.freeze
+
     before_action :validate_metadata!
     rescue_from ValidationException, with: :render_validation_error
 

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -63,7 +63,7 @@ module VendorAPI
     end
 
     def render_application
-      render json: %({"data":#{ApplicationPresenter.new(application_choice).serialized_json}})
+      render json: %({"data":#{ApplicationPresenter.new(version_number, application_choice).serialized_json}})
     end
 
     def respond_to_decision(decision)

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -1,7 +1,5 @@
 module VendorAPI
   class DecisionsController < VendorAPIController
-    VERSION = '1.0'.freeze
-
     before_action :validate_metadata!
     rescue_from ValidationException, with: :render_validation_error
 

--- a/app/controllers/vendor_api/ping_controller.rb
+++ b/app/controllers/vendor_api/ping_controller.rb
@@ -1,7 +1,5 @@
 module VendorAPI
   class PingController < VendorAPIController
-    VERSION = '1.0'.freeze
-
     def ping
       render json: { data: 'pong' }
     end

--- a/app/controllers/vendor_api/ping_controller.rb
+++ b/app/controllers/vendor_api/ping_controller.rb
@@ -1,5 +1,7 @@
 module VendorAPI
   class PingController < VendorAPIController
+    VERSION = '1.0'.freeze
+
     def ping
       render json: { data: 'pong' }
     end

--- a/app/controllers/vendor_api/reference_data_controller.rb
+++ b/app/controllers/vendor_api/reference_data_controller.rb
@@ -1,5 +1,7 @@
 module VendorAPI
   class ReferenceDataController < VendorAPIController
+    VERSION = '1.0'.freeze
+
     def gcse_subjects
       render json: { data: GCSE_SUBJECTS }
     end

--- a/app/controllers/vendor_api/reference_data_controller.rb
+++ b/app/controllers/vendor_api/reference_data_controller.rb
@@ -1,7 +1,5 @@
 module VendorAPI
   class ReferenceDataController < VendorAPIController
-    VERSION = '1.0'.freeze
-
     def gcse_subjects
       render json: { data: GCSE_SUBJECTS }
     end

--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -1,7 +1,5 @@
 module VendorAPI
   class TestDataController < VendorAPIController
-    VERSION = '1.0'.freeze
-
     before_action :check_this_is_a_test_environment
 
     MAX_COUNT = 100

--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -1,5 +1,7 @@
 module VendorAPI
   class TestDataController < VendorAPIController
+    VERSION = '1.0'.freeze
+
     before_action :check_this_is_a_test_environment
 
     MAX_COUNT = 100

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -3,6 +3,7 @@ module VendorAPI
     include ActionController::HttpAuthentication::Token::ControllerMethods
     include RequestQueryParams
     include RemoveBrowserOnlyHeaders
+    include Versioning
 
     rescue_from ActiveRecord::RecordNotFound, with: :application_not_found
     rescue_from ActionController::ParameterMissing, with: :parameter_missing

--- a/app/lib/allowed_cross_namespace_usage.rb
+++ b/app/lib/allowed_cross_namespace_usage.rb
@@ -7,4 +7,5 @@
 module AllowedCrossNamespaceUsage
   VendorAPIApplicationPresenter = VendorAPI::ApplicationPresenter
   RegisterAPISingleApplicationPresenter = RegisterAPI::SingleApplicationPresenter
+  VENDOR_API_VERSION = VendorAPI::VERSION
 end

--- a/app/lib/concerns/versioning_helpers.rb
+++ b/app/lib/concerns/versioning_helpers.rb
@@ -3,6 +3,10 @@ module VersioningHelpers
     (version.scan(/1\.(\d+)/).flatten.first.to_i || 0)
   end
 
+  def extract_version(url_param)
+    url_param.match(/^v(?<number>.*)/)[:number]
+  end
+
   def major_version_number(version)
     Gem::Version.new(version).segments[0]
   end

--- a/app/lib/concerns/versioning_helpers.rb
+++ b/app/lib/concerns/versioning_helpers.rb
@@ -1,0 +1,5 @@
+module VersioningHelpers
+  def minor_version(version)
+    (version.scan(/1\.(\d+)/).flatten.first.to_i || 0)
+  end
+end

--- a/app/lib/concerns/versioning_helpers.rb
+++ b/app/lib/concerns/versioning_helpers.rb
@@ -1,8 +1,4 @@
 module VersioningHelpers
-  def minor_version(version)
-    (version.scan(/1\.(\d+)/).flatten.first.to_i || 0)
-  end
-
   def extract_version(url_param)
     url_param.match(/^v(?<number>.*)/)[:number]
   end

--- a/app/lib/concerns/versioning_helpers.rb
+++ b/app/lib/concerns/versioning_helpers.rb
@@ -2,4 +2,16 @@ module VersioningHelpers
   def minor_version(version)
     (version.scan(/1\.(\d+)/).flatten.first.to_i || 0)
   end
+
+  def major_version_number(version)
+    Gem::Version.new(version).segments[0]
+  end
+
+  def minor_version_number(version)
+    Gem::Version.new(version).segments[1] || 0
+  end
+
+  def version_number(version)
+    "#{major_version_number(version)}.#{minor_version_number(version)}"
+  end
 end

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -1,3 +1,9 @@
 module VendorAPI
   VERSION = '1.0'.freeze
+
+  VERSIONS = {
+    '1.0' => {
+      'VendorAPI::ApplicationsController' => [:index],
+    },
+  }.freeze
 end

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -1,0 +1,3 @@
+module VendorAPI
+  VERSION = '1.0'.freeze
+end

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -18,6 +18,8 @@ module VendorAPI
       Changes::ClearTestData,
       Changes::RegenerateTestData,
       Changes::PingEndpoint,
+      Changes::ExperimentalClearTestData,
+      Changes::ExperimentalGenerateTestData,
     ],
   }.freeze
 end

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -16,6 +16,7 @@ module VendorAPI
       Changes::AAndAsLevelGrades,
       Changes::GenerateTestData,
       Changes::ClearTestData,
+      Changes::RegenerateTestData,
       Changes::PingEndpoint,
     ],
   }.freeze

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -2,8 +2,21 @@ module VendorAPI
   VERSION = '1.0'.freeze
 
   VERSIONS = {
-    '1.0' => {
-      'VendorAPI::ApplicationsController' => [:index],
-    },
+    '1.0' => [
+      Changes::RetrieveApplications,
+      Changes::RetrieveSingleApplication,
+      Changes::MakeAnOffer,
+      Changes::ConfirmEnrolment,
+      Changes::ConfirmConditionsMet,
+      Changes::ConditionsNotMet,
+      Changes::RejectApplication,
+      Changes::GcseSubjects,
+      Changes::GcseGrades,
+      Changes::AAndAsLevelSubjects,
+      Changes::AAndAsLevelGrades,
+      Changes::GenerateTestData,
+      Changes::ClearTestData,
+      Changes::PingEndpoint,
+    ],
   }.freeze
 end

--- a/app/lib/vendor_api/changes/a_and_as_level_grades.rb
+++ b/app/lib/vendor_api/changes/a_and_as_level_grades.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  module Changes
+    class AAndAsLevelGrades < VersionChange
+      description 'An array of possible A and AS level grades.'
+
+      action ReferenceDataController, :a_and_as_level_grades
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/a_and_as_level_subjects.rb
+++ b/app/lib/vendor_api/changes/a_and_as_level_subjects.rb
@@ -1,0 +1,12 @@
+module VendorAPI
+  module Changes
+    class AAndAsLevelSubjects < VersionChange
+      description \
+        "An array of possible A and AS level subjects.\n" \
+        "Candidates are offered these in an autocomplete when filling in the form, \n" \
+        'but are also able to provide free-text responses.'
+
+      action ReferenceDataController, :a_and_as_level_subjects
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/clear_test_data.rb
+++ b/app/lib/vendor_api/changes/clear_test_data.rb
@@ -1,0 +1,12 @@
+module VendorAPI
+  module Changes
+    class ClearTestData < VersionChange
+      description \
+        "Clear test data \n" \
+        'Deletes ALL application data for the current provider regardless of how it was created.' \
+        'Only available on the Sandbox. EXPERIMENTAL — this endpoint may change or disappear.'
+
+      action TestDataController, :clear!
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/conditions_not_met.rb
+++ b/app/lib/vendor_api/changes/conditions_not_met.rb
@@ -1,0 +1,12 @@
+module VendorAPI
+  module Changes
+    class ConditionsNotMet < VersionChange
+      description \
+        " Conditions not met\n" \
+        "The candidate has not met all the conditions set out in the offer.\n" \
+        'This will transition the application to the conditions_not_met state.'
+
+      action DecisionsController, :conditions_not_met
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/confirm_conditions_met.rb
+++ b/app/lib/vendor_api/changes/confirm_conditions_met.rb
@@ -1,0 +1,12 @@
+module VendorAPI
+  module Changes
+    class ConfirmConditionsMet < VersionChange
+      description \
+        "Confirm offer conditions\n" \
+        "Confirm that the candidate has met all the conditions set out in the offer\n" \
+        'This will transition the application to the recruited state.'
+
+      action DecisionsController, :confirm_conditions_met
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/confirm_enrolment.rb
+++ b/app/lib/vendor_api/changes/confirm_enrolment.rb
@@ -1,0 +1,12 @@
+module VendorAPI
+  module Changes
+    class ConfirmEnrolment < VersionChange
+      description \
+        "Confirm enrolment (DEPRECATED)\n" \
+        "This endpoint has been deprecated and will return the application without changing it.\n" \
+        'There is currently no meaning to `enrolment` in Apply for teacher training.'
+
+      action DecisionsController, :confirm_enrolment
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/experimental_clear_test_data.rb
+++ b/app/lib/vendor_api/changes/experimental_clear_test_data.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  module Changes
+    class ExperimentalClearTestData < VersionChange
+      description 'Experimental Clear test data'
+
+      action TestDataController, :experimental_endpoint_moved
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/experimental_generate_test_data.rb
+++ b/app/lib/vendor_api/changes/experimental_generate_test_data.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  module Changes
+    class ExperimentalGenerateTestData < VersionChange
+      description 'Experimental Generate test data'
+
+      action TestDataController, :experimental_endpoint_moved
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/gcse_grades.rb
+++ b/app/lib/vendor_api/changes/gcse_grades.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  module Changes
+    class GcseGrades < VersionChange
+      description 'An array of possible GCSE grades including double-award grades.'
+
+      action ReferenceDataController, :gcse_grades
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/gcse_subjects.rb
+++ b/app/lib/vendor_api/changes/gcse_subjects.rb
@@ -1,0 +1,12 @@
+module VendorAPI
+  module Changes
+    class GcseSubjects < VersionChange
+      description \
+        "An array of possible GCSE subjects.\n" \
+        'Candidates are offered these in an autocomplete when filling in the form, ' \
+        'but are also able to provide free-text responses.'
+
+      action ReferenceDataController, :gcse_subjects
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/generate_test_data.rb
+++ b/app/lib/vendor_api/changes/generate_test_data.rb
@@ -1,0 +1,13 @@
+module VendorAPI
+  module Changes
+    class GenerateTestData < VersionChange
+      description \
+        "Generate test data \n" \
+        'Submits a request to generate n new applications, defaulting to 100 applications with one course choice per' \
+        'application. The applications are generated asynchronously, and will appear once they have been generated.' \
+        'Does not change existing data. Only available on the Sandbox. EXPERIMENTAL — this endpoint may change or disappear.'
+
+      action TestDataController, :generate
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/make_an_offer.rb
+++ b/app/lib/vendor_api/changes/make_an_offer.rb
@@ -1,0 +1,12 @@
+module VendorAPI
+  module Changes
+    class MakeAnOffer < VersionChange
+      description \
+        "Make an offer to the candidate.\n" \
+        "This will transition the application to the offer state.\n" \
+        'If the application has already received an offer, POSTing a second offer will change that offer.'
+
+      action DecisionsController, :make_offer
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/ping_endpoint.rb
+++ b/app/lib/vendor_api/changes/ping_endpoint.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  module Changes
+    class PingEndpoint < VersionChange
+      description 'Pong'
+
+      action PingController, :ping
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/regenerate_test_data.rb
+++ b/app/lib/vendor_api/changes/regenerate_test_data.rb
@@ -1,0 +1,11 @@
+module VendorAPI
+  module Changes
+    class RegenerateTestData < VersionChange
+      description \
+        "Regenerate test data \n" \
+        'This endpoint has been deprecated'
+
+      action TestDataController, :regenerate
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/reject_application.rb
+++ b/app/lib/vendor_api/changes/reject_application.rb
@@ -1,0 +1,12 @@
+module VendorAPI
+  module Changes
+    class RejectApplication < VersionChange
+      description \
+        "Reject application\n" \
+        "Reject the candidate’s application with a reason.\n" \
+        'This will transition the application to the rejected state.'
+
+      action DecisionsController, :reject
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/retrieve_applications.rb
+++ b/app/lib/vendor_api/changes/retrieve_applications.rb
@@ -1,0 +1,15 @@
+module VendorAPI
+  module Changes
+    class RetrieveApplications < VersionChange
+      description \
+        'This endpoint can be used to retrieve applications for the authenticating provider. ' \
+        'Applications are returned with the most recently updated ones first.' \
+        'Use the `since` parameter to limit the number of results. This is intended to make it possible ' \
+        'to check for new or updated applications regularly'
+
+      action ApplicationsController, :index
+
+      resource ApplicationPresenter
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/retrieve_single_application.rb
+++ b/app/lib/vendor_api/changes/retrieve_single_application.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  module Changes
+    class RetrieveSingleApplication < VersionChange
+      description 'Get single application'
+
+      action ApplicationsController, :show
+    end
+  end
+end

--- a/app/lib/version_change.rb
+++ b/app/lib/version_change.rb
@@ -1,0 +1,28 @@
+class VersionChange
+  def resources
+    {}
+  end
+
+  def self.description(text)
+    define_method(:description) { text }
+  end
+
+  def self.action(controller, controller_action)
+    define_method(:actions) do
+      controller_actions = {}
+      controller_actions[controller] ||= []
+      controller_actions[controller] << controller_action
+      controller_actions
+    end
+  end
+
+  def self.resource(resource, modules = [])
+    resources = new.resources
+
+    define_method(:resources) do
+      resources[resource] ||= []
+      resources[resource] |= modules
+      resources
+    end
+  end
+end

--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -1,14 +1,12 @@
 module VendorAPI
   class ApplicationPresenter < Base
-    VERSIONS = {
-      '1.0' => [CandidateAPIData,
-                QualificationAPIData,
-                ContactDetailsAPIData,
-                CourseAPIData,
-                WorkExperienceAPIData,
-                DecisionsAPIData,
-                HesaIttDataAPIData],
-    }.freeze
+    include CandidateAPIData
+    include QualificationAPIData
+    include ContactDetailsAPIData
+    include CourseAPIData
+    include WorkExperienceAPIData
+    include DecisionsAPIData
+    include HesaIttDataAPIData
 
     API_APPLICATION_STATES = { offer_withdrawn: 'rejected',
                                interviewing: 'awaiting_provider_decision' }.freeze

--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -1,14 +1,14 @@
 module VendorAPI
-  class ApplicationPresenter
-    include Rails.application.routes.url_helpers
-
-    include CandidateAPIData
-    include QualificationAPIData
-    include ContactDetailsAPIData
-    include CourseAPIData
-    include WorkExperienceAPIData
-    include DecisionsAPIData
-    include HesaIttDataAPIData
+  class ApplicationPresenter < Base
+    VERSIONS = {
+      '1.0' => [CandidateAPIData,
+                QualificationAPIData,
+                ContactDetailsAPIData,
+                CourseAPIData,
+                WorkExperienceAPIData,
+                DecisionsAPIData,
+                HesaIttDataAPIData],
+    }.freeze
 
     API_APPLICATION_STATES = { offer_withdrawn: 'rejected',
                                interviewing: 'awaiting_provider_decision' }.freeze
@@ -16,7 +16,8 @@ module VendorAPI
 
     attr_reader :application_choice
 
-    def initialize(application_choice)
+    def initialize(version, application_choice)
+      super(version)
       @application_choice = ApplicationChoiceExportDecorator.new(application_choice)
     end
 

--- a/app/presenters/vendor_api/base.rb
+++ b/app/presenters/vendor_api/base.rb
@@ -10,11 +10,19 @@ module VendorAPI
     def initialize(active_version)
       @active_version = active_version
 
-      self.class::VERSIONS.each do |version, modules|
-        modules.each do |mod|
-          singleton_class.send(:prepend, mod) if minor_version(@active_version) >= minor_version(version)
+      VendorAPI::VERSIONS.each_pair do |version, changes|
+        next if minor_version_number(version) > minor_version_number(@active_version)
+
+        changes.each do |change_module|
+          resources_for_class(change_module).each do |resource|
+            singleton_class.send(:prepend, resource) if minor_version(@active_version) >= minor_version(version)
+          end
         end
       end
+    end
+
+    def resources_for_class(change_class)
+      change_class.new.resources[self.class] || []
     end
   end
 end

--- a/app/presenters/vendor_api/base.rb
+++ b/app/presenters/vendor_api/base.rb
@@ -9,9 +9,9 @@ module VendorAPI
     def initialize(active_version)
       @active_version = active_version
 
-      self.class::VERSIONS.each do |_, modules|
+      self.class::VERSIONS.each do |version, modules|
         modules.each do |mod|
-          self.class.send(:prepend, mod)
+          singleton_class.send(:prepend, mod) if @active_version >= version
         end
       end
     end

--- a/app/presenters/vendor_api/base.rb
+++ b/app/presenters/vendor_api/base.rb
@@ -5,24 +5,41 @@ module VendorAPI
 
     VERSIONS = {}.freeze
 
-    attr_reader :active_version
+    attr_reader :active_version, :available_in_active_version
 
     def initialize(active_version)
       @active_version = active_version
 
       VendorAPI::VERSIONS.each_pair do |version, changes|
-        next if minor_version_number(version) > minor_version_number(@active_version)
+        next unless active_version_in_retrieved_version?(version)
 
         changes.each do |change_module|
           resources_for_class(change_module).each do |resource|
-            singleton_class.send(:prepend, resource) if minor_version(@active_version) >= minor_version(version)
+            singleton_class.send(:prepend, resource)
           end
         end
       end
+
+      raise PresenterNotVersioned unless available_in_active_version
     end
 
+  private
+
     def resources_for_class(change_class)
-      change_class.new.resources[self.class] || []
+      return [] unless change_class.new.resources.include?(self.class)
+
+      available_in_active_version!
+      change_class.new.resources[self.class]
+    end
+
+    def available_in_active_version!
+      @available_in_active_version = true
+    end
+
+    def active_version_in_retrieved_version?(version)
+      minor_version_number(active_version) >= minor_version_number(version)
     end
   end
 end
+
+class PresenterNotVersioned < StandardError; end

--- a/app/presenters/vendor_api/base.rb
+++ b/app/presenters/vendor_api/base.rb
@@ -1,6 +1,7 @@
 module VendorAPI
   class Base
     include Rails.application.routes.url_helpers
+    include VersioningHelpers
 
     VERSIONS = {}.freeze
 
@@ -11,7 +12,7 @@ module VendorAPI
 
       self.class::VERSIONS.each do |version, modules|
         modules.each do |mod|
-          singleton_class.send(:prepend, mod) if @active_version >= version
+          singleton_class.send(:prepend, mod) if minor_version(@active_version) >= minor_version(version)
         end
       end
     end

--- a/app/presenters/vendor_api/base.rb
+++ b/app/presenters/vendor_api/base.rb
@@ -1,0 +1,19 @@
+module VendorAPI
+  class Base
+    include Rails.application.routes.url_helpers
+
+    VERSIONS = {}.freeze
+
+    attr_reader :active_version
+
+    def initialize(active_version)
+      @active_version = active_version
+
+      self.class::VERSIONS.each do |_, modules|
+        modules.each do |mod|
+          self.class.send(:prepend, mod)
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/route_validators.rb
+++ b/config/initializers/route_validators.rb
@@ -5,7 +5,17 @@ class ValidRecruitmentCycleYear
 end
 
 class ValidVendorApiRoute
+  extend VersioningHelpers
+
   def self.matches?(request)
-    request.params[:api_version].match(/v1(\z|.\d+\z)/).present?
+    api_version = request.params[:api_version]
+    controller_name = request.controller_class.to_s
+    action = request.params[:action]
+
+    version = api_version.match(/^v(?<number>.*)/)[:number]
+
+    true if VendorAPI::VERSIONS[version_number(version)][controller_name].include?(action.to_sym)
+  rescue ArgumentError, NoMethodError
+    false
   end
 end

--- a/config/initializers/route_validators.rb
+++ b/config/initializers/route_validators.rb
@@ -3,3 +3,9 @@ class ValidRecruitmentCycleYear
     [RecruitmentCycle.current_year, RecruitmentCycle.previous_year].include?(request.params['year'].to_i)
   end
 end
+
+class ValidVendorApiRoute
+  def self.matches?(request)
+    request.params[:api_version].match(/v1(\z|.\d+)/).present?
+  end
+end

--- a/config/initializers/route_validators.rb
+++ b/config/initializers/route_validators.rb
@@ -9,12 +9,15 @@ class ValidVendorApiRoute
 
   def self.matches?(request)
     api_version = request.params[:api_version]
-    controller_name = request.controller_class.to_s
+    controller_class = request.controller_class
     action = request.params[:action]
 
-    version = api_version.match(/^v(?<number>.*)/)[:number]
+    version = extract_version(api_version)
 
-    true if VendorAPI::VERSIONS[version_number(version)][controller_name].include?(action.to_sym)
+    VendorAPI::VERSIONS[version_number(version)].each do |change_module|
+      return true if change_module.new.actions[controller_class].include?(action.to_sym)
+    end
+    false
   rescue ArgumentError, NoMethodError
     false
   end

--- a/config/initializers/route_validators.rb
+++ b/config/initializers/route_validators.rb
@@ -6,6 +6,6 @@ end
 
 class ValidVendorApiRoute
   def self.matches?(request)
-    request.params[:api_version].match(/v1(\z|.\d+)/).present?
+    request.params[:api_version].match(/v1(\z|.\d+\z)/).present?
   end
 end

--- a/config/initializers/route_validators.rb
+++ b/config/initializers/route_validators.rb
@@ -15,7 +15,7 @@ class ValidVendorApiRoute
     version = extract_version(api_version)
 
     VendorAPI::VERSIONS[version_number(version)].each do |change_module|
-      return true if change_module.new.actions[controller_class].include?(action.to_sym)
+      return true if change_module.new.actions[controller_class]&.include?(action.to_sym)
     end
     false
   rescue ArgumentError, NoMethodError

--- a/config/initializers/route_validators.rb
+++ b/config/initializers/route_validators.rb
@@ -21,6 +21,8 @@ class ValidVendorApiRoute
     end
 
     def match?
+      return false if locked_version_lower_than_current_version?
+
       versions_up_to_current.each do |version|
         VendorAPI::VERSIONS[version].each do |change_class|
           return true if change_class.new.actions[controller_class]&.include?(action.to_sym)
@@ -32,6 +34,11 @@ class ValidVendorApiRoute
   private
 
     delegate :controller_class, to: :request
+
+    def locked_version_lower_than_current_version?
+      major_version_number(VendorAPI::VERSION) == major_version_number(version) &&
+        minor_version_number(VendorAPI::VERSION) < minor_version_number(version)
+    end
 
     def versions_up_to_current
       VendorAPI::VERSIONS.keys.filter do |version_number|

--- a/config/initializers/route_validators.rb
+++ b/config/initializers/route_validators.rb
@@ -5,20 +5,42 @@ class ValidRecruitmentCycleYear
 end
 
 class ValidVendorApiRoute
-  extend VersioningHelpers
-
   def self.matches?(request)
-    api_version = request.params[:api_version]
-    controller_class = request.controller_class
-    action = request.params[:action]
-
-    version = extract_version(api_version)
-
-    VendorAPI::VERSIONS[version_number(version)].each do |change_module|
-      return true if change_module.new.actions[controller_class]&.include?(action.to_sym)
-    end
-    false
+    VersionMatcher.new(request).match?
   rescue ArgumentError, NoMethodError
     false
+  end
+
+  class VersionMatcher
+    include VersioningHelpers
+
+    attr_reader :request
+
+    def initialize(request)
+      @request = request
+    end
+
+    def match?
+      VendorAPI::VERSIONS[version_number(version)].each do |change_class|
+        return true if change_class.new.actions[controller_class]&.include?(action.to_sym)
+      end
+      false
+    end
+
+  private
+
+    delegate :controller_class, to: :request
+
+    def api_version
+      request.params[:api_version]
+    end
+
+    def action
+      request.params[:action]
+    end
+
+    def version
+      extract_version(api_version)
+    end
   end
 end

--- a/config/initializers/route_validators.rb
+++ b/config/initializers/route_validators.rb
@@ -21,8 +21,10 @@ class ValidVendorApiRoute
     end
 
     def match?
-      VendorAPI::VERSIONS[version_number(version)].each do |change_class|
-        return true if change_class.new.actions[controller_class]&.include?(action.to_sym)
+      versions_up_to_current.each do |version|
+        VendorAPI::VERSIONS[version].each do |change_class|
+          return true if change_class.new.actions[controller_class]&.include?(action.to_sym)
+        end
       end
       false
     end
@@ -30,6 +32,13 @@ class ValidVendorApiRoute
   private
 
     delegate :controller_class, to: :request
+
+    def versions_up_to_current
+      VendorAPI::VERSIONS.keys.filter do |version_number|
+        major_version_number(version_number) == major_version_number(version) &&
+          minor_version_number(version_number) <= minor_version_number(version)
+      end
+    end
 
     def api_version
       request.params[:api_version]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -617,7 +617,7 @@ Rails.application.routes.draw do
     get '/refuse-feedback', to: redirect(path: '/reference')
   end
 
-  namespace :vendor_api, path: 'api/v1' do
+  namespace :vendor_api, path: 'api/:api_version', api_version: /v[.0-9]+/, constraints: ValidVendorApiRoute do
     get '/applications' => 'applications#index'
     get '/applications/:application_id' => 'applications#show'
 

--- a/spec/presenters/vendor_api/base_spec.rb
+++ b/spec/presenters/vendor_api/base_spec.rb
@@ -45,4 +45,19 @@ RSpec.describe VendorAPI::Base do
       end
     end
   end
+
+  context 'accessing a presenter that is introduced in a later version' do
+    before do
+      stub_const('VendorAPI::VERSIONS', { '1.1' => [APITest::FirstTestVersionChange],
+                                          '1.2' => [APITest::SecondTestVersionChange] })
+    end
+
+    subject(:presenter) { APITest::PresenterClass.new(version) }
+
+    let(:version) { '1.0' }
+
+    it 'throws an exception' do
+      expect { presenter }.to raise_error(PresenterNotVersioned)
+    end
+  end
 end

--- a/spec/presenters/vendor_api/base_spec.rb
+++ b/spec/presenters/vendor_api/base_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe VendorAPI::Base do
+  subject(:presenter) { PresenterClass.new(version) }
+
+  let(:version) { '1.0' }
+  let(:presenter_class) { Class.new(described_class) }
+
+  before do
+    stub_const('PresenterClass', presenter_class)
+  end
+
+  it 'sets the active version' do
+    expect(presenter.active_version).to eq(version)
+  end
+end

--- a/spec/presenters/vendor_api/base_spec.rb
+++ b/spec/presenters/vendor_api/base_spec.rb
@@ -1,16 +1,51 @@
 require 'rails_helper'
 
 RSpec.describe VendorAPI::Base do
-  subject(:presenter) { PresenterClass.new(version) }
+  include APITest
 
   let(:version) { '1.0' }
-  let(:presenter_class) { Class.new(described_class) }
 
-  before do
-    stub_const('PresenterClass', presenter_class)
+  context 'class with the minimum setup' do
+    subject(:presenter) { PresenterClass.new(version) }
+
+    let(:presenter_class) { Class.new(described_class) }
+
+    before do
+      stub_const('PresenterClass', presenter_class)
+    end
+
+    it 'sets the active version' do
+      expect(presenter.active_version).to eq(version)
+    end
   end
 
-  it 'sets the active version' do
-    expect(presenter.active_version).to eq(version)
+  context 'class with versioned modules' do
+    subject(:presenter) { APITest::PresenterClass.new(version) }
+
+    context 'when the version is 1.1' do
+      let(:version) { '1.1' }
+
+      it 'includes all the specified modules' do
+        expect(presenter.class.included_modules.map(&:to_s)).to include('APITest::TestModule')
+      end
+
+      it 'merges attributes in the order they were specified' do
+        expect(presenter.schema).to eq({
+          one: 'two keys',
+          two: 'three keys',
+        })
+      end
+    end
+
+    context 'when the version is 1.0', wip: true do
+      let(:version) { '1.0' }
+
+      it 'merges attributes for versions up to the active one' do
+        expect(presenter.schema).to eq({
+          one: 'two keys',
+          two: 'two keys',
+        })
+      end
+    end
   end
 end

--- a/spec/presenters/vendor_api/base_spec.rb
+++ b/spec/presenters/vendor_api/base_spec.rb
@@ -2,17 +2,16 @@ require 'rails_helper'
 
 RSpec.describe VendorAPI::Base do
   include APITest
+  before do
+    stub_const('VendorAPI::VERSIONS', { '1.0' => [APITest::FirstTestVersionChange],
+                                        '1.1' => [APITest::SecondTestVersionChange],
+                                        '1.2' => [APITest::ThirdTestVersionChange] })
+  end
 
-  let(:version) { '1.0' }
+  subject(:presenter) { APITest::PresenterClass.new(version) }
 
-  context 'class with the minimum setup' do
-    subject(:presenter) { PresenterClass.new(version) }
-
-    let(:presenter_class) { Class.new(described_class) }
-
-    before do
-      stub_const('PresenterClass', presenter_class)
-    end
+  context 'class with no versioned modules' do
+    let(:version) { '1.0' }
 
     it 'sets the active version' do
       expect(presenter.active_version).to eq(version)
@@ -20,10 +19,8 @@ RSpec.describe VendorAPI::Base do
   end
 
   context 'class with versioned modules' do
-    subject(:presenter) { APITest::PresenterClass.new(version) }
-
-    context 'when the version is 1.1' do
-      let(:version) { '1.1' }
+    context 'when the version is 1.2' do
+      let(:version) { '1.2' }
 
       it 'includes all the specified modules' do
         expect(presenter.singleton_class.included_modules.map(&:to_s)).to include('APITest::TestModule')
@@ -37,8 +34,8 @@ RSpec.describe VendorAPI::Base do
       end
     end
 
-    context 'when the version is 1.0' do
-      let(:version) { '1.0' }
+    context 'when the version is 1.1' do
+      let(:version) { '1.1' }
 
       it 'merges attributes for versions up to the active one' do
         expect(presenter.schema).to eq({

--- a/spec/presenters/vendor_api/base_spec.rb
+++ b/spec/presenters/vendor_api/base_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe VendorAPI::Base do
       let(:version) { '1.1' }
 
       it 'includes all the specified modules' do
-        expect(presenter.class.included_modules.map(&:to_s)).to include('APITest::TestModule')
+        expect(presenter.singleton_class.included_modules.map(&:to_s)).to include('APITest::TestModule')
       end
 
       it 'merges attributes in the order they were specified' do
@@ -37,7 +37,7 @@ RSpec.describe VendorAPI::Base do
       end
     end
 
-    context 'when the version is 1.0', wip: true do
+    context 'when the version is 1.0' do
       let(:version) { '1.0' }
 
       it 'merges attributes for versions up to the active one' do

--- a/spec/requests/vendor_api/post_test_data_regenerate_spec.rb
+++ b/spec/requests/vendor_api/post_test_data_regenerate_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - POST /api/v1/test-data/regenerate', type: :request, sidekiq: true do
+  include VendorAPISpecHelpers
+
+  before { FeatureFlag.activate(:region_from_postcode) }
+
+  it 'returns an error' do
+    post_api_request '/api/v1/test-data/regenerate'
+
+    expect(response).to have_http_status(:ok)
+    expect(parsed_response['errors'][0]['error'])
+      .to eq('Functionality for this endpoint has been removed. Please use /test-data/clear and /test-data/generate.')
+  end
+end

--- a/spec/requests/vendor_api/versioning_spec.rb
+++ b/spec/requests/vendor_api/versioning_spec.rb
@@ -20,10 +20,12 @@ RSpec.describe 'Versioning', type: :request do
     end
   end
 
-  context 'accessing the API with a version that is greater than the current version' do
+  context 'accessing the API with a minor version that is greater than the current minor version' do
     it 'returns an error' do
-      get_api_request "/api/v1.1/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
-      expect(error_response['message']).to eq('Version v1.1 does not exist')
+      stub_const('VendorAPI::VERSION', '1.2')
+
+      get_api_request "/api/v1.101/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
+      expect(error_response['message']).to eq('Version v1.101 does not exist')
     end
   end
 
@@ -40,6 +42,13 @@ RSpec.describe 'Versioning', type: :request do
     it 'returns a 404' do
       get_api_request "/api/v1..0/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
       expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'accessing a route with a patch version specified' do
+    it 'returns a 404' do
+      get_api_request "/api/v1.0.0/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
+      expect(response.status).to eq(404)
     end
   end
 end

--- a/spec/requests/vendor_api/versioning_spec.rb
+++ b/spec/requests/vendor_api/versioning_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'Versioning', type: :request do
+  include VendorAPISpecHelpers
+
+  let(:course) { create(:course, provider: currently_authenticated_provider) }
+  let(:course_option) { create(:course_option, course: course) }
+
+  before do
+    create(:submitted_application_choice,
+           :with_completed_application_form,
+           :awaiting_provider_decision,
+           course_option: course_option)
+  end
+
+  context 'specifying an equivalent minor api version' do
+    it 'returns applications' do
+      get_api_request "/api/v1.0/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
+      expect(parsed_response['data'].size).to eq(1)
+    end
+  end
+
+  context 'accessing the API with a version that is greater than the current version' do
+    it 'returns an error' do
+      get_api_request "/api/v1.1/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
+      expect(error_response['message']).to eq('Version v1.1 does not exist')
+    end
+  end
+
+  context 'accessing a route with a version that is prior to the version that it was introduced in' do
+    it 'returns an error' do
+      stub_const('VendorAPI::ApplicationsController::VERSION', '1.1')
+
+      get_api_request "/api/v1.0/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
+      expect(error_response['message']).to eq('Not available in version v1.0')
+    end
+  end
+
+  context 'accessing a route with an invalid version parameter' do
+    it 'returns a 404' do
+      get_api_request "/api/v1..0/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/vendor_api/versioning_spec.rb
+++ b/spec/requests/vendor_api/versioning_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe 'Versioning', type: :request do
            course_option: course_option)
   end
 
+  before do
+    stub_const('VendorAPI::VERSION', '1.2')
+  end
+
   context 'specifying an equivalent minor api version' do
     it 'returns applications' do
       get_api_request "/api/v1.0/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
@@ -19,9 +23,10 @@ RSpec.describe 'Versioning', type: :request do
     end
   end
 
-  context 'accessing the API with a minor version that is greater than the current minor version' do
+  context 'accessing the API with a version that is greater than the current locked version' do
     it 'returns a not found error' do
-      stub_const('VendorAPI::VERSION', '1.2')
+      stub_const('VendorAPI::VERSIONS', { '1.1' => [VendorAPI::Changes::RetrieveApplications],
+                                          '1.101' => [VendorAPI::Changes::RetrieveSingleApplication] })
 
       get_api_request "/api/v1.101/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
       expect(response).to have_http_status(:not_found)

--- a/spec/requests/vendor_api/versioning_spec.rb
+++ b/spec/requests/vendor_api/versioning_spec.rb
@@ -73,5 +73,15 @@ RSpec.describe 'Versioning', type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context 'when specifying a version after the route was made available' do
+      it 'processes the route' do
+        stub_const('VendorAPI::VERSIONS', { '1.1' => [VendorAPI::Changes::RetrieveApplications],
+                                            '1.2' => [VendorAPI::Changes::RetrieveSingleApplication] })
+        get_api_request "/api/v1.2/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
+
+        expect(response.status).to eq(200)
+      end
+    end
   end
 end

--- a/spec/requests/vendor_api/versioning_spec.rb
+++ b/spec/requests/vendor_api/versioning_spec.rb
@@ -20,20 +20,20 @@ RSpec.describe 'Versioning', type: :request do
   end
 
   context 'accessing the API with a minor version that is greater than the current minor version' do
-    it 'returns an error' do
+    it 'returns a not found error' do
       stub_const('VendorAPI::VERSION', '1.2')
 
       get_api_request "/api/v1.101/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
-      expect(error_response['message']).to eq('Version v1.101 does not exist')
+      expect(response).to have_http_status(:not_found)
     end
   end
 
   context 'accessing a route with a version that is prior to the version that it was introduced in' do
-    it 'returns an error' do
-      stub_const('VendorAPI::ApplicationsController::VERSION', '1.1')
+    it 'returns a not found error' do
+      stub_const('VendorAPI::VERSIONS', { '1.1' => [VendorAPI::Changes::RetrieveApplications] })
 
       get_api_request "/api/v1.0/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
-      expect(error_response['message']).to eq('Not available in version v1.0')
+      expect(response).to have_http_status(:not_found)
     end
   end
 
@@ -67,6 +67,7 @@ RSpec.describe 'Versioning', type: :request do
 
     context 'when a route is not available for the specified version' do
       it 'returns a not found error' do
+        stub_const('VendorAPI::VERSIONS', { '1.2' => [VendorAPI::Changes::RetrieveSingleApplication] })
         get_api_request "/api/v1/applications/#{application_choice.id}"
 
         expect(response).to have_http_status(:not_found)

--- a/spec/support/test_helpers/api_test_presenter_class.rb
+++ b/spec/support/test_helpers/api_test_presenter_class.rb
@@ -1,10 +1,6 @@
 module APITest
   module TestModule
-    VERSION = '1.0'.freeze
-
     def schema
-      return super unless active_version >= VERSION
-
       super.merge!({
         one: 'two keys',
         two: 'two keys',
@@ -13,11 +9,7 @@ module APITest
   end
 
   module SecondTestModule
-    VERSION = '1.1'.freeze
-
     def schema
-      return super unless active_version >= VERSION
-
       super.merge!({
         two: 'three keys',
       })

--- a/spec/support/test_helpers/api_test_presenter_class.rb
+++ b/spec/support/test_helpers/api_test_presenter_class.rb
@@ -17,13 +17,20 @@ module APITest
   end
 
   class PresenterClass < VendorAPI::Base
-    VERSIONS = {
-      '1.0' => [TestModule],
-      '1.1' => [SecondTestModule],
-    }.freeze
-
     def schema
       { one: 'a key' }
     end
+  end
+
+  class FirstTestVersionChange < VersionChange
+    resource PresenterClass
+  end
+
+  class SecondTestVersionChange < VersionChange
+    resource PresenterClass, [TestModule]
+  end
+
+  class ThirdTestVersionChange < VersionChange
+    resource PresenterClass, [SecondTestModule]
   end
 end

--- a/spec/support/test_helpers/api_test_presenter_class.rb
+++ b/spec/support/test_helpers/api_test_presenter_class.rb
@@ -1,0 +1,37 @@
+module APITest
+  module TestModule
+    VERSION = '1.0'.freeze
+
+    def schema
+      return super unless active_version >= VERSION
+
+      super.merge!({
+        one: 'two keys',
+        two: 'two keys',
+      })
+    end
+  end
+
+  module SecondTestModule
+    VERSION = '1.1'.freeze
+
+    def schema
+      return super unless active_version >= VERSION
+
+      super.merge!({
+        two: 'three keys',
+      })
+    end
+  end
+
+  class PresenterClass < VendorAPI::Base
+    VERSIONS = {
+      '1.0' => [TestModule],
+      '1.1' => [SecondTestModule],
+    }.freeze
+
+    def schema
+      { one: 'a key' }
+    end
+  end
+end

--- a/spec/system/support_interface/view_vendor_api_requests_spec.rb
+++ b/spec/system/support_interface/view_vendor_api_requests_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature 'Vendor API Requests' do
       request_path: '/api/v1/applications/9999/offer',
     )
 
-    visit vendor_api_path(@first_application_choice)
+    visit vendor_api_path('v1', @first_application_choice)
 
     provider = @last_application_choice.provider
     unhashed_token, hashed_token = Devise.token_generator.generate(VendorAPIToken, :hashed_token)
@@ -58,7 +58,7 @@ RSpec.feature 'Vendor API Requests' do
 
     Capybara.current_session.driver.header('Authorization', "Bearer #{unhashed_token}")
 
-    visit vendor_api_path(@last_application_choice)
+    visit vendor_api_path('v1', @last_application_choice)
 
     Capybara.current_session.driver.header('Authorization', nil)
   end
@@ -69,8 +69,8 @@ RSpec.feature 'Vendor API Requests' do
 
   def then_i_see_the_api_request
     expect(page).to have_selector('p.govuk-body', exact_text: '/api/v1/applications/9999/offer')
-    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path(@first_application_choice))
-    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path(@last_application_choice))
+    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path('v1', @first_application_choice))
+    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path('v1', @last_application_choice))
   end
 
   def and_i_see_the_status_of_the_request
@@ -95,8 +95,8 @@ RSpec.feature 'Vendor API Requests' do
   end
 
   def then_i_only_see_api_requests_filtered_by_status
-    expect(page).not_to have_selector('p.govuk-body', exact_text: vendor_api_path(@first_application_choice))
-    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path(@last_application_choice))
+    expect(page).not_to have_selector('p.govuk-body', exact_text: vendor_api_path('v1', @first_application_choice))
+    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path('v1', @last_application_choice))
     expect(page).to have_selector('p.govuk-body', exact_text: '/api/v1/applications/9999/offer')
   end
 
@@ -110,8 +110,8 @@ RSpec.feature 'Vendor API Requests' do
   end
 
   def then_i_see_api_requests_filtered_by_request_method
-    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path(@first_application_choice))
-    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path(@last_application_choice))
+    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path('v1', @first_application_choice))
+    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path('v1', @last_application_choice))
     expect(page).not_to have_selector('p.govuk-body', exact_text: '/api/v1/applications/9999/offer')
   end
 
@@ -121,8 +121,8 @@ RSpec.feature 'Vendor API Requests' do
   end
 
   def then_i_only_see_api_requests_filtered_by_the_search
-    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path(@first_application_choice))
-    expect(page).not_to have_selector('p.govuk-body', exact_text: vendor_api_path(@last_application_choice))
+    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path('v1', @first_application_choice))
+    expect(page).not_to have_selector('p.govuk-body', exact_text: vendor_api_path('v1', @last_application_choice))
   end
 
   def when_i_filter_by_provider
@@ -132,7 +132,7 @@ RSpec.feature 'Vendor API Requests' do
   end
 
   def then_i_only_see_api_requests_filtered_by_provider
-    expect(page).not_to have_selector('p.govuk-body', exact_text: vendor_api_path(@first_application_choice))
-    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path(@last_application_choice))
+    expect(page).not_to have_selector('p.govuk-body', exact_text: vendor_api_path('v1', @first_application_choice))
+    expect(page).to have_selector('p.govuk-body', exact_text: vendor_api_path('v1', @last_application_choice))
   end
 end


### PR DESCRIPTION
## Context
https://trello.com/c/7X4CxCi5/4563-implement-versioning-in-the-api

Background
After the Spike to version the API in Spike API versioning we would now like to modularise and implement the versioning strategy in the vendor API

This is done when
We have added a versioning strategy in the API that defines the following
- Different minor versions on top of the base major version
- Modules and controllers which are only accessible via a version
- OUT OF SCOPE: we aren't going to prepare for a new major version yet
