### PR TITLE
Fix environment check for review apps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,9 +116,9 @@ jobs:
           result-encoding: string
           script: |
 
-            let environmentName = process.env.DEPLOY_ENV;
+            const environmentName = process.env.DEPLOY_ENV;
 
-            github.rest.repos.getEnvironment({
+            const result = await github.rest.repos.getEnvironment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 environment_name: environmentName
@@ -137,6 +137,9 @@ jobs:
                 console.error(err)
 
             });
+
+            console.log(`Setting the task output to ${result}`)
+            return result;
 
       - name: Start ${{ env.DEPLOY_ENV }} Deployment
         if: ${{ always() }}
@@ -203,7 +206,7 @@ jobs:
           CONFIRM_PRODUCTION: true
 
       - name: Seed Review App
-        if:  github.event.inputs.review != '' && steps.review-environment-exists.outputs.result == 'false'
+        if: github.event.inputs.review != '' && steps.review-environment-exists.outputs.result == 'false'
         run: |
           cf ssh apply-review-${PR_NUMBER} -c "export DISABLE_DATABASE_ENVIRONMENT_CHECK=1 && cd /app && /usr/local/bin/bundle exec rake setup_local_dev_data setup_all_provider_relationships"
 


### PR DESCRIPTION
## Context

If the PR environment doesn't exist, we should be seeding the new app. The environment check was being awaited so nothing was being returned from the callbacks.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Await the check then return the variable from the task.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Open a new PR and use the `deploy` label or look at this run: https://github.com/DFE-Digital/apply-for-teacher-training/runs/4587268352?check_suite_focus=true

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/06HGSYUG/477-apply-review-app-seed-condition-not-being-correctly-evaluated
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
