### PR TITLE
Upload "last run" coverage artifact from main branch

### DIFF
--- a/.github/scripts/simplecov_collate.rb
+++ b/.github/scripts/simplecov_collate.rb
@@ -2,6 +2,6 @@ require 'simplecov'
 
 SimpleCov.root '/app'
 
-SimpleCov.collate Dir['*-result/.resultset.json'], 'rails' do
+SimpleCov.collate Dir['*-coverage/.resultset.json'], 'rails' do
   enable_coverage :branch
 end

--- a/.github/scripts/simplecov_collate.rb
+++ b/.github/scripts/simplecov_collate.rb
@@ -2,8 +2,6 @@ require 'simplecov'
 
 SimpleCov.root '/app'
 
-SimpleCov.start do
+SimpleCov.collate Dir['*-result/.resultset.json'], 'rails' do
   enable_coverage :branch
 end
-
-SimpleCov.collate Dir['*-result/.resultset.json']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,6 +202,7 @@ jobs:
         env:
           INCLUDE_PATTERN: ${{ matrix.include-pattern }}
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern || ' ' }}
+          TEST_MATRIX_NODE_NAME: ${{ matrix.tests }}
           DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
       - name: Read flakey test results
         id: set_flakey_test_results_var

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,19 +215,10 @@ jobs:
           else
             echo "No flakey tests logged"
           fi
-      - name: Upload pull request coverage report
-        if: github.event_name == 'pull_request'
+      - name: Upload coverage report
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.tests }}-head-result
-          path: /app/coverage/.resultset.json
-          retention-days: 1
-
-      - name: Upload main coverage report
-        if: github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.tests }}-base-result
+          name: ${{ matrix.tests }}-coverage
           path: /app/coverage/.resultset.json
           retention-days: 1
 
@@ -265,7 +256,7 @@ jobs:
             const script = require('/home/runner/work/apply-for-teacher-training/apply-for-teacher-training/.github/scripts/comment_on_flakey_specs.js')
             script({github, context})
 
-  collate-coverage:
+  collate-and-compare-coverage:
     name: Collate test coverage reports
     needs: [build, test]
     runs-on: ubuntu-latest
@@ -287,41 +278,24 @@ jobs:
       - name: Collate PR coverage results
         run: bundle exec ruby .github/scripts/simplecov_collate.rb
 
-      - name: Replace compound command name with 'RSpec'
-        run: sed -i 's/"RSpec-.*"/"RSpec"/' coverage/.resultset.json
-
-      - name: Upload collated pull request coverage report
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v2
-        with:
-          name: head-result
-          path: coverage/.resultset.json
-          retention-days: 1
-
       - name: Upload collated main branch coverage report
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v2
         with:
-          name: base-result
-          path: coverage/.resultset.json
+          name: base-coverage
+          path: coverage/.last_run.json
           retention-days: 5
 
       - name: Delete test matrix coverage artifacts
         uses: geekyeggo/delete-artifact@v1
         with:
           name: |
-            unit_shared-base-result
-            unit_candidate-provider-base-result
-            unit_support-referee-api-base-result
-            integration_shared-base-result
-            integration_provider-base-result
-            integration_candidate-base-result
-            unit_shared-head-result
-            unit_candidate-provider-head-result
-            unit_support-referee-api-head-result
-            integration_shared-head-result
-            integration_provider-head-result
-            integration_candidate-head-result
+            unit_shared-coverage
+            unit_candidate-provider-coverage
+            unit_support-referee-api-coverage
+            integration_shared-coverage
+            integration_provider-coverage
+            integration_candidate-coverage
 
   trigger-deployment:
     name: Trigger Deployment

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,12 +21,13 @@ SimpleCov.formatters = [
   SimpleCov::Formatter::CoberturaFormatter,
 ]
 
-# Give each coverage report a unique ID if we are running parallel tests
-if ENV['TEST_ENV_NUMBER']
-  SimpleCov.command_name("RSpec-#{SecureRandom.hex(4)}")
-else
-  SimpleCov.command_name('RSpec')
-end
+# Give each coverage object a unique ID based on the matrix name and number from parallel tests
+command_name = 'RSpec'
+command_name += "-#{ENV['TEST_MATRIX_NODE_NAME']}"      if ENV['TEST_MATRIX_NODE_NAME']
+command_name += "-#{ENV['DEFAULT_FEATURE_FLAG_STATE']}" if ENV['DEFAULT_FEATURE_FLAG_STATE']
+command_name += "-#{ENV['TEST_ENV_NUMBER']}"            if ENV['TEST_ENV_NUMBER']
+
+SimpleCov.command_name(command_name)
 
 SimpleCov.start 'rails' do
   enable_coverage :branch


### PR DESCRIPTION
## Context

In order to make code coverage comparisons with main branch we need data from the last main branch build.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Uploads SimpleCov's `.last_run.json` artifact from main branch builds.
- Simplifies artifact naming for test matrix coverage reports (changing `-base|head-result` suffix to `-coverage`)
- Uses test matrix and process vars where applicable to build `SimpleCov#command name` (this helps when collating results).
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

No artifact will be generated on this PR build as this will only happen on main branch builds.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/G2D7y5XO/4465-%F0%9F%8F%88-improve-testing-and-coverage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
