### PR TITLE
Hide empty reasons for rejection in the structured reasons for rejection report in support

### DIFF
--- a/app/components/support_interface/reasons_for_rejection_search_results_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.rb
@@ -10,11 +10,12 @@ module SupportInterface
 
     def summary_list_rows_for(application_choice)
       application_choice.structured_rejection_reasons.map do |reason, value|
-        next unless top_level_reason?(reason, value)
+        reason_detail_text = reason_detail_text_for(application_choice, reason)
+        next unless top_level_reason?(reason, value) && reason_detail_text.presence
 
         {
           key: reason_text_for(reason),
-          value: reason_detail_text_for(application_choice, reason),
+          value: reason_detail_text,
         }
       end.compact
     end

--- a/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
@@ -1,91 +1,80 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
-  def render_result(
-    application_choices,
-    search_attribute = :quality_of_application_y_n,
-    search_value = 'Yes'
-  )
-    @rendered_result ||= render_inline(
-      described_class.new(
-        search_attribute: search_attribute,
-        search_value: search_value,
-        application_choices: application_choices,
-      ),
-    )
+  def render_result(application_choices, search_attribute = :quality_of_application_y_n, search_value = 'Yes')
+    render_inline(described_class.new(search_attribute: search_attribute,
+                                      search_value: search_value,
+                                      application_choices: application_choices))
   end
 
   context 'for a top-level reason' do
-    before do
-      @application_choice = build(
-        :application_choice,
-        structured_rejection_reasons: {
-          performance_at_interview_y_n: 'Yes',
-          performance_at_interview_what_to_improve: 'Avoid humming',
-          qualifications_y_n: 'Yes',
-          qualifications_which_qualifications: %w[no_maths_gcse no_degree],
-          quality_of_application_y_n: 'Yes',
-          quality_of_application_which_parts_needed_improvement: %w[other],
-          quality_of_application_other_details: 'Too many emojis',
-          interested_in_future_applications_y_n: 'Yes',
-          other_advice_or_feedback_y_n: 'Yes',
-          other_advice_or_feedback_details: 'You need a haircut',
-          why_are_you_rejecting_this_application: ''
+    let(:application_choice) do
+      build(:application_choice,
+            structured_rejection_reasons: {
+              performance_at_interview_y_n: 'Yes',
+              performance_at_interview_what_to_improve: 'Avoid humming',
+              qualifications_y_n: 'Yes',
+              qualifications_which_qualifications: %w[no_maths_gcse no_degree],
+              quality_of_application_y_n: 'Yes',
+              quality_of_application_which_parts_needed_improvement: %w[other],
+              quality_of_application_other_details: 'Too many emojis',
+              interested_in_future_applications_y_n: 'Yes',
+              other_advice_or_feedback_y_n: 'Yes',
+              other_advice_or_feedback_details: 'You need a haircut',
+              why_are_you_rejecting_this_application: '',
 
-        },
-        application_form_id: 123,
-      )
-      render_result([@application_choice])
+            },
+            application_form_id: 123)
     end
 
+    let(:rendered_result) { render_result([application_choice]) }
+
     it 'renders a link to the application form' do
-      expect(@rendered_result.css("a[href='/support/applications/123']")).to be_present
+      expect(rendered_result.css("a[href='/support/applications/123']")).to be_present
     end
 
     it 'renders top-level reasons' do
-      expect(@rendered_result.text).to include('Qualifications')
-      expect(@rendered_result.text).to include('Quality of application')
-      expect(@rendered_result.text).to include('Performance at interview')
-      expect(@rendered_result.text).to include('Avoid humming')
-      expect(@rendered_result.text).to include('Future applications')
-      expect(@rendered_result.text).not_to include('Something you did')
+      expect(rendered_result.text).to include('Qualifications')
+      expect(rendered_result.text).to include('Quality of application')
+      expect(rendered_result.text).to include('Performance at interview')
+      expect(rendered_result.text).to include('Avoid humming')
+      expect(rendered_result.text).to include('Future applications')
+      expect(rendered_result.text).not_to include('Something you did')
     end
 
     it 'renders sub-reasons' do
-      expect(@rendered_result.text).to include('No Maths GCSE')
-      expect(@rendered_result.text).to include('No degree')
-      expect(@rendered_result.text).to include('Other - Too many emojis')
-      expect(@rendered_result.text).to include('Yes')
-      expect(@rendered_result.text).to include('You need a haircut')
-      expect(@rendered_result.text).not_to include('No Science GCSE')
-      expect(@rendered_result.text).not_to include('No English GCSE')
+      expect(rendered_result.text).to include('No Maths GCSE')
+      expect(rendered_result.text).to include('No degree')
+      expect(rendered_result.text).to include('Other - Too many emojis')
+      expect(rendered_result.text).to include('Yes')
+      expect(rendered_result.text).to include('You need a haircut')
+      expect(rendered_result.text).not_to include('No Science GCSE')
+      expect(rendered_result.text).not_to include('No English GCSE')
     end
 
     it 'highlights the search term' do
