### PR TITLE
Display count of deferred apps on monthly stats

### DIFF
--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -32,12 +32,18 @@ module Publications
       redirect_to root_path unless FeatureFlag.active?(:publish_monthly_statistics)
     end
 
+    def valid_date?
+      params[:date] == '2021-11'
+    end
+
     def calculate_download_sizes(report)
       report.statistics.map do |k, raw_data|
+        next unless raw_data.is_a?(Hash)
+
         header_row = raw_data['rows'].first.keys
         data = SafeCSV.generate(raw_data['rows'].map(&:values), header_row)
         [k, data.size]
-      end
+      end.compact
     end
   end
 end

--- a/app/models/publications/monthly_statistics/deferred_applications.rb
+++ b/app/models/publications/monthly_statistics/deferred_applications.rb
@@ -1,0 +1,13 @@
+module Publications
+  module MonthlyStatistics
+    class DeferredApplications
+      def count
+        ApplicationForm
+          .joins(:application_choices)
+          .where('application_choices.current_recruitment_cycle_year > application_forms.recruitment_cycle_year')
+          .distinct('application_forms.id')
+          .count
+      end
+    end
+  end
+end

--- a/app/models/publications/monthly_statistics/monthly_statistics_report.rb
+++ b/app/models/publications/monthly_statistics/monthly_statistics_report.rb
@@ -24,6 +24,15 @@ module Publications
         load_applications_by_provider_area
       end
 
+      def deferred_application_count
+        @deferred_application_count ||=
+          ApplicationForm.
+            joins(:application_choices).
+            where('application_choices.current_recruitment_cycle_year > application_forms.recruitment_cycle_year').
+            distinct('application_forms.id').
+            count
+      end
+
     private
 
       def load_by_course_age_group

--- a/app/models/publications/monthly_statistics/monthly_statistics_report.rb
+++ b/app/models/publications/monthly_statistics/monthly_statistics_report.rb
@@ -22,15 +22,7 @@ module Publications
         load_applications_by_primary_specialist_subject
         load_applications_by_secondary_subject
         load_applications_by_provider_area
-      end
-
-      def deferred_application_count
-        @deferred_application_count ||=
-          ApplicationForm.
-            joins(:application_choices).
-            where('application_choices.current_recruitment_cycle_year > application_forms.recruitment_cycle_year').
-            distinct('application_forms.id').
-            count
+        load_deferred_applications_count
       end
 
     private
@@ -102,6 +94,13 @@ module Publications
         write_statistic(
           :by_provider_area,
           Publications::MonthlyStatistics::ByProviderArea.new.table_data,
+        )
+      end
+
+      def load_deferred_applications_count
+        write_statistic(
+          :deferred_applications_count,
+          Publications::MonthlyStatistics::DeferredApplications.new.count,
         )
       end
     end

--- a/app/presenters/publications/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/monthly_statistics_presenter.rb
@@ -35,5 +35,9 @@ module Publications
     def exports
       MonthlyStatisticsTimetable.current_exports
     end
+
+    def deferred_applications_count
+      report.statistics['deferred_applications_count'] || 0
+    end
   end
 end

--- a/app/presenters/publications/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/monthly_statistics_presenter.rb
@@ -6,7 +6,7 @@ module Publications
       self.report = report
     end
 
-    delegate :statistics, :month, to: :report
+    delegate :statistics, :deferred_application_count, :month, to: :report
 
     def next_cycle_name
       RecruitmentCycle.cycle_name(CycleTimetable.next_year)

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -293,11 +293,11 @@
 
     <p class="govuk-body">The Apply for teacher training service is the sole service for postgraduate Initial Teacher Training (ITT) applications in England to Higher Education Institution (HEI), School Centred Initial Teacher Training (SCITT)-based, School Direct, School Direct (salaried) and Teaching Apprenticeship courses.</p>
 
-    <% if @presenter.deferred_applications_count.zero? %>
-      <p class="govuk-body">
-        Deferred candidates are counted in a separate column in the tables.
-      </p>
+    <p class="govuk-body">
+      Deferred candidates are counted in a separate column in the tables.
+    </p>
 
