### PR TITLE
Add "Chat Support" to variant features

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -49,8 +49,9 @@ class FeatureFlag
   # across environments and we won't be notified if inconsistent. All other features
   # will default to `invariant` which means they will need to be consistently marked
   # as active/inactive across all our environments, and we will be notified about otherwise.
-  VARIANT_FEATURES = [
-    :send_request_data_to_bigquery,
+  VARIANT_FEATURES = %i[
+    send_request_data_to_bigquery
+    enable_chat_support
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).to_h do |name, description, owner|


### PR DESCRIPTION
## Context

If a feature will always be different across different envs we need to add to the variant features, to avoid getting alerts around inconsistencies across envs

## Changes proposed in this pull request

Add chat support to the variant features, as this feature will only be on in prod, as this links to zendesk.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
