### PR TITLE
Feature flag 'Date of entry into the UK' question

### DIFF
--- a/app/controllers/candidate_interface/personal_details/immigration_entry_date_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/immigration_entry_date_controller.rb
@@ -3,6 +3,10 @@ module CandidateInterface
     class ImmigrationEntryDateController < CandidateInterfaceController
       before_action :redirect_to_dashboard_if_submitted
 
+      # Remove this callback and method when dropping the
+      # `immigration_entry_date` feature flag
+      before_action :check_feature_flag_active
+
       def new
         @form = ImmigrationEntryDateForm.build_from_application(current_application)
       end
@@ -23,6 +27,10 @@ module CandidateInterface
       end
 
     private
+
+      def check_feature_flag_active
+        render_404 unless FeatureFlag.active?(:immigration_entry_date)
+      end
 
       def create_params
         strip_whitespace(

--- a/app/controllers/candidate_interface/personal_details/immigration_status_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/immigration_status_controller.rb
@@ -13,7 +13,13 @@ module CandidateInterface
         )
 
         if @form.save(current_application)
-          redirect_to candidate_interface_immigration_entry_date_path
+          if FeatureFlag.active?(:immigration_entry_date)
+            redirect_to candidate_interface_immigration_entry_date_path
+          elsif LanguagesSectionPolicy.hide?(current_application)
+            redirect_to candidate_interface_personal_details_show_path
+          else
+            redirect_to candidate_interface_languages_path
+          end
         else
           track_validation_error(@form)
           render :new

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -206,7 +206,7 @@ module CandidateInterface
           }
         end
 
-        if @application_form.immigration_entry_date
+        if @application_form.immigration_entry_date && FeatureFlag.active?(:immigration_entry_date)
           rows << {
             key: I18n.t('application_form.personal_details.immigration_entry_date.label'),
             value: formatted_immigration_entry_date,

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -39,6 +39,7 @@ class FeatureFlag
     [:region_from_postcode, 'Uses an external service to find the region code for each candidate using their postcode', 'Steve Hook'],
     [:publish_monthly_statistics, 'Publish monthly statistics at publications/monthly-statistics', 'Duncan Brown'],
     [:draft_vendor_api_specification, 'The specification for Draft Vendor API v1.1', 'Abeer Salameh'],
+    [:immigration_entry_date, 'Extends the restructured_immigration_status feature to include the "Date of entry into the UK" question', 'Steve Hook'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_2022_without_entry_date_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_2022_without_entry_date_spec.rb
@@ -1,11 +1,12 @@
 require 'rails_helper'
 
+# Delete this test when removing `immigration_entry_date` feature flag
 RSpec.describe 'Entering personal details' do
   include CandidateHelper
 
   before do
     FeatureFlag.activate(:restructured_immigration_status)
-    FeatureFlag.activate(:immigration_entry_date)
+    FeatureFlag.deactivate(:immigration_entry_date)
   end
 
   scenario 'I can specify that I need to apply for right to work or study in the UK' do
@@ -74,11 +75,7 @@ RSpec.describe 'Entering personal details' do
     fill_in 'What is your immigration status?', with: 'I have permanent residence'
     click_button t('save_and_continue')
 
-    expect(page).to have_content 'When did you enter the UK?'
-    fill_in 'Day', with: '1'
-    fill_in 'Month', with: '2'
-    fill_in 'Year', with: '2003'
-    click_button t('save_and_continue')
+    expect(page).not_to have_content 'When did you enter the UK?'
 
     expect(page).to have_current_path candidate_interface_personal_details_show_path
     expect(page).to have_content 'Name'
@@ -86,7 +83,7 @@ RSpec.describe 'Entering personal details' do
     expect(page).to have_content 'Pakistani'
     expect(page).to have_content "Do you have the right to work or study in the UK?\nYes"
     expect(page).to have_content "Immigration status\nI have permanent residence"
-    expect(page).to have_content "Date of entry into the UK\n1 February 2003"
+    expect(page).not_to have_content 'Date of entry into the UK'
   end
 
   def and_i_can_change_nationality_to_an_eu_country_with_settled_status
@@ -106,17 +103,13 @@ RSpec.describe 'Entering personal details' do
     choose 'EU settled status'
     click_button t('save_and_continue')
 
-    expect(page).to have_content 'When did you enter the UK?'
-    fill_in 'Day', with: '3'
-    fill_in 'Month', with: '2'
-    fill_in 'Year', with: '2001'
-    click_button t('save_and_continue')
+    expect(page).not_to have_content 'When did you enter the UK?'
 
     expect(page).to have_current_path candidate_interface_personal_details_show_path
     expect(page).to have_content "Nationality\nFrench"
     expect(page).to have_content "Do you have the right to work or study in the UK?\nYes"
     expect(page).to have_content "Immigration status\nEU settled status"
-    expect(page).to have_content "Date of entry into the UK\n3 February 2001"
+    expect(page).not_to have_content 'Date of entry into the UK'
   end
 
   def and_i_can_change_immigration_status


### PR DESCRIPTION
## Context

The new immigration flow is activated by the `restructured_immigration_status` feature flag. We want to be able to activate the 'Date of entry into the UK' question separately (after `restructured_immigration_status` goes live) because it may need further work.

## Changes proposed in this pull request

- [x] Add `immigration_entry_date` feature flag.
- [x] Show/hide the entry date on the summary card of the review page.
- [x] Show/skip the entry date form in the new immigration status flow.
- [x] Duplicate the existing system spec to work with `immigration_entry_date` being both active/inactive.

## Guidance to review

- Is there anything I've missed?
- Do we need other tests here?

## Link to Trello card

https://trello.com/c/rTq2XHGI/4212-separate-when-did-you-enter-the-uk-question-from-the-restructured-immigration-status-feature-flag

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
