### PR TITLE
Duplicate matching - automatically block and email candidates

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -39,6 +39,7 @@ class FeatureFlag
     [:publish_monthly_statistics, 'Publish monthly statistics at publications/monthly-statistics', 'Duncan Brown'],
     [:draft_vendor_api_specification, 'The specification for Draft Vendor API v1.1', 'Abeer Salameh'],
     [:immigration_entry_date, 'Extends the restructured_immigration_status feature to include the "Date of entry into the UK" question', 'Steve Hook'],
+    [:duplicate_matching, 'Replaces the fraud matching feature including a re-designed support interface', 'Steve Hook'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/app/services/support_interface/send_duplicate_match_email.rb
+++ b/app/services/support_interface/send_duplicate_match_email.rb
@@ -1,0 +1,13 @@
+module SupportInterface
+  class SendDuplicateMatchEmail
+    attr_reader :candidate
+
+    def initialize(candidate)
+      @candidate = candidate
+    end
+
+    def call
+      CandidateMailer.fraud_match_email(@candidate.current_application).deliver_later
+    end
+  end
+end

--- a/app/services/update_duplicate_matches.rb
+++ b/app/services/update_duplicate_matches.rb
@@ -21,9 +21,12 @@ class UpdateDuplicateMatches
 private
 
   def save_match(match)
-    fraud_match, candidate = create_or_update_fraud_match(match)
+    fraud_match, candidate = nil
+    ActiveRecord::Base.transaction do
+      fraud_match, candidate = create_or_update_fraud_match(match)
+      candidate.update!(submission_blocked: true)
+    end
     notify_candidate(candidate, fraud_match)
-    candidate.update!(submission_blocked: true)
   end
 
   def create_or_update_fraud_match(match)

--- a/app/services/update_duplicate_matches.rb
+++ b/app/services/update_duplicate_matches.rb
@@ -1,0 +1,52 @@
+class UpdateDuplicateMatches
+  def initialize
+    @matches = GetFraudMatches.call
+  end
+
+  def save!
+    @matches.each do |match|
+      fraud_match = FraudMatch.find_by(last_name: match['last_name'], postcode: match['postcode'], date_of_birth: match['date_of_birth'])
+      candidate = Candidate.find(match['candidate_id'])
+      if fraud_match.present?
+        fraud_match.candidates << candidate unless fraud_match.candidates.include?(candidate)
+      else
+        fraud_match = FraudMatch.create!(
+          recruitment_cycle_year: RecruitmentCycle.current_year,
+          last_name: match['last_name'],
+          postcode: match['postcode'],
+          date_of_birth: match['date_of_birth'],
+          candidates: [candidate],
+        )
+      end
+
+      SupportInterface::SendDuplicateMatchEmail.new(candidate).call
+      candidate.update!(submission_blocked: true)
+
+      # TODO: should this attribute be moved to the `Candidate` class?
+      fraud_match.update!(candidate_last_contacted_at: Time.zone.now)
+    end
+
+    message = <<~MSG
+      \n#{Rails.application.routes.url_helpers.support_interface_fraud_auditing_matches_url}
+      :face_with_monocle: There #{new_match_count == 1 ? 'is' : 'are'} #{new_match_count} new duplicate candidate #{'match'.pluralize(new_match_count)} today :face_with_monocle:
+      :gavel: #{fraudulent_match_count} #{'match'.pluralize(fraudulent_match_count)} #{fraudulent_match_count == 1 ? 'has' : 'have'} been marked as fraudulent :gavel:
+      :female-detective: In total there #{total_match_count == 1 ? 'is' : 'are'} #{total_match_count} #{'match'.pluralize(total_match_count)} :male-detective:
+    MSG
+
+    SlackNotificationWorker.perform_async(message)
+  end
+
+private
+
+  def new_match_count
+    @new_match_count ||= FraudMatch.where('created_at > ?', 1.day.ago).count
+  end
+
+  def fraudulent_match_count
+    @fraudulent_match_count ||= FraudMatch.where(recruitment_cycle_year: CycleTimetable.current_year, fraudulent: true).count
+  end
+
+  def total_match_count
+    @total_match_count ||= FraudMatch.where(recruitment_cycle_year: CycleTimetable.current_year).count
+  end
+end

--- a/app/workers/update_fraud_matches_worker.rb
+++ b/app/workers/update_fraud_matches_worker.rb
@@ -4,7 +4,12 @@ class UpdateFraudMatchesWorker
   sidekiq_options retry: 0, queue: :low_priority
 
   def perform
-    matches = UpdateFraudMatches.new
-    matches.save!
+    if FeatureFlag.active?(:duplicate_matching)
+      matches = UpdateDuplicateMatches.new
+      matches.save!
+    else
+      matches = UpdateFraudMatches.new
+      matches.save!
+    end
   end
 end

--- a/app/workers/update_fraud_matches_worker.rb
+++ b/app/workers/update_fraud_matches_worker.rb
@@ -4,12 +4,12 @@ class UpdateFraudMatchesWorker
   sidekiq_options retry: 0, queue: :low_priority
 
   def perform
-    if FeatureFlag.active?(:duplicate_matching)
-      matches = UpdateDuplicateMatches.new
-      matches.save!
-    else
-      matches = UpdateFraudMatches.new
-      matches.save!
-    end
+    matches =
+      if FeatureFlag.active?(:duplicate_matching)
+        UpdateDuplicateMatches.new
+      else
+        UpdateFraudMatches.new
+      end
+    matches.save!
   end
 end

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -25,7 +25,8 @@ FactoryBot.define do
 
     trait :duplicate_candidates do
       date_of_birth { ApplicationForm.last&.date_of_birth || '01-01-1996' }
-      postcode { ApplicationForm.last&.postcode || 'SW1P 3BT' }
+      postcode { ApplicationForm.last&.postcode || 'W6 9BH' }
+      last_name { 'Thompson' }
     end
 
     trait :international_address do

--- a/spec/services/support_interface/send_duplicate_match_email_spec.rb
+++ b/spec/services/support_interface/send_duplicate_match_email_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::SendDuplicateMatchEmail do
+  describe '#call' do
+    let(:fraud_match) { create(:fraud_match) }
+
+    before do
+      @candidate = fraud_match.candidates.first
+      build(
+        :application_form,
+        candidate: @candidate,
+      )
+
+      mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+      allow(CandidateMailer).to receive(:fraud_match_email).and_return(mail)
+    end
+
+    it 'sends an email to the candidate' do
+      described_class.new(@candidate).call
+      expect(CandidateMailer).to have_received(:fraud_match_email).once
+    end
+  end
+end

--- a/spec/services/support_interface/send_fraud_match_email_spec.rb
+++ b/spec/services/support_interface/send_fraud_match_email_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SupportInterface::SendFraudMatchEmail do
       allow(CandidateMailer).to receive(:fraud_match_email).and_return(mail)
     end
 
-    it 'sends a chaser email to the provider' do
+    it 'sends a chaser email to the candidate' do
       described_class.new(fraud_match).call
 
       expect(CandidateMailer).to have_received(:fraud_match_email).twice

--- a/spec/services/update_duplicate_matches_spec.rb
+++ b/spec/services/update_duplicate_matches_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe UpdateDuplicateMatches, sidekiq: true do
+  let(:candidate1) { create(:candidate, email_address: 'exemplar1@example.com') }
+  let(:candidate2) { create(:candidate, email_address: 'exemplar2@example.com') }
+
+  let(:expected_slack_message) do
+    <<~MSG
+      \n#{Rails.application.routes.url_helpers.support_interface_fraud_auditing_matches_url}
+      :face_with_monocle: There is 1 new duplicate candidate match today :face_with_monocle:
+      :gavel: 1 match has been marked as fraudulent :gavel:
+      :female-detective: In total there are 2 matches :male-detective:
+    MSG
+  end
+
+  before do
+    Timecop.freeze(Time.zone.local(2020, 8, 23, 12, 0o0, 0o0)) do
+      create(:application_form, candidate: candidate1, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH', submitted_at: Time.zone.now)
+      create(:application_form, candidate: candidate2, first_name: 'Joffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH')
+      allow(SlackNotificationWorker).to receive(:perform_async)
+    end
+  end
+
+  describe '#save!' do
+    context 'when there is no fraud match for the given candidates' do
+      it 'creates a fraud match with associated candidates' do
+        described_class.new.save!
+
+        match = FraudMatch.first
+
+        expect(match.postcode).to eq('W6 9BH')
+        expect(match.date_of_birth).to eq(candidate1.application_forms.first.date_of_birth)
+        expect(match.last_name).to eq('Thompson')
+        expect(match.recruitment_cycle_year).to eq(RecruitmentCycle.current_year)
+        expect(match.candidates.first).to eq(candidate1)
+        expect(match.candidates.second).to eq(candidate2)
+      end
+
+      it 'sets `Candidate#submission_blocked` to true' do
+        described_class.new.save!
+        expect(candidate1.reload.submission_blocked).to be(true)
+        expect(candidate2.reload.submission_blocked).to be(true)
+      end
+
+      it 'sends an email to each candidate' do
+        expect { described_class.new.save! }.to change { ActionMailer::Base.deliveries.count }.by(2)
+        # TODO:
+      end
+
+      it 'sends a slack message' do
+        application_form1 = create(:application_form, first_name: 'Jeffrey', last_name: 'Thompsun', date_of_birth: '1998-08-08', postcode: 'W6 9BH', submitted_at: Time.zone.now)
+        application_form2 = create(:application_form, first_name: 'Joffrey', last_name: 'Thompsun', date_of_birth: '1998-08-08', postcode: 'W6 9BH')
+
+        create(:fraud_match,
+               candidates: [application_form1.candidate, application_form2.candidate],
+               last_name: 'Thompsun',
+               date_of_birth: '1998-08-08',
+               postcode: 'W6 9BH',
+               fraudulent: true,
+               created_at: 2.days.ago)
+
+        described_class.new.save!
+
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(expected_slack_message)
+      end
+    end
+
+    context 'when a fraud match exists for the given candidates' do
+      it 'updates an existing fraud match with new candidate' do
+        described_class.new.save!
+
+        match = FraudMatch.first
+        expect(match.candidates.third).to eq(nil)
+
+        create(:application_form, candidate: create(:candidate, email_address: 'exemplar3@example.com'), first_name: 'Jaffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'W6 9BH')
+        described_class.new.save!
+
+        match = FraudMatch.first
+
+        expect(match.candidates.third.email_address).to eq('exemplar3@example.com')
+
+        expect(match.postcode).to eq('W6 9BH')
+        expect(match.date_of_birth).to eq(candidate1.application_forms.first.date_of_birth)
+        expect(match.last_name).to eq('Thompson')
+        expect(match.recruitment_cycle_year).to eq(RecruitmentCycle.current_year)
+      end
+
+      it 'sets `Candidate#submission_blocked` to true' do
+        described_class.new.save!
+        expect(candidate1.reload.submission_blocked).to be(true)
+        expect(candidate2.reload.submission_blocked).to be(true)
+      end
+
+      it 'sends an email to each candidate' do
+        expect { described_class.new.save! }.to change { ActionMailer::Base.deliveries.count }.by(2)
+        # TODO:
+      end
+    end
+  end
+end

--- a/spec/services/update_duplicate_matches_spec.rb
+++ b/spec/services/update_duplicate_matches_spec.rb
@@ -44,7 +44,12 @@ RSpec.describe UpdateDuplicateMatches, sidekiq: true do
 
       it 'sends an email to each candidate' do
         expect { described_class.new.save! }.to change { ActionMailer::Base.deliveries.count }.by(2)
-        # TODO:
+        expect(ActionMailer::Base.deliveries.map(&:to)).to match_array(
+          [
+            ['exemplar1@example.com'],
+            ['exemplar2@example.com'],
+          ],
+        )
       end
 
       it 'sends a slack message' do
@@ -93,7 +98,12 @@ RSpec.describe UpdateDuplicateMatches, sidekiq: true do
 
       it 'sends an email to each candidate' do
         expect { described_class.new.save! }.to change { ActionMailer::Base.deliveries.count }.by(2)
-        # TODO:
+        expect(ActionMailer::Base.deliveries.map(&:to)).to match_array(
+          [
+            ['exemplar1@example.com'],
+            ['exemplar2@example.com'],
+          ],
+        )
       end
     end
   end

--- a/spec/system/support_interface/duplicate_candidate_matches_spec.rb
+++ b/spec/system/support_interface/duplicate_candidate_matches_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature 'See Duplicate candidate matches' do
 
   scenario 'Support agent visits Duplicate candidate matches page', sidekiq: true do
     given_i_am_a_support_user
+    and_the_duplicate_matching_feature_flag_is_deactivated
     and_i_go_to_duplicate_candidate_matches_page
     then_i_should_see_a_message_declaring_that_there_are_no_matches
 
@@ -195,5 +196,9 @@ RSpec.feature 'See Duplicate candidate matches' do
       open_email(@candidate_two.email_address)
       expect(current_email.subject).to have_content t('candidate_mailer.fraud_match.subject')
     end
+  end
+
+  def and_the_duplicate_matching_feature_flag_is_deactivated
+    FeatureFlag.deactivate(:duplicate_matching)
   end
 end

--- a/spec/workers/update_fraud_matches_worker_spec.rb
+++ b/spec/workers/update_fraud_matches_worker_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe UpdateFraudMatchesWorker do
+  describe '#perform' do
+    let(:worker) { described_class.new }
+
+    before do
+      @fraud_service = instance_double(UpdateFraudMatches, save!: nil)
+      allow(UpdateFraudMatches).to receive(:new).and_return(@fraud_service)
+
+      @duplicate_service = instance_double(UpdateDuplicateMatches, save!: nil)
+      allow(UpdateDuplicateMatches).to receive(:new).and_return(@duplicate_service)
+    end
+
+    context 'when the `duplicate_matching` feature flag is inactive' do
+      it 'calls UpdateFraudMatches' do
+        FeatureFlag.deactivate(:duplicate_matching)
+        worker.perform
+        expect(@duplicate_service).not_to have_received(:save!)
+        expect(@fraud_service).to have_received(:save!)
+      end
+    end
+
+    context 'when the `duplicate_matching` feature flag is active' do
+      it 'calls UpdateDuplicateMatches' do
+        FeatureFlag.activate(:duplicate_matching)
+        worker.perform
+        expect(@fraud_service).not_to have_received(:save!)
+        expect(@duplicate_service).to have_received(:save!)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

The current behaviour of the Duplicate match detection routine is to create a fraud match. Support users must then go to the support panel and click buttons to block submission and email the candidates.

We want to automate these steps so that candidates are automatically blocked from submitting their application and notified about this.

## Changes proposed in this pull request

- [x] Add a `duplicate_matching` feature flag to cover this change (and others that follow).
- [x] Mirror the existing service classes that perform duplicate matching with a new set `UpdateDuplicateMatches` and `SendDuplicateMatchEmail`.
- [x] Modify `UpdateDuplicateMatchesWorker` so that it uses the new services iff the `duplicate_matching` feature flag is active.
- [x] Add the new functionality to `UpdateDuplicateMatches` (send email and update `Candidate#submission_blocked`.

## Guidance to review

- Is the feature flag watertight?
- Do the new services make sense?
- Are the tests adequate?

Note that we've not changed the way that the `FraudMatch#candidate_last_contacted_at` timestamp is modified though the intention going forward would be to rely on the email log to find out the times of these emails sent to candidates.

## Link to Trello card

https://trello.com/c/Ek5JR1lT/4240-duplicate-matching-automatically-block-and-email-candidates-once-match-is-identified-and-introduce-feature-flag

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
