### PR TITLE
Update 'Confirm deferred offer' page for unavailable course

### DIFF
--- a/app/views/provider_interface/reconfirm_deferred_offers/new.html.erb
+++ b/app/views/provider_interface/reconfirm_deferred_offers/new.html.erb
@@ -1,11 +1,11 @@
-<% content_for :browser_title, title_with_error_prefix('Review deferred offer', @application_choice.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix('Confirm deferred offer', @application_choice.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(previous_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
-      Review deferred offer
+      Confirm deferred offer
     </h1>
 
     <div class="govuk-!-margin-bottom-7">
@@ -13,37 +13,46 @@
         <p class="govuk-body-m">
           The course offered to the candidate in the previous cycle is available in the current cycle. On the next screen, you can change the status of the conditions of the offer.
         </p>
-       <% else %>
-        <p class="govuk-body-m">
-          The details of the course you offered previously are not available in the current cycle.
-        </p>
-       <% end %>
-      <%= govuk_details(
-        summary_text: 'Details of deferred offer',
-        classes: 'govuk-!-margin-bottom-0 app-details--no-boder',
-      ) do %>
-        <%= render ProviderInterface::DeferredOfferDetailsComponent.new(application_choice: @wizard.modified_application_choice) %>
-      <% end %>
 
-      <% unless @wizard.applicable? %>
-        <p class="govuk-body-m govuk-!-margin-top-5">
-          To change the details of this offer, contact us at <%= bat_contact_mail_to %>.
+        <%= govuk_details(
+          summary_text: 'Details of deferred offer',
+          classes: 'govuk-!-margin-bottom-0 app-details--no-boder',
+        ) do %>
+          <%= render ProviderInterface::DeferredOfferDetailsComponent.new(application_choice: @wizard.modified_application_choice) %>
+        <% end %>
+      <% else %>
+        <p class="govuk-body-m">
+        The course you offered the candidate in the previous recruitment cycle is not available in the current recruitment cycle.
         </p>
-        <p class="govuk-body-m">Tell us which of the following details you’d like to change:</p>
+
+        <p class="govuk-body-m">
+        To confirm the deferred offer, send an email to
+        <a class="govuk-link govuk-link--no-visited-state" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.
+        </p>
+
+        <p class="govuk-body-m">
+        You need to provide the following details in the email:
         <ul class="govuk-list govuk-list--bullet">
-          <li>provider</li>
-          <li>course</li>
-          <li>location</li>
-          <li>whether it’s full time or part time</li>
+          <li>training provider, subject, location and whether it’s full time or part time</li>
+          <li>any offer conditions that are pending or met</li>
         </ul>
-
-        <p class="govuk-body-m">
-          You should also let us know if any of the conditions of the offer are currently pending.
         </p>
 
         <p class="govuk-body-m">
-          We’ll contact you within one working day to confirm that the offer has been updated. We’ll also contact the candidate confirming the new details.
+        We’ll contact you within one working day to tell you that your offer has been confirmed. We’ll also email the candidate about their new offer.
         </p>
+
+      <h2 class="govuk-heading-l">Details of deferred offer</h2>
+
+      <%= render ProviderInterface::ReadOnlyCompletedOfferSummaryComponent.new(application_choice: @application_choice,
+                                                                               course_option: @application_choice.current_course_option,
+                                                                               conditions: @application_choice.offer.conditions,
+                                                                               course: @application_choice.current_course,
+                                                                               available_providers: [],
+                                                                               available_courses: [],
+                                                                               available_course_options: [],
+                                                                               border: true,
+                                                                               editable: false) %>
       <% end %>
     </div>
 


### PR DESCRIPTION
## Context

Update the content of this page to be in line with https://bat-design-history.netlify.app/manage-teacher-training-applications/confirming-a-deferred-offer-iteration-3/#confirm-offer-when-the-course-is-unavailable

## Changes proposed in this pull request

Before:

![image](https://user-images.githubusercontent.com/107591/148081281-028ef202-8bc7-40bf-a5f3-8c522c57bf23.png)

After:

![image](https://user-images.githubusercontent.com/107591/148081108-1976f0b2-b0e9-4f10-ae49-446a3fbe4f2a.png)

## Guidance to review

You need to find an application deferred in the previous cycle, with no equivalent course in the current cycle.

## Link to Trello card

https://trello.com/c/4j0BcG7M

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
