### PR TITLE
Update withdraw & decline services to populate the withdrawn_or_declined_for_candidate_by_provider flag

### DIFF
--- a/app/services/decline_offer.rb
+++ b/app/services/decline_offer.rb
@@ -5,7 +5,10 @@ class DeclineOffer
 
   def save!
     ApplicationStateChange.new(@application_choice).decline!
-    @application_choice.update!(declined_at: Time.zone.now)
+    @application_choice.update!(
+      declined_at: Time.zone.now,
+      withdrawn_or_declined_for_candidate_by_provider: false,
+    )
 
     if @application_choice.application_form.ended_without_success?
       CandidateMailer.decline_last_application_choice(@application_choice).deliver_later

--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -10,7 +10,11 @@ class DeclineOfferByDefault
 
     ActiveRecord::Base.transaction do
       application_form.application_choices.offer.each do |application_choice|
-        application_choice.update!(declined_by_default: true, declined_at: Time.zone.now)
+        application_choice.update!(
+          declined_by_default: true,
+          declined_at: Time.zone.now,
+          withdrawn_or_declined_for_candidate_by_provider: false,
+        )
         ApplicationStateChange.new(application_choice).decline_by_default!
         application_choices << application_choice
       end

--- a/app/services/provider_interface/decline_or_withdraw_application.rb
+++ b/app/services/provider_interface/decline_or_withdraw_application.rb
@@ -35,6 +35,7 @@ module ProviderInterface
         @application_choice.update!(
           declined_at: Time.zone.now,
           audit_comment: I18n.t('transient_application_states.withdrawn_at_candidates_request.declined.audit_comment'),
+          withdrawn_or_declined_for_candidate_by_provider: true,
         )
       end
     end
@@ -49,6 +50,7 @@ module ProviderInterface
         @application_choice.update!(
           withdrawn_at: Time.zone.now,
           audit_comment: I18n.t('transient_application_states.withdrawn_at_candidates_request.withdrawn.audit_comment'),
+          withdrawn_or_declined_for_candidate_by_provider: true,
         )
         SetDeclineByDefault.new(application_form: @application_choice.application_form).call
       end

--- a/app/services/reinstate_declined_offer.rb
+++ b/app/services/reinstate_declined_offer.rb
@@ -11,6 +11,7 @@ class ReinstateDeclinedOffer
       status: 'offer',
       declined_at: nil,
       decline_by_default_at: set_dbd_value,
+      withdrawn_or_declined_for_candidate_by_provider: nil,
       audit_comment: "Reinstate offer Zendesk request: #{@zendesk_ticket}",
     )
   end

--- a/app/services/support_interface/revert_withdrawal.rb
+++ b/app/services/support_interface/revert_withdrawal.rb
@@ -10,6 +10,7 @@ module SupportInterface
         status: :awaiting_provider_decision,
         withdrawn_at: nil,
         withdrawal_feedback: nil,
+        withdrawn_or_declined_for_candidate_by_provider: nil,
         audit_comment: "Support request after candidate withdrew their application in error: #{@zendesk_ticket}",
       )
     end

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -6,7 +6,10 @@ class WithdrawApplication
   def save!
     ActiveRecord::Base.transaction do
       ApplicationStateChange.new(application_choice).withdraw!
-      application_choice.update!(withdrawn_at: Time.zone.now)
+      application_choice.update!(
+        withdrawn_at: Time.zone.now,
+        withdrawn_or_declined_for_candidate_by_provider: false,
+      )
       SetDeclineByDefault.new(application_form: application_choice.application_form).call
     end
 

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -59,6 +59,13 @@ FactoryBot.define do
     trait :withdrawn do
       status { :withdrawn }
       withdrawn_at { Time.zone.now }
+      withdrawn_or_declined_for_candidate_by_provider { false }
+    end
+
+    trait :withdrawn_at_candidates_request do
+      status { :withdrawn }
+      withdrawn_at { Time.zone.now }
+      withdrawn_or_declined_for_candidate_by_provider { true }
     end
 
     trait :unsubmitted do
@@ -71,11 +78,13 @@ FactoryBot.define do
       status { :declined }
       declined_by_default { true }
       decline_by_default_days { 10 }
+      withdrawn_or_declined_for_candidate_by_provider { false }
     end
 
     trait :withdrawn_with_survey_completed do
       status { :withdrawn }
       withdrawn_at { Time.zone.now }
