### PR TITLE
Make duplicate matching more tolerant of casing and spacing

### DIFF
--- a/app/queries/get_fraud_matches.rb
+++ b/app/queries/get_fraud_matches.rb
@@ -3,38 +3,38 @@ class GetFraudMatches
     ActiveRecord::Base.connection.exec_query(
       "SELECT DISTINCT application_details.candidate_id,
           application_details.first_name,
-          application_details.last_name,
+          application_details.last_name last_name,
           TRIM(UPPER(application_details.postcode)) postcode,
           application_details.date_of_birth,
           email_address,
           submitted_at
         FROM application_forms application_details
         JOIN(
-          SELECT application_forms.last_name, application_forms.date_of_birth, application_forms.postcode
+          SELECT TRIM(UPPER(application_forms.last_name)) last_name, application_forms.date_of_birth, REPLACE(UPPER(application_forms.postcode), ' ', '') postcode
           FROM application_forms
           WHERE application_forms.previous_application_form_id IS NULL
-          GROUP BY application_forms.last_name, application_forms.date_of_birth, application_forms.postcode
+          GROUP BY TRIM(UPPER(application_forms.last_name)), application_forms.date_of_birth, REPLACE(UPPER(application_forms.postcode), ' ', '')
           HAVING (count(*) > 1)
         ) duplicate_attributes
-        ON application_details.postcode = duplicate_attributes.postcode
+        ON REPLACE(UPPER(application_details.postcode), ' ', '') = duplicate_attributes.postcode
         AND application_details.date_of_birth = duplicate_attributes.date_of_birth
-        AND application_details.last_name = duplicate_attributes.last_name
+        AND TRIM(UPPER(application_details.last_name)) = duplicate_attributes.last_name
         JOIN(
-          SELECT application_forms.last_name, application_forms.date_of_birth, application_forms.postcode
+          SELECT TRIM(UPPER(application_forms.last_name)) last_name, application_forms.date_of_birth, REPLACE(UPPER(application_forms.postcode), ' ', '') postcode
           FROM application_forms
           WHERE application_forms.previous_application_form_id IS NULL
           AND application_forms.submitted_at IS NOT NULL
         ) duplicate_submitted_attributes
-        ON application_details.postcode = duplicate_submitted_attributes.postcode
+        ON REPLACE(UPPER(application_details.postcode), ' ', '') = duplicate_submitted_attributes.postcode
         AND application_details.date_of_birth = duplicate_submitted_attributes.date_of_birth
-        AND application_details.last_name = duplicate_submitted_attributes.last_name
+        AND TRIM(UPPER(application_details.last_name)) = duplicate_submitted_attributes.last_name
         JOIN(
           SELECT candidates.id, candidates.email_address
           FROM candidates
         ) candidate_details
-        ON application_details.candidate_id = candidate_details.id
+                     ON application_details.candidate_id = candidate_details.id
         WHERE application_details.previous_application_form_id IS NULL
-        ORDER BY application_details.last_name, application_details.date_of_birth, postcode;",
+        ORDER BY last_name, application_details.date_of_birth, postcode;",
     ).to_a
   end
 end

--- a/spec/queries/get_fraud_matches_spec.rb
+++ b/spec/queries/get_fraud_matches_spec.rb
@@ -1,41 +1,79 @@
 require 'rails_helper'
 
 RSpec.describe GetFraudMatches do
