### PR TITLE
Update HESA report info text for previous cycles

### DIFF
--- a/app/views/provider_interface/reports/hesa_exports/index.html.erb
+++ b/app/views/provider_interface/reports/hesa_exports/index.html.erb
@@ -15,7 +15,7 @@
       <%= RecruitmentCycle.cycle_name %> (current)
     </h2>
     <p class="govuk-body">
-      <%= t('provider_interface.reports.hesa.info', date: CycleTimetable.apply_opens.to_s(:govuk_date)) %>
+      <%= t('provider_interface.reports.hesa.current_cycle.info', date: CycleTimetable.apply_opens.to_s(:govuk_date)) %>
     </p>
     <p class="govuk-body">
       <%= govuk_link_to t('provider_interface.reports.hesa.download_link', cycle_name: RecruitmentCycle.cycle_name),
@@ -26,7 +26,7 @@
       <%= RecruitmentCycle.cycle_name(RecruitmentCycle.previous_year) %>
     </h2>
     <p class="govuk-body">
-      <%= t('provider_interface.reports.hesa.info', date: CycleTimetable.apply_opens(RecruitmentCycle.previous_year).to_s(:govuk_date)) %>
+      <%= t('provider_interface.reports.hesa.previous_cycle.info', start_date: CycleTimetable.apply_opens(RecruitmentCycle.previous_year).to_s(:govuk_date), end_date: CycleTimetable.apply_2_deadline(RecruitmentCycle.previous_year).to_s(:govuk_date)) %>
     </p>
     <p class="govuk-body">
       <%= govuk_link_to t('provider_interface.reports.hesa.download_link', cycle_name: RecruitmentCycle.cycle_name(RecruitmentCycle.previous_year)),

--- a/config/locales/provider_interface/reports.yml
+++ b/config/locales/provider_interface/reports.yml
@@ -3,5 +3,8 @@ en:
     reports:
       hesa:
         diversity_text: Sex, disability and ethnicity information will be marked as confidential if you do not have permission to view it.
-        info: 'The data will include all candidates who have accepted an offer since %{date}.'
         download_link: 'Export data for %{cycle_name} (CSV)'
+        current_cycle:
+          info: 'The data will include all candidates who have accepted an offer since %{date}.'
+        previous_cycle:
+          info: 'The data will include all candidates who have accepted an offer from %{start_date} to %{end_date}.'

--- a/spec/system/provider_interface/export_applications_in_hesa_format_spec.rb
+++ b/spec/system/provider_interface/export_applications_in_hesa_format_spec.rb
@@ -11,7 +11,8 @@ RSpec.feature 'Export applications in HESA format' do
     and_i_sign_in_to_the_provider_interface
     when_i_visit_the_reports_page
     and_i_click_export_hesa_data
-    then_i_can_download_application_data_as_csv_for_the_current_recruitment_cycle
+    then_i_can_see_links_to_the_report_for_the_current_and_previous_cycles
+    and_i_can_download_application_data_as_csv_for_the_current_recruitment_cycle
     and_i_can_download_application_data_as_csv_for_the_previous_recruitment_cycle
   end
 
@@ -51,7 +52,12 @@ RSpec.feature 'Export applications in HESA format' do
     click_on 'Export data for Higher Education Statistics Agency (HESA)'
   end
 
-  def then_i_can_download_application_data_as_csv_for_the_current_recruitment_cycle
+  def then_i_can_see_links_to_the_report_for_the_current_and_previous_cycles
+    expect(page).to have_content("The data will include all candidates who have accepted an offer since #{CycleTimetable.apply_opens(RecruitmentCycle.current_year).to_s(:govuk_date)}")
+    expect(page).to have_content("The data will include all candidates who have accepted an offer from #{CycleTimetable.apply_opens(RecruitmentCycle.previous_year).to_s(:govuk_date)} to #{CycleTimetable.apply_2_deadline(RecruitmentCycle.previous_year).to_s(:govuk_date)}.")
+  end
+
+  def and_i_can_download_application_data_as_csv_for_the_current_recruitment_cycle
     click_on "Export data for #{RecruitmentCycle.previous_year} to #{RecruitmentCycle.current_year} (CSV)"
 
     csv = CSV.parse(page.body, headers: true)


### PR DESCRIPTION
## Context

Change content for Hesa reports for previous cycles to display time interval of returned data.


## Link to Trello card

https://trello.com/c/bCDsUpsb/4705-export-report-data-for-hesa

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
