### PR TITLE
Add pagination to new duplicate matching support UI

### DIFF
--- a/app/components/support_interface/duplicate_matches_table_component.html.erb
+++ b/app/components/support_interface/duplicate_matches_table_component.html.erb
@@ -19,3 +19,5 @@
     <% end %>
   </tbody>
 </table>
+
+<%= render(PaginatorComponent.new(scope: @matches)) %>

--- a/app/controllers/support_interface/duplicate_matches_controller.rb
+++ b/app/controllers/support_interface/duplicate_matches_controller.rb
@@ -1,9 +1,10 @@
 module SupportInterface
   class DuplicateMatchesController < SupportInterfaceController
+    DUPLICATE_MATCHES_PER_PAGE = 100
     before_action :check_feature_flag
 
     def index
-      @matches = fraud_matches(resolved: resolved?).page(params[:page]).per(100)
+      @matches = fraud_matches(resolved: resolved?).page(params[:page]).per(DUPLICATE_MATCHES_PER_PAGE)
       @under_review_count = fraud_matches(resolved: false).count
     end
 

--- a/app/controllers/support_interface/duplicate_matches_controller.rb
+++ b/app/controllers/support_interface/duplicate_matches_controller.rb
@@ -3,7 +3,7 @@ module SupportInterface
     before_action :check_feature_flag
 
     def index
-      @matches = fraud_matches(resolved: resolved?)
+      @matches = fraud_matches(resolved: resolved?).page(params[:page]).per(100)
       @under_review_count = fraud_matches(resolved: false).count
     end
 

--- a/app/controllers/support_interface/duplicate_matches_controller.rb
+++ b/app/controllers/support_interface/duplicate_matches_controller.rb
@@ -32,7 +32,7 @@ module SupportInterface
       FraudMatch.where(
         recruitment_cycle_year: RecruitmentCycle.current_year,
         resolved: resolved,
-      ).order(:created_at)
+      ).order(created_at: :desc)
     end
 
     def check_feature_flag

--- a/spec/components/support_interface/duplicate_matches_table_component_spec.rb
+++ b/spec/components/support_interface/duplicate_matches_table_component_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe SupportInterface::DuplicateMatchesTableComponent do
 
   it 'renders the correct match descriptions' do
     result = render_inline(
-      described_class.new(matches: [@fraud_match1, @fraud_match2]),
+      described_class.new(
+        matches: Kaminari.paginate_array([@fraud_match1, @fraud_match2]).page(1).per(10),
+      ),
     )
 
     expect(result.css('tbody tr')[0].text).to include('3 candidates with postcode W6 9BH and DOB 8 Aug 1998')

--- a/spec/components/support_interface/duplicate_matches_table_component_spec.rb
+++ b/spec/components/support_interface/duplicate_matches_table_component_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe SupportInterface::DuplicateMatchesTableComponent do
   it 'renders the correct match descriptions' do
     result = render_inline(
       described_class.new(
-        matches: Kaminari.paginate_array([@fraud_match1, @fraud_match2]).page(1).per(10),
+        matches: Kaminari.paginate_array([@fraud_match1, @fraud_match2])
+                         .page(1)
+                         .per(SupportInterface::DuplicateMatchesController::DUPLICATE_MATCHES_PER_PAGE),
       ),
     )
 


### PR DESCRIPTION
## Context

This PR adds pagination to the new duplicate matches support UI

## Changes proposed in this pull request

An example with 3 pages of 1 record per page (just an example, the real page will have 100 duplicate matches per page)

<img width="1040" alt="Screenshot 2022-01-13 at 13 25 42" src="https://user-images.githubusercontent.com/27509/149429349-b0141426-0213-45b9-b116-3c3f61866e82.png">

## Guidance to review

- Create more than 100 duplicate match records or change the duplicate matches controller to exhibit less records so you can see the pagination previous, pages and next link
- Enable duplicate matching feature flag
- Enter on support -> candidates -> duplicate matching 

## Link to Trello card

https://trello.com/c/5RXvpVBr/4290-add-pagination-to-new-duplicate-matching-support-ui

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
