### PR TITLE
Improve the defer offer confirmation page content

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -68,6 +68,8 @@
             You did not make a decision about the application within <%= application_choice.reject_by_default_days %> working days. Tell the candidate why their application was unsuccessful.
           </p>
           <%= govuk_button_link_to 'Give feedback', provider_interface_reasons_for_rejection_initial_questions_path(application_choice) %>
+        <% elsif deferred_offer_in_current_cycle? -%>
+          Your offer will need to be confirmed at the start of the next recruitment cycle.
         <% end -%>
       <% end %>
     </div>

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -29,7 +29,8 @@ module ProviderInterface
         rejection_reason_required? ||
         awaiting_decision_but_cannot_respond? ||
         set_up_interview? ||
-        offer_will_be_declined_by_default?
+        offer_will_be_declined_by_default? ||
+        deferred_offer_in_current_cycle?
     end
 
     def respond_to_application?
@@ -46,6 +47,12 @@ module ProviderInterface
       application_choice.status == 'offer_deferred' &&
         application_choice.current_course_option.in_next_cycle &&
         application_choice.current_course_option.in_next_cycle.course.open_on_apply
+    end
+
+    def deferred_offer_in_current_cycle?
+      application_choice.status == 'offer_deferred' &&
+        application_choice.recruitment_cycle == RecruitmentCycle.current_year &&
+        !application_choice.current_course_option.in_next_cycle
     end
 
     def rejection_reason_required?

--- a/app/views/provider_interface/decisions/new_defer_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_defer_offer.html.erb
@@ -11,9 +11,7 @@
         <%= t('page_titles.provider.new_defer_offer') %>
       </h1>
 
-      <p class="govuk-body">This application will be marked as deferred.</p>
-      <p class="govuk-body">You must review and confirm your offer again at the start of the next cycle (<%= RecruitmentCycle.cycle_name(@application_choice.recruitment_cycle + 1) %>).</p>
-      <p class="govuk-body">We’ll email the candidate notifying them of the deferral after you confirm below.</p>
+      <p class="govuk-body">The candidate will be sent an email to confirm that your offer has been deferred.</p>
 
       <%= f.button 'Confirm offer deferral', class: 'govuk-button', data: { module: 'govuk-button' } %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -209,7 +209,7 @@ en:
       confirm_offer: Check and confirm offer
       confirm_reject: Check feedback and reject application
       confirm_withdraw_offer: Check and confirm withdrawal
-      new_defer_offer: Check and confirm offer deferral
+      new_defer_offer: Confirm that you want to defer the offer
       new_edit_response: Change response
       new_offer: Conditions of offer
       new_reject: Reject application

--- a/spec/components/provider_interface/application_choice_header_component_spec.rb
+++ b/spec/components/provider_interface/application_choice_header_component_spec.rb
@@ -187,6 +187,35 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
     end
   end
 
+  describe '#deferred_offer_in_current_cycle?' do
+    it 'is true for a deferred offer without an open offered option' do
+      course_option = instance_double(CourseOption, course: instance_double(Course, open_on_apply: false))
+      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred', recruitment_cycle: RecruitmentCycle.current_year)
+      allow(course_option).to receive(:in_next_cycle).and_return(false)
+      allow(application_choice).to receive(:current_course_option).and_return(course_option)
+
+      expect(described_class.new(application_choice: application_choice).deferred_offer_in_current_cycle?).to be true
+    end
+
+    it 'is false for a deferred offer with an open offered option' do
+      course_option = instance_double(CourseOption, course: instance_double(Course, open_on_apply: false))
+      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred', recruitment_cycle: RecruitmentCycle.current_year)
+      allow(course_option).to receive(:in_next_cycle).and_return(course_option)
+      allow(application_choice).to receive(:current_course_option).and_return(course_option)
+
+      expect(described_class.new(application_choice: application_choice).deferred_offer_in_current_cycle?).to be false
+    end
+
+    it 'is false for a deferred offer from the previous cycle' do
+      course_option = instance_double(CourseOption, course: instance_double(Course, open_on_apply: false))
+      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred', recruitment_cycle: RecruitmentCycle.previous_year)
+      allow(course_option).to receive(:in_next_cycle).and_return(course_option)
+      allow(application_choice).to receive(:current_course_option).and_return(course_option)
+
+      expect(described_class.new(application_choice: application_choice).deferred_offer_in_current_cycle?).to be false
+    end
+  end
+
   describe '#rejection_reason_required' do
     it 'is true for a rejected by default application without a rejection reason' do
       application_choice = instance_double(ApplicationChoice, status: 'rejected', rejected_by_default: true, rejection_reason: nil, structured_rejection_reasons: nil)


### PR DESCRIPTION
## Context

We're simplifying the confirmation page that users see when they defer an offer. 

## Changes proposed in this pull request

Content changed on the deferred offer confirmation page:
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/47917431/148045056-f5cc7df1-b306-4394-af6a-db9ea30ec4ed.png)|![image](https://user-images.githubusercontent.com/47917431/148045009-8024ffb8-405d-4569-b470-a0bf347cbf13.png)|

New inset text for deferred offers in the current cycle:
<img src=https://user-images.githubusercontent.com/47917431/148054485-1cb2f1c7-e3c2-442d-9ffe-8ae565768ee9.png width="50%">  

## Guidance to review

Is `deferred_offer_in_current_cycle?` overkill for what we need here?
[Design history](https://bat-design-history.netlify.app/manage-teacher-training-applications/deferring-an-offer-iteration-3/)

## Link to Trello card

https://trello.com/c/p64hKavp

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
