### PR TITLE
4204 - Update email templates

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -3,6 +3,8 @@ class CandidateMailer < ApplicationMailer
 
   def application_submitted(application_form)
     @candidate_magic_link = candidate_magic_link(application_form.candidate)
+    @application_choice = application_form.application_choices.first
+    @reject_by_default_date = @application_choice.reject_by_default_at.to_s(:govuk_date)
 
     email_for_candidate(
       application_form,
@@ -11,6 +13,7 @@ class CandidateMailer < ApplicationMailer
 
   def application_submitted_apply_again(application_form)
     @application_choice = application_form.application_choices.first
+    @reject_by_default_date = @application_choice.reject_by_default_at.to_s(:govuk_date)
 
     email_for_candidate(
       application_form,

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -1,13 +1,31 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
-You have submitted an application for:
+<% if @application_form.application_choices.count > 1 %>
+
+  You have submitted an application for:
 
 <% @application_form.application_choices.each do |application_choice| %>
-* <%= application_choice.course_option.course.provider.name %> - <%= application_choice.course_option.course.name %> (<%= application_choice.course_option.course.code %>)
+  * <%= application_choice.course_option.course.provider.name %> - <%= application_choice.course_option.course.name %> (<%= application_choice.course_option.course.code %>)
 <% end %>
 
-Sign in to your account anytime to check the progress of your application:
+<% else %>
+
+  You have submitted an application for <%= @application_choice.course_option.course.name_and_code %> at <%= @application_choice.course_option.course.provider.name %>.
+
+<% end %>
+
+Sign in to your account to check the progress of your application:
 
 <%= @candidate_magic_link %>
 
-If your training provider decides to progress your application, they’ll contact you to organise an interview.
+<% if @application_form.application_choices.count > 1 %>
+
+  If your training providers decide to progress your application, they’ll contact you to organise an interview.
+
+<% else %>
+
+  If your training provider decides to progress your application, they’ll contact you to organise an interview.
+
+<% end %>
+
+They have until <%= @reject_by_default_date %> to make a decision on your application.

--- a/app/views/candidate_mailer/application_submitted_apply_again.text.erb
+++ b/app/views/candidate_mailer/application_submitted_apply_again.text.erb
@@ -1,11 +1,11 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
-You’ve submitted an application for <%= @application_choice.course_option.course.name_and_code %> at <%= @application_choice.course_option.course.provider.name %>.
-
-Your application reference is <%= @application_form.support_reference %>.
+You have submitted an application for <%= @application_choice.course_option.course.name_and_code %> at <%= @application_choice.course_option.course.provider.name %>.
 
 Sign in to your account to check the progress of your application:
 
 <%= candidate_magic_link(@application_form.candidate) %>
 
 If your training provider decides to progress your application, they’ll contact you to organise an interview.
+
+They have until <%= @reject_by_default_date %> to make a decision on your application.

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -34,13 +34,40 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe '.application_submitted' do
+    let(:application_choice) { build_stubbed(:application_choice, reject_by_default_at: 5.days.from_now) }
+    let(:application_form) {
+      build_stubbed(:application_form, first_name: 'Jimbo',
+                                       candidate: candidate,
+                                       application_choices: [application_choice])
+    }
     let(:email) { mailer.application_submitted(application_form) }
 
     it_behaves_like(
       'a mail with subject and content',
       I18n.t!('candidate_mailer.application_submitted.subject'),
-      'intro' => 'You have submitted an application for:',
+      'intro' => 'You have submitted an application for',
       'magic link to authenticate' => 'http://localhost:3000/candidate/sign-in/confirm?token=raw_token',
+      'dynamic paragraph' => 'If your training provider decides to progress your application',
+      'reject_by_default date' => 5.days.from_now.to_s(:govuk_date),
+    )
+  end
+
+  describe '.application_submitted_apply_again' do
+    let(:application_choice) { build_stubbed(:application_choice, reject_by_default_at: 5.days.from_now) }
+    let(:application_form) {
+      build_stubbed(:application_form, first_name: 'Olaji',
+                                       candidate: candidate,
+                                       application_choices: [application_choice])
+    }
+    let(:email) { mailer.application_submitted_apply_again(application_form) }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      I18n.t!('candidate_mailer.application_submitted_apply_again.subject'),
+      'intro' => 'You have submitted an application for',
+      'magic link to authenticate' => 'http://localhost:3000/candidate/sign-in/confirm?token=raw_token',
+      'dynamic paragraph' => 'If your training provider decides to progress your application',
+      'reject_by_default date' => 5.days.from_now.to_s(:govuk_date),
     )
   end
 

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -4,6 +4,7 @@ class CandidateMailerPreview < ActionMailer::Preview
       :completed_application_form,
       candidate: candidate,
       support_reference: 'ABCDEF',
+      application_choices: FactoryBot.build_stubbed_list(:application_choice, 1, :awaiting_provider_decision, course_option: course_option),
     )
 
     CandidateMailer.application_submitted(application_form)

