### PR TITLE
Check if subject is present to render or render not entered

### DIFF
--- a/app/components/shared/qualification_subject_component.html.erb
+++ b/app/components/shared/qualification_subject_component.html.erb
@@ -1,4 +1,4 @@
-<% if subject %>
+<% if subject.present? %>
   <%= subject %>
   <% if hesa_code %>
     <span class='govuk-hint govuk-!-margin-bottom-1 govuk-!-font-size-16'>(<%= hesa_code %>)</span>


### PR DESCRIPTION
## Context

The subject if not entered is returning and empty string, add present to ensure `not entered` is rendered

## Changes proposed in this pull request

Use `present` to ensure empty strings as well as `nil` subject values are not rendered

## Guidance to review
![Screenshot 2022-01-11 at 10 13 30](https://user-images.githubusercontent.com/2732945/148906390-f2890445-9905-4338-b84d-76915e4d08e5.png)

## Link to Trello card

https://trello.com/c/Xab0IqYJ/4610-making-it-clearer-that-a-candidate-has-chosen-not-to-add-a-levels-and-other-qualifications

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
