### PR TITLE
Disable log4j2 jndi lookups within jmeter

### DIFF
--- a/jmeter/run.sh
+++ b/jmeter/run.sh
@@ -2,7 +2,8 @@ if [ -z "$JMETER_TARGET_PLAN" ]; then exit 1; fi
 
 bundle exec ruby plans/$JMETER_TARGET_PLAN.rb && \
   bundle exec ruby add_prometheus_xml.rb && \
-    jmeter -Japp=$JMETER_TARGET_APP -Jguid=$CF_INSTANCE_GUID -Jorganisation=dfe \
+    jmeter -Dlog4j2.formatMsgNoLookups=true \
+    -Japp=$JMETER_TARGET_APP -Jguid=$CF_INSTANCE_GUID -Jorganisation=dfe \
     -Jspace=$JMETER_TARGET_APP_SPACE -Jinstance=$CF_INSTANCE_INTERNAL_IP:8080 -Jexported_instance=$CF_INSTANCE_INDEX \
     -Jprometheus.ip=0.0.0.0 -Jprometheus.save.jvm=false \
     -Jprometheus.port=8080 -Jprometheus.delay=120 -n -t testplan.jmx


### PR DESCRIPTION
## Context

~toaster~ JMeter

See https://www.ubik-ingenierie.com/blog/jmeter-log4j-vulnerability/

![image](https://user-images.githubusercontent.com/107591/146359868-00c2594a-aca6-411b-bb3b-df85d14fcb52.png)

## Changes proposed in this pull request

Low-priority, but why not?

Disable the source of log4shell vulnerability, log4j2 jndi lookups.
