### PR TITLE
Guard against `nil` last names when generating prefilled applications

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -138,7 +138,7 @@ private
 
       traits << :with_equality_and_diversity_data
 
-      last_name_on_application_form = traits.include?(:duplicate_candidates) && ApplicationForm.last ? ApplicationForm.last.last_name : last_name
+      last_name_on_application_form = traits.include?(:duplicate_candidates) && ApplicationForm.last&.last_name ? ApplicationForm.last.last_name : last_name
 
       simulate_signin(candidate)
 


### PR DESCRIPTION
## Context

It has been reported that when pre-filling applications on sandbox, applications might have a `nil` last name sometimes. This is because we are filling in the last name if the duplicate trait is sampled with the last name from the last application form.
However an application can still have this value empty as it might not have been filled in yet, meaning we will be leaving
the last name blank in some new applications, rendering them invalid

## Changes proposed in this pull request

Make sure to use the last name only if the last application form's last name is present.

## Guidance to review

Have I missed anything?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
