### PR TITLE
copy edit footer

### DIFF
--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -2,7 +2,7 @@
 
 # Get support
 
-Call Get Into Teaching or talk to an adviser online:
+Call 0800 389 2500 or talk to an adviser online:
 
 <%= t('get_into_teaching.url_online_chat') %>
 

--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -2,7 +2,7 @@
 
 # Get support
 
-You can chat to a <%= t('service_name.get_into_teaching') %> adviser online for help and advice:
+Chat online with an adviser at <%= t('service_name.get_into_teaching') %>:
 
 <%= t('get_into_teaching.url_online_chat') %>
 

--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -2,7 +2,7 @@
 
 # Get help
 
-Call <%= t('get_into_teaching.tel') %> or talk to an adviser online:
+Call <%= t('get_into_teaching.tel') %> or chat online:
 
 <%= t('get_into_teaching.url_online_chat') %>
 

--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -6,4 +6,4 @@ Call Get Into Teaching or talk to an adviser online:
 
 <%= t('get_into_teaching.url_online_chat') %>
 
-You can also call for free on <%= t('get_into_teaching.tel') %>, <%= t('get_into_teaching.opening_times') %>.
+You can get help <%= t('get_into_teaching.opening_times') %>.

--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -1,9 +1,9 @@
 <%= yield %>
 
-# Get support
+# Get help
 
 Call <%= t('get_into_teaching.tel') %> or talk to an adviser online:
 
 <%= t('get_into_teaching.url_online_chat') %>
 
-You can get help <%= t('get_into_teaching.opening_times') %>.
+You can get help from <%= t('get_into_teaching.opening_times') %>.

--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -2,7 +2,7 @@
 
 # Get support
 
-Chat online with an adviser:
+Talk to an adviser online:
 
 <%= t('get_into_teaching.url_online_chat') %>
 

--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -6,4 +6,4 @@ Call <%= t('get_into_teaching.tel') %> or chat online:
 
 <%= t('get_into_teaching.url_online_chat') %>
 
-You can get help from <%= t('get_into_teaching.opening_times') %>.
+<%= t('get_into_teaching.opening_times') %>.

--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -2,7 +2,7 @@
 
 # Get support
 
-Call 0800 389 2500 or talk to an adviser online:
+Call <%= t('get_into_teaching.tel') %> or talk to an adviser online:
 
 <%= t('get_into_teaching.url_online_chat') %>
 

--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -2,7 +2,7 @@
 
 # Get support
 
-Talk to an adviser online:
+Call Get Into Teaching or talk to an adviser online:
 
 <%= t('get_into_teaching.url_online_chat') %>
 

--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -2,7 +2,7 @@
 
 # Get support
 
-Chat online with an adviser at <%= t('service_name.get_into_teaching') %>:
+Chat online with an adviser:
 
 <%= t('get_into_teaching.url_online_chat') %>
 


### PR DESCRIPTION
- Make email footer content cleaner
- don't call TTAs 'Get Into Teaching advisers' (because we don't do this anywhere else)
- use 'Get help' rather than 'Get support' in line with Apply web footer 

Before:
![Screenshot 2022-01-21 at 17 37 02](https://user-images.githubusercontent.com/56349171/150573984-97067225-d25a-4b1c-b4eb-f593efb53a4f.png)

After:
![Screenshot 2022-01-21 at 17 35 44](https://user-images.githubusercontent.com/56349171/150573794-f728110e-aad2-4942-ad44-e74fefa43fef.png)

