### PR TITLE
Automate cycle dates in provider emails

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -190,7 +190,7 @@ class ProviderMailer < ApplicationMailer
 
     provider_notify_email(
       to: @provider_user.email_address,
-      subject: I18n.t!('provider_mailer.apply_service_is_now_open.subject'),
+      subject: I18n.t!('provider_mailer.apply_service_is_now_open.subject', time_period: CycleTimetable.cycle_year_range),
     )
   end
 
@@ -199,7 +199,7 @@ class ProviderMailer < ApplicationMailer
 
     provider_notify_email(
       to: @provider_user.email_address,
-      subject: I18n.t!('provider_mailer.find_service_is_now_open.subject'),
+      subject: I18n.t!('provider_mailer.find_service_is_now_open.subject', time_period: CycleTimetable.cycle_year_range),
     )
   end
 

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -36,6 +36,6 @@ en:
     permissions_removed_by_support:
       subject: "You've been removed from %{organisation}"
     apply_service_is_now_open:
-      subject: "Candidates can now apply for teacher training courses for 2022 to 2023"
+      subject: "Candidates can now apply for teacher training courses for %{time_period}"
     find_service_is_now_open:
-      subject: "Candidates can now find teacher training courses for 2022 to 2023"
+      subject: "Candidates can now find teacher training courses for %{time_period}"


### PR DESCRIPTION
## Context

Automate retrieval of cycle dates in provider emails to avoid requiring fixes between cycles.

## Link to Trello card

https://trello.com/c/lonwVAdw/4612-automate-cycle-dates-in-provider-emails

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
