### PR TITLE
Amend vendor api caching to respect version of the api

### DIFF
--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -20,13 +20,13 @@ module VendorAPI
     end
 
     def serialized_json
-      Rails.cache.fetch(cache_key(application_choice), expires_in: CACHE_EXPIRES_IN) do
+      Rails.cache.fetch(cache_key(application_choice, active_version), expires_in: CACHE_EXPIRES_IN) do
         schema.to_json
       end
     end
 
     def as_json
-      Rails.cache.fetch(cache_key(application_choice, 'as_json'), expires_in: CACHE_EXPIRES_IN) do
+      Rails.cache.fetch(cache_key(application_choice, active_version, 'as_json'), expires_in: CACHE_EXPIRES_IN) do
         schema
       end
     end
@@ -105,8 +105,8 @@ module VendorAPI
       }
     end
 
-    def cache_key(model, method = '')
-      CacheKey.generate("#{model.cache_key_with_version}#{method}")
+    def cache_key(model, api_version, method = '')
+      CacheKey.generate("#{api_version}_#{model.cache_key_with_version}#{method}")
     end
   end
 end

--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -104,9 +104,5 @@ module VendorAPI
         safeguarding_concerns: reference.has_safeguarding_concerns_to_declare?,
       }
     end
-
-    def cache_key(model, api_version, method = '')
-      CacheKey.generate("#{api_version}_#{model.cache_key_with_version}#{method}")
-    end
   end
 end

--- a/app/presenters/vendor_api/base.rb
+++ b/app/presenters/vendor_api/base.rb
@@ -39,6 +39,10 @@ module VendorAPI
     def active_version_in_retrieved_version?(version)
       minor_version_number(active_version) >= minor_version_number(version)
     end
+
+    def cache_key(model, api_version, method = '')
+      CacheKey.generate("#{api_version}_#{model.cache_key_with_version}#{method}")
+    end
   end
 end
 

--- a/spec/presenters/vendor_api/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/application_presenter_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe VendorAPI::ApplicationPresenter do
       allow(Rails.cache).to receive(:fetch)
       described_class.new(version, application_choice).as_json
 
-      expect(Rails.cache).to have_received(:fetch).with(CacheKey.generate("#{application_choice.cache_key_with_version}as_json"), expires_in: 1.day)
+      expect(Rails.cache).to have_received(:fetch).with(CacheKey.generate("#{version}_#{application_choice.cache_key_with_version}as_json"), expires_in: 1.day)
     end
   end
 
@@ -80,7 +80,7 @@ RSpec.describe VendorAPI::ApplicationPresenter do
       described_class.new(version, application_choice).serialized_json
 
       expect(Rails.cache)
-        .to have_received(:fetch).with(CacheKey.generate(application_choice.cache_key_with_version), expires_in: 1.day)
+        .to have_received(:fetch).with(CacheKey.generate("#{version}_#{application_choice.cache_key_with_version}"), expires_in: 1.day)
     end
   end
 


### PR DESCRIPTION
## Context

- [x] Update ApplicationPresenter to take into account version when caching.
- [x] Look into the Redis Cache in prod, and the % of keys used in the application choice. Discuss with the team if its over 40%.
- [x] Make sure deployment SHA is part of the cache key
- [x] Extract cache key generation to the base presenter 

## Link to Trello card

https://trello.com/c/rYd9ZpKV/4662-api-v11-amend-vendor-api-caching-to-respect-version-of-the-api

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
