### PR TITLE
Stop multiple PR build triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,17 @@ jobs:
       IMAGE_TAG: ${{ env.IMAGE_TAG }}
       GIT_BRANCH: ${{ env.GIT_BRANCH }}
 
+    if: |-
+
+      ${{
+        !( github.event_name == 'pull_request' && github.event.action=='labeled') ||
+        (
+          github.event_name == 'pull_request' &&
+          github.event.action=='labeled' &&
+          contains(github.event.pull_request.labels.*.name, 'deploy')
+        )
+      }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## Context

PR builds are being triggered multiple times. This is because you get one for the creation of a PR then one per label.. this is mainly problematic for dependabot PRs.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
