### PR TITLE
Support tooling – Update course choice

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -75,7 +75,7 @@ module SupportInterface
     def course_row
       return if application_choice.different_offer?
 
-      { key: 'Course', value: render(CourseOptionDetailsComponent.new(course_option: application_choice.course_option)) }
+      { key: 'Course', value: render(CourseOptionDetailsComponent.new(course_option: application_choice.course_option)) }.merge(change_course_choice_link)
     end
 
     def rejected_at_or_by_default_at_row
@@ -184,6 +184,21 @@ module SupportInterface
       GetRecruitedApplicationChoices.call(
         recruitment_cycle_year: RecruitmentCycle.current_year,
       ).find_by(id: application_choice.id).present?
+    end
+
+    def change_course_choice_link
+      return {} unless @application_choice.application_form.editable?
+
+      if application_choice.awaiting_provider_decision?
+        {
+          action: {
+            href: support_interface_application_form_change_course_choice_path(application_choice_id: @application_choice.id),
+            text: 'Change course choice',
+          },
+        }
+      else
+        {}
+      end
     end
 
     def status_action_link

--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -187,18 +187,14 @@ module SupportInterface
     end
 
     def change_course_choice_link
-      return {} unless @application_choice.application_form.editable?
+      return {} unless @application_choice.application_form.editable? && ApplicationStateChange::DECISION_PENDING_STATUSES.include?(application_choice.status.to_sym)
 
-      if application_choice.awaiting_provider_decision?
-        {
-          action: {
-            href: support_interface_application_form_change_course_choice_path(application_choice_id: @application_choice.id),
-            text: 'Change course choice',
-          },
-        }
-      else
-        {}
-      end
+      {
+        action: {
+          href: support_interface_application_form_change_course_choice_path(application_form_id: @application_choice.application_form.id, application_choice_id: @application_choice.id),
+          text: 'Change course choice',
+        },
+      }
     end
 
     def status_action_link

--- a/app/controllers/support_interface/application_forms/courses_controller.rb
+++ b/app/controllers/support_interface/application_forms/courses_controller.rb
@@ -59,15 +59,9 @@ module SupportInterface
           else
             render :edit
           end
-        rescue ActiveRecord::RecordNotFound
-          flash[:warning] = 'This is not a valid course option'
-          render :confirm_change
-        rescue ActiveRecord::RecordInvalid
-          flash[:warning] = 'This course option has already been taken'
-          render :confirm_change
-        rescue RuntimeError
-          flash[:warning] = 'You can‘t change a course choice if the provider is not on the interview'
-          render :confirm_change
+        rescue CourseChoiceError, ProviderInterviewError => e
+          flash[:warning] = e.message
+          render :edit
         end
       end
 

--- a/app/controllers/support_interface/application_forms/courses_controller.rb
+++ b/app/controllers/support_interface/application_forms/courses_controller.rb
@@ -65,6 +65,9 @@ module SupportInterface
         rescue ActiveRecord::RecordInvalid
           flash[:warning] = 'This course option has already been taken'
           render :confirm_change
+        rescue RuntimeError
+          flash[:warning] = 'You can‘t change a course choice if the provider is not on the interview'
+          render :confirm_change
         end
       end
 

--- a/app/controllers/support_interface/application_forms/courses_controller.rb
+++ b/app/controllers/support_interface/application_forms/courses_controller.rb
@@ -45,6 +45,29 @@ module SupportInterface
         end
       end
 
+      def edit
+        @change_course_choice = ChangeCourseChoiceForm.new
+      end
+
+      def update
+        @change_course_choice = ChangeCourseChoiceForm.new(change_course_choice_params)
+
+        begin
+          if @change_course_choice.save(params[:application_choice_id])
+            flash[:success] = 'Course successfully changed'
+            redirect_to support_interface_application_form_path(application_form_id)
+          else
+            render :edit
+          end
+        rescue ActiveRecord::RecordNotFound
+          flash[:warning] = 'This is not a valid course option'
+          render :confirm_change
+        rescue ActiveRecord::RecordInvalid
+          flash[:warning] = 'This course option has already been taken'
+          render :confirm_change
+        end
+      end
+
     private
 
       def course_option_id
