### PR TITLE
Only comment on coverage when there is a significant change.

### DIFF
--- a/.github/scripts/compare_coverage.js
+++ b/.github/scripts/compare_coverage.js
@@ -4,7 +4,7 @@ module.exports = ({github, context}) => {
   const { BASE_COVERAGE_DATA, PR_COVERAGE_DATA } = process.env;
   const BASE_COVERAGE_OBJ = BASE_COVERAGE_DATA.length ? JSON.parse(BASE_COVERAGE_DATA) : NO_DATA;
   const PR_COVERAGE_OBJ = PR_COVERAGE_DATA.length ? JSON.parse(PR_COVERAGE_DATA) : NO_DATA;
-  const DELTA = 0.5;
+  const DELTA = 0.25;
 
   const compareCoverage = (baseCoverage, prCoverage) => {
     return (baseCoverage == prCoverage) ? 0 : prCoverage - baseCoverage;

--- a/.github/scripts/compare_coverage.js
+++ b/.github/scripts/compare_coverage.js
@@ -19,43 +19,45 @@ module.exports = ({github, context}) => {
   }
 
   const emoji = (difference) => {
-    if (Math.abs(difference) < DELTA) {
-      return ':left_right_arrow:';
-    } else if (difference > DELTA) {
+    if (difference > DELTA) {
       return ':arrow_up:';
     } else {
       return ':arrow_down:';
     }
   }
 
-  const coverageExplanation = `<details><summary><b>Line vs. Branch coverage</b></summary>
-      <p>Branch coverage concerns itself with whether a particular branch of a condition had been executed.<br>
-      Line coverage is only interested in whether a line of code has been executed.<br>
-      This comes in handy for measuring one line conditionals.<br>
-      eg.</p>
-      <p><pre>
-        def do_something_with_even_numbers(number)
-          return if number.odd?
-          ...
-      </pre></p>
-      <p>If all the code in the method was covered you would never know if the guard clause was ever triggered with line coverage as just evaluating the condition marks it as covered.</p>
-    </details>`;
+  const baseBranchCoverage = BASE_COVERAGE_OBJ.result.branch;
+  const baseLineCoverage = BASE_COVERAGE_OBJ.result.line;
+  const prBranchCoverage = PR_COVERAGE_OBJ.result.branch;
+  const prLineCoverage = PR_COVERAGE_OBJ.result.line;
+  const branchDifference = compareCoverage(baseBranchCoverage, prBranchCoverage);
+  const lineDifference = compareCoverage(baseLineCoverage, prLineCoverage);
+  const reportedLineCoverage = reportedCoverage(baseLineCoverage, prLineCoverage, lineDifference);
+  const reportedBranchCoverage = reportedCoverage(baseBranchCoverage, prBranchCoverage, branchDifference);
 
-  const baseCoverageBranch = BASE_COVERAGE_OBJ.result.branch;
-  const prCoverageBranch = PR_COVERAGE_OBJ.result.branch;
-  const baseCoverageLine = BASE_COVERAGE_OBJ.result.line;
-  const prCoverageLine = PR_COVERAGE_OBJ.result.line;
-  const branchDifference = compareCoverage(baseCoverageBranch, prCoverageBranch);
-  const lineDifference = compareCoverage(baseCoverageLine, prCoverageLine);
+  if (reportedLineCoverage != baseLineCoverage || reportedBranchCoverage != baseBranchCoverage) {
+    const coverageExplanation = `<details><summary><b>Line vs. Branch coverage</b></summary>
+        <p>Branch coverage concerns itself with whether a particular branch of a condition had been executed.<br>
+        Line coverage is only interested in whether a line of code has been executed.<br>
+        This comes in handy for measuring one line conditionals.<br>
+        eg.</p>
+        <p><pre>
+          def do_something_with_even_numbers(number)
+            return if number.odd?
+            ...
+        </pre></p>
+        <p>If all the code in the method was covered you would never know if the guard clause was ever triggered with line coverage as just evaluating the condition marks it as covered.</p>
+      </details>`;
 
-  let coverageBody = '<h2>Code Coverage</h2>'
-  coverageBody += '<table><thead><tr><th></th><th>Coverage type</th><th>From</th><th>To</th></tr></thead><tbody>';
-  coverageBody += `<tr><td>${emoji(lineDifference)}</td><td>Lines covered</td><td><b>${baseCoverageLine}%</b></td>`;
-  coverageBody += `<td><b>${reportedCoverage(baseCoverageLine, prCoverageLine, lineDifference)}%</b></td></tr>`;
-  coverageBody += `<tr><td>${emoji(branchDifference)}</td><td>Branches covered</td><td><b>${baseCoverageBranch}%</b></td>`;
-  coverageBody += `<td><b>${reportedCoverage(baseCoverageBranch, prCoverageBranch, branchDifference)}%</b></td></tr>`;
-  coverageBody += '</tbody></table><br>';
-  coverageBody += coverageExplanation;
+    let coverageBody = '<h2>Code Coverage</h2>'
+    coverageBody += '<table><thead><tr><th></th><th>Coverage type</th><th>From</th><th>To</th></tr></thead><tbody>';
+    coverageBody += `<tr><td>${emoji(lineDifference)}</td><td>Lines covered</td><td><b>${baseLineCoverage}%</b></td>`;
+    coverageBody += `<td><b>${reportedLineCoverage}%</b></td></tr>`;
+    coverageBody += `<tr><td>${emoji(branchDifference)}</td><td>Branches covered</td><td><b>${baseBranchCoverage}%</b></td>`;
+    coverageBody += `<td><b>${reportedBranchCoverage}%</b></td></tr>`;
+    coverageBody += '</tbody></table><br>';
+    coverageBody += coverageExplanation;
 
-  github.issues.createComment({ issue_number, owner, repo, body: coverageBody });
+    github.issues.createComment({ issue_number, owner, repo, body: coverageBody });
+  }
 }


### PR DESCRIPTION
## Context

We post a comment on every PR regardless of code coverage changes. Are these relevant if there's no significant change in coverage?

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Do not post coverage change comments on PRs where the coverage change is below the threshold of 0.25%
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
