### PR TITLE
Move application choice includes to application data concerns

### DIFF
--- a/app/controllers/concerns/vendor_api/application_data_concerns.rb
+++ b/app/controllers/concerns/vendor_api/application_data_concerns.rb
@@ -18,7 +18,7 @@ module VendorAPI
       %({"data":#{ApplicationPresenter.new(version_number, application_choice).serialized_json}})
     end
 
-    def application_choices_visible_to_provider(includes = nil)
+    def application_choices_visible_to_provider(includes = include_properties)
       options = { providers: [current_provider],
                   exclude_deferrals: exclude_deferrals }
       options.merge!(includes: includes) if includes.present?
@@ -28,6 +28,15 @@ module VendorAPI
 
     def exclude_deferrals
       full_api_version_number.eql?(VendorAPI::PRELIMINARY_VERSION)
+    end
+
+    def include_properties
+      [
+        offer: %i[conditions],
+        application_form: %i[candidate application_qualifications application_references application_work_experiences application_work_history_breaks application_volunteering_experiences english_proficiency],
+        course_option: [{ course: %i[provider] }, :site],
+        current_course_option: [{ course: %i[provider] }, :site],
+      ]
     end
   end
 end

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -21,20 +21,11 @@ module VendorAPI
     end
 
     def get_application_choices_for_provider_since(since:)
-      application_choices_visible_to_provider(include_properties)
+      application_choices_visible_to_provider
         .where('application_choices.updated_at > ?', since)
         .find_each(batch_size: 500)
         .sort_by(&:updated_at)
         .reverse
-    end
-
-    def include_properties
-      [
-        offer: %i[conditions],
-        application_form: %i[candidate application_qualifications application_references application_work_experiences application_work_history_breaks application_volunteering_experiences english_proficiency],
-        course_option: [{ course: %i[provider] }, :site],
-        current_course_option: [{ course: %i[provider] }, :site],
-      ]
     end
 
     def since_param

--- a/spec/controllers/concerns/vendor_api/application_data_concerns_spec.rb
+++ b/spec/controllers/concerns/vendor_api/application_data_concerns_spec.rb
@@ -4,6 +4,15 @@ RSpec.describe VendorAPI::ApplicationDataConcerns do
 
   let(:provider) { build(:provider) }
 
+  let(:include_properties) do
+    [
+      offer: %i[conditions],
+      application_form: %i[candidate application_qualifications application_references application_work_experiences application_work_history_breaks application_volunteering_experiences english_proficiency],
+      course_option: [{ course: %i[provider] }, :site],
+      current_course_option: [{ course: %i[provider] }, :site],
+    ]
+  end
+
   describe '#application_choices_visible_to_provider' do
     before do
       allow(GetApplicationChoicesForProviders).to receive(:call)
@@ -16,7 +25,7 @@ RSpec.describe VendorAPI::ApplicationDataConcerns do
         application_data_concerns.send(:application_choices_visible_to_provider)
 
         expect(GetApplicationChoicesForProviders)
-          .to have_received(:call).with(providers: [provider], exclude_deferrals: true)
+          .to have_received(:call).with(providers: [provider], exclude_deferrals: true, includes: include_properties)
       end
     end
 
@@ -27,7 +36,7 @@ RSpec.describe VendorAPI::ApplicationDataConcerns do
         application_data_concerns.send(:application_choices_visible_to_provider)
 
         expect(GetApplicationChoicesForProviders)
-          .to have_received(:call).with(providers: [provider], exclude_deferrals: true)
+          .to have_received(:call).with(providers: [provider], exclude_deferrals: true, includes: include_properties)
       end
     end
 
@@ -38,7 +47,7 @@ RSpec.describe VendorAPI::ApplicationDataConcerns do
         application_data_concerns.send(:application_choices_visible_to_provider)
 
         expect(GetApplicationChoicesForProviders)
-          .to have_received(:call).with(providers: [provider], exclude_deferrals: false)
+          .to have_received(:call).with(providers: [provider], exclude_deferrals: false, includes: include_properties)
       end
     end
   end


### PR DESCRIPTION
## Context

https://github.com/DFE-Digital/apply-for-teacher-training/pull/6387 adds interviews to the includes section. It's probably better if these includes are always used by default, even for a single application choice (e.g. `render_application`)

## Changes proposed in this pull request

Quick refactor, no visible changes.

## Guidance to review

Do the tests pass?

## Link to Trello card

https://trello.com/c/wscdvugg

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
