### PR TITLE
Add NOT NULL check constraint to notes.user_id

### DIFF
--- a/db/migrate/20220120110445_make_notes_user_not_nullable.rb
+++ b/db/migrate/20220120110445_make_notes_user_not_nullable.rb
@@ -1,0 +1,7 @@
+class MakeNotesUserNotNullable < ActiveRecord::Migration[6.1]
+  def change
+    add_check_constraint :notes, 'user_id IS NOT NULL', name: 'notes_user_id_null', validate: false
+    change_column_null :notes, :user_id, false
+    remove_check_constraint :notes, name: 'notes_user_id_null'
+  end
+end

--- a/db/migrate/20220120114848_validate_make_notes_user_not_nullable.rb
+++ b/db/migrate/20220120114848_validate_make_notes_user_not_nullable.rb
@@ -1,0 +1,5 @@
+class ValidateMakeNotesUserNotNullable < ActiveRecord::Migration[6.1]
+  def change
+    validate_check_constraint :notes, name: "notes_user_id_null"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -520,6 +520,7 @@ ActiveRecord::Schema.define(version: 2022_01_20_104427) do
     t.string "user_type"
     t.index ["application_choice_id"], name: "index_notes_on_application_choice_id"
     t.index ["user_id", "user_type"], name: "index_notes_on_user_id_and_user_type"
+    t.check_constraint "user_id IS NOT NULL", name: "notes_user_id_null"
   end
 
   create_table "offer_conditions", force: :cascade do |t|


### PR DESCRIPTION
## Context

I tried to change the column `notes.user_id` to be `null: false` but AR Migrations whinged at me that I should add a check constraint instead.

I for one welcome our new computer overlords.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Add a not null check constraint on `notes.user_id`
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Is this the right thing to do? It appears to be a non-locking operation which is better in terms of applying to a production db.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/KbERcpa3/4664-%F0%9F%8F%88-api-v11-add-notes
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
