### PR TITLE
Fix age range monthly report spec

### DIFF
--- a/spec/support/monthly_statistics_test_helper.rb
+++ b/spec/support/monthly_statistics_test_helper.rb
@@ -110,11 +110,6 @@ module MonthlyStatisticsTestHelper
   end
 
   def date_of_birth(years_ago:)
-    # go back an extra year because we calculate d.o.b. backwards from 1 August
-    if Time.zone.today > Date.parse('1st August')
-      years_ago.years.ago
-    else
-      (years_ago + 1).years.ago
-    end
+    years_ago.years.ago
   end
 end


### PR DESCRIPTION
## Context

We calculate the age according to the beginning of August and end
of July when generating reports. However if we change the logic in
the specs we risk having to generate different results each time.

Remove the logic around adding a year after August to keep the
spec expectation the same.

## Changes proposed in this pull request

Calculate exact year passed in to avoid failures

## Guidance to review

This needs more thought, will merge to unblock main

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
