### PR TITLE
Write to notes user association

### DIFF
--- a/app/controllers/provider_interface/notes_controller.rb
+++ b/app/controllers/provider_interface/notes_controller.rb
@@ -40,7 +40,7 @@ module ProviderInterface
 
     def note_params
       params.require(:provider_interface_new_note_form).permit(:message, :referer)
-        .merge(application_choice: @application_choice, provider_user: current_provider_user)
+        .merge(application_choice: @application_choice, user: current_provider_user)
     end
   end
 end

--- a/app/forms/provider_interface/new_note_form.rb
+++ b/app/forms/provider_interface/new_note_form.rb
@@ -1,16 +1,17 @@
 module ProviderInterface
   class NewNoteForm
     include ActiveModel::Model
-    attr_accessor :application_choice, :message, :provider_user, :referer
+    attr_accessor :application_choice, :message, :referer, :user
 
-    validates :application_choice, :provider_user, presence: true
+    validates :application_choice, :user, presence: true
     validates :message, length: { maximum: 500 }, presence: true
 
     def save
       if valid?
         Note.new(
           application_choice: application_choice,
-          provider_user: provider_user,
+          provider_user: user,
+          user: user,
           message: message,
         ).save
       end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,4 +1,5 @@
 class Note < ApplicationRecord
   belongs_to :application_choice, touch: true
   belongs_to :provider_user
+  belongs_to :user, polymorphic: true
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -334,8 +334,8 @@ en:
             message:
               blank: Enter a note
               too_long: "The note must be %{count} characters or fewer"
-            provider_user:
-              blank: Missing provider_user
+            user:
+              blank: Missing user
         provider_interface/provider_user_form:
           attributes:
             email_address:

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       note = Note.new(
         provider_user: provider_user,
         message: 'Notes are a new feature',
+        user: provider_user,
       )
       application_choice.notes << note
       rendered = render_inline(described_class.new(application_choice: application_choice))

--- a/spec/factories/note.rb
+++ b/spec/factories/note.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :note do
     application_choice
     provider_user
+    user { create(:provider_user) }
 
     message { Faker::Quote.most_interesting_man_in_the_world }
   end

--- a/spec/factories/note.rb
+++ b/spec/factories/note.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :note do
     application_choice
     provider_user
-    user { create(:provider_user) }
+    user { [0, 1].sample.zero? ? create(:vendor_api_user) : create(:provider_user) }
 
     message { Faker::Quote.most_interesting_man_in_the_world }
   end

--- a/spec/forms/provider_interface/new_note_form_spec.rb
+++ b/spec/forms/provider_interface/new_note_form_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe ProviderInterface::NewNoteForm do
         .with_message('The note must be 500 characters or fewer')
     end
 
-    it 'validates presence of :provider_user' do
-      expect(described_class.new).to validate_presence_of(:provider_user)
-        .with_message('Missing provider_user')
+    it 'validates presence of :user' do
+      expect(described_class.new).to validate_presence_of(:user)
+        .with_message('Missing user')
     end
   end
 
@@ -29,7 +29,7 @@ RSpec.describe ProviderInterface::NewNoteForm do
     it 'creates a new note' do
       valid_form_object = described_class.new(
         application_choice: application_choice,
-        provider_user: provider_user,
+        user: provider_user,
         message: 'Some text',
       )
 


### PR DESCRIPTION
## Context

As part of associating `VendorApiUser`s to `Note`s, and [once we've added the `user_id` and `user_type` columns](https://github.com/DFE-Digital/apply-for-teacher-training/pull/6340) we need to start to populate the `user` association (as well as the `provider_user` association)
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds polymorphic association `user` to `Note`
- Amends `NewNoteForm` to write to the `user` association

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/7VrvjyP5/4701-api-v11-write-to-noteuser-association-when-creating-notes

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
