### PR TITLE
Don't attempt to comment on invalid flakey spec log data

### DIFF
--- a/.github/scripts/comment_on_flakey_specs.js
+++ b/.github/scripts/comment_on_flakey_specs.js
@@ -20,11 +20,13 @@ module.exports = ({github, context}) => {
       dataStr = rows[idx];
       if (dataStr.length) {
         dataAry = dataStr.split(',');
-        [attempts, retryCount, errorLocation, ...errorMessages] = dataAry;
-        errorPath = `/${owner}/${repo}/blob/${branchName}/${errorLocation.replace(':', '#L')}`;
-        errorLink = `<a href="${errorPath}">${errorLocation}</a>`;
-        commentBody += `Failed ${attempts} out of ${retryCount} times at ${errorLink}: :warning: ${errorMessages.toString()}<br>`;
-        createComment = true;
+        if (dataAry.length >= 4) {
+          [attempts, retryCount, errorLocation, ...errorMessages] = dataAry;
+          errorPath = `/${owner}/${repo}/blob/${branchName}/${errorLocation.replace(':', '#L')}`;
+          errorLink = `<a href="${errorPath}">${errorLocation}</a>`;
+          commentBody += `Failed ${attempts} out of ${retryCount} times at ${errorLink}: :warning: ${errorMessages.toString()}<br>`;
+          createComment = true;
+        }
       }
     }
     if (createComment) {


### PR DESCRIPTION
## Context

Some recent RSpec formatting issues/changes have meant that error messages can span multiple lines.
We are applying a fix for this in the rspec-retry gem but it's also worth bailing out if the data we use to create the comment doesn't seem to be valid.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds a guard around commenting on flakey specs.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
