### PR TITLE
API v1.1 - Deferrals -  Refactor confirm deferred offer services

### DIFF
--- a/app/controllers/provider_interface/reconfirm_deferred_offers_controller.rb
+++ b/app/controllers/provider_interface/reconfirm_deferred_offers_controller.rb
@@ -35,19 +35,10 @@ module ProviderInterface
 
       render :check and return unless @wizard.valid_for_current_step?
 
-      service_class = if @wizard.conditions_met?
-                        ReinstateConditionsMet
-                      else
-                        ReinstatePendingConditions
-                      end
-
-      service = service_class.new(
-        actor: current_provider_user,
-        application_choice: @application_choice,
-        course_option: @wizard.course_option,
-      )
-
-      if service.save
+      if ConfirmDeferredOffer.new(actor: current_provider_user,
+                                  application_choice: @application_choice,
+                                  course_option: @wizard.course_option,
+                                  conditions_met: @wizard.conditions_met?).save
         @wizard.clear_state!
         flash[:success] = 'Deferred offer successfully confirmed for current cycle'
         redirect_to next_path

--- a/app/services/confirm_deferred_offer.rb
+++ b/app/services/confirm_deferred_offer.rb
@@ -1,0 +1,22 @@
+class ConfirmDeferredOffer
+  attr_reader :actor, :application_choice, :course_option, :conditions_met
+
+  def initialize(actor:, application_choice:, course_option:, conditions_met:)
+    @actor = actor
+    @application_choice = application_choice
+    @course_option = course_option
+    @conditions_met = conditions_met
+  end
+
+  def save!
+    service.new(actor: actor,
+                application_choice: application_choice,
+                course_option: course_option).save!
+  end
+
+private
+
+  def service
+    conditions_met ? ReinstateConditionsMet : ReinstatePendingConditions
+  end
+end

--- a/app/services/confirm_deferred_offer.rb
+++ b/app/services/confirm_deferred_offer.rb
@@ -14,6 +14,13 @@ class ConfirmDeferredOffer
                 course_option: course_option).save!
   end
 
+  def save
+    save!
+    true
+  rescue ValidationException, Workflow::NoTransitionAllowed
+    false
+  end
+
 private
 
   def service

--- a/app/services/confirm_deferred_offer_validations.rb
+++ b/app/services/confirm_deferred_offer_validations.rb
@@ -1,0 +1,21 @@
+class ConfirmDeferredOfferValidations
+  include ActiveModel::Model
+
+  attr_accessor :application_choice, :course_option
+
+  validates :course_option, presence: true
+  validate :course_open_in_apply, if: :course_option
+  validate :course_exists_in_current_cycle, if: :course_option
+
+  def course_open_in_apply
+    if !course_option.course.open_on_apply
+      errors.add(:course_option, :not_open_on_apply)
+    end
+  end
+
+  def course_exists_in_current_cycle
+    if course_option.course.recruitment_cycle_year != RecruitmentCycle.current_year
+      errors.add(:course_option, :not_in_current_cycle)
+    end
+  end
+end

--- a/app/services/defer_offer.rb
+++ b/app/services/defer_offer.rb
@@ -2,27 +2,36 @@ class DeferOffer
   include ActiveModel::Model
   include ImpersonationAuditHelper
 
+  attr_reader :actor, :application_choice, :course_option
+
   def initialize(actor:, application_choice:)
-    @auth = ProviderAuthorisation.new(actor: actor)
+    @actor = actor
     @application_choice = application_choice
+    @course_option = application_choice.current_course_option
   end
 
   def save!
-    @auth.assert_can_make_decisions!(application_choice: @application_choice, course_option_id: @application_choice.current_course_option.id)
+    auth.assert_can_make_decisions!(application_choice: application_choice, course_option: course_option)
 
-    audit(@auth.actor) do
-      prior_status = @application_choice.status
+    audit(actor) do
+      previous_status = application_choice.status
 
       ActiveRecord::Base.transaction do
