### PR TITLE
Correction to monthly stats reporting period

### DIFF
--- a/app/presenters/publications/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/monthly_statistics_presenter.rb
@@ -29,7 +29,7 @@ module Publications
     end
 
     def current_reporting_period
-      "#{CycleTimetable.apply_opens.to_s(:govuk_date)} to #{report.created_at.to_s(:govuk_date)}"
+      "#{CycleTimetable.apply_opens.to_s(:govuk_date)} to #{MonthlyStatisticsTimetable.current_published_reports_generation_date.to_s(:govuk_date)}"
     end
 
     def exports

--- a/app/services/monthly_statistics_timetable.rb
+++ b/app/services/monthly_statistics_timetable.rb
@@ -49,6 +49,16 @@ module MonthlyStatisticsTimetable
     end
   end
 
+  def self.current_published_reports_generation_date
+    report_date_for_current_month = PUBLISHING_DATES[Date::MONTHNAMES[Time.zone.today.month]]
+
+    if report_date_for_current_month > Time.zone.today
+      last_months_generation_date
+    else
+      current_months_generation_date
+    end
+  end
+
   def self.last_months_generation_date
     GENERATION_DATES[Date::MONTHNAMES[(Time.zone.today - 1.month).month]]
   end

--- a/spec/presenters/publications/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/monthly_statistics_presenter_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Publications::MonthlyStatisticsPresenter do
 
   describe '#current_reporting_period' do
     it 'returns the date range for the current reporting period' do
-      expect(presenter.current_reporting_period).to eq('12 October 2021 to 23 November 2021')
+      expect(presenter.current_reporting_period).to eq('12 October 2021 to 22 November 2021')
     end
   end
 end

--- a/spec/services/monthly_statistics_timetable_spec.rb
+++ b/spec/services/monthly_statistics_timetable_spec.rb
@@ -39,6 +39,24 @@ RSpec.describe MonthlyStatisticsTimetable do
     end
   end
 
+  describe '#current_published_reports_generation_date' do
+    context 'when the most recent generation date is within the same month' do
+      it 'returns the correct value' do
+        Timecop.travel(described_class::PUBLISHING_DATES.values.first + 1.day) do
+          expect(described_class.current_published_reports_generation_date).to eq described_class::GENERATION_DATES.values.first
+        end
+      end
+    end
+
+    context 'when the most recent generation date was last month' do
+      it 'returns the correct value' do
+        Timecop.travel(described_class::PUBLISHING_DATES.values.second - 1.day) do
+          expect(described_class.current_published_reports_generation_date).to eq described_class::GENERATION_DATES.values.first
+        end
+      end
+    end
+  end
+
   describe '#in_qa_period?' do
     context 'when it is before the generation date for the current month' do
       it 'returns false' do


### PR DESCRIPTION
## Context

@duncanjbrown pointed out that the end of the reporting period for the current report cannot reliably be obtained from `MonthlyStatisticsReport#created_at`. Instead we should lookup the latest published report's generation date.

## Changes proposed in this pull request

Added a new helper method `MonthlyStatisticsTimetable.current_published_reports_generation_date` to determine the date on which the latest published report was generated.

As of right now on production the date is incorrect because the report was created on 3 December despite the data being from 22 November. This is what it should look like:

![image](https://user-images.githubusercontent.com/450843/147167391-ee918d63-b976-43ea-9646-339bea725859.png)


## Guidance to review

Does the logic for working out which report is the latest make sense?

## Link to Trello card

This is the original card:
https://trello.com/c/wehZ0e0y/4189-monthly-report-make-dates-in-copy-dynamic

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
