### PR TITLE
4313 address duplicate matching feedback

### DIFF
--- a/app/frontend/styles/support/_app-count.scss
+++ b/app/frontend/styles/support/_app-count.scss
@@ -1,23 +1,21 @@
 .app-count {
+  display: inline-block;
+
+  margin-left: 3px;
+
+  // Display as a 28px x 28px circle, which will expand into a wider
+  // lozenge shape when there are 3 digits or more.
+  min-width: 24px;
+  height: 28px;
+  padding-left: 2px;
+  padding-right: 2px;
+  border-radius: 14px;
+  line-height: 28px;
+  vertical-align: middle;
+
   background-color: $govuk-brand-colour;
   color: govuk-colour("white");
-  display: inline-block;
-  border-radius: 13px;
-  line-height: 26px;
+
   font-weight: bold;
   text-align: center;
-  vertical-align: middle;
-  margin-left: 3px;
-}
-
-.app-count-standard {
-  width: 26px;
-  height: 26px;
-}
-
-.app-count-large {
-  width: 52px;
-  height: 52px;
-  line-height: 52px;
-  border-radius: 26px;
 }

--- a/app/frontend/styles/support/_app-count.scss
+++ b/app/frontend/styles/support/_app-count.scss
@@ -2,12 +2,22 @@
   background-color: $govuk-brand-colour;
   color: govuk-colour("white");
   display: inline-block;
-  width: 26px;
-  height: 26px;
   border-radius: 13px;
   line-height: 26px;
   font-weight: bold;
   text-align: center;
   vertical-align: middle;
   margin-left: 3px;
+}
+
+.app-count-standard {
+  width: 26px;
+  height: 26px;
+}
+
+.app-count-large {
+  width: 52px;
+  height: 52px;
+  line-height: 52px;
+  border-radius: 26px;
 }