-        ApplicationStateChange.new(@application_choice).defer_offer!
-        @application_choice.update!(
-          status_before_deferral: prior_status,
+        ApplicationStateChange.new(application_choice).defer_offer!
+        application_choice.update!(
+          status_before_deferral: previous_status,
           offer_deferred_at: Time.zone.now,
         )
       end
 
-      CandidateMailer.deferred_offer(@application_choice).deliver_later
-      StateChangeNotifier.call(:defer_offer, application_choice: @application_choice)
+      CandidateMailer.deferred_offer(application_choice).deliver_later
+      StateChangeNotifier.call(:defer_offer, application_choice: application_choice)
     end
+  end
+
+private
+
+  def auth
+    @auth ||= ProviderAuthorisation.new(actor: actor)
   end
 end

--- a/app/services/reinstate_conditions_met.rb
+++ b/app/services/reinstate_conditions_met.rb
@@ -1,59 +1,58 @@
 class ReinstateConditionsMet
-  include ActiveModel::Validations
   include ImpersonationAuditHelper
 
-  attr_reader :application_choice, :course_option
-
-  validates :course_option, presence: true
-  validate :validate_course_option_is_open_on_apply
-  validate :validate_course_option_belongs_to_current_cycle
+  attr_reader :actor, :application_choice, :course_option
 
   def initialize(actor:, application_choice:, course_option:)
-    @auth = ProviderAuthorisation.new(actor: actor)
+    @actor = actor
     @application_choice = application_choice
     @course_option = course_option
   end
 
-  def save
-    @auth.assert_can_make_decisions!(application_choice: application_choice, course_option_id: @course_option.id)
+  def save!
+    auth.assert_can_make_decisions!(application_choice: application_choice,
+                                    course_option: course_option)
 
-    audit(@auth.actor) do
-      if valid?
-        new_recruited_at = if application_choice.status_before_deferral == 'recruited'
-                             application_choice.recruited_at # conditions are 'still met'
-                           else
-                             Time.zone.now
-                           end
-
+    if deferred_offer.valid?
+      audit(actor) do
         ActiveRecord::Base.transaction do
           ApplicationStateChange.new(application_choice).reinstate_conditions_met!
 
           application_choice.update_course_option_and_associated_fields!(
-            @course_option,
-            other_fields: { recruited_at: new_recruited_at },
+            course_option,
+            other_fields: { recruited_at: recruited_at },
           )
           application_choice.offer.conditions.each(&:met!)
-          CandidateMailer.reinstated_offer(application_choice).deliver_later
         end
+        CandidateMailer.reinstated_offer(application_choice).deliver_later
       end
+    else
+      raise ValidationException, deferred_offer.errors.map(&:message)
     end
-  rescue Workflow::NoTransitionAllowed
-    errors.add(
-      :base,
-      I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition'),
-    )
+  end
+
+  def save
+    save!
+    true
+  rescue ValidationException, Workflow::NoTransitionAllowed
     false
   end
 
-  def validate_course_option_is_open_on_apply
-    if course_option.present? && !course_option.course.open_on_apply
-      errors.add(:course_option, :not_open_on_apply)
-    end
+private
+
+  def auth
+    @auth ||= ProviderAuthorisation.new(actor: actor)
   end
 
-  def validate_course_option_belongs_to_current_cycle
-    if course_option.present? && course_option.course.recruitment_cycle_year != RecruitmentCycle.current_year
-      errors.add(:course_option, :not_in_current_cycle)
+  def deferred_offer
+    @deferred_offer ||= ConfirmDeferredOfferValidations.new(course_option: course_option)
+  end
+
+  def recruited_at
+    if application_choice.status_before_deferral == 'recruited'
+      application_choice.recruited_at # conditions are 'still met'
+    else
+      Time.zone.now
     end
   end
 end

--- a/app/services/reinstate_conditions_met.rb
+++ b/app/services/reinstate_conditions_met.rb
@@ -31,13 +31,6 @@ class ReinstateConditionsMet
     end
   end
 
-  def save
-    save!
-    true
-  rescue ValidationException, Workflow::NoTransitionAllowed
-    false
-  end
-
 private
 
   def auth

--- a/app/services/reinstate_pending_conditions.rb
+++ b/app/services/reinstate_pending_conditions.rb
@@ -31,13 +31,6 @@ class ReinstatePendingConditions
     end
   end
 
-  def save
-    save!
-    true
-  rescue ValidationException, Workflow::NoTransitionAllowed
-    false
-  end
-
 private
 
   def deferred_offer

--- a/app/services/reinstate_pending_conditions.rb
+++ b/app/services/reinstate_pending_conditions.rb
@@ -1,52 +1,50 @@
 class ReinstatePendingConditions
-  include ActiveModel::Validations
   include ImpersonationAuditHelper
 
-  attr_reader :application_choice, :course_option
-
-  validates :course_option, presence: true
-  validate :validate_course_option_is_open_on_apply
-  validate :validate_course_option_belongs_to_current_cycle
+  attr_reader :actor, :application_choice, :course_option
 
   def initialize(actor:, application_choice:, course_option:)
-    @auth = ProviderAuthorisation.new(actor: actor)
+    @actor = actor
     @application_choice = application_choice
     @course_option = course_option
   end
 
-  def save
-    @auth.assert_can_make_decisions!(application_choice: application_choice, course_option_id: course_option.id)
+  def save!
+    auth.assert_can_make_decisions!(application_choice: application_choice,
+                                    course_option: course_option)
 
-    audit(@auth.actor) do
-      if valid?
+    if deferred_offer.valid?
+      audit(actor) do
         ActiveRecord::Base.transaction do
           ApplicationStateChange.new(application_choice).reinstate_pending_conditions!
+
           application_choice.offer.conditions.each(&:pending!)
-          @application_choice.update_course_option_and_associated_fields!(
+          application_choice.update_course_option_and_associated_fields!(
             course_option,
             other_fields: { recruited_at: nil },
           )
           CandidateMailer.reinstated_offer(application_choice).deliver_later
         end
       end
+    else
+      raise ValidationException, deferred_offer.errors.map(&:message)
     end
-  rescue Workflow::NoTransitionAllowed
-    errors.add(
-      :base,
-      I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition'),
-    )
+  end
+
+  def save
+    save!
+    true
+  rescue ValidationException, Workflow::NoTransitionAllowed
     false
   end
 
-  def validate_course_option_is_open_on_apply
-    if course_option.present? && !course_option.course.open_on_apply
-      errors.add(:course_option, :not_open_on_apply)
-    end
+private
+
+  def deferred_offer
+    @deferred_offer ||= ConfirmDeferredOfferValidations.new(course_option: course_option)
   end
 
-  def validate_course_option_belongs_to_current_cycle
-    if course_option.present? && course_option.course.recruitment_cycle_year != RecruitmentCycle.current_year
-      errors.add(:course_option, :not_in_current_cycle)
-    end
+  def auth
+    @auth ||= ProviderAuthorisation.new(actor: actor)
   end
 end

--- a/app/views/provider_interface/reconfirm_deferred_offers/check.html.erb
+++ b/app/views/provider_interface/reconfirm_deferred_offers/check.html.erb
@@ -1,7 +1,7 @@
 <% content_for :browser_title, title_with_error_prefix('Review offer', @wizard.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(previous_path) %>
 
-<%= form_with model: @wizard, url: provider_interface_reconfirm_deferred_offer_path(@application_choice.id), method: :post do |f| %>
+<%= form_with model: @wizard, url: provider_interface_reconfirm_deferred_offer_path(@application_choice), method: :post do |f| %>
   <%= f.govuk_error_summary %>
   <%= f.hidden_field :course_option_id %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -384,12 +384,11 @@ en:
           attributes:
             conditions_status:
               blank: Select yes if the candidate has met all of the conditions
-        reinstate_conditions_met:
+        confirm_deferred_offer_validations:
           attributes:
             course_option:
-              blank: could not be found
-              not_open_on_apply: is not open for applications via the Apply service
-              not_in_current_cycle: does not belong to the current cycle
+              not_open_on_apply: The requested course is not open for applications via the Apply service
+              not_in_current_cycle: The requested course does not exist in the current cycle
         reinstate_pending_conditions:
           attributes:
             course_option:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -389,12 +389,6 @@ en:
             course_option:
               not_open_on_apply: The requested course is not open for applications via the Apply service
               not_in_current_cycle: The requested course does not exist in the current cycle
-        reinstate_pending_conditions:
-          attributes:
-            course_option:
-              blank: could not be found
-              not_open_on_apply: is not open for applications via the Apply service
-              not_in_current_cycle: does not belong to the current cycle
         provider_interface/rejected_by_default_feedback_form:
           attributes:
             rejection_reason:

--- a/spec/services/confirm_deferred_offer_spec.rb
+++ b/spec/services/confirm_deferred_offer_spec.rb
@@ -11,12 +11,13 @@ RSpec.describe ConfirmDeferredOffer do
   let(:application_choice) { build(:application_choice) }
   let(:actor) { build(:provider) }
   let(:course_option) { build(:course_option) }
-  let(:stubbed_service) { instance_double(:service, save!: nil) }
+  let(:conditions_met) { true }
 
   context 'when conditions_met is set to true' do
+    let(:stubbed_service) { instance_double(ReinstateConditionsMet, save!: nil) }
     let(:conditions_met) { true }
 
-    it 'calls the ReinstantConditionsMet service' do
+    it 'calls the ReinstateConditionsMet service' do
       allow(ReinstateConditionsMet).to receive(:new).and_return(stubbed_service)
 
       service.save!
@@ -26,6 +27,7 @@ RSpec.describe ConfirmDeferredOffer do
   end
 
   context 'when conditions_met is set to false' do
+    let(:stubbed_service) { instance_double(ReinstatePendingConditions, save!: nil) }
     let(:conditions_met) { false }
 
     it 'calls the ReinstatePendingConditions service' do
@@ -33,6 +35,25 @@ RSpec.describe ConfirmDeferredOffer do
 
       service.save!
       expect(ReinstatePendingConditions).to have_received(:new)
+    end
+  end
+
+  context 'when save is called' do
+    context 'when errors are raised' do
+      it 'returns false' do
+        expect(service.save).to be false
+      end
+    end
+
+    context 'when no errors are raised' do
+      let(:stubbed_service) { instance_double(ReinstatePendingConditions, save!: nil) }
+      let(:conditions_met) { false }
+
+      it 'returns true' do
+        allow(ReinstatePendingConditions).to receive(:new).and_return(stubbed_service)
+
+        expect(service.save).to be true
+      end
     end
   end
 end

--- a/spec/services/confirm_deferred_offer_spec.rb
+++ b/spec/services/confirm_deferred_offer_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe ConfirmDeferredOffer do
+  subject(:service) do
+    described_class.new(actor: actor,
+                        application_choice: application_choice,
+                        course_option: course_option,
+                        conditions_met: conditions_met)
+  end
+
+  let(:application_choice) { build(:application_choice) }
+  let(:actor) { build(:provider) }
+  let(:course_option) { build(:course_option) }
+  let(:stubbed_service) { instance_double(:service, save!: nil) }
+
+  context 'when conditions_met is set to true' do
+    let(:conditions_met) { true }
+
+    it 'calls the ReinstantConditionsMet service' do
+      allow(ReinstateConditionsMet).to receive(:new).and_return(stubbed_service)
+
+      service.save!
+
+      expect(ReinstateConditionsMet).to have_received(:new)
+    end
+  end
+
+  context 'when conditions_met is set to false' do
+    let(:conditions_met) { false }
+
+    it 'calls the ReinstatePendingConditions service' do
+      allow(ReinstatePendingConditions).to receive(:new).and_return(stubbed_service)
+
+      service.save!
+      expect(ReinstatePendingConditions).to have_received(:new)
+    end
+  end
+end

--- a/spec/services/data_api/tad_export_spec.rb
+++ b/spec/services/data_api/tad_export_spec.rb
@@ -46,7 +46,10 @@ RSpec.describe DataAPI::TADExport do
     support_user = create(:support_user)
 
     # we roll the course_option from :previous_year to the current cycle, which is the "next" cycle from its POV
-    ReinstateConditionsMet.new(actor: support_user, application_choice: choice, course_option: choice.course_option.in_next_cycle).save
+    ConfirmDeferredOffer.new(actor: support_user,
+                             application_choice: choice,
+                             course_option: choice.course_option.in_next_cycle,
+                             conditions_met: true).save
 
     result = described_class.new.data_for_export
     expect(result.count).to eq 5

--- a/spec/services/reinstate_conditions_met_spec.rb
+++ b/spec/services/reinstate_conditions_met_spec.rb
@@ -63,72 +63,15 @@ RSpec.describe ReinstateConditionsMet do
     end
   end
 
-  describe 'validations' do
-    context 'checks the course option is present' do
-      let(:new_course_option) { nil }
-
-      it 'save! raises a ValidationException' do
-        expect { service.save! }
-          .to raise_error(ValidationException, 'Please provide a course_option or course_option_id')
-      end
-
-      it 'save returns false' do
-        expect(service.save).to be false
-      end
-    end
-
-    context 'checks the course is open on apply' do
-      let(:new_course_option) do
-        create(:course_option,
-               course: create(:course, provider: provider, open_on_apply: false))
-      end
-
-      it 'save! raises a ValidationException' do
-        expect { service.save! }
-          .to raise_error(ValidationException, 'The requested course is not open for applications via the Apply service')
-      end
-
-      it 'save returns false' do
-        expect(service.save).to be false
-      end
-    end
-
-    context 'checks course option matches the current RecruitmentCycle' do
-      let(:new_course_option) { previous_course_option }
-
-      it 'save! raises a ValidationException' do
-        expect { service.save! }
-          .to raise_error(ValidationException, 'The requested course does not exist in the current cycle')
-      end
-
-      it 'save returns false' do
-        expect(service.save).to be false
-      end
-    end
-
-    context 'when the application is not in a state allowing to reinstate conditions met' do
-      let(:application_choice) do
-        create(:application_choice, :awaiting_provider_decision,
-               course_option: previous_course_option)
-      end
-
-      it 'save! raises a Workflow::NoTransitionAllowed error' do
-        expect { service.save!  }
-          .to raise_error(Workflow::NoTransitionAllowed,
-                          'There is no event reinstate_conditions_met defined for the awaiting_provider_decision state')
-      end
-
-      it 'save returns false' do
-        expect(service.save).to be false
-      end
-    end
-  end
-
   describe 'other dependencies' do
     it 'calls update_course_option_and_associated_fields!' do
       allow(application_choice).to receive(:update_course_option_and_associated_fields!)
       service.save
       expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
     end
+  end
+
+  describe 'validations' do
+    include_examples 'confirm deferred offer validations', :reinstate_conditions_met
   end
 end

--- a/spec/services/reinstate_conditions_met_spec.rb
+++ b/spec/services/reinstate_conditions_met_spec.rb
@@ -1,16 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe ReinstateConditionsMet do
+  subject(:service) do
+    described_class.new(actor: provider_user,
+                        application_choice: application_choice,
+                        course_option: new_course_option)
+  end
+
   let(:provider_user) { create(:provider_user, :with_provider, :with_make_decisions) }
   let(:provider) { provider_user.providers.first }
   let(:original_course) { create(:course, :open_on_apply, :previous_year_but_still_available, provider: provider) }
   let(:previous_course_option) { create(:course_option, course: original_course) }
   let(:new_course_option) { create(:course_option, course: original_course.in_next_cycle) }
   let(:application_choice) { create(:application_choice, :with_deferred_offer, course_option: previous_course_option) }
-
-  def service
-    described_class.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option)
-  end
 
   it 'changes application status to \'recruited\'' do
     expect { service.save }.to change(application_choice, :status).to('recruited')
@@ -27,10 +29,8 @@ RSpec.describe ReinstateConditionsMet do
   end
 
   it 'does not modify recruited_at if conditions had already been met before' do
-    application_choice.update(
-      status_before_deferral: 'recruited',
-      recruited_at: application_choice.accepted_at + 7.days,
-    )
+    application_choice.update(status_before_deferral: 'recruited',
+                              recruited_at: application_choice.accepted_at + 7.days)
 
     Timecop.freeze do
       expect { service.save }.not_to change(application_choice, :recruited_at)
@@ -63,30 +63,64 @@ RSpec.describe ReinstateConditionsMet do
     end
   end
 
-  describe 'course option validation' do
-    it 'checks the course option is present' do
-      reinstate = described_class.new(actor: provider_user, application_choice: application_choice, course_option: nil)
+  describe 'validations' do
+    context 'checks the course option is present' do
+      let(:new_course_option) { nil }
 
-      expect(reinstate).not_to be_valid
+      it 'save! raises a ValidationException' do
+        expect { service.save! }
+          .to raise_error(ValidationException, 'Please provide a course_option or course_option_id')
+      end
 
-      expect(reinstate.errors[:course_option]).to include('could not be found')
+      it 'save returns false' do
+        expect(service.save).to be false
+      end
     end
 
-    it 'checks the course is open on apply' do
-      new_course_option = create(:course_option, course: create(:course, provider: provider, open_on_apply: false))
-      reinstate = described_class.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option)
+    context 'checks the course is open on apply' do
+      let(:new_course_option) do
+        create(:course_option,
+               course: create(:course, provider: provider, open_on_apply: false))
+      end
 
-      expect(reinstate).not_to be_valid
+      it 'save! raises a ValidationException' do
+        expect { service.save! }
+          .to raise_error(ValidationException, 'The requested course is not open for applications via the Apply service')
+      end
 
-      expect(reinstate.errors[:course_option]).to include('is not open for applications via the Apply service')
+      it 'save returns false' do
+        expect(service.save).to be false
+      end
     end
 
-    it 'checks course option matches the current RecruitmentCycle' do
-      reinstate = described_class.new(actor: provider_user, application_choice: application_choice, course_option: previous_course_option)
+    context 'checks course option matches the current RecruitmentCycle' do
+      let(:new_course_option) { previous_course_option }
 
-      expect(reinstate).not_to be_valid
+      it 'save! raises a ValidationException' do
+        expect { service.save! }
+          .to raise_error(ValidationException, 'The requested course does not exist in the current cycle')
+      end
 
-      expect(reinstate.errors[:course_option]).to include('does not belong to the current cycle')
+      it 'save returns false' do
+        expect(service.save).to be false
+      end
+    end
+
+    context 'when the application is not in a state allowing to reinstate conditions met' do
+      let(:application_choice) do
+        create(:application_choice, :awaiting_provider_decision,
+               course_option: previous_course_option)
+      end
+
+      it 'save! raises a Workflow::NoTransitionAllowed error' do
+        expect { service.save!  }
+          .to raise_error(Workflow::NoTransitionAllowed,
+                          'There is no event reinstate_conditions_met defined for the awaiting_provider_decision state')
+      end
+
+      it 'save returns false' do
+        expect(service.save).to be false
+      end
     end
   end
 

--- a/spec/services/reinstate_conditions_met_spec.rb
+++ b/spec/services/reinstate_conditions_met_spec.rb
@@ -15,16 +15,16 @@ RSpec.describe ReinstateConditionsMet do
   let(:application_choice) { create(:application_choice, :with_deferred_offer, course_option: previous_course_option) }
 
   it 'changes application status to \'recruited\'' do
-    expect { service.save }.to change(application_choice, :status).to('recruited')
+    expect { service.save! }.to change(application_choice, :status).to('recruited')
   end
 
   it 'changes current_course_option_id for the application choice' do
-    expect { service.save }.to change(application_choice, :current_course_option_id)
+    expect { service.save! }.to change(application_choice, :current_course_option_id)
   end
 
   it 'sets the application\'s recruited_at date if conditions had not been met before' do
     Timecop.freeze do
-      expect { service.save }.to change(application_choice, :recruited_at).to(Time.zone.now)
+      expect { service.save! }.to change(application_choice, :recruited_at).to(Time.zone.now)
     end
   end
 
@@ -33,14 +33,14 @@ RSpec.describe ReinstateConditionsMet do
                               recruited_at: application_choice.accepted_at + 7.days)
 
     Timecop.freeze do
