### PR TITLE
Make similar unsubmitted applications as duplicate match

### DIFF
--- a/app/queries/get_fraud_matches.rb
+++ b/app/queries/get_fraud_matches.rb
@@ -23,7 +23,6 @@ class GetFraudMatches
           SELECT TRIM(UPPER(application_forms.last_name)) last_name, application_forms.date_of_birth, REPLACE(UPPER(application_forms.postcode), ' ', '') postcode
           FROM application_forms
           WHERE application_forms.previous_application_form_id IS NULL
-          AND application_forms.submitted_at IS NOT NULL
         ) duplicate_submitted_attributes
         ON REPLACE(UPPER(application_details.postcode), ' ', '') = duplicate_submitted_attributes.postcode
         AND application_details.date_of_birth = duplicate_submitted_attributes.date_of_birth
@@ -32,7 +31,7 @@ class GetFraudMatches
           SELECT candidates.id, candidates.email_address
           FROM candidates
         ) candidate_details
-                     ON application_details.candidate_id = candidate_details.id
+        ON application_details.candidate_id = candidate_details.id
         WHERE application_details.previous_application_form_id IS NULL
         ORDER BY last_name, application_details.date_of_birth, postcode;",
     ).to_a

--- a/app/views/layouts/_footer_meta_candidate.html.erb
+++ b/app/views/layouts/_footer_meta_candidate.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m"><%= t('layout.support.title') %></h2>
 
-<p class="govuk-body-s govuk-!-margin-bottom-1">Call <%= t('get_into_teaching.tel') %> or <%= link_to "chat online", t('get_into_teaching.url_online_chat'), class: 'govuk-footer__link' %></p>
+<p class="govuk-body-s govuk-!-margin-bottom-1">Call <%= t('get_into_teaching.tel') %> or <%= link_to 'chat online', t('get_into_teaching.url_online_chat'), class: 'govuk-footer__link' %></p>
 <p class="govuk-body-s govuk-!-margin-bottom-1"><%= t('get_into_teaching.opening_times') %></p>
 <p class="govuk-body-s">Free of charge</p>
 

--- a/spec/queries/get_fraud_matches_spec.rb
+++ b/spec/queries/get_fraud_matches_spec.rb
@@ -87,8 +87,7 @@ RSpec.describe GetFraudMatches do
       end
 
       it 'returns all duplicates' do
-        expect(candidate_ids).to include(candidate1.id)
-        expect(candidate_ids).to include(candidate2.id)
+        expect(candidate_ids).to include(candidate1.id, candidate2.id)
       end
     end
   end

--- a/spec/queries/get_fraud_matches_spec.rb
+++ b/spec/queries/get_fraud_matches_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GetFraudMatches do
 
     context 'matches two identical names in identical casing' do
       before do
-        Timecop.freeze(Time.zone.local(2020, 8, 23, 12, 0o0, 0o0)) do
+        Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
           create(:application_form, candidate: candidate1, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: Time.zone.now)
           create(:application_form, candidate: candidate2, first_name: 'Joffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: Time.zone.now)
         end
@@ -80,7 +80,7 @@ RSpec.describe GetFraudMatches do
       let(:candidate_ids) { returned_array_of_hashes.map { |element| element['candidate_id'] } }
 
       before do
-        Timecop.freeze(Time.zone.local(2020, 8, 23, 12, 0o0, 0o0)) do
+        Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
           create(:application_form, candidate: candidate1, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: nil)
           create(:application_form, candidate: candidate2, first_name: 'Joffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: nil)
         end

--- a/spec/queries/get_fraud_matches_spec.rb
+++ b/spec/queries/get_fraud_matches_spec.rb
@@ -75,5 +75,21 @@ RSpec.describe GetFraudMatches do
         expect(postcodes).to include('W69BH')
       end
     end
+
+    context 'when duplicated unsubmitted applications' do
+      let(:candidate_ids) { returned_array_of_hashes.map { |element| element['candidate_id'] } }
+
+      before do
+        Timecop.freeze(Time.zone.local(2020, 8, 23, 12, 0o0, 0o0)) do
+          create(:application_form, candidate: candidate1, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: nil)
+          create(:application_form, candidate: candidate2, first_name: 'Joffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', submitted_at: nil)
+        end
+      end
+
+      it 'returns all duplicates' do
+        expect(candidate_ids).to include(candidate1.id)
+        expect(candidate_ids).to include(candidate2.id)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

A duplicate match should occur even if two or more candidates with a matching postcode, date of birth, and last name haven't yet submitted their application.

## Guidance to review

1. Enable duplicate_matching feature flag
2. Create two candidates 
3. On one candidate leave one unsubmitted and the other whatever (submitted or not)
4. Wait for 1 pm for the clockwork job (😆 - asked Duncan if we can change to run more frequently) and this should create a duplicate match with the unsubmitted application marked as "submission blocked".

## Link to Trello card

https://trello.com/c/EYgmf6I6/4320-unsubmitted-applications-that-are-eligible-to-be-a-duplicate-match-should-be-considered-duplicate-matches

## Things to check

- [x] If the code removes any existing feature flags, data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
