### PR TITLE
Update the application details page when a deferred offer needs to be confirmed

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -45,20 +45,15 @@
           </p>
         <% elsif deferred_offer_wizard_applicable? -%>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-            Review and confirm the deferred offer
+            Confirm deferred offer
           </h2>
 
-          <% if deferred_offer_equivalent_course_option_available? %>
-            <p class="govuk-body">
-              The course offered to the candidate in the previous cycle is available in the current cycle.
-            </p>
-          <% else %>
-            <p class="govuk-body">
-              The course offered to the candidate in the previous cycle is not available in the current cycle.
-            </p>
-          <% end %>
+          <p class="govuk-body">
+            You need to confirm your deferred offer.
+          </p>
 
-          <%= govuk_button_link_to 'Review deferred offer', provider_interface_reconfirm_deferred_offer_path(application_choice) %>
+          <%= govuk_button_link_to 'Confirm deferred offer', provider_interface_reconfirm_deferred_offer_path(application_choice) %>
+
         <% elsif rejection_reason_required? -%>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
             Give feedback
@@ -70,6 +65,8 @@
           <%= govuk_button_link_to 'Give feedback', provider_interface_reasons_for_rejection_initial_questions_path(application_choice) %>
         <% elsif deferred_offer_in_current_cycle? -%>
           Your offer will need to be confirmed at the start of the next recruitment cycle.
+        <% elsif deferred_offer_but_cannot_respond? -%>
+          The deferred offer needs to be confirmed.
         <% end -%>
       <% end %>
     </div>

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -30,7 +30,8 @@ module ProviderInterface
         awaiting_decision_but_cannot_respond? ||
         set_up_interview? ||
         offer_will_be_declined_by_default? ||
-        deferred_offer_in_current_cycle?
+        deferred_offer_in_current_cycle? ||
+        deferred_offer_but_cannot_respond?
     end
 
     def respond_to_application?
@@ -43,16 +44,16 @@ module ProviderInterface
         application_choice.recruitment_cycle == RecruitmentCycle.previous_year
     end
 
-    def deferred_offer_equivalent_course_option_available?
-      application_choice.status == 'offer_deferred' &&
-        application_choice.current_course_option.in_next_cycle &&
-        application_choice.current_course_option.in_next_cycle.course.open_on_apply
-    end
-
     def deferred_offer_in_current_cycle?
       application_choice.status == 'offer_deferred' &&
         application_choice.recruitment_cycle == RecruitmentCycle.current_year &&
         !application_choice.current_course_option.in_next_cycle
+    end
+
+    def deferred_offer_but_cannot_respond?
+      !provider_can_respond &&
+        application_choice.status == 'offer_deferred' &&
+        application_choice.recruitment_cycle == RecruitmentCycle.previous_year
     end
 
     def rejection_reason_required?

--- a/app/helpers/task_view_helper.rb
+++ b/app/helpers/task_view_helper.rb
@@ -1,7 +1,7 @@
 module TaskViewHelper
   def task_view_header(choice)
     case choice&.task_view_group
-    when 1 then 'Deferred offers: review and confirm'
+    when 1 then 'Confirm deferred offers'
     when 2 then 'Deadline approaching: make decision about application'
     when 3 then 'Give feedback: you did not make a decision in time'
     when 4 then 'Ready for review'

--- a/spec/components/provider_interface/application_choice_header_component_spec.rb
+++ b/spec/components/provider_interface/application_choice_header_component_spec.rb
@@ -158,32 +158,12 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
     end
   end
 
-  describe '#deferred_offer_equivalent_course_option_available' do
-    it 'is true for a deferred offer with an offered course option' do
-      course_option = instance_double(CourseOption, course: instance_double(Course, open_on_apply: true))
+  describe '#deferred_offer_but_cannot_respond?' do
+    it 'is true if the provider cannot respond to the application' do
       application_choice = instance_double(ApplicationChoice, status: 'offer_deferred')
-      allow(course_option).to receive(:in_next_cycle).and_return(course_option)
-      allow(application_choice).to receive(:current_course_option).and_return(course_option)
+      allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.previous_year)
 
-      expect(described_class.new(application_choice: application_choice).deferred_offer_equivalent_course_option_available?).to be true
-    end
-
-    it 'is false for a deferred offer without an offered option' do
-      course_option = instance_double(CourseOption)
-      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred')
-      allow(course_option).to receive(:in_next_cycle).and_return(false)
-      allow(application_choice).to receive(:current_course_option).and_return(course_option)
-
-      expect(described_class.new(application_choice: application_choice).deferred_offer_equivalent_course_option_available?).to be false
-    end
-
-    it 'is false for a deferred offer without an offered option open on apply' do
-      course_option = instance_double(CourseOption, course: instance_double(Course, open_on_apply: false))
-      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred')
-      allow(course_option).to receive(:in_next_cycle).and_return(course_option)
-      allow(application_choice).to receive(:current_course_option).and_return(course_option)
-
-      expect(described_class.new(application_choice: application_choice).deferred_offer_equivalent_course_option_available?).to be false
+      expect(described_class.new(application_choice: application_choice, provider_can_respond: false).deferred_offer_but_cannot_respond?).to be true
     end
   end
 

--- a/spec/system/provider_interface/provider_reinstates_deferred_offer_spec.rb
+++ b/spec/system/provider_interface/provider_reinstates_deferred_offer_spec.rb
@@ -90,15 +90,15 @@ RSpec.feature 'Provider reinstates deferred offer' do
   end
 
   def then_i_do_not_see_a_prompt_to_review_the_deferred_offer
-    expect(page).not_to have_content 'Review deferred offer'
+    expect(page).not_to have_content 'Confirm deferred offer'
   end
 
   def then_i_see_a_prompt_to_review_the_deferred_offer
-    expect(page).to have_content 'Review deferred offer'
+    expect(page).to have_content 'Confirm deferred offer'
   end
 
   def when_i_click_to_review_the_deferred_offer
-    click_on 'Review deferred offer'
+    click_on 'Confirm deferred offer'
   end
 
   def then_i_can_see_the_details_of_the_deferred_offer


### PR DESCRIPTION
## Context

As part of the design changes for the deferring an offer flow, we no longer mention whether the course is available in the prompt, because the details are on the next page.

Because of this we now just tell the user they need to confirm the deferred offer. The button will also only be rendered if they have the correct permissions.

## Changes proposed in this pull request

Updated header:
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/47917431/148082495-45ba6890-c06a-475d-9821-4a6d2c7d4ee4.png)|![image](https://user-images.githubusercontent.com/47917431/148082569-8f5d7470-a062-49d2-b0aa-4dbbc4a29018.png)|

If the user has the correct permissions:
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/47917431/148082309-4b602d8b-ac07-416f-954c-19a4901c1863.png)|![image](https://user-images.githubusercontent.com/47917431/148079937-3d8e8a96-84e0-43f2-8a25-6d4b62f06b82.png)|

If they don't:
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/47917431/148082766-2d921fb4-cd45-480e-b10c-5a90952be51e.png)|![image](https://user-images.githubusercontent.com/47917431/148082862-02b5efd4-e0b7-40a5-aadb-b05b6c95d7cc.png)|

## Guidance to review

[Design history](https://bat-design-history.netlify.app/manage-teacher-training-applications/confirming-a-deferred-offer-iteration-3/)

## Link to Trello card

https://trello.com/c/txygZ0vivv
https://trello.com/c/x9xsCc8W

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
