### PR TITLE
Fix square box characters in application pdfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN bundle exec rake assets:precompile && \
 FROM ${BASE_RUBY_IMAGE} AS production
 
 ENV WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine \
+    LANG=en_GB.UTF-8 \
     RAILS_ENV=production \
     GOVUK_NOTIFY_API_KEY=TestKey \
     AUTHORISED_HOSTS=127.0.0.1 \
@@ -55,7 +56,7 @@ ENV WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine \
     REDIS_CACHE_URL=redis://127.0.0.1:6379
 
 RUN apk -U upgrade && \
-    apk add --update --no-cache tzdata libpq libxml2 libxslt graphviz && \
+    apk add --update --no-cache tzdata libpq libxml2 libxslt graphviz ttf-dejavu ttf-droid ttf-freefont ttf-liberation && \
     echo "Europe/London" > /etc/timezone && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime
 


### PR DESCRIPTION
## Context

In parts of the application (e.g. personal statement), provider users often notice random squares, often at the end of sentences or instead of normal spaces, like this one:

![image](https://user-images.githubusercontent.com/107591/149756018-26b458d3-9b95-4f67-ac8d-83a2dd50df40.png)

In this specific example, the string `.<square>I` consists of the following bytes: 46, 226, 128, 175, 73 Which actually maps to the Unicode character U+202F, which stands for NARROW NO-BREAK SPACE.

They must have copy-pasted from a word-processor (which I assume is common practice).

## Changes proposed in this pull request

Before: (please ignore the blur effect, just a different image resolution)
![image](https://user-images.githubusercontent.com/107591/149756515-77a26ce0-b7e4-41f1-a8b2-a4cc1cdb01dc.png)

After:
![image](https://user-images.githubusercontent.com/107591/149756538-512e836c-91eb-4b42-8bc8-41c8051756e7.png)

## Guidance to review

Reproducible locally, but only using the docker pipeline of `make setup`, `make serve`.

## Link to Trello card

https://trello.com/c/WjqVcJuH

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
