### PR TITLE
API v1.1 Withdrawals backfill the candidate request flag

### DIFF
--- a/app/services/data_migrations/backfill_withdrawn_or_declined_for_candidate_by_provider.rb
+++ b/app/services/data_migrations/backfill_withdrawn_or_declined_for_candidate_by_provider.rb
@@ -1,0 +1,28 @@
+module DataMigrations
+  class BackfillWithdrawnOrDeclinedForCandidateByProvider
+    TIMESTAMP = 20220120161816
+    MANUAL_RUN = false
+
+    def change
+      audits_joins_sql = <<-SQL.squish
+        INNER JOIN audits ON audits.auditable_type = 'ApplicationChoice'
+        AND audits.auditable_id = application_choices.id
+        AND audits.user_type = 'ProviderUser'
+        AND audits.comment IN ('Declined on behalf of the candidate', 'Withdrawn on behalf of the candidate')
+      SQL
+
+      provider_actor_applications = ApplicationChoice
+                                       .joins(audits_joins_sql)
+                                       .where('application_choices.status': %w[declined withdrawn])
+                                       .distinct
+
+      other_actor_applications = ApplicationChoice
+                                   .where.not(id: provider_actor_applications.pluck(:id))
+                                   .where(status: %w[declined withdrawn])
+                                   .distinct
+
+      provider_actor_applications.update_all(withdrawn_or_declined_for_candidate_by_provider: true)
+      other_actor_applications.update_all(withdrawn_or_declined_for_candidate_by_provider: false)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillWithdrawnOrDeclinedForCandidateByProvider',
   'DataMigrations::BackfillUserColumnsOnNotes',
   'DataMigrations::RemoveDuplicateProvider',
   'DataMigrations::FixLatLongFlipFlops',

--- a/spec/factories/audit.rb
+++ b/spec/factories/audit.rb
@@ -19,6 +19,26 @@ FactoryBot.define do
     end
   end
 
+  factory :declined_at_candidates_request_audit, class: 'Audited::Audit' do
+    action { 'update' }
+    user { create(:provider_user) }
+    version { 1 }
+    request_uuid { SecureRandom.uuid }
+    comment { 'Declined on behalf of the candidate' }
+    created_at { Time.zone.now }
+
+    transient do
+      application_choice { build_stubbed(:application_choice, :with_declined_offer) }
+      changes { {} }
+    end
+
+    after(:build) do |audit, evaluator|
+      audit.auditable_type = 'ApplicationChoice'
+      audit.auditable_id = evaluator.application_choice.id
+      audit.audited_changes = evaluator.changes
+    end
+  end
+
   factory :interview_audit, class: 'Audited::Audit' do
     action { 'create' }
     user { create(:provider_user) }

--- a/spec/services/data_migrations/backfill_withdrawn_or_declined_for_candidate_by_provider_spec.rb
+++ b/spec/services/data_migrations/backfill_withdrawn_or_declined_for_candidate_by_provider_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillWithdrawnOrDeclinedForCandidateByProvider do
+  let(:withdrawn_application) { create(:application_choice, :withdrawn, withdrawn_or_declined_for_candidate_by_provider: nil) }
+  let(:declined_application) { create(:application_choice, :with_declined_offer, withdrawn_or_declined_for_candidate_by_provider: nil) }
+
+  it 'backfills withdrawn_or_declined_for_candidate_by_provider to true with provider actor' do
+    create(:withdrawn_at_candidates_request_audit, application_choice: withdrawn_application)
+    create(:declined_at_candidates_request_audit, application_choice: declined_application)
+
+    described_class.new.change
+
+    expect(withdrawn_application.reload.withdrawn_or_declined_for_candidate_by_provider).to eq(true)
+    expect(declined_application.reload.withdrawn_or_declined_for_candidate_by_provider).to eq(true)
+  end
+
+  it 'backfills withdrawn_or_declined_for_candidate_by_provider to false with non-provider actors' do
+    create(:withdrawn_at_candidates_request_audit, user: create(:candidate), application_choice: withdrawn_application)
+    create(:declined_at_candidates_request_audit, user: create(:candidate), application_choice: declined_application)
+
+    described_class.new.change
+
+    expect(withdrawn_application.reload.withdrawn_or_declined_for_candidate_by_provider).to eq(false)
+    expect(declined_application.reload.withdrawn_or_declined_for_candidate_by_provider).to eq(false)
+  end
+end


### PR DESCRIPTION
## Context
https://trello.com/c/jHWwfREN/4714-api-v11-withdrawals-backfill-the-candidate-request-flag
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Add a data migration to fill in the `withdrawn_or_declined_for_candidate_by_provider` field on all declined/withdrawn applicaiton choices. 

They will have this field set to true or false based on their audit record, which checks to see if there is a corresponding audit with a comment that indicates it moved into the withdrawn/declined state through a provider's action.
<!-- If there are UI changes, please include Before and After screenshots. -->

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
