### PR TITLE
Use default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GH_CONTAINER_REGISTRY_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build gems-node-modules Docker Image
         uses: docker/build-push-action@v2
@@ -126,8 +126,8 @@ jobs:
       image: ghcr.io/dfe-digital/apply-teacher-training-gems-node-modules:${{ needs.build.outputs.IMAGE_TAG }}
       options: -a STDOUT -a STDERR -t
       credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GH_CONTAINER_REGISTRY_TOKEN }}
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: ${{ matrix.tests }}
         run: ${{ env.COMMAND }}
@@ -190,8 +190,8 @@ jobs:
     container:
       image: ghcr.io/dfe-digital/apply-teacher-training:${{ needs.build.outputs.IMAGE_TAG }}
       credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GH_CONTAINER_REGISTRY_TOKEN }}
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       env:
         RAILS_ENV: test
         DB_HOSTNAME: postgres


### PR DESCRIPTION
## Context

Rather than using a user based PAT token for container registry actions we should use the default GITHUB_TOKEN secret that is provided by actions.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Move all instances of `GH_CONTAINER_REGISTRY_TOKEN` to `GH_TOKEN` in `build.yml`

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Check if builds still operate as expected.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/PEf8QnKD/463-apply-dependabot-prs-failing
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
