### PR TITLE
Substitute double quotes in flakey test output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,6 +227,7 @@ jobs:
           if [ ! -z "$file_text" ]
           then
             file_text="${file_text//$'\n'/%0A}"
+            file_text="${file_text//\"/\'}"
             echo "::set-output name=flakey_tests::$file_text"
           else
             echo "No flakey tests logged"


### PR DESCRIPTION
## Context

It's possible our flakey test error messages contain doule quotes, these don't always play nicely with Github actions expressions.

eg.

```
Run echo "1,3,./spec/services/accept_unconditional_offer_spec.rb:53,Expected "[TEST]   accepted your offer for Applied Science (Psychology) - manage teacher training applications"
/home/runner/work/_temp/bec3686c-af93-4c8d-a092-bdef68996d83.sh: line 1: syntax error near unexpected token `('
Error: Process completed with exit code 2.
```

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Substitute double quotes for single quotes in flakey test error messages before they are set as workflow job outputs.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Create a file locally with the following contents

```
1,3,./spec/services/accept_unconditional_offer_spec.rb:53,Expected "[TEST]   accepted your offer for Applied Science (Psychology) - manage teacher training applications
```

the cat into a variable the same way the GH workflow does:

```
file_text=$(cat file.txt)
file_text="${file_text//\"/\'}"
echo "$file_text"
```

double quotes should be replaced by single quotes.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
