### PR TITLE
Assign users to Notes#user when generating test applications

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -491,7 +491,7 @@ private
       FactoryBot.create(
         :note,
         application_choice: choice,
-        provider_user: provider_user,
+        user: provider_user,
         created_at: time,
         updated_at: time,
       )


### PR DESCRIPTION
## Context

Missed in https://github.com/DFE-Digital/apply-for-teacher-training/pull/6355 we should no longer write to `Notes#provider_user` as this association will soon be removed.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Associate the user with notes via the polymorphic `user` field when generating test applications.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

We may need to re-run the backfill data migration on QA and Sandbox after rolling this amendment out.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
