### PR TITLE
Add month to monthly statistics report

### DIFF
--- a/db/migrate/20211217113124_add_month_to_monthly_statistics_reports.rb
+++ b/db/migrate/20211217113124_add_month_to_monthly_statistics_reports.rb
@@ -1,0 +1,5 @@
+class AddMonthToMonthlyStatisticsReports < ActiveRecord::Migration[6.1]
+  def change
+    add_column :monthly_statistics_reports, :month, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -506,6 +506,7 @@ ActiveRecord::Schema.define(version: 2021_12_30_112625) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.json "statistics"
+    t.string "month"
   end
 
   create_table "notes", force: :cascade do |t|


### PR DESCRIPTION
## Context
This is the data migration needed for adding month to the `monthly_statistics_report` table.
Separate PR #6226 updates the monthly statistic sidekiq job and backfills data etc to avoid migration issues

## Changes proposed in this pull request
* String month column

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/80DIe2o3/4215-monthly-report-data

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
