### PR TITLE
4246 remove fraudulent property from fraudmatch

### DIFF
--- a/app/models/fraud_match.rb
+++ b/app/models/fraud_match.rb
@@ -1,6 +1,4 @@
 class FraudMatch < ApplicationRecord
-  self.ignored_columns = %w[fraudulent]
-
   audited
 
   has_many :candidates

--- a/db/migrate/20220119093751_remove_fraudulent_from_fraud_match.rb
+++ b/db/migrate/20220119093751_remove_fraudulent_from_fraud_match.rb
@@ -1,0 +1,5 @@
+class RemoveFraudulentFromFraudMatch < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :fraud_matches, :fraudulent, :boolean }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2022_01_25_164558) do
-
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -475,7 +474,6 @@ ActiveRecord::Schema.define(version: 2022_01_25_164558) do
     t.string "last_name"
     t.date "date_of_birth"
     t.string "postcode"
-    t.boolean "fraudulent", default: false
     t.boolean "blocked", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,7 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
   'DataMigrations::RemoveDuplicateMatchingFeatureFlag',
-  'DataMigrations::ResolveAllFraudulentDuplicateMatches',
   'DataMigrations::FixupCandidatesSubmissionBlocked',
   'DataMigrations::BackfillWithdrawnOrDeclinedForCandidateByProvider',
   'DataMigrations::BackfillUserColumnsOnNotes',

--- a/spec/services/update_duplicate_matches_spec.rb
+++ b/spec/services/update_duplicate_matches_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe UpdateDuplicateMatches, sidekiq: true do
     <<~MSG
       \n#{Rails.application.routes.url_helpers.support_interface_duplicate_matches_url}
       :face_with_monocle: There is 1 new duplicate candidate match today :face_with_monocle:
+      :gavel: 1 match has been marked as a duplicate :gavel:
       :female-detective: In total there are 2 matches :male-detective:
     MSG
   end
@@ -83,10 +84,7 @@ RSpec.describe UpdateDuplicateMatches, sidekiq: true do
                last_name: 'Thompsun',
                date_of_birth: '1998-08-08',
                postcode: 'W6 9BH',
-<<<<<<< HEAD
                blocked: true,
-=======
->>>>>>> 70e5a09ef (Remove the usage of fraudulent column)
                created_at: 2.days.ago)
 
         described_class.new.save!

--- a/spec/services/update_duplicate_matches_spec.rb
+++ b/spec/services/update_duplicate_matches_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe UpdateDuplicateMatches, sidekiq: true do
     <<~MSG
       \n#{Rails.application.routes.url_helpers.support_interface_duplicate_matches_url}
       :face_with_monocle: There is 1 new duplicate candidate match today :face_with_monocle:
-      :gavel: 1 match has been marked as a duplicate :gavel:
       :female-detective: In total there are 2 matches :male-detective:
     MSG
   end
@@ -84,7 +83,10 @@ RSpec.describe UpdateDuplicateMatches, sidekiq: true do
                last_name: 'Thompsun',
                date_of_birth: '1998-08-08',
                postcode: 'W6 9BH',
+<<<<<<< HEAD
                blocked: true,
+=======
+>>>>>>> 70e5a09ef (Remove the usage of fraudulent column)
                created_at: 2.days.ago)
 
         described_class.new.save!


### PR DESCRIPTION
## Context

The `FraudMatch` model has a `fraudulent` property which is not used anywhere except in the fraud UI and a slack notification, and it is not useful these places. 

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Remove `fraudulent` column from the `FraudMatch` table.
Remove the fraudulent matches text from the slack notification.

## Guidance to review

Do we want to replace the fraudulent line in the slack message with something else? We were under the impression that the slack notification didn't serve any real value.

## Link to Trello card

https://trello.com/c/4a98THpg/4246-remove-fraudulent-property-from-fraudmatch

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
