### PR TITLE
Unblock submissions if they weren't blocked deliberately

### DIFF
--- a/app/services/data_migrations/fixup_candidates_submission_blocked.rb
+++ b/app/services/data_migrations/fixup_candidates_submission_blocked.rb
@@ -1,0 +1,14 @@
+module DataMigrations
+  class FixupCandidatesSubmissionBlocked
+    TIMESTAMP = 20220125163203
+    MANUAL_RUN = false
+
+    def change
+      FraudMatch.all.each do |fraud_match|
+        fraud_match.candidates.each do |candidate|
+          candidate.update(submission_blocked: false) unless fraud_match.blocked?
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::FixupCandidatesSubmissionBlocked',
   'DataMigrations::BackfillWithdrawnOrDeclinedForCandidateByProvider',
   'DataMigrations::BackfillUserColumnsOnNotes',
   'DataMigrations::RemoveDuplicateProvider',

--- a/spec/services/data_migrations/fixup_candidates_submission_blocked_spec.rb
+++ b/spec/services/data_migrations/fixup_candidates_submission_blocked_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::FixupCandidatesSubmissionBlocked do
+  before do
+    @candidate_one = create(:candidate, submission_blocked: true)
+    @candidate_two = create(:candidate, submission_blocked: true)
+
+    @fraud_match_one = create(:fraud_match, candidates: [@candidate_one, @candidate_two], blocked: true)
+
+    @candidate_third = create(:candidate, submission_blocked: true)
+    @candidate_fourth = create(:candidate, submission_blocked: true)
+
+    @fraud_match_two = create(:fraud_match, candidates: [@candidate_third, @candidate_fourth], blocked: false)
+  end
+
+  it 'updates blocked submissions as false if they were not blocked deliberately' do
+    described_class.new.change
+    expect(@candidate_one.reload).to be_submission_blocked
+    expect(@candidate_two.reload).to be_submission_blocked
+
+    expect(@candidate_third.reload).not_to be_submission_blocked
+    expect(@candidate_fourth.reload).not_to be_submission_blocked
+  end
+end


### PR DESCRIPTION
## Context

Because of the new duplicate matching issues, we had to turn off the
feature flag and end up having many candidates with submissions blocked
that should be unblocked.

## Link to Trello card

https://trello.com/c/EIEFGwJS/4379-unblock-submissions-that-werent-blocked-deliberately

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
