### PR TITLE
Add interviews to API v1.1 application responses

### DIFF
--- a/app/controllers/concerns/vendor_api/add_interviews_to_application_api_data.rb
+++ b/app/controllers/concerns/vendor_api/add_interviews_to_application_api_data.rb
@@ -1,0 +1,15 @@
+module VendorAPI
+  module AddInterviewsToApplicationAPIData
+    def schema
+      super.deep_merge!({
+        attributes: {
+          interviews: interviews.map { |interview| InterviewPresenter.new(active_version, interview).schema },
+        },
+      })
+    end
+
+    def interviews
+      application_choice.interviews.order(updated_at: :desc)
+    end
+  end
+end

--- a/app/controllers/concerns/vendor_api/application_data_concerns.rb
+++ b/app/controllers/concerns/vendor_api/application_data_concerns.rb
@@ -36,6 +36,7 @@ module VendorAPI
         application_form: %i[candidate application_qualifications application_references application_work_experiences application_work_history_breaks application_volunteering_experiences english_proficiency],
         course_option: [{ course: %i[provider] }, :site],
         current_course_option: [{ course: %i[provider] }, :site],
+        interviews: %i[provider],
       ]
     end
   end

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -24,6 +24,7 @@ module VendorAPI
     ],
     '1.1' => [
       Changes::DeferAnOffer,
+      Changes::AddInterviewsToApplication,
     ],
   }.freeze
 end

--- a/app/lib/vendor_api/changes/add_interviews_to_application.rb
+++ b/app/lib/vendor_api/changes/add_interviews_to_application.rb
@@ -1,0 +1,10 @@
+module VendorAPI
+  module Changes
+    class AddInterviewsToApplication < VersionChange
+      description 'Include interviews in application json responses.'
+
+      resource InterviewPresenter
+      resource ApplicationPresenter, [AddInterviewsToApplicationAPIData]
+    end
+  end
+end

--- a/app/presenters/vendor_api/interview_presenter.rb
+++ b/app/presenters/vendor_api/interview_presenter.rb
@@ -1,0 +1,26 @@
+class VendorAPI::InterviewPresenter < VendorAPI::Base
+  attr_reader :interview
+
+  def initialize(version, interview)
+    super(version)
+    @interview = interview
+  end
+
+  def as_json
+    schema.to_json
+  end
+
+  def schema
+    {
+      id: interview.id.to_s,
+      provider_code: interview.provider.code,
+      date_and_time: interview.date_and_time.iso8601,
+      location: interview.location,
+      additional_details: interview.additional_details,
+      cancelled_at: interview.cancelled_at&.iso8601,
+      cancellation_reason: interview.cancellation_reason,
+      created_at: interview.created_at.iso8601,
+      updated_at: interview.updated_at.iso8601,
+    }
+  end
+end

--- a/spec/controllers/concerns/vendor_api/application_data_concerns_spec.rb
+++ b/spec/controllers/concerns/vendor_api/application_data_concerns_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe VendorAPI::ApplicationDataConcerns do
       application_form: %i[candidate application_qualifications application_references application_work_experiences application_work_history_breaks application_volunteering_experiences english_proficiency],
       course_option: [{ course: %i[provider] }, :site],
       current_course_option: [{ course: %i[provider] }, :site],
+      interviews: %i[provider],
     ]
   end
 

--- a/spec/presenters/vendor_api/interview_presenter_spec.rb
+++ b/spec/presenters/vendor_api/interview_presenter_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe VendorAPI::InterviewPresenter do
+  subject(:interview_json) { described_class.new(version, interview).as_json }
+
+  let(:version) { '1.1' }
+
+  let(:expected_json) do
+    {
+      id: interview.id.to_s,
+      provider_code: Provider.find(interview.provider_id).code,
+      date_and_time: interview.date_and_time.iso8601,
+      location: interview.location,
+      additional_details: interview.additional_details,
+      cancelled_at: interview.cancelled_at&.iso8601,
+      cancellation_reason: interview.cancellation_reason,
+      created_at: interview.created_at.iso8601,
+      updated_at: interview.updated_at.iso8601,
+    }.to_json
+  end
+
+  describe 'active interview' do
+    let(:interview) { create(:interview, :future_date_and_time) }
+
+    it 'includes all advertised fields' do
+      expect(interview_json).to eq(expected_json)
+    end
+  end
+
+  describe 'cancelled interview' do
+    let(:interview) { create(:interview, :cancelled) }
+
+    it 'includes all advertised fields' do
+      expect(interview_json).to eq(expected_json)
+    end
+  end
+end