@@ -54,6 +77,11 @@ module SupportInterface
       def course_search_params
         params.require(:support_interface_application_forms_course_search_form)
               .permit(:course_code)
+      end
+
+      def change_course_choice_params
+        params.require(:support_interface_application_forms_change_course_choice_form)
+              .permit(:application_choice_id, :provider_code, :course_code, :study_mode, :site_code, :audit_comment_ticket, :accept_guidance)
       end
 
       def application_form_id

--- a/app/errors/course_choice_error.rb
+++ b/app/errors/course_choice_error.rb
@@ -1,0 +1,1 @@
+class CourseChoiceError < StandardError; end

--- a/app/errors/provider_interview_error.rb
+++ b/app/errors/provider_interview_error.rb
@@ -1,0 +1,1 @@
+class ProviderInterviewError < StandardError; end

--- a/app/forms/support_interface/application_forms/change_course_choice_form.rb
+++ b/app/forms/support_interface/application_forms/change_course_choice_form.rb
@@ -15,12 +15,24 @@ module SupportInterface
 
         SupportInterface::ChangeApplicationChoiceCourseOption.new(
           application_choice_id: application_choice,
-          provider_id: Provider.find_by(code: provider_code).id,
+          provider_id: provider_id,
           course_code: course_code,
           study_mode: study_mode,
           site_code: site_code,
           audit_comment: audit_comment_ticket,
         ).call
+      rescue ActiveRecord::RecordNotFound
+        raise CourseChoiceError, 'This is not a valid course option'
+      rescue ActiveRecord::RecordInvalid
+        raise CourseChoiceError, 'This course option has already been taken'
+      end
+
+      def provider_id
+        provider = Provider.find_by(code: provider_code)
+
+        raise CourseChoiceError, 'This is not a valid provider code' if provider.nil?
+
+        provider.id
       end
     end
   end

