### PR TITLE
When returning from confirming environment to change a feature flag, return to an #anchor

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -112,11 +112,11 @@ module ViewHelper
     number_to_percentage(percentage, precision: precision, strip_insignificant_zeros: true)
   end
 
-  def protect_against_mistakes
+  def protect_against_mistakes(anchor:)
     if session[:confirmed_environment_at] && session[:confirmed_environment_at] > 5.minutes.ago
       yield
     else
-      govuk_link_to 'Confirm environment to make changes', support_interface_confirm_environment_path(from: request.fullpath)
+      govuk_link_to 'Confirm environment to make changes', support_interface_confirm_environment_path(from: [request.fullpath, anchor].join('#'))
     end
   end
 

--- a/app/views/support_interface/settings/feature_flags.html.erb
+++ b/app/views/support_interface/settings/feature_flags.html.erb
@@ -29,7 +29,8 @@
     },
   ].compact) do %>
     <%= render SummaryCardHeaderComponent.new(title: feature_name.humanize, heading_level: 2) do %>
-      <% protect_against_mistakes do %>
+      <% protect_against_mistakes(anchor: feature_name.dasherize) do %>
+        <span id="<%= feature_name.dasherize %>"></span>
         <%= render SupportInterface::FeatureToggleComponent.new(feature_name: feature_name) %>
       <% end %>
     <% end %>


### PR DESCRIPTION
Scratching an itch: it is annoying to have to scroll back to the button you originally wanted to press

## Changes proposed in this pull request

Previously, once you entered the current environment to enable the on/off switch for a feature flag you would be returned to the top of the page. Pass an identifier into the `protect_against_mistakes` method to be used as an anchor, and return us to the anchor.

The `span` isn't very semantic, but it works. Improvement welcome!