### PR TITLE
Monthly report statistics data

### DIFF
--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -1,6 +1,7 @@
 module Publications
   class MonthlyStatisticsController < ApplicationController
     before_action :redirect_unless_published
+    rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
     def show
       @presenter = if params[:month].present?
@@ -16,8 +17,6 @@ module Publications
       @csv_export_types_and_sizes = calculate_download_sizes(@presenter)
       @academic_year_name = RecruitmentCycle.cycle_name(CycleTimetable.next_year)
       @current_cycle_name = RecruitmentCycle.verbose_cycle_name
-    rescue ActiveRecord::RecordNotFound
-      render_404
     end
 
     def download

--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -16,11 +16,11 @@ module Publications
       @csv_export_types_and_sizes = calculate_download_sizes(@presenter)
       @academic_year_name = RecruitmentCycle.cycle_name(CycleTimetable.next_year)
       @current_cycle_name = RecruitmentCycle.verbose_cycle_name
+    rescue ActiveRecord::RecordNotFound
+      render_404
     end
 
     def download
-      return render_404 unless valid_month?
-
       export_type = params[:export_type]
       export_filename = "#{export_type}-#{params[:month]}.csv"
       raw_data = MonthlyStatisticsTimetable.report_for_current_period.statistics[export_type]
@@ -31,10 +31,6 @@ module Publications
 
     def redirect_unless_published
       redirect_to root_path unless FeatureFlag.active?(:publish_monthly_statistics)
-    end
-
-    def valid_month?
-      params[:month] == '2021-11'
     end
 
     def calculate_download_sizes(report)

--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -23,7 +23,7 @@ module Publications
     def download
       export_type = params[:export_type]
       export_filename = "#{export_type}-#{params[:month]}.csv"
-      raw_data = MonthlyStatisticsTimetable.report_for_current_period.statistics[export_type]
+      raw_data = MonthlyStatisticsTimetable.report_for(params[:month]).statistics[export_type]
       header_row = raw_data['rows'].first.keys
       data = SafeCSV.generate(raw_data['rows'].map(&:values), header_row)
       send_data data, filename: export_filename, disposition: :attachment

--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -19,10 +19,10 @@ module Publications
     end
 
     def download
-      return render_404 unless valid_date?
+      return render_404 unless valid_month?
 
       export_type = params[:export_type]
-      export_filename = "#{export_type}-#{params[:date]}.csv"
+      export_filename = "#{export_type}-#{params[:month]}.csv"
       raw_data = MonthlyStatisticsTimetable.report_for_current_period.statistics[export_type]
       header_row = raw_data['rows'].first.keys
       data = SafeCSV.generate(raw_data['rows'].map(&:values), header_row)
@@ -33,8 +33,8 @@ module Publications
       redirect_to root_path unless FeatureFlag.active?(:publish_monthly_statistics)
     end
 
-    def valid_date?
-      params[:date] == '2021-11'
+    def valid_month?
+      params[:month] == '2021-11'
     end
 
     def calculate_download_sizes(report)

--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -3,9 +3,15 @@ module Publications
     before_action :redirect_unless_published
 
     def show
-      @presenter = Publications::MonthlyStatisticsPresenter.new(
-        MonthlyStatisticsTimetable.current_report,
-      )
+      @presenter = if params[:month].present?
+                     Publications::MonthlyStatisticsPresenter.new(
+                       MonthlyStatisticsTimetable.report_for(params[:month]),
+                     )
+                   else
+                     Publications::MonthlyStatisticsPresenter.new(
+                       MonthlyStatisticsTimetable.report_for_current_period,
+                     )
+                   end
       @monthly_statistics_report = MonthlyStatisticsTimetable.current_report
       @statistics = @monthly_statistics_report.statistics
       @report = calculate_download_size

--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -12,7 +12,7 @@ module Publications
                        MonthlyStatisticsTimetable.report_for_current_period,
                      )
                    end