+    <% if @presenter.deferred_applications_count.zero? %>
       <p class="govuk-body">
         They’re counted in the statistics report for the academic year in which they start their training after their offer is re-confirmed, as well as the year in which they apply.
       </p>
@@ -306,16 +306,9 @@
         This means that anyone who applied this year but deferring until next year will be counted in next year’s report, as well as this one.
       </p>
 
+    <% else %>
       <p class="govuk-body">
-        Deferred candidates are counted in the academic year in which they start their course after training providers have re-confirmed their deferred offer. Providers need to do this before candidates intend to start their training.
-      </p>
-    <% elsif @presenter.deferred_applications_count == 1 %>
-      <p class="govuk-body">
-        Deferred candidates are counted in a separate column in the tables.
-      </p>
-
-      <p class="govuk-body">
-        There is one deferred candidate in this data report that was also counted in last year’s publication by UCAS.
+        There <%= 'is'.pluralize(@presenter.deferred_applications_count) %> <%= pluralize(@presenter.deferred_applications_count, 'deferred candidate') %> in this data report that <%= 'was'.pluralize(@presenter.deferred_applications_count) %> also counted in last year’s publication by UCAS.
       </p>
 
       <p class="govuk-body">
@@ -328,35 +321,11 @@
 
       <p class="govuk-body">
         Anyone who applied this year but deferring until next year will be counted in next year’s report, as well as this one.
-      </p>
-
-      <p class="govuk-body">
-        Deferred candidates are counted in the academic year in which they start their course after training providers have re-confirmed their deferred offer. Providers need to do this before candidates intend to start their training. 
-      </p>
-    <% elsif @presenter.deferred_applications_count > 1 %>
-      <p class="govuk-body">
-        Deferred candidates are counted in a separate column in the tables.
-      </p>
-
-      <p class="govuk-body">
-        There are <%= pluralize(@presenter.deferred_applications_count, 'deferred candidate') %> in this data report that were also counted in last year’s publication by UCAS.
-      </p>
-
-      <p class="govuk-body">
-        This is because UCAS counted deferred candidates in the statistics report for the academic year in which they applied, rather than the year in which they start training.
-      </p>
-
-      <p class="govuk-body">
-        This report, on the other hand, counts deferred candidates in the year in which they start their training, as well as the year in which they apply.
-      </p>
-
-      <p class="govuk-body">
-        Anyone who applied this year but deferring until next year will be counted in next year’s report, as well as this one.
-      </p>
-
-      <p class="govuk-body">
-        Deferred candidates are counted in the academic year in which they start their course after training providers have re-confirmed their deferred offer. Providers need to do this before candidates intend to start their training.
       </p>
     <% end %>
+
+    <p class="govuk-body">
+      Deferred candidates are counted in the academic year in which they start their course after training providers have re-confirmed their deferred offer. Providers need to do this before candidates intend to start their training.
+    </p>
   </div>
 </div>

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -307,7 +307,7 @@
       </p>
 
       <p class="govuk-body">
-        Deferred candidates are only counted in the academic year that they start their course in once training providers re-confirm their deferred offer. Providers need to do this before candidates intend to start their training.
+        Deferred candidates are counted in the academic year in which they start their course after training providers have re-confirmed their deferred offer. Providers need to do this before candidates intend to start their training.
       </p>
     <% elsif @presenter.deferred_applications_count == 1 %>
       <p class="govuk-body">
@@ -331,7 +331,7 @@
       </p>
 
       <p class="govuk-body">
-        Deferred candidates are only counted once training providers re-confirm their deferred offer. Providers need to do this before candidates intend to start their training. 
+        Deferred candidates are counted in the academic year in which they start their course after training providers have re-confirmed their deferred offer. Providers need to do this before candidates intend to start their training. 
       </p>
     <% elsif @presenter.deferred_applications_count > 1 %>
       <p class="govuk-body">
