### PR TITLE
R4R: Ensure visa question paragraphs are rendered

### DIFF
--- a/app/components/shared/reasons_for_rejection_component.html.erb
+++ b/app/components/shared/reasons_for_rejection_component.html.erb
@@ -205,7 +205,7 @@
 <% if reasons_for_rejection.cannot_sponsor_visa_y_n == 'Yes' %>
   <div class="app-rejection">
     <%= content_tag(subheading_tag_name, I18n.t('reasons_for_rejection.cannot_sponsor_visa.title'), class: 'govuk-heading-s') %>
-    <% paragraphs(reasons_for_rejection.cannot_sponsor_visa_details) do |paragraph| %>
+    <% paragraphs(reasons_for_rejection.cannot_sponsor_visa_details).each do |paragraph| %>
       <p class="govuk-body govuk-!-margin-bottom-3"><%= paragraph %></p>
     <% end %>
 


### PR DESCRIPTION
## Context

We weren't rendering the visa question text as there is an `each` missing when going through paragraphs

## Changes proposed in this pull request

Add `each` back to the loop to render the paragraphs

## Guidance to review

Reject an application, and answer the visa question with yes, and fill in the free text box.

## Link to Trello card

https://trello.com/c/638j9axq/4693-r4r-visa-application-sponsorship-answer-does-not-appear-in-summary

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
