### PR TITLE
Append manage teacher training applications to all provider emails

### DIFF
--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -1,5 +1,10 @@
 en:
   provider_mailer:
+    subject: "%{subject} - manage teacher training applications"
+    account_created:
+      subject: Sign in
+    confirm_sign_in:
+      subject: New sign in
     offer_accepted:
       subject: "%{candidate_name} (%{support_reference}) has accepted your offer"
     unconditional_offer_accepted:
@@ -8,35 +13,31 @@ en:
       subject: "%{candidate_name}’s (%{support_reference}) application withdrawn automatically"
     declined:
       subject: "%{candidate_name} (%{support_reference}) declined an offer"
-    account_created:
-      subject: Sign in to manage teacher training applications
     application_submitted:
-      subject: Application received for %{course_name_and_code}
+      subject: 'Application received for %{course_name_and_code}'
     application_submitted_with_safeguarding_issues:
-      subject: Application with safeguarding issues received for %{course_name_and_code}
+      subject: 'Application with safeguarding issues received for %{course_name_and_code}'
     application_rejected_by_default:
-      subject: "%{candidate_name}’s application was automatically rejected - manage teacher training applications"
+      subject: "%{candidate_name}’s application was automatically rejected"
     application_waiting_for_decision:
       subject: "Respond to %{candidate_name}’s (%{support_reference}) application"
     application_withdrawn:
       subject: "%{candidate_name} (%{support_reference}) withdrew their application"
-    confirm_sign_in:
-      subject: New sign in to Manage teacher training applications
     organisation_permissions_set_up:
       subject: "%{provider} has set up organisation permissions for teacher training courses you work on with them"
     organisation_permissions_updated:
       subject: "%{provider} has changed organisation permissions for teacher training courses you work on with them"
-    apply_service_is_now_open:
-      subject: "Candidates can now apply for teacher training courses for 2022 to 2023 - manage teacher training applications"
-    find_service_is_now_open:
-      subject: "Candidates can now find teacher training courses for 2022 to 2023 - manage teacher training applications"
     set_up_organisation_permissions:
-      subject: "Set up organisation permissions - manage teacher training applications"
+      subject: "Set up organisation permissions"
     permissions_granted:
-      subject: '%{permissions_granted_by_user} has added you to %{organisation} - manage teacher training applications'
+      subject: '%{permissions_granted_by_user} has added you to %{organisation}'
     permissions_granted_by_support:
-      subject: "You've been added to %{organisation} - manage teacher training applications"
+      subject: "You've been added to %{organisation}"
     permissions_removed:
-      subject: '%{permissions_removed_by_user} has removed you from %{organisation} - manage teacher training applications'
+      subject: '%{permissions_removed_by_user} has removed you from %{organisation}'
     permissions_removed_by_support:
-      subject: "You've been removed from %{organisation} - manage teacher training applications"
+      subject: "You've been removed from %{organisation}"
+    apply_service_is_now_open:
+      subject: "Candidates can now apply for teacher training courses for 2022 to 2023"
+    find_service_is_now_open:
+      subject: "Candidates can now find teacher training courses for 2022 to 2023"

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'Feedback on your application for Brighthurst Technical',
+        'Feedback on your application for Brighthurst Technical College',
         'heading' => 'Dear Bob',
         'provider name' => 'Brighthurst Technical College',
         'name and code for course' => 'Applied Science (Psychology) (3TT5)',
@@ -289,7 +289,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'Feedback on your application for Brighthurst Technical',
+        'Feedback on your application for Brighthurst Technical College',
         'heading' => 'Dear Bob',
         'provider name' => 'Brighthurst Technical College',
         'name and code for course' => 'Applied Science (Psychology) (3TT5)',
@@ -398,7 +398,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'Brighthurst Technical College',
+        'Offer changed by Brighthurst Technical College',
         'heading' => 'Dear Bob',
         'name for original course' => 'Applied Science (Psychology)',
         'name for new course' => 'Course: Forensic Science',
@@ -414,7 +414,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'Brighthurst Technical College',
+        'Offer changed by Brighthurst Technical College',
         'heading' => 'Dear Bob',
         'name for original course' => 'Applied Science (Psychology)',
         'name for new course' => 'Course: Forensic Science',

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ProviderMailer, type: :mailer do
     let(:email) { described_class.account_created(provider_user) }
 
     it_behaves_like('a mail with subject and content',
-                    I18n.t!('provider_mailer.account_created.subject'),
+                    'Sign in - manage teacher training applications',
                     'provider name' => 'Dear Johny English',
                     'sign in path' => '/provider/sign-in')
   end
