### PR TITLE
Persist active application filters in Redis

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -7,7 +7,7 @@ module ProviderInterface
       @filter = ProviderApplicationsFilter.new(
         params: params,
         provider_user: current_provider_user,
-        state_store: session,
+        state_store: StateStores::RedisStore.new(key: state_store_key),
       )
 
       application_choices = GetApplicationChoicesForProviders.call(
@@ -80,6 +80,10 @@ module ProviderInterface
 
     def auth
       ProviderAuthorisation.new(actor: current_provider_user)
+    end
+
+    def state_store_key
+      CacheKey.generate("#{ProviderApplicationsFilter::STATE_STORE_KEY}_#{current_provider_user.id}")
     end
   end
 end

--- a/app/lib/state_stores/redis_store.rb
+++ b/app/lib/state_stores/redis_store.rb
@@ -1,0 +1,22 @@
+require 'redis'
+
+module StateStores
+  class RedisStore
+    def initialize(key:)
+      @redis = Redis.current
+      @key = key
+    end
+
+    def write(value, expires = 24.hours.to_i)
+      @redis.set(@key, value, ex: expires)
+    end
+
+    def read
+      @redis.get(@key)
+    end
+
+    def delete
+      @redis.del(@key)
+    end
+  end
+end

--- a/app/lib/wizard_state_stores/redis_store.rb
+++ b/app/lib/wizard_state_stores/redis_store.rb
@@ -1,22 +1,9 @@
 require 'redis'
 
 module WizardStateStores
-  class RedisStore
-    def initialize(key:)
-      @redis = Redis.current
-      @key = key
-    end
-
+  class RedisStore < StateStores::RedisStore
     def write(value)
-      @redis.set(@key, value, ex: 4.hours.to_i)
-    end
-
-    def read
-      @redis.get(@key)
-    end
-
-    def delete
-      @redis.del(@key)
+      super(value, 4.hours.to_i)
     end
   end
 end

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -48,11 +48,11 @@ module ProviderInterface
     end
 
     def save_filter_state!
-      @state_store[STATE_STORE_KEY] = @applied_filters.to_json
+      @state_store.write(@applied_filters.to_json)
     end
 
     def last_saved_filter_state
-      JSON.parse(@state_store[STATE_STORE_KEY] || '{}').with_indifferent_access
+      JSON.parse(@state_store.read || '{}').with_indifferent_access
     end
 
     def search_filter

--- a/spec/components/utility/filter_component_spec.rb
+++ b/spec/components/utility/filter_component_spec.rb
@@ -36,12 +36,15 @@ RSpec.describe FilterComponent do
   let(:provider_2) { create(:provider) }
 
   let(:current_provider_user) { build_stubbed(:provider_user) }
+  let(:state_store) do
+    StateStores::RedisStore.new(key: "#{ProviderInterface::ProviderApplicationsFilter::STATE_STORE_KEY}_#{current_provider_user.id}")
+  end
 
   it 'marks checkboxes as checked if they have already been pre-selected' do
     filter = ProviderInterface::ProviderApplicationsFilter.new(
       params: applied_filters,
       provider_user: current_provider_user,
-      state_store: {},
+      state_store: state_store,
     )
 
     result = render_inline described_class.new(filter: filter)
@@ -61,7 +64,7 @@ RSpec.describe FilterComponent do
     filter = ProviderInterface::ProviderApplicationsFilter.new(
       params: ActionController::Parameters.new({}),
       provider_user: current_provider_user,
-      state_store: {},
+      state_store: state_store,
     )
     result = render_inline described_class.new(filter: filter)
 
@@ -80,7 +83,7 @@ RSpec.describe FilterComponent do
     filter = ProviderInterface::ProviderApplicationsFilter.new(
       params: applied_filters,
       provider_user: current_provider_user,
-      state_store: {},
+      state_store: state_store,
     )
 
     result = render_inline described_class.new(filter: filter)
@@ -92,7 +95,7 @@ RSpec.describe FilterComponent do
     filter = ProviderInterface::ProviderApplicationsFilter.new(
       params: applied_filters,
       provider_user: current_provider_user,
-      state_store: {},
+      state_store: state_store,
     )
 
     result = render_inline described_class.new(filter: filter)
@@ -104,7 +107,7 @@ RSpec.describe FilterComponent do
     filter = ProviderInterface::ProviderApplicationsFilter.new(
       params: ActionController::Parameters.new({}),
       provider_user: current_provider_user,
-      state_store: {},
+      state_store: state_store,
     )
 
     result = render_inline described_class.new(filter: filter)

--- a/spec/models/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/models/provider_interface/provider_applications_filter_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
 
   let(:provider_user) { create(:provider_user, providers: [provider1, provider2, accredited_provider]) }
   let(:another_provider_user) { create(:provider_user, providers: [provider1]) }
+  let(:state_store) do
+    StateStores::RedisStore.new(key: "#{described_class::STATE_STORE_KEY}_#{provider_user.id}")
+  end
 
   describe '#filters' do
     let(:headings) { filter.filters.map { |f| f[:heading] } }
@@ -31,7 +34,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
         let(:filter) do
           described_class.new(params: params,
                               provider_user: provider_user,
-                              state_store: {})
+                              state_store: state_store)
         end
 
         it 'does not include the Locations filter' do
