### PR TITLE
[4200] Change gov.uk header links to link to gov.uk instead of root path

### DIFF
--- a/app/components/utility/header_component.html.erb
+++ b/app/components/utility/header_component.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_header(
   classes: "govuk-!-display-none-print #{classes}",
-  homepage_url: service_link,
+  homepage_url: govuk_url,
   service_name: service_name,
   service_url: service_link,
   navigation_classes: navigation_classes,

--- a/app/components/utility/header_component.rb
+++ b/app/components/utility/header_component.rb
@@ -10,4 +10,8 @@ class HeaderComponent < ViewComponent::Base
     @navigation_items   = navigation_items
     @navigation_classes = navigation_classes
   end
+
+  def govuk_url
+    t('govuk.url')
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,8 @@ en:
       short_name_with_naric: UK ENIC or NARIC
       full_name: UK ENIC (the UK agency that recognises international qualifications and skills)
       url: https://www.enic.org.uk
+  govuk:
+    url: https://www.gov.uk
   teacher_training_courses_api:
     documentation_url: https://api.publish-teacher-training-courses.service.gov.uk/
   publish_teacher_training_courses:


### PR DESCRIPTION
## Context

The gov.uk text in the header used to the `root_path`, they now link to gov.uk

## Guidance to review

- Navigate to any page
- Click on GOV.UK in the header
- You should be taken to `https://www.gov.uk`
- The service name text "Apply for teacher training" should still link to the `root_path`