### PR TITLE
Change daily API integration reports from vendor slack channels to weekly

### DIFF
--- a/app/models/support_interface/vendor_api_monitor.rb
+++ b/app/models/support_interface/vendor_api_monitor.rb
@@ -29,6 +29,13 @@ module SupportInterface
         .where("last_sync < now() - interval '24 hours' OR last_sync IS NULL").order('last_sync DESC')
     end
 
+    def no_sync_in_7d
+      connected
+        .select('last_syncs.last_sync as last_sync, vendor_id')
+        .joins("LEFT JOIN (#{VendorAPIRequest.successful.syncs.select('provider_id, MAX(vendor_api_requests.created_at) as last_sync').group('provider_id').to_sql}) last_syncs on last_syncs.provider_id = providers.id")
+        .where("last_sync < now() - interval '7 days' OR last_sync IS NULL").order('last_sync DESC')
+    end
+
     def no_decisions_in_7d
       connected
         .select('last_decisions.last_decision as last_decision, vendor_id')

--- a/app/workers/vendor_integration_stats_worker.rb
+++ b/app/workers/vendor_integration_stats_worker.rb
@@ -72,7 +72,7 @@ private
       [
         "*API integration report for #{@vendor.name.titleize}* (#{Time.zone.now.to_s(:govuk_date)}, #{HostingEnvironment.environment_name})",
         ":negative_squared_cross_mark:\n```#{never_connected_text}```",
-        ":satellite_antenna:\n```#{no_sync_in_24h_text}```",
+        ":satellite_antenna:\n```#{no_sync_in_7d_text}```",
         ":checkered_flag:\n```#{no_decisions_in_7d_text}```",
         ":thinking_face:\n```#{providers_with_errors_text}```",
       ]
@@ -86,15 +86,15 @@ private
       NEVER_CONNECTED_TEXT
     end
 
-    def no_sync_in_24h_text
-      <<~NO_SYNC_IN_24H_TEXT
-        #{justify("No API sync in the last 24h (#{@monitor.no_sync_in_24h.size} found)", 'Last sync')}
+    def no_sync_in_7d_text
+      <<~NO_SYNC_IN_7D_TEXT
+        #{justify("No API sync in the last 7 days (#{@monitor.no_sync_in_7d.size} found)", 'Last sync')}
         -----------------------------------------------------------------------------
         #{
-          @monitor.no_sync_in_24h.map { |p| justify(p.name, p.try(:last_sync)) }
+          @monitor.no_sync_in_7d.map { |p| justify(p.name, p.try(:last_sync)) }
             .join("\n")
         }
-      NO_SYNC_IN_24H_TEXT
+      NO_SYNC_IN_7D_TEXT
     end
 
     def no_decisions_in_7d_text

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -56,7 +56,7 @@ class Clock
   every(7.days, 'ApplicationsBySubjectRouteAndDegreeGradeExport', at: 'Sunday 23:59') { SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport.run_weekly }
   every(7.days, 'ApplicationsByDemographicDomicileAndDegreeClassExport', at: 'Sunday 23:59') { SupportInterface::ApplicationsByDemographicDomicileAndDegreeClassExport.run_weekly }
 
-  every(1.day, 'VendorIntegrationStatsWorker', at: '09:00', if: ->(t) { t.weekday? }) do
+  every(7.days, 'VendorIntegrationStatsWorker', at: 'Monday 09:00') do
     VendorIntegrationStatsWorker.perform_async('tribal')
     VendorIntegrationStatsWorker.perform_async('ellucian')
     VendorIntegrationStatsWorker.perform_async('unit4')

--- a/spec/workers/vendor_integration_stats_worker_spec.rb
+++ b/spec/workers/vendor_integration_stats_worker_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe VendorIntegrationStatsWorker do
       before do
         double = instance_double(SupportInterface::VendorAPIMonitor)
         allow(double).to receive(:never_connected).and_return(providers)
-        allow(double).to receive(:no_sync_in_24h).and_return(providers)
+        allow(double).to receive(:no_sync_in_7d).and_return(providers)
         allow(double).to receive(:no_decisions_in_7d).and_return(providers)
         allow(double).to receive(:providers_with_errors).and_return(providers)
 
@@ -99,7 +99,7 @@ RSpec.describe VendorIntegrationStatsWorker do
         expect(report).to include('```')
         expect(report).to include('Tribal')
         expect(report).to include('Never connected via API')
-        expect(report).to include('No API sync in the last 24h')
+        expect(report).to include('No API sync in the last 7 days')
         expect(report).to include('No API decisions in the last 7 days')
         expect(report).to include('Providers with API errors')
       end


### PR DESCRIPTION
## Context
Move the daily API integration report slack notifications (and associated code) from vendor slack channels to weekly rather than daily as we are implementing v1.1 in the API to allow vendors to keep checking if anything is wrong.

## Link to Trello card

https://trello.com/c/sSBHJPHF/4690-decide-what-to-do-with-the-daily-api-integration-reports-from-vendor-slack-channels

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
