### PR TITLE
Add some guidance about per_page and since when using pagination

### DIFF
--- a/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
@@ -132,9 +132,39 @@ We will also support requesting a specific minor version via the URL. For exampl
 <p class="govuk-body">
   Pagination has been added to the API through a <code>page</code> parameter as well as a <code>per_page</code> parameter. These parameters are both optional on the <%= govuk_link_to 'GET applications endpoint', '#get-applications' %>. If not supplied, the endpoint will return all records updated since the timestamp passed into the <code>since</code> parameter.
 </p>
+
 <p class="govuk-body">
-To enable pagination for applications two new sections have been added to the response: a <%= govuk_link_to 'links', '#links-object' %> as well as a <%= govuk_link_to 'meta', '#responsemetamultiple-object' %> section. Both sections will always be returned in the API if the pagination parameters are supplied or not. The links section will determine the navigation through the API, and if no pagination is set, only the relevant fields will be populated and it can be ignored. The meta section will hold the API version, the total number of applications listed as well as the timestamp of the API call.
+When using pagination, we recommend setting <code>per_page</code> to <code>50</code> and using overlapping time periods with previous application syncs for the <code>since</code> parameter. One possible strategy could be to always set <code>since</code> to two (or more) syncs ago. For example:
 </p>
+
+<p class="govuk-body">
+First GET /applications: (at time <code>D</code>, using <code>since=B</code>)
+<pre>
+A     --->    B    --->    C    --->    D    --->    E
+                           |            |
+                       last sync       now
+------------------------------------------------------
+since:                     A            B
+
+</pre>
+</p>
+
+<p class="govuk-body">
+Second GET /applications: (at time <code>E</code>, using <code>since=C</code>)
+<pre>
+A     --->    B    --->    C    --->    D    --->    E
+                                        |            |
+                                    last sync       now
+-------------------------------------------------------
+since:                                  B            C
+
+</pre>
+</p>
+
+<p class="govuk-body">
+To assist pagination for applications two new sections have been added to the response: a <%= govuk_link_to 'links', '#links-object' %> as well as a <%= govuk_link_to 'meta', '#responsemetamultiple-object' %> section. Both sections will always be returned in the API if the pagination parameters are supplied or not. The links section will determine the navigation through the API, and if no pagination is set, only the relevant fields will be populated and it can be ignored. The meta section will hold the API version, the total number of applications listed as well as the timestamp of the API call.
+</p>
+
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
 
 <h2 class="govuk-heading-l" id="developing">Developing on the API</h2>

--- a/config/vendor_api/v1.1.yml
+++ b/config/vendor_api/v1.1.yml
@@ -45,7 +45,7 @@ paths:
         schema:
           type: integer
       - name: per_page
-        description: Number of records to return per page
+        description: Number of records to return per page (e.g. 50)
         in: query
         required: false
         example: 100


### PR DESCRIPTION
## Context

When paginating while retrieving applications via the Vendor API (by supplying a `per_page` alongside the mandatory `since` param) there is the possibility that applications may be missed, as their location in the list of applications may change between one page of applications and the next. Applications are sorted by the value of `updated_at`, which will be updated with any change to an application, and are returned in reverse chronological order. Our busiest providers seem to be updating around 100 applications per day.

## Changes proposed in this pull request

Add some guidance to minimise the likelihood of any missed applications.

![image](https://user-images.githubusercontent.com/107591/146415534-92ff8dc5-08e0-47cb-8df2-6c89ecbfd011.png)

## Guidance to review

Does it make sense?

## Link to Trello card

https://trello.com/c/ioiLlLzk

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
