### PR TITLE
Update header component homepage_url to be configurable

### DIFF
--- a/app/components/utility/header_component.html.erb
+++ b/app/components/utility/header_component.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_header(
   classes: "govuk-!-display-none-print #{classes}",
-  homepage_url: govuk_url,
+  homepage_url: homepage_url,
   service_name: service_name,
   service_url: service_link,
   navigation_classes: navigation_classes,

--- a/app/components/utility/header_component.rb
+++ b/app/components/utility/header_component.rb
@@ -1,9 +1,10 @@
 class HeaderComponent < ViewComponent::Base
   attr_reader :classes, :product_name, :service_name, :service_link, :phase_tag, :navigation_items, :navigation_classes
 
-  def initialize(service_link:, classes: '', product_name: nil, service_name: nil, phase_tag: false, navigation_items: [], navigation_classes: '')
+  def initialize(service_link:, classes: '', product_name: nil, homepage_url: nil, service_name: nil, phase_tag: false, navigation_items: [], navigation_classes: '')
     @classes            = classes
     @product_name       = product_name
+    @homepage_url       = homepage_url
     @service_name       = service_name
     @service_link       = service_link
     @phase_tag          = phase_tag
@@ -11,7 +12,13 @@ class HeaderComponent < ViewComponent::Base
     @navigation_classes = navigation_classes
   end
 
+private
+
   def govuk_url
     t('govuk.url')
+  end
+
+  def homepage_url
+    @homepage_url || govuk_url
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -24,6 +24,7 @@
   <%= render(HeaderComponent.new(
     classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border app-header--wide-logo",
     product_name: service_name,
+    homepage_url: service_link,
     service_link: service_link,
     navigation_items: NavigationItems.for_provider_account_nav(try(:current_provider_user), controller, performing_setup: @provider_setup&.pending?),
     navigation_classes: 'govuk-header__navigation--end',

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,6 +11,7 @@
   <%= render(HeaderComponent.new(
     classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border app-header--wide-logo",
     product_name: service_name,
+    homepage_url: service_link,
     service_link: service_link,
     phase_tag: true,
     navigation_items: NavigationItems.for_support_account_nav(try(:current_support_user)),

--- a/spec/components/utility/header_component_spec.rb
+++ b/spec/components/utility/header_component_spec.rb
@@ -2,9 +2,28 @@ require 'rails_helper'
 
 RSpec.describe HeaderComponent do
   let(:navigation_items) { [] }
+  let(:homepage_url) { nil }
 
   subject(:rendered_component) do
-    render_inline(described_class.new(navigation_items: navigation_items, service_name: '', service_link: '#'))
+    render_inline(described_class.new(navigation_items: navigation_items, homepage_url: homepage_url, service_name: '', service_link: '#'))
+  end
+
+  describe 'rendering the homepage_url' do
+    let(:header_link_xpath) { './/a[@class="govuk-header__link govuk-header__link--homepage"]/@href' }
+
+    context 'when no homepage_url is not set' do
+      it 'defauls to the govuk website' do
+        expect(rendered_component.xpath(header_link_xpath).first.value).to eq('https://www.gov.uk')
+      end
+    end
+
+    context 'when no homepage_url is set' do
+      let(:homepage_url) { '/provider' }
+
+      it 'links to the specified url' do
+        expect(rendered_component.xpath(header_link_xpath).first.value).to eq(homepage_url)
+      end
+    end
   end
 
   describe 'rendering NavigationItems' do


### PR DESCRIPTION
## Context
Updates header component homepage_url to be configurable and configures the value so that the provider header links to manage rather than govuk.

## Link to Trello card

https://trello.com/c/mZCtcC2Z/4702-fix-header-link-manage

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
