### PR TITLE
API v1.1 Update GetApplicationChoiceFromProviders service

### DIFF
--- a/app/controllers/concerns/vendor_api/application_data_concerns.rb
+++ b/app/controllers/concerns/vendor_api/application_data_concerns.rb
@@ -1,0 +1,33 @@
+module VendorAPI
+  module ApplicationDataConcerns
+  private
+
+    def application_choice_id
+      params.permit(:application_id)[:application_id]
+    end
+
+    def application_choice
+      @application_choice ||= application_choices_visible_to_provider.find(application_choice_id)
+    end
+
+    def render_application
+      render json: application_json
+    end
+
+    def application_json
+      %({"data":#{ApplicationPresenter.new(version_number, application_choice).serialized_json}})
+    end
+
+    def application_choices_visible_to_provider(includes = nil)
+      options = { providers: [current_provider],
+                  exclude_deferrals: exclude_deferrals }
+      options.merge!(includes: includes) if includes.present?
+
+      GetApplicationChoicesForProviders.call(options)
+    end
+
+    def exclude_deferrals
+      full_api_version_number.eql?(VendorAPI::PRELIMINARY_VERSION)
+    end
+  end
+end

--- a/app/controllers/concerns/versioning.rb
+++ b/app/controllers/concerns/versioning.rb
@@ -11,4 +11,8 @@ private
   def version_number
     @version_number = extract_version(version_param)
   end
+
+  def full_api_version_number
+    "#{major_version_number(version_number)}.#{minor_version_number(version_number)}"
+  end
 end

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -1,13 +1,13 @@
 module VendorAPI
   class ApplicationsController < VendorAPIController
+    include ApplicationDataConcerns
+
     def index
       render json: serialized_application_choices_data
     end
 
     def show
-      application_choice = application_choices_visible_to_provider.find(params[:application_id])
-
-      render json: %({"data":#{ApplicationPresenter.new(version_number, application_choice).serialized_json}})
+      render_application
     end
 
   private
@@ -20,26 +20,21 @@ module VendorAPI
       %({"data":[#{json_data.join(',')}]})
     end
 
-    def application_choices_visible_to_provider
-      GetApplicationChoicesForProviders
-        .call(
-          providers: [current_provider],
-          exclude_deferrals: true,
-          includes: [
-            offer: %i[conditions],
-            application_form: %i[candidate application_qualifications application_references application_work_experiences application_work_history_breaks application_volunteering_experiences english_proficiency],
-            course_option: [{ course: %i[provider] }, :site],
-            current_course_option: [{ course: %i[provider] }, :site],
-          ],
-        )
-    end
-
     def get_application_choices_for_provider_since(since:)
-      application_choices_visible_to_provider
+      application_choices_visible_to_provider(include_properties)
         .where('application_choices.updated_at > ?', since)
         .find_each(batch_size: 500)
         .sort_by(&:updated_at)
         .reverse
+    end
+
+    def include_properties
+      [
+        offer: %i[conditions],
+        application_form: %i[candidate application_qualifications application_references application_work_experiences application_work_history_breaks application_volunteering_experiences english_proficiency],
+        course_option: [{ course: %i[provider] }, :site],
+        current_course_option: [{ course: %i[provider] }, :site],
+      ]
     end
 
     def since_param

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -24,7 +24,7 @@ module VendorAPI
       GetApplicationChoicesForProviders
         .call(
           providers: [current_provider],
-          vendor_api: true,
+          exclude_deferrals: true,
           includes: [
             offer: %i[conditions],
             application_form: %i[candidate application_qualifications application_references application_work_experiences application_work_history_breaks application_volunteering_experiences english_proficiency],

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -57,7 +57,7 @@ module VendorAPI
   private
 
     def application_choice
-      @application_choice ||= GetApplicationChoicesForProviders.call(providers: [current_provider], vendor_api: true).find(params[:application_id])
+      @application_choice ||= GetApplicationChoicesForProviders.call(providers: [current_provider], exclude_deferrals: true).find(params[:application_id])
     end
 
     def render_application

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -1,5 +1,7 @@
 module VendorAPI
   class DecisionsController < VendorAPIController
+    include ApplicationDataConcerns
+
     before_action :validate_metadata!
     rescue_from ValidationException, with: :render_validation_error
 
@@ -55,14 +57,6 @@ module VendorAPI
     end
 
   private
-
-    def application_choice
-      @application_choice ||= GetApplicationChoicesForProviders.call(providers: [current_provider], exclude_deferrals: true).find(params[:application_id])
-    end
-
-    def render_application
-      render json: %({"data":#{ApplicationPresenter.new(version_number, application_choice).serialized_json}})
-    end
 
     def respond_to_decision(decision)
       if [MakeOffer, ChangeOffer].include?(decision.class)

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -1,5 +1,6 @@
 module VendorAPI
-  VERSION = '1.0'.freeze
+  PRELIMINARY_VERSION = '1.0'.freeze
+  VERSION = PRELIMINARY_VERSION
 
   VERSIONS = {
     '1.0' => [

--- a/app/queries/get_application_choices_for_providers.rb
+++ b/app/queries/get_application_choices_for_providers.rb
@@ -13,7 +13,7 @@ class GetApplicationChoicesForProviders
 
   def self.call(
     providers:,
-    vendor_api: false,
+    exclude_deferrals: false,
     includes: DEFAULT_INCLUDES,
     recruitment_cycle_year: RecruitmentCycle.years_visible_to_providers
   )
@@ -23,7 +23,7 @@ class GetApplicationChoicesForProviders
     raise MissingProvider if providers.blank? || providers.any?(&:blank?)
 
     provider_ids = providers.map(&:id)
-    statuses = vendor_api ? ApplicationStateChange.states_visible_to_provider_without_deferred : ApplicationStateChange.states_visible_to_provider
+    statuses = exclude_deferrals ? ApplicationStateChange.states_visible_to_provider_without_deferred : ApplicationStateChange.states_visible_to_provider
 
     ApplicationChoice
       .where(provider_ids_check(provider_ids))

--- a/spec/controllers/concerns/vendor_api/application_data_concerns_spec.rb
+++ b/spec/controllers/concerns/vendor_api/application_data_concerns_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+RSpec.describe VendorAPI::ApplicationDataConcerns do
+  subject(:application_data_concerns) { ::TestApplicationDataConcerns.new(provider, api_version: version) }
+
+  let(:provider) { build(:provider) }
+
+  describe '#application_choices_visible_to_provider' do
+    before do
+      allow(GetApplicationChoicesForProviders).to receive(:call)
+    end
+
+    context 'when version is v1' do
+      let(:version) { 'v1' }
+
+      it 'excludes deferrals' do
+        application_data_concerns.send(:application_choices_visible_to_provider)
+
+        expect(GetApplicationChoicesForProviders)
+          .to have_received(:call).with(providers: [provider], exclude_deferrals: true)
+      end
+    end
+
+    context 'when version is v1.0' do
+      let(:version) { 'v1.0' }
+
+      it 'excludes deferrals' do
+        application_data_concerns.send(:application_choices_visible_to_provider)
+
+        expect(GetApplicationChoicesForProviders)
+          .to have_received(:call).with(providers: [provider], exclude_deferrals: true)
+      end
+    end
+
+    context 'when version is v1.1' do
+      let(:version) { 'v1.1' }
+
+      it 'does not excludes deferrals' do
+        application_data_concerns.send(:application_choices_visible_to_provider)
+
+        expect(GetApplicationChoicesForProviders)
+          .to have_received(:call).with(providers: [provider], exclude_deferrals: false)
+      end
+    end
+  end
+end
+
+class TestApplicationDataConcerns
+  include VendorAPI::ApplicationDataConcerns
+  include Versioning
+
+  attr_reader :current_provider, :params
+
+  def initialize(provider, params)
+    @current_provider = provider
+    @params = params
+  end
+end

--- a/spec/queries/get_application_choices_for_providers_spec.rb
+++ b/spec/queries/get_application_choices_for_providers_spec.rb
@@ -232,8 +232,8 @@ RSpec.describe GetApplicationChoicesForProviders do
     expect(returned_applications.map(&:id)).not_to include(ratified_choice_for_previous_cycle.id)
   end
 
-  context 'when vendor_api argument is true' do
-    it 'returns applications that are in a state visible to providers in vendor api' do
+  context 'when exclude_deferrals argument is true' do
+    it 'returns applications that without deferrals' do
       current_provider = create(:provider, code: 'BAT')
 
       create_list(
@@ -249,7 +249,7 @@ RSpec.describe GetApplicationChoicesForProviders do
         status: 'offer_deferred',
       )
 
-      returned_applications = described_class.call(providers: [current_provider], vendor_api: true)
+      returned_applications = described_class.call(providers: [current_provider], exclude_deferrals: true)
       expect(returned_applications.size).to eq(1)
     end
   end


### PR DESCRIPTION
## Context

Update GetApplicationChoiceFromProviders service to optionally return deferred offers for vendor api and refactor reusable code in controller concern.

## Link to Trello card

https://trello.com/c/ydJZg7xW/4722-api-v11-deferrals-updates-to-getapplicationchoicefromproviders-service

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
