### PR TITLE
Service to revert RBDs

### DIFF
--- a/app/services/revert_rejected_by_default.rb
+++ b/app/services/revert_rejected_by_default.rb
@@ -12,6 +12,13 @@ class RevertRejectedByDefault
         .where(application_form_id: ids)
         .where(rejected_by_default: true)
         .find_each do |application_choice|
+          statuses_for_form = application_choice.self_and_siblings.pluck(:status)
+
+          # do not continue if the application has an accepted offer
+          next if statuses_for_form.any? do |s|
+            ApplicationStateChange::ACCEPTED_STATES.include?(s.to_sym)
+          end
+
           application_choice.update!(
             reject_by_default_at: new_rbd_date,
             status: :awaiting_provider_decision,

--- a/app/services/revert_rejected_by_default.rb
+++ b/app/services/revert_rejected_by_default.rb
@@ -1,0 +1,24 @@
+class RevertRejectedByDefault
+  attr_reader :ids, :new_rbd_date
+
+  def initialize(ids:, new_rbd_date:)
+    @ids = ids
+    @new_rbd_date = new_rbd_date
+  end
+
+  def call
+    Audited.audit_class.as_user('RevertRejectedByDefault worker') do
+      ApplicationChoice
+        .where(application_form_id: ids)
+        .where(rejected_by_default: true)
+        .find_each do |application_choice|
+          application_choice.update!(
+            reject_by_default_at: new_rbd_date,
+            status: :awaiting_provider_decision,
+            rejected_by_default: false,
+            rejected_at: nil,
+          )
+        end
+    end
+  end
+end

--- a/app/services/revert_rejected_by_default.rb
+++ b/app/services/revert_rejected_by_default.rb
@@ -18,6 +18,11 @@ class RevertRejectedByDefault
             rejected_by_default: false,
             rejected_at: nil,
           )
+
+          application_choice.self_and_siblings.where(status: :offer).update_all(
+            decline_by_default_at: nil,
+            decline_by_default_days: nil,
+          )
         end
     end
   end

--- a/app/services/revert_rejected_by_default.rb
+++ b/app/services/revert_rejected_by_default.rb
@@ -24,6 +24,14 @@ class RevertRejectedByDefault
             decline_by_default_days: nil,
           )
         end
+
+      ApplicationForm
+        .where(id: ids)
+        .find_each do |form|
+          form.chasers_sent
+            .where(chaser_type: :candidate_decision_request)
+            .destroy_all
+        end
     end
   end
 end

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -93,6 +93,8 @@ FactoryBot.define do
     end
 
     trait :with_rejection_by_default do
+      awaiting_provider_decision
+
       status { 'rejected' }
       rejected_at { 2.minutes.ago }
       rejected_by_default { true }

--- a/spec/services/revert_rejected_by_default_spec.rb
+++ b/spec/services/revert_rejected_by_default_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe RevertRejectedByDefault do
+  let!(:form_with_single_rbd) do
+    form = create(:application_form)
+    create(:application_choice, :with_rejection_by_default, application_form: form)
+    form
+  end
+
+  let!(:form_without_rbd) do
+    form = create(:application_form)
+    create(:application_choice, :awaiting_provider_decision, application_form: form)
+    form
+  end
+
+  let!(:form_with_two_rbds) do
+    form = create(:application_form)
+    create(:application_choice, :with_rejection_by_default, application_form: form)
+    create(:application_choice, :with_rejection_by_default, application_form: form)
+    form
+  end
+
+  let(:new_rbd_date) { 1.day.from_now }
+
+  def call_service
+    described_class.new(
+      ids: ApplicationForm.pluck(:id),
+      new_rbd_date: new_rbd_date,
+    ).call
+  end
+
+  it 'correctly reverts an RBD application without siblings' do
+    choice = form_with_single_rbd.application_choices.first
+
+    call_service
+
+    expect(choice.reload.reject_by_default_at).to be_within(1.minute).of new_rbd_date
+  end
+
+  it 'correctly reverts all RBD applications for a given form' do
+    choices = form_with_two_rbds.application_choices
+
+    call_service
+
+    choices.each do |choice|
+      expect(choice.reload.reject_by_default_at).to be_within(1.minute).of new_rbd_date
+    end
+  end
+
+  it 'correctly no-ops on an application without RBDs' do
+    choice = form_without_rbd.application_choices.first
+
+    expect {
+      call_service
+    }.not_to(change { choice.reload.reject_by_default_at })
+  end
+end

--- a/spec/services/revert_rejected_by_default_spec.rb
+++ b/spec/services/revert_rejected_by_default_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe RevertRejectedByDefault do
     # :grimacing: we have to do this manually. Factories should really use
     # the MakeOffer machinery.
     SetDeclineByDefault.new(application_form: form).call
+
+    # Send a DBD chaser to the candidate. We’ll want to delete this so that
+    # when DBD starts again they can get a fresh email.
+    SendChaseEmailToCandidate.call(application_form: form)
+
     form
   end
 
@@ -71,9 +76,10 @@ RSpec.describe RevertRejectedByDefault do
     # we need to prevent DBD, which is accomplished by removing the date.
     choices = form_with_rbd_and_offer.application_choices
 
-    # assert that we correctly set a DBD on the offered app,
+    # assert that we correctly set a DBD on the offered app and that we sent a chaser,
     # or this spec is meaningless
     expect(choices.map(&:decline_by_default_at).compact.first).to be_present
+    expect(form_with_rbd_and_offer.chasers_sent).to be_present
 
     call_service
 
@@ -81,5 +87,6 @@ RSpec.describe RevertRejectedByDefault do
 
     expect(choices.map(&:decline_by_default_at)).to all be_nil
     expect(choices.map(&:decline_by_default_days)).to all be_nil
+    expect(form_with_rbd_and_offer.reload.chasers_sent).to be_empty
   end
 end


### PR DESCRIPTION
## Context

We need to revert some RBDs which have fallen to early for providers to do anything about them, given covid etc.

## Changes proposed in this pull request

Introduce `RevertRejectionByDefault` service and specs.

## Guidance to review

Commit by commit.

Though it arguably isn't needed here, I find the approach of having all tests run on all the test data helps this all feel side-effect-free.

## Link to Trello card

Various, on the support board!