### PR TITLE
Making it clearer that a candidate has chosen not to add a levels and other qualifications

### DIFF
--- a/app/components/shared/qualification_grade_component.html.erb
+++ b/app/components/shared/qualification_grade_component.html.erb
@@ -1,4 +1,8 @@
-<%= grade %>
-<% if hesa_code %>
-  <span class='govuk-hint govuk-!-margin-bottom-1 govuk-!-font-size-16'>(<%= hesa_code %>)</span>
+<% if grade %>
+  <%= grade %>
+  <% if hesa_code %>
+    <span class='govuk-hint govuk-!-margin-bottom-1 govuk-!-font-size-16'>(<%= hesa_code %>)</span>
+  <% end %>
+<% else %>
+  Not entered
 <% end %>

--- a/app/components/shared/qualification_grade_component.rb
+++ b/app/components/shared/qualification_grade_component.rb
@@ -8,7 +8,7 @@ class QualificationGradeComponent < ViewComponent::Base
     if @qualification.predicted_grade?
       "#{@qualification.grade} (predicted)"
     else
-      @qualification.grade.presence || 'Not entered'
+      @qualification.grade.presence
     end
   end
 

--- a/app/components/shared/qualification_row_component.html.erb
+++ b/app/components/shared/qualification_row_component.html.erb
@@ -1,12 +1,13 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">
-    <b><%= render QualificationSubjectComponent.new(qualification: qualification) %></b>
     <%= render QualificationTitleComponent.new(qualification: qualification) %>
   </td>
-  <% if qualification.missing_qualification? %>
-    <td colspan="2" class="govuk-table__cell"><%= qualification.not_completed_explanation %></td>
-  <% else %>
-    <td class="govuk-table__cell"><%= qualification.award_year %></td>
-    <td class="govuk-table__cell"><%= render QualificationGradeComponent.new(qualification: qualification) %></td>
-  <% end %>
+  <td class="govuk-table__cell">
+    <%= render QualificationSubjectComponent.new(qualification: qualification) %>
+  </td>
+  <td class="govuk-table__cell">
+    <%= country %>
+  </td>
+  <td class="govuk-table__cell"><%= qualification.award_year %></td>
+  <td class="govuk-table__cell"><%= render QualificationGradeComponent.new(qualification: qualification) %></td>
 </tr>

--- a/app/components/shared/qualification_row_component.rb
+++ b/app/components/shared/qualification_row_component.rb
@@ -5,4 +5,8 @@ class QualificationRowComponent < ViewComponent::Base
   def initialize(qualification:)
     @qualification = qualification
   end
+
+  def country
+    COUNTRIES_AND_TERRITORIES[qualification.institution_country]
+  end
 end

--- a/app/components/shared/qualification_subject_component.html.erb
+++ b/app/components/shared/qualification_subject_component.html.erb
@@ -1,4 +1,8 @@
-<%= subject %>
-<% if hesa_code %>
-  <span class='govuk-hint govuk-!-margin-bottom-1 govuk-!-font-size-16'>(<%= hesa_code %>)</span>
+<% if subject %>
+  <%= subject %>
+  <% if hesa_code %>
+    <span class='govuk-hint govuk-!-margin-bottom-1 govuk-!-font-size-16'>(<%= hesa_code %>)</span>
+  <% end %>
+<% else %>
+  Not entered
 <% end %>

--- a/app/components/shared/qualifications_component.html.erb
+++ b/app/components/shared/qualifications_component.html.erb
@@ -8,6 +8,6 @@
     editable: editable?,
   ) %>
   <%= render GcseQualificationCardsComponent.new(application_form, editable: editable?) %>
-  <%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.other, header: 'Other qualifications') %>
+  <%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.other, header: 'A levels and other qualifications', subheader: 'Details of A levels and other qualifications') %>
   <%= render EflQualificationCardComponent.new(application_form) %>
 </section>

--- a/app/components/shared/qualifications_table_component.html.erb
+++ b/app/components/shared/qualifications_table_component.html.erb
@@ -1,16 +1,10 @@
 <h3 class="govuk-heading-m govuk-!-margin-top-6" id="other-qualifications"><%= header %></h3>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render SummaryListComponent.new(add_other_qualifications_q_a) %>
-  </div>
-</div>
-
 <% if qualifications.any? %>
-  <h4 class="govuk-heading-m govuk-!-margin-top-6" id="other-qualifications"><%= subheader %></h4>
+  <h4 class="govuk-heading-s govuk-!-margin-top-6" id="other-qualifications"><%= subheader %></h4>
   <table class="govuk-table govuk-!-width-full" data-qa="qualifications-table-<%= header.parameterize %>">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header govuk-table__header">Qualification</th>