-      @monthly_statistics_report = MonthlyStatisticsTimetable.current_report
+      @monthly_statistics_report = MonthlyStatisticsTimetable.report_for_current_period
       @statistics = @monthly_statistics_report.statistics
       @report = calculate_download_size
       @academic_year_name = RecruitmentCycle.cycle_name(CycleTimetable.next_year)
@@ -24,7 +24,7 @@ module Publications
 
       export_type = params[:export_type]
       export_filename = "#{export_type}-#{params[:date]}.csv"
-      raw_data = MonthlyStatisticsTimetable.current_report.statistics[export_type]
+      raw_data = MonthlyStatisticsTimetable.report_for_current_period.statistics[export_type]
       header_row = raw_data['rows'].first.keys
       data = SafeCSV.generate(raw_data['rows'].map(&:values), header_row)
       send_data data, filename: export_filename, disposition: :attachment

--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -12,9 +12,8 @@ module Publications
                        MonthlyStatisticsTimetable.report_for_current_period,
                      )
                    end
-      @monthly_statistics_report = MonthlyStatisticsTimetable.report_for_current_period
-      @statistics = @monthly_statistics_report.statistics
-      @report = calculate_download_size
+
+      @csv_export_types_and_sizes = calculate_download_sizes(@presenter)
       @academic_year_name = RecruitmentCycle.cycle_name(CycleTimetable.next_year)
       @current_cycle_name = RecruitmentCycle.verbose_cycle_name
     end
@@ -38,8 +37,8 @@ module Publications
       params[:date] == '2021-11'
     end
 
-    def calculate_download_size
-      @monthly_statistics_report.statistics.map do |k, raw_data|
+    def calculate_download_sizes(report)
+      report.statistics.map do |k, raw_data|
         header_row = raw_data['rows'].first.keys
         data = SafeCSV.generate(raw_data['rows'].map(&:values), header_row)
         [k, data.size]

--- a/app/models/publications/monthly_statistics/monthly_statistics_report.rb
+++ b/app/models/publications/monthly_statistics/monthly_statistics_report.rb
@@ -24,6 +24,10 @@ module Publications
         load_applications_by_provider_area
       end
 
+      def set_month
+        self.month = Time.zone.today.strftime('%Y-%m')
+      end
+
     private
 
       def load_by_course_age_group

--- a/app/models/publications/monthly_statistics/monthly_statistics_report.rb
+++ b/app/models/publications/monthly_statistics/monthly_statistics_report.rb
@@ -24,10 +24,6 @@ module Publications
         load_applications_by_provider_area
       end
 
-      def set_month
-        self.month = Time.zone.today.strftime('%Y-%m')
-      end
-
     private
 
       def load_by_course_age_group

--- a/app/presenters/publications/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/monthly_statistics_presenter.rb
@@ -6,7 +6,7 @@ module Publications
       self.report = report
     end
 
-    delegate :statistics, to: :report
+    delegate :statistics, :month, to: :report
 
     def next_cycle_name
       RecruitmentCycle.cycle_name(CycleTimetable.next_year)

--- a/app/services/data_migrations/backfill_monthly_statistics_data.rb
+++ b/app/services/data_migrations/backfill_monthly_statistics_data.rb
@@ -1,0 +1,13 @@
+module DataMigrations
+  class BackfillMonthlyStatisticsData
+    TIMESTAMP = 20211221113405
+    MANUAL_RUN = false
+
+    def change
+      reports_with_unset_months = Publications::MonthlyStatistics::MonthlyStatisticsReport.where(month: nil)
+      reports_with_unset_months.each do |report|
+        report.update(month: report.created_at.strftime('%Y-%m'))
+      end
+    end
+  end
+end

--- a/app/services/data_migrations/backfill_monthly_statistics_data.rb
+++ b/app/services/data_migrations/backfill_monthly_statistics_data.rb
@@ -6,7 +6,14 @@ module DataMigrations
     def change
       reports_with_unset_months = Publications::MonthlyStatistics::MonthlyStatisticsReport.where(month: nil)
       reports_with_unset_months.each do |report|
