### PR TITLE
Update provider email content and footers - application rejected by default

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -1,5 +1,6 @@
 class ProviderMailer < ApplicationMailer
   layout 'provider_email_with_footer', except: %i[fallback_sign_in_email]
+  layout 'provider_email', only: %i[application_rejected_by_default]
 
   def confirm_sign_in(provider_user, device:)
     @provider_user = provider_user

--- a/app/views/layouts/provider_email.text.erb
+++ b/app/views/layouts/provider_email.text.erb
@@ -1,0 +1,7 @@
+<%= yield %>
+
+# Get help
+
+Get help, report a problem or give feedback at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+
+<%= yield :additional_footer_content %>

--- a/app/views/provider_mailer/_notification_preferences.text.erb
+++ b/app/views/provider_mailer/_notification_preferences.text.erb
@@ -1,0 +1,3 @@
+You can change your email notification settings:
+
+<%= provider_interface_notifications_url %>

--- a/app/views/provider_mailer/application_rejected_by_default.text.erb
+++ b/app/views/provider_mailer/application_rejected_by_default.text.erb
@@ -1,11 +1,12 @@
-<% content_for :additional_footer_content do %><%= render 'unsubscribe' %><% end %>
-Dear <%= @provider_user_name || 'colleague' %>
+Dear <%= @provider_user_name %>
 
-<%= @application.candidate_name %>'s application to study <%= @application.course_name_and_code %> was automatically rejected.
+<%= @application.candidate_name %>'s application to <%= @application.course_name_and_code %> was automatically rejected.
 
-This is because you did not respond within <%= @application.rbd_days %> working days.
+This is because you did not make a decision about their application within <%= @application.rbd_days %> working days.
 
 <% if @provider_can_give_feedback %>
-  You need to tell <%= @application.candidate_name %> why their application was unsuccessful:
-  <%= provider_interface_application_choice_url(@application.application_choice_id) %>
+  Tell <%= @application.candidate_name %> why their application was unsuccessful:
+  <%= provider_interface_application_choice_url(@application.application_choice) %>
 <% end %>
+
+<% content_for :additional_footer_content do %><%= render 'notification_preferences' %><% end %>

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -51,7 +51,10 @@ RSpec.describe ProviderMailer, type: :mailer do
                       'candidate name' => 'Harry Potter',
                       'course name and code' => 'Computer Science (6IND)',
                       'reject by default days' => 'within 123 working days',
-                      'feedback_text' => 'You need to tell Harry Potter why their application was unsuccessful')
+                      'feedback_text' => 'Tell Harry Potter why their application was unsuccessful:',
+                      'link to application' => /http:\/\/localhost:3000\/provider\/applications\/\d+/,
+                      'notification settings' => 'You can change your email notification settings',
+                      'footer' => 'Get help, report a problem or give feedback')
     end
 
     context 'when the provider user cannot make decisions' do


### PR DESCRIPTION
## Changes proposed in this pull request

### Provider can make decisions
<img width="814" alt="rbd_can_make_decisions" src="https://user-images.githubusercontent.com/159200/147668707-c341b973-70ae-44e9-b559-99266e68f623.png">

### Provider cant make decisions
<img width="820" alt="rbd_cant_make_decisions" src="https://user-images.githubusercontent.com/159200/147668735-d8da8aa7-373f-4f3d-aa02-66f7eb4043e6.png">



## Guidance to review

https://docs.google.com/document/d/1n05Y66yvLyxj03UEr9TjLqjiZO--fUVB9KGrHZS_uJs/edit#heading=h.6mvuz2dwrdxn

## Link to Trello card

https://trello.com/c/1YyvarMf/4613-update-provider-email-content-and-footers

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