-      expect { service.save }.not_to change(application_choice, :recruited_at)
+      expect { service.save! }.not_to change(application_choice, :recruited_at)
     end
   end
 
   it 'updates the status of all conditions to met' do
     offer = Offer.find_by(application_choice: application_choice)
 
-    expect { service.save }.to change { offer.reload.conditions.first.status }.from('pending').to('met')
+    expect { service.save! }.to change { offer.reload.conditions.first.status }.from('pending').to('met')
   end
 
   context 'when the application does not have an offer object associated' do
@@ -55,7 +55,7 @@ RSpec.describe ReinstateConditionsMet do
     end
 
     it 'creates an offer object' do
-      service.save
+      service.save!
 
       offer = Offer.find_by(application_choice: application_choice)
       expect(offer).not_to be_nil
@@ -66,7 +66,7 @@ RSpec.describe ReinstateConditionsMet do
   describe 'other dependencies' do
     it 'calls update_course_option_and_associated_fields!' do
       allow(application_choice).to receive(:update_course_option_and_associated_fields!)
-      service.save
+      service.save!
       expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
     end
   end

--- a/spec/services/reinstate_pending_conditions_spec.rb
+++ b/spec/services/reinstate_pending_conditions_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe ReinstatePendingConditions do
   let(:application_choice) { create(:application_choice, :with_deferred_offer, course_option: previous_course_option) }
 
   it 'changes application status to \'pending_conditions\'' do