-      expect(@rendered_result.css('mark').text).to eq 'Quality of application'
+      expect(rendered_result.css('mark').text).to eq 'Quality of application'
     end
 
     it 'hides empty rejection reasons' do
-      expect(@rendered_result.text).not_to include 'Reasons why your application was unsuccessful'
+      expect(rendered_result.text).not_to include 'Reasons why your application was unsuccessful'
     end
   end
 
   context 'for a sub-reason' do
-    before do
-      @application_choice = build(
-        :application_choice,
-        structured_rejection_reasons: {
-          qualifications_y_n: 'Yes',
-          qualifications_which_qualifications: %w[no_maths_gcse no_degree],
-          quality_of_application_y_n: 'Yes',
-        },
-        application_form_id: 123,
-      )
-      render_result([@application_choice], :qualifications_which_qualifications, :no_degree)
+    let(:application_choice) do
+      build(:application_choice,
+            structured_rejection_reasons: {
+              qualifications_y_n: 'Yes',
+              qualifications_which_qualifications: %w[no_maths_gcse no_degree],
+              quality_of_application_y_n: 'Yes',
+            },
+            application_form_id: 123)
     end
+    let(:rendered_result) { render_result([application_choice], :qualifications_which_qualifications, :no_degree) }
 
     it 'highlights the search term' do
-      expect(@rendered_result.css('mark').text).to eq 'No degree'
+      expect(rendered_result.css('mark').text).to eq 'No degree'
     end
   end
 
@@ -98,17 +87,21 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
       expect { render_result([], :qualifications_which_qualifications, 'no_pilots_licence') }.not_to raise_error
     end
 
-    it 'handles an invalid reason and sub-reason' do
-      @application_choice = build(
-        :application_choice,
-        structured_rejection_reasons: {
-          performance_at_singing_y_n: 'Yes',
-          qualifications_y_n: 'Yes',
-          qualifications_which_qualifications: %w[no_cycling_proficiency],
-        },
-        application_form_id: 123,
-      )
-      expect { render_result([@application_choice], :qualifications_which_qualifications, 'no_degree') }.not_to raise_error
+    context 'for an invalid reason and sub-reason' do
+      let(:application_choice) do
+        build(:application_choice,
+              structured_rejection_reasons: {
+                performance_at_singing_y_n: 'Yes',
+                qualifications_y_n: 'Yes',
+                qualifications_which_qualifications: %w[no_cycling_proficiency],
+              },
+              application_form_id: 123)
+      end
+      let(:rendered_results) { render_result([application_choice], :qualifications_which_qualifications, 'no_degree') }
+
+      it 'is handled' do
+        expect { rendered_results }.not_to raise_error
+      end
     end
   end
 end

--- a/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
           interested_in_future_applications_y_n: 'Yes',
           other_advice_or_feedback_y_n: 'Yes',
           other_advice_or_feedback_details: 'You need a haircut',
+          why_are_you_rejecting_this_application: ''
+
         },
         application_form_id: 123,
       )
@@ -61,6 +63,10 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
 
     it 'highlights the search term' do
       expect(@rendered_result.css('mark').text).to eq 'Quality of application'
+    end
+
+    it 'hides empty rejection reasons' do
+      expect(@rendered_result.text).not_to include 'Reasons why your application was unsuccessful'
     end
   end
 

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -143,6 +143,7 @@ private
       structured_rejection_reasons: {
         course_full_y_n: 'No',
         candidate_behaviour_y_n: 'Yes',
+        candidate_behaviour_what_did_the_candidate_do: %w[other],
         honesty_and_professionalism_y_n: 'No',
         performance_at_interview_y_n: 'No',
         qualifications_y_n: 'No',
@@ -266,7 +267,7 @@ private
     within '#candidate-behaviour' do
       expect(page).to have_content('Didn’t reply to our interview offer 40% 2 of 5 40% 2 of 5 50% 1 of 2 50% 1 of 2')
       expect(page).to have_content('Didn’t attend interview 20% 1 of 5 20% 1 of 5 0% 0 of 2 0% 0 of 2')
-      expect(page).to have_content('Other 0% 0 of 5 0% 0 of 5 0% 0 of 2 0% 0 of 2')
+      expect(page).to have_content('Other 40% 2 of 5 40% 2 of 5 50% 1 of 2 50% 1 of 2')
     end
   end
 


### PR DESCRIPTION
## Context

Don't show a reason for rejection on the performance dashboard report when it doesn't have any content.

## Link to Trello card

https://trello.com/c/5YrWsf6h/4547-hide-empty-reasons-for-rejection-in-the-structured-reasons-for-rejection-report-in-support

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