-  let(:candidate1) { create(:candidate, id: '1', email_address: 'exemplar1@example.com') }
-  let(:candidate2) { create(:candidate, id: '2', email_address: 'exemplar2@example.com') }
-
-  before do
-    Timecop.freeze(Time.zone.local(2020, 8, 23, 12, 0o0, 0o0)) do
-      create(:application_form, candidate: candidate1, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: Time.zone.now)
-      create(:application_form, candidate: candidate2, first_name: 'Joffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: Time.zone.now)
-    end
-  end
+  let(:candidate1) { create(:candidate, email_address: 'exemplar1@example.com') }
+  let(:candidate2) { create(:candidate, email_address: 'exemplar2@example.com') }
 
   describe '#call' do
-    let(:returned_array_of_hashes) { described_class.call }
+    subject(:returned_array_of_hashes) { described_class.call }
 
-    it 'returns an array of hashes with the correct keys' do
-      expect(returned_array_of_hashes.count).to eq(2)
-      expect(returned_array_of_hashes.first.keys).to \
-        eq %w[candidate_id first_name last_name postcode date_of_birth email_address submitted_at]
+    context 'matches two identical names in identical casing' do
+      before do
+        Timecop.freeze(Time.zone.local(2020, 8, 23, 12, 0o0, 0o0)) do
+          create(:application_form, candidate: candidate1, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: Time.zone.now)
+          create(:application_form, candidate: candidate2, first_name: 'Joffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: Time.zone.now)
+        end
+      end
+
+      it 'returns an array of hashes with the correct keys' do
+        expect(returned_array_of_hashes.count).to eq(2)
+        expect(returned_array_of_hashes.first.keys).to \
+          eq %w[candidate_id first_name last_name postcode date_of_birth email_address submitted_at]
+      end
+
+      it 'returns an array of hashes the correct values' do
+        expect(returned_array_of_hashes.first['candidate_id']).to eq(candidate1.id)
+        expect(returned_array_of_hashes.first['first_name']).to eq('Jeffrey')
+        expect(returned_array_of_hashes.first['last_name']).to eq('Thompson')
+        expect(returned_array_of_hashes.first['date_of_birth']).to eq('1998-08-08')
+        expect(returned_array_of_hashes.first['postcode']).to eq('W6 9BH')
+        expect(returned_array_of_hashes.first['email_address']).to eq('exemplar1@example.com')
+        expect(returned_array_of_hashes.first['submitted_at'].strftime('%F')).to eq('2020-08-23')
+
+        expect(returned_array_of_hashes.second['candidate_id']).to eq(candidate2.id)
+        expect(returned_array_of_hashes.second['first_name']).to eq('Joffrey')
+        expect(returned_array_of_hashes.second['last_name']).to eq('Thompson')
+        expect(returned_array_of_hashes.second['date_of_birth']).to eq('1998-08-08')
+        expect(returned_array_of_hashes.second['postcode']).to eq('W6 9BH')
+        expect(returned_array_of_hashes.second['email_address']).to eq('exemplar2@example.com')
+        expect(returned_array_of_hashes.second['submitted_at'].strftime('%F')).to eq('2020-08-23')
+      end
     end
 
-    it 'returns an array of hashes the correct values' do
-      expect(returned_array_of_hashes.first['candidate_id']).to eq(1)
-      expect(returned_array_of_hashes.first['first_name']).to eq('Jeffrey')
-      expect(returned_array_of_hashes.first['last_name']).to eq('Thompson')
-      expect(returned_array_of_hashes.first['date_of_birth']).to eq('1998-08-08')
-      expect(returned_array_of_hashes.first['postcode']).to eq('W6 9BH')
-      expect(returned_array_of_hashes.first['email_address']).to eq('exemplar1@example.com')
-      expect(returned_array_of_hashes.first['submitted_at'].strftime('%F')).to eq('2020-08-23')
+    context 'matches a capitalised name with a lowercase name' do
+      let(:last_names) { returned_array_of_hashes.map { |element| element['last_name'] } }
 
-      expect(returned_array_of_hashes.second['candidate_id']).to eq(2)
-      expect(returned_array_of_hashes.second['first_name']).to eq('Joffrey')
-      expect(returned_array_of_hashes.second['last_name']).to eq('Thompson')
-      expect(returned_array_of_hashes.second['date_of_birth']).to eq('1998-08-08')
-      expect(returned_array_of_hashes.second['postcode']).to eq('W6 9BH')
-      expect(returned_array_of_hashes.second['email_address']).to eq('exemplar2@example.com')
-      expect(returned_array_of_hashes.second['submitted_at'].strftime('%F')).to eq('2020-08-23')
+      before do
+        create(:application_form, candidate: candidate1, last_name: 'THOMPSON', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: Time.zone.now)
+        create(:application_form, candidate: candidate2, last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: Time.zone.now)
+      end
+
+      it 'returns an array of hashes with the correct keys' do
+        expect(returned_array_of_hashes.count).to eq(2)
+      end
+
+      it 'returns all duplicates' do
+        expect(last_names).to include('THOMPSON')
+        expect(last_names).to include('Thompson')
+      end
+    end
+
+    context 'matches a postcode with or without a space' do
+      let(:postcodes) { returned_array_of_hashes.map { |element| element['postcode'] } }
+
+      before do
+        create(:application_form, candidate: candidate1, last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: Time.zone.now)
+        create(:application_form, candidate: candidate2, last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w69bh ', submitted_at: Time.zone.now)
+      end
+
+      it 'returns an array of hashes with the correct keys' do
+        expect(returned_array_of_hashes.count).to eq(2)
+      end
+
+      it 'returns all duplicates' do
+        expect(postcodes).to include('W6 9BH')
+        expect(postcodes).to include('W69BH')
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

Currently the fraud matching system doesn't check for case insensitive last names, or spaces between postcodes. This PR aims to address this.

## Changes proposed in this pull request

Allowing matches between case insensitive last names
Allowing matches between postcodes with spaces in the middle

## Guidance to review

- Take one of the matches and change the casing of one of the last names and run the SQL script to check if it still matches.
- Take one of the matches and remove a space from of the postcodes and run the SQL script to check if it still matches.

## Link to Trello card

https://trello.com/c/gmBRTDQ9/4253-make-duplicate-matching-more-tolerant-of-casing-and-spacing
