### PR TITLE
Add `Candidate#submission_blocked`

### DIFF
--- a/app/components/support_interface/fraud_auditing_matches_table_component.rb
+++ b/app/components/support_interface/fraud_auditing_matches_table_component.rb
@@ -26,7 +26,7 @@ module SupportInterface
     end
 
     def candidate_blocked?(fraud_id)
-      FraudMatch.find(fraud_id).blocked
+      FraudMatch.find(fraud_id).candidates.first&.submission_blocked?
     end
 
   private

--- a/app/forms/support_interface/block_submission_form.rb
+++ b/app/forms/support_interface/block_submission_form.rb
@@ -11,9 +11,11 @@ module SupportInterface
 
       return false unless valid?
 
-      FraudMatch.find(fraud_match_id).candidates.all? do |candidate|
-        candidate.update(submission_blocked: true)
+      FraudMatch.find(fraud_match_id).candidates.each do |candidate|
+        return false unless candidate.update(submission_blocked: true)
       end
+
+      true
     end
   end
 end

--- a/app/forms/support_interface/block_submission_form.rb
+++ b/app/forms/support_interface/block_submission_form.rb
@@ -11,7 +11,11 @@ module SupportInterface
 
       return false unless valid?
 
-      FraudMatch.find(fraud_match_id).update!(blocked: true, fraudulent: true)
+      FraudMatch.find(fraud_match_id).candidates.each do |candidate|
+        return unless candidate.update(submission_blocked: true)
+      end
+
+      true
     end
   end
 end

--- a/app/forms/support_interface/block_submission_form.rb
+++ b/app/forms/support_interface/block_submission_form.rb
@@ -11,11 +11,9 @@ module SupportInterface
 
       return false unless valid?
 
-      FraudMatch.find(fraud_match_id).candidates.each do |candidate|
-        return unless candidate.update(submission_blocked: true)
+      FraudMatch.find(fraud_match_id).candidates.all? do |candidate|
+        candidate.update(submission_blocked: true)
       end
-
-      true
     end
   end
 end

--- a/app/forms/support_interface/unblock_submission_form.rb
+++ b/app/forms/support_interface/unblock_submission_form.rb
@@ -11,7 +11,11 @@ module SupportInterface
 
       return false unless valid?
 
-      FraudMatch.find(fraud_match_id).update!(blocked: false, fraudulent: false)
+      FraudMatch.find(fraud_match_id).candidates.each do |candidate|
+        return unless candidate.update(submission_blocked: false)
+      end
+
+      true
     end
   end
 end

--- a/app/forms/support_interface/unblock_submission_form.rb
+++ b/app/forms/support_interface/unblock_submission_form.rb
@@ -11,11 +11,9 @@ module SupportInterface
 
       return false unless valid?
 
-      FraudMatch.find(fraud_match_id).candidates.each do |candidate|
-        return unless candidate.update(submission_blocked: false)
+      FraudMatch.find(fraud_match_id).candidates.all? do |candidate|
+        candidate.update(submission_blocked: false)
       end
-
-      true
     end
   end
 end

--- a/app/services/data_migrations/backfill_candidates_submission_blocked.rb
+++ b/app/services/data_migrations/backfill_candidates_submission_blocked.rb
@@ -1,0 +1,14 @@
+module DataMigrations
+  class BackfillCandidatesSubmissionBlocked
+    TIMESTAMP = 20211224095546
+    MANUAL_RUN = false
+
+    def change
+      FraudMatch.where(blocked: true).find_each do |fraud_match|
+        fraud_match.candidates.each do |candidate|
+          candidate.update(submission_blocked: true)
+        end
+      end
+    end
+  end
+end

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -37,7 +37,7 @@
 
 <%= render partial: 'candidate_interface/application_form/review', locals: { application_form: @application_form, editable: true } %>
 
-<% if @application_form.candidate&.fraud_match&.blocked %>
+<% if @application_form.candidate&.submission_blocked? %>
   <p class='govuk-body'>We’ve noticed that you’ve started multiple applications.</p>
   <p class='govuk-body'>Submitting applications for more than 3 courses at a time is not allowed, as stated in our terms of use.</p>
   <p class='govuk-body'>We have halted this application and you will be unable to submit.</p>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -65,7 +65,7 @@
       <%= render 'task_list', application_form: @application_form_presenter.application_form, application_form_presenter: @application_form_presenter %>
     <% end %>
 
