### PR TITLE
Implement email to notify users when their user permissions are updated

### DIFF
--- a/app/controllers/provider_interface/user_permissions_controller.rb
+++ b/app/controllers/provider_interface/user_permissions_controller.rb
@@ -21,11 +21,11 @@ module ProviderInterface
 
     def commit
       wizard = EditUserPermissionsWizard.new(edit_user_permissions_store)
-      provider_permissions = @provider_user.provider_permissions.find_by!(provider: @provider)
 
-      update_provider_permissions(provider_permissions, wizard)
-
-      if provider_permissions.save
+      if EditProviderUserPermissions.new(actor: current_provider_user,
+                                         provider: @provider,
+                                         provider_user: @provider_user,
+                                         permissions: wizard.permissions).save
         wizard.clear_state!
         flash[:success] = 'User permissions updated'
         redirect_to provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user)
@@ -48,12 +48,6 @@ module ProviderInterface
         check_provider_interface_organisation_settings_organisation_user_permissions_path(@provider, @provider_user)
       else
         provider_interface_organisation_settings_organisation_user_path(@provider, @provider_user)
-      end
-    end
-
-    def update_provider_permissions(provider_permissions, wizard)
-      ProviderPermissions::VALID_PERMISSIONS.each do |permission|
-        provider_permissions.send("#{permission}=", wizard.permissions.include?(permission.to_s))
       end
     end
 

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -157,6 +157,24 @@ class ProviderMailer < ApplicationMailer
     provider_notify_email({ to: @provider_user.email_address }.merge!(email_attributes))
   end
 
+  def permissions_updated(provider_user, provider, permissions, permissions_updated_by = nil)
+    @provider_user = provider_user
+    @provider = provider
+    @permissions_updated_by = permissions_updated_by
+    @permissions = permissions
+
+    email_attributes = if @permissions_updated_by
+                         { subject: I18n.t!('provider_mailer.permissions_updated.subject',
+                                            permissions_updated_by_user: @permissions_updated_by.full_name,
+                                            organisation: @provider.name) }
+                       else
+                         { subject: I18n.t!('provider_mailer.permissions_updated_by_support.subject',
+                                            organisation: @provider.name) }
+                       end
+
+    provider_notify_email({ to: @provider_user.email_address }.merge!(email_attributes))
+  end
+
   def permissions_removed(provider_user, provider, permissions_removed_by = nil)
     @provider_user = provider_user
     @provider = provider

--- a/app/services/provider_interface/edit_provider_user_permissions.rb
+++ b/app/services/provider_interface/edit_provider_user_permissions.rb
@@ -1,0 +1,52 @@
+module ProviderInterface
+  class EditProviderUserPermissions
+    include ImpersonationAuditHelper
+
+    attr_accessor :actor, :provider, :provider_user, :permissions
+
+    def initialize(actor:, provider:, provider_user:, permissions:)
+      @actor = actor
+      @provider = provider
+      @provider_user = provider_user
+      @permissions = permissions.reject(&:empty?)
+    end
+
+    def save
+      audit(actor) do
+        ActiveRecord::Base.transaction do
+          assert_actor_can_manage_users_for_provider!
+          update_provider_permissions!
+        end
+
+        send_permissions_updated_email
+      end
+    end
+
+  private
+
+    def assert_actor_can_manage_users_for_provider!
+      return if actor.authorisation.can_manage_users_for?(provider: provider)
+
+      raise ProviderInterface::AccessDenied.new({
+        permission: 'manage_users',
+        training_provider: provider,
+        provider_user: actor,
+      }), 'manage_users required'
+    end
+
+    def update_provider_permissions!
+      ProviderPermissions::VALID_PERMISSIONS.each do |permission|
+        provider_permissions.send("#{permission}=", permissions.include?(permission.to_s))
+      end
+      provider_permissions.save!
+    end
+
+    def send_permissions_updated_email
+      ProviderMailer.permissions_updated(provider_user, provider, permissions, actor).deliver_later
+    end
+
+    def provider_permissions
+      @provider_permissions ||= provider_user.provider_permissions.find_by!(provider: provider)
+    end
+  end
+end

--- a/app/services/save_provider_user.rb
+++ b/app/services/save_provider_user.rb
@@ -39,7 +39,12 @@ private
   def updated_existing_provider_permissions!
     existing_provider_permissions = provider_permissions & provider_user.provider_permissions
     existing_provider_permissions.each do |provider_permissions|
-      provider_permissions.save! if provider_permissions.changed?
+      next unless provider_permissions.changed?
+
+      provider_permissions.save!
+      ProviderMailer.permissions_updated(provider_user,
+                                         provider_permissions.provider,
+                                         extract_permission_keys(provider_permissions)).deliver_later
     end
   end
 