@@ -355,7 +355,7 @@
       </p>
 
       <p class="govuk-body">
-        Deferred candidates are only counted once training providers re-confirm their deferred offer. Providers need to do this before candidates intend to start their training.
+        Deferred candidates are counted in the academic year in which they start their course after training providers have re-confirmed their deferred offer. Providers need to do this before candidates intend to start their training.
       </p>
     <% end %>
   </div>

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -293,12 +293,70 @@
 
     <p class="govuk-body">The Apply for teacher training service is the sole service for postgraduate Initial Teacher Training (ITT) applications in England to Higher Education Institution (HEI), School Centred Initial Teacher Training (SCITT)-based, School Direct, School Direct (salaried) and Teaching Apprenticeship courses.</p>
 
-    <p class="govuk-body">
-      <% if @presenter.deferred_applications_count == 1 %>
-        There is 1 candidate in the tables that was counted in last year’s publication by UCAS, as previous UCAS publications have included deferred candidates (who would not be starting their courses in the 2022 to 2023 academic year) in the totals.
-      <% elsif @presenter.deferred_applications_count > 1 %>
-        There are <%= pluralize(@presenter.deferred_applications_count, 'candidate') %> in the tables that were counted in last year’s publication by UCAS, as previous UCAS publications have included deferred candidates (who would not be starting their courses in the 2022 to 2023 academic year) in the totals.
-      <% end %>
-      Deferred candidates are included in their own column here. They will also be counted in future tables for the academic year that they intend to start their course, once the provider reconfirms their application.</p>
+    <% if @presenter.deferred_applications_count.zero? %>
+      <p class="govuk-body">
+        Deferred candidates are counted in a separate column in the tables.
+      </p>
+
+      <p class="govuk-body">
+        They’re counted in the statistics report for the academic year in which they start their training after their offer is re-confirmed, as well as the year in which they apply.
+      </p>
+
+      <p class="govuk-body">
+        This means that anyone who applied this year but deferring until next year will be counted in next year’s report, as well as this one.
+      </p>
+
+      <p class="govuk-body">
+        Deferred candidates are only counted in the academic year that they start their course in once training providers re-confirm their deferred offer. Providers need to do this before candidates intend to start their training.
+      </p>
+    <% elsif @presenter.deferred_applications_count == 1 %>
+      <p class="govuk-body">
+        Deferred candidates are counted in a separate column in the tables.
+      </p>
+
+      <p class="govuk-body">
+        There is one deferred candidate in this data report that was also counted in last year’s publication by UCAS.
+      </p>
+
+      <p class="govuk-body">
+        This is because UCAS counted deferred candidates in the statistics report for the academic year in which they applied, rather than the year in which they start training.
+      </p>
+
+      <p class="govuk-body">
+        This report, on the other hand, counts deferred candidates in the year in which they start their training, as well as the year in which they apply.
+      </p>
+
+      <p class="govuk-body">
+        Anyone who applied this year but deferring until next year will be counted in next year’s report, as well as this one.
+      </p>
+
+      <p class="govuk-body">
+        Deferred candidates are only counted once training providers re-confirm their deferred offer. Providers need to do this before candidates intend to start their training. 
+      </p>
+    <% elsif @presenter.deferred_applications_count > 1 %>
+      <p class="govuk-body">
+        Deferred candidates are counted in a separate column in the tables.
+      </p>
+
+      <p class="govuk-body">
+        There are <%= pluralize(@presenter.deferred_applications_count, 'deferred candidate') %> in this data report that were also counted in last year’s publication by UCAS.
+      </p>
+
+      <p class="govuk-body">
+        This is because UCAS counted deferred candidates in the statistics report for the academic year in which they applied, rather than the year in which they start training.
+      </p>
+
+      <p class="govuk-body">
+        This report, on the other hand, counts deferred candidates in the year in which they start their training, as well as the year in which they apply.
+      </p>
+
+      <p class="govuk-body">
+        Anyone who applied this year but deferring until next year will be counted in next year’s report, as well as this one.
+      </p>
+
+      <p class="govuk-body">
+        Deferred candidates are only counted once training providers re-confirm their deferred offer. Providers need to do this before candidates intend to start their training.
+      </p>
+    <% end %>
   </div>
 </div>

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -294,10 +294,10 @@
     <p class="govuk-body">The Apply for teacher training service is the sole service for postgraduate Initial Teacher Training (ITT) applications in England to Higher Education Institution (HEI), School Centred Initial Teacher Training (SCITT)-based, School Direct, School Direct (salaried) and Teaching Apprenticeship courses.</p>
 
     <p class="govuk-body">
