### PR TITLE
Ensure we clear any rejection reasons fields when reverting

### DIFF
--- a/app/services/revert_rejected_by_default.rb
+++ b/app/services/revert_rejected_by_default.rb
@@ -24,6 +24,8 @@ class RevertRejectedByDefault
             status: :awaiting_provider_decision,
             rejected_by_default: false,
             rejected_at: nil,
+            rejection_reason: nil,
+            structured_rejection_reasons: nil,
           )
 
           application_choice.self_and_siblings.where(status: :offer).update(

--- a/spec/services/revert_rejected_by_default_spec.rb
+++ b/spec/services/revert_rejected_by_default_spec.rb
@@ -117,4 +117,18 @@ RSpec.describe RevertRejectedByDefault do
 
     expect(choices.reload.pluck(:status)).to match_array(statuses)
   end
+
+  it 'clears reasons for rejection fields' do
+    form = create(:application_form)
+    rr_choice = create(:application_choice, :with_rejection_by_default, rejection_reason: 'RBD done it', application_form: form)
+    sr4r_choice = create(:application_choice, :with_rejection_by_default, :with_structured_rejection_reasons, application_form: form)
+
+    described_class.new(
+      ids: form.id,
+      new_rbd_date: new_rbd_date,
+    ).call
+
+    expect(rr_choice.reload.rejection_reason).to be nil
+    expect(sr4r_choice.reload.structured_rejection_reasons).to be nil
+  end
 end


### PR DESCRIPTION
## Context

If an application has been rejected and reasons given, the reverting service should clear the fields, this won't happen often as the service is intended for RBD'd applications but there have been instances where the application does have data in one of the rejection reasons fields and this breaks the API presentation.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Make `ApplicationChoice#rejection_reason` and `ApplicationChoice#structured_rejection_reasons` `nil` when extending the RBD date of an application.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