-        report.update(month: report.created_at.strftime('%Y-%m'))
+        created_at_month = report.created_at.month
+        generation_date_of_created_at_month = MonthlyStatisticsTimetable::GENERATION_DATES[Date::MONTHNAMES[created_at_month]]
+        month = if report.created_at < generation_date_of_created_at_month
+                  MonthlyStatisticsTimetable::GENERATION_DATES[Date::MONTHNAMES[created_at_month - 1]]
+                else
+                  generation_date_of_created_at_month
+                end
+        report.update(month: month.strftime('%Y-%m'))
       end
     end
   end

--- a/app/services/monthly_statistics_timetable.rb
+++ b/app/services/monthly_statistics_timetable.rb
@@ -64,18 +64,19 @@ module MonthlyStatisticsTimetable
     Time.zone.today.between?(generation_date_for_current_month, publish_date_for_current_month)
   end
 
-  def self.current_report
-    return Publications::MonthlyStatistics::MonthlyStatisticsReport.last if Publications::MonthlyStatistics::MonthlyStatisticsReport.count == 1
-
-    in_qa_period? ? report_for_previous_period : report_for_current_period
-  end
-
   def self.report_for_current_period
-    Publications::MonthlyStatistics::MonthlyStatisticsReport.order(:created_at).last
+    publish_date_for_current_month = PUBLISHING_DATES[Date::MONTHNAMES[Time.zone.today.month]]
+    publish_date_for_previous_month = PUBLISHING_DATES[Date::MONTHNAMES[(Time.zone.today - 1.month).month]]
+
+    if publish_date_for_current_month > Time.zone.today
+      Publications::MonthlyStatistics::MonthlyStatisticsReport.where(month: publish_date_for_previous_month.strftime('%Y-%m')).order(created_at: :desc).first
+    else
+      Publications::MonthlyStatistics::MonthlyStatisticsReport.where(month: publish_date_for_current_month.strftime('%Y-%m')).order(created_at: :desc).first
+    end
   end
 
-  def self.report_for_previous_period
-    Publications::MonthlyStatistics::MonthlyStatisticsReport.order(:created_at).last(2).first
+  def self.report_for(month)
+    Publications::MonthlyStatistics::MonthlyStatisticsReport.where(month: month.strftime('%Y-%m')).order(created_at: :desc).first
   end
 
   def self.current_exports

--- a/app/services/monthly_statistics_timetable.rb
+++ b/app/services/monthly_statistics_timetable.rb
@@ -80,7 +80,7 @@ module MonthlyStatisticsTimetable
   end
 
   def self.report_for(month)
-    Publications::MonthlyStatistics::MonthlyStatisticsReport.where(month: month).order(created_at: :desc).first
+    Publications::MonthlyStatistics::MonthlyStatisticsReport.where(month: month).order(created_at: :desc).first!
   end
 
   def self.current_exports

--- a/app/services/monthly_statistics_timetable.rb
+++ b/app/services/monthly_statistics_timetable.rb
@@ -39,6 +39,10 @@ module MonthlyStatisticsTimetable
     Time.zone.today == GENERATION_DATES[Date::MONTHNAMES[Time.zone.today.month]]
   end
 
+  def self.month_to_generate_for
+    GENERATION_DATES[Date::MONTHNAMES[Time.zone.today.month]]
+  end
+
   def self.current_reports_generation_date
     report_date_for_current_month = GENERATION_DATES[Date::MONTHNAMES[Time.zone.today.month]]
 
@@ -69,14 +73,14 @@ module MonthlyStatisticsTimetable
     publish_date_for_previous_month = PUBLISHING_DATES[Date::MONTHNAMES[(Time.zone.today - 1.month).month]]
 
     if publish_date_for_current_month > Time.zone.today
