### PR TITLE
Remove account created email

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -1,14 +1,5 @@
 class ProviderMailer < ApplicationMailer
-  layout 'provider_email_with_footer', except: %i[account_created fallback_sign_in_email]
-
-  def account_created(provider_user)
-    @provider_user = provider_user
-
-    provider_notify_email(
-      to: @provider_user.email_address,
-      subject: t('provider_mailer.account_created.subject'),
-    )
-  end
+  layout 'provider_email_with_footer', except: %i[fallback_sign_in_email]
 
   def confirm_sign_in(provider_user, device:)
     @provider_user = provider_user

--- a/app/services/invite_provider_user.rb
+++ b/app/services/invite_provider_user.rb
@@ -16,7 +16,6 @@ class InviteProviderUser
 
   def notify
     lookup_provider_user
-    send_welcome_email
     send_slack_notification
   end
 
@@ -40,10 +39,6 @@ private
 
     response = HTTP.auth(auth_string).post dfe_invite_url, json: request_params
     raise DfeSignInAPIError, response unless response.status.success?
-  end
-
-  def send_welcome_email
-    ProviderMailer.account_created(@provider_user).deliver_later
   end
 
   def send_slack_notification

--- a/app/services/provider_interface/add_user_to_provider.rb
+++ b/app/services/provider_interface/add_user_to_provider.rb
@@ -10,7 +10,7 @@ module ProviderInterface
       @email_address = email_address.downcase
       @first_name = first_name
       @last_name = last_name
-      @permissions = permissions
+      @permissions = permissions.reject(&:empty?)
     end
 
     def call!
@@ -61,7 +61,7 @@ module ProviderInterface
     end
 
     def send_permissions_granted_email(provider_user)
-      ProviderMailer.permissions_granted(provider_user, provider, permissions, actor)
+      ProviderMailer.permissions_granted(provider_user, provider, permissions, actor).deliver_later
     end
   end
 end

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -1,8 +1,6 @@
 en:
   provider_mailer:
     subject: "%{subject} - manage teacher training applications"
-    account_created:
-      subject: Sign in
     confirm_sign_in:
       subject: New sign in
     offer_accepted:

--- a/lib/sandbox_interceptor.rb
+++ b/lib/sandbox_interceptor.rb
@@ -1,5 +1,5 @@
 class SandboxInterceptor
-  PROVIDER_EMAIL_ALLOWLIST = %w[fallback_sign_in_email account_created].freeze
+  PROVIDER_EMAIL_ALLOWLIST = %w[fallback_sign_in_email permissions_granted].freeze
 
   def self.delivering_email(message)
     return unless HostingEnvironment.sandbox_mode?

--- a/spec/lib/sandbox_interceptor_spec.rb
+++ b/spec/lib/sandbox_interceptor_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe SandboxInterceptor do
         expect(message.perform_deliveries).to be true
       end
 
-      it 'still permits account_created' do
-        message = email_with_mailer_and_template_headers('provider_mailer', 'account_created')
+      it 'still permits permissions granted' do
+        message = email_with_mailer_and_template_headers('provider_mailer', 'permissions_granted')
 
         described_class.delivering_email(message)
 

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -9,10 +9,6 @@ class ProviderMailerPreview < ActionMailer::Preview
     )
   end
 
-  def account_created_email
-    ProviderMailer.account_created(provider_user)
-  end
-
   def application_submitted
     ProviderMailer.application_submitted(provider_user, application_choice)
   end

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -29,15 +29,6 @@ RSpec.describe ProviderMailer, type: :mailer do
     end
   end
 
-  describe 'Send account created email' do
-    let(:email) { described_class.account_created(provider_user) }
-
-    it_behaves_like('a mail with subject and content',
-                    'Sign in - manage teacher training applications',
-                    'provider name' => 'Dear Johny English',
-                    'sign in path' => '/provider/sign-in')
-  end
-
   describe 'Send application received email' do
     let(:email) { described_class.application_submitted(provider_user, application_choice) }
 

--- a/spec/services/invite_provider_user_spec.rb
+++ b/spec/services/invite_provider_user_spec.rb
@@ -100,10 +100,6 @@ RSpec.describe InviteProviderUser, sidekiq: true do
       described_class.new(provider_user: provider_user).notify
     end
 
-    it 'queues an email' do
-      expect(ProviderMailer.deliveries.count).to be 1
-    end
-
     it 'sends a slack message' do
       expect_slack_message_with_text(":technologist: Provider user Firstname has been invited to join #{provider.name}")
     end

--- a/spec/system/provider_interface/invite_user_spec.rb
+++ b/spec/system/provider_interface/invite_user_spec.rb
@@ -159,6 +159,8 @@ RSpec.feature 'Provider user invitation' do
 
   def and_the_new_user_gets_an_invitation_email
     open_email('john.smith@example.com')
-    expect(current_email.subject).to have_content t('provider_mailer.account_created.subject')
+    expect(current_email.subject).to have_content I18n.t('provider_mailer.permissions_granted.subject',
+                                                         permissions_granted_by_user: @provider_user.full_name,
+                                                         organisation: @provider.name)
   end
 end

--- a/spec/system/support_interface/adding_a_new_provider_user_spec.rb
+++ b/spec/system/support_interface/adding_a_new_provider_user_spec.rb
@@ -157,6 +157,6 @@ RSpec.feature 'Managing provider users v2' do
 
   def and_the_user_should_be_sent_a_welcome_email
     open_email('harrison@example.com')
-    expect(current_email.subject).to have_content t('provider_mailer.account_created.subject')
+    expect(current_email.subject).to have_content t('provider_mailer.permissions_granted_by_support.subject', organisation: @provider.name)
   end
 end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -35,7 +35,6 @@ RSpec.feature 'Docs' do
 
   def and_it_contains_documentation_for_all_emails
     emails_outside_of_states = %w[
-      provider_mailer-account_created
       provider_mailer-fallback_sign_in_email
       candidate_mailer-apply_again_call_to_action
       candidate_mailer-course_unavailable_notification


### PR DESCRIPTION
## Context

Remove account_created email as new users now receive a permissions granted email instead.

## Link to Trello card

https://trello.com/c/LOvfdhMF/4560-remove-account-created-email

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