+      withdrawn_or_declined_for_candidate_by_provider { false }
       withdrawal_feedback do
         {
           CandidateInterface::WithdrawalQuestionnaire::EXPLANATION_QUESTION => 'yes',
@@ -223,6 +232,7 @@ FactoryBot.define do
     trait :with_declined_offer do
       with_offer
       status { 'declined' }
+      withdrawn_or_declined_for_candidate_by_provider { false }
       declined_at { 2.days.ago }
     end
 
@@ -230,6 +240,7 @@ FactoryBot.define do
       with_offer
       status { 'declined' }
       declined_at { Time.zone.now }
+      withdrawn_or_declined_for_candidate_by_provider { false }
       declined_by_default { true }
     end
 

--- a/spec/services/decline_offer_by_default_spec.rb
+++ b/spec/services/decline_offer_by_default_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe DeclineOfferByDefault do
 
     expect(application_choice.declined_by_default).to eq(true)
     expect(application_choice.declined_at).not_to be_nil
+    expect(application_choice.withdrawn_or_declined_for_candidate_by_provider).to be false
   end
 
   it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do

--- a/spec/services/decline_offer_spec.rb
+++ b/spec/services/decline_offer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe DeclineOffer do
       expect {
         described_class.new(application_choice: application_choice).save!
       }.to change { application_choice.declined_at }.to(Time.zone.now)
+       .and change { application_choice.withdrawn_or_declined_for_candidate_by_provider }.to false
     end
   end
 

--- a/spec/services/provider_interface/decline_or_withdraw_application_spec.rb
+++ b/spec/services/provider_interface/decline_or_withdraw_application_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ProviderInterface::DeclineOrWithdrawApplication do
       expect(application_choice.reload.declined_at).not_to be nil
       expect(application_choice).to be_declined
       expect(application_choice).not_to be_withdrawn
+      expect(application_choice.withdrawn_or_declined_for_candidate_by_provider).to be true
     end
 
     it 'withdraws applications which are withdrawable' do
@@ -24,6 +25,7 @@ RSpec.describe ProviderInterface::DeclineOrWithdrawApplication do
       expect(application_choice.reload.withdrawn_at).not_to be nil
       expect(application_choice).to be_withdrawn
       expect(application_choice).not_to be_declined
+      expect(application_choice.withdrawn_or_declined_for_candidate_by_provider).to be true
     end
 
     it 'returns false when the application is not under offer and is not withdrawable' do

--- a/spec/services/reinstate_declined_offer_spec.rb
+++ b/spec/services/reinstate_declined_offer_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe ReinstateDeclinedOffer, with_audited: true do
 
         expect(course_choice).to eq original_course_choice
         expect(course_choice.audits.last.comment).to include(zendesk_ticket)
+        expect(course_choice.withdrawn_or_declined_for_candidate_by_provider).to eq nil
       end
     end
 

--- a/spec/services/support_interface/revert_withdrawal_spec.rb
+++ b/spec/services/support_interface/revert_withdrawal_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe SupportInterface::RevertWithdrawal, with_audited: true do
 
       expect(application_choice).to eq(original_application_choice)
       expect(application_choice.audits.last.comment).to include(zendesk_ticket)
+      expect(application_choice.withdrawn_or_declined_for_candidate_by_provider).to eq nil
     end
   end
 end

--- a/spec/services/withdraw_application_spec.rb
+++ b/spec/services/withdraw_application_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe WithdrawApplication do
 
       described_class.new(application_choice: choice).save!
 
-      expect(choice.reload.status).to eq 'withdrawn'
+      choice.reload
+      expect(choice.status).to eq 'withdrawn'
+      expect(choice.withdrawn_or_declined_for_candidate_by_provider).to be false
     end
 
     it 'calls SetDeclineByDefault with the withdrawn application’s application_form' do


### PR DESCRIPTION
## Context

For the v1.1 API withdraw application feature we have added a boolean flag ([#6386](https://github.com/DFE-Digital/apply-for-teacher-training/pull/6386)) to indicate if a provider has withdrawn/declined an application at the candidates request

We now need to update the provider service that performs this, to also populate the flag.

## Changes proposed in this pull request

The following services will now set the flag to **true**:
- [x] DeclineOrWithdrawApplication

The following services will now set the flag to **false**:
- [x] DeclineOffer
- [x] DeclineOfferByDefault
- [x] WithdrawApplication

The following services will now set the flag back to **nil**:
- [x] RevertWithdrawal
- [x] ReinstateDeclinedOffer


## Guidance to review
Review per commit - each one is fairly minor

## Link to Trello card

https://trello.com/c/0PrUwZNW

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