-    expect { service.save }.to change(application_choice, :status).to('pending_conditions')
+    expect { service.save! }.to change(application_choice, :status).to('pending_conditions')
   end
 
   it 'changes current_course_option_id for the application choice' do
-    expect { service.save }.to change(application_choice, :current_course_option_id)
+    expect { service.save! }.to change(application_choice, :current_course_option_id)
   end
 
   it 'sets recruited_at to nil if conditions are no longer met' do
@@ -29,14 +29,14 @@ RSpec.describe ReinstatePendingConditions do
     )
 
     Timecop.freeze do
-      expect { service.save }.to change(application_choice, :recruited_at).to(nil)
+      expect { service.save! }.to change(application_choice, :recruited_at).to(nil)
     end
   end
 
   it 'updates the status of all conditions to pending' do
     application_choice.offer.conditions.update(status: :met)
 
-    expect { service.save }.to change { application_choice.offer.conditions.first.status }.from('met').to('pending')
+    expect { service.save! }.to change { application_choice.offer.conditions.first.status }.from('met').to('pending')
   end
 
   context 'when the application does not have an offer object associated' do
@@ -49,7 +49,7 @@ RSpec.describe ReinstatePendingConditions do
     end
 
     it 'creates an offer object' do
-      service.save
+      service.save!
 
       expect(application_choice.offer).not_to be_nil
       expect(application_choice.offer.conditions.first.status).to eq('pending')
