### PR TITLE
Move Key dates Banner title spec into correct time period 

### DIFF
--- a/spec/components/provider_interface/key_dates_banner_spec.rb
+++ b/spec/components/provider_interface/key_dates_banner_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe ProviderInterface::KeyDatesBanner do
 
   let(:christmas_period) { "#{CycleTimetable.holidays[:christmas].first.to_s(:govuk_date)} to #{CycleTimetable.holidays[:christmas].last.to_s(:govuk_date)}" }
 
-  it 'renders the banner title' do
-    expect(result.text).to include('Important')
-  end
-
   describe 'rendering the banner content' do
     around do |example|
       Timecop.freeze(time) { example.run }
@@ -25,6 +21,10 @@ RSpec.describe ProviderInterface::KeyDatesBanner do
 
     context '20 days, or more, after the cycle opens' do
       let(:time) { 20.business_days.after(CycleTimetable.apply_opens).end_of_day }
+
+      it 'renders the banner title' do
+        expect(result.text).to include('Important')
+      end
 
       it 'renders the non working period content' do
         expect(result.text).to include(t('key_dates_banner.christmas_header'))

--- a/spec/services/support_interface/persona_export_spec.rb
+++ b/spec/services/support_interface/persona_export_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SupportInterface::PersonaExport do
 
   describe '#data_for_export' do
     around do |example|
-      Timecop.freeze do
+      Timecop.freeze(Time.zone.local(2021, 6, 1, 12, 30, 0)) do
         example.run
       end
     end


### PR DESCRIPTION
## Context

We hide the banner after a certain time, make sure this is reflected in the specs.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
