### PR TITLE
Escape course names as they can contain parenthesis

### DIFF
--- a/spec/services/accept_unconditional_offer_spec.rb
+++ b/spec/services/accept_unconditional_offer_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe AcceptUnconditionalOffer do
       application_choice = build(:application_choice, :with_offer, course_option: course_option)
 
       expect { described_class.new(application_choice: application_choice).save! }.to change { ActionMailer::Base.deliveries.count }.by(3)
-      expect(ActionMailer::Base.deliveries.first.subject).to match(/accepted your offer for #{application_choice.course.name}/)
+      expect(ActionMailer::Base.deliveries.first.subject).to match(/accepted your offer for #{Regexp.escape(application_choice.course.name)}/)
 
       mailer_recipients = ActionMailer::Base.deliveries.map(&:to).flatten
       expect(mailer_recipients).to include(training_provider_user.email_address)


### PR DESCRIPTION
## Context

Course names such as `Applied Science (Psychology)` won't behave as expected with RSpec's regex matcher.
There should be a Faker bug emoji.

eg.

```
Failure/Error: expect('Applied Science (Psychology)').to match(/Applied Science (Psychology)/)
       Expected "Applied Science (Psychology)" to match /Applied Science (Psychology)/.
```

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Use `Regexp.escape` to escape parenthesis in course names.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/L47XCUZW/4654-flakey-spec-spec-services-acceptunconditionalofferspecrb53
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
