### PR TITLE
Update manage to refer to recruitment cycles consistently

### DIFF
--- a/app/components/provider_interface/application_summary_component.rb
+++ b/app/components/provider_interface/application_summary_component.rb
@@ -31,7 +31,7 @@ module ProviderInterface
 
     def recruitment_cycle_year
       {
-        key: 'Year received',
+        key: 'Recruitment cycle',
         value: recruitment_cycle_year_name,
       }
     end
@@ -44,7 +44,7 @@ module ProviderInterface
     end
 
     def recruitment_cycle_year_name
-      RecruitmentCycle::CYCLES.fetch(application_form.recruitment_cycle_year.to_s)
+      RecruitmentCycle.cycle_string(application_form.recruitment_cycle_year)
     end
 
     attr_reader :application_form

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -71,14 +71,14 @@ module ProviderInterface
           year_str = year.to_s
           {
             value: year_str,
-            label: RecruitmentCycle::CYCLES[year_str],
+            label: RecruitmentCycle.cycle_string(year_str),
             checked: applied_filters[:recruitment_cycle_year]&.include?(year_str),
           }
         end
 
       {
         type: :checkboxes,
-        heading: 'Year received',
+        heading: 'Recruitment cycle',
         name: 'recruitment_cycle_year',
         options: cycle_options,
       }

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -1,9 +1,14 @@
 module RecruitmentCycle
   CYCLES = {
-    '2022' => '2021 to 2022 (starts 2022)',
-    '2021' => '2020 to 2021 (starts 2021)',
-    '2020' => '2019 to 2020 (starts 2020)',
+    '2022' => '2021 to 2022',
+    '2021' => '2020 to 2021',
+    '2020' => '2019 to 2020',
   }.freeze
+
+  def self.cycle_string(year)
+    cycle = CYCLES.fetch(year.to_s)
+    current_year.to_s == year.to_s ? "#{cycle} - current" : cycle
+  end
 
   def self.current_year
     CycleTimetable.current_year

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -61,17 +61,17 @@ module SupportInterface
   private
 
     def year_filter
-      cycle_options = RecruitmentCycle::CYCLES.map do |year, label|
+      cycle_options = RecruitmentCycle::CYCLES.map do |year, _|
         {
           value: year,
-          label: label,
+          label: RecruitmentCycle.cycle_string(year),
           checked: applied_filters[:year]&.include?(year),
         }
       end
 
       {
         type: :checkboxes,
-        heading: 'Recruitment cycle year',
+        heading: 'Recruitment cycle',
         name: 'year',
         options: cycle_options,
       }

--- a/app/views/provider_interface/application_data_export/new.html.erb
+++ b/app/views/provider_interface/application_data_export/new.html.erb
@@ -17,7 +17,7 @@
 
       <%= f.govuk_check_boxes_fieldset :recruitment_cycle_years, legend: { text: 'Recruitment cycle', size: 'm' } do %>
         <% RecruitmentCycle.years_visible_to_providers.each do |year| %>
-          <%= f.govuk_check_box :recruitment_cycle_years, year.to_s, label: { text: RecruitmentCycle::CYCLES[year.to_s] }, link_errors: true %>
+          <%= f.govuk_check_box :recruitment_cycle_years, year.to_s, label: { text: RecruitmentCycle.cycle_string(year) }, link_errors: true %>
         <% end %>
       <% end %>
 

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -1,6 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe RecruitmentCycle do
+  describe '.cycle_string' do
+    it 'throws an error when a cycle does not exist for the specified year' do
+      expect { described_class.cycle_string(2000) }
+        .to raise_error(KeyError)
+    end
+
+    it 'formats the displayed cycle string' do
+      expect(described_class.cycle_string(described_class.previous_year))
+        .to eq("#{described_class.previous_year - 1} to #{described_class.previous_year}")
+    end
+
+    it 'indicates the current cycle' do
+      expect(described_class.cycle_string(described_class.current_year))
+        .to eq("#{described_class.previous_year} to #{described_class.current_year} - current")
+    end
+  end
+
   describe '.current_year' do
     it 'delegates to CycleTimetable' do
       allow(CycleTimetable).to receive(:current_year)

--- a/spec/support/test_helpers/cycle_timetable_helper.rb
+++ b/spec/support/test_helpers/cycle_timetable_helper.rb
@@ -15,3 +15,12 @@ module CycleTimetableHelper
     CycleTimetable.apply_reopens(2021) + 1.day
   end
 end
+
+module RecruitmentCycle
+  CYCLES = {
+    '2022' => '2021 to 2022',
+    '2021' => '2020 to 2021',
+    '2020' => '2019 to 2020',
+    '2019' => '2018 to 2019',
+  }.freeze
+end


### PR DESCRIPTION
## Context

At the moment we're inconsistent in how we refer to recruitment cycles. We want to be consistent across Manage to make it easier for providers to understand what we mean

## Link to Trello card

https://trello.com/c/MFNbq75v/4611-update-manage-in-service-content-to-refer-to-recruitment-cycles-consistently

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
