### PR TITLE
Use `current_course_option` for course level in TAD export

### DIFF
--- a/app/services/data_api/tad_application_export.rb
+++ b/app/services/data_api/tad_application_export.rb
@@ -2,7 +2,7 @@ module DataAPI
   class TADApplicationExport
     attr_reader :application_choice
 
-    delegate :course_option, :course, :application_form, to: :application_choice
+    delegate :application_form, to: :application_choice
     delegate :candidate, to: :application_form
 
     def initialize(application_choice)
@@ -54,7 +54,7 @@ module DataAPI
         accrediting_provider_id: accrediting_provider.id,
         accrediting_provider_name: accrediting_provider.name,
 
-        course_level: course.level,
+        course_level: application_choice.current_course.level,
         program_type: application_choice.current_course.program_type,
         programme_outcome: application_choice.current_course.description,
         course_name: application_choice.current_course.name,

--- a/spec/services/data_api/tad_export_spec.rb
+++ b/spec/services/data_api/tad_export_spec.rb
@@ -2,10 +2,28 @@ require 'rails_helper'
 
 RSpec.describe DataAPI::TADExport do
   before do
-    create(:submitted_application_choice, :with_completed_application_form, status: 'rejected', rejected_by_default: true)
-    create(:submitted_application_choice, :with_completed_application_form, status: 'declined', declined_by_default: true)
-    create(:submitted_application_choice, :with_completed_application_form, status: 'rejected')
-    create(:submitted_application_choice, :with_completed_application_form, status: 'declined')
+    create(
+      :submitted_application_choice,
+      :with_completed_application_form,
+      status: 'rejected',
+      rejected_by_default: true,
+    )
+    create(
+      :submitted_application_choice,
+      :with_completed_application_form,
+      status: 'declined',
+      declined_by_default: true,
+    )
+    create(
+      :submitted_application_choice,
+      :with_completed_application_form,
+      status: 'rejected',
+    )
+    create(
+      :submitted_application_choice,
+      :with_completed_application_form,
+      status: 'declined',
+    )
   end
 
   it_behaves_like 'a data export'
@@ -32,5 +50,19 @@ RSpec.describe DataAPI::TADExport do
 
     result = described_class.new.data_for_export
     expect(result.count).to eq 5
+  end
+
+  it 'returns course level for current course' do
+    primary_course = create(:course, level: :primary)
+    secondary_course = create(:course, level: :secondary)
+    create(
+      :submitted_application_choice,
+      :with_completed_application_form,
+      status: 'offer',
+      course_option: create(:course_option, course: secondary_course),
+      current_course_option: create(:course_option, course: primary_course),
+    )
+    result = described_class.new.data_for_export
+    expect(result.find { |application| application[:status] = 'offer' }[:course_level]).to eq('primary')
   end
 end


### PR DESCRIPTION
## Context

Background: We think that discrepancies between the _Applications by course level_ monthly reports and the numbers that TAD are extracting from the daily TAD exports are off because Apply is using the `current_course` and TAD is using `course` (because that's what we are giving them in the TAD export report). The values are different in a handful of cases causing minor discrepancies between the two sides.

Previously we were extracting `course.level` where `course` was
delegated to `application_choice`. We should be using
`current_course_option` or `current_course` for all course data that we
export for this report so that we reflect the course that the candidate
ended up being offered over then one that they originally applied for
(on the odd occasions that they are different).

## Changes proposed in this pull request

- Use `ApplicationChoice#current_course` for the `course_level` field that we include in the TAD data exports.
- Remove delegates to `ApplicationChoice#course` and `ApplicationChoice#course_option` because they are now redundant (and we don't want to mistakenly use them in future).

## Guidance to review

- Does this make sense and is it the right thing to do?
- Perhaps we should move the tests for the TAD export over to the new 'standard' test data. Leaving that for now.

## Link to Trello card

https://trello.com/c/mpp02RdH/4185-epic-make-monthly-report-production-ready

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