@@ -59,7 +59,7 @@ RSpec.describe ReinstatePendingConditions do
   describe 'other dependencies' do
     it 'calls update_course_option_and_associated_fields!' do
       allow(application_choice).to receive(:update_course_option_and_associated_fields!)
-      service.save
+      service.save!
       expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
     end
   end

--- a/spec/services/reinstate_pending_conditions_spec.rb
+++ b/spec/services/reinstate_pending_conditions_spec.rb
@@ -56,72 +56,15 @@ RSpec.describe ReinstatePendingConditions do
     end
   end
 
-  describe 'validations' do
-    context 'checks the course option is present' do
-      let(:new_course_option) { nil }
-
-      it 'save! raises a ValidationException' do
-        expect { service.save! }
-          .to raise_error(ValidationException, 'Please provide a course_option or course_option_id')
-      end
-
-      it 'save returns false' do
-        expect(service.save).to be false
-      end
-    end
-
-    context 'checks the course is open on apply' do
-      let(:new_course_option) do
-        create(:course_option,
-               course: create(:course, provider: provider, open_on_apply: false))
-      end
-
-      it 'save! raises a ValidationException' do
-        expect { service.save! }
-          .to raise_error(ValidationException, 'The requested course is not open for applications via the Apply service')
-      end
-
-      it 'save returns false' do
-        expect(service.save).to be false
-      end
-    end
-
-    context 'checks course option matches the current RecruitmentCycle' do
-      let(:new_course_option) { previous_course_option }
-
-      it 'save! raises a ValidationException' do
-        expect { service.save! }
-          .to raise_error(ValidationException, 'The requested course does not exist in the current cycle')
-      end
-
-      it 'save returns false' do
-        expect(service.save).to be false
-      end
-    end
-
-    context 'when the application is not in a state allowing to reinstate conditions met' do
-      let(:application_choice) do
-        create(:application_choice, :awaiting_provider_decision,
-               course_option: previous_course_option)
-      end
-
-      it 'save! raises a Workflow::NoTransitionAllowed error' do
-        expect { service.save!  }
-          .to raise_error(Workflow::NoTransitionAllowed,
-                          'There is no event reinstate_pending_conditions defined for the awaiting_provider_decision state')
-      end
-
-      it 'save returns false' do
-        expect(service.save).to be false
-      end
-    end
-  end
-
   describe 'other dependencies' do
     it 'calls update_course_option_and_associated_fields!' do
       allow(application_choice).to receive(:update_course_option_and_associated_fields!)
       service.save
       expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
     end
