### PR TITLE
Add withdrawn_or_declined_for_candidate_by_provider to ApplicationChoices

### DIFF
--- a/db/migrate/20220119122040_add_withdrawn_or_declined_for_candidate_by_provider_to_application_choices.rb
+++ b/db/migrate/20220119122040_add_withdrawn_or_declined_for_candidate_by_provider_to_application_choices.rb
@@ -1,0 +1,5 @@
+class AddWithdrawnOrDeclinedForCandidateByProviderToApplicationChoices < ActiveRecord::Migration[6.1]
+  def change
+    add_column :application_choices, :withdrawn_or_declined_for_candidate_by_provider, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 2022_01_20_104427) do
     t.bigint "current_course_option_id"
     t.bigint "provider_ids", default: [], array: true
     t.integer "current_recruitment_cycle_year"
+    t.boolean "withdrawn_or_declined_for_candidate_by_provider"
     t.index ["application_form_id", "course_option_id"], name: "index_course_option_to_application_form_id", unique: true
     t.index ["application_form_id"], name: "index_application_choices_on_application_form_id"
     t.index ["course_option_id"], name: "index_application_choices_on_course_option_id"


### PR DESCRIPTION
## Context

As part of the work to implement v1.1 of the vendor API, we need to add a flag to indicate if a withdrawn or declined application entered this state because a provider performed this action at the request of the candidate.

## Changes proposed in this pull request

add the `withdrawn_or_declined_for_candidate_by_provider` boolean column to `ApplicationChoices`.

## Guidance to review

Backfill to be raised in a separate PR.

## Link to Trello card

https://trello.com/c/0PrUwZNW

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
