### PR TITLE
Stop assigning/writing to Note#provider_user

### DIFF
--- a/app/forms/provider_interface/new_note_form.rb
+++ b/app/forms/provider_interface/new_note_form.rb
@@ -10,7 +10,6 @@ module ProviderInterface
       if valid?
         Note.new(
           application_choice: application_choice,
-          provider_user: user,
           user: user,
           message: message,
         ).save

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,5 +1,4 @@
 class Note < ApplicationRecord
   belongs_to :application_choice, touch: true
-  belongs_to :provider_user
   belongs_to :user, polymorphic: true
 end

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -84,7 +84,6 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
     it 'renders note event' do
       application_choice = create(:application_choice)
       note = Note.new(
-        provider_user: provider_user,
         message: 'Notes are a new feature',
         user: provider_user,
       )

--- a/spec/factories/note.rb
+++ b/spec/factories/note.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :note do
     application_choice
-    provider_user
     user { [0, 1].sample.zero? ? create(:vendor_api_user) : create(:provider_user) }
 
     message { Faker::Quote.most_interesting_man_in_the_world }

--- a/spec/forms/provider_interface/new_note_form_spec.rb
+++ b/spec/forms/provider_interface/new_note_form_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::NewNoteForm do
   let(:application_choice) { build(:application_choice) }
-  let(:provider_user) { build(:provider_user) }
+  let(:user) { build(:provider_user) }
 
   describe 'validations' do
     it 'validates presence of :application_choice' do
@@ -29,7 +29,7 @@ RSpec.describe ProviderInterface::NewNoteForm do
     it 'creates a new note' do
       valid_form_object = described_class.new(
         application_choice: application_choice,
-        user: provider_user,
+        user: user,
         message: 'Some text',
       )
 


### PR DESCRIPTION
## Context

We are moving the association of notes and different types of users to `Note#user`
We've relaxed the db `notes.provider_user_id` `NULL` constraints and removed the index.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Stop assigning/writing to `Note#provider_user`
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/KbERcpa3/4664-%F0%9F%8F%88-api-v11-add-notes
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
