### PR TITLE
Refactor duplicate request specs

### DIFF
--- a/config/data-api.yml
+++ b/config/data-api.yml
@@ -170,6 +170,48 @@ components:
           format: date-time
           description: Time of last change
           example: 2021-05-20T12:34:00Z
+    UnauthorizedResponse:
+      type: object
+      required:
+      - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: Unauthorized
+            message: Please provide a valid authentication token
+    ParameterMissingResponse:
+      type: object
+      required:
+      - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: ParameterMissing
+            message: "param is missing or the value is empty: updated_since"
+    ParameterInvalidResponse:
+      type: object
+      required:
+      - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: ParameterInvalid
+            message: "Parameter is invalid: updated_since"
     ParameterInvalidResponse:
       type: object
       required:

--- a/spec/requests/candidate_api/get_candidates_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'GET /candidate-api/candidates', type: :request do
   include CandidateAPISpecHelper
 
-  it_behaves_like 'an index API endpoint', '/candidate-api/candidates', 'updated_since', ServiceAPIUser.candidate_user.create_magic_link_token!
+  it_behaves_like 'an API endpoint requiring a date param', '/candidate-api/candidates', 'updated_since', ServiceAPIUser.candidate_user.create_magic_link_token!
 
   it 'does not allow access to the API from other data users' do
     api_token = ServiceAPIUser.test_data_user.create_magic_link_token!

--- a/spec/requests/candidate_api/get_candidates_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe 'GET /candidate-api/candidates', type: :request do
   include CandidateAPISpecHelper
 
+  it_behaves_like 'an index API endpoint', '/candidate-api/candidates', 'updated_since', ServiceAPIUser.candidate_user.create_magic_link_token!
+
   it 'does not allow access to the API from other data users' do
     api_token = ServiceAPIUser.test_data_user.create_magic_link_token!
     get_api_request "/candidate-api/candidates?updated_since=#{CGI.escape(1.month.ago.iso8601)}", token: api_token
@@ -145,44 +147,6 @@ RSpec.describe 'GET /candidate-api/candidates', type: :request do
 
     expect(response).to have_http_status(:ok)
     expect(response.headers['page-items']).to eq '20'
-  end
-
-  it 'returns an error if the token is incorrect' do
-    get "/candidate-api/candidates?updated_since=#{CGI.escape(1.day.ago.iso8601)}", headers: { Authorization: 'invalid-token' }
-
-    expect(response).to have_http_status(:unauthorized)
-    expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
-  end
-
-  it 'returns an error if no API token is present' do
-    get "/candidate-api/candidates?updated_since=#{CGI.escape(1.day.ago.iso8601)}", headers: { Authorization: nil }
-
-    expect(response).to have_http_status(:unauthorized)
-    expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
-  end
-
-  it 'returns HTTP status 422 given an unparseable `updated_since` date value' do
-    get_api_request '/candidate-api/candidates?updated_since=17/07/2020T12:00:42Z', token: candidate_api_token
-
-    expect(response).to have_http_status(:unprocessable_entity)
-    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): updated_since')
-    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
-  end
-
-  it 'returns HTTP status 422 when encountering a KeyError from ActiveSupport::TimeZone' do
-    get_api_request '/candidate-api/candidates?updated_since=12936', token: candidate_api_token
-
-    expect(response).to have_http_status(:unprocessable_entity)
-    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): updated_since')
-    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
-  end
-
-  it 'returns HTTP status 422 given a parseable but nonsensensical `updated_since` date value' do
-    get_api_request '/candidate-api/candidates?updated_since=-004713-03-23T11:52:19.448Z', token: candidate_api_token
-
-    expect(response).to have_http_status(:unprocessable_entity)
-    expect(error_response['message']).to eql('Parameter is invalid (date is nonsense): updated_since')
-    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
   end
 
   it 'returns HTTP status 422 when given a parseable page value that exceeds the range' do

--- a/spec/requests/data_api/tad_exports_spec.rb
+++ b/spec/requests/data_api/tad_exports_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'GET /data-api/tad-data-exports', type: :request, sidekiq: true do
   include DataAPISpecHelper
 
-  it_behaves_like 'an index API endpoint', '/data-api/tad-data-exports', 'updated_since', ServiceAPIUser.tad_user.create_magic_link_token!
+  it_behaves_like 'an API endpoint requiring a date param', '/data-api/tad-data-exports', 'updated_since', ServiceAPIUser.tad_user.create_magic_link_token!
 
   it 'allows access to the API for TAD users' do
     get_api_request "/data-api/tad-data-exports?updated_since=#{CGI.escape(1.month.ago.iso8601)}", token: tad_api_token