--- a/app/views/provider_mailer/permissions_updated.text.erb
+++ b/app/views/provider_mailer/permissions_updated.text.erb
@@ -1,0 +1,21 @@
+Dear <%= @provider_user.full_name %>
+
+<% if @permissions_updated_by %>
+  <%= @permissions_updated_by.full_name %> updated your permissions for <%= @provider.name %>.
+<% else %>
+  Your permissions have been updated for <%= @provider.name %>.
+<% end %>
+
+
+<% if @permissions.any? %>
+  You have permission to:
+  <% @permissions.each do |permission| %>
+  - <%= I18n.t("user_permissions.#{permission}.description").downcase %>
+  <% end %>
+<% else %>
+  You only have permission to view applications.
+<% end %>
+
+Manage applications:
+
+<%= provider_interface_sign_in_url %>

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -31,6 +31,10 @@ en:
       subject: '%{permissions_granted_by_user} has added you to %{organisation}'
     permissions_granted_by_support:
       subject: "You've been added to %{organisation}"
+    permissions_updated:
+      subject: '%{permissions_updated_by_user} updated your permissions for %{organisation}'
+    permissions_updated_by_support:
+      subject: "Your permissions have been updated for %{organisation}"
     permissions_removed:
       subject: '%{permissions_removed_by_user} has removed you from %{organisation}'
     permissions_removed_by_support:

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -108,6 +108,32 @@ class ProviderMailerPreview < ActionMailer::Preview
     ProviderMailer.permissions_granted(provider_user, provider, permissions, nil)
   end
 
+  def permissions_updated
+    provider = FactoryBot.create(:provider)
+    permissions_updated_by_user = FactoryBot.create(:provider_user)
+    provider_user = FactoryBot.create(:provider_user, providers: [provider])
+    permissions = ProviderPermissions::VALID_PERMISSIONS.map(&:to_s).sample(3)
+
+    ProviderMailer.permissions_updated(provider_user, provider, permissions, permissions_updated_by_user)
+  end
+
+  def permissions_updated__all_permissions_removed
+    provider = FactoryBot.create(:provider)
+    permissions_updated_by_user = FactoryBot.create(:provider_user)
+    provider_user = FactoryBot.create(:provider_user, providers: [provider])
+    permissions = []
+
+    ProviderMailer.permissions_updated(provider_user, provider, permissions, permissions_updated_by_user)
+  end
+
+  def permissions_updated_by_support
+    provider = FactoryBot.create(:provider)
+    provider_user = FactoryBot.create(:provider_user, providers: [provider])
+    permissions = ProviderPermissions::VALID_PERMISSIONS.map(&:to_s).sample(3)
+
+    ProviderMailer.permissions_updated(provider_user, provider, permissions, nil)
+  end
+
   def permissions_removed
     provider = FactoryBot.create(:provider)
     permissions_revoked_by_user = FactoryBot.create(:provider_user)

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -278,6 +278,64 @@ RSpec.describe ProviderMailer, type: :mailer do
     )
   end
 
+  describe 'permissions_updated' do
+    let(:provider) { FactoryBot.create(:provider, name: 'Hogwards University') }
+    let(:permissions_updated_by_user) { FactoryBot.create(:provider_user, first_name: 'Jane', last_name: 'Doe') }
+    let(:provider_user) { FactoryBot.create(:provider_user, first_name: 'Princess', last_name: 'Fiona', providers: [provider]) }
+    let(:permissions) { %i[view_safeguarding_information view_diversity_information] }
+
+    let(:email) do
+      described_class.permissions_updated(provider_user, provider, permissions, permissions_updated_by_user)
+    end
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Jane Doe updated your permissions for Hogwards University - manage teacher training applications',
+      'salutation' => 'Dear Princess Fiona',
+      'heading' => 'Jane Doe updated your permissions for Hogwards University.',
+      'view safeguarding' => 'view criminal convictions and professional misconduct',
+      'view diversity' => 'view sex, disability and ethnicity information',
+    )
+  end
+
+  describe 'permissions_updated with all permissions removed' do
+    let(:provider) { FactoryBot.create(:provider, name: 'Hogwards University') }
+    let(:permissions_updated_by_user) { FactoryBot.create(:provider_user, first_name: 'Jane', last_name: 'Doe') }
+    let(:provider_user) { FactoryBot.create(:provider_user, first_name: 'Princess', last_name: 'Fiona', providers: [provider]) }
+    let(:permissions) { %i[] }
+
+    let(:email) do
+      described_class.permissions_updated(provider_user, provider, permissions, permissions_updated_by_user)
+    end
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Jane Doe updated your permissions for Hogwards University - manage teacher training applications',
+      'salutation' => 'Dear Princess Fiona',
+      'heading' => 'Jane Doe updated your permissions for Hogwards University.',
+      'permissiosn' => 'You only have permission to view applications.',
+    )
+  end
+
+  describe 'permissions_updated_by_support' do
+    let(:provider) { FactoryBot.create(:provider, name: 'Hogwards University') }
+    let(:provider_user) { FactoryBot.create(:provider_user, first_name: 'Princess', last_name: 'Fiona', providers: [provider]) }
+    let(:permissions) { %i[make_decisions view_safeguarding_information] }
+
+    let(:email) do
+      described_class.permissions_updated(provider_user, provider, permissions, nil)
+    end
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Your permissions have been updated for Hogwards University - manage teacher training applications',
+      'salutation' => 'Dear Princess Fiona',
+      'heading' => 'Your permissions have been updated for Hogwards University.',
+      'make decisions' => 'make offers and reject application',
+      'view safeguarding' => 'view criminal convictions and professional misconduct',
+    )
+  end
+
   describe 'permissions_removed' do
     let(:provider) { FactoryBot.create(:provider, name: 'Hogwards University') }
     let(:permissions_removed_by_user) { FactoryBot.create(:provider_user, first_name: 'Jane', last_name: 'Doe') }

