### PR TITLE
Remove custom environment check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,39 +108,6 @@ jobs:
         env:
           DOCKER_IMAGE: ${{ format('ghcr.io/dfe-digital/apply-teacher-training:{0}', github.event.inputs.sha) }}
 
-      - name: Check if a review environment exists
-        id: review-environment-exists
-        if:  github.event.inputs.review != ''
-        uses: actions/github-script@v5
-        with:
-          result-encoding: string
-          script: |
-
-            const environmentName = process.env.DEPLOY_ENV;
-
-            const result = await github.rest.repos.getEnvironment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                environment_name: environmentName
-            }).then(res => {
-
-                console.log(`The environment ${environmentName} exists in the repository.`)
-                return "true"
-
-            }).catch(err => {
-
-                if (err.status == "404") {
-                    console.log(`The environment ${environmentName} does not exist in the repository.`)
-                    return "false"
-                }
-
-                console.error(err)
-
-            });
-
-            console.log(`Setting the task output to ${result}`)
-            return result;
-
       - name: Start ${{ env.DEPLOY_ENV }} Deployment
         if: ${{ always() }}
         uses: bobheadxi/deployments@v0.4.3
@@ -206,7 +173,7 @@ jobs:
           CONFIRM_PRODUCTION: true
 
       - name: Seed Review App
-        if: github.event.inputs.review != '' && steps.review-environment-exists.outputs.result == 'false'
+        if: github.event.inputs.review != ''
         run: |
           cf ssh apply-review-${PR_NUMBER} -c "export DISABLE_DATABASE_ENVIRONMENT_CHECK=1 && cd /app && /usr/local/bin/bundle exec rake setup_review_app_data"
 


### PR DESCRIPTION
## Context

PR #6330 introduced a new rake task for review apps. This means that a custom check based on the review app environment name is no longer needed.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This PR removes the custom JS that checks for the review app environment and condition on the cf ssh command step.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Check that the workflow is valid

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/7WGcsC40/4692-bugfix-apply-review-app-not-seeded

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
