### PR TITLE
Include Duplicate match data in setup_local_dev test data

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -134,32 +134,36 @@ private
     Audited.audit_class.as_user(candidate) do
       traits = [%i[with_safeguarding_issues_disclosed
                    with_safeguarding_issues_never_asked
-                   minimum_info]].sample
+                   minimum_info duplicate_candidates].sample]
+
       traits << :with_equality_and_diversity_data
+
+      last_name_on_application_form = traits.include?(:duplicate_candidates) && ApplicationForm.last ? ApplicationForm.last.last_name : last_name
 
       simulate_signin(candidate)
 
-      @application_form = FactoryBot.create(
-        :completed_application_form,
-        *traits,
-        :with_degree,
-        :with_gcses,
-        :with_a_levels,
-        application_choices_count: 0,
-        full_work_history: true,
-        volunteering_experiences_count: 1,
-        submitted_at: nil,
-        candidate: candidate,
-        first_name: first_name,
-        last_name: last_name,
-        created_at: time,
-        updated_at: time,
-        recruitment_cycle_year: recruitment_cycle_year,
-        phase: apply_again ? 'apply_2' : 'apply_1',
-        work_history_completed: false,
-        previous_application_form: previous_application_form,
-        references_count: 0,
-      )
+      @application_form =
+        FactoryBot.create(
+          :completed_application_form,
+          *traits,
+          :with_degree,
+          :with_gcses,
+          :with_a_levels,
+          application_choices_count: 0,
+          full_work_history: true,
+          volunteering_experiences_count: 1,
+          submitted_at: nil,
+          candidate: candidate,
+          first_name: first_name,
+          last_name: last_name_on_application_form,
+          created_at: time,
+          updated_at: time,
+          recruitment_cycle_year: recruitment_cycle_year,
+          phase: apply_again ? 'apply_2' : 'apply_1',
+          work_history_completed: false,
+          previous_application_form: previous_application_form,
+          references_count: 0,
+        )
 
       @application_form.application_work_experiences.each { |experience| experience.update!(created_at: time) }
       @application_form.application_volunteering_experiences.each { |experience| experience.update!(created_at: time) }

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -20,6 +20,9 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
   CreateVendorAPIMonitorDummyData.call
 
   Rake::Task['generate_test_applications'].invoke
+
+  puts 'Finding fraudulent applications'
+  UpdateFraudMatchesWorker.new.perform
 end
 
 desc 'Sync some pilot-enabled providers and open all their courses'

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -23,6 +23,11 @@ FactoryBot.define do
       submitted_at { Faker::Time.backward(days: 7, period: :day) }
     end
 
+    trait :duplicate_candidates do
+      date_of_birth { ApplicationForm.last&.date_of_birth || '01-01-1996' }
+      postcode { ApplicationForm.last&.postcode || 'SW1P 3BT' }
+    end
+
     trait :international_address do
       address_type { :international }
       country { Faker::Address.country_code }


### PR DESCRIPTION
## Context

It is difficult to test the Duplicate matching dashboard in local dev because there is not easy way to create test data to populate it.

This PR enhances the `setup_local_dev_data` task to also create a few duplicate applications which can populate the dashboard.

## Changes proposed in this pull request

- Add new trait where the DOB and postcode is hardcoded
- Perform `UpdateFraudMatchesWorker` at the end of the `setup_local_dev_data` rake task

## Guidance to review

Does it make more sense to add the duplcates to applications in other states?

## Link to Trello card

https://trello.com/c/jKuLyz0l/4245-include-duplicate-match-data-in-setuplocaldev-test-data
