### PR TITLE
Add default scope to Course#subjects accociation

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -4,7 +4,7 @@ class Course < ApplicationRecord
   has_many :application_choices, through: :course_options
   has_many :sites, through: :course_options
   has_many :course_subjects
-  has_many :subjects, through: :course_subjects
+  has_many :subjects, -> { order('id ASC') }, through: :course_subjects
   belongs_to :accredited_provider, class_name: 'Provider', optional: true
 
   validates :level, presence: true


### PR DESCRIPTION
## Context

This PR is an attempt to fix a flakey test in https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/spec/services/support_interface/ministerial_report_applications_export_spec.rb

e.g. https://github.com/DFE-Digital/apply-for-teacher-training/runs/4817982554?check_suite_focus=true

## Changes proposed in this pull request

These failures seem to be happening because the method to determine the 'dominant' subject for a course relies on a consistent ordering in the event of a tie (e.g. when there are two subjects that can't be prioritised any other way). 

https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/app/lib/ministerial_report.rb#L216

The most logical thing to do here is to define 'first' as the first record in the DB, i.e. the one with the lowest `id`. This method doesn't do the database query and is called from a variety of places so I've added a default scope just to set a deterministic order on the `Course#subjects` association.

## Guidance to review

Is adding a default scope OK here? It _seems_ reasonable given that it's limited to defining an order and doesn't violate the principle of least surprise.

There are already tests that depend on this behaviour such as the one that is being persistently flagged as flakey. I'm not sure whether there another more specific test is possible.

## Link to Trello card

https://trello.com/c/eUV96RHu/4294-fix-flakey-ministerial-report-export-spec

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
