### PR TITLE
Update the personal statement questions

### DIFF
--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -78,7 +78,7 @@ module VendorAPI
     end
 
     def personal_statement
-      "Why do you want to become a teacher?: #{application_form.becoming_a_teacher} \n " \
+      "Why do you want to be a teacher?: #{application_form.becoming_a_teacher} \n " \
         "What is your subject knowledge?: #{application_form.subject_knowledge}"
     end
 

--- a/config/locales/components/shared.yml
+++ b/config/locales/components/shared.yml
@@ -1,6 +1,6 @@
 en:
   personal_statement:
     title: Personal statement
-    vocation: Why do you want to become a teacher?
-    subject_knowledge: What do you know about the subject you want to teach?
+    vocation: Why do you want to be a teacher?
+    subject_knowledge: Why are you suited to teach your subjects or age group?
     further_information: Further information

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -90,7 +90,7 @@ ApplicationQualification.find(_id).update!(start_year: '2011', award_year: '2014
 The personal statement is split into database fields:
 
 - `becoming_a_teacher` - Why do you want to be a teacher? (‘Vocation' in support)
-- `subject_knowledge` - What do you know about the subject you want to teach?
+- `subject_knowledge` - Why are you suited to teach your subjects or age group?
 
 Make sure you know which part you are amending. Add `\r\n\r\n` for carriage return.
 

--- a/spec/presenters/vendor_api/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/application_presenter_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe VendorAPI::ApplicationPresenter do
     let!(:application_choice) { create(:submitted_application_choice, :offer_withdrawn, :with_completed_application_form) }
 
     it 'formats and returns the personal statement information' do
-      personal_statement = "Why do you want to become a teacher?: #{application_choice.application_form.becoming_a_teacher} \n " \
+      personal_statement = "Why do you want to be a teacher?: #{application_choice.application_form.becoming_a_teacher} \n " \
                            "What is your subject knowledge?: #{application_choice.application_form.subject_knowledge}"
 
       expect(attributes[:personal_statement]).to eq(personal_statement)

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Vendor receives the application' do
       attributes: {
         application_url: "http://localhost:3000/provider/applications/#{@provider.application_choices.first.id}",
         support_reference: @provider.application_forms.first.support_reference,
-        personal_statement: "Why do you want to become a teacher?: I believe I would be a first-rate teacher \n What is your subject knowledge?: Everything",
+        personal_statement: "Why do you want to be a teacher?: I believe I would be a first-rate teacher \n What is your subject knowledge?: Everything",
         interview_preferences: 'Not on a Wednesday',
         hesa_itt_data: nil,
         offer: nil,


### PR DESCRIPTION
## Context

The personal statement questions were changed on the Candidate side of Apply. We want to update the labels on the application details page to give an accurate picture of the questions that candidates were actually asked. 

## Changes proposed in this pull request

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/47917431/147123586-0e69064c-b169-4d13-9680-03b0c600e57e.png)|![image](https://user-images.githubusercontent.com/47917431/147121093-d2530079-01d5-4504-afac-e17f4c370b97.png)|

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/fcTapwkV

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
