### PR TITLE
Fix domicile codes for test applications

### DIFF
--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -134,8 +134,11 @@ FactoryBot.define do
       disclose_disability { %w[true false].sample }
       disability_disclosure { Faker::Lorem.paragraph_by_chars(number: 300) }
       address_line3 { Faker::Address.city }
-      address_line4 { Faker::Address.county }
-      postcode { Faker::Address.postcode }
+      address_line4 { uk_country }
+      postcode {
+        new_prefix = DomicileResolver::POSTCODE_PREFIXES[uk_country].sample
+        Faker::Address.postcode.sub(/^[a-zA-Z]+/, new_prefix)
+      }
       becoming_a_teacher { Faker::Lorem.paragraph_by_chars(number: 500) }
       subject_knowledge { Faker::Lorem.paragraph_by_chars(number: 300) }
       work_history_explanation { Faker::Lorem.paragraph_by_chars(number: 400) }
@@ -169,6 +172,7 @@ FactoryBot.define do
         references_state { :feedback_provided }
         references_selected { false }
         full_work_history { false }
+        uk_country { Faker::Address.uk_country }
       end
 
       after(:create) do |application_form, evaluator|


### PR DESCRIPTION
## Context

We use the faker gem to generate UK postcodes which are valid UK postcodes (in terms of format) but do not correspond to a UK country (e.g. England, Wales etc.) and therefore produce the generic `XK` code (rather than `XF`, `XI` etc.) See ￼`app/lib/domicile_resolver.rb` for how domicile codes are derived from the postcode.

This impacts the ability of vendors to test consuming such codes on sandbox.

## Changes proposed in this pull request

Use country-specific postcode prefixes, which is how we derive domicile codes. Change address_line4 to display uk_country, rather than county, because postcode prefixes and counties will not match (unless we build detailed postcode area knowledge into the system, but not worth it).

## Guidance to review

Open a rails console, generate some test applications with `FactoryBot.build(:completed_application_form)` and notice the new addresses/postcodes.

## Link to Trello card

https://trello.com/c/XioxJkEN

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