--- a/spec/presenters/vendor_api/v1.1/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.1/application_presenter_spec.rb
@@ -47,4 +47,31 @@ RSpec.describe VendorAPI::ApplicationPresenter do
       end
     end
   end
+
+  describe 'interviews section' do
+    let!(:application_choice) do
+      create(
+        :application_choice,
+        :with_completed_application_form,
+        :with_cancelled_interview,
+        :with_scheduled_interview,
+      )
+    end
+
+    it 'includes an interviews section' do
+      expect(attributes[:interviews]).to be_present
+    end
+
+    it 'returns all interviews, including cancelled' do
+      expect(attributes[:interviews].count).to eq(2)
+    end
+
+    it 'sorts interviews in descending updated_at order' do
+      ordered = application_choice.interviews.order('updated_at DESC').all
+      expected = ordered.map(&:id)
+
+      observed = attributes[:interviews].map { |interview| interview[:id].to_i }
+      expect(observed).to eq(expected)
+    end
+  end
 end

--- a/spec/requests/vendor_api/v1.1/get_single_application_spec.rb
+++ b/spec/requests/vendor_api/v1.1/get_single_application_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - GET /api/v1.1/applications/:application_id', type: :request do
+  include VendorAPISpecHelpers
+  include CourseOptionHelpers
+
+  before do
+    stub_const('VendorAPI::VERSION', '1.1')
+  end
+
+  it 'returns a response that is valid according to the OpenAPI schema' do
+    skip 'depends on validation versions spike'
+
+    application_choice = create_application_choice_for_currently_authenticated_provider(
+      status: 'awaiting_provider_decision',
+    )
+
+    get_api_request "/api/v1.1/applications/#{application_choice.id}"
+
+    expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse', '1.1')
+  end
+
+  it 'includes an interviews section' do
+    application_choice = create_application_choice_for_currently_authenticated_provider(
+      status: 'awaiting_provider_decision',
+    )
+
+    get_api_request "/api/v1.1/applications/#{application_choice.id}"
+
+    expect(response).to have_http_status(:ok)
+    expect(parsed_response['data']['attributes']['interviews']).not_to be_nil
+  end
+end


### PR DESCRIPTION
## Context

The draft API v1.1 spec requires an interviews block, as part of the single application representation.

![image](https://user-images.githubusercontent.com/107591/150001191-719479e7-d66b-4981-af7e-a1a57d52c848.png)

## Changes proposed in this pull request

Include an `interviews` section to both single application and multiple application json responses, when api consumers use `/api/v1.1` urls. Add an `InterviewPresenter`, so that there is a versioned base presenter for interviews, in case of future changes.

## Guidance to review

I have introduced `1.1` directories within both request and presenter spec folders, as agreed last week. The relevant tests only check for attributes that have changed across versions. Not testing the `AddInterviewsToApplicationPresenter` module directly, but this is exercised through the request specs.

~The tests currently fail because the OpenAPI schema validation fails:~
```
       - The item did not contain a required property of 'meta' in schema e27045fe-e48c-596e-b100-689176f18040#
       - The property '#/data/attributes' did not contain a required property of 'notes' in schema e27045fe-e48c-596e-b100-689176f18040#
       - The property '#/data/attributes' did not contain a required property of 'withdrawn_or_declined_for_candidate' in schema e27045fe-e48c-596e-b100-689176f18040#
       - The property '#/data/attributes' did not contain a required property of 'withdrawn_at' in schema e27045fe-e48c-596e-b100-689176f18040#
```

UPDATE: we have decided to skip schema validation checks until the version validations spike is complete.

## Link to Trello card

https://trello.com/c/wscdvugg

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
