### PR TITLE
External report: changes to TAD applications export

### DIFF
--- a/app/services/data_api/tad_application_export.rb
+++ b/app/services/data_api/tad_application_export.rb
@@ -59,7 +59,7 @@ module DataAPI
         programme_outcome: application_choice.course.description,
         course_name: application_choice.course.name,
         course_code: application_choice.course.code,
-        nctl_subject: concatenate(application_choice.course.subject_codes),
+        nctl_subject: concatenate(application_choice.course.subjects.map(&:code)),
       }
     end
 

--- a/app/services/data_api/tad_application_export.rb
+++ b/app/services/data_api/tad_application_export.rb
@@ -11,7 +11,7 @@ module DataAPI
 
     # Documented in app/exports/tad_export.yml
     def as_json
-      accrediting_provider = application_choice.accredited_provider || application_choice.provider
+      accrediting_provider = application_choice.current_accredited_provider || application_choice.current_provider
       degree = application_form.application_qualifications.find { |q| q.level == 'degree' }
       equality_and_diversity = application_form.equality_and_diversity.to_h
 
@@ -47,19 +47,19 @@ module DataAPI
         degree_classification_hesa_code: degree&.grade_hesa_code,
 
         # Provider
-        provider_code: application_choice.provider.code,
-        provider_id: application_choice.provider.id,
-        provider_name: application_choice.provider.name,
+        provider_code: application_choice.current_provider.code,
+        provider_id: application_choice.current_provider.id,
+        provider_name: application_choice.current_provider.name,
         accrediting_provider_code: accrediting_provider.code,
         accrediting_provider_id: accrediting_provider.id,
         accrediting_provider_name: accrediting_provider.name,
 
         course_level: course.level,
-        program_type: application_choice.course.program_type,
-        programme_outcome: application_choice.course.description,
-        course_name: application_choice.course.name,
-        course_code: application_choice.course.code,
-        nctl_subject: concatenate(application_choice.course.subjects.map(&:code)),
+        program_type: application_choice.current_course.program_type,
+        programme_outcome: application_choice.current_course.description,
+        course_name: application_choice.current_course.name,
+        course_code: application_choice.current_course.code,
+        nctl_subject: concatenate(application_choice.current_course.subjects.map(&:code)),
       }
     end
 

--- a/app/services/data_api/tad_export.rb
+++ b/app/services/data_api/tad_export.rb
@@ -35,7 +35,7 @@ module DataAPI
           :candidate,
         ).preload(
           :application_qualifications,
-          application_choices: %i[course provider accredited_provider audits],
+          application_choices: [{ course: :subjects }, :provider, :accredited_provider, :audits],
         )
         .where('candidates.hide_in_reporting' => false)
         .where.not(submitted_at: nil)

--- a/app/services/data_api/tad_export.rb
+++ b/app/services/data_api/tad_export.rb
@@ -20,7 +20,9 @@ module DataAPI
 
     def data_for_export(*)
       relevant_applications.flat_map do |application_form|
-        application_form.application_choices.map do |application_choice|
+        # if a form belongs to previous year, we only want to consider the choice that was deferred
+        # for non-deferred apps this set will be equivalent to all choices
+        application_form.application_choices.select { |ac| ac.current_recruitment_cycle_year == RecruitmentCycle.current_year }.map do |application_choice|
           TADApplicationExport.new(application_choice).as_json
         end
       end
@@ -30,12 +32,18 @@ module DataAPI
 
     def relevant_applications
       ApplicationForm
+        .joins(:application_choices)
         .current_cycle
-        .includes(
+        .or(
+          ApplicationForm
+            .joins(:application_choices)
+            .where('application_forms.recruitment_cycle_year < ?', RecruitmentCycle.current_year)
+            .where('application_choices.current_recruitment_cycle_year' => RecruitmentCycle.current_year),
+        ).includes(
           :candidate,
         ).preload(
           :application_qualifications,
-          application_choices: [{ course: :subjects }, :provider, :accredited_provider, :audits],
+          application_choices: [{ current_course: :subjects }, :provider, :accredited_provider, :audits],
         )
         .where('candidates.hide_in_reporting' => false)
         .where.not(submitted_at: nil)


### PR DESCRIPTION
## Context

During the report QA process we discovered some issues with the data we send TAD every day.

## Changes proposed in this pull request

See commits.

Note the logic of the OR in the query for Application Forms: get all the forms in the current cycle **plus** any forms in previous cycles having application choices for courses in the current cycle (which is the definition of a deffered application that's been confirmed in the current cycle).

## Link to Trello card

https://trello.com/c/j4kcaT5T/4191-monthly-report-clean-up-code