-      Publications::MonthlyStatistics::MonthlyStatisticsReport.where(month: publish_date_for_previous_month.strftime('%Y-%m')).order(created_at: :desc).first
+      report_for(publish_date_for_previous_month.strftime('%Y-%m'))
     else
-      Publications::MonthlyStatistics::MonthlyStatisticsReport.where(month: publish_date_for_current_month.strftime('%Y-%m')).order(created_at: :desc).first
+      report_for(publish_date_for_current_month.strftime('%Y-%m'))
     end
   end
 
   def self.report_for(month)
-    Publications::MonthlyStatistics::MonthlyStatisticsReport.where(month: month.strftime('%Y-%m')).order(created_at: :desc).first
+    Publications::MonthlyStatistics::MonthlyStatisticsReport.where(month: month).order(created_at: :desc).first
   end
 
   def self.current_exports

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -281,7 +281,7 @@
 
     <% @csv_export_types_and_sizes.each do |export_type, size| %>
       <p class='govuk-body'>
-      <%= govuk_link_to t("#{export_type}.label") + " #{size.to_s(:human_size)}", publications_monthly_report_download_path(export_type: export_type, date: '2021-11') %>
+      <%= govuk_link_to t("#{export_type}.label") + " #{size.to_s(:human_size)}", publications_monthly_report_download_path(export_type: export_type, month: @presenter.month, format: :csv) %>
        </p>
     <% end %>
   </div>

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -279,7 +279,7 @@
 
     <p class="govuk-body">You can download all of the data on this page in CSV (comma separated values) format, which can be opened in a spreadsheet and used in other analysis tools.</p>
 
-    <% @report.each do |export_type, size| %>
+    <% @csv_export_types_and_sizes.each do |export_type, size| %>
       <p class='govuk-body'>
       <%= govuk_link_to t("#{export_type}.label") + " #{size.to_s(:human_size)}", publications_monthly_report_download_path(export_type: export_type, date: '2021-11') %>
        </p>

--- a/app/workers/generate_monthly_statistics.rb
+++ b/app/workers/generate_monthly_statistics.rb
@@ -8,6 +8,7 @@ class GenerateMonthlyStatistics
 
     dashboard = Publications::MonthlyStatistics::MonthlyStatisticsReport.new
     dashboard.load_table_data
+    dashboard.set_month
     dashboard.save!
   end
 end

--- a/app/workers/generate_monthly_statistics.rb
+++ b/app/workers/generate_monthly_statistics.rb
@@ -6,9 +6,8 @@ class GenerateMonthlyStatistics
   def perform
     return false unless MonthlyStatisticsTimetable.generate_monthly_statistics?
 
-    dashboard = Publications::MonthlyStatistics::MonthlyStatisticsReport.new
+    dashboard = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: MonthlyStatisticsTimetable.month_to_generate_for.strftime('%Y-%m'))
     dashboard.load_table_data
-    dashboard.set_month
     dashboard.save!
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1170,7 +1170,7 @@ Rails.application.routes.draw do
   get '/check/version', to: 'healthcheck#version'
 
   namespace :publications, path: '/publications' do
-    get '/monthly-statistics' => 'monthly_statistics#show', as: :monthly_report
+    get '/monthly-statistics(/:month)' => 'monthly_statistics#show', as: :monthly_report
     get '/monthly-statistics/:month/:export_type' => 'monthly_statistics#download', as: :monthly_report_download
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1171,7 +1171,7 @@ Rails.application.routes.draw do
 
   namespace :publications, path: '/publications' do
     get '/monthly-statistics' => 'monthly_statistics#show', as: :monthly_report
-    get '/monthly-statistics/:date/:export_type' => 'monthly_statistics#download', as: :monthly_report_download
+    get '/monthly-statistics/:month/:export_type' => 'monthly_statistics#download', as: :monthly_report_download
   end
 
   mount Yabeda::Prometheus::Exporter => '/metrics'

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,6 +1,7 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
   'DataMigrations::DropBlockFraudulentSubmissionFeatureFlag',
