### PR TITLE
Remove `block_fraudulent_submission` feature flag

### DIFF
--- a/app/components/support_interface/fraud_auditing_matches_table_component.html.erb
+++ b/app/components/support_interface/fraud_auditing_matches_table_component.html.erb
@@ -50,15 +50,11 @@
         </td>
 
         <td class="govuk-table__cell">
-        <% if FeatureFlag.active?(:block_fraudulent_submission) %>
           <% if candidate_blocked?(table_row[:blocked]) %>
             <%= govuk_link_to 'Unblock', support_interface_fraud_auditing_matches_confirm_unblock_submission_path(table_row[:blocked]) %>
           <% else %>
             <%= govuk_link_to 'Block', support_interface_fraud_auditing_matches_confirm_block_submission_path(table_row[:blocked]) %>
           <% end %>
-        <% else %>
-          Currently unavailable
-        <% end %>
         </td>
 
         <td class="govuk-table__cell">

--- a/app/services/data_migrations/drop_block_fraudulent_submission_feature_flag.rb
+++ b/app/services/data_migrations/drop_block_fraudulent_submission_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class DropBlockFraudulentSubmissionFeatureFlag
+    TIMESTAMP = 20211223124239
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :block_fraudulent_submission).first&.destroy
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -34,7 +34,6 @@ class FeatureFlag
     [:withdraw_at_candidates_request, "Allows providers to withdraw an application at the candidate's request", 'Steve Laing'],
     [:summer_recruitment_banner, 'Show a banner to indicate a shorter recruitment timeframe during summer', 'Richard Pattinson'],
     [:restructured_immigration_status, 'New model for right to work and study in the UK to be released from 2022 cycle', 'Steve Hook'],
-    [:block_fraudulent_submission, 'A button used on the fraud audit page to block submissions', 'James Glenn'],
     [:support_user_revert_withdrawn_offer, 'Allows a support user to revert an application withdrawn by the candidate', 'James Glenn'],
     [:region_from_postcode, 'Uses an external service to find the region code for each candidate using their postcode', 'Steve Hook'],
     [:publish_monthly_statistics, 'Publish monthly statistics at publications/monthly-statistics', 'Duncan Brown'],

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -37,7 +37,7 @@
 
 <%= render partial: 'candidate_interface/application_form/review', locals: { application_form: @application_form, editable: true } %>
 
-<% if @application_form.candidate&.fraud_match&.blocked && FeatureFlag.active?(:block_fraudulent_submission) %>
+<% if @application_form.candidate&.fraud_match&.blocked %>
   <p class='govuk-body'>We’ve noticed that you’ve started multiple applications.</p>
   <p class='govuk-body'>Submitting applications for more than 3 courses at a time is not allowed, as stated in our terms of use.</p>
   <p class='govuk-body'>We have halted this application and you will be unable to submit.</p>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -65,7 +65,7 @@
       <%= render 'task_list', application_form: @application_form_presenter.application_form, application_form_presenter: @application_form_presenter %>
     <% end %>
 
-    <% if @application_form_presenter.application_form.candidate&.fraud_match&.blocked && FeatureFlag.active?(:block_fraudulent_submission) %>
+    <% if @application_form_presenter.application_form.candidate&.fraud_match&.blocked %>
       <p class='govuk-body'>We’ve noticed that you’ve started multiple applications.</p>
       <p class='govuk-body'>Submitting applications for more than 3 courses at a time is not allowed, as stated in our terms of use.</p>
       <p class='govuk-body'>We have halted this application and you will be unable to submit.</p>

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::DropBlockFraudulentSubmissionFeatureFlag',
   'DataMigrations::FixCandidateAPIUpdatedAt',
   'DataMigrations::BackfillCarriedOverApplicationsDegreesComplete',
   'DataMigrations::BackfillWorkHistoryStatusForCurrentCycle',

--- a/spec/components/support_interface/fraud_auditing_matches_table_component_spec.rb
+++ b/spec/components/support_interface/fraud_auditing_matches_table_component_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe SupportInterface::FraudAuditingMatchesTableComponent do
   let(:fraud_match2) { create(:fraud_match, fraudulent: true) }
 
   before do
-    FeatureFlag.activate(:block_fraudulent_submission)
     Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
       fraud_match2.update!(candidate_last_contacted_at: Time.zone.now)
       create(:application_form, candidate: fraud_match1.candidates.first, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH', submitted_at: Time.zone.now)

--- a/spec/services/data_migrations/drop_block_fraudulent_submission_feature_flag_spec.rb
+++ b/spec/services/data_migrations/drop_block_fraudulent_submission_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::DropBlockFraudulentSubmissionFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: 'block_fraudulent_submission')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'block_fraudulent_submission')).to be_blank
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end

--- a/spec/system/support_interface/duplicate_candidate_matches_spec.rb
+++ b/spec/system/support_interface/duplicate_candidate_matches_spec.rb
@@ -12,7 +12,6 @@ RSpec.feature 'See Duplicate candidate matches' do
 
   scenario 'Support agent visits Duplicate candidate matches page', sidekiq: true do
     given_i_am_a_support_user
-    and_the_feature_flag_is_active
     and_i_go_to_duplicate_candidate_matches_page
     then_i_should_see_a_message_declaring_that_there_are_no_matches
 
@@ -52,10 +51,6 @@ RSpec.feature 'See Duplicate candidate matches' do
 
   def given_i_am_a_support_user
     sign_in_as_support_user
-  end
-
-  def and_the_feature_flag_is_active
-    FeatureFlag.activate(:block_fraudulent_submission)
   end
 
   def then_i_should_see_a_message_declaring_that_there_are_no_matches


### PR DESCRIPTION
## Context

This flag has been active on production since 28 October 2021. Removing it will make it easier to rework the 'fraud' matches feature.

## Changes proposed in this pull request

- [x] Drop the `block_fraudulent_submission` feature flag.
- [x] Data migration to drop the `block_fraudulent_submission` feature flag record.

## Guidance to review

Anything missing?

## Link to Trello card

https://trello.com/c/V7occWOj/4242-duplicate-matches-remove-existing-feature-flag

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
