### PR TITLE
Fix paragraph formatting for remaining R4R Other fields

### DIFF
--- a/app/components/shared/reasons_for_rejection_component.html.erb
+++ b/app/components/shared/reasons_for_rejection_component.html.erb
@@ -5,8 +5,12 @@
       <% reasons_for_rejection.candidate_behaviour_what_did_the_candidate_do.each do |reason| %>
         <li>
           <% if reason == 'other' %>
-            <p><%= reasons_for_rejection.candidate_behaviour_other %></p>
-            <p><%= reasons_for_rejection.candidate_behaviour_what_to_improve %></p>
+            <% paragraphs(reasons_for_rejection.candidate_behaviour_other).each do |paragraph| %>
+              <p><%= paragraph %></p>
+            <% end %>
+            <% paragraphs(reasons_for_rejection.candidate_behaviour_what_to_improve).each do |paragraph| %>
+              <p><%= paragraph %></p>
+            <% end %>
           <% else %>
             <p><%= t("reasons_for_rejection.candidate_behaviour_what_did_the_candidate_do.#{reason}") %>.</p>
           <% end %>
@@ -28,11 +32,19 @@
       <% reasons_for_rejection.quality_of_application_which_parts_needed_improvement.each do |reason| %>
         <li>
           <% if reason == 'other' %>
-            <p><%= reasons_for_rejection.quality_of_application_other_details %></p>
-            <p><%= reasons_for_rejection.quality_of_application_other_what_to_improve %></p>
+            <% paragraphs(reasons_for_rejection.quality_of_application_other_details).each do |paragraph| %>
+              <p><%= paragraph %></p>
+            <% end %>
+            <% paragraphs(reasons_for_rejection.quality_of_application_other_what_to_improve).each do |paragraph| %>
+              <p><%= paragraph %></p>
+            <% end %>
           <% else %>
-            <p><%= t("reasons_for_rejection.quality_of_application.#{reason}") %>.</p>
-            <p><%= reasons_for_rejection.send(:"quality_of_application_#{reason}_what_to_improve") %>.</p>
+            <% paragraphs(t("reasons_for_rejection.quality_of_application.#{reason}")).each do |paragraph| %>
+              <p><%= paragraph %></p>
+            <% end %>
+            <% paragraphs(reasons_for_rejection.send(:"quality_of_application_#{reason}_what_to_improve")).each do |paragraph| %>
+              <p><%= paragraph %></p>
+            <% end %>
           <% end %>
         </li>
       <% end %>
@@ -52,7 +64,9 @@
       <% reasons_for_rejection.qualifications_which_qualifications.each do |reason| %>
         <li>
           <% if reason == 'other' %>
-            <p><%= reasons_for_rejection.qualifications_other_details %></p>
+            <% paragraphs(reasons_for_rejection.qualifications_other_details).each do |paragraph| %>
+              <p><%= paragraph %></p>
+            <% end %>
           <% else %>
             <p><%= t("reasons_for_rejection.qualifications_which_qualifications.#{reason}") %>.</p>
           <% end %>
@@ -119,22 +133,30 @@
     <ul class="govuk-list govuk-list--spaced">
       <% if reasons_for_rejection.honesty_and_professionalism_concerns_information_false_or_inaccurate_details.present? %>
         <li>
-          <%= reasons_for_rejection.honesty_and_professionalism_concerns_information_false_or_inaccurate_details %>
+          <% paragraphs(reasons_for_rejection.honesty_and_professionalism_concerns_information_false_or_inaccurate_details).each do |paragraph| %>
+            <p><%= paragraph %></p>
+          <% end %>
         </li>
       <% end %>
       <% if reasons_for_rejection.honesty_and_professionalism_concerns_plagiarism_details.present? %>
         <li>
-          <%= reasons_for_rejection.honesty_and_professionalism_concerns_plagiarism_details %>
+          <% paragraphs(reasons_for_rejection.honesty_and_professionalism_concerns_plagiarism_details).each do |paragraph| %>
+            <p><%= paragraph %></p>
+          <% end %>
         </li>
       <% end %>
       <% if reasons_for_rejection.honesty_and_professionalism_concerns_references_details.present? %>
         <li>
-          <%= reasons_for_rejection.honesty_and_professionalism_concerns_references_details %>
+          <% paragraphs(reasons_for_rejection.honesty_and_professionalism_concerns_references_details).each do |paragraph| %>
+            <p><%= paragraph %></p>
+          <% end %>
         </li>
       <% end %>
       <% if reasons_for_rejection.honesty_and_professionalism_concerns_other_details.present? %>
         <li>
-          <%= reasons_for_rejection.honesty_and_professionalism_concerns_other_details %>
+          <% paragraphs(reasons_for_rejection.honesty_and_professionalism_concerns_other_details).each do |paragraph| %>
+            <p><%= paragraph %></p>
+          <% end %>
         </li>
       <% end %>
     </ul>
@@ -152,17 +174,23 @@
     <ul class="govuk-list govuk-list--spaced">
       <% if reasons_for_rejection.safeguarding_concerns_candidate_disclosed_information_details.present? %>
         <li>
-          <%= reasons_for_rejection.safeguarding_concerns_candidate_disclosed_information_details %>
+          <% paragraphs(reasons_for_rejection.safeguarding_concerns_candidate_disclosed_information_details).each do |paragraph| %>
+            <p><%= paragraph %></p>
+          <% end %>
         </li>
       <% end %>
       <% if reasons_for_rejection.safeguarding_concerns_vetting_disclosed_information_details.present? %>
         <li>
-          <%= reasons_for_rejection.safeguarding_concerns_vetting_disclosed_information_details %>
+          <% paragraphs(reasons_for_rejection.safeguarding_concerns_vetting_disclosed_information_details).each do |paragraph| %>
+            <p><%= paragraph %></p>
+          <% end %>
         </li>
       <% end %>
       <% if reasons_for_rejection.safeguarding_concerns_other_details.present? %>
         <li>
-          <%= reasons_for_rejection.safeguarding_concerns_other_details %>
+          <% paragraphs(reasons_for_rejection.safeguarding_concerns_other_details).each do |paragraph| %>
+            <p><%= paragraph %></p>
+          <% end %>
         </li>
       <% end %>
     </ul>

--- a/spec/system/candidate_interface/rejection/candidate_reviews_reasons_for_rejection_spec.rb
+++ b/spec/system/candidate_interface/rejection/candidate_reviews_reasons_for_rejection_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Candidate can see their structured reasons for rejection when rev
 
   def then_i_can_see_my_rejection_reasons
     expect(page).to have_content('Quality of application')
-    expect(page).to have_content('Use a spellchecker.')
+    expect(page).to have_content('Use a spellchecker')
   end
 
   def when_i_apply_again
@@ -43,7 +43,7 @@ RSpec.feature 'Candidate can see their structured reasons for rejection when rev
 
   def then_i_can_see_rejection_reasons_from_the_earlier_application
     expect(page).to have_content('Quality of application')
-    expect(page).to have_content('Use a spellchecker.')
+    expect(page).to have_content('Use a spellchecker')
   end
 
   def and_i_should_see_unsuccessful_status


### PR DESCRIPTION
## Context

Missed some 'Reasons for rejetion' free-text fields when fixing paragraph formatting last time.

## Changes proposed in this pull request

Apply the same fix in more places.

## Guidance to review

![image](https://user-images.githubusercontent.com/107591/148403635-96f4e4ed-7cd0-4a06-af9d-fdca5df792ba.png)

## Link to Trello card

https://trello.com/c/VVt7BMXH

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
