### PR TITLE
RevertRejectedByDefault: include DBD changes in audit log

### DIFF
--- a/app/services/revert_rejected_by_default.rb
+++ b/app/services/revert_rejected_by_default.rb
@@ -26,7 +26,7 @@ class RevertRejectedByDefault
             rejected_at: nil,
           )
 
-          application_choice.self_and_siblings.where(status: :offer).update_all(
+          application_choice.self_and_siblings.where(status: :offer).update(
             decline_by_default_at: nil,
             decline_by_default_days: nil,
           )


### PR DESCRIPTION
## Context

We didn't audit the changes to DBD because we used `update_all`, which doesn't run callbacks. This made it difficult to check everything worked (though it did).

## Changes proposed in this pull request

Use `update` instead, beef up specs.