+  'DataMigrations::BackfillMonthlyStatisticsData',
   'DataMigrations::FixCandidateAPIUpdatedAt',
   'DataMigrations::BackfillCarriedOverApplicationsDegreesComplete',
   'DataMigrations::BackfillWorkHistoryStatusForCurrentCycle',

--- a/lib/tasks/monthly_report.rake
+++ b/lib/tasks/monthly_report.rake
@@ -14,7 +14,7 @@ EXPORTS = [
 
 desc 'Generate a new MonthlyStatisticsReport as of right now'
 task run_monthly_report: :environment do
-  report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new
+  report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: MonthlyStatisticsTimetable.month_to_generate_for.strftime('%Y-%m'))
   report.load_table_data
   report.save!
 end

--- a/spec/requests/publications/monthly_statistics_spec.rb
+++ b/spec/requests/publications/monthly_statistics_spec.rb
@@ -27,6 +27,9 @@ RSpec.describe 'Monthly Statistics', type: :request do
     end
 
     it 'returns the report for 2021-10' do
+      get '/publications/monthly-statistics/'
+      expect(response).to have_http_status(:ok)
+
       get '/publications/monthly-statistics/2021-10'
       expect(response).to have_http_status(:ok)
 

--- a/spec/requests/publications/monthly_statistics_spec.rb
+++ b/spec/requests/publications/monthly_statistics_spec.rb
@@ -18,6 +18,31 @@ RSpec.describe 'Monthly Statistics', type: :request do
     report.save
   end
 
+  describe 'getting reports for different dates' do
+    before do
+      # assign the current numbers to the 2021-10 report so we can test retrieving that report
+      report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: '2021-10')
+      report.load_table_data
+      report.save
+    end
+
+    it 'returns the report for 2021-10' do
+      get '/publications/monthly-statistics/2021-10'
+      expect(response).to have_http_status(:ok)
+
+      get '/publications/monthly-statistics/2021-11'
+      expect(response).to have_http_status(:ok)
+
+      get '/publications/monthly-statistics/2021-12'
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns application by status csv for 2021-10' do
+      get '/publications/monthly-statistics/2021-10/applications_by_status.csv'
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   it 'returns application by status csv' do
     get '/publications/monthly-statistics/2021-11/applications_by_status.csv'
     expect(response).to have_http_status(:ok)

--- a/spec/requests/publications/monthly_statistics_spec.rb
+++ b/spec/requests/publications/monthly_statistics_spec.rb
@@ -2,11 +2,18 @@ require 'rails_helper'
 
 RSpec.describe 'Monthly Statistics', type: :request do
   include MonthlyStatisticsTestHelper
+
+  around do |example|
+    Timecop.freeze(2021, 11, 29) do
+      example.run
+    end
+  end
+
   before do
     FeatureFlag.activate(:publish_monthly_statistics)
     generate_monthly_statistics_test_data
 
-    report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new
+    report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: '2021-11')
     report.load_table_data
     report.save
   end

--- a/spec/services/data_migrations/backfill_monthly_statistics_data_spec.rb
+++ b/spec/services/data_migrations/backfill_monthly_statistics_data_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillMonthlyStatisticsData do
+  describe 'monthly statistics report data' do
+    it 'update the month for a future report' do
+      Timecop.freeze(Date.new(2022, 1, 21)) do
+        report_with_unset_month = Publications::MonthlyStatistics::MonthlyStatisticsReport.create(month: nil)
+        report_with_set_month = Publications::MonthlyStatistics::MonthlyStatisticsReport.create(month: '2021-07')
+
+        expect { described_class.new.change }.to change { report_with_unset_month.reload.month }.to('2022-01')
+        expect { described_class.new.change }.not_to(change { report_with_set_month.reload.month })
+      end
+    end
+  end
+end

