### PR TITLE
External report: fix copy, suppress publication with a feature flag

### DIFF
--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -39,6 +39,8 @@ module Publications
     def current_report
       if params[:month].present?
         MonthlyStatisticsTimetable.report_for(params[:month])
+      elsif FeatureFlag.active? :lock_external_report_to_december_2021
+        MonthlyStatisticsTimetable.report_for('2021-12')
       else
         MonthlyStatisticsTimetable.report_for_current_period
       end

--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -32,10 +32,6 @@ module Publications
       redirect_to root_path unless FeatureFlag.active?(:publish_monthly_statistics)
     end
 
-    def valid_date?
-      params[:date] == '2021-11'
-    end
-
     def calculate_download_sizes(report)
       report.statistics.map do |k, raw_data|
         next unless raw_data.is_a?(Hash)

--- a/app/presenters/publications/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/monthly_statistics_presenter.rb
@@ -29,7 +29,8 @@ module Publications
     end
 
     def current_reporting_period
-      "#{CycleTimetable.apply_opens.to_s(:govuk_date)} to #{report.created_at.to_s(:govuk_date)}"
+      start, finish = MonthlyStatisticsTimetable.reporting_period(report.month)
+      "#{start.to_s(:govuk_date)} to #{finish.to_s(:govuk_date)}"
     end
 
     def exports

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -21,6 +21,7 @@ class FeatureFlag
     [:service_unavailable_page, 'Displays a maintenance page on the whole application', 'Apply team'],
     [:send_request_data_to_bigquery, 'Send request data to Google Bigquery via background worker', 'Apply team'],
     [:enable_chat_support, 'Enable Zendesk chat support', 'Apply team'],
