### PR TITLE
Visual flags for locked/blocked candidates in support interface

### DIFF
--- a/app/components/support_interface/application_card_component.html.erb
+++ b/app/components/support_interface/application_card_component.html.erb
@@ -4,8 +4,12 @@
       <%= govuk_link_to candidate_name, support_interface_application_form_path(application_form) %>
       <span class="govuk-body-s"><%= support_reference %> <%= apply_again_context %></span>
     </h<%= @heading_level %>>
-    <p class="govuk-body-s govuk-!-margin-bottom-2"><strong><%= overall_status %></strong></p>
+    <p class="govuk-body-s govuk-!-margin-bottom-2">
+      <strong><%= overall_status %></strong><br/>
+    </p>
   </header>
+
+  <%= render SupportInterface::DuplicateCandidateWarningComponent.new(candidate: application_form.candidate) %>
 
   <% if application_choices.any? %>
   <ul class="app-application-card__list govuk-list govuk-list--bullet">

--- a/app/components/support_interface/application_card_component.html.erb
+++ b/app/components/support_interface/application_card_component.html.erb
@@ -5,7 +5,7 @@
       <span class="govuk-body-s"><%= support_reference %> <%= apply_again_context %></span>
     </h<%= @heading_level %>>
     <p class="govuk-body-s govuk-!-margin-bottom-2">
-      <strong><%= overall_status %></strong><br/>
+      <strong><%= overall_status %></strong>
     </p>
   </header>
 

--- a/app/components/support_interface/duplicate_candidate_warning_component.html.erb
+++ b/app/components/support_interface/duplicate_candidate_warning_component.html.erb
@@ -1,0 +1,5 @@
+<% if @candidate.account_locked? %>
+  <%= govuk_warning_text(text: 'Account locked') %>
+<% elsif @candidate.submission_blocked? %>
+  <%= govuk_warning_text(text: 'Submission blocked') %>
+<% end %>

--- a/app/components/support_interface/duplicate_candidate_warning_component.rb
+++ b/app/components/support_interface/duplicate_candidate_warning_component.rb
@@ -1,0 +1,13 @@
+module SupportInterface
+  class DuplicateCandidateWarningComponent < ViewComponent::Base
+    include ViewHelper
+
+    def initialize(candidate:)
+      @candidate = candidate
+    end
+
+    def render?
+      @candidate.submission_blocked? || @candidate.account_locked?
+    end
+  end
+end

--- a/app/views/support_interface/application_forms/_application_navigation.html.erb
+++ b/app/views/support_interface/application_forms/_application_navigation.html.erb
@@ -10,7 +10,7 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l"><%= @application_form.support_reference %></span>
     <h1 class="govuk-heading-l"><%= break_email_address(@application_form.candidate.email_address) %></h1>
-    <% unless HostingEnvironment.production? %>
+    <% unless HostingEnvironment.production? || @application_form.candidate.account_locked? %>
       <%= govuk_button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@application_form.candidate) %>
     <% end %>
   </div>

--- a/app/views/support_interface/application_forms/_application_navigation.html.erb
+++ b/app/views/support_interface/application_forms/_application_navigation.html.erb
@@ -29,6 +29,8 @@
   <% end %>
 <% end %>
 
