### PR TITLE
Update provider email content and footers -  permissions updated

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -5,7 +5,7 @@ class ProviderMailer < ApplicationMailer
                                     chase_provider_decision confirm_sign_in declined declined_by_default
                                     find_service_is_now_open offer_accepted organisation_permissions_set_up
                                     organisation_permissions_updated permissions_granted permissions_removed
-                                    set_up_organisation_permissions unconditional_offer_accepted]
+                                    set_up_organisation_permissions unconditional_offer_accepted permissions_updated]
 
   def confirm_sign_in(provider_user, device:)
     @provider_user = provider_user

--- a/app/views/provider_mailer/permissions_updated.text.erb
+++ b/app/views/provider_mailer/permissions_updated.text.erb
@@ -18,4 +18,4 @@ Dear <%= @provider_user.full_name %>
 
 Manage applications:
 
-<%= provider_interface_sign_in_url %>
+<%= provider_interface_applications_url %>

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -343,6 +343,8 @@ RSpec.describe ProviderMailer, type: :mailer do
       'heading' => 'Jane Doe updated your permissions for Hogwards University.',
       'view safeguarding' => 'view criminal convictions and professional misconduct',
       'view diversity' => 'view sex, disability and ethnicity information',
+      'link to applications' => 'http://localhost:3000/provider/applications',
+      'footer' => 'Get help, report a problem or give feedback',
     )
   end
 
@@ -361,7 +363,9 @@ RSpec.describe ProviderMailer, type: :mailer do
       'Jane Doe updated your permissions for Hogwards University - manage teacher training applications',
       'salutation' => 'Dear Princess Fiona',
       'heading' => 'Jane Doe updated your permissions for Hogwards University.',
-      'permissiosn' => 'You only have permission to view applications.',
+      'permissions' => 'You only have permission to view applications.',
+      'link to applications' => 'http://localhost:3000/provider/applications',
+      'footer' => 'Get help, report a problem or give feedback',
     )
   end
 
@@ -381,6 +385,8 @@ RSpec.describe ProviderMailer, type: :mailer do
       'heading' => 'Your permissions have been updated for Hogwards University.',
       'make decisions' => 'make offers and reject application',
       'view safeguarding' => 'view criminal convictions and professional misconduct',
+      'link to applications' => 'http://localhost:3000/provider/applications',
+      'footer' => 'Get help, report a problem or give feedback',
     )
   end
 


### PR DESCRIPTION
## Changes proposed in this pull request

### Permissions updated
<img width="789" alt="Screenshot 2021-12-30 at 01 03 34" src="https://user-images.githubusercontent.com/159200/147713638-2d7b4fca-0294-40f4-8d32-e96d8dc368bd.png">

### Permissions updated - all permissions removed
<img width="839" alt="Screenshot 2021-12-30 at 01 03 48" src="https://user-images.githubusercontent.com/159200/147713641-5a877563-00e3-4678-9ffc-29b3649d41a3.png">

## Guidance to review

https://docs.google.com/document/d/1n05Y66yvLyxj03UEr9TjLqjiZO--fUVB9KGrHZS_uJs/edit#heading=h.6mvuz2dwrdxn

## Link to Trello card

https://trello.com/c/1YyvarMf/4613-update-provider-email-content-and-footers

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