+    [:lock_external_report_to_december_2021, 'Lock the current external report to December 2021', 'Apply team'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [

--- a/app/services/monthly_statistics_timetable.rb
+++ b/app/services/monthly_statistics_timetable.rb
@@ -43,6 +43,13 @@ module MonthlyStatisticsTimetable
     GENERATION_DATES[Date::MONTHNAMES[Time.zone.today.month]]
   end
 
+  def self.reporting_period(month)
+    # @todo see comment above - this data model needs revisiting
+    month_key = Date.parse("#{month}-01").strftime('%B')
+
+    [CycleTimetable.apply_opens, GENERATION_DATES[month_key]]
+  end
+
   def self.current_reports_generation_date
     report_date_for_current_month = GENERATION_DATES[Date::MONTHNAMES[Time.zone.today.month]]
 

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -168,6 +168,9 @@
       in England only and thus is not directly comparable to previous figures
       published by UCAS, which also included candidates applying to providers in
       Wales.</p>
+    <p class="govuk-body">The unsuccessful count reported in Tables 4.1 to 11.1
+      includes candidates who have withdrawn their application or declined an
+      offer.</p>
   </div>
 </div>
 
@@ -262,7 +265,7 @@
     <h2 class="govuk-heading-l govuk-!-padding-top-4" id="by-provider-area">11. Provider region</h2>
     <p class="govuk-body">Provider areas are derived from their contact address. These areas may be different to where students
        do their training.</p>
-    <p class="govuk-body">This table counts all candidates by the area of the provider they applied to.</p>
+    <p class="govuk-body">This table counts all applications by the area of the provider they applied to.</p>
     <p class="govuk-body">This table is not directly comparable to previous
       figures published by UCAS for applications to providers in England.
       Previous UCAS tables excluded non-UK residents from their table of provider
@@ -271,7 +274,7 @@
   </div>
 </div>
 
-<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 11.1: Candidates by provider region of England', statistics: @presenter.statistics['by_provider_area']) %>
+<%= render CandidateInterface::MonthlyStatisticsTableComponent.new(caption: 'Table 11.1: Applications by provider region of England', statistics: @presenter.statistics['by_provider_area']) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -326,6 +329,16 @@
 
     <p class="govuk-body">
       Deferred candidates are counted in the academic year in which they start their course after training providers have re-confirmed their deferred offer. Providers need to do this before candidates intend to start their training.
+    </p>
+
+    <p class="govuk-body">
+      Statistical releases from previous months during ITT2022 can be found here:
+      <%= govuk_link_to 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment', 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment' %>.
+    </p>
+
+    <p class="govuk-body">
+      If you have any feedback on the monthly ITT statistical reports, please
+      get in touch at <%= bat_contact_mail_to %>.
     </p>
   </div>
 </div>

--- a/config/locales/candidate_interface/application_form.yml
+++ b/config/locales/candidate_interface/application_form.yml
@@ -8,7 +8,7 @@ en:
     region_codes:
       channel_islands: Channel Islands
       east_midlands: East Midlands
-      eastern: Eastern
+      eastern: East of England
       isle_of_man: Isle of Man
       london: London
       no_region: No region

--- a/config/locales/candidate_interface/provider_regions.yml
+++ b/config/locales/candidate_interface/provider_regions.yml
@@ -2,7 +2,7 @@ en:
   provider_regions:
     channel_islands: Channel Islands
     east_midlands: East Midlands
-    eastern: Eastern
+    eastern: East of England
     isle_of_man: Isle of Man
     london: London
     no_region: No region

--- a/spec/models/publications/monthly_statistics/by_area_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_area_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Publications::MonthlyStatistics::ByArea do
     expect_report_rows(column_headings: ['Area', 'Recruited', 'Conditions pending', 'Deferrals', 'Received an offer', 'Awaiting provider decisions', 'Unsuccessful', 'Total']) do
       [['Channel Islands',          0, 0, 0, 0, 0, 0, 0],
        ['East Midlands',            0, 0, 0, 0, 1, 0, 1],
-       ['Eastern',                  1, 0, 0, 0, 0, 0, 1],
+       ['East of England',          1, 0, 0, 0, 0, 0, 1],
        ['Isle of Man',              0, 0, 0, 0, 0, 0, 0],
        ['London',                   1, 0, 1, 0, 0, 0, 2],
        ['No region',                0, 0, 0, 0, 0, 1, 1],

--- a/spec/presenters/publications/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/monthly_statistics_presenter_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Publications::MonthlyStatisticsPresenter do
       Publications::MonthlyStatistics::MonthlyStatisticsReport,
       statistics: statistics,
       created_at: Date.new(2021, 11, 23),
+      month: '2021-11',
     )
   end
 
@@ -46,12 +47,6 @@ RSpec.describe Publications::MonthlyStatisticsPresenter do
     end
   end
 
-  describe '#current_reporting_period' do
-    it 'returns the date range for the current reporting period' do
-      expect(presenter.current_reporting_period).to eq('12 October 2021 to 23 November 2021')
-    end
-  end
-
   describe '#deferred_applications_count' do
     context 'when no data is available' do
       it 'returns 0' do
@@ -65,6 +60,12 @@ RSpec.describe Publications::MonthlyStatisticsPresenter do
       it 'returns the correct count' do
         expect(presenter.deferred_applications_count).to eq(37)
       end
+    end
+  end
+
+  describe '#current_reporting_period' do
+    it 'returns the correct dates per the Timetable' do
+      expect(presenter.current_reporting_period).to eq '12 October 2021 to 22 November 2021'
     end
   end
 end

--- a/spec/requests/publications/monthly_statistics_spec.rb
+++ b/spec/requests/publications/monthly_statistics_spec.rb
@@ -26,15 +26,18 @@ RSpec.describe 'Monthly Statistics', type: :request do
       report.save
     end
 
-    it 'returns the report for 2021-10' do
+    it 'returns the report for 2021-11' do
       get '/publications/monthly-statistics/'
       expect(response).to have_http_status(:ok)
+      expect(response.body).to include('to 22 November 2021')
 
       get '/publications/monthly-statistics/2021-10'
       expect(response).to have_http_status(:ok)
+      expect(response.body).to include('to 18 October 2021')
 
       get '/publications/monthly-statistics/2021-11'
       expect(response).to have_http_status(:ok)
+      expect(response.body).to include('to 22 November 2021')
 
       get '/publications/monthly-statistics/2021-12'
       expect(response).to have_http_status(:not_found)

--- a/spec/requests/publications/monthly_statistics_spec.rb
+++ b/spec/requests/publications/monthly_statistics_spec.rb
@@ -47,6 +47,23 @@ RSpec.describe 'Monthly Statistics', type: :request do
       get '/publications/monthly-statistics/2021-10/applications_by_status.csv'
       expect(response).to have_http_status(:ok)
     end
+
+    context 'when the "lock external report to December 2021" feature flag is on' do
+      before do
+        report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: '2021-12')
+        report.load_table_data
+        report.save
+
+        FeatureFlag.activate('lock_external_report_to_december_2021')
+      end
+
+      it 'displays that month’s report' do
+        get '/publications/monthly-statistics/'
+
+        expect(response.body).to include('to 20 December 2021')
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 
   it 'returns application by status csv' do


### PR DESCRIPTION
## Context

Prepare for the January external report.

We need to make some copy changes to the report before we publish it. We would also like to be able to suppress publication until we're ready to go.

## Changes proposed in this pull request

- refactor the stats controller so we can route all report retrieval through one method, where we can then add the feature flag. 
- The flag has a very short shelf life but will get us what we need in the short term.
- make the date range on the report correct, keying it from the month for which the report was generated (superseding #6235)
- use those deterministic dates to test and add a feature flag to keep publishing the December report
- fix some copy

## Guidance to review

Commit by commit.

## Link to Trello card

https://trello.com/c/KK6mYmGn/4314-copy-changes-for-the-external-report

## Things to check

- [X] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
