### PR TITLE
Rename Yabeda exported_instance label

### DIFF
--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -7,7 +7,7 @@ if ENV.key?('VCAP_APPLICATION')
 
   Yabeda.configure do
     default_tag :app, app_name
-    default_tag :exported_instance, app_instance
+    default_tag :app_instance, app_instance
     default_tag :organisation, org_name
     default_tag :space, space_name
   end


### PR DESCRIPTION
## Context
We currently send the cloud foundry instance id as "exported_instance" label so it doesn't override the "instance" label generated by prometheus. But we want to drop the prometheus one because it changes at each deployment and creates millions of time series in prometheus and influxdb.

## Changes proposed in this pull request

Instead we're going to send the instance id as "app_instance" which is used to replace the prometheus instance label as configured in cf-monitoring.

Related to: https://github.com/DFE-Digital/cf-monitoring/pull/45

## Guidance to review
Check metrics in the review app
Check configuration in cf-monitoring and use https://relabeler.promlabs.com/

## Link to Trello card

https://trello.com/c/SgUDbsA2

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