-    <% if @application_form_presenter.application_form.candidate&.fraud_match&.blocked %>
+    <% if @application_form_presenter.application_form.candidate&.submission_blocked? %>
       <p class='govuk-body'>We’ve noticed that you’ve started multiple applications.</p>
       <p class='govuk-body'>Submitting applications for more than 3 courses at a time is not allowed, as stated in our terms of use.</p>
       <p class='govuk-body'>We have halted this application and you will be unable to submit.</p>

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillCandidatesSubmissionBlocked',
   'DataMigrations::DropBlockFraudulentSubmissionFeatureFlag',
   'DataMigrations::FixCandidateAPIUpdatedAt',
   'DataMigrations::BackfillCarriedOverApplicationsDegreesComplete',

--- a/spec/components/support_interface/fraud_auditing_matches_table_component_spec.rb
+++ b/spec/components/support_interface/fraud_auditing_matches_table_component_spec.rb
@@ -62,7 +62,10 @@ RSpec.describe SupportInterface::FraudAuditingMatchesTableComponent do
   end
 
   it 'renders the option to unblock the candidate if currently blocked' do
-    blocked_fraud_match = create(:fraud_match, blocked: true)
+    blocked_fraud_match = create(
+      :fraud_match,
+      candidates: create_list(:candidate, 2, submission_blocked: true),
+    )
 
     create(:application_form, candidate: blocked_fraud_match.candidates.first, first_name: 'Joffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH')
     create(:application_form, candidate: blocked_fraud_match.candidates.second, first_name: 'Joffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH')

--- a/spec/factories/course_option.rb
+++ b/spec/factories/course_option.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :course_option do
+    initialize_with { CourseOption.find_or_initialize_by(course: course, site: site) }
     course
+
     site { association(:site, provider: course.provider) }
 
     vacancy_status { 'vacancies' }

--- a/spec/factories/course_option.rb
+++ b/spec/factories/course_option.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :course_option do
-    initialize_with { CourseOption.find_or_initialize_by(course: course, site: site) }
     course
 
     site { association(:site, provider: course.provider) }

--- a/spec/factories/site.rb
+++ b/spec/factories/site.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :site do
     provider
 
+    initialize_with { Site.find_or_initialize_by(provider: provider, code: code) }
     code { Faker::Alphanumeric.unique.alphanumeric(number: 5).upcase }
     name { "#{Faker::Educator.secondary_school} #{rand(100..999)}" }
     address_line1 { Faker::Address.street_address }

--- a/spec/forms/support_interface/block_submission_form_spec.rb
+++ b/spec/forms/support_interface/block_submission_form_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::BlockSubmissionForm, type: :model do
-  let(:fraud_match) { create(:fraud_match) }
-  let(:first_application) { create(:application_form, candidate: fraud_match.candidates.first, first_name: 'Jeffrey', submitted_at: Time.zone.now) }
-  let(:second_application) { create(:application_form, candidate: fraud_match.candidates.second, first_name: 'Geoffrey') }
+  let(:fraud_match) { create(:fraud_match, candidates: [create(:candidate, submission_blocked: false)]) }
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:accept_guidance) }
@@ -11,14 +9,11 @@ RSpec.describe SupportInterface::BlockSubmissionForm, type: :model do
 
   describe '#save' do
     it 'blocks the candidate from being able to submit' do
-      candidate_to_block = described_class.new({ accept_guidance: true })
+      service = described_class.new({ accept_guidance: true })
 
-      expect(candidate_to_block.save(fraud_match.id)).to eq true
+      expect(service.save(fraud_match.id)).to be(true)
 
-      fraud_match.reload
-
-      expect(fraud_match.blocked).to eq true
-      expect(fraud_match.fraudulent).to eq true
+      expect(fraud_match.candidates.first.reload.submission_blocked).to be(true)
     end
   end
 end

--- a/spec/forms/support_interface/unblock_submission_form_spec.rb
+++ b/spec/forms/support_interface/unblock_submission_form_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::UnblockSubmissionForm, type: :model do
-  let(:fraud_match) { create(:fraud_match, blocked: true, fraudulent: true) }
-  let(:first_application) { create(:application_form, candidate: fraud_match.candidates.first, first_name: 'Jeffrey', submitted_at: Time.zone.now) }
-  let(:second_application) { create(:application_form, candidate: fraud_match.candidates.second, first_name: 'Geoffrey') }
+  let(:fraud_match) { create(:fraud_match, candidates: [create(:candidate, submission_blocked: true)]) }
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:accept_guidance) }
@@ -11,14 +9,11 @@ RSpec.describe SupportInterface::UnblockSubmissionForm, type: :model do
 
   describe '#save' do
     it 'unblocks the candidate after being blocked' do
