### PR TITLE
Allow a margin of 0.5% coverage change before reporting a difference

### DIFF
--- a/.github/scripts/compare_coverage.js
+++ b/.github/scripts/compare_coverage.js
@@ -4,15 +4,24 @@ module.exports = ({github, context}) => {
   const { BASE_COVERAGE_DATA, PR_COVERAGE_DATA } = process.env;
   const BASE_COVERAGE_OBJ = BASE_COVERAGE_DATA.length ? JSON.parse(BASE_COVERAGE_DATA) : NO_DATA;
   const PR_COVERAGE_OBJ = PR_COVERAGE_DATA.length ? JSON.parse(PR_COVERAGE_DATA) : NO_DATA;
+  const DELTA = 0.5;
 
   const compareCoverage = (baseCoverage, prCoverage) => {
     return (baseCoverage == prCoverage) ? 0 : prCoverage - baseCoverage;
   }
 
+  const reportedCoverage = (baseCoverage, prCoverage, difference) => {
+    if (Math.abs(difference) < DELTA) {
+      return baseCoverage;
+    } else {
+      return prCoverage;
+    }
+  }
+
   const emoji = (difference) => {
-    if (difference == 0) {
+    if (Math.abs(difference) < DELTA) {
       return ':left_right_arrow:';
-    } else if (difference > 0) {
+    } else if (difference > DELTA) {
       return ':arrow_up:';
     } else {
       return ':arrow_down:';
@@ -20,11 +29,17 @@ module.exports = ({github, context}) => {
   }
 
   const coverageExplanation = `<details><summary><b>Line vs. Branch coverage</b></summary>
-      <p>Branch coverage concerns itself with whether a particular branch of a condition had been executed. Line coverage on the other hand is only interested in whether a line of code has been executed. This comes in handy for measuring one line conditionals.</p>
-      <p>eg. <code>return if number.odd?</code></p>
-      <p>If all the code in that method was covered you would never know if the guard clause was ever triggered with line coverage as just evaluating the condition marks it as covered.</p>
-    </details>
-  `
+      <p>Branch coverage concerns itself with whether a particular branch of a condition had been executed.<br>
+      Line coverage is only interested in whether a line of code has been executed.<br>
+      This comes in handy for measuring one line conditionals.<br>
+      eg.</p>
+      <p><pre>
+        def do_something_with_even_numbers(number)
+          return if number.odd?
+          ...
+      </pre></p>
+      <p>If all the code in the method was covered you would never know if the guard clause was ever triggered with line coverage as just evaluating the condition marks it as covered.</p>
+    </details>`;
 
   const baseCoverageBranch = BASE_COVERAGE_OBJ.result.branch;
   const prCoverageBranch = PR_COVERAGE_OBJ.result.branch;
@@ -35,8 +50,10 @@ module.exports = ({github, context}) => {
 
   let coverageBody = '<h2>Code Coverage</h2>'
   coverageBody += '<table><thead><tr><th></th><th>Coverage type</th><th>From</th><th>To</th></tr></thead><tbody>';
-  coverageBody += `<tr><td>${emoji(lineDifference)}</td><td>Lines covered</td><td><b>${baseCoverageLine}%</b></td><td><b>${prCoverageLine}%</b></td></tr>`;
-  coverageBody += `<tr><td>${emoji(branchDifference)}</td><td>Branches covered</td><td><b>${baseCoverageBranch}%</b></td><td><b>${prCoverageBranch}%</b></td></tr>`;
+  coverageBody += `<tr><td>${emoji(lineDifference)}</td><td>Lines covered</td><td><b>${baseCoverageLine}%</b></td>`;
+  coverageBody += `<td><b>${reportedCoverage(baseCoverageLine, prCoverageLine, lineDifference)}%</b></td></tr>`;
+  coverageBody += `<tr><td>${emoji(branchDifference)}</td><td>Branches covered</td><td><b>${baseCoverageBranch}%</b></td>`;
+  coverageBody += `<td><b>${reportedCoverage(baseCoverageBranch, prCoverageBranch, branchDifference)}%</b></td></tr>`;
   coverageBody += '</tbody></table><br>';
   coverageBody += coverageExplanation;
 


### PR DESCRIPTION
## Context

We get marginal percentage differences in code coverage which aren't particularly relevant.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds a threshold of 0.5% before we consider coverage changes significant.
- Content changes to coverage explanation for clarity.

 
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/G2D7y5XO/4465-%F0%9F%8F%88-improve-testing-and-coverage

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
