### PR TITLE
Add reject by default to status tag

### DIFF
--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -6,7 +6,7 @@
   </p>
 <% elsif @application_choice.decision_pending? && @application_choice.reject_by_default_at&.future? %>
   <p class="govuk-body govuk-!-margin-top-2">
-   You'll get a decision on your application by <%= @application_choice.reject_by_default_at.to_s(:govuk_date) %>.
+   You’ll get a decision on your application by <%= @application_choice.reject_by_default_at.to_s(:govuk_date) %>.
   </p>
 <% elsif @application_choice.withdrawn_at_candidates_request? %>
   <p class="govuk-body govuk-!-margin-top-2">

--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -6,7 +6,7 @@
   </p>
 <% elsif @application_choice.decision_pending? && @application_choice.reject_by_default_at&.future? %>
   <p class="govuk-body govuk-!-margin-top-2">
-   The provider must make a decision by <%= @application_choice.reject_by_default_at.to_s(:govuk_date) %>.
+   You'll get a decision on your application by <%= @application_choice.reject_by_default_at.to_s(:govuk_date) %>.
   </p>
 <% elsif @application_choice.withdrawn_at_candidates_request? %>
   <p class="govuk-body govuk-!-margin-top-2">

--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -4,6 +4,10 @@
   <p class="govuk-body govuk-!-margin-top-2">
     Your application was not sent for this course because references were not given before the deadline.
   </p>
+<% elsif @application_choice.decision_pending? && @application_choice.reject_by_default_at&.future? %>
+  <p class="govuk-body govuk-!-margin-top-2">
+   The provider must make a decision by <%= @application_choice.reject_by_default_at.to_s(:govuk_date) %>.
+  </p>
 <% elsif @application_choice.withdrawn_at_candidates_request? %>
   <p class="govuk-body govuk-!-margin-top-2">
     You requested to withdraw your application. If you did not request this, email <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.

--- a/spec/components/candidate_interface/application_status_tag_component_spec.rb
+++ b/spec/components/candidate_interface/application_status_tag_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
         result = render_inline(described_class.new(application_choice: application_choice))
 
         expect(result.text).to include(
-          "You'll get a decision on your application by #{5.days.from_now.to_s(:govuk_date)}.",
+          "You’ll get a decision on your application by #{5.days.from_now.to_s(:govuk_date)}.",
         )
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
         result = render_inline(described_class.new(application_choice: application_choice))
 
         expect(result.text).to include(
-          "You'll get a decision on your application by #{14.days.from_now.to_s(:govuk_date)}.",
+          "You’ll get a decision on your application by #{14.days.from_now.to_s(:govuk_date)}.",
         )
       end
 
@@ -54,7 +54,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
         )
         result = render_inline(described_class.new(application_choice: application_choice))
 
-        expect(result.text).not_to include('You'll get a decision on your application by')
+        expect(result.text).not_to include('You’ll get a decision on your application by')
       end
     end
 
@@ -120,6 +120,17 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
       expect(result.text).not_to include(
         'You requested to withdraw your application. If you did not request this, email becomingateacher@digital.education.gov.uk.',
       )
+    end
+
+    it 'does not render the reject by default date' do
+      application_choice = create(
+        :application_choice,
+        :with_offer,
+        reject_by_default_at: 5.days.from_now,
+      )
+      result = render_inline(described_class.new(application_choice: application_choice))
+
+      expect(result.text).not_to include('You’ll get a decision on your application by')
     end
   end
 end

--- a/spec/components/candidate_interface/application_status_tag_component_spec.rb
+++ b/spec/components/candidate_interface/application_status_tag_component_spec.rb
@@ -17,6 +17,47 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
       end
     end
 
+    context 'when the application choice is in the `interviewing` state' do
+      it 'tells the candidate when the reject by default date will be' do
+        application_choice = create(
+          :application_choice,
+          :interviewing,
+          reject_by_default_at: 5.days.from_now,
+        )
+        result = render_inline(described_class.new(application_choice: application_choice))
+
+        expect(result.text).to include(
+          "The provider must make a decision by #{5.days.from_now.to_s(:govuk_date)}.",
+        )
+      end
+    end
+
+    context 'when the application choice is in the `awaiting_provider_decision` state' do
+      it 'tells the candidate when the reject by default date will be' do
+        application_choice = create(
+          :application_choice,
+          :awaiting_provider_decision,
+          reject_by_default_at: 14.days.from_now,
+        )
+        result = render_inline(described_class.new(application_choice: application_choice))
+
+        expect(result.text).to include(
+          "The provider must make a decision by #{14.days.from_now.to_s(:govuk_date)}.",
+        )
+      end
+
+      it 'handles nil values for `reject_by_default_at`' do
+        application_choice = create(
+          :application_choice,
+          :awaiting_provider_decision,
+          reject_by_default_at: nil,
+        )
+        result = render_inline(described_class.new(application_choice: application_choice))
+
+        expect(result.text).not_to include('The provider must make a decision by')
+      end
+    end
+
     context 'when the application choice is in the offer_deferred state' do
       it 'tells the candidate when their course will start' do
         application_choice = create(:application_choice, :offer_deferred, course: course)

--- a/spec/components/candidate_interface/application_status_tag_component_spec.rb
+++ b/spec/components/candidate_interface/application_status_tag_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
         result = render_inline(described_class.new(application_choice: application_choice))
 
         expect(result.text).to include(
-          "The provider must make a decision by #{5.days.from_now.to_s(:govuk_date)}.",
+          "You'll get a decision on your application by #{5.days.from_now.to_s(:govuk_date)}.",
         )
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
         result = render_inline(described_class.new(application_choice: application_choice))
 
         expect(result.text).to include(
-          "The provider must make a decision by #{14.days.from_now.to_s(:govuk_date)}.",
+          "You'll get a decision on your application by #{14.days.from_now.to_s(:govuk_date)}.",
         )
       end
 
@@ -54,7 +54,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
         )
         result = render_inline(described_class.new(application_choice: application_choice))
 
-        expect(result.text).not_to include('The provider must make a decision by')
+        expect(result.text).not_to include('You'll get a decision on your application by')
       end
     end
 


### PR DESCRIPTION
## Context

Candidates should see a message on the post submission dashboard telling them when the provider must make a decision by (the reject by default date).

## Changes proposed in this pull request

- [x] Add given content to the CandidateInterface::ApplicationStatusTagComponent:

<img width="961" alt="image" src="https://user-images.githubusercontent.com/450843/146010960-a336953c-9426-49d2-a754-6b3d306306dd.png">


- [x] Update component specs

## Guidance to review

Is there anything I've missed? Other components that display application status to the candidate?

## Link to Trello card

https://trello.com/c/iX6q1niR/4203-add-provider-deadline-rbd-to-the-candidate-post-submission-dashboard-page

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
