### PR TITLE
API v1.1 - Updates to rspec schema validator to support testing different API versions

### DIFF
--- a/spec/support/vendor_api/shared_examples.rb
+++ b/spec/support/vendor_api/shared_examples.rb
@@ -1,11 +1,13 @@
-RSpec.shared_examples 'an endpoint that requires metadata' do |action|
+RSpec.shared_examples 'an endpoint that requires metadata' do |action, version = '1.0'|
+  include VersioningHelpers
+
   it 'returns an error when Metadata is not provided' do
     application_choice = create(:application_choice)
 
-    post_api_request "/api/v1/applications/#{application_choice.id}/#{action}", params: { 'meta' => nil }
+    post_api_request "/api/v#{version}/applications/#{application_choice.id}/#{action}", params: { 'meta' => nil }
 
     expect(response).to have_http_status(:unprocessable_entity)
-    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse', version_number(version))
   end
 
   it 'returns an error when Metadata is invalid' do
@@ -13,10 +15,10 @@ RSpec.shared_examples 'an endpoint that requires metadata' do |action|
 
     invalid_metadata = { invalid: :metadata }
 
-    post_api_request "/api/v1/applications/#{application_choice.id}/#{action}", params: { 'meta' => invalid_metadata }
+    post_api_request "/api/v#{version}/applications/#{application_choice.id}/#{action}", params: { 'meta' => invalid_metadata }
 
     expect(response).to have_http_status(:unprocessable_entity)
-    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse', version_number(version))
 
     errors = parsed_response['errors']
 

--- a/spec/support/vendor_api/vendor_api_spec_helpers.rb
+++ b/spec/support/vendor_api/vendor_api_spec_helpers.rb
@@ -60,7 +60,7 @@ module VendorAPISpecHelpers
     parsed_response['errors'].first
   end
 
-  def be_valid_against_openapi_schema(expected)
-    ValidAgainstOpenAPISchemaMatcher.new(expected, VendorAPISpecification.new.as_hash)
+  def be_valid_against_openapi_schema(expected, version = nil)
+    ValidAgainstOpenAPISchemaMatcher.new(expected, VendorAPISpecification.new(version: version).as_hash)
   end
 end


### PR DESCRIPTION
## Context


Updates to spec helpers and schema validation so that different versions can be tested at the same time by specifying the version as a parameter.

## Link to Trello card

https://trello.com/c/FeqIBxeu/4721-api-v11-deferrals-updates-to-schema-validator-to-support-different-versions

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