--- a/spec/requests/data_api/tad_exports_spec.rb
+++ b/spec/requests/data_api/tad_exports_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'GET /data-api/tad-data-exports', type: :request, sidekiq: true do
   include DataAPISpecHelper
 
-  it_behaves_like 'a TAD API endpoint', '/'
+  it_behaves_like 'an index API endpoint', '/data-api/tad-data-exports', 'updated_since', ServiceAPIUser.tad_user.create_magic_link_token!
 
   it 'allows access to the API for TAD users' do
     get_api_request "/data-api/tad-data-exports?updated_since=#{CGI.escape(1.month.ago.iso8601)}", token: tad_api_token
@@ -55,29 +55,5 @@ RSpec.describe 'GET /data-api/tad-data-exports', type: :request, sidekiq: true d
       expect(response).to have_http_status(:success)
       expect(parsed_response).to be_valid_against_openapi_schema('TADDataExportList')
     end
-  end
-
-  it 'returns an error if the `updated_since` parameter is missing' do
-    get_api_request '/data-api/tad-data-exports', token: tad_api_token
-
-    expect(response).to have_http_status(:unprocessable_entity)
-    expect(error_response['message']).to eql('param is missing or the value is empty: updated_since')
-    expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse')
-  end
-
-  it 'returns HTTP status 422 given an unparseable `updated_since` date value' do
-    get_api_request '/data-api/tad-data-exports?updated_since=17/07/2020T12:00:42Z', token: tad_api_token
-
-    expect(response).to have_http_status(:unprocessable_entity)
-    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): updated_since')
-    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
-  end
-
-  it 'returns HTTP status 422 when encountering a KeyError from ActiveSupport::TimeZone' do
-    get_api_request '/data-api/tad-data-exports?updated_since=12936', token: tad_api_token
-
-    expect(response).to have_http_status(:unprocessable_entity)
-    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): updated_since')
-    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
   end
 end

--- a/spec/support/data_api/shared_examples.rb
+++ b/spec/support/data_api/shared_examples.rb
@@ -3,5 +3,6 @@ RSpec.shared_examples 'a TAD API endpoint' do |path|
     get_api_request "/data-api/tad-data-exports#{path}", token: nil
 
     expect(response).to have_http_status(:unauthorized)
+    expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
   end
 end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,0 +1,39 @@
+RSpec.shared_examples 'an index API endpoint' do |path, date_param, api_token|
+  it 'returns an error if the token is incorrect' do
+    get "#{path}?#{date_param}=#{CGI.escape(1.day.ago.iso8601)}", headers: { Authorization: 'invalid-token' }
+
+    expect(response).to have_http_status(:unauthorized)
+    expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
+  end
+
+  it 'returns an error if no API token is present' do
+    get "#{path}?#{date_param}=#{CGI.escape(1.day.ago.iso8601)}", headers: { Authorization: nil }
+
+    expect(response).to have_http_status(:unauthorized)
+    expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
+  end
+
+  it "returns an error if the #{date_param} parameter is missing" do
+    get_api_request path, token: api_token
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(error_response['message']).to eql('param is missing or the value is empty: updated_since')
+    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
+  end
+
+  it "returns HTTP status 422 given an unparseable #{date_param} date value" do
+    get_api_request "#{path}?#{date_param}=17/07/2020T12:00:42Z", token: api_token
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): updated_since')
+    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
+  end
+
+  it 'returns HTTP status 422 when encountering a KeyError from ActiveSupport::TimeZone' do
+    get_api_request "#{path}?#{date_param}=12936", token: api_token
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): updated_since')
+    expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
+  end
+end

--- a/spec/support/shared_examples/an_api_endpoint_requiring_a_date_param.rb
+++ b/spec/support/shared_examples/an_api_endpoint_requiring_a_date_param.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples 'an index API endpoint' do |path, date_param, api_token|
+RSpec.shared_examples 'an API endpoint requiring a date param' do |path, date_param, api_token|
   it 'returns an error if the token is incorrect' do
     get "#{path}?#{date_param}=#{CGI.escape(1.day.ago.iso8601)}", headers: { Authorization: 'invalid-token' }
 


### PR DESCRIPTION
## Context

There were duplicate request specs across Candidate API + Data API 
Similar request specs in vendor API + register api were slightly different so left unchanged

## Changes proposed in this pull request
* Use of shared examples to reduce duplication

## Guidance to review

Verify correct behaviour of shared examples vs existing tests

## Link to Trello card

https://trello.com/c/GP7xlTKd/4376-refactor-duplicate-request-specs

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
