### PR TITLE
Add write permission to packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
       - main
     types: [opened, reopened, synchronize, labeled]
 
+permissions:
+  packages: write
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ on:
 
 permissions:
   packages: write
+  contents: write
+  pull-requests: write
 
 jobs:
   build:


### PR DESCRIPTION
## Context
Dependabot builds fail when trying to push to our container registry. It actually looks like this is not the intended default behaviour.

There are a few mitigations. One is to try explicitly setting the permissions for the workflow.

https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/

https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#changing-github_token-permissions

https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds write permission explicitly for packages.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Only dependabot can confirm this for us!

Permissions scope has been tested [in this pr](https://github.com/DFE-Digital/apply-for-teacher-training/pull/6230) from an external user.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/NLziz08t/467-do-not-trigger-build-multiple-times-on-dependabot-prs
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
