### PR TITLE
Handle removed conditions in the offer wizard

### DIFF
--- a/app/forms/concerns/wizard.rb
+++ b/app/forms/concerns/wizard.rb
@@ -13,8 +13,8 @@ module Wizard
       @state_store = state_store
 
       attrs = sanitize_attrs(attrs) if defined?(sanitize_attrs)
-
-      super(last_saved_state.deep_merge(attrs))
+      state = defined?(sanitize_last_saved_state) ? sanitize_last_saved_state(last_saved_state, attrs) : last_saved_state
+      super(state.deep_merge(attrs))
 
       initialize_extra(attrs) if defined?(initialize_extra)
       setup_path_history(attrs) if defined?(setup_path_history)

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -37,6 +37,19 @@ module ProviderInterface
       new(state_store, attrs)
     end
 
+    def initialize_extra(attrs)
+      return unless attrs.key?('further_condition_attrs')
+
+      new_conditions = attrs['further_condition_attrs']
+      stored_conditions = further_condition_attrs
+      new_condition_ids = new_conditions.values.map { |v| v['condition_id'] }
+      removed_conditions = stored_conditions.select { |_, v| new_condition_ids.exclude?(v['condition_id'].to_s) }
+
+      if removed_conditions.any?
+        @further_condition_attrs = further_condition_attrs.except(*removed_conditions.keys)
+      end
+    end
+
     def conditions
       @conditions = (standard_conditions + further_condition_models.map(&:text).uniq).compact_blank
     end

