### PR TITLE
Add CONFIRM_PRODUCTION flag to clock removal

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -191,6 +191,7 @@ jobs:
           make ${{ matrix.environment }} ci delete-clock
         env:
           PR_NUMBER:                ${{ env.PR_NUMBER }}
+          CONFIRM_PRODUCTION: true
 
       - name: Terraform init, plan & apply
         run: make ${{ matrix.environment }} ci deploy


### PR DESCRIPTION
## Context

The delete-clock target won't run without the CONFIRM_PRODUCTION tag. This commit adds it to ensure that the task will run in sandbox and production.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

`CONFIRM_PRODUCTION: true` is now set for clock removal.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/EcjwNoMf/474-apply-clean-up-cloud-foundry-routing

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