+        <th class="govuk-table__header govuk-table__header">Qualification type</th>
         <th class="govuk-table__header govuk-table__header">Subject</th>
         <th class="govuk-table__header govuk-table__header">Country</th>
         <th class="govuk-table__header govuk-table__header">Year awarded</th>
@@ -23,4 +17,10 @@
       <% end %>
     </tbody>
   </table>
+<% else %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render SummaryListComponent.new(add_other_qualifications_q_a) %>
+    </div>
+  </div>
 <% end %>

--- a/app/components/shared/qualifications_table_component.html.erb
+++ b/app/components/shared/qualifications_table_component.html.erb
@@ -1,11 +1,19 @@
-<% if qualifications.any? %>
-  <h3 class="govuk-heading-m govuk-!-margin-top-6" id="other-qualifications"><%= header %></h3>
+<h3 class="govuk-heading-m govuk-!-margin-top-6" id="other-qualifications"><%= header %></h3>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render SummaryListComponent.new(add_other_qualifications_q_a) %>
+  </div>
+</div>
 
-  <table class="govuk-table govuk-!-width-two-thirds" data-qa="qualifications-table-<%= header.parameterize %>">
+<% if qualifications.any? %>
+  <h4 class="govuk-heading-m govuk-!-margin-top-6" id="other-qualifications"><%= subheader %></h4>
+  <table class="govuk-table govuk-!-width-full" data-qa="qualifications-table-<%= header.parameterize %>">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header govuk-table__header">Qualification</th>
-        <th class="govuk-table__header govuk-table__header">Awarded</th>
+        <th class="govuk-table__header govuk-table__header">Subject</th>
+        <th class="govuk-table__header govuk-table__header">Country</th>
+        <th class="govuk-table__header govuk-table__header">Year awarded</th>
         <th class="govuk-table__header govuk-table__header">Grade</th>
       </tr>
     </thead>

--- a/app/components/shared/qualifications_table_component.rb
+++ b/app/components/shared/qualifications_table_component.rb
@@ -1,9 +1,17 @@
 # NOTE: This component is used by both provider and support UIs
 class QualificationsTableComponent < ViewComponent::Base
-  attr_reader :qualifications, :header
+  attr_reader :qualifications, :header, :subheader
 
-  def initialize(qualifications:, header:)
+  def initialize(qualifications:, header:, subheader:)
     @qualifications = qualifications
     @header = header
+    @subheader = subheader
+  end
+
+  def add_other_qualifications_q_a
+    {
+      rows: [{ key: 'Do you want to add A levels and other qualifications?',
+               value: qualifications.any? ? 'Yes' : 'No' }],
+    }
   end
 end

--- a/app/components/shared/qualifications_table_component.rb
+++ b/app/components/shared/qualifications_table_component.rb
@@ -11,7 +11,7 @@ class QualificationsTableComponent < ViewComponent::Base
   def add_other_qualifications_q_a
     {
       rows: [{ key: 'Do you want to add A levels and other qualifications?',
-               value: qualifications.any? ? 'Yes' : 'No' }],
+               value: 'No' }],
     }
   end
 end

--- a/spec/components/utility/qualification_row_component_spec.rb
+++ b/spec/components/utility/qualification_row_component_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe QualificationRowComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text.gsub(/\s+/, ' ')).to include('Psychology BSc')
-    expect(result.text).not_to include('2015')
-    expect(result.text).to include('2018')
-    expect(result.text).to include('Upper second')
+    expect(result.css('td')[0].text).to include('BSc')
+    expect(result.css('td')[1].text).to include('Psychology')
+    expect(result.css('td')[3].text).to include('2018')
+    expect(result.css('td')[4].text).to include('Upper second')
   end
 
   it 'renders a qualification with a predicted grade' do
@@ -34,9 +34,10 @@ RSpec.describe QualificationRowComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text.gsub(/\s+/, ' ')).to include('Engineering MEng')
-    expect(result.text).to include('2020')
-    expect(result.text).to include('First (predicted)')
+    expect(result.css('td')[0].text).to include('MEng')
+    expect(result.css('td')[1].text).to include('Engineering')
+    expect(result.css('td')[3].text).to include('2020')
+    expect(result.css('td')[4].text).to include('First (predicted)')
   end
 
   it 'renders a qualification with a free text grade' do
@@ -52,9 +53,11 @@ RSpec.describe QualificationRowComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text.gsub(/\s+/, ' ')).to include('Chemistry BSc')
-    expect(result.text).to include('2001')
-    expect(result.text).to include('I did my best')
+    expect(result.css('td')[0].text).to include('BSc')
+    expect(result.css('td')[1].text).to include('Chemistry')
+    expect(result.css('td')[2].text).to include('United Kingdom')
+    expect(result.css('td')[3].text).to include('2001')
+    expect(result.css('td')[4].text).to include('I did my best')
   end
 
   it 'renders a qualification with a not_completed_explanation' do