@@ -42,8 +42,7 @@ RSpec.describe ProviderMailer, type: :mailer do
     let(:email) { described_class.application_submitted(provider_user, application_choice) }
 
     it_behaves_like('a mail with subject and content',
-                    I18n.t!('provider_mailer.application_submitted.subject',
-                            course_name_and_code: 'Computer Science (6IND)'),
+                    'Application received for Computer Science (6IND) - manage teacher training applications',
                     'provider name' => 'Dear Johny English',
                     'candidate name' => 'Harry Potter',
                     'course name and code' => 'Computer Science (6IND)',
@@ -56,8 +55,7 @@ RSpec.describe ProviderMailer, type: :mailer do
       let(:email) { described_class.application_rejected_by_default(provider_user, application_choice, can_make_decisions: true) }
 
       it_behaves_like('a mail with subject and content',
-                      I18n.t!('provider_mailer.application_rejected_by_default.subject',
-                              candidate_name: 'Harry Potter'),
+                      'Harry Potter’s application was automatically rejected - manage teacher training applications',
                       'provider name' => 'Dear Johny English',
                       'candidate name' => 'Harry Potter',
                       'course name and code' => 'Computer Science (6IND)',
@@ -69,8 +67,7 @@ RSpec.describe ProviderMailer, type: :mailer do
       let(:email) { described_class.application_rejected_by_default(provider_user, application_choice, can_make_decisions: false) }
 
       it_behaves_like('a mail with subject and content',
-                      I18n.t!('provider_mailer.application_rejected_by_default.subject',
-                              candidate_name: 'Harry Potter'),
+                      'Harry Potter’s application was automatically rejected - manage teacher training applications',
                       'provider name' => 'Dear Johny English',
                       'candidate name' => 'Harry Potter',
                       'course name and code' => 'Computer Science (6IND)',
@@ -88,8 +85,7 @@ RSpec.describe ProviderMailer, type: :mailer do
     end
 
     it_behaves_like('a mail with subject and content',
-                    I18n.t!('provider_mailer.application_waiting_for_decision.subject',
-                            candidate_name: 'Harry Potter', support_reference: '123A'),
+                    'Respond to Harry Potter’s (123A) application - manage teacher training applications',
                     'provider name' => 'Dear Johny English',
                     'candidate name' => 'Harry Potter',
                     'course name and code' => 'Computer Science (6IND)',
@@ -103,7 +99,7 @@ RSpec.describe ProviderMailer, type: :mailer do
     let(:email) { described_class.offer_accepted(provider_user, application_choice) }
 
     it_behaves_like('a mail with subject and content',
-                    'Harry Potter (123A) has accepted your offer',
+                    'Harry Potter (123A) has accepted your offer - manage teacher training applications',
                     'provider name' => 'Dear Johny English',
                     'course name and code' => 'Computer Science (6IND)')
 
@@ -112,7 +108,7 @@ RSpec.describe ProviderMailer, type: :mailer do
       let(:current_course_option) { build_stubbed(:course_option, course: alternative_course, site: site) }
 
       it_behaves_like('a mail with subject and content',
-                      'Harry Potter (123A) has accepted your offer',
+                      'Harry Potter (123A) has accepted your offer - manage teacher training applications',
                       'provider name' => 'Dear Johny English',
                       'course name and code' => 'Welding (9ABC)')
     end
@@ -122,7 +118,7 @@ RSpec.describe ProviderMailer, type: :mailer do
     let(:email) { described_class.unconditional_offer_accepted(provider_user, application_choice) }
 
     it_behaves_like('a mail with subject and content',
-                    'Harry Potter (123A) has accepted your offer',
+                    'Harry Potter (123A) has accepted your offer - manage teacher training applications',
                     'provider name' => 'Dear Johny English',
                     'course name and code' => 'Computer Science (6IND)')
 
@@ -131,7 +127,7 @@ RSpec.describe ProviderMailer, type: :mailer do
       let(:current_course_option) { build_stubbed(:course_option, course: alternative_course, site: site) }
 
       it_behaves_like('a mail with subject and content',
-                      'Harry Potter (123A) has accepted your offer',
+                      'Harry Potter (123A) has accepted your offer - manage teacher training applications',
                       'provider name' => 'Dear Johny English',
                       'course name and code' => 'Welding (9ABC)')
     end
@@ -141,7 +137,7 @@ RSpec.describe ProviderMailer, type: :mailer do
     let(:email) { described_class.declined_by_default(provider_user, application_choice) }
 
     it_behaves_like('a mail with subject and content',
-                    'Harry Potter’s (123A) application withdrawn automatically',
+                    'Harry Potter’s (123A) application withdrawn automatically - manage teacher training applications',
                     'provider name' => 'Dear Johny English',
                     'candidate name' => 'Harry Potter',
                     'course name and code' => 'Computer Science (6IND)')
@@ -151,7 +147,7 @@ RSpec.describe ProviderMailer, type: :mailer do
       let(:current_course_option) { build_stubbed(:course_option, course: alternative_course, site: site) }
 
       it_behaves_like('a mail with subject and content',
-                      'Harry Potter’s (123A) application withdrawn automatically',
+                      'Harry Potter’s (123A) application withdrawn automatically - manage teacher training applications',
                       'provider name' => 'Dear Johny English',
                       'course name and code' => 'Welding (9ABC)')
     end
@@ -162,7 +158,7 @@ RSpec.describe ProviderMailer, type: :mailer do
     let(:email) { described_class.application_withdrawn(provider_user, application_choice, number_of_cancelled_interviews) }
 
     it_behaves_like('a mail with subject and content',
-                    'Harry Potter (123A) withdrew their application',
+                    'Harry Potter (123A) withdrew their application - manage teacher training applications',
                     'provider name' => 'Dear Johny English',
                     'candidate name' => 'Harry Potter',
                     'course name and code' => 'Computer Science (6IND)')
@@ -172,7 +168,7 @@ RSpec.describe ProviderMailer, type: :mailer do
       let(:current_course_option) { build_stubbed(:course_option, course: alternative_course, site: site) }
 
       it_behaves_like('a mail with subject and content',
-                      'Harry Potter (123A) withdrew their application',
+                      'Harry Potter (123A) withdrew their application - manage teacher training applications',
                       'provider name' => 'Dear Johny English',
                       'course name and code' => 'Welding (9ABC)')
     end
@@ -181,7 +177,7 @@ RSpec.describe ProviderMailer, type: :mailer do
       let(:number_of_cancelled_interviews) { 2 }
 
       it_behaves_like('a mail with subject and content',
-                      'Harry Potter (123A) withdrew their application',
+                      'Harry Potter (123A) withdrew their application - manage teacher training applications',
                       'provider name' => 'Dear Johny English',
                       'candidate name' => 'Harry Potter',
                       'course name and code' => 'Computer Science (6IND)',
@@ -193,7 +189,7 @@ RSpec.describe ProviderMailer, type: :mailer do
     let(:email) { described_class.declined(provider_user, application_choice) }
 
     it_behaves_like('a mail with subject and content',
-                    'Harry Potter (123A) declined an offer',
+                    'Harry Potter (123A) declined an offer - manage teacher training applications',
                     'provider name' => 'Dear Johny English',
                     'candidate name' => 'Harry Potter',
                     'course name and code' => 'Computer Science (6IND)')
@@ -216,7 +212,7 @@ RSpec.describe ProviderMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      'University of Croydon has set up organisation permissions for teacher training courses you work on with them',
+      'University of Croydon has set up organisation permissions for teacher training courses you work on with them - manage teacher training applications',
       'salutation' => 'Dear Johny English',
       'heading' => 'University of Croydon has set up organisation permissions for teacher training courses you work on with them',
       'make offers' => /Make offers and reject applications:\s+- University of Purley/,
@@ -242,7 +238,7 @@ RSpec.describe ProviderMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      'University of Croydon has changed organisation permissions for teacher training courses you work on with them',
+      'University of Croydon has changed organisation permissions for teacher training courses you work on with them - manage teacher training applications',
       'salutation' => 'Dear Johny English',
       'heading' => 'University of Croydon has changed organisation permissions for teacher training courses you work on with them',
       'make offers' => /Make offers and reject applications:\s+- University of Purley/,

--- a/spec/support/shared_examples/mailers.rb
+++ b/spec/support/shared_examples/mailers.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples 'a mail with subject and content' do |email_subject, content|
   it "sends an email with the correct subject and #{content.keys.to_sentence} in the body" do
-    expect(email.subject).to include(email_subject)
+    expect(email.subject).to eq(email_subject)
 
     content.each do |_, expectation|
       if expectation.is_a?(Regexp)


### PR DESCRIPTION
## Context

Append `- manage teacher training applications` to all provider mailers subjects.

## Changes proposed in this pull request

- Add reusable `provider_notify_email` method that appends the provided text to all mailers
- Update spec matcher to check for exact email subject so this can be tested
- Update specs to check for exact subejct text instead of using locale

## Link to Trello card

https://trello.com/c/r55rkCUz/4561-append-manage-teacher-training-applications-to-all-provider-emails

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
