### PR TITLE
Detect out-of-date provider_ids in application_choices

### DIFF
--- a/app/queries/find_application_choices_with_out_of_date_provider_ids.rb
+++ b/app/queries/find_application_choices_with_out_of_date_provider_ids.rb
@@ -1,0 +1,37 @@
+class FindApplicationChoicesWithOutOfDateProviderIds
+  def self.call
+    with_course_joins = ApplicationChoice
+                          .joins('INNER JOIN course_options AS current_course_option ON current_course_option_id = current_course_option.id')
+                          .joins('INNER JOIN course_options AS original_option ON course_option_id = original_option.id')
+                          .joins('INNER JOIN courses AS current_course ON current_course_option.course_id = current_course.id')
+                          .joins('INNER JOIN courses AS original_course ON original_option.course_id = original_course.id')
+
+    # SQL equivalent for .compact.uniq
+    get_expected_provider_ids_sql = <<~GET_EXPECTED_PROVIDER_IDS_SQL.squish
+      application_choices.id,
+      ARRAY(
+        SELECT DISTINCT i FROM unnest(
+          ARRAY[
+            original_course.provider_id,
+            original_course.accredited_provider_id,
+            current_course.provider_id,
+            current_course.accredited_provider_id
+          ]
+        ) AS a(i) WHERE i IS NOT NULL
+      ) AS expected_provider_ids
+    GET_EXPECTED_PROVIDER_IDS_SQL
+
+    provider_ids_do_not_match_sql = <<~COMPARE_ARRAYS_AS_SETS.squish
+      NOT(
+        provider_ids @> expected_provider_ids
+        AND expected_provider_ids @> provider_ids
+      )
+    COMPARE_ARRAYS_AS_SETS
+
+    ApplicationChoice
+      .with(extended: with_course_joins.select(get_expected_provider_ids_sql))
+      .joins('INNER JOIN extended ON application_choices.id = extended.id')
+      .where(provider_ids_do_not_match_sql)
+      .select('application_choices.*, expected_provider_ids')
+  end
+end

--- a/app/queries/find_application_choices_with_out_of_date_provider_ids.rb
+++ b/app/queries/find_application_choices_with_out_of_date_provider_ids.rb
@@ -29,8 +29,8 @@ class FindApplicationChoicesWithOutOfDateProviderIds
     COMPARE_ARRAYS_AS_SETS
 
     ApplicationChoice
-      .with(extended: with_course_joins.select(get_expected_provider_ids_sql))
-      .joins('INNER JOIN extended ON application_choices.id = extended.id')
+      .with(with_expected_provider_ids: with_course_joins.select(get_expected_provider_ids_sql))
+      .joins('INNER JOIN with_expected_provider_ids ON application_choices.id = with_expected_provider_ids.id')
       .where(provider_ids_do_not_match_sql)
       .select('application_choices.*, expected_provider_ids')
   end

--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -9,6 +9,7 @@ class DetectInvariantsDailyCheck
     detect_submitted_applications_with_more_than_two_selected_references
     detect_applications_submitted_with_the_same_course
     detect_submitted_applications_with_more_than_three_course_choices
+    detect_application_choices_with_out_of_date_provider_ids
     detect_obsolete_feature_flags
   end
 
@@ -142,6 +143,15 @@ class DetectInvariantsDailyCheck
     end
   end
 
+  def detect_application_choices_with_out_of_date_provider_ids
+    out_of_date_choices = FindApplicationChoicesWithOutOfDateProviderIds.call
+
+    if out_of_date_choices.present?
+      message = out_of_date_choices.map(&:id).join(', ')
+      Sentry.capture_exception(ApplicationChoicesWithOutOfDateProviderIds.new(message))
+    end
+  end
+
   def detect_obsolete_feature_flags
     feature_names = FeatureFlag::FEATURES.map(&:first)
     obsolete_features = Feature.where.not(name: feature_names)
@@ -159,6 +169,7 @@ class DetectInvariantsDailyCheck
   class ApplicationSubmittedWithMoreThanTwoSelectedReferences < StandardError; end
   class ApplicationSubmittedWithTheSameCourse < StandardError; end
   class SubmittedApplicationHasMoreThanThreeChoices < StandardError; end
+  class ApplicationChoicesWithOutOfDateProviderIds < StandardError; end
   class ObsoleteFeatureFlags < StandardError; end
 
 private

--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -147,7 +147,7 @@ class DetectInvariantsDailyCheck
     out_of_date_choices = FindApplicationChoicesWithOutOfDateProviderIds.call
 
     if out_of_date_choices.present?
-      message = out_of_date_choices.map(&:id).join(', ')
+      message = "Out-of-date application choices: #{out_of_date_choices.map(&:id).join(', ')}"
       Sentry.capture_exception(ApplicationChoicesWithOutOfDateProviderIds.new(message))
     end
   end

--- a/spec/queries/find_application_choices_with_out_of_date_provider_ids_spec.rb
+++ b/spec/queries/find_application_choices_with_out_of_date_provider_ids_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe FindApplicationChoicesWithOutOfDateProviderIds do
+  let!(:application_choices) { create_list(:application_choice, 3) }
+
+  describe '#call' do
+    it 'returns an empty set if no out-of-date provider_ids are found' do
+      expect(described_class.call).to be_empty
+    end
+
+    it 'returns application choices with empty provider_ids' do
+      empty_ids = application_choices.second
+      empty_ids.update(provider_ids: [])
+      expect(described_class.call).to eq([empty_ids])
+    end
+
+    it 'returns application choices with wrong provider_ids' do
+      wrong_ids = application_choices.second
+      wrong_ids.update(provider_ids: [123456])
+      expect(described_class.call).to eq([wrong_ids])
+    end
+
+    it 'does not mind if provider_ids are in a different order' do
+      accredited_course = create(:course, :with_accredited_provider)
+      accredited_option = create(:course_option, course: accredited_course)
+      reverse_ids = create(:application_choice, course_option: accredited_option)
+      reverse_ids.update(provider_ids: reverse_ids.provider_ids.reverse)
+      expect(described_class.call).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Context

If changes are made via the rails console or the support interface, the `provider_ids` part of an application choice may not be updated. This means the application may not show up in the applications list or the Vendor API feed.

## Changes proposed in this pull request

Add a daily check to detect this and alert us with a list of application choice ids to be fixed.

## Guidance to review

Very SQL-driven for performance reasons. Processing 48k applications takes about 300ms on a laptop.

## Link to Trello card

https://trello.com/c/ERKKQcaR

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