--- a/app/views/support_interface/candidates/edit_candidate_account_status.html.erb
+++ b/app/views/support_interface/candidates/edit_candidate_account_status.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_content, govuk_back_link_to( support_interface_candidate_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to(support_interface_candidate_path, 'Back') %>
 
 <%= form_with(
   model: @candidate_account_status,

--- a/app/views/support_interface/candidates/edit_candidate_account_status.html.erb
+++ b/app/views/support_interface/candidates/edit_candidate_account_status.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_content, govuk_back_link_to(support_interface_candidate_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to(support_interface_candidate_path(@candidate), 'Back') %>
 
 <%= form_with(
   model: @candidate_account_status,

--- a/app/views/support_interface/candidates/edit_candidate_account_status.html.erb
+++ b/app/views/support_interface/candidates/edit_candidate_account_status.html.erb
@@ -1,3 +1,5 @@
+<% content_for :before_content, govuk_back_link_to( support_interface_candidate_path, 'Back') %>
+
 <%= form_with(
   model: @candidate_account_status,
   method: :patch,

--- a/app/views/support_interface/duplicate_matches/index.html.erb
+++ b/app/views/support_interface/duplicate_matches/index.html.erb
@@ -13,7 +13,7 @@
     </span>
   <% else %>
     <span class="govuk-!-margin-right-4 govuk-!-font-weight-bold">
-      Under review<span class="app-count <%= @under_review_count > 99 ? 'app-count-large' : 'app-count-standard' %>"><%= @under_review_count %></span>
+      Under review <span class="app-count"><%= @under_review_count %></span>
     </span>
     <%= govuk_link_to(
       'Resolved',

--- a/app/views/support_interface/duplicate_matches/index.html.erb
+++ b/app/views/support_interface/duplicate_matches/index.html.erb
@@ -13,7 +13,7 @@
     </span>
   <% else %>
     <span class="govuk-!-margin-right-4 govuk-!-font-weight-bold">
-      Under review<span class="app-count"><%= @under_review_count %></span>
+      Under review<span class="app-count <%= @under_review_count > 99 ? 'app-count-large' : 'app-count-standard' %>"><%= @under_review_count %></span>
     </span>
     <%= govuk_link_to(
       'Resolved',

--- a/app/views/support_interface/duplicate_matches/show.html.erb
+++ b/app/views/support_interface/duplicate_matches/show.html.erb
@@ -1,10 +1,7 @@
 <% content_for :browser_title, SupportInterface::DuplicateMatchesTableComponent.description_for(@match) %>
 
-<% if @match.resolved? %>
-  <% content_for :before_content, govuk_back_link_to(support_interface_duplicate_matches_path(resolved: true), 'Back') %>
-<% else %>
-  <% content_for :before_content, govuk_back_link_to(support_interface_duplicate_matches_path, 'Back') %>
-<% end %>
+<% content_for :before_content,
+  govuk_back_link_to(support_interface_duplicate_matches_path(resolved: @match.resolved?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/support_interface/duplicate_matches/show.html.erb
+++ b/app/views/support_interface/duplicate_matches/show.html.erb
@@ -1,5 +1,10 @@
 <% content_for :browser_title, SupportInterface::DuplicateMatchesTableComponent.description_for(@match) %>
-<% content_for :before_content, govuk_back_link_to(support_interface_duplicate_matches_path, 'Back') %>
+
+<% if @match.resolved? %>
+  <% content_for :before_content, govuk_back_link_to(support_interface_duplicate_matches_path(resolved: true), 'Back') %>
+<% else %>
+  <% content_for :before_content, govuk_back_link_to(support_interface_duplicate_matches_path, 'Back') %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/system/support_interface/duplicate_matches_spec.rb
+++ b/spec/system/support_interface/duplicate_matches_spec.rb
@@ -31,7 +31,6 @@ RSpec.feature 'See Duplicate candidate matches' do
     and_i_click_the_back_link
     i_should_be_taken_to_the_under_review_view
 
-
     when_i_click_on_a_the_resolved_link
     and_click_on_a_match_that_is_resolved
     and_i_click_the_back_link
@@ -121,9 +120,7 @@ RSpec.feature 'See Duplicate candidate matches' do
   end
 
   def and_i_should_see_a_counter_for_under_review_duplicates
-    within('span[class=app-count]') do
-      expect(page).to have_content('1')
-    end
+    expect(page.find('span.app-count').text).to eq('1')
   end
 
   def when_i_click_on_a_the_resolved_link

--- a/spec/system/support_interface/duplicate_matches_spec.rb
+++ b/spec/system/support_interface/duplicate_matches_spec.rb
@@ -27,7 +27,15 @@ RSpec.feature 'See Duplicate candidate matches' do
     then_i_should_see_list_of_under_review_duplicates
     and_i_should_see_a_counter_for_under_review_duplicates
 
+    when_i_click_on_a_match_that_is_not_resolved
+    and_i_click_the_back_link
+    i_should_be_taken_to_the_under_review_view
+
+
     when_i_click_on_a_the_resolved_link
+    and_click_on_a_match_that_is_resolved
+    and_i_click_the_back_link
+    i_should_be_taken_to_the_resolved_view
     then_i_should_see_list_of_resolved_duplicates
 
     when_i_click_on_a_the_under_review_link
@@ -90,6 +98,26 @@ RSpec.feature 'See Duplicate candidate matches' do
   def then_i_should_see_list_of_under_review_duplicates
     expect(page).to have_content('2 candidates with postcode W6 9BH and DOB 8 Aug 1998')
     expect(page).not_to have_link('2 candidates with postcode W3 6ET')
+  end
+
+  def when_i_click_on_a_match_that_is_not_resolved
+    click_link '2 candidates with postcode W6 9BH and DOB 8 Aug 1998'
+  end
+
+  def and_i_click_the_back_link
+    click_link 'Back'
+  end
+
+  def i_should_be_taken_to_the_under_review_view
+    expect(page).to have_current_path(support_interface_duplicate_matches_path)
+  end
+
+  def and_click_on_a_match_that_is_resolved
+    click_link '2 candidates with postcode W3 6ET and DOB 12 Oct 1999'
+  end
+
+  def i_should_be_taken_to_the_resolved_view
+    expect(page).to have_current_path(support_interface_duplicate_matches_path(resolved: true))
   end
 
   def and_i_should_see_a_counter_for_under_review_duplicates

--- a/spec/system/support_interface/duplicate_matches_spec.rb
+++ b/spec/system/support_interface/duplicate_matches_spec.rb
@@ -108,7 +108,7 @@ RSpec.feature 'See Duplicate candidate matches' do
   end
 
   def i_should_be_taken_to_the_under_review_view
-    expect(page).to have_current_path(support_interface_duplicate_matches_path)
+    expect(page).to have_current_path(support_interface_duplicate_matches_path(resolved: @bob.reload.fraud_match.resolved))
   end
 
   def and_click_on_a_match_that_is_resolved
@@ -116,7 +116,7 @@ RSpec.feature 'See Duplicate candidate matches' do
   end
 
   def i_should_be_taken_to_the_resolved_view
-    expect(page).to have_current_path(support_interface_duplicate_matches_path(resolved: true))
+    expect(page).to have_current_path(support_interface_duplicate_matches_path(resolved: @ali.reload.fraud_match.resolved))
   end
 
   def and_i_should_see_a_counter_for_under_review_duplicates


### PR DESCRIPTION
## Context

This addresses feedback from the duplicate matches product review

## Changes proposed in this pull request
 - Add back link to `/support/candidates/{{id}}/status`
 - Back link dynamically changes based on resolved match for the following page `support/duplicate-matches/{{id}}`
 - Add CSS classes for more than 2 digits in the blue circle on `support/duplicate-matches`
 - Fix extra space for the linter in `app/views/support_interface/candidates/edit_candidate_account_status.html.erb` 


## Guidance to review

- Enable the `duplicate_matching` feature flag
- Open the relevent pages and check the back links work as expected

- Get over 99 duplicate matches and check that you can still see the three or four digit number within the blue circle

## Link to Trello card

https://trello.com/c/OLYe4yz6/4313-address-duplicate-matching-feedback
