### PR TITLE
Remove false line from external report

### DIFF
--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -279,8 +279,6 @@
 
     <p class="govuk-body">You can download all of the data on this page in CSV (comma separated values) format, which can be opened in a spreadsheet and used in other analysis tools.</p>
 
-    <p class="govuk-body">The downloads include some further breakdowns of the data by combining fields - for example, applicant age and sex.</p>
-
     <% @report.each do |export_type, size| %>
       <p class='govuk-body'>
       <%= govuk_link_to t("#{export_type}.label") + " #{size.to_s(:human_size)}", publications_monthly_report_download_path(export_type: export_type, date: '2021-11') %>


### PR DESCRIPTION
This isn't true - the CSVs only include the information on the page

## Context

Raised on a support ticket: https://ukgovernmentdfe.slack.com/archives/C01L213TT0C/p1641306884005300

## Changes proposed in this pull request

Remove the offending line. Checked with Policy.

## Things to check

- [X] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
