### PR TITLE
Update set_up_organisation_permissions for single provider email text

### DIFF
--- a/app/views/provider_mailer/_multiple_provider_relationship_set_up.text.erb
+++ b/app/views/provider_mailer/_multiple_provider_relationship_set_up.text.erb
@@ -1,4 +1,4 @@
-Candidates can now find courses on GOV.UK that you work on with the partner organisations listed below.
+Candidates can now find courses you run with the partner organisations listed below.
 
 You cannot manage applications to these courses until either you or your partner organisations have set up organisation permissions.
 
@@ -10,3 +10,5 @@ For <%= organisation %>, you need to set up permissions for courses you work on 
 - <%= partner_organisation %>
 <% end %>
 <% end -%>
+
+You’ll be asked to set up organisation permissions when you sign in, unless your partner organisations set them up first.

--- a/app/views/provider_mailer/_single_provider_relationship_set_up.text.erb
+++ b/app/views/provider_mailer/_single_provider_relationship_set_up.text.erb
@@ -1,7 +1,9 @@
-Candidates can now find courses on GOV.UK that you work on with:
+Candidates can now find courses you run with:
 
 <% @relationships_to_set_up.values.flatten.each do |partner_organisation| -%>
 - <%= partner_organisation %>
 <% end -%>
 
-Either you or these partner organisations must set up organisation permissions before you can manage teacher training applications.
+<%= I18n.t('provider_mailer.set_up_organisation_permissions.content.single_provider.relationship_setup_info', count: @relationships_to_set_up.values.flatten.count) %>
+
+<%= I18n.t('provider_mailer.set_up_organisation_permissions.content.single_provider.when_to_setup_relationship', count: @relationships_to_set_up.values.flatten.count) %>

--- a/app/views/provider_mailer/set_up_organisation_permissions.text.erb
+++ b/app/views/provider_mailer/set_up_organisation_permissions.text.erb
@@ -2,8 +2,6 @@ Dear <%= @provider_user.full_name %>
 
 <%= render "#{@single_or_multiple}_provider_relationship_set_up" %>
 
-You’ll be asked to set up organisation permissions when you sign in, unless your partner organisations set them up first.
-
 Set up organisation permissions:
 
-<%= provider_interface_sign_in_url %>
+<%= provider_interface_applications_url %>

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -27,6 +27,14 @@ en:
       subject: "%{provider} changed organisation permissions"
     set_up_organisation_permissions:
       subject: "Set up organisation permissions"
+      content:
+        single_provider:
+          relationship_setup_info:
+            one: Either you or this partner organisation must set up organisation permissions before you can manage teacher training applications.
+            other: Either you or these partner organisations must set up organisation permissions before you can manage teacher training applications.
+          when_to_setup_relationship:
+            one: You’ll be asked to set up organisation permissions when you sign in, unless your partner organisation sets them up first.
+            other: You’ll be asked to set up organisation permissions when you sign in, unless your partner organisations set them up first.
     permissions_granted:
       subject: '%{permissions_granted_by_user} added you to %{organisation}'
     permissions_granted_by_support:

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -172,7 +172,15 @@ class ProviderMailerPreview < ActionMailer::Preview
     ProviderMailer.set_up_organisation_permissions(provider_user, relationships_to_set_up)
   end
 
-  def set_up_organisation_permissions_single_provider
+  def set_up_organisation_permissions_single_provider_one_relationship
+    relationships_to_set_up = {
+      'University of Dundee' => ['University of Broughty Ferry'],
+    }
+    provider_user = FactoryBot.create(:provider_user)
+    ProviderMailer.set_up_organisation_permissions(provider_user, relationships_to_set_up)
+  end
+
+  def set_up_organisation_permissions_single_provider_multiple_relationships
     relationships_to_set_up = {
       'University of Dundee' => ['University of Broughty Ferry', 'University of Forfar', 'University of Wormit'],
     }

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -455,7 +455,28 @@ RSpec.describe ProviderMailer, type: :mailer do
     )
   end
 