+  end
+
+  describe 'validations' do
+    include_examples 'confirm deferred offer validations', :reinstate_pending_conditions
   end
 end

--- a/spec/support/shared_examples/confirm_deferred_offer_validations.rb
+++ b/spec/support/shared_examples/confirm_deferred_offer_validations.rb
@@ -1,0 +1,60 @@
+RSpec.shared_examples 'confirm deferred offer validations' do |transition_event|
+  context 'checks the course option is present' do
+    let(:new_course_option) { nil }
+
+    it 'save! raises a ValidationException' do
+      expect { service.save! }
+        .to raise_error(ValidationException, 'Please provide a course_option or course_option_id')
+    end
+
+    it 'save returns false' do
+      expect(service.save).to be false
+    end
+  end
+
+  context 'checks the course is open on apply' do
+    let(:new_course_option) do
+      create(:course_option,
+             course: create(:course, provider: provider, open_on_apply: false))
+    end
+
+    it 'save! raises a ValidationException' do
+      expect { service.save! }
+        .to raise_error(ValidationException, 'The requested course is not open for applications via the Apply service')
+    end
+
+    it 'save returns false' do
+      expect(service.save).to be false
+    end
+  end
+
+  context 'checks course option matches the current RecruitmentCycle' do
+    let(:new_course_option) { previous_course_option }
+
+    it 'save! raises a ValidationException' do
+      expect { service.save! }
+        .to raise_error(ValidationException, 'The requested course does not exist in the current cycle')
+    end
+
+    it 'save returns false' do
+      expect(service.save).to be false
+    end
+  end
+
+  context 'when the application is not in a state allowing to reinstate conditions met' do
+    let(:application_choice) do
+      create(:application_choice, :awaiting_provider_decision,
+             course_option: previous_course_option)
+    end
+
+    it 'save! raises a Workflow::NoTransitionAllowed error' do
+      expect { service.save!  }
+        .to raise_error(Workflow::NoTransitionAllowed,
+                        "There is no event #{transition_event} defined for the awaiting_provider_decision state")
+    end
+
+    it 'save returns false' do
+      expect(service.save).to be false
+    end
+  end
+end