-      candidate_to_block = described_class.new({ accept_guidance: true })
+      service = described_class.new({ accept_guidance: true })
 
-      expect(candidate_to_block.save(fraud_match.id)).to eq true
+      expect(service.save(fraud_match.id)).to be(true)
 
-      fraud_match.reload
-
-      expect(fraud_match.blocked).to eq false
-      expect(fraud_match.fraudulent).to eq false
+      expect(fraud_match.candidates.first.reload.submission_blocked).to be(false)
     end
   end
 end

--- a/spec/services/data_migrations/backfill_candidates_submission_blocked_spec.rb
+++ b/spec/services/data_migrations/backfill_candidates_submission_blocked_spec.rb
@@ -5,17 +5,17 @@ RSpec.describe DataMigrations::BackfillCandidatesSubmissionBlocked do
     blocked_fraud_match = FraudMatch.create(blocked: true)
     non_blocked_fraud_match = FraudMatch.create(blocked: false)
 
-    @blocked_duplicate_candidates = FactoryBot.create_list(
+    @blocked_duplicate_candidates = create_list(
       :candidate,
       2,
       fraud_match: blocked_fraud_match,
     )
-    @non_blocked_duplicate_candidates = FactoryBot.create_list(
+    @non_blocked_duplicate_candidates = create_list(
       :candidate,
       2,
       fraud_match: non_blocked_fraud_match,
     )
-    @non_duplicate_candidate = FactoryBot.create(:candidate)
+    @non_duplicate_candidate = create(:candidate)
   end
 
   it 'sets submission_blocked only on the correct candidates' do

--- a/spec/services/data_migrations/backfill_candidates_submission_blocked_spec.rb
+++ b/spec/services/data_migrations/backfill_candidates_submission_blocked_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillCandidatesSubmissionBlocked do
+  before do
+    blocked_fraud_match = FraudMatch.create(blocked: true)
+    non_blocked_fraud_match = FraudMatch.create(blocked: false)
+
+    @blocked_duplicate_candidates = FactoryBot.create_list(
+      :candidate,
+      2,
+      fraud_match: blocked_fraud_match,
+    )
+    @non_blocked_duplicate_candidates = FactoryBot.create_list(
+      :candidate,
+      2,
+      fraud_match: non_blocked_fraud_match,
+    )
+    @non_duplicate_candidate = FactoryBot.create(:candidate)
+  end
+
+  it 'sets submission_blocked only on the correct candidates' do
+    described_class.new.change
+
+    @blocked_duplicate_candidates.each do |candidate|
+      expect(candidate.reload.submission_blocked).to be(true)
+    end
+
+    @non_blocked_duplicate_candidates.each do |candidate|
+      expect(candidate.reload.submission_blocked).to be(false)
+    end
+
+    expect(@non_duplicate_candidate.reload.submission_blocked).to be(false)
+  end
+end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -177,8 +177,8 @@ module CandidateHelper
     course2 =
       Course.find_by(code: '2397', provider: @provider) ||
       create(:course, exposed_in_find: true, open_on_apply: true, name: 'Drama', code: '2397', provider: @provider, start_date: Date.new(2020, 9, 1), level: :primary)
-    create(:course_option, site: site, course: course)
-    create(:course_option, site: site, course: course2)
+    create(:course_option, site: site, course: course) unless CourseOption.find_by(site: site, course: course, study_mode: :full_time)
+    create(:course_option, site: site, course: course2) unless CourseOption.find_by(site: site, course: course2, study_mode: :full_time)
   end
 
   def candidate_fills_in_course_choices

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -171,8 +171,12 @@ module CandidateHelper
   def given_courses_exist
     @provider = create(:provider, name: 'Gorse SCITT', code: '1N1', provider_type: 'scitt')
     site = create(:site, name: 'Main site', code: '-', provider: @provider)
-    course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Primary', code: '2XT2', provider: @provider, start_date: Date.new(2020, 9, 1))
-    course2 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Drama', code: '2397', provider: @provider, start_date: Date.new(2020, 9, 1))
+    course =
+      Course.find_by(code: '2XT2', provider: @provider) ||
+      create(:course, exposed_in_find: true, open_on_apply: true, name: 'Primary', code: '2XT2', provider: @provider, start_date: Date.new(2020, 9, 1), level: :primary)
+    course2 =
+      Course.find_by(code: '2397', provider: @provider) ||
+      create(:course, exposed_in_find: true, open_on_apply: true, name: 'Drama', code: '2397', provider: @provider, start_date: Date.new(2020, 9, 1), level: :primary)
     create(:course_option, site: site, course: course)
     create(:course_option, site: site, course: course2)
   end

--- a/spec/system/candidate_interface/references/candidate_submits_a_duplicate_application_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_submits_a_duplicate_application_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.feature 'Submitting an application' do
+  include CandidateHelper
+
+  scenario 'Candidate submits complete application' do
+    given_i_am_signed_in
+    and_i_have_completed_my_first_application
+
+    when_i_submit_the_application
+    then_i_can_see_my_application_has_been_successfully_submitted
+
+    when_i_am_signed_in_using_a_new_account
+    and_i_complete_a_second_duplicate_application
+    and_the_duplicate_matching_service_runs
+    then_i_can_see_a_warning_message
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_am_signed_in_using_a_new_account
+    @current_candidate = create(:candidate)
+    create_and_sign_in_candidate
+  end
+
+  def and_i_have_completed_my_first_application
+    candidate_completes_application_form
+  end
+
+  def and_i_complete_a_second_duplicate_application
+    candidate_completes_application_form
+  end
+
+  def and_i_submit_the_application
+    visit candidate_interface_application_form_path
+    click_link 'Check and submit your application'
+    click_link t('continue')
+  end
+  alias_method :when_i_submit_the_application, :and_i_submit_the_application
+
+  def then_i_can_see_my_application_has_been_successfully_submitted
+    click_link t('continue')
+
+    # What is your sex?
+    choose 'Prefer not to say'
+    click_button t('continue')
+
+    # Are you disabled?
+    choose 'Prefer not to say'
+    click_button t('continue')
+
+    # What is your ethnic group?
+    choose 'Prefer not to say'
+    click_button t('continue')
+
+    # Review page
+    click_link t('continue')
+
+    # Is there anything else you would like to tell us about your application?
+    choose 'No'
+    click_button 'Send application'
+
+    # Your feedback
+    click_button 'Continue'
+    expect(page).to have_content 'Application successfully submitted'
+  end
+
+  def and_the_duplicate_matching_service_runs
+    UpdateFraudMatches.new.save!
+    FraudMatch.first.candidates.each { |candidate| candidate.update!(submission_blocked: true) }
+  end
+
+  def then_i_can_see_a_warning_message
+    visit candidate_interface_application_form_path
+    expect(page).to have_content('We’ve noticed that you’ve started multiple applications')
+    expect(page).not_to have_button('Check and submit')
+  end
+end

--- a/spec/system/support_interface/duplicate_candidate_matches_spec.rb
+++ b/spec/system/support_interface/duplicate_candidate_matches_spec.rb
@@ -156,9 +156,8 @@ RSpec.feature 'See Duplicate candidate matches' do
   end
 
   def and_the_fraud_match_should_be_set_as_blocked
-    blocked_candidate = FraudMatch.first
-    expect(blocked_candidate.blocked).to eq true
-    expect(blocked_candidate.fraudulent).to eq true
+    fraud_match = FraudMatch.first
+    expect(fraud_match.candidates.map(&:submission_blocked)).to all(be true)
   end
 
   def when_i_unblock_the_candidate
@@ -172,9 +171,8 @@ RSpec.feature 'See Duplicate candidate matches' do
   end
 
   def and_the_fraud_match_should_be_set_as_unblocked
-    unblocked_candidate = FraudMatch.first
-    expect(unblocked_candidate.blocked).to eq false
-    expect(unblocked_candidate.fraudulent).to eq false
+    fraud_match = FraudMatch.first
+    expect(fraud_match.candidates.map(&:submission_blocked)).to all(be false)
   end
 
   def when_i_click_to_send_a_fraud_match_email_to_the_candidate


### PR DESCRIPTION
## Context

We want to move the `FraudMatch#blocked` attribute to `Candidate#submission_blocked` where it makes more sense (and has a clearer name). https://github.com/DFE-Digital/apply-for-teacher-training/pull/6240 added the new column to the schema. This PR completes the change.

## Changes proposed in this pull request

- [x] Data migration to copy `true` values from `FraudMatch#blocked` attribute to `Candidate#submission_blocked`.
- [x] Switch the existing support UI to use the new attribute.
- [x] Update the Candidate UI (the submission blocking part).

Not in scope:

- Dropping the old column. We'll need a follow-up migration PR to do that.

## Guidance to review

STILL DRAFT

## Link to Trello card

https://trello.com/c/1vhgJEMk/4238-add-a-submissionblocked-flag-to-candidate

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
