### PR TITLE
Remove application reference number from email

### DIFF
--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -6,8 +6,6 @@ You have submitted an application for:
 * <%= application_choice.course_option.course.provider.name %> - <%= application_choice.course_option.course.name %> (<%= application_choice.course_option.course.code %>)
 <% end %>
 
-Your application reference is <%= @application_form.support_reference %>.
-
 Sign in to your account anytime to check the progress of your application:
 
 <%= @candidate_magic_link %>

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe CandidateMailer, type: :mailer do
   let(:application_form) do
     build_stubbed(:application_form, first_name: 'Fred',
                                      candidate: candidate,
-                                     support_reference: 'SUPPORT-REFERENCE',
                                      application_choices: application_choices)
   end
   let(:candidate) { build_stubbed(:candidate) }
@@ -41,7 +40,6 @@ RSpec.describe CandidateMailer, type: :mailer do
       'a mail with subject and content',
       I18n.t!('candidate_mailer.application_submitted.subject'),
       'intro' => 'You have submitted an application for:',
-      'support reference' => 'SUPPORT-REFERENCE',
       'magic link to authenticate' => 'http://localhost:3000/candidate/sign-in/confirm?token=raw_token',
     )
   end


### PR DESCRIPTION
We already removed the application reference number from the candidate web interface (in #4439) as it wasn't needed. This also removes it from the confirmation email sent to the candidate.