--- a/app/forms/support_interface/application_forms/change_course_choice_form.rb
+++ b/app/forms/support_interface/application_forms/change_course_choice_form.rb
@@ -1,0 +1,27 @@
+module SupportInterface
+  module ApplicationForms
+    class ChangeCourseChoiceForm
+      include ActiveModel::Model
+
+      attr_accessor :application_choice_id, :provider_code, :course_code, :study_mode, :site_code, :accept_guidance, :audit_comment_ticket
+
+      validates :provider_code, :course_code, :study_mode, :site_code, :accept_guidance, :audit_comment_ticket, presence: true
+      validates :audit_comment_ticket, format: { with: /\A((http|https):\/\/)?(www.)?becomingateacher.zendesk.com\/agent\/tickets\// }
+
+      def save(application_choice)
+        self.accept_guidance = ActiveModel::Type::Boolean.new.cast(accept_guidance)
+
+        return false unless valid?
+
+        SupportInterface::ChangeApplicationChoiceCourseOption.new(
+          application_choice_id: application_choice,
+          provider_id: Provider.find_by(code: provider_code).id,
+          course_code: course_code,
+          study_mode: study_mode,
+          site_code: site_code,
+          audit_comment: audit_comment_ticket,
+        ).call
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/application_forms/change_course_choice_form.rb
+++ b/app/forms/support_interface/application_forms/change_course_choice_form.rb
@@ -6,7 +6,7 @@ module SupportInterface
       attr_accessor :application_choice_id, :provider_code, :course_code, :study_mode, :site_code, :accept_guidance, :audit_comment_ticket
 
       validates :provider_code, :course_code, :study_mode, :site_code, :accept_guidance, :audit_comment_ticket, presence: true
-      validates :audit_comment_ticket, format: { with: /\A((http|https):\/\/)?(www.)?becomingateacher.zendesk.com\/agent\/tickets\// }
+      validates_with ZendeskUrlValidator
 
       def save(application_choice)
         self.accept_guidance = ActiveModel::Type::Boolean.new.cast(accept_guidance)

--- a/app/forms/support_interface/application_forms/reinstate_declined_offer_form.rb
+++ b/app/forms/support_interface/application_forms/reinstate_declined_offer_form.rb
@@ -6,7 +6,7 @@ module SupportInterface
       attr_accessor :accept_guidance, :status, :audit_comment_ticket
 
       validates :accept_guidance, :audit_comment_ticket, presence: true
-      validates :audit_comment_ticket, format: { with: /\A((http|https):\/\/)?(www.)?becomingateacher.zendesk.com\/agent\/tickets\// }
+      validates_with ZendeskUrlValidator
 
       def save(course_choice)
         self.accept_guidance = ActiveModel::Type::Boolean.new.cast(accept_guidance)

--- a/app/forms/support_interface/application_forms/revert_rejection_form.rb
+++ b/app/forms/support_interface/application_forms/revert_rejection_form.rb
@@ -6,7 +6,7 @@ module SupportInterface
       attr_accessor :accept_guidance, :audit_comment_ticket
 
       validates :accept_guidance, :audit_comment_ticket, presence: true
-      validates :audit_comment_ticket, format: { with: /\A((http|https):\/\/)?(www.)?becomingateacher.zendesk.com\/agent\/tickets\// }
+      validates_with ZendeskUrlValidator
 
       def save(application_choice)
         self.accept_guidance = ActiveModel::Type::Boolean.new.cast(accept_guidance)

--- a/app/forms/support_interface/application_forms/revert_withdrawal_form.rb
+++ b/app/forms/support_interface/application_forms/revert_withdrawal_form.rb
@@ -6,7 +6,7 @@ module SupportInterface
       attr_accessor :accept_guidance, :audit_comment_ticket
 
       validates :accept_guidance, :audit_comment_ticket, presence: true
-      validates :audit_comment_ticket, format: { with: /\A((http|https):\/\/)?(www.)?becomingateacher.zendesk.com\/agent\/tickets\// }
+      validates_with ZendeskUrlValidator
 
       def save(application_choice)
         self.accept_guidance = ActiveModel::Type::Boolean.new.cast(accept_guidance)

--- a/app/forms/support_interface/application_forms/update_offered_course_option_form.rb
+++ b/app/forms/support_interface/application_forms/update_offered_course_option_form.rb
@@ -6,7 +6,7 @@ module SupportInterface
       attr_accessor :course_option_id, :audit_comment, :accept_guidance
 
       validates :course_option_id, :audit_comment, :accept_guidance, presence: true
-      validates :audit_comment, format: { with: /\A((http|https):\/\/)?(www.)?becomingateacher.zendesk.com\/agent\/tickets\// }
+      validates_with ZendeskUrlValidator
 
       def save(application_choice)
         self.accept_guidance = ActiveModel::Type::Boolean.new.cast(accept_guidance)

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -22,9 +22,9 @@ module SupportInterface
 
     validates :application_choice, presence: true
     validates :audit_comment_ticket, presence: true
-    validates :audit_comment_ticket, format: { with: /\A((http|https):\/\/)?(www.)?becomingateacher.zendesk.com\/agent\/tickets\// }
     validate :condition_count_valid
     validate :further_conditions_lengths_valid
+    validates_with ZendeskUrlValidator
 
     def self.build_from_application_choice(application_choice, attrs = {})
       attrs = {

--- a/app/services/support_interface/change_application_choice_course_option.rb
+++ b/app/services/support_interface/change_application_choice_course_option.rb
@@ -20,6 +20,7 @@ module SupportInterface
 
     def call
       check_application_state!
+      check_interviewing_providers!
 
       application_choice.update_course_option_and_associated_fields!(course_option,
                                                                      other_fields: { course_option: course_option },
@@ -32,6 +33,12 @@ module SupportInterface
       return if VALID_STATES.include?(application_choice.status.to_sym)
 
       raise "Changing the course option of application choices in the #{application_choice.status} state is not allowed"
+    end
+
+    def check_interviewing_providers!
+      return if !application_choice.interviewing? || (application_choice.interviewing? && application_choice.provider_ids.include?(provider_id))
+
+      raise 'Changing a course choice when the provider is not on the interview is not allowed'
     end
 
     def course_option

--- a/app/services/support_interface/change_application_choice_course_option.rb
+++ b/app/services/support_interface/change_application_choice_course_option.rb
@@ -38,7 +38,7 @@ module SupportInterface
     def check_interviewing_providers!
       return if !application_choice.interviewing? || (application_choice.interviewing? && application_choice.provider_ids.include?(provider_id))
 
-      raise 'Changing a course choice when the provider is not on the interview is not allowed'
+      raise ProviderInterviewError, 'Changing a course choice when the provider is not on the interview is not allowed'
     end
 
     def course_option

--- a/app/validators/zendesk_url_validator.rb
+++ b/app/validators/zendesk_url_validator.rb
@@ -1,0 +1,11 @@
+class ZendeskUrlValidator < ActiveModel::Validator
+  ZENDESK_URL = /\A((http|https):\/\/)?(www.)?becomingateacher.zendesk.com\/agent\/tickets\//.freeze
+
+  def validate(record)
+    field = record.respond_to?(:audit_comment) ? :audit_comment : :audit_comment_ticket
+
+    if record.send(field) !~ ZENDESK_URL
+      record.errors.add(field, 'Enter a valid Zendesk ticket URL')
+    end
+  end
+end

--- a/app/views/support_interface/application_forms/courses/edit.html.erb
+++ b/app/views/support_interface/application_forms/courses/edit.html.erb
@@ -1,0 +1,48 @@
+<% content_for :browser_title, title_with_error_prefix('Add a course', @change_course_choice.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @change_course_choice,
+      url: support_interface_application_form_change_course_choice_path,
+    ) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">Change a course choice</h1>
+
+      <p class="govuk-body">If the provider specifies an alternative course but not a site, you should reuse the site code of the existing course.
+      Similarly you should also use the study mode of the existing course unless otherwise specified.</p>
+
+      <p class="govuk-body">In case a site's name was specified but not
+      the site code, you can identify the code by navigating through the support interface to the course's vacancies tab where you can find the
+      site code printed after the course name.<p>
+
+      <p class="govuk-body">Once the course choice has been changed, please email the candidate and the provider to let them know.</p>
+
+      <%= f.govuk_text_field :provider_code, label: { text: 'Provider code', size: 's' }, width: 5 %>
+      <%= f.govuk_text_field :course_code, label: { text: 'Course code', size: 's' }, width: 5 %>
+      <%= f.govuk_radio_buttons_fieldset :study_mode, legend: { text: 'Study mode', size: 's' } do %>
+        <%= f.govuk_radio_button :study_mode, :full_time, label: { text: 'Full time' } %>
+        <%= f.govuk_radio_button :study_mode, :part_time, label: { text: 'Part time' } %>
+      <% end %>
+      <%= f.govuk_text_field :site_code, label: { text: 'Site code', size: 's' }, width: 5 %>
+
+      <%= f.govuk_text_field(
+        :audit_comment_ticket,
+        label: {
+          text: t('support_interface.audit_comment_ticket.label'),
+          size: 'm',
+        },
+        rows: 1,
+        hint: { text: t('support_interface.audit_comment_ticket.hint') },
+      ) %>
+
+      <%= f.govuk_check_boxes_fieldset :accept_guidance, legend: nil do %>
+        <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
+      <% end %>
+
+      <%= f.govuk_submit 'Change' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -54,6 +54,21 @@ en:
           attributes:
             course_option_id:
               blank: Please select a course
+        support_interface/application_forms/change_course_choice_form:
+          attributes:
+            provider_code:
+              blank: Please enter a provider code
+            course_code:
+              blank: Please enter a course code
+            study_mode:
+              blank: Select a study mode option
+            site_code:
+              blank: Please enter a site code
+            accept_guidance:
+              blank: Select that you have read the guidance
+            audit_comment_ticket:
+              blank: Enter a Zendesk ticket URL
+              invalid: Enter a valid Zendesk ticket URL
         support_interface/application_comment_form:
           attributes:
             comment:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -862,6 +862,9 @@ Rails.application.routes.draw do
       get '/add-course/:course_code' => 'application_forms/courses#new', as: :application_form_new_course
       post '/add-course/:course_code' => 'application_forms/courses#create', as: :application_form_create_course
 
+      get '/change-course-choice/:application_choice_id' => 'application_forms/courses#edit', as: :application_form_change_course_choice
+      post '/change-course-choice/:application_choice_id' => 'application_forms/courses#update'
+
       get '/audit' => 'application_forms#audit', as: :application_form_audit
       get '/comments/new' => 'application_forms/comments#new', as: :application_form_new_comment
       post '/comments' => 'application_forms/comments#create', as: :application_form_comments

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -102,18 +102,7 @@ ApplicationForm.find(_id).update!(becoming_a_teacher: 'new text', subject_knowle
 
 ### Changing a course or course location
 
-A provider may request that a candidate is placed on a different course, or a different site. You should make the change by manually executing the `SupportInterface::ChangeApplicationChoiceCourseOption` service to ensure that all required changes take place and  that the application is in a supported state.
-
-If the provider specifies an alternative course but not a site, you should reuse the site code of the existing course. Similarly you should also use the study mode of the existing course unless otherwise specified. In case a site's name was specified but not the site code, you can identify the code by navigating through the support interface to the course's vacancies tab where you can find the site code printed after the course name.
-
-```ruby
-SupportInterface::ChangeApplicationChoiceCourseOption.new(application_choice_id: _application_choice_id_,
-                                                          provider_id: _provider_id_,
-                                                          course_code: _course_code_,
-                                                          study_mode: _study_mode_,
-                                                          site_code: _site_code_,
-                                                          audit_comment: audit_comment).call
-```
+This is possible via the support UI.
 
 ## Offers
 

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::ApplicationChoiceComponent do
+  include Rails.application.routes.url_helpers
+
   context 'Declined offer' do
     let(:declined_offer) { create(:application_choice, :with_completed_application_form, :with_declined_offer) }
 
@@ -277,6 +279,7 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
       :application_choice,
       :with_completed_application_form,
       :awaiting_provider_decision,
+      current_course_option: create(:course_option),
     )
 
     result = render_inline(described_class.new(application_choice))

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -180,6 +180,73 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
     end
   end
 
+  context 'Changing a course choice' do
+    it 'Renders a link when the application is awaiting provider decision' do
+      course_option = create(:course_option)
+      application_choice = create(
+        :application_choice,
+        :with_completed_application_form,
+        :awaiting_provider_decision,
+        course_option: course_option,
+        current_course_option: course_option,
+      )
+
+      result = render_inline(described_class.new(application_choice))
+
+      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
+        Rails.application.routes.url_helpers.support_interface_application_form_change_course_choice_path(
+          application_form_id: application_choice.application_form.id,
+          application_choice_id: application_choice.id,
+        ),
+      )
+
+      expect(result.css('.govuk-summary-list__actions').text.strip).to include('Change course choice')
+    end
+
+    it 'Renders a link when the application is interviewing' do
+      course_option = create(:course_option)
+      application_choice = create(
+        :application_choice,
+        :with_completed_application_form,
+        :interviewing,
+        course_option: course_option,
+        current_course_option: course_option,
+      )
+
+      result = render_inline(described_class.new(application_choice))
+
+      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
+        Rails.application.routes.url_helpers.support_interface_application_form_change_course_choice_path(
+          application_form_id: application_choice.application_form.id,
+          application_choice_id: application_choice.id,
+        ),
+      )
+
+      expect(result.css('.govuk-summary-list__actions').text.strip).to include('Change course choice')
+    end
+
+    it 'Does not render a link when the application has an offer' do
+      application_choice = create(
+        :application_choice,
+        :with_completed_application_form,
+        :with_offer,
+        offered_at: Time.zone.local(2020, 1, 1, 10),
+        decline_by_default_at: nil,
+      )
+
+      result = render_inline(described_class.new(application_choice))
+
+      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).not_to include(
+        Rails.application.routes.url_helpers.support_interface_application_form_change_course_choice_path(
+          application_form_id: application_choice.application_form.id,
+          application_choice_id: application_choice.id,
+        ),
+      )
+
+      expect(result.css('.govuk-summary-list__actions').text.strip).not_to include('Change course choice')
+    end
+  end
+
   it 'displays the date an application was rejected' do
     application_choice = create(:application_choice,
                                 :with_completed_application_form,

--- a/spec/forms/support_interface/application_forms/change_course_choice_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/change_course_choice_form_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationForms::ChangeCourseChoiceForm, type: :model, with_audited: true do
+  include CourseOptionHelpers
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:accept_guidance) }
+    it { is_expected.to validate_presence_of(:audit_comment_ticket) }
+    it { is_expected.to validate_presence_of(:provider_code) }
+    it { is_expected.to validate_presence_of(:course_code) }
+    it { is_expected.to validate_presence_of(:study_mode) }
+    it { is_expected.to validate_presence_of(:site_code) }
+
+    context 'for an invalid zendesk link' do
+      invalid_link = 'nonsense'
+      it { is_expected.not_to allow_value(invalid_link).for(:audit_comment_ticket) }
+    end
+
+    context 'for an valid zendesk link' do
+      valid_link = 'www.becomingateacher.zendesk.com/agent/tickets/example'
+      it { is_expected.to allow_value(valid_link).for(:audit_comment_ticket) }
+    end
+  end
+
+  describe '#save!' do
+    context 'if the new course is already an existing choice' do
+      it 'raises an ActiveRecord error' do
+        first_course_option = create(:course_option)
+        second_course_option = create(:course_option)
+        application_form = create(:application_form)
+        application_choice_to_change = create(:application_choice, :awaiting_provider_decision, course_option: first_course_option, application_form: application_form)
+        create(:application_choice, :awaiting_provider_decision, course_option: second_course_option, application_form: application_form)
+
+        zendesk_ticket = 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+
+        form = described_class.new(
+          application_choice_id: application_choice_to_change.id,
+          provider_code: second_course_option.provider.code,
+          course_code: second_course_option.course.code,
+          study_mode: second_course_option.study_mode,
+          site_code: second_course_option.site.code,
+          audit_comment_ticket: zendesk_ticket,
+          accept_guidance: true,
+        )
+
+        expect { form.save(application_choice_to_change.id) }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+
+    context 'if the new course is not a valid choice' do
+      it 'raises an ActiveRecord error' do
+        original_course_option = create(:course_option)
+        application_choice = create(:application_choice, :awaiting_provider_decision, course_option: original_course_option)
+
+        course_option = create(:course_option, study_mode: :full_time)
+        zendesk_ticket = 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+
+        form = described_class.new(
+          application_choice_id: application_choice.id,
+          provider_code: course_option.provider.code,
+          course_code: course_option.course.code,
+          study_mode: :part_time,
+          site_code: course_option.site.code,
+          audit_comment_ticket: zendesk_ticket,
+          accept_guidance: true,
+        )
+
+        expect { form.save(application_choice.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'if the new course details are correct' do
+      it 'updates the application choice' do
+        original_course_option = create(:course_option)
+        application_choice = create(:application_choice, :awaiting_provider_decision, course_option: original_course_option)
+
+        course_option = create(:course_option, study_mode: :full_time)
+        zendesk_ticket = 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+
+        form = described_class.new(
+          application_choice_id: application_choice.id,
+          provider_code: course_option.provider.code,
+          course_code: course_option.course.code,
+          study_mode: course_option.course.study_mode,
+          site_code: course_option.site.code,
+          audit_comment_ticket: zendesk_ticket,
+          accept_guidance: true,
+        )
+
+        expect(form.save(application_choice.id)).to eq(true)
+
+        expect(application_choice.reload.course.name).to eq course_option.course.name
+        expect(application_choice.course.id).not_to eq original_course_option.course.id
+        expect(application_choice.audits.last.comment).to include(zendesk_ticket)
+      end
+    end
+  end
+end

--- a/spec/forms/support_interface/application_forms/change_course_choice_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/change_course_choice_form_spec.rb
@@ -69,6 +69,29 @@ RSpec.describe SupportInterface::ApplicationForms::ChangeCourseChoiceForm, type:
       end
     end
 
+    context 'if the new provider is not on the interview' do
+      it 'raises a RuntimeError' do
+        original_course_option = create(:course_option)
+        application_choice = create(:application_choice, :interviewing, course_option: original_course_option)
+
+        course_option = create(:course_option, study_mode: :full_time)
+        other_provider = create(:provider)
+        zendesk_ticket = 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+
+        form = described_class.new(
+          application_choice_id: application_choice.id,
+          provider_code: other_provider.code,
+          course_code: course_option.course.code,
+          study_mode: course_option.course.study_mode,
+          site_code: course_option.site.code,
+          audit_comment_ticket: zendesk_ticket,
+          accept_guidance: true,
+        )
+
+        expect { form.save(application_choice.id) }.to raise_error(RuntimeError)
+      end
+    end
+
     context 'if the new course details are correct' do
       it 'updates the application choice' do
         original_course_option = create(:course_option)

--- a/spec/services/support_interface/change_application_choice_course_option_spec.rb
+++ b/spec/services/support_interface/change_application_choice_course_option_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
   describe '#call' do
-    let!(:application_choice) { create(:application_choice, :interviewing) }
+    let!(:application_choice) { create(:application_choice, :awaiting_provider_decision) }
     let!(:course_option) { create(:course_option, study_mode: :full_time) }
     let(:other_provider) { create(:provider) }
     let(:audit_comment) { 'Zendesk ticket 2 - update course' }
@@ -79,6 +79,21 @@ RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
                               site_code: course_option.site.code,
                               audit_comment: audit_comment).call
         }.to raise_error(RuntimeError, "Changing the course option of application choices in the #{application_choice.status} state is not allowed")
+      end
+    end
+
+    context 'application choice interviewing providers check' do
+      let!(:application_choice) { create(:application_choice, :interviewing) }
+
+      it 'raises an error if the provider is not on the interview' do
+        expect {
+          described_class.new(application_choice_id: application_choice.id,
+                              provider_id: other_provider.id,
+                              course_code: course_option.course.code,
+                              study_mode: course_option.course.study_mode,
+                              site_code: course_option.site.code,
+                              audit_comment: audit_comment).call
+        }.to raise_error(RuntimeError, 'Changing a course choice when the provider is not on the interview is not allowed')
       end
     end
   end

--- a/spec/services/support_interface/change_application_choice_course_option_spec.rb
+++ b/spec/services/support_interface/change_application_choice_course_option_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
                               study_mode: course_option.course.study_mode,
                               site_code: course_option.site.code,
                               audit_comment: audit_comment).call
-        }.to raise_error(RuntimeError, 'Changing a course choice when the provider is not on the interview is not allowed')
+        }.to raise_error(ProviderInterviewError, 'Changing a course choice when the provider is not on the interview is not allowed')
       end
     end
   end

--- a/spec/system/support_interface/change_course_choice_spec.rb
+++ b/spec/system/support_interface/change_course_choice_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+RSpec.feature 'Change course choice' do
+  include DfESignInHelpers
+
+  scenario 'Change the course choice on an application form', with_audited: true do
+    given_i_am_a_support_user
+    and_there_is_an_application_choice_awaiting_provider_decision
+
+    when_i_visit_the_application_page
+    then_i_see_a_change_course_choice_link
+
+    when_i_click_change_course_choice
+    then_i_see_a_confirmation_page_prompting_for_course_details
+
+    when_i_click_continue
+    then_i_see_a_validation_error
+
+    when_i_enter_the_new_course_choice_and_press_change
+    then_i_see_the_application_page
+    and_the_new_course_choice
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_an_application_choice_awaiting_provider_decision
+    application_form = create(
+      :application_form,
+      submitted_at: Time.zone.now,
+    )
+    @application_choice = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      application_form: application_form,
+    )
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@application_choice.application_form_id)
+  end
+
+  def then_i_see_a_change_course_choice_link
+    expect(page).to have_link('Change course choice')
+  end
+
+  def when_i_click_change_course_choice
+    click_link('Change course choice')
+  end
+
+  def then_i_see_a_confirmation_page_prompting_for_course_details
+    expect(page).to have_current_path(
+      support_interface_application_form_change_course_choice_path(
+        application_form_id: @application_choice.application_form_id,
+        application_choice_id: @application_choice.id,
+      ),
+    )
+    expect(page).to have_content('Change a course choice')
+  end
+
+  def when_i_click_continue
+    click_on 'Change'
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_current_path(
+      support_interface_application_form_change_course_choice_path(
+        application_form_id: @application_choice.application_form_id,
+        application_choice_id: @application_choice.id,
+      ),
+    )
+    expect(page).to have_content('Please enter a provider code')
+    expect(page).to have_content('Please enter a course code')
+    expect(page).to have_content('Select a study mode option')
+    expect(page).to have_content('Please enter a site code')
+    expect(page).to have_content('Enter a Zendesk ticket URL')
+    expect(page).to have_content('Select that you have read the guidance')
+  end
+
+  def when_i_enter_the_new_course_choice_and_press_change
+    @course_option = create(:course_option, study_mode: :full_time)
+
+    fill_in 'Provider code', with: @course_option.course.provider.code
+    fill_in 'Course code', with: @course_option.course.code
+    choose 'Full time'
+    fill_in 'Site code', with: @course_option.site.code
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/123'
+    check 'I have read the guidance'
+    click_on 'Change'
+  end
+
+  def then_i_see_the_application_page
+    expect(page).to have_current_path(support_interface_application_form_path(@application_choice.application_form_id))
+  end
+
+  def and_the_new_course_choice
+    expect(page).to have_content 'Course successfully changed'
+    expect(page).to have_content @course_option.course.name
+    expect(page).to have_content @course_option.provider.name
+    expect(page).to have_content @course_option.course.study_mode
+    expect(page).to have_content @course_option.site.name
+  end
+end


### PR DESCRIPTION
## Context

We allow course options to be changed for candidates but currently we can only perform this by calling a service manually in the console. Due to an increase in support requests we're building this functionality into the support UI.

## Changes proposed in this pull request

Build a new `ChangeCourseChoice` flow.

![image](https://user-images.githubusercontent.com/47917431/145850831-6e6e09c7-3f53-4c95-8457-1ba918814f67.png)

## Guidance to review

Following similar design pattern used in other pieces of support functionality. Do I need additional validations?

## Link to Trello card

https://trello.com/c/LglxncQF

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
