### PR TITLE
Copy changes on offer details page

### DIFF
--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -17,7 +17,6 @@
 
       <% if @offer_count > 1 %>
          <p class="govuk-body">If you accept this offer, your other <%= 'offer'.pluralize(@offer_count - 1) %> will be automatically declined.</p>
-         <p class="govuk-body"><a href="#" class="https://getintoteaching.education.gov.uk/#talk-to-us">Talk to us</a> if you need advice.</p>
 
       <% end %>
         

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -19,8 +19,6 @@
          <p class="govuk-body">If you accept this offer, your other <%= 'offer'.pluralize(@offer_count - 1) %> will be automatically declined.</p>
 
       <% end %>
-        
-
 
       <%= f.govuk_radio_buttons_fieldset :response, legend: { text: t('decisions.response.legend'), size: 'm' } do %>
         <% if @application_choice.unconditional_offer? %>

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -15,16 +15,13 @@
 
       <%= render(CandidateInterface::OfferReviewComponent.new(course_choice: @application_choice)) %>
 
-      <p class="govuk-body">Before you accept:</p>
+      <% if @offer_count > 1 %>
+         <p class="govuk-body">If you accept this offer, your other <%= 'offer'.pluralize(@offer_count - 1) %> will be automatically declined.</p>
+      <% end %>
+        
+      <p class="govuk-body">If you decline your <%= 'offer'.pluralize(@offer_count - 1) %>, or do not respond in time, you can still apply for courses that start this academic year.</li>
 
-      <ul class="govuk-list govuk-list--bullet">
-        <% if @offer_count > 1 %>
-          <li>if you accept this offer, your other <%= 'offer'.pluralize(@offer_count - 1) %> will be automatically declined</li>
-        <% end %>
-        <li>if you decline all of your offers, or do not respond in time, you can still apply for courses that start this academic year</li>
-      </ul>
-
-      <p class="govuk-body">If you need help, you can speak to our <%= govuk_link_to 'teacher training advisers', t('get_into_teaching.url_get_an_adviser') %>.</p>
+      <p class="govuk-body">Talk to a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser') %> if you need advice.</p>
 
       <%= f.govuk_radio_buttons_fieldset :response, legend: { text: t('decisions.response.legend'), size: 'm' } do %>
         <% if @application_choice.unconditional_offer? %>

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -17,7 +17,7 @@
 
       <% if @offer_count > 1 %>
          <p class="govuk-body">If you accept this offer, your other <%= 'offer'.pluralize(@offer_count - 1) %> will be automatically declined.</p>
-         <p class="govuk-body">Talk to a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser') %> if you need advice.</p>
+         <p class="govuk-body"><a href="#" class="Talk to us">https://getintoteaching.education.gov.uk/#talk-to-us</a> if you need advice.</p>
 
       <% end %>
         

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -22,7 +22,6 @@
       <% end %>
         
 
-      <p class="govuk-body">Talk to a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser') %> if you need advice.</p>
 
       <%= f.govuk_radio_buttons_fieldset :response, legend: { text: t('decisions.response.legend'), size: 'm' } do %>
         <% if @application_choice.unconditional_offer? %>

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -19,7 +19,7 @@
          <p class="govuk-body">If you accept this offer, your other <%= 'offer'.pluralize(@offer_count - 1) %> will be automatically declined.</p>
       <% end %>
         
-      <p class="govuk-body">If you decline your <%= 'offer'.pluralize(@offer_count - 1) %>, or do not respond in time, you can still apply for courses that start this academic year.</li>
+      <p class="govuk-body">If you decline your <%= 'offer'.pluralize(@offer_count - 1) %>, or do not respond in time, you can still apply for courses that start this academic year.</p>
 
       <p class="govuk-body">Talk to a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser') %> if you need advice.</p>
 

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -17,7 +17,7 @@
 
       <% if @offer_count > 1 %>
          <p class="govuk-body">If you accept this offer, your other <%= 'offer'.pluralize(@offer_count - 1) %> will be automatically declined.</p>
-         <p class="govuk-body"><a href="#" class="Talk to us">https://getintoteaching.education.gov.uk/#talk-to-us</a> if you need advice.</p>
+         <p class="govuk-body"><a href="#" class="https://getintoteaching.education.gov.uk/#talk-to-us">Talk to us</a> if you need advice.</p>
 
       <% end %>
         

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -19,7 +19,6 @@
          <p class="govuk-body">If you accept this offer, your other <%= 'offer'.pluralize(@offer_count - 1) %> will be automatically declined.</p>
       <% end %>
         
-      <p class="govuk-body">If you decline your <%= 'offer'.pluralize(@offer_count - 1) %>, or do not respond in time, you can still apply for courses that start this academic year.</p>
 
       <p class="govuk-body">Talk to a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser') %> if you need advice.</p>
 

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -17,6 +17,8 @@
 
       <% if @offer_count > 1 %>
          <p class="govuk-body">If you accept this offer, your other <%= 'offer'.pluralize(@offer_count - 1) %> will be automatically declined.</p>
+         <p class="govuk-body">Talk to a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser') %> if you need advice.</p>
+
       <% end %>
         
 

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def and_i_am_told_my_other_offer_will_be_automatically_declined
-    expect(page).to have_content('if you accept this offer, your other offer will be automatically declined')
+    expect(page).to have_content('If you accept this offer, your other offer will be automatically declined.')
   end
 
   def when_i_continue_without_selecting_a_response


### PR DESCRIPTION
**Delete the following content so that it no longer shows when a candidate only has one offer**

----

Before you accept:

* if you decline all of your offers, or do not respond in time, you can still apply for courses that start this academic year

If you need help, you can speak to our [teacher training advisers](link).

---

**If the candidate has more than one offer, edit the content to:**

---

If you accept this offer, your other offer(s) will be declined. 

---

## Why are we doing this?

- the bullets are unnecessary when there's only one bullet
- the bit about still being able to apply again if you decline could get very confusing if you're waiting to hear back about other offers (also I don't think we have evidence that this content is actually needed here) 
- there isn't any end of cycle logic in the existing code, meaning that 'you can still apply for courses starting this academic year' is sometime inaccurate 
- I'm not sure whether we really need the link to get help given this content is right next to the get help footer