### PR TITLE
Candidate account locking

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -114,7 +114,6 @@ module CandidateInterface
     def check_account_locked
       if current_candidate&.account_locked?
         sign_out(current_candidate)
-        flash[:error] = 'You\'re account has been locked'
         redirect_to candidate_interface_account_locked_path
       end
     end

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -4,6 +4,7 @@ module CandidateInterface
     before_action :authenticate_candidate!
     before_action :set_user_context
     before_action :check_cookie_preferences
+    before_action :check_account_locked
     layout 'application'
     alias audit_user current_candidate
     alias current_user current_candidate
@@ -108,6 +109,14 @@ module CandidateInterface
 
       payload.merge!({ candidate_id: current_candidate&.id })
       payload.merge!(query_params: request_query_params)
+    end
+
+    def check_account_locked
+      if current_candidate&.account_locked?
+        sign_out(current_candidate)
+        flash[:error] = 'You\'re account has been locked'
+        redirect_to candidate_interface_account_locked_path
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/errors_controller.rb
+++ b/app/controllers/candidate_interface/errors_controller.rb
@@ -3,6 +3,10 @@ module CandidateInterface
     skip_before_action :verify_authenticity_token
     skip_before_action :authenticate_candidate!
 
+    def account_locked
+      render 'errors/account_locked', status: :forbidden, formats: :html
+    end
+
     def not_found
       render 'errors/not_found', status: :not_found, formats: :html
     end

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -27,6 +27,10 @@ class Candidate < ApplicationRecord
     end
   end
 
+  # def active_for_authentication?
+  #   super && !account_locked?
+  # end
+
   def touch_application_choices_and_forms
     return unless application_choices.any?
 

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -27,10 +27,6 @@ class Candidate < ApplicationRecord
     end
   end
 
-  # def active_for_authentication?
-  #   super && !account_locked?
-  # end
-
   def touch_application_choices_and_forms
     return unless application_choices.any?
 

--- a/app/views/errors/account_locked.html.erb
+++ b/app/views/errors/account_locked.html.erb
@@ -3,11 +3,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('page_titles.account_locked') %></h1>
-    <p class="govuk-body">Your account has been locked.</p>
+    <p class="govuk-body">This is because you created more than one account.</p>
     <p class="govuk-body">
-      You have created multiple accounts with similar
-      contact details and can no longer access this service. Please contact the support
-      team if you require further assistance.
+      Get in touch at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> if you need help.
     </p>
   </div>
 </div>

--- a/app/views/errors/account_locked.html.erb
+++ b/app/views/errors/account_locked.html.erb
@@ -1,0 +1,13 @@
+<%= content_for :title, t('page_titles.account_locked') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('page_titles.account_locked') %></h1>
+    <p class="govuk-body">Your account has been locked.</p>
+    <p class="govuk-body">
+      You have created multiple accounts with similar
+      contact details and can no longer access this service. Please contact the support
+      team if you require further assistance.
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
     not_found: Page not found
     monthly_statistics: Initial teacher training application statistics for courses starting in the %{academic_year_name} academic year
     forbidden: Access denied
+    account_locked: Account locked
     internal_server_error: Sorry, there’s a problem with the service
     unprocessable_entity: Sorry, there’s a problem with the service
     personal_details: Personal details

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,7 +65,7 @@ en:
     not_found: Page not found
     monthly_statistics: Initial teacher training application statistics for courses starting in the %{academic_year_name} academic year
     forbidden: Access denied
-    account_locked: Account locked
+    account_locked: You can no longer access this account
     internal_server_error: Sorry, there’s a problem with the service
     unprocessable_entity: Sorry, there’s a problem with the service
     personal_details: Personal details

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -585,6 +585,8 @@ Rails.application.routes.draw do
       end
     end
 
+    get '/account-locked', to: 'errors#account_locked'
+
     get '*path', to: 'errors#not_found'
   end
 

--- a/spec/system/candidate_interface/entering_details/candidate_account_locking_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_account_locking_spec.rb
@@ -35,6 +35,7 @@ RSpec.feature 'Candidate account locking' do
 
   def then_i_am_redirected_to_the_account_locked_page
     expect(page).to have_current_path(candidate_interface_account_locked_path)
+    expect(page).to have_content('You can no longer access this account')
   end
 
   def when_i_try_to_login_again

--- a/spec/system/candidate_interface/entering_details/candidate_account_locking_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_account_locking_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate account locking' do
+  include CandidateHelper
+  include SignInHelper
+
+  scenario 'Candidate attempts to continue their application while account is locked' do
+    given_i_am_signed_in
+    and_i_visit_the_site
+    and_my_account_is_locked
+
+    when_i_click_on_contact_information
+    then_i_am_redirected_to_the_account_locked_page
+
+    when_i_try_to_login_again
+    then_i_am_redirected_to_the_account_locked_page
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def and_my_account_is_locked
+    @email_address = current_candidate.email_address
+    current_candidate.update!(account_locked: true)
+  end
+
+  def when_i_click_on_contact_information
+    click_link t('page_titles.contact_information')
+  end
+
+  def then_i_am_redirected_to_the_account_locked_page
+    expect(page).to have_current_path(candidate_interface_account_locked_path)
+  end
+
+  def when_i_try_to_login_again
+    visit candidate_interface_sign_in_path
+    fill_in t('authentication.sign_up.email_address.label'), with: @email_address
+    click_on t('continue')
+    open_email(@email_address)
+    click_magic_link_in_email
+    confirm_sign_in
+  end
+end


### PR DESCRIPTION
## Context

When a candidate's account is identified as a belonging to the same person as an existing account, we need to be able to lock that account.

## Changes proposed in this pull request

- [x] Add logic to check the `Candidate#account_locked` attribute on each candidate request and redirect to a new account locked page if `true`:

<img width="832" alt="image" src="https://user-images.githubusercontent.com/450843/148754088-fa02047a-47a0-4e70-b1a5-bcd4e6748b89.png">

- [x] System spec for this feature.
- [x] Add content for the account locked page.

## Guidance to review

- Does the business logic for this feature make sense? Are the tests sufficient?

## Link to Trello card

https://trello.com/c/zM88ZhQg/4244-add-an-accountlocked-feature-to-candidates

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
