### PR TITLE
Update provider email content and footers - organisation permissions set up

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -3,7 +3,7 @@ class ProviderMailer < ApplicationMailer
   layout 'provider_email', only: %i[application_rejected_by_default application_submitted
                                     application_submitted_with_safeguarding_issues apply_service_is_now_open
                                     chase_provider_decision confirm_sign_in declined declined_by_default
-                                    find_service_is_now_open offer_accepted]
+                                    find_service_is_now_open offer_accepted organisation_permissions_set_up]
 
   def confirm_sign_in(provider_user, device:)
     @provider_user = provider_user

--- a/app/views/provider_mailer/organisation_permissions_set_up.text.erb
+++ b/app/views/provider_mailer/organisation_permissions_set_up.text.erb
@@ -1,10 +1,8 @@
 Dear <%= @provider_user.full_name %>
 
-# <%= @partner_organisation.name %> has set up organisation permissions for teacher training courses you work on with them
+<%= @partner_organisation.name %> set up organisation permissions for courses you run with them.
 
-You can now manage applications made through GOV.UK for the courses you work on with <%= @partner_organisation.name %>.
-
-They have set up the following organisation permissions.
+They set the following organisation permissions.
 
 <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| -%>
 <%= I18n.t("provider_relationship_permissions.#{permission_name}.description") %>:
@@ -14,8 +12,6 @@ They have set up the following organisation permissions.
 
 <% end -%>
 
-# Change organisation permissions
-
-You can change these organisation permissions in your organisation settings:
+You can change organisation permissions:
 
 <%= provider_interface_organisation_settings_organisation_organisation_permissions_url(@recipient_organisation) %>

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -22,7 +22,7 @@ en:
     application_withdrawn:
       subject: "%{candidate_name} (%{support_reference}) withdrew their application"
     organisation_permissions_set_up:
-      subject: "%{provider} has set up organisation permissions for teacher training courses you work on with them"
+      subject: "%{provider} set up organisation permissions"
     organisation_permissions_updated:
       subject: "%{provider} has changed organisation permissions for teacher training courses you work on with them"
     set_up_organisation_permissions:

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -221,8 +221,8 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe 'organisation_permissions_set_up' do
-    let(:training_provider) { build_stubbed(:provider, name: 'University of Purley') }
-    let(:ratifying_provider) { build_stubbed(:provider, name: 'University of Croydon') }
+    let(:training_provider) { build_stubbed(:provider, id: 123,  name: 'University of Purley') }
+    let(:ratifying_provider) { build_stubbed(:provider, id: 345, name: 'University of Croydon') }
     let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English', providers: [training_provider]) }
     let(:permissions) do
       build_stubbed(
@@ -237,12 +237,14 @@ RSpec.describe ProviderMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      'University of Croydon has set up organisation permissions for teacher training courses you work on with them - manage teacher training applications',
+      'University of Croydon set up organisation permissions - manage teacher training applications',
       'salutation' => 'Dear Johny English',
-      'heading' => 'University of Croydon has set up organisation permissions for teacher training courses you work on with them',
+      'heading' => 'University of Croydon set up organisation permissions for courses you run with them',
       'make offers' => /Make offers and reject applications:\s+- University of Purley/,
       'view safeguarding' => /View criminal convictions and professional misconduct:\s+- University of Purley\s+- University of Croydon/,
       'view diversity' => /View criminal convictions and professional misconduct:\s+- University of Purley\s+- University of Croydon/,
+      'link to manage organisation permissions' => '/provider/organisation-settings/organisations/123/organisation-permissions',
+      'footer' => 'Get help, report a problem or give feedback',
     )
   end
 


### PR DESCRIPTION
## Changes proposed in this pull request
<img width="911" alt="Screenshot 2021-12-30 at 00 15 04" src="https://user-images.githubusercontent.com/159200/147712130-5aa25b3f-729b-40ff-ab91-0e2a1b703892.png">

## Guidance to review

https://docs.google.com/document/d/1n05Y66yvLyxj03UEr9TjLqjiZO--fUVB9KGrHZS_uJs/edit#heading=h.6mvuz2dwrdxn

## Link to Trello card

https://trello.com/c/1YyvarMf/4613-update-provider-email-content-and-footers

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