--- a/spec/system/candidate_interface/signup_and_signin/candidate_clicking_on_expired_magic_link_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_clicking_on_expired_magic_link_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature 'Candidate clicks on an expired magic link' do
   def and_i_am_a_candidate_with_an_application
     @candidate = create(:candidate)
     @application_form = create(:application_form, candidate: @candidate)
+    create(:application_choice, application_form: @application_form, reject_by_default_at: 5.days.from_now)
   end
 
   def and_i_received_the_submitted_application_email

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -205,7 +205,7 @@ RSpec.feature 'Candidate submits the application' do
   def and_i_receive_an_email_confirmation
     open_email(current_candidate.email_address)
     expect(current_email).to have_content 'You have submitted an application'
-    expect(current_email).to have_content 'Gorse SCITT - Primary (2XT2)'
+    expect(current_email).to have_content 'Primary (2XT2) at Gorse SCITT'
   end
 
   def and_i_am_redirected_to_the_application_dashboard

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -35,6 +35,9 @@ RSpec.feature 'See an application' do
       :with_gcses,
       references_state: :feedback_requested,
     )
+
+    create(:application_choice, application_form: @completed_application, status: 'unsubmitted')
+
     SubmitApplication.new(@completed_application).call
     @unsubmitted_application = create(:application_form)
     @application_with_reference = create(


### PR DESCRIPTION
## Context

Updates to the content on two of our email templates, this includes the addition of logic to render different text, dependendent on conditional statements.

## Changes proposed in this pull request

- Update `application_submitted` email template
- Update `application_submitted_apply_again` email template
- Add dynamic content to both of these templates

### Application Submitted (Before)

<img width="664" alt="image" src="https://user-images.githubusercontent.com/50492247/146540941-c68e66b8-7dc7-4ee9-bd73-3c4358136a8d.png">

### Application Submitted (After)
<img width="535" alt="image" src="https://user-images.githubusercontent.com/50492247/147085812-a5a1eb95-966d-4aa0-bac9-2ea7645037cc.png">

### Application Submitted (multiple courses)(After)

<img width="517" alt="image" src="https://user-images.githubusercontent.com/50492247/146932117-8c3e07c5-b368-4433-8f71-5af737c044b9.png">

### Application Submitted Apply Again (Before)

<img width="623" alt="image" src="https://user-images.githubusercontent.com/50492247/146541001-1b8479e1-06ff-4655-baf5-47621d42072c.png">


### Application Submitted Apply Again(After)

<img width="533" alt="image" src="https://user-images.githubusercontent.com/50492247/146932159-a49ba3fe-aacf-4ed7-bf30-3ba6daef1a72.png">


## Guidance to review

- Could `application_form.application_choices` ever be `nil` at the point that this email is fired? 🤔 
- Could `reject_by_default_at`ever be `nil` at the point that this email is fired? 🤔 

- You can view the new Application Submitted email [here](https://apply-for-te-4204-chang-17flie.herokuapp.com/rails/mailers/candidate_mailer/application_submitted).
- You can view the new Application Submitted Apply Again [here](https://apply-for-te-4204-chang-17flie.herokuapp.com/rails/mailers/candidate_mailer/application_submitted_apply_again).