+<%= render SupportInterface::DuplicateCandidateWarningComponent.new(candidate: @application_form.candidate) %>
+
 <%= render TabNavigationComponent.new(items: [
   { name: 'Details', url: support_interface_application_form_path(@application_form) },
   { name: 'History', url: support_interface_application_form_audit_path(@application_form) },

--- a/spec/components/support_interface/duplicate_candidate_warning_component_spec.rb
+++ b/spec/components/support_interface/duplicate_candidate_warning_component_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::DuplicateCandidateWarningComponent do
+  context 'when the candidate is not locked or blocked' do
+    it 'renders nothing' do
+      result = render_inline described_class.new(candidate: Candidate.new)
+      expect(result.text).to be_blank
+    end
+  end
+
+  context 'when submission_blocked is true' do
+    it 'renders a warning message' do
+      result = render_inline described_class.new(candidate: Candidate.new(submission_blocked: true))
+      expect(result.text).to include('Submission blocked')
+    end
+  end
+
+  context 'when account_locked and submission_blocked are both true' do
+    it 'renders a warning message' do
+      result = render_inline described_class.new(candidate: Candidate.new(account_locked: true, submission_blocked: true))
+      expect(result.text).to include('Account locked')
+    end
+  end
+end

--- a/spec/system/support_interface/duplicate_candidate_matches_locking_spec.rb
+++ b/spec/system/support_interface/duplicate_candidate_matches_locking_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.feature 'See Duplicate candidate matches' do
+  include DfESignInHelpers
+
+  around do |example|
+    @today = Time.zone.local(2021, 12, 24, 12)
+    Timecop.freeze(@today) do
+      example.run
+    end
+  end
+
+  scenario 'Support agent visits Duplicate candidate matches page', sidekiq: true do
+    given_i_am_a_support_user
+    and_there_are_candidates_with_duplicate_applications_in_the_system
+    and_the_update_fraud_matches_worker_has_run
+    and_a_candidate_has_a_locked_account
+
+    when_i_view_the_locked_candidate
+    then_i_can_see_a_warning_message
+    and_i_cannot_impersonate_the_candidate
+
+    when_i_view_the_unlocked_candidate
+    then_i_cannot_see_a_warning_message
+    and_i_can_impersonate_the_candidate
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_are_candidates_with_duplicate_applications_in_the_system
+    @candidate_one = create(:candidate, email_address: 'exemplar1@example.com')
+    @candidate_two = create(:candidate, email_address: 'exemplar2@example.com')
+
+    @application_form_one = create(:application_form, candidate: @candidate_one, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH', submitted_at: 7.days.ago)
+    @application_form_two = create(:application_form, candidate: @candidate_two, first_name: 'Joffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH')
+  end
+
+  def and_a_candidate_has_a_locked_account
+    @candidate_one.update!(account_locked: true)
+  end
+
+  def and_the_update_fraud_matches_worker_has_run
+    UpdateFraudMatchesWorker.perform_async
+  end
+
+  def when_i_view_the_locked_candidate
+    visit support_interface_application_form_path(application_form_id: @application_form_one.id)
+  end
+
+  def then_i_can_see_a_warning_message
+    expect(page).to have_content('Account locked')
+  end
+
+  def and_i_cannot_impersonate_the_candidate
+    expect(page).not_to have_button('Sign in as this candidate')
+  end
+
+  def when_i_view_the_unlocked_candidate
+    visit support_interface_application_form_path(application_form_id: @application_form_two.id)
+  end
+
+  def then_i_cannot_see_a_warning_message
+    expect(page).not_to have_content('Account locked')
+  end
+
+  def and_i_can_impersonate_the_candidate
+    expect(page).to have_button('Sign in as this candidate')
+  end
+end


### PR DESCRIPTION
## Context

https://github.com/DFE-Digital/apply-for-teacher-training/pull/6275 and https://github.com/DFE-Digital/apply-for-teacher-training/pull/6244 add `submission_blocked` and `account_locked` attributes to `Candidate`. Support users should be able to see the state of these flags for each candidate.

## Changes proposed in this pull request

- [x] Add a `SupportInterface::DuplicateCandidateWarningComponent` that encapsulates a design system warning text component.
- [x] Render a `SupportInterface::DuplicateCandidateWarningComponent` on the application index and show pages for each candidate.

<img width="1184" alt="image" src="https://user-images.githubusercontent.com/450843/147832126-4f6d5b02-8610-4dc0-b719-6de4b47c22f7.png">

<img width="826" alt="image" src="https://user-images.githubusercontent.com/450843/147832136-6c185982-c028-460d-9dae-ab69888fcbae.png">

- [ ] Review the UX 


## Guidance to review

- How can we improve the UX?

## Link to Trello card

https://trello.com/c/VS0PUaxA/4248-add-a-submissionblocked-flag-to-candidates

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