-      <% if @presenter.deferred_application_count == 1 %>
-        There is 1 candidate in the tables that was counted in last year’s publication by UCAS, as previous UCAS publications have included deferred candidates (who would not be starting their courses in the 2022 to 2023 academic year) in the totals. 
-      <% elsif @presenter.deferred_application_count > 1 %>
-        There are <%= pluralize(@presenter.deferred_application_count, 'candidate') %> in the tables that were counted in last year’s publication by UCAS, as previous UCAS publications have included deferred candidates (who would not be starting their courses in the 2022 to 2023 academic year) in the totals. 
+      <% if @presenter.deferred_applications_count == 1 %>
+        There is 1 candidate in the tables that was counted in last year’s publication by UCAS, as previous UCAS publications have included deferred candidates (who would not be starting their courses in the 2022 to 2023 academic year) in the totals.
+      <% elsif @presenter.deferred_applications_count > 1 %>
+        There are <%= pluralize(@presenter.deferred_applications_count, 'candidate') %> in the tables that were counted in last year’s publication by UCAS, as previous UCAS publications have included deferred candidates (who would not be starting their courses in the 2022 to 2023 academic year) in the totals.
       <% end %>
       Deferred candidates are included in their own column here. They will also be counted in future tables for the academic year that they intend to start their course, once the provider reconfirms their application.</p>
   </div>

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -293,6 +293,12 @@
 
     <p class="govuk-body">The Apply for teacher training service is the sole service for postgraduate Initial Teacher Training (ITT) applications in England to Higher Education Institution (HEI), School Centred Initial Teacher Training (SCITT)-based, School Direct, School Direct (salaried) and Teaching Apprenticeship courses.</p>
 
-    <p class="govuk-body">There are 35 candidates in the tables that were counted in last year’s publication by UCAS, as previous UCAS publications have included deferred candidates (who would not be starting their courses in the 2022 to 2023 academic year) in the totals. Deferred candidates are included in their own column here. They will also be counted in future tables for the academic year that they intend to start their course, once the provider reconfirms their application.</p>
+    <p class="govuk-body">
+      <% if @presenter.deferred_application_count == 1 %>
+        There is 1 candidate in the tables that was counted in last year’s publication by UCAS, as previous UCAS publications have included deferred candidates (who would not be starting their courses in the 2022 to 2023 academic year) in the totals. 
+      <% elsif @presenter.deferred_application_count > 1 %>
+        There are <%= pluralize(@presenter.deferred_application_count, 'candidate') %> in the tables that were counted in last year’s publication by UCAS, as previous UCAS publications have included deferred candidates (who would not be starting their courses in the 2022 to 2023 academic year) in the totals. 
+      <% end %>
+      Deferred candidates are included in their own column here. They will also be counted in future tables for the academic year that they intend to start their course, once the provider reconfirms their application.</p>
   </div>
 </div>

--- a/config/initializers/inflector.rb
+++ b/config/initializers/inflector.rb
@@ -9,4 +9,5 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.irregular 'provider_permissions', 'provider_permissions'
   inflect.irregular 'has', 'have'
   inflect.irregular 'was', 'were'
+  inflect.irregular 'is', 'are'
 end

