### PR TITLE
Escape course name to allow for parenthesis

### DIFF
--- a/spec/services/accept_offer_spec.rb
+++ b/spec/services/accept_offer_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe AcceptOffer do
 
       emails_to_providers = ActionMailer::Base.deliveries.take(2) # email 3 goes to candidate
 
-      expect(emails_to_providers.map(&:subject)).to all(match(/accepted your offer for #{course_option.course.name}/))
+      expect(emails_to_providers.map(&:subject)).to all(match(/accepted your offer for #{Regexp.escape(course_option.course.name)}/))
       expect(emails_to_providers.flat_map(&:to)).to match_array([training_provider_user.email_address, ratifying_provider_user.email_address])
     end
 


### PR DESCRIPTION
## Context

Course names generated by Faker can have parenthesis in them, this doesn't work as expected with RSpec regexp matchers.

eg.

```
Failure/Error: expect('Applied Science (Psychology)').to match(/Applied Science (Psychology)/)
       Expected "Applied Science (Psychology)" to match /Applied Science (Psychology)/.
```
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Use `Regexp.escape` to ensure course name doesn't contain bare parenthesis.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/58pB8axx/4653-flakey-spec-spec-services-acceptofferspecrb54
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
