### PR TITLE
Read from Note#user association

### DIFF
--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -53,7 +53,7 @@ module ProviderInterface
         application_choice.notes.order('created_at').map do |note|
           Event.new(
             'Note added',
-            provider_name(note.provider_user),
+            note.user.full_name,
             note.created_at,
             'View note',
             provider_interface_application_choice_note_path(application_choice, note),
@@ -117,7 +117,7 @@ module ProviderInterface
       if change.user.is_a?(Candidate)
         'Candidate'
       elsif change.user.is_a?(ProviderUser)
-        provider_name(change.user)
+        change.user.full_name
       elsif change_by_support?(change.audit)
         'Apply support'
       elsif change.user.is_a?(VendorApiUser)
@@ -143,10 +143,6 @@ module ProviderInterface
       return [nil, nil] if interview.discarded?
 
       ['View interview', provider_interface_application_choice_interviews_path(application_choice, anchor: "interview-#{interview.id}")]
-    end
-
-    def provider_name(provider_user)
-      provider_user.full_name
     end
   end
 end

--- a/app/views/provider_interface/notes/index.html.erb
+++ b/app/views/provider_interface/notes/index.html.erb
@@ -20,7 +20,7 @@
               <% end %>
             </div>
             <p class="meta">
-              <%= "#{note.provider_user.full_name}," if note.provider_user.full_name.present? %>
+              <%= "#{note.user.full_name}," if note.user.full_name.present? %>
               <%= note.created_at.to_s(:govuk_date_and_time) %>
             </p>
           </div>

--- a/app/views/provider_interface/notes/show.html.erb
+++ b/app/views/provider_interface/notes/show.html.erb
@@ -6,7 +6,7 @@
         <%= simple_format(@note.message) %>
       </div>
       <p class="meta">
-        <%= "#{@note.provider_user.full_name}," if @note.provider_user.full_name.present? %>
+        <%= "#{@note.user.full_name}," if @note.user.full_name.present? %>
         <%= @note.created_at.to_s(:govuk_date_and_time) %>
       </p>
     </div>

--- a/spec/services/support_interface/notes_export_spec.rb
+++ b/spec/services/support_interface/notes_export_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SupportInterface::NotesExport do
       application_choice = create(:application_choice, candidate: candidate, course_option: create(:course_option, course: course))
       provider_user = create(:provider_user, providers: [training_provider])
 
-      create(:note, application_choice: application_choice, provider_user: provider_user)
+      create(:note, application_choice: application_choice, user: provider_user)
     end
 
     it_behaves_like 'a data export'
@@ -28,8 +28,8 @@ RSpec.describe SupportInterface::NotesExport do
       provider_user2 = create(:provider_user, providers: [ratifying_provider])
       create(:provider_relationship_permissions, training_provider: training_provider, ratifying_provider: ratifying_provider)
       create(:provider_relationship_permissions, training_provider: create(:provider), ratifying_provider: training_provider)
-      note1 = create(:note, application_choice: application_choice1, provider_user: provider_user1)
-      note2 = create(:note, application_choice: application_choice2, provider_user: provider_user2)
+      note1 = create(:note, application_choice: application_choice1, user: provider_user1)
+      note2 = create(:note, application_choice: application_choice2, user: provider_user2)
 
       data = described_class.new.data_for_export
 
@@ -74,8 +74,8 @@ RSpec.describe SupportInterface::NotesExport do
       create(:provider_relationship_permissions, training_provider: training_provider1, ratifying_provider: ratifying_provider)
       create(:provider_relationship_permissions, training_provider: training_provider2, ratifying_provider: ratifying_provider)
 
-      note1 = create(:note, application_choice: application_choice, provider_user: provider_user1)
-      note2 = create(:note, application_choice: application_choice, provider_user: provider_user2)
+      note1 = create(:note, application_choice: application_choice, user: provider_user1)
+      note2 = create(:note, application_choice: application_choice, user: provider_user2)
 
       data = described_class.new.data_for_export
 


### PR DESCRIPTION
## Do not merge

Depends on https://github.com/DFE-Digital/apply-for-teacher-training/pull/6356

## Context

As part of associating different user types with notes (as authors) we need to read from the new polymorphic `user` association.
This can only be safely done once we're writing to this field and have backfillled any existing notes.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Amend notes views to read from `user` field.
- Amend `ApplciationTimelineComponent` to read from the `user` field.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Based on https://github.com/DFE-Digital/apply-for-teacher-training/pull/6355
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/D9WUpK0b/4707-read-from-notesuser-association
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