@@ -66,11 +69,13 @@ RSpec.describe QualificationRowComponent do
       grade: nil,
       award_year: nil,
       not_completed_explanation: 'I am taking the exam this summer',
+      predicted_grade: nil,
     )
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text.gsub(/\s+/, ' ')).to include('Maths GCSE')
-    expect(result.text).to include('I am taking the exam this summer')
+    expect(result.css('td')[0].text).to include('GCSE')
+    expect(result.css('td')[1].text).to include('Maths')
+    expect(result.css('td')[4].text).to include('Not entered')
   end
 end

--- a/spec/components/utility/qualifications_table_component_spec.rb
+++ b/spec/components/utility/qualifications_table_component_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe QualificationsTableComponent do
     result = render_inline(described_class.new(qualifications: qualifications, header: 'My header', subheader: 'My subheader'))
 
     expect(result.css('table').first['data-qa']).to eq 'qualifications-table-my-header'
-    expect(result.css('table thead th')[0].text).to include('Qualification')
-    expect(result.css('thead tr th')[1].text).to include('Subject')
-    expect(result.css('thead tr th')[2].text).to include('Country')
-    expect(result.css('thead tr th')[3].text).to include('Year awarded')
-    expect(result.css('thead tr th')[4].text).to include('Grade')
+    expect(result.css('table thead th')[0].text).to eq('Qualification type')
+    expect(result.css('thead tr th')[1].text).to eq('Subject')
+    expect(result.css('thead tr th')[2].text).to eq('Country')
+    expect(result.css('thead tr th')[3].text).to eq('Year awarded')
+    expect(result.css('thead tr th')[4].text).to eq('Grade')
 
     expect(result.css('tbody td')[0].text).to include('BSc')
     expect(result.css('tbody td')[1].text).to include('Rocket Surgery')

--- a/spec/components/utility/qualifications_table_component_spec.rb
+++ b/spec/components/utility/qualifications_table_component_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe QualificationsTableComponent do
   it 'renders nothing when no qualifications present' do
-    result = render_inline(described_class.new(qualifications: [], header: 'My header'))
+    result = render_inline(described_class.new(qualifications: [], header: 'My header', subheader: 'My subheader'))
 
     expect(result.css('table')).to be_blank
   end
@@ -18,10 +18,19 @@ RSpec.describe QualificationsTableComponent do
         award_year: '2020',
       ),
     ]
-    result = render_inline(described_class.new(qualifications: qualifications, header: 'My header'))
+    result = render_inline(described_class.new(qualifications: qualifications, header: 'My header', subheader: 'My subheader'))
 
     expect(result.css('table').first['data-qa']).to eq 'qualifications-table-my-header'
-    expect(result.css('table thead tr')[0].text.gsub(/\s+/, ' ')).to include('Qualification Awarded Grade')
-    expect(result.css('table tbody tr')[0].text.gsub(/\s+/, ' ')).to include('Rocket Surgery BSc 2020 Third')
+    expect(result.css('table thead th')[0].text).to include('Qualification')
+    expect(result.css('thead tr th')[1].text).to include('Subject')
+    expect(result.css('thead tr th')[2].text).to include('Country')
+    expect(result.css('thead tr th')[3].text).to include('Year awarded')
+    expect(result.css('thead tr th')[4].text).to include('Grade')
+
+    expect(result.css('tbody td')[0].text).to include('BSc')
+    expect(result.css('tbody td')[1].text).to include('Rocket Surgery')
+    expect(result.css('tbody td')[2].text).to include('United Kingdom')
+    expect(result.css('tbody td')[3].text).to include('2020')
+    expect(result.css('tbody td')[4].text).to include('Third')
   end
 end

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   end
 
   def and_i_should_see_the_candidates_other_qualifications
-    expect(page).to have_selector('[data-qa="qualifications-table-other-qualifications"] tbody tr', count: 3)
+    expect(page).to have_selector('[data-qa="qualifications-table-a-levels-and-other-qualifications"] tbody tr', count: 3)
   end
 
   def and_i_should_see_the_candidates_work_history


### PR DESCRIPTION
## Context

Enable provider to understand that entering qualification is something that a candidate can choose and is not mandatory so they are in a position to make better informed decisions.

## Changes proposed in this pull request

Updates to the other qualifications section of an application choice.


## Link to Trello card

https://trello.com/c/Xab0IqYJ/4610-making-it-clearer-that-a-candidate-has-chosen-not-to-add-a-levels-and-other-qualifications

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
