### PR TITLE
Update `GenerateMonthlyStatistics` Sidekiq config

### DIFF
--- a/app/workers/generate_monthly_statistics.rb
+++ b/app/workers/generate_monthly_statistics.rb
@@ -1,7 +1,7 @@
 class GenerateMonthlyStatistics
   include Sidekiq::Worker
 
-  sidekiq_options retry: 3, queue: :high_priority
+  sidekiq_options retry: 3, queue: :default
 
   def perform
     return false unless MonthlyStatisticsTimetable.generate_monthly_statistics?


### PR DESCRIPTION

## Context

The `GenerateMonthlyStatistics` worker was configured to use the `high_priority` queue. This queue is not serviced by any of the workers so these jobs never run. 

## Changes proposed in this pull request

- [x] Move `GenerateMonthlyStatistics` to the `default` queue as that one is configured.
- [x] Cleaned out the `high_priority` queue on production.

## Guidance to review

Is there any more to this?

## Link to Trello card

https://trello.com/c/0Xpkhmjs/4188-monthly-report-fix-queueing-of-monthly-job

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
