### PR TITLE
Update content for the duplicate matching email

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -463,6 +463,15 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def duplicate_match_email(application_form, submitted)
+    @application_form = application_form
+    @submitted = submitted
+    email_for_candidate(
+      application_form,
+      subject: I18n.t!('candidate_mailer.duplicate_match.subject'),
+    )
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/services/support_interface/send_duplicate_match_email.rb
+++ b/app/services/support_interface/send_duplicate_match_email.rb
@@ -7,7 +7,11 @@ module SupportInterface
     end
 
     def call
-      CandidateMailer.fraud_match_email(@candidate.current_application).deliver_later
+      CandidateMailer.duplicate_match_email(@candidate.current_application, submitted).deliver_later
+    end
+
+    def submitted
+      @candidate.application_forms.map(&:submitted_at).any?
     end
   end
 end

--- a/app/views/candidate_mailer/duplicate_match_email.text.erb
+++ b/app/views/candidate_mailer/duplicate_match_email.text.erb
@@ -1,0 +1,11 @@
+Dear <%= @application_form.first_name %>
+
+You’ve created more than one account on Apply for teacher training.
+
+<% if @submitted %>
+  As you have already submitted an application, the account with the unsubmitted application will be locked.
+<% else %>
+  Your access to the account you set up most recently will be removed.
+<% end %>
+
+If you think this is a mistake, reply to this email to let us know.

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -118,3 +118,5 @@ en:
       subject: Find your teacher training course now
     fraud_match:
       subject: Duplicate application detected
+    duplicate_match:
+      subject: Duplicate application detected

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -562,4 +562,32 @@ RSpec.describe CandidateMailer, type: :mailer do
       )
     end
   end
+
+  describe '.duplicate_match_email' do
+    context 'when the candidate has submitted applications' do
+      let(:application_form) { build_stubbed(:application_form, :minimum_info, first_name: 'Fred') }
+      let(:email) { mailer.duplicate_match_email(application_form, true) }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Duplicate application detected',
+        'greeting' => 'Dear Fred',
+        'details' => 'You’ve created more than one account on Apply for teacher training.',
+        'dynamic content' => 'As you have already submitted an application, the account with the unsubmitted application will be locked.',
+      )
+    end
+
+    context 'when the candidate has not submitted any applications' do
+      let(:application_form) { build_stubbed(:application_form, first_name: 'Fred') }
+      let(:email) { mailer.duplicate_match_email(application_form, false) }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Duplicate application detected',
+        'greeting' => 'Dear Fred',
+        'details' => 'You’ve created more than one account on Apply for teacher training.',
+        'dynamic content' => 'Your access to the account you set up most recently will be removed.',
+      )
+    end
+  end
 end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -781,6 +781,13 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.fraud_match_email(application_form)
   end
 
+  def duplicate_match_email
+    application_form = FactoryBot.build(:application_form, first_name: 'Tester', submitted_at: Time.zone.now)
+    submitted = true
+
+    CandidateMailer.duplicate_match_email(application_form, submitted)
+  end
+
   def find_has_opened_no_name
     application_form = FactoryBot.build(:application_form, first_name: nil, submitted_at: nil)
 

--- a/spec/services/support_interface/send_duplicate_match_email_spec.rb
+++ b/spec/services/support_interface/send_duplicate_match_email_spec.rb
@@ -1,23 +1,47 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::SendDuplicateMatchEmail do
-  describe '#call' do
-    let(:fraud_match) { create(:fraud_match) }
+  let(:duplicate_match) { create(:fraud_match) }
+  let(:candidate) { duplicate_match.candidates.first }
 
+  describe '#call' do
     before do
-      @candidate = fraud_match.candidates.first
       build(
         :application_form,
-        candidate: @candidate,
+        candidate: candidate,
       )
 
       mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
-      allow(CandidateMailer).to receive(:fraud_match_email).and_return(mail)
+      allow(CandidateMailer).to receive(:duplicate_match_email).and_return(mail)
     end
 
     it 'sends an email to the candidate' do
-      described_class.new(@candidate).call
-      expect(CandidateMailer).to have_received(:fraud_match_email).once
+      described_class.new(candidate).call
+      expect(CandidateMailer).to have_received(:duplicate_match_email).once
+    end
+  end
+
+  describe '#submitted' do
+    context 'when a candidate has a submitted application' do
+      before do
+        create(:submitted_application_choice, :with_completed_application_form, status: 'rejected', candidate: candidate)
+      end
+
+      it 'returns true' do
+        submitted = described_class.new(candidate).submitted
+        expect(submitted).to eq(true)
+      end
+    end
+
+    context 'when a candidate does not have any submitted applications' do
+      before do
+        create(:application_choice, :application_not_sent, candidate: candidate)
+      end
+
+      it 'returns false' do
+        submitted = described_class.new(candidate).submitted
+        expect(submitted).to eq(false)
+      end
     end
   end
 end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -41,6 +41,7 @@ RSpec.feature 'Docs' do
       candidate_mailer-eoc_deadline_reminder
       candidate_mailer-new_cycle_has_started
       candidate_mailer-fraud_match_email
+      candidate_mailer-duplicate_match_email
       candidate_mailer-find_has_opened
       candidate_mailer-unconditional_offer_accepted
       candidate_mailer-conditions_statuses_changed


### PR DESCRIPTION
## Context

This current email is not correct. It talks about "withdrawing" the "duplicate application". Whereas in fact we remove access to whichever candidate account was created latest. This PR addresses this with a new `duplicate_match` email template which will soon replace the old `fraud_match` template.

## Changes proposed

- Dynamically render different content based on whether the candidate has any submitted applications or not

## Before

<img width="544" alt="image" src="https://user-images.githubusercontent.com/50492247/148537213-b9125bb5-576d-4176-bc77-103dcec3bb17.png">

## After (if application submitted)

<img width="519" alt="image" src="https://user-images.githubusercontent.com/50492247/148999171-f3dbc2d5-8c01-413f-9009-3e4c37850ae4.png">


## After (if no application submitted)

<img width="517" alt="image" src="https://user-images.githubusercontent.com/50492247/148999245-dc010a22-7fe7-4503-aa84-4c7ac6a5cd59.png">



## Link to Trello card

https://trello.com/c/1CrwwvTt/4247-rewrite-the-initial-duplicate-match-email