### PR TITLE
Work history section redirect bug

### DIFF
--- a/app/components/shared/restructured_work_history/review_component.html.erb
+++ b/app/components/shared/restructured_work_history/review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :work_experience, section_path: CandidateInterface::ApplicationFormPresenter.new(@application_form).work_experience_path, error: @missing_error)) %>
+  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :work_experience, section_path: change_path, error: @missing_error)) %>
 <% else %>
   <section class="app-summary-card govuk-!-margin-bottom-6">
     <div class="app-summary-card__body">

--- a/app/components/shared/restructured_work_history/review_component.rb
+++ b/app/components/shared/restructured_work_history/review_component.rb
@@ -56,5 +56,9 @@ module RestructuredWorkHistory
     def breaks_in_work_history?
       CheckBreaksInWorkHistory.call(@application_form)
     end
+
+    def change_path
+      CandidateInterface::ApplicationFormPresenter.new(@application_form).work_experience_path('return-to' => 'application-review') if @return_to_application_review
+    end
   end
 end

--- a/app/components/shared/restructured_work_history/review_component.rb
+++ b/app/components/shared/restructured_work_history/review_component.rb
@@ -58,7 +58,11 @@ module RestructuredWorkHistory
     end
 
     def change_path
-      CandidateInterface::ApplicationFormPresenter.new(@application_form).work_experience_path('return-to' => 'application-review') if @return_to_application_review
+      if @return_to_application_review
+        CandidateInterface::ApplicationFormPresenter.new(@application_form).work_experience_path('return-to' => 'application-review')
+      else
+        CandidateInterface::ApplicationFormPresenter.new(@application_form).work_experience_path
+      end
     end
   end
 end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -177,10 +177,10 @@ module CandidateInterface
       end
     end
 
-    def work_experience_path
+    def work_experience_path(params = nil)
       if application_form.feature_restructured_work_history
         if application_form.application_work_experiences.any? || application_form.work_history_explanation.present?
-          Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_review_path('return-to' => 'application-review')
+          Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_review_path(params)
         else
           Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_path
         end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -182,12 +182,12 @@ module CandidateInterface
         if application_form.application_work_experiences.any? || application_form.work_history_explanation.present?
           Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_review_path(params)
         else
-          Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_path
+          Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_path(params)
         end
       elsif application_form.application_work_experiences.any? || application_form.work_history_explanation.present?
-        Rails.application.routes.url_helpers.candidate_interface_work_history_show_path
+        Rails.application.routes.url_helpers.candidate_interface_work_history_show_path(params)
       else
-        Rails.application.routes.url_helpers.candidate_interface_work_history_length_path
+        Rails.application.routes.url_helpers.candidate_interface_work_history_length_path(params)
       end
     end
 

--- a/spec/components/restructured_work_history/review_component_spec.rb
+++ b/spec/components/restructured_work_history/review_component_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe RestructuredWorkHistory::ReviewComponent do
-  include Rails.application.routes.url_helpers
-
   around do |example|
     Timecop.freeze(Time.zone.now) do
       example.run
@@ -56,11 +54,11 @@ RSpec.describe RestructuredWorkHistory::ReviewComponent do
   end
 
   context 'when the application is incomplete' do
-    context 'when we click from the application review page' do
-      it 'renders incomplete component with correct path' do
+    context 'when return_to_application_review is true' do
+      it 'renders incomplete component with correct parameter appended to the path' do
         result = render_inline(described_class.new(application_form: application_form_with_no_breaks, show_incomplete: true, return_to_application_review: true))
 
-        expect(result.to_s).to include(candidate_interface_restructured_work_history_review_path('return-to' => 'application-review'))
+        expect(result.to_s).to include('return-to=application-review')
       end
     end
   end

--- a/spec/components/restructured_work_history/review_component_spec.rb
+++ b/spec/components/restructured_work_history/review_component_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe RestructuredWorkHistory::ReviewComponent do
+  include Rails.application.routes.url_helpers
+
   around do |example|
     Timecop.freeze(Time.zone.now) do
       example.run
@@ -51,6 +53,16 @@ RSpec.describe RestructuredWorkHistory::ReviewComponent do
         build_stubbed(:application_work_experience, start_date: 2.months.ago, end_date: 1.month.ago),
       ],
     )
+  end
+
+  context 'when the application is incomplete' do
+    context 'when we click from the application review page' do
+      it 'renders incomplete component with correct path' do
+        result = render_inline(described_class.new(application_form: application_form_with_no_breaks, show_incomplete: true, return_to_application_review: true))
+
+        expect(result.to_s).to include(candidate_interface_restructured_work_history_review_path('return-to' => 'application-review'))
+      end
+    end
   end
 
   context 'when the application is editable' do

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -468,7 +468,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
         presenter = described_class.new(application_form)
 
         expect(presenter.work_experience_path).to eq(
-          Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_review_path('return-to' => 'application-review'),
+          Rails.application.routes.url_helpers.candidate_interface_restructured_work_history_review_path,
         )
       end
     end


### PR DESCRIPTION
## Context
The bug is as follows:
If the application has work experience
* When you navigate to the work history section from application page, both the back button and the continue will redirect to the application review page instead of the application page

## Changes proposed in this pull request
* Refactor so that restructured work history review component is now responsible for incomplete section link. It can now can be unit tested
* Application presenter no longer hardcodes a param appending the route as it is only needed for review component

## Guidance to review
Check that the bug is no longer there

## Link to Trello card

https://trello.com/c/PDjUQKrj/4197-work-history-section-incorrectly-redirects-to-application-review-page

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
