### PR TITLE
Update FactoryBot call to build_stubbed application so that offer con…

### DIFF
--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -795,7 +795,7 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def reinstated_offer_with_conditions
-    application_choice = FactoryBot.build(
+    application_choice = FactoryBot.build_stubbed(
       :application_choice,
       :with_accepted_offer,
       application_form: application_form,


### PR DESCRIPTION
…ditions are generated


This is because conditions are stubbed so the code generating them will only be executed when using `build_stubbed`
https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/spec/factories/application_choice.rb#L185


## Before

<img width="944" alt="Screenshot 2022-01-19 at 14 14 15" src="https://user-images.githubusercontent.com/159200/150148031-fab5e57c-0fc1-4379-a933-63326e432a10.png">


## After
<img width="954" alt="Screenshot 2022-01-19 at 14 13 32" src="https://user-images.githubusercontent.com/159200/150148037-27fe658a-8852-4242-8ee5-69996a4e273c.png">
