### PR TITLE
Stop the de-duplication of further conditions

### DIFF
--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -38,7 +38,7 @@ module ProviderInterface
     end
 
     def conditions
-      @conditions = (standard_conditions + further_condition_models.map(&:text).uniq).compact_blank
+      @conditions = (standard_conditions + further_condition_models.map(&:text)).compact_blank
     end
 
     def conditions_to_render

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -338,14 +338,27 @@ RSpec.describe ProviderInterface::OfferWizard do
   end
 
   describe '#conditions' do
-    let(:standard_conditions) { ['', OfferCondition::STANDARD_CONDITIONS.last] }
-    let(:further_condition_1) { 'Receiving an A* on their Maths A Level' }
-    let(:further_condition_3) { 'They must graduate from their current course with an Honors' }
+    context 'when adding conditions to an offer' do
+      let(:standard_conditions) { ['', OfferCondition::STANDARD_CONDITIONS.last] }
+      let(:further_condition_1) { 'Receiving an A* on their Maths A Level' }
+      let(:further_condition_3) { 'They must graduate from their current course with an Honors' }
 
-    it 'constructs an array with the offer conditions' do
-      expect(wizard.conditions).to eq([OfferCondition::STANDARD_CONDITIONS.last,
-                                       further_condition_1,
-                                       further_condition_3])
+      it 'constructs an array with the offer conditions' do
+        expect(wizard.conditions).to eq([OfferCondition::STANDARD_CONDITIONS.last,
+                                         further_condition_1,
+                                         further_condition_3])
+      end
+    end
+
+    context 'when adding duplicated conditions to an offer' do
+      let(:standard_conditions) { [''] }
+      let(:further_condition_1) { 'This is a duplicated condition' }
+      let(:further_condition_2) { 'This is a duplicated condition' }
+
+      it 'constructs an array with the offer conditions' do
+        expect(wizard.conditions).to eq([further_condition_1,
+                                         further_condition_2])
+      end
     end
   end
 


### PR DESCRIPTION
## Context

When you add a further condition, if you enter duplicated text i.e. you end up with two further conditions that contain the same text value, this is being de-duplicated on the review page, before you send the new offer. However, these duplicated conditions are still persisted to the offer.

## Changes proposed in this pull request

Stop the de-duplication on the 'Check and send new offer' page.

## Guidance to review

## Link to Trello card

https://trello.com/c/kMj81rqG

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
