### PR TITLE
Update provider email content and footers - declined by default

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -2,7 +2,7 @@ class ProviderMailer < ApplicationMailer
   layout 'provider_email_with_footer', except: %i[fallback_sign_in_email]
   layout 'provider_email', only: %i[application_rejected_by_default application_submitted
                                     application_submitted_with_safeguarding_issues apply_service_is_now_open
-                                    chase_provider_decision confirm_sign_in declined]
+                                    chase_provider_decision confirm_sign_in declined declined_by_default]
 
   def confirm_sign_in(provider_user, device:)
     @provider_user = provider_user
@@ -92,11 +92,11 @@ class ProviderMailer < ApplicationMailer
   end
 
   def declined_by_default(provider_user, application_choice)
-    @application_choice = application_choice
+    @application = map_application_choice_params(application_choice)
     email_for_provider(
       provider_user,
       application_choice.application_form,
-      subject: I18n.t!('provider_mailer.decline_by_default.subject', candidate_name: application_choice.application_form.full_name, support_reference: @application_choice.application_form.support_reference),
+      subject: I18n.t!('provider_mailer.decline_by_default.subject', candidate_name: @application.candidate_name, course_name: @application.course_name),
     )
   end
 

--- a/app/views/provider_mailer/declined_by_default.text.erb
+++ b/app/views/provider_mailer/declined_by_default.text.erb
@@ -1,8 +1,11 @@
-<% content_for :additional_footer_content do %><%= render 'unsubscribe' %><% end %>
-Dear <%= @provider_user.full_name || 'colleague' %>
+Dear <%= @provider_user.full_name %>
 
-# Offer declined by default
+<%= @application.candidate_name %>'s offer for <%= @application.course_name_and_code %> was automatically declined.
 
-<%= @application_choice.application_form.full_name %> had 10 working days to respond to your offer to study <%= @application_choice.current_course_option.course.name_and_code %>. They have not replied, so the offer has been automatically declined.
+This is because the candidate did not respond within 10 working days.
 
-<%= provider_interface_application_choice_url(@application_choice) %>
+View the offer:
+
+<%= provider_interface_application_choice_offer_url(@application.application_choice) %>
+
+<% content_for :additional_footer_content do %><%= render 'notification_preferences' %><% end %>

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -8,7 +8,7 @@ en:
     unconditional_offer_accepted:
       subject: "%{candidate_name} (%{support_reference}) has accepted your offer"
     decline_by_default:
-      subject: "%{candidate_name}’s (%{support_reference}) application withdrawn automatically"
+      subject: "%{candidate_name}’s offer for %{course_name} was automatically declined"
     declined:
       subject: "%{candidate_name} declined your offer"
     application_submitted:

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -150,17 +150,20 @@ RSpec.describe ProviderMailer, type: :mailer do
     let(:email) { described_class.declined_by_default(provider_user, application_choice) }
 
     it_behaves_like('a mail with subject and content',
-                    'Harry Potter’s (123A) application withdrawn automatically - manage teacher training applications',
+                    'Harry Potter’s offer for Computer Science was automatically declined - manage teacher training applications',
                     'provider name' => 'Dear Johny English',
                     'candidate name' => 'Harry Potter',
-                    'course name and code' => 'Computer Science (6IND)')
+                    'course name and code' => 'Computer Science (6IND)',
+                    'offer link' => /http:\/\/localhost:3000\/provider\/applications\/\d+\/offers/,
+                    'notification settings' => 'You can change your email notification settings',
+                    'footer' => 'Get help, report a problem or give feedback')
 
     context 'with an alternative course offer' do
       let(:alternative_course) { build_stubbed(:course, provider: provider, name: 'Welding', code: '9ABC') }
       let(:current_course_option) { build_stubbed(:course_option, course: alternative_course, site: site) }
 
       it_behaves_like('a mail with subject and content',
-                      'Harry Potter’s (123A) application withdrawn automatically - manage teacher training applications',
+                      'Harry Potter’s offer for Welding was automatically declined - manage teacher training applications',
                       'provider name' => 'Dear Johny English',
                       'course name and code' => 'Welding (9ABC)')
     end

--- a/spec/system/decline_by_default_spec.rb
+++ b/spec/system/decline_by_default_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature 'Decline by default' do
   def and_the_provider_receives_an_email
     open_email(@provider_user.email_address)
 
-    expect(current_email.subject).to include("Harry Potter’s (#{@application_form.support_reference}) application withdrawn automatically")
+    expect(current_email.subject).to include("Harry Potter’s offer for #{@application_choice.current_course.name} was automatically declined")
   end
 
   def and_the_candidate_receives_a_decline_by_default_email


### PR DESCRIPTION
## Changes proposed in this pull request
<img width="728" alt="Screenshot 2021-12-29 at 23 23 27" src="https://user-images.githubusercontent.com/159200/147710295-5207c345-f1e0-461d-a946-40a72ed22216.png">

## Guidance to review

https://docs.google.com/document/d/1n05Y66yvLyxj03UEr9TjLqjiZO--fUVB9KGrHZS_uJs/edit#heading=h.6mvuz2dwrdxn

## Link to Trello card

https://trello.com/c/1YyvarMf/4613-update-provider-email-content-and-footers

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
