### PR TITLE
TAD Data API times out

### DIFF
--- a/config/data-api.yml
+++ b/config/data-api.yml
@@ -18,6 +18,15 @@ paths:
     get:
       summary: Get a list of TAD data exports
       description: This endpoint returns a list of data exports
+      parameters:
+        - in: query
+          name: updated_since
+          schema: 
+            type: string
+            format: date-time
+            example: 2021-05-20T12:34:00Z
+          required: true
+          description: A list of TAD data exports updated since this date
       responses:
         '200':
           description: A list of TAD data exports
@@ -156,6 +165,54 @@ components:
           type: string
           description: A human-readable description of the export
           example: Daily export of applications for TAD
+        updated_at:
+          type: string
+          format: date-time
+          description: Time of last change
+          example: 2021-05-20T12:34:00Z
+    ParameterInvalidResponse:
+      type: object
+      required:
+      - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: ParameterInvalid
+            message: "Parameter is invalid: updated_since"
+    ParameterMissingResponse:
+      type: object
+      required:
+      - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: ParameterMissing
+            message: "param is missing or the value is empty: updated_since"
+    Error:
+      type: object
+      additionalProperties: false
+      properties:
+        error:
+          type: string
+          description: Name of the current error
+          example: Unauthorized
+        message:
+          type: string
+          description: Description of the current error
+          example: Please provide a valid authentication token
+      required:
+      - error
+      - message
   securitySchemes:
     tokenAuth:
       type: http

--- a/spec/requests/data_api/tad_exports_spec.rb
+++ b/spec/requests/data_api/tad_exports_spec.rb
@@ -3,20 +3,92 @@ require 'rails_helper'
 RSpec.describe 'GET /data-api/tad-data-exports', type: :request, sidekiq: true do
   include DataAPISpecHelper
 
+  let!(:create_data_export) do
+    DataExport.create!(name: 'Daily export of applications for TAD', export_type: :tad_applications)
+  end
+
+  let!(:export_data_export) do
+    DataExporter.perform_async(DataAPI::TADExport, create_data_export.id)
+  end
+
   it_behaves_like 'a TAD API endpoint', '/'
 
-  it 'returns a list of data exports' do
-    create(:submitted_application_choice, :with_completed_application_form, status: 'rejected')
-
-    data_export = DataExport.create!(name: 'Daily export of applications for TAD')
-    DataExporter.perform_async(DataAPI::TADExport, data_export.id)
-
-    data_export = DataExport.create!(name: 'Daily export of applications for TAD')
-    DataExporter.perform_async(DataAPI::TADExport, data_export.id)
-
-    get_api_request '/data-api/tad-data-exports', token: tad_api_token
+  it 'allows access to the API for TAD users' do
+    get_api_request "/data-api/tad-data-exports?updated_since=#{CGI.escape(1.month.ago.iso8601)}", token: tad_api_token
 
     expect(response).to have_http_status(:success)
     expect(parsed_response).to be_valid_against_openapi_schema('TADDataExportList')
+  end
+
+  it 'returns a list of data exports' do
+    create(:submitted_application_choice, :with_completed_application_form)
+
+    create_data_export
+    export_data_export
+
+    get_api_request "/data-api/tad-data-exports?updated_since=#{CGI.escape(1.day.ago.iso8601)}", token: tad_api_token
+
+    expect(response).to have_http_status(:success)
+    expect(parsed_response).to be_valid_against_openapi_schema('TADDataExportList')
+  end
+
+  it 'returns data exports response JSON values as expected' do
+    create(:submitted_application_choice, :with_completed_application_form)
+
+    data_export = create_data_export
+    export_data_export
+
+    data_export = DataExport.find(data_export.id)
+
+    get_api_request "/data-api/tad-data-exports?updated_since=#{CGI.escape(1.day.ago.iso8601)}", token: tad_api_token
+
+    response_data = parsed_response.dig('data', 0)
+
+    expect(response_data['export_date'].to_time.iso8601).to eq(data_export.completed_at.iso8601)
+    expect(response_data['description']).to eq(data_export.name)
+    expect(response_data['url']).to eq(data_api_tad_export_url(data_export.id))
+    expect(response_data['updated_at'].to_time.iso8601).to eq(data_export.updated_at.iso8601)
+  end
+
+  it 'returns data exports filtered by `updated_since`' do
+    Timecop.travel(2.days.ago) do
+      create(:submitted_application_choice, :with_completed_application_form)
+      create_data_export
+      export_data_export
+    end
+
+    create(:submitted_application_choice, :with_completed_application_form)
+
+    create_data_export
+    export_data_export
+
+    get_api_request "/data-api/tad-data-exports?updated_since=#{CGI.escape(1.day.ago.iso8601)}", token: tad_api_token
+
+    expect(parsed_response['data'].size).to eq(1)
+    expect(response).to have_http_status(:success)
+  end
+
+  it 'returns an error if the `updated_since` parameter is missing' do
+    get_api_request '/data-api/tad-data-exports', token: tad_api_token
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(error_response['message']).to eql('param is missing or the value is empty: updated_since')
+    expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse')
+  end
+
+  it 'returns HTTP status 422 given an unparseable `updated_since` date value' do
+    get_api_request '/data-api/tad-data-exports?updated_since=17/07/2020T12:00:42Z', token: tad_api_token
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): updated_since')
+    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
+  end
+
+  it 'returns HTTP status 422 when encountering a KeyError from ActiveSupport::TimeZone' do
+    get_api_request '/data-api/tad-data-exports?updated_since=12936', token: tad_api_token
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): updated_since')
+    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
   end
 end

--- a/spec/support/data_api/data_api_spec_helper.rb
+++ b/spec/support/data_api/data_api_spec_helper.rb
@@ -17,6 +17,10 @@ module DataAPISpecHelper
     JSON.parse(response.body)
   end
 
+  def error_response
+    parsed_response['errors'].first
+  end
+
   def be_valid_against_openapi_schema(expected)
     ValidAgainstOpenAPISchemaMatcher.new(expected, DataAPISpecification.as_hash)
   end


### PR DESCRIPTION
## Context

There was a need to add required updated_since param in order to limit request/response to avoid `/tad-data-exports` endpoint timing out.

## Changes proposed in this pull request
Largely follows candidate api implementation:
* Exports returned are filtered by updated_since param
* Update `data-api` YML
* Update specs to cover edge cases/errors and verify correct JSON is returned

## Guidance to review
Use Postman and/or check the request specs

## Link to Trello card
https://trello.com/c/FY3XWtd6/4311-the-tad-data-api-times-out-when-requesting-a-list-of-reports

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