--- a/spec/system/provider_interface/provider_changes_conditions_on_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_conditions_on_an_offer_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+
+RSpec.feature 'Change offer conditions' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+
+  scenario 'Provider user changes the conditions on an offer' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_an_authorised_provider_user
+    and_i_can_access_the_provider_interface
+
+    when_i_navigate_to_an_offer
+    and_i_navigate_to_the_offer_tab
+    and_i_click_on_add_or_change_conditions
+    and_i_add_further_conditions
+    then_i_see_the_new_conditions
+
+    when_i_click_on_add_or_change_conditions
+    and_i_remove_a_condition
+    then_i_expect_to_see_the_updated_conditions
+
+    when_i_click_on_add_or_change_conditions
+    then_i_should_not_see_the_removed_condition
+
+    when_i_send_the_new_offer
+    then_the_candidate_should_have_the_new_conditions
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_am_an_authorised_provider_user
+    @provider = create(:provider, :with_signed_agreement)
+    create(:provider_user, providers: [@provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    permit_make_decisions!
+  end
+
+  def and_i_can_access_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+    visit provider_interface_applications_path
+    expect(page).to have_current_path provider_interface_applications_path
+  end
+
+  def when_i_navigate_to_an_offer
+    course_option = course_option_for_provider_code(provider_code: @provider.code)
+    @application_form = create(
+      :completed_application_form,
+      first_name: 'John',
+      last_name: 'Smith',
+    )
+    @condition = create(:offer_condition)
+    @application_choice = create(
+      :application_choice,
+      :with_offer,
+      offer: create(:offer, conditions: [@condition]),
+      current_course_option: course_option,
+      application_form: @application_form,
+    )
+    visit provider_interface_application_choice_path(@application_choice)
+  end
+
+  def and_i_navigate_to_the_offer_tab
+    click_on 'Offer'
+  end
+
+  def and_i_click_on_add_or_change_conditions
+    click_on 'Add or change conditions'
+  end
+
+  alias_method :when_i_click_on_add_or_change_conditions, :and_i_click_on_add_or_change_conditions
+
+  def and_i_add_further_conditions
+    click_button 'Add another condition'
+    fill_in 'Condition 2', with: 'condition'
+    click_button 'Add another condition'
+    fill_in 'Condition 3', with: 'and another'
+    click_button 'Continue'
+  end
+
+  def then_i_see_the_new_conditions
+    expect(page).to have_content @condition.text
+    expect(page).to have_content 'condition'
+    expect(page).to have_content 'and another'
+  end
+
+  def and_i_remove_a_condition
+    click_button 'Remove condition 3'
+    click_button 'Continue'
+  end
+
+  def then_i_expect_to_see_the_updated_conditions
+    expect(page).to have_content @condition.text
+    expect(page).to have_content 'condition'
+    expect(page).not_to have_content 'and another'
+  end
+
+  def then_i_should_not_see_the_removed_condition
+    expect(page).to have_content 'Conditions of offer'
+    expect(page).to have_content @condition.text
+    expect(page).to have_content 'condition'
+    expect(page).not_to have_content 'and another'
+    click_button 'Continue'
+  end
+
+  def when_i_send_the_new_offer
+    click_button 'Send new offer'
+  end
+
+  def then_the_candidate_should_have_the_new_conditions
+    conditions = @application_choice.reload.offer.conditions
+    expect(conditions.first.text).to eq @condition.text
+    expect(conditions.second.text).to eq 'condition'
+  end
+end

--- a/spec/system/provider_interface/provider_removes_conditions_from_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_removes_conditions_from_an_offer_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-RSpec.feature 'Change offer conditions' do
+RSpec.feature 'Remove offer conditions' do
   include CourseOptionHelpers
   include DfESignInHelpers
   include ProviderUserPermissionsHelper
 
-  scenario 'Provider user changes the conditions on an offer with javascript on', js: true do
+  scenario 'Provider user removes the conditions from an offer with javascript on', js: true do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_an_authorised_provider_user
     and_i_can_access_the_provider_interface
@@ -13,11 +13,7 @@ RSpec.feature 'Change offer conditions' do
     when_i_navigate_to_an_offer
     and_i_navigate_to_the_offer_tab
     and_i_click_on_add_or_change_conditions
-    and_i_add_further_conditions
-    then_i_see_the_new_conditions
-
-    when_i_click_on_add_or_change_conditions
-    and_i_remove_a_condition
+    and_i_remove_all_conditions
     then_i_expect_to_see_the_updated_conditions
 
     when_i_click_on_add_or_change_conditions
@@ -27,7 +23,7 @@ RSpec.feature 'Change offer conditions' do
     then_the_candidate_should_have_the_new_conditions
   end
 
-  scenario 'Provider user changes the conditions on an offer with javascript off', js: false do
+  scenario 'Provider user removes the conditions from an offer with javascript off', js: false do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_an_authorised_provider_user
     and_i_can_access_the_provider_interface
@@ -35,11 +31,7 @@ RSpec.feature 'Change offer conditions' do
     when_i_navigate_to_an_offer
     and_i_navigate_to_the_offer_tab
     and_i_click_on_add_or_change_conditions
-    and_i_add_further_conditions
-    then_i_see_the_new_conditions
-
-    when_i_click_on_add_or_change_conditions
-    and_i_remove_a_condition
+    and_i_remove_all_conditions
     then_i_expect_to_see_the_updated_conditions
 
     when_i_click_on_add_or_change_conditions
@@ -72,11 +64,11 @@ RSpec.feature 'Change offer conditions' do
       first_name: 'John',
       last_name: 'Smith',
     )
-    @condition = create(:offer_condition)
+    @conditions = create_list(:offer_condition, 3)
     @application_choice = create(
       :application_choice,
       :with_offer,
-      offer: create(:offer, conditions: [@condition]),
+      offer: create(:offer, conditions: @conditions),
       current_course_option: course_option,
       application_form: @application_form,
     )
@@ -93,36 +85,24 @@ RSpec.feature 'Change offer conditions' do
 
   alias_method :when_i_click_on_add_or_change_conditions, :and_i_click_on_add_or_change_conditions
 
-  def and_i_add_further_conditions
-    click_button 'Add another condition'
-    fill_in 'Condition 2', with: 'condition'
-    click_button 'Add another condition'
-    fill_in 'Condition 3', with: 'and another'
-    click_button 'Continue'
-  end
-
-  def then_i_see_the_new_conditions
-    expect(page).to have_content @condition.text
-    expect(page).to have_content 'condition'
-    expect(page).to have_content 'and another'
-  end
-
-  def and_i_remove_a_condition
+  def and_i_remove_all_conditions
     click_button 'Remove condition 3'
+    click_button 'Remove condition 2'
+    click_button 'Remove condition 1'
     click_button 'Continue'
   end
 
   def then_i_expect_to_see_the_updated_conditions
-    expect(page).to have_content @condition.text
-    expect(page).to have_content 'condition'
-    expect(page).not_to have_content 'and another'
+    expect(page).not_to have_content @conditions.first.text
+    expect(page).not_to have_content @conditions.second.text
+    expect(page).not_to have_content @conditions.third.text
   end
 
   def then_i_should_not_see_the_removed_condition
     expect(page).to have_content 'Conditions of offer'
-    expect(page).to have_content @condition.text
-    expect(page).to have_content 'condition'
-    expect(page).not_to have_content 'and another'
+    expect(page).not_to have_content @conditions.first.text
+    expect(page).not_to have_content @conditions.second.text
+    expect(page).not_to have_content @conditions.third.text
     click_button 'Continue'
   end
 
@@ -132,7 +112,6 @@ RSpec.feature 'Change offer conditions' do
 
   def then_the_candidate_should_have_the_new_conditions
     conditions = @application_choice.reload.offer.conditions
-    expect(conditions.first.text).to eq @condition.text
-    expect(conditions.second.text).to eq 'condition'
+    expect(conditions).to be_empty
   end
 end


### PR DESCRIPTION
## Context

When a provider edits a candidate's existing offer conditions, the wizard doesn't correctly store the conditions in the datastore. 

## Changes proposed in this pull request

Add a new `initialize_extra` method to the offer wizard. This will compare the existing conditions against the new ones and will remove any that no longer exist.

## Guidance to review

Original scenario to replicate the bug:

- Find or move a candidate into the offered state
- Go to their offer, and select `Add or change conditions`
- Add a set of 3 conditions with independent text content, and continue
- on the review page, click Add or change conditions
- remove one of the conditions, and click continue
- Again click on Add or change conditions
- A duplicate text box for a mystery conditions should have appeared. It becomes quite difficult to know what conditions the offer will end up with when submitted. 

## Link to Trello card

https://trello.com/c/ESf9274g

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