--- a/spec/support/shared_examples/confirm_deferred_offer_validations.rb
+++ b/spec/support/shared_examples/confirm_deferred_offer_validations.rb
@@ -2,13 +2,9 @@ RSpec.shared_examples 'confirm deferred offer validations' do |transition_event|
   context 'checks the course option is present' do
     let(:new_course_option) { nil }
 
-    it 'save! raises a ValidationException' do
+    it 'raises a ValidationException' do
       expect { service.save! }
         .to raise_error(ValidationException, 'Please provide a course_option or course_option_id')
-    end
-
-    it 'save returns false' do
-      expect(service.save).to be false
     end
   end
 
@@ -18,26 +14,18 @@ RSpec.shared_examples 'confirm deferred offer validations' do |transition_event|
              course: create(:course, provider: provider, open_on_apply: false))
     end
 
-    it 'save! raises a ValidationException' do
+    it 'raises a ValidationException' do
       expect { service.save! }
         .to raise_error(ValidationException, 'The requested course is not open for applications via the Apply service')
-    end
-
-    it 'save returns false' do
-      expect(service.save).to be false
     end
   end
 
   context 'checks course option matches the current RecruitmentCycle' do
     let(:new_course_option) { previous_course_option }
 
-    it 'save! raises a ValidationException' do
+    it 'raises a ValidationException' do
       expect { service.save! }
         .to raise_error(ValidationException, 'The requested course does not exist in the current cycle')
