### PR TITLE
Use Alphanumeric#unique for subject code

### DIFF
--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :subject do
     name { Faker::Educator.subject }
-    code { Faker::Alphanumeric.alphanumeric(number: 4) }
+    code { Faker::Alphanumeric.unique.alphanumeric(number: 4) }
   end
 end


### PR DESCRIPTION
## Context

Caught by flakey test detection, `Subject#code` as generated by Faker was not unique.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

User Faker's `unique` method for `Subject#code`
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/r5Bd2NwU/4594-flakey-spec-services-supportinterface-externalreportapplicationsexportspecrb5
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
