### PR TITLE
Extend 2022 xmas holidays

### DIFF
--- a/app/components/provider_interface/key_dates_banner.html.erb
+++ b/app/components/provider_interface/key_dates_banner.html.erb
@@ -1,8 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= govuk_notification_banner(title_text: t('key_dates_banner.title')) do |notification_banner| %>
-      <% notification_banner.heading(text: t('key_dates_banner.christmas_header', non_working_days_period: non_working_days_period)) %>
-      <p class="govuk-body"><%= t('key_dates_banner.christmas_body') %></p>
+      <% notification_banner.heading(text: t('key_dates_banner.christmas_header')) %>
+      <p class="govuk-body"><%= t('key_dates_banner.christmas_body', non_working_days_period: non_working_days_period) %></p>
     <% end %>
   </div>
 </div>

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -43,7 +43,7 @@ class CycleTimetable
       reject_by_default: Time.zone.local(2022, 9, 29, 23, 59, 59), # This is a placeholder till we know the real date
       find_closes: Time.zone.local(2022, 10, 4, 23, 59, 59), # This is a placeholder till we know the real date
       holidays: { # Placeholders
-        christmas: Date.new(2021, 12, 21)..Date.new(2022, 1, 1),
+        christmas: Date.new(2021, 12, 14)..Date.new(2022, 1, 16),
         easter: Date.new(2022, 4, 2)..Date.new(2022, 4, 6),
       },
     },

--- a/config/locales/key_dates_banner.yml
+++ b/config/locales/key_dates_banner.yml
@@ -1,5 +1,5 @@
 en:
   key_dates_banner:
     title: Important
-    christmas_header: '%{non_working_days_period} do not count as working days'
-    christmas_body: The Christmas period will not be included when calculating dates for applications to be automatically rejected.
+    christmas_header: 'Extension to automatic rejection dates'
+    christmas_body: '%{non_working_days_period} are not counted when calculating automatic rejection dates. This extension is to help providers deal with the impact of coronavirus (COVID-19) in the Christmas period.'

--- a/spec/components/provider_interface/key_dates_banner_spec.rb
+++ b/spec/components/provider_interface/key_dates_banner_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe ProviderInterface::KeyDatesBanner do
       let(:time) { 10.business_days.after(CycleTimetable.apply_opens).end_of_day }
 
       it 'does renders the non working period content' do
-        expect(result.text).not_to include(t('key_dates_banner.christmas_header', non_working_days_period: christmas_period))
-        expect(result.text).not_to include(t('key_dates_banner.christmas_body'))
+        expect(result.text).not_to include(t('key_dates_banner.christmas_header'))
+        expect(result.text).not_to include(t('key_dates_banner.christmas_body', non_working_days_period: christmas_period))
       end
     end
 
@@ -27,8 +27,8 @@ RSpec.describe ProviderInterface::KeyDatesBanner do
       let(:time) { 20.business_days.after(CycleTimetable.apply_opens).end_of_day }
 
       it 'renders the non working period content' do
-        expect(result.text).to include(t('key_dates_banner.christmas_header', non_working_days_period: christmas_period))
-        expect(result.text).to include(t('key_dates_banner.christmas_body'))
+        expect(result.text).to include(t('key_dates_banner.christmas_header'))
+        expect(result.text).to include(t('key_dates_banner.christmas_body', non_working_days_period: christmas_period))
       end
     end
 
@@ -36,8 +36,8 @@ RSpec.describe ProviderInterface::KeyDatesBanner do
       let(:time) { 1.business_days.after(CycleTimetable.holidays[:christmas].last).end_of_day }
 
       it 'does renders the non working period content' do
-        expect(result.text).not_to include(t('key_dates_banner.christmas_header', non_working_days_period: christmas_period))
-        expect(result.text).not_to include(t('key_dates_banner.christmas_body'))
+        expect(result.text).not_to include(t('key_dates_banner.christmas_header'))
+        expect(result.text).not_to include(t('key_dates_banner.christmas_body', non_working_days_period: christmas_period))
       end
     end
   end

--- a/spec/services/set_reject_by_default_spec.rb
+++ b/spec/services/set_reject_by_default_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SetRejectByDefault do
       ['1 Jul 2019 9:00:00 AM BST',  '30 Jul 2019 0:00:00 AM BST', 'safely within BST'],
       ['4 Jan 2019 11:00:00 PM GMT', '2 Mar 2019 0:00:00 AM GMT',  'safely within GMT'],
       ['1 Jul 2020 11:00:00 PM BST', '30 Jul 2020 0:00:00 AM BST', 'during the 20-day summer period'],
-      ['21 Nov 2021 12:00:00 PM GMT', '1 Feb 2022 0:00:00 AM GMT', 'near the Christmas holidays'],
+      ['21 Nov 2021 12:00:00 PM GMT', '18 Feb 2022 23:59:59 PM GMT', 'near the Christmas holidays'],
       ['1 Sept 2021 0:00:00 AM BST', '29 Sept 2021 23:59:59 PM BST', '7 days before the apply 1 deadline'],
       ['7 Sept 2021 0:00:00 AM BST', '29 Sept 2021 23:59:59 PM BST', '1 day before apply 1 deadline'],
       ['20 Sept 2021 0:00:00 AM BST', '29 Sep 2021 23:59:59 PM BST', '1 day before apply 2 deadline'],


### PR DESCRIPTION
## Context

We'd like to recalculate reject by default dates to give organisations and candidates more time to interview after the christmas holiday period.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Extends the 2021/2022 christmas holiday period to allow us to run a recalculation for recent and imminent RBD dates.
- Amends key dates banner content with an explanation of why the dates have changed.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