-    end
-
-    it 'save returns false' do
-      expect(service.save).to be false
     end
   end
 
@@ -47,14 +35,10 @@ RSpec.shared_examples 'confirm deferred offer validations' do |transition_event|
              course_option: previous_course_option)
     end
 
-    it 'save! raises a Workflow::NoTransitionAllowed error' do
-      expect { service.save!  }
+    it 'raises a Workflow::NoTransitionAllowed error' do
+      expect { service.save! }
         .to raise_error(Workflow::NoTransitionAllowed,
                         "There is no event #{transition_event} defined for the awaiting_provider_decision state")
-    end
-
-    it 'save returns false' do
-      expect(service.save).to be false
     end
   end
 end


### PR DESCRIPTION
## Context
In order for the API to be able to render the correct error messages when a vendor api use attempts to confirm a deferred offer, refactor the existing services so they raise ValidationExceptions with the relevant error messages, similar to Make and ChangeOffer.


## Changes proposed in this pull request

Refactor existing services that confirm a deferred offer. Extend to support raising exceptions when calling `save!`, so that a similar implementation to the one used in the `VendorAPI#DecisionsController` can be achieved and we don't need to do any additional processing to extract errors. 

This PR also introduces a validation object, shared by the existing services, to perform common validations, shared examples for testing the validatiosn and a wrapper service that deals with calling the correct service depending on whether `conditions_met` is set to true or false.

## Link to Trello card
https://trello.com/c/1N7oRKce/4723-api-v11-deferrals-refactor-reinstate-deferred-offer-services-to-raise-exceptions

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