--- a/spec/services/provider_interface/edit_provider_user_permissions_spec.rb
+++ b/spec/services/provider_interface/edit_provider_user_permissions_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::EditProviderUserPermissions do
+  let(:mailer_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+  let(:provider_user) { create(:provider_user, :with_provider) }
+  let(:provider) { provider_user.providers.first }
+  let(:permissions) { %w[make_decisions view_safeguarding_information view_diversity_information] }
+  let(:updated_permissions) { %w[make_decisions view_safeguarding_information] }
+  let(:actor) { create(:provider_user) }
+  let(:service) do
+    described_class.new(actor: actor,
+                        provider: provider,
+                        provider_user: provider_user,
+                        permissions: updated_permissions)
+  end
+
+  before do
+    provider_permissions = provider_user.provider_permissions.find_by(provider: provider)
+    ProviderPermissions::VALID_PERMISSIONS.each do |permission|
+      provider_permissions.send("#{permission}=", permissions.include?(permission.to_s))
+    end
+    provider_permissions.save!
+  end
+
+  describe '#save' do
+    context 'when the actor does not have the manage users permission' do
+      it 'raises an access denied error' do
+        expect { service.save }.to raise_error(ProviderInterface::AccessDenied)
+      end
+    end
+
+    context 'when the actor can manage users for the given provider' do
+      let(:actor) { create(:provider_user, :with_manage_users, providers: [provider]) }
+
+      it 'updates the relationship between user and provider' do
+        service.save
+
+        provider_permissions = provider_user.provider_permissions.find_by(provider: provider)
+        expect(provider_permissions.view_diversity_information).to be false
+        expect(provider_permissions.make_decisions).to be true
+        expect(provider_permissions.view_safeguarding_information).to be true
+      end
+
+      it 'audits the change', with_audited: true do
+        expect { service.save }.to change(provider_user.associated_audits, :count).by(1)
+        expect(provider_user.associated_audits.last.audited_changes).to eq({ 'view_diversity_information' => [true, false] })
+      end
+
+      it 'sends a permissions updated email to the user' do
+        allow(ProviderMailer).to receive(:permissions_updated).and_return(mailer_delivery)
+
+        service.save
+
+        expect(ProviderMailer).to have_received(:permissions_updated).with(provider_user, provider, updated_permissions, actor)
+      end
+    end
+  end
+end

--- a/spec/services/save_provider_user_spec.rb
+++ b/spec/services/save_provider_user_spec.rb
@@ -69,6 +69,18 @@ RSpec.describe SaveProviderUser do
       end
     end
 
+    context 'when permissions are updated' do
+      let(:mailer_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+      it 'sends a permissions updated email' do
+        allow(ProviderMailer).to receive(:permissions_updated).and_return(mailer_delivery)
+
+        service.call!
+
+        expect(ProviderMailer).to have_received(:permissions_updated)
+      end
+    end
+
     it 'adds the notification preferences record to a ProviderUser' do
       expect { service.call! }.to change(ProviderUserNotificationPreferences, :count).by(1)
     end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -53,6 +53,7 @@ RSpec.feature 'Docs' do
       provider_mailer-set_up_organisation_permissions
       provider_mailer-permissions_granted
       provider_mailer-permissions_removed
+      provider_mailer-permissions_updated
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"


### PR DESCRIPTION
## Context

Send a permissions update email when
- a provider user updates a colleague's user permissions 
- a member of the support team updates a user's permissions

## Link to Trello card

https://trello.com/c/O0uN4BMI/4606-implement-email-to-notify-users-when-their-user-permissions-are-updated

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
