### PR TITLE
Add associated type to where clause to stop timeouts

### DIFF
--- a/app/workers/detect_invariants_hourly_check.rb
+++ b/app/workers/detect_invariants_hourly_check.rb
@@ -36,7 +36,7 @@ class DetectInvariantsHourlyCheck
     unauthorised_changes = Audited::Audit
       .joins("INNER JOIN application_forms ON audits.associated_type = 'ApplicationForm' AND application_forms.id = audits.associated_id")
       .joins('INNER JOIN candidates ON candidates.id = application_forms.candidate_id')
-      .where(user_type: 'Candidate')
+      .where(user_type: 'Candidate', associated_type: 'ApplicationForm')
       .where('candidates.id != audits.user_id')
       .pluck('application_forms.id').uniq
       .sort


### PR DESCRIPTION
## Context

The invariant check query is timing out: https://sentry.io/organizations/dfe-bat/issues/2527648396/?project=1765973&referrer=slack

We have to revisit bloat in the audits table, however for now we have attempted to limit this query further to allow it to run.

## Changes proposed in this pull request

Specify the `associated_type` in the where clause as those are the only records we care about, allowing the query to finish and not time out. 

## Guidance to review

This query was tested on prod and now finishes successfully

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
