### PR TITLE
Limit enic reference to 100 characters

### DIFF
--- a/app/forms/candidate_interface/degree_enic_form.rb
+++ b/app/forms/candidate_interface/degree_enic_form.rb
@@ -9,7 +9,7 @@ module CandidateInterface
     alias have_enic_reference? have_enic_reference
 
     validates :have_enic_reference, presence: true
-    validates :enic_reference, presence: true, if: -> { have_enic_reference == 'yes' }
+    validates :enic_reference, presence: true, length: { maximum: 100 }, if: -> { have_enic_reference == 'yes' }
     validates :comparable_uk_degree, presence: true, if: -> { have_enic_reference == 'yes' }
 
     def save

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -121,6 +121,7 @@ en:
               blank: Select whether you have a UK ENIC reference number or not
             enic_reference:
               blank: Enter the UK ENIC reference number
+              too_long: Your UK ENIC reference number must be %{count} characters or fewer
             comparable_uk_degree:
               blank: Select the comparable UK degree
         candidate_interface/degree_completion_status_form:

--- a/spec/forms/candidate_interface/degree_enic_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_enic_form_spec.rb
@@ -65,4 +65,41 @@ RSpec.describe CandidateInterface::DegreeEnicForm do
       end
     end
   end
+
+  describe 'ENIC reference validations' do
+    let(:form) {
+      described_class.new(
+        degree: degree,
+        have_enic_reference: 'yes',
+        enic_reference: number_of_characters,
+        comparable_uk_degree: 'bachelor_ordinary_degree',
+      )
+    }
+
+    let(:degree) {
+      build(
+        :degree_qualification,
+        international: true,
+        application_form: build(:application_form),
+      )
+    }
+
+    context 'when enic_reference is more than 100 characters' do
+      let(:number_of_characters) { SecureRandom.alphanumeric(101) }
+
+      it 'DegreeForm is invalid' do
+        expect(form.save).to eq false
+        expect(form.errors.full_messages).to match_array(['Enic reference Your UK ENIC reference number must be 100 characters or fewer'])
+      end
+    end
+
+    context 'when enic_reference is 100 characters or less' do
+      let(:number_of_characters) { SecureRandom.alphanumeric(99) }
+
+      it 'DegreeForm is valid' do
+        expect(form.save).to eq true
+        expect(degree.reload.enic_reference).to eq(number_of_characters)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context
User is currently able to add any number of characters to enic reference for international degree

## Changes proposed in this pull request
A validation on UI which prevents user entry of more than 100 characters for enic reference
## Guidance to review
Visit `/candidate/application/degrees/{id}/enic/edit`

After
<img width="837" alt="Screenshot 2021-12-22 at 16 18 45" src="https://user-images.githubusercontent.com/58793682/147123092-f8252a18-57f9-4ba5-9fd6-44319447b57c.png">


## Link to Trello card

https://trello.com/c/feTDV9sk/4223-limit-enic-reference-to-100-characters

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