-  describe 'set_up_organisation_permissions' do
+  describe 'set_up_organisation_permissions for single provider with one relationship' do
+    let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English') }
+    let(:relationships_to_set_up) do
+      { 'University of Selsdon' => ['University of Croydon'] }
+    end
+
+    let(:email) { described_class.set_up_organisation_permissions(provider_user, relationships_to_set_up) }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Set up organisation permissions - manage teacher training applications',
+      'salutation' => 'Dear Johny English',
+      'main paragraph' => 'Candidates can now find courses you run with:',
+      'partner providers' => '- University of Croydon',
+      'relationship_setup_paragraph' => 'Either you or this partner organisation',
+      'when_to_setup_relationship' => 'unless your partner organisation sets them up',
+      'link to applications' => 'http://localhost:3000/provider/applications',
+      'footer' => 'Get help, report a problem or give feedback',
+    )
+  end
+
+  describe 'set_up_organisation_permissions for single provider with multiple relationships' do
     let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English') }
     let(:relationships_to_set_up) do
       { 'University of Selsdon' => ['University of Croydon', 'University of Purley'] }
@@ -467,9 +488,11 @@ RSpec.describe ProviderMailer, type: :mailer do
       'a mail with subject and content',
       'Set up organisation permissions - manage teacher training applications',
       'salutation' => 'Dear Johny English',
-      'main paragraph' => 'Candidates can now find courses on GOV.UK that you work on with:',
+      'main paragraph' => 'Candidates can now find courses you run with:',
       'partner providers' => "- University of Croydon\r\n- University of Purley",
-      'link to sign in' => 'http://localhost:3000/provider/sign-in',
+      'relationship_setup_paragraph' => 'Either you or these partner organisations',
+      'when_to_setup_relationship' => 'unless your partner organisations set them up',
+      'link to applications' => 'http://localhost:3000/provider/applications',
       'footer' => 'Get help, report a problem or give feedback',
     )
   end
@@ -489,12 +512,12 @@ RSpec.describe ProviderMailer, type: :mailer do
       'a mail with subject and content',
       'Set up organisation permissions - manage teacher training applications',
       'salutation' => 'Dear Johny English',
-      'main paragraph' => 'Candidates can now find courses on GOV.UK that you work on with the partner organisations listed below.',
+      'main paragraph' => 'Candidates can now find courses you run with the partner organisations listed below.',
       'first relationship group' => 'For University of Dundee, you need to set up permissions for courses you work on with:',
       'first group of partner providers' => "- University of Broughty Ferry\r\n- University of Carnoustie",
       'second relationship group' => 'For University of Selsdon, you need to set up permissions for courses you work on with:',
       'second group of partner providers' => "- University of Croydon\r\n- University of Purley",
-      'link to sign in' => 'http://localhost:3000/provider/sign-in',
+      'link to applications' => 'http://localhost:3000/provider/applications',
       'footer' => 'Get help, report a problem or give feedback',
     )
   end


### PR DESCRIPTION
## Context
Update set_up_organisation_permissions email for a single provider with one relationship and other minor updates for text to reflect one specified in doc - https://docs.google.com/document/d/1n05Y66yvLyxj03UEr9TjLqjiZO--fUVB9KGrHZS_uJs/edit#heading=h.3tprgp8t26w0

## Changes proposed in this pull request

Single provider relationship permissions

for one provider
https://apply-for-te-4613-updat-irepso.herokuapp.com/rails/mailers/provider_mailer/set_up_organisation_permissions_single_provider_one_relationship

for multiple providers
https://apply-for-te-4613-updat-irepso.herokuapp.com/rails/mailers/provider_mailer/set_up_organisation_permissions_single_provider_multiple_relationships

## Link to Trello card

https://trello.com/c/1YyvarMf/4613-update-provider-email-content-and-footers

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