--- a/spec/services/data_migrations/backfill_monthly_statistics_data_spec.rb
+++ b/spec/services/data_migrations/backfill_monthly_statistics_data_spec.rb
@@ -2,13 +2,35 @@ require 'rails_helper'
 
 RSpec.describe DataMigrations::BackfillMonthlyStatisticsData do
   describe 'monthly statistics report data' do
-    it 'update the month for a future report' do
-      Timecop.freeze(Date.new(2022, 1, 21)) do
-        report_with_unset_month = Publications::MonthlyStatistics::MonthlyStatisticsReport.create(month: nil)
-        report_with_set_month = Publications::MonthlyStatistics::MonthlyStatisticsReport.create(month: '2021-07')
+    context 'when month does not exist' do
+      it 'update the month for a future report' do
+        Timecop.freeze(Date.new(2022, 1, 21)) do
+          report_with_unset_month = Publications::MonthlyStatistics::MonthlyStatisticsReport.create(month: nil)
+          report_with_set_month = Publications::MonthlyStatistics::MonthlyStatisticsReport.create(month: '2021-07')
 
-        expect { described_class.new.change }.to change { report_with_unset_month.reload.month }.to('2022-01')
-        expect { described_class.new.change }.not_to(change { report_with_set_month.reload.month })
+          expect { described_class.new.change }.to change { report_with_unset_month.reload.month }.to('2022-01')
+          expect { described_class.new.change }.not_to(change { report_with_set_month.reload.month })
+        end
+      end
+    end
+
+    context 'when report is created in following month' do
+      it 'updates the month to the previous month' do
+        Timecop.freeze(Date.new(2021, 12, 11)) do
+          report_with_unset_month = Publications::MonthlyStatistics::MonthlyStatisticsReport.create(month: nil)
+
+          expect { described_class.new.change }.to change { report_with_unset_month.reload.month }.to('2021-11')
+        end
+      end
+    end
+
+    context 'when report is created in same month' do
+      it 'updates to same month' do
+        Timecop.freeze(Date.new(2021, 12, 21)) do
+          report_with_unset_month = Publications::MonthlyStatistics::MonthlyStatisticsReport.create(month: nil)
+
+          expect { described_class.new.change }.to change { report_with_unset_month.reload.month }.to('2021-12')
+        end
       end
     end
   end

--- a/spec/services/monthly_statistics_timetable_spec.rb
+++ b/spec/services/monthly_statistics_timetable_spec.rb
@@ -65,39 +65,23 @@ RSpec.describe MonthlyStatisticsTimetable do
     end
   end
 
-  describe '#current_report' do
-    context 'when there is only one monthly report' do
-      it 'returns the report' do
-        report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new
-        report.save
+  describe '#report_for_current_period' do
+    let!(:current_report) { Publications::MonthlyStatistics::MonthlyStatisticsReport.create(month: '2021-12') }
+    let!(:previous_report) { Publications::MonthlyStatistics::MonthlyStatisticsReport.create(month: '2021-11') }
 
-        expect(described_class.current_report).to eq report
+    context 'when today is before the publishing date in the current month' do
+      it 'returns the previous report' do
+        Timecop.freeze(Date.new(2021, 12, 21)) do
+          expect(described_class.report_for_current_period).to eq(previous_report)
+        end
       end
     end
 