--- a/spec/models/publications/monthly_statistics/deferred_applications_spec.rb
+++ b/spec/models/publications/monthly_statistics/deferred_applications_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Publications::MonthlyStatistics::DeferredApplications do
+  describe '#count' do
+    around do |example|
+      ApplicationForm.with_unsafe_application_choice_touches { example.run }
+    end
+
+    it 'returns the correct value' do
+      create(
+        :completed_application_form,
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+        application_choices: [
+          create(
+            :application_choice,
+            :pending_conditions,
+            current_recruitment_cycle_year: RecruitmentCycle.current_year,
+          ),
+        ],
+      )
+      create(
+        :completed_application_form,
+        recruitment_cycle_year: RecruitmentCycle.previous_year,
+        application_choices: [
+          create(
+            :application_choice,
+            :pending_conditions,
+            current_recruitment_cycle_year: RecruitmentCycle.current_year,
+          ),
+        ],
+      )
+      expect(described_class.new.count).to be(1)
+    end
+  end
+end

--- a/spec/models/publications/monthly_statistics/monthly_statistics_report_spec.rb
+++ b/spec/models/publications/monthly_statistics/monthly_statistics_report_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Publications::MonthlyStatistics::MonthlyStatisticsReport do
       by_age_group_monthly_statistics_double = instance_double(Publications::MonthlyStatistics::ByAgeGroup)
       applications_by_secondary_subject_double = instance_double(Publications::MonthlyStatistics::BySecondarySubject)
       applications_by_provider_area_double = instance_double(Publications::MonthlyStatistics::ByProviderArea)
+      deferred_applications_double = instance_double(Publications::MonthlyStatistics::DeferredApplications)
 
       table_data = [{ 'foo' => 'bar' }]
 
@@ -70,6 +71,7 @@ RSpec.describe Publications::MonthlyStatistics::MonthlyStatisticsReport do
       allow(Publications::MonthlyStatistics::ByAgeGroup).to receive(:new).and_return(by_age_group_monthly_statistics_double)
       allow(Publications::MonthlyStatistics::BySecondarySubject).to receive(:new).and_return(applications_by_secondary_subject_double)
       allow(Publications::MonthlyStatistics::ByProviderArea).to receive(:new).and_return(applications_by_provider_area_double)
+      allow(Publications::MonthlyStatistics::DeferredApplications).to receive(:new).and_return(deferred_applications_double)
 
       allow(course_age_group_monthly_statistics_double).to receive(:table_data).and_return(table_data)
       allow(area_monthly_statistics_double).to receive(:table_data).and_return(table_data)
@@ -81,6 +83,7 @@ RSpec.describe Publications::MonthlyStatistics::MonthlyStatisticsReport do
       allow(by_age_group_monthly_statistics_double).to receive(:table_data).and_return(table_data)
       allow(applications_by_secondary_subject_double).to receive(:table_data).and_return(table_data)
       allow(applications_by_provider_area_double).to receive(:table_data).and_return(table_data)
+      allow(deferred_applications_double).to receive(:count).and_return(57)
 
       report = described_class.new
       report.load_table_data
@@ -96,39 +99,8 @@ RSpec.describe Publications::MonthlyStatistics::MonthlyStatisticsReport do
         'by_age_group' => table_data,
         'by_secondary_subject' => table_data,
         'by_provider_area' => table_data,
+        'deferred_applications_count' => 57,
       )
-    end
-  end
-
-  describe '#deferred_application_count' do
-    around do |example|
-      ApplicationForm.with_unsafe_application_choice_touches { example.run }
-    end
-
-    it 'returns the correct value' do
-      create(
-        :completed_application_form,
-        recruitment_cycle_year: RecruitmentCycle.current_year,
-        application_choices: [
-          create(
-            :application_choice,
-            :pending_conditions,
-            current_recruitment_cycle_year: RecruitmentCycle.current_year,
-          )
-        ]
-      )
-      create(
-        :completed_application_form,
-        recruitment_cycle_year: RecruitmentCycle.previous_year,
-        application_choices: [
-          create(
-            :application_choice,
-            :pending_conditions,
-            current_recruitment_cycle_year: RecruitmentCycle.current_year,
-          )
-        ]
-      )
-      expect(subject.deferred_application_count).to be(1)
     end
   end
 end

