### PR TITLE
Fix reasons for rejection paragraph formatting bugs

### DIFF
--- a/app/components/shared/reasons_for_rejection_component.html.erb
+++ b/app/components/shared/reasons_for_rejection_component.html.erb
@@ -73,7 +73,9 @@
 <% if reasons_for_rejection.performance_at_interview_y_n == 'Yes' %>
   <div class="app-rejection">
     <%= content_tag(subheading_tag_name, 'Performance at interview', class: 'govuk-heading-s') %>
-    <p class="govuk-body"><%= reasons_for_rejection.performance_at_interview_what_to_improve %></p>
+    <% paragraphs(reasons_for_rejection.performance_at_interview_what_to_improve).each do |paragraph| %>
+      <p class="govuk-body govuk-!-margin-bottom-3"><%= paragraph %></p>
+    <% end %>
 
     <% if editable? %>
       <p class="app-rejection__actions">
@@ -99,7 +101,9 @@
 <% if reasons_for_rejection.offered_on_another_course_y_n == 'Yes' %>
   <div class="app-rejection">
     <%= content_tag(subheading_tag_name, 'They offered you a place on another course', class: 'govuk-heading-s') %>
-    <p class="govuk-body"><%= reasons_for_rejection.offered_on_another_course_details %></p>
+    <% paragraphs(reasons_for_rejection.offered_on_another_course_details).each do |paragraph| %>
+      <p class="govuk-body govuk-!-margin-bottom-3"><%= paragraph %></p>
+    <% end %>
 
     <% if editable? %>
       <p class="app-rejection__actions">
@@ -173,7 +177,9 @@
 <% if reasons_for_rejection.cannot_sponsor_visa_y_n == 'Yes' %>
   <div class="app-rejection">
     <%= content_tag(subheading_tag_name, I18n.t('reasons_for_rejection.cannot_sponsor_visa.title'), class: 'govuk-heading-s') %>
-    <p class="govuk-body"><%= reasons_for_rejection.cannot_sponsor_visa_details %></p>
+    <% paragraphs(reasons_for_rejection.cannot_sponsor_visa_details) do |paragraph| %>
+      <p class="govuk-body govuk-!-margin-bottom-3"><%= paragraph %></p>
+    <% end %>
 
     <% if editable? %>
       <p class="app-rejection__actions">
@@ -186,7 +192,9 @@
 <% if reasons_for_rejection.why_are_you_rejecting_this_application.present? %>
   <div class="app-rejection">
     <%= content_tag(subheading_tag_name, I18n.t('reasons_for_rejection.why_are_you_rejecting_this_application.title'), class: 'govuk-heading-s') %>
-    <p class="govuk-body"><%= reasons_for_rejection.why_are_you_rejecting_this_application %></p>
+    <% paragraphs(reasons_for_rejection.why_are_you_rejecting_this_application).each do |paragraph| %>
+      <p class="govuk-body govuk-!-margin-bottom-3"><%= paragraph %></p>
+    <% end %>
     <% if editable? %>
       <p class="app-rejection__actions">
         <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_other_reasons_path(application_choice) %>
@@ -198,7 +206,9 @@
 <% if reasons_for_rejection.other_advice_or_feedback_y_n == 'Yes' %>
   <div class="app-rejection">
     <%= content_tag(subheading_tag_name, 'Additional feedback', class: 'govuk-heading-s') %>
-    <p class="govuk-body"><%= reasons_for_rejection.other_advice_or_feedback_details %></p>
+    <% paragraphs(reasons_for_rejection.other_advice_or_feedback_details).each do |paragraph| %>
+      <p class="govuk-body govuk-!-margin-bottom-3"><%= paragraph %></p>
+    <% end %>
     <% if editable? %>
       <p class="app-rejection__actions">
         <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_other_reasons_path(application_choice) %>

--- a/app/components/shared/reasons_for_rejection_component.rb
+++ b/app/components/shared/reasons_for_rejection_component.rb
@@ -17,4 +17,8 @@ class ReasonsForRejectionComponent < ViewComponent::Base
   def subheading_tag_name
     editable? ? :h2 : :h3
   end
+
+  def paragraphs(input)
+    input.split("\r\n")
+  end
 end

--- a/app/views/candidate_mailer/_reasons_for_rejection.text.erb
+++ b/app/views/candidate_mailer/_reasons_for_rejection.text.erb
@@ -2,9 +2,11 @@
 
 ^ # <%=  title %>
 
-   <% reasons.each do |reason| %>
-    ^ <%= reason %>
-    ^
+    <% reasons.each do |reason| %>
+      <% reason&.split("\r\n")&.each do |paragraph| %>
+        ^ <%= paragraph %>
+        ^
+      <% end %>
     <% end %>
 
     <% if title == 'Qualifications' %>


### PR DESCRIPTION
## Context

If provider users enter multi-line text into the 'Reasons for Rejection' free text inputs, paragraphs are not properly formatted in views and emails.

## Changes proposed in this pull request

### Views

Before:

---

![image](https://user-images.githubusercontent.com/107591/148095560-b68c0f27-9d71-4445-bbe5-22debe662512.png)

After:

---

![image](https://user-images.githubusercontent.com/107591/148095581-77308745-da27-4f5e-bf67-da0919080e84.png)

### Emails

Before:
![image](https://user-images.githubusercontent.com/107591/148095633-2334454a-bf26-440c-8861-478869d7b328.png)

After:
![image](https://user-images.githubusercontent.com/107591/148095673-f92f14f1-fe19-4822-9e88-760667d3adcd.png)

## Guidance to review

Reject an application, enter many different paragraphs in one or more of the free text fields. Observe components/emails.

## Link to Trello card

https://trello.com/c/VVt7BMXH

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
