### PR TITLE
Add standardised sorting to conditions list component

### DIFF
--- a/app/components/provider_interface/conditions_list_component.rb
+++ b/app/components/provider_interface/conditions_list_component.rb
@@ -3,7 +3,13 @@ module ProviderInterface
     attr_reader :conditions
 
     def initialize(conditions)
-      @conditions = conditions
+      @conditions = sorted_conditions(conditions)
+    end
+
+  private
+
+    def sorted_conditions(conditions)
+      conditions.sort_by { |c| [OfferCondition::STANDARD_CONDITIONS.index(c.text) || Float::INFINITY, c.created_at] }
     end
   end
 end

--- a/spec/components/provider_interface/conditions_list_component_spec.rb
+++ b/spec/components/provider_interface/conditions_list_component_spec.rb
@@ -27,4 +27,24 @@ RSpec.describe ProviderInterface::ConditionsListComponent do
       expect(render.css('.govuk-summary-list__value').last.text.squish).to eq('Met')
     end
   end
+
+  context 'when there are standard conditions' do
+    let(:standard_condition_1) { build_stubbed(:offer_condition, text: 'Fitness to train to teach check') }
+    let(:standard_condition_2) { build_stubbed(:offer_condition, text: 'Disclosure and Barring Service (DBS) check') }
+    let(:further_condition) { build_stubbed(:offer_condition) }
+
+    let(:conditions) do
+      [
+        further_condition,
+        standard_condition_2,
+        standard_condition_1,
+      ]
+    end
+
+    it 'renders a list of conditions with their statuses' do
+      expect(render.css('.govuk-summary-list__key').first.text.squish).to eq(standard_condition_1.text)
+      expect(render.css('.govuk-summary-list__key')[1].text.squish).to eq(standard_condition_2.text)
+      expect(render.css('.govuk-summary-list__key').last.text.squish).to eq(further_condition.text)
+    end
+  end
 end


### PR DESCRIPTION
## Context
https://trello.com/c/pLy2g8v0/4717-update-order-of-conditions-on-offer-page
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Added a sorting aspect to the conditions list component. This sorts conditions primarily by whether their text matches the standard conditions, and then their `created_at` date. 

@JR-G and I spent a while trying to work out the sorting bit - and we're not totally sure it's the most readable it can be. 
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Go to a candidate with an offer, and mess around with the conditions. No matter what, they should always appear in lists with their standard ones first (if any), and then the rest in the order they were created. 
![image](https://user-images.githubusercontent.com/25597009/149960542-c64b80f0-e0d3-45be-8a43-fdabae898c8b.png)

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
