### PR TITLE
Make data migration for candidate API fix manual

### DIFF
--- a/app/services/data_migrations/fix_candidate_api_updated_at.rb
+++ b/app/services/data_migrations/fix_candidate_api_updated_at.rb
@@ -1,7 +1,7 @@
 module DataMigrations
   class FixCandidateAPIUpdatedAt
     TIMESTAMP = 20211208172459
-    MANUAL_RUN = false
+    MANUAL_RUN = true
 
     # Ensure that all the candidates have a `candidate_api_updated_at` that is
     # no earlier than the `created_at` of the most recent application form.

--- a/app/services/data_migrations/fix_candidate_api_updated_at.rb
+++ b/app/services/data_migrations/fix_candidate_api_updated_at.rb
@@ -32,11 +32,13 @@ module DataMigrations
         .where('candidate_api_updated_at < max_form_created_at OR candidate_api_updated_at < forms_with_earliest_audit.earliest_update')
         .where("created_at > '2021-01-01'")
 
-      candidates.find_in_batches(batch_size: 10) do |batch|
+      candidates.find_in_batches(batch_size: 100).with_index do |batch, index|
+        Rails.logger.info("FixCandidateAPIUpdatedAt processing batch #{index}...")
         batch.each do |candidate|
           candidate.update!(candidate_api_updated_at: calculate_candidate_api_updated_at(candidate))
         end
       end
+      Rails.logger.info('FixCandidateAPIUpdatedAt done')
     end
 
   private


### PR DESCRIPTION
## Context

This is a follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/6163 to deal with some problems with running the migration in production.

## Changes proposed in this pull request

- [x] Make the data migration manual so we can control when it runs and monitor it more easily
- [x] Add some rudimentary logging

## Guidance to review

- Does this make sense?

## Link to Trello card

https://trello.com/c/f00SH2Mz/4184-candidate-api-does-not-correctly-populate-updatedat-when-an-application-is-carried-over


## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