--- a/spec/models/publications/monthly_statistics/monthly_statistics_report_spec.rb
+++ b/spec/models/publications/monthly_statistics/monthly_statistics_report_spec.rb
@@ -99,4 +99,36 @@ RSpec.describe Publications::MonthlyStatistics::MonthlyStatisticsReport do
       )
     end
   end
+
+  describe '#deferred_application_count' do
+    around do |example|
+      ApplicationForm.with_unsafe_application_choice_touches { example.run }
+    end
+
+    it 'returns the correct value' do
+      create(
+        :completed_application_form,
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+        application_choices: [
+          create(
+            :application_choice,
+            :pending_conditions,
+            current_recruitment_cycle_year: RecruitmentCycle.current_year,
+          )
+        ]
+      )
+      create(
+        :completed_application_form,
+        recruitment_cycle_year: RecruitmentCycle.previous_year,
+        application_choices: [
+          create(
+            :application_choice,
+            :pending_conditions,
+            current_recruitment_cycle_year: RecruitmentCycle.current_year,
+          )
+        ]
+      )
+      expect(subject.deferred_application_count).to be(1)
+    end
+  end
 end

--- a/spec/presenters/publications/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/monthly_statistics_presenter_spec.rb
@@ -5,9 +5,11 @@ RSpec.describe Publications::MonthlyStatisticsPresenter do
     Timecop.freeze(Date.new(2021, 12, 1)) { example.run }
   end
 
+  let(:statistics) { {} }
   let(:report) do
     instance_double(
       Publications::MonthlyStatistics::MonthlyStatisticsReport,
+      statistics: statistics,
       created_at: Date.new(2021, 11, 23),
     )
   end
@@ -47,6 +49,22 @@ RSpec.describe Publications::MonthlyStatisticsPresenter do
   describe '#current_reporting_period' do
     it 'returns the date range for the current reporting period' do
       expect(presenter.current_reporting_period).to eq('12 October 2021 to 23 November 2021')
+    end
+  end
+
+  describe '#deferred_applications_count' do
+    context 'when no data is available' do
+      it 'returns 0' do
+        expect(presenter.deferred_applications_count).to eq(0)
+      end
+    end
+
+    context 'when a count is available' do
+      let(:statistics) { { deferred_applications_count: 37 }.with_indifferent_access }
+
+      it 'returns the correct count' do
+        expect(presenter.deferred_applications_count).to eq(37)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

The deferred applications counter in the _Footnote_ section of the monthly statistics report is hard-coded. This PR adds a helper to `MonthlyStatisticsReport` to calculate the correct number to render.

## Changes proposed in this pull request

- Added MonthlyStatisticsReport#deferred_application_count helper.
- Display this in the view template and handle different cases (0, 1 or
  more deferred applications) with appropriate content.

#### when there are no deferred applications (or data is missing):
<img width="683" alt="image" src="https://user-images.githubusercontent.com/450843/147071365-284dcf74-33fe-415f-8bd4-779a6ecd9352.png">

#### when there is one deferred application:
<img width="683" alt="image" src="https://user-images.githubusercontent.com/450843/147071537-5aa51a3a-dece-4da7-be25-9f51085e09a0.png">

#### when there are multiple deferred application:
<img width="683" alt="image" src="https://user-images.githubusercontent.com/450843/147071798-6dbaa9e8-67b5-4033-88f3-274a8298b17d.png">

## Guidance to review

- Is the query that fetches the number correct? (I found only 1 application in the current cycle that matched).
- Should this number be 'cached' as part of the `MonthlyStatisticsReport` record so that it represents the correct number at the time the report was generated?
- What changes do we need to make to the copy to (a) make it clearer (b) work next year when UCAS wasn't involved in the previous cycle?

## Link to Trello card

https://trello.com/c/Eo5jeO7a/4214-work-out-what-to-do-with-monthly-stats-footnotes

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
