### PR TITLE
Consider interviewing applications when calculating days to respond

### DIFF
--- a/app/services/provider_interface/sort_application_choices.rb
+++ b/app/services/provider_interface/sort_application_choices.rb
@@ -137,7 +137,7 @@ module ProviderInterface
     def self.pg_days_left_to_respond
       <<~PG_DAYS_LEFT_TO_RESPOND.squish
         CASE
-          WHEN status = 'awaiting_provider_decision'
+          WHEN status IN ('awaiting_provider_decision', 'interviewing')
           AND (DATE(reject_by_default_at) >= DATE('#{Time.zone.now.iso8601}'))
           THEN (DATE(reject_by_default_at) - DATE('#{Time.zone.now.iso8601}'))
           ELSE NULL END

--- a/spec/services/provider_interface/sort_application_choices_spec.rb
+++ b/spec/services/provider_interface/sort_application_choices_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe ProviderInterface::SortApplicationChoices do
       create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 3.days.from_now.end_of_day)
       expect(pg_days_left_to_respond).to eq(3)
     end
+
+    it 'is the correct number of days when reject_by_default_at is in the future for interviewing applications' do
+      create(:application_choice, :interviewing, reject_by_default_at: 4.days.from_now.end_of_day)
+      expect(pg_days_left_to_respond).to eq(4)
+    end
   end
 
   describe 'task view groups' do


### PR DESCRIPTION
## Context

Applications in the `interviewing` state do not contain the number of days left to respond in the applications index.

![screenshot_2021-12-15_at_11 10 10_2x](https://user-images.githubusercontent.com/93511/146186741-84e8fcf2-6c8d-4e2d-9e89-9cb1f927dc8f.png)



<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds the `interviewing` state to the SQL clause which calculates days left to respond.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Interviewing applications should appear with days left to respond on the applications index.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/DfEUaN1h/4598-consider-interviewing-state-when-surfacing-remaining-days-in-provider-application-lists
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