-    context 'when there are multiple reports and the MonthlyStatisticsTimetable returns false for #in_qa_period?' do
-      it 'returns the latest report' do
-        allow(described_class).to receive(:in_qa_period?).and_return false
-        report1 = Publications::MonthlyStatistics::MonthlyStatisticsReport.new
-        report1.save
-
-        report2 = Publications::MonthlyStatistics::MonthlyStatisticsReport.new
-        report2.save
-
-        expect(described_class.current_report).to eq report2
-      end
-    end
-
-    context 'when there are multiple reports and the MonthlyStatisticsTimetable returns true for #in_qa_period?' do
-      it 'returns last months report' do
-        allow(described_class).to receive(:in_qa_period?).and_return true
-        report1 = Publications::MonthlyStatistics::MonthlyStatisticsReport.new
-        report1.save
-
-        report2 = Publications::MonthlyStatistics::MonthlyStatisticsReport.new
-        report2.save
-
-        expect(described_class.current_report).to eq report1
+    context 'when today is after the publishing date in the current month' do
+      it 'returns the previous report' do
+        Timecop.freeze(Date.new(2021, 12, 28)) do
+          expect(described_class.report_for_current_period).to eq(current_report)
+        end
       end
     end
   end

--- a/spec/system/monthly_statistics/monthly_statistics_page_spec.rb
+++ b/spec/system/monthly_statistics/monthly_statistics_page_spec.rb
@@ -1,7 +1,14 @@
 require 'rails_helper'
 
-RSpec.feature 'Monthly statistics page' do
+RSpec.feature 'Monthly statistics page', mid_cycle: false do
   include MonthlyStatisticsTestHelper
+
+  around do |example|
+    Timecop.freeze(2021, 12, 29) do
+      example.run
+    end
+  end
+
   before do
     allow(MonthlyStatisticsTimetable).to receive(:generate_monthly_statistics?).and_return true
     FeatureFlag.activate('publish_monthly_statistics')

--- a/spec/workers/generate_monthly_statistics_spec.rb
+++ b/spec/workers/generate_monthly_statistics_spec.rb
@@ -24,4 +24,13 @@ RSpec.describe GenerateMonthlyStatistics, sidekiq: true do
 
     expect(Publications::MonthlyStatistics::MonthlyStatisticsReport.count).to eq(0)
   end
+
+  it 'sets the month when generating the report' do
+    allow(MonthlyStatisticsTimetable).to receive(:generate_monthly_statistics?).and_return true
+    generate_monthly_statistics_test_data
+
+    described_class.new.perform
+
+    expect(Publications::MonthlyStatistics::MonthlyStatisticsReport.first.month).to eq(Time.zone.today.strftime('%Y-%m'))
+  end
 end

--- a/spec/workers/generate_monthly_statistics_spec.rb
+++ b/spec/workers/generate_monthly_statistics_spec.rb
@@ -26,11 +26,13 @@ RSpec.describe GenerateMonthlyStatistics, sidekiq: true do
   end
 
   it 'sets the month when generating the report' do
-    allow(MonthlyStatisticsTimetable).to receive(:generate_monthly_statistics?).and_return true
-    generate_monthly_statistics_test_data
+    Timecop.freeze(2021, 12, 21) do
+      allow(MonthlyStatisticsTimetable).to receive(:generate_monthly_statistics?).and_return true
+      generate_monthly_statistics_test_data
 
-    described_class.new.perform
+      described_class.new.perform
 
-    expect(Publications::MonthlyStatistics::MonthlyStatisticsReport.first.month).to eq(Time.zone.today.strftime('%Y-%m'))
+      expect(Publications::MonthlyStatistics::MonthlyStatisticsReport.first.month).to eq('2021-12')
+    end
   end
 end


### PR DESCRIPTION
## Context
Builds on #6225
## Changes proposed in this pull request
1) Writes the month to the monthly statistics report table when the `generate_monthly_statistics` job is run
2) Backfills the data by updating records where the month is nil by deriving month from `created_at`
3) Refactors `MonthlyStatisticsTimetable` service to use the new month column. This allows for retrieval of previous reports by user once that ability is surfaced in the UI. If current date is before publishing date, last months report will be retrieved as before. 
4) Unit tests to verify correct behaviour

## Guidance to review
Run `generate_monthly_statistics` job and check that pr has desired logic
What should happen at the beginning of cycle when there is no previous report to be published?


## Link to Trello card

https://trello.com/c/80DIe2o3/4215-monthly-report-data

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