@@ -52,7 +55,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
         let(:filter) do
           described_class.new(params: params,
                               provider_user: another_provider_user,
-                              state_store: {})
+                              state_store: state_store)
         end
 
         it 'does not include the Providers filter' do
@@ -69,7 +72,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
         let(:filter) do
           described_class.new(params: params,
                               provider_user: another_provider_user,
-                              state_store: {})
+                              state_store: state_store)
         end
 
         it 'displays the location filter by default' do
@@ -91,7 +94,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
       let(:filter) do
         described_class.new(params: params,
                             provider_user: provider_user,
-                            state_store: {})
+                            state_store: state_store)
       end
 
       it 'can return filter config for a list of provider locations' do
@@ -113,7 +116,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
       let(:filter) do
         described_class.new(params: params,
                             provider_user: provider_user,
-                            state_store: {})
+                            state_store: state_store)
       end
 
       it 'can return filter config for a list of provider subjects' do
@@ -130,7 +133,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
       let(:filter) do
         described_class.new(params: params,
                             provider_user: provider_user,
-                            state_store: {})
+                            state_store: state_store)
       end
 
       it 'can return a filter config for a list of study modes' do
@@ -151,7 +154,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
     let(:filter) do
       described_class.new(params: params,
                           provider_user: provider_user,
-                          state_store: {})
+                          state_store: state_store)
     end
 
     it 'returns a has of permitted parameters' do
@@ -165,7 +168,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
     let(:filter) do
       described_class.new(params: params,
                           provider_user: provider_user,
-                          state_store: {})
+                          state_store: state_store)
     end
 
     context 'when filters' do
@@ -182,14 +185,12 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
       let(:params) { ActionController::Parameters.new }
 
       it 'returns false' do
-        filter = described_class.new(params: params, provider_user: provider_user, state_store: {})
+        filter = described_class.new(params: params, provider_user: provider_user, state_store: state_store)
         expect(filter.filtered?).to eq(false)
       end
     end
 
     it 'can load and persist its own state' do
-      state_store = {}
-
       state_one = described_class.new(
         params: ActionController::Parameters.new({ 'candidate_name' => 'Tom Thumb' }),
         provider_user: provider_user,
@@ -225,7 +226,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
       let(:filter) do
         described_class.new(params: params,
                             provider_user: provider_user,
-                            state_store: {})
+                            state_store: state_store)
       end
 
       it 'returns a relevant message' do
@@ -238,7 +239,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
       let(:filter) do
         described_class.new(params: params,
                             provider_user: provider_user,
-                            state_store: {})
+                            state_store: state_store)
       end
 
       it 'returns a relevant message' do
@@ -251,7 +252,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
       let(:filter) do
         described_class.new(params: params,
                             provider_user: provider_user,
-                            state_store: {})
+                            state_store: state_store)
       end
 
       it 'returns a relevant message' do

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -93,6 +93,31 @@ RSpec.feature 'Providers should be able to filter applications' do
     and_i_click_the_sign_out_button
   end
 
+  scenario 'filters should persist across sessions' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_permitted_to_see_applications_from_multiple_providers
+    and_my_organisation_has_courses_with_applications
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_visit_the_provider_page
+    then_i_expect_to_see_the_filter_dialogue
+
+    when_i_filter_by_providers
+    then_i_only_see_applications_for_a_given_provider
+    then_i_expect_the_relevant_provider_tags_to_be_visible
+
+    and_i_click_the_sign_out_button
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_visit_the_provider_page
+    then_i_only_see_applications_for_a_given_provider
+    then_i_expect_the_relevant_provider_tags_to_be_visible
+
+    when_i_clear_the_filters
+    then_i_expect_all_applications_to_be_visible_again
+    and_i_click_the_sign_out_button
+  end
+
   def and_i_click_the_sign_out_button
     click_link 'Sign out'
   end


### PR DESCRIPTION
## Context

Active applications filters are currently stored in the user's session, which means that when they close their browser the active filters are reset. Users have mentioned in testing that they would expect and prefer that the filters be retained.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds `StateStores::RedisStore` as a generic way to read and write data to Redis.
- Uses `RedisStore` with `ProviderApplicationsFilter` to persist active filters for the default time (24 hours) 

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/OiV06f7g/4568-not-remembering-filters-on-application-list-in-manage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
