### PR TITLE
Update provider email content and footers - declined

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -261,7 +261,7 @@ private
       application_choice.application_form.submitted_at&.to_s(:govuk_date),
       application_choice.id,
       application_choice,
-      application_choice.reject_by_default_at.to_s(:govuk_date),
+      application_choice.reject_by_default_at&.to_s(:govuk_date),
       application_choice.reject_by_default_days,
       application_choice.application_form.support_reference,
     )

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -258,7 +258,7 @@ private
       application_choice.application_form.full_name,
       application_choice.current_course_option.course.name_and_code,
       application_choice.current_course_option.course.name,
-      application_choice.application_form.submitted_at.to_s(:govuk_date).strip,
+      application_choice.application_form.submitted_at&.to_s(:govuk_date),
       application_choice.id,
       application_choice,
       application_choice.reject_by_default_at.to_s(:govuk_date),

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -2,7 +2,7 @@ class ProviderMailer < ApplicationMailer
   layout 'provider_email_with_footer', except: %i[fallback_sign_in_email]
   layout 'provider_email', only: %i[application_rejected_by_default application_submitted
                                     application_submitted_with_safeguarding_issues apply_service_is_now_open
-                                    chase_provider_decision confirm_sign_in]
+                                    chase_provider_decision confirm_sign_in declined]
 
   def confirm_sign_in(provider_user, device:)
     @provider_user = provider_user
@@ -112,11 +112,11 @@ class ProviderMailer < ApplicationMailer
   end
 
   def declined(provider_user, application_choice)
-    @application_choice = application_choice
+    @application = map_application_choice_params(application_choice)
     email_for_provider(
       provider_user,
       application_choice.application_form,
-      subject: I18n.t!('provider_mailer.declined.subject', candidate_name: application_choice.application_form.full_name, support_reference: @application_choice.application_form.support_reference),
+      subject: I18n.t!('provider_mailer.declined.subject', candidate_name: @application.candidate_name),
     )
   end
 

--- a/app/views/provider_mailer/declined.text.erb
+++ b/app/views/provider_mailer/declined.text.erb
@@ -1,8 +1,9 @@
-<% content_for :additional_footer_content do %><%= render 'unsubscribe' %><% end %>
-Dear <%= @provider_user.full_name || 'colleague' %>
+Dear <%= @provider_user.full_name %>
 
-# Offer declined
+<%= @application.candidate_name %> declined your offer for <%= @application.course_name_and_code %>.
 
-<%= @application_choice.application_form.full_name %> has declined your offer to study <%= @application_choice.current_course_option.course.name_and_code %>.
+View the offer:
 
-<%= provider_interface_application_choice_url(@application_choice) %>
+<%= provider_interface_application_choice_offer_url(@application.application_choice) %>
+
+<% content_for :additional_footer_content do %><%= render 'notification_preferences' %><% end %>

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -10,7 +10,7 @@ en:
     decline_by_default:
       subject: "%{candidate_name}’s (%{support_reference}) application withdrawn automatically"
     declined:
-      subject: "%{candidate_name} (%{support_reference}) declined an offer"
+      subject: "%{candidate_name} declined your offer"
     application_submitted:
       subject: '%{candidate_name} submitted an application for %{course_name}'
     application_submitted_with_safeguarding_issues:

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -202,10 +202,13 @@ RSpec.describe ProviderMailer, type: :mailer do
     let(:email) { described_class.declined(provider_user, application_choice) }
 
     it_behaves_like('a mail with subject and content',
-                    'Harry Potter (123A) declined an offer - manage teacher training applications',
+                    'Harry Potter declined your offer - manage teacher training applications',
                     'provider name' => 'Dear Johny English',
                     'candidate name' => 'Harry Potter',
-                    'course name and code' => 'Computer Science (6IND)')
+                    'course name and code' => 'Computer Science (6IND)',
+                    'offer link' => /http:\/\/localhost:3000\/provider\/applications\/\d+\/offers/,
+                    'notification settings' => 'You can change your email notification settings',
+                    'footer' => 'Get help, report a problem or give feedback')
   end
 
   describe 'organisation_permissions_set_up' do

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_declines_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_declines_offer_spec.rb
@@ -89,7 +89,7 @@ RSpec.feature 'Candidate declines an offer' do
 
   def and_the_provider_receives_a_notification
     open_email(@provider_user.email_address)
-    expect(current_email.subject).to have_content 'Harry Potter (123A) declined an offer'
+    expect(current_email.subject).to have_content 'Harry Potter declined your offer'
   end
 
   def when_i_click_on_view_and_respond_to_my_last_offer_link


### PR DESCRIPTION
## Changes proposed in this pull request
<img width="702" alt="Screenshot 2021-12-29 at 22 31 52" src="https://user-images.githubusercontent.com/159200/147708240-a1b63228-bdcb-4d28-bb47-bb1b088f5dd9.png">

## Guidance to review

https://docs.google.com/document/d/1n05Y66yvLyxj03UEr9TjLqjiZO--fUVB9KGrHZS_uJs/edit#heading=h.6mvuz2dwrdxn

## Link to Trello card

https://trello.com/c/1YyvarMf/4613-update-provider-email-content-and-footers

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
