### PR TITLE
Migration to add duplicate_match_resolved column to FraudMatch table

### DIFF
--- a/db/migrate/20220105101802_add_resolved_to_fraud_match.rb
+++ b/db/migrate/20220105101802_add_resolved_to_fraud_match.rb
@@ -1,0 +1,5 @@
+class AddResolvedToFraudMatch < ActiveRecord::Migration[6.1]
+  def change
+    add_column :fraud_matches, :resolved, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_30_112625) do
+ActiveRecord::Schema.define(version: 2022_01_05_101802) do
 
   create_sequence "qualifications_public_id_seq", start: 120000
 
@@ -478,6 +478,7 @@ ActiveRecord::Schema.define(version: 2021_12_30_112625) do
     t.boolean "blocked", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "resolved", default: false, null: false
   end
 
   create_table "ielts_qualifications", force: :cascade do |t|


### PR DESCRIPTION
## Context

We want to be able to mark duplicate matches as resolved once any necessary blocking or unblocking has been done, this will enable us to filter it out of the default dashboard view in Support.

This PR adds the migration to add the `resolved` column to the `FraudMatch` table.


## Guidance to review

The new column is not null and defaults to `false`

## Link to Trello card

https://trello.com/c/pQADTKLf/4249-mark-duplicate-matches-as-resolved

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
