### PR TITLE
Add extra validation to safeguarding and disability forms

### DIFF
--- a/app/forms/candidate_interface/safeguarding_issues_declaration_form.rb
+++ b/app/forms/candidate_interface/safeguarding_issues_declaration_form.rb
@@ -5,6 +5,7 @@ module CandidateInterface
     attr_accessor :share_safeguarding_issues, :safeguarding_issues
 
     validates :share_safeguarding_issues, presence: true
+    validates :safeguarding_issues, presence: true, if: :share_safeguarding_issues?
     validates :safeguarding_issues, word_count: { maximum: 400 }
 
     def self.build_from_application(application_form)
@@ -20,7 +21,7 @@ module CandidateInterface
     def save(application_form)
       return false unless valid?
 
-      if share_safeguarding_issues == 'Yes'
+      if share_safeguarding_issues?
         application_form.update(
           safeguarding_issues: safeguarding_issues,
           safeguarding_issues_status: :has_safeguarding_issues_to_declare,
@@ -31,6 +32,10 @@ module CandidateInterface
           safeguarding_issues_status: :no_safeguarding_issues_to_declare,
         )
       end
+    end
+
+    def share_safeguarding_issues?
+      share_safeguarding_issues == 'Yes'
     end
   end
 end

--- a/app/forms/candidate_interface/training_with_a_disability_form.rb
+++ b/app/forms/candidate_interface/training_with_a_disability_form.rb
@@ -5,10 +5,8 @@ module CandidateInterface
     attr_accessor :disclose_disability, :disability_disclosure
 
     validates :disclose_disability, inclusion: { in: %w[yes no] }
-
-    validates :disability_disclosure,
-              word_count: { maximum: 400 },
-              allow_blank: true
+    validates :disability_disclosure, presence: true, if: :disclose_disability?
+    validates :disability_disclosure, word_count: { maximum: 400 }
 
     def self.build_from_application(application_form)
       new(
@@ -46,6 +44,10 @@ module CandidateInterface
         false
       end
       # nil by default
+    end
+
+    def disclose_disability?
+      disclose_disability == 'yes'
     end
   end
 end

--- a/config/locales/candidate_interface/safeguarding.yml
+++ b/config/locales/candidate_interface/safeguarding.yml
@@ -8,3 +8,4 @@ en:
               blank: Choose if you want to share any safeguarding issues
             safeguarding_issues:
               too_many_words: Safeguarding issues must be %{count} words or fewer
+              blank: Enter any relevent information, or select 'No'

--- a/config/locales/candidate_interface/training_with_a_disability.yml
+++ b/config/locales/candidate_interface/training_with_a_disability.yml
@@ -19,3 +19,5 @@ en:
           attributes:
             disclose_disability:
               inclusion: Choose if you want to ask for help to become a teacher
+            disability_disclosure:
+              blank: Enter any relevent information, or select 'No'

--- a/spec/forms/candidate_interface/safeguarding_issues_declaration_form_spec.rb
+++ b/spec/forms/candidate_interface/safeguarding_issues_declaration_form_spec.rb
@@ -92,16 +92,16 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
     end
 
     context 'when sharing safeguarding issues is "Yes" but no details provided' do
-      it 'returns true' do
+      it 'returns false' do
         form = described_class.new(
           share_safeguarding_issues: 'Yes',
           safeguarding_issues: '',
         )
 
-        expect(form.save(application_form)).to be(true)
+        expect(form.save(application_form)).to be(false)
       end
 
-      it 'updates safeguarding issues of the application form to provided issues if empty string' do
+      it 'does not update safeguarding issues of the application form to provided issues if empty string' do
         form = described_class.new(
           share_safeguarding_issues: 'Yes',
           safeguarding_issues: '',
@@ -109,11 +109,11 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
 
         form.save(application_form)
 
-        expect(application_form.safeguarding_issues_status.to_sym).to eq :has_safeguarding_issues_to_declare
-        expect(application_form.safeguarding_issues).to eq ''
+        expect(application_form.safeguarding_issues_status.to_sym).to eq :not_answered_yet
+        expect(application_form.safeguarding_issues).to eq nil
       end
 
-      it 'updates safeguarding issues of the application form to provided issues if nil' do
+      it 'does not update safeguarding issues of the application form if nil' do
         form = described_class.new(
           share_safeguarding_issues: 'Yes',
           safeguarding_issues: nil,
@@ -121,7 +121,7 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
 
         form.save(application_form)
 
-        expect(application_form.safeguarding_issues_status.to_sym).to eq :has_safeguarding_issues_to_declare
+        expect(application_form.safeguarding_issues_status.to_sym).to eq :not_answered_yet
         expect(application_form.safeguarding_issues).to eq nil
       end
     end

--- a/spec/forms/candidate_interface/training_with_a_disability_form_spec.rb
+++ b/spec/forms/candidate_interface/training_with_a_disability_form_spec.rb
@@ -50,6 +50,23 @@ RSpec.describe CandidateInterface::TrainingWithADisabilityForm, type: :model do
       end
     end
 
+    context 'when the user discloses a disability but provides no written information' do
+      let(:form_data) do
+        {
+          disclose_disability: 'yes',
+          disability_disclosure: '',
+        }
+      end
+
+      it 'does not update the provided ApplicationForm' do
+        expect(disability_form.save(application_form)).to eq(false)
+        expect(application_form).to have_attributes(
+          disclose_disability: nil,
+          disability_disclosure: nil,
+        )
+      end
+    end
+
     context 'when valid and the user does not want to disclose a disability' do
       let(:form_data) do
         {


### PR DESCRIPTION
## Context

If a user selects "Yes" to the safegaurding or disability question the user should provide details. This PR prevents the submission of a blank text field for these forms. 

## Changes proposed in this pull request

- Add validation to the safeguarding form to prevent submission of empty text field

- Add validation to the disability form to prevent submission of empty text field

## Guidance to review

- Create a new candidate application
- Scroll down and click on `Declare any safeguarding issues` (`candidate/application/safeguarding/edit`)
- Click `Yes, I want to share something`
- Ensure you cannot submit the form without inputting any information in the free text field. 
- Ensure you can submit as normal when you click `No`

- Repeat for the disability question

## Link to Trello card

https://trello.com/c/Te20csqg/4225-defect-optional-field-for-safeguarding-question
