### PR TITLE
remove reference to 8 days

### DIFF
--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -15,7 +15,7 @@ Sign in and select the 2 references you want to include in your application:
 <% else %>
 You need to get another reference back before you can send your application to training providers.
 
-It takes 8 days to get a reference on average. You can request as many references as you like to increase the chances of getting 2 quickly.
+You can request as many references as you like to increase the chances of getting 2 quickly.
 
 Sign in to manage your reference requests:
 <% end %>


### PR DESCRIPTION
we removed the line about it taking 8 days to get a reference from the web interface, so doing the same on the email too 

we removed it from the interface as UR showed that this line wasn't having an impact on encouraging candidates to get a reference more quickly 
