### PR TITLE
Fix for duplicate matches with one candidate

### DIFF
--- a/app/models/fraud_match.rb
+++ b/app/models/fraud_match.rb
@@ -2,4 +2,14 @@ class FraudMatch < ApplicationRecord
   audited
 
   has_many :candidates
+
+  def self.match_for(last_name:, postcode:, date_of_birth:)
+    FraudMatch.where(
+      'TRIM(UPPER(last_name)) = ?',
+      last_name.upcase.strip,
+    ).where(
+      "REPLACE(UPPER(postcode), ' ', '') = ?",
+      postcode.upcase.gsub(' ', ''),
+    ).where(date_of_birth: date_of_birth).first
+  end
 end

--- a/app/services/data_migrations/fixup_single_candidate_duplicate_matches.rb
+++ b/app/services/data_migrations/fixup_single_candidate_duplicate_matches.rb
@@ -30,10 +30,10 @@ module DataMigrations
         fraud_matches = FraudMatch.where(id: result['fraud_match_ids'])
         first_fraud_match = fraud_matches.first
         all_candidates = fraud_matches.inject([]) { |candidates, fraud_match| candidates + fraud_match.candidates }
-        puts "Adding candidates #{all_candidates.map(&:id)} to fraud match #{first_fraud_match.id}"
+        Rails.logger.debug { "Adding candidates #{all_candidates.map(&:id)} to fraud match #{first_fraud_match.id}" }
         fraud_matches
           .reject { |fraud_match| fraud_match.id == first_fraud_match.id }
-          .each { |fraud_match| puts "Delete fraud match #{fraud_match.id}" }
+          .each { |fraud_match| Rails.logger.debug "Delete fraud match #{fraud_match.id}" }
       end
     end
   end

--- a/app/services/data_migrations/fixup_single_candidate_duplicate_matches.rb
+++ b/app/services/data_migrations/fixup_single_candidate_duplicate_matches.rb
@@ -1,0 +1,26 @@
+module DataMigrations
+  class FixupSingleCandidateDuplicateMatches
+    TIMESTAMP = 20220125153152
+    MANUAL_RUN = true
+
+    FIND_DUPLICATE_FRAUD_MATCHES =
+      "select count(*), TRIM(UPPER(last_name)) as last_name, REPLACE(UPPER(postcode), ' ', '') as postcode, date_of_birth, array_agg(id) as fraud_match_ids
+      from fraud_matches
+      group by TRIM(UPPER(last_name)), REPLACE(UPPER(postcode), ' ', ''), date_of_birth
+      having count(*) > 1;".freeze
+
+    def change
+      results = ActiveRecord::Base.connection.execute(FIND_DUPLICATE_FRAUD_MATCHES)
+      results.type_map = PG::BasicTypeMapForResults.new(ActiveRecord::Base.connection.raw_connection)
+      results.each do |result|
+        fraud_matches = FraudMatch.where(id: result['fraud_match_ids'])
+        first_fraud_match = fraud_matches.first
+        all_candidates = fraud_matches.inject([]) { |candidates, fraud_match| candidates + fraud_match.candidates }
+        first_fraud_match.update(candidates: all_candidates)
+        fraud_matches
+          .reject { |fraud_match| fraud_match.id == first_fraud_match.id }
+          .each(&:destroy)
+      end
+    end
+  end
+end

--- a/app/services/data_migrations/fixup_single_candidate_duplicate_matches.rb
+++ b/app/services/data_migrations/fixup_single_candidate_duplicate_matches.rb
@@ -4,7 +4,7 @@ module DataMigrations
     MANUAL_RUN = true
 
     FIND_DUPLICATE_FRAUD_MATCHES =
-      "select count(*), TRIM(UPPER(last_name)) as last_name, REPLACE(UPPER(postcode), ' ', '') as postcode, date_of_birth, array_agg(id) as fraud_match_ids
+      "select count(*), TRIM(UPPER(last_name)) as last_name, REPLACE(UPPER(postcode), ' ', '') as postcode, date_of_birth, array_agg(id ORDER BY id) as fraud_match_ids
       from fraud_matches
       group by TRIM(UPPER(last_name)), REPLACE(UPPER(postcode), ' ', ''), date_of_birth
       having count(*) > 1;".freeze

--- a/app/services/update_duplicate_matches.rb
+++ b/app/services/update_duplicate_matches.rb
@@ -30,7 +30,14 @@ private
   end
 
   def create_or_update_fraud_match(match)
-    fraud_match = FraudMatch.find_by(last_name: match['last_name'], postcode: match['postcode'], date_of_birth: match['date_of_birth'])
+    fraud_match = FraudMatch.where(
+      'TRIM(UPPER(last_name)) = ?',
+      match['last_name'].upcase.strip,
+    ).where(
+      "REPLACE(UPPER(postcode), ' ', '') = ?",
+      match['postcode'].upcase.gsub(' ', ''),
+    ).where(date_of_birth: match['date_of_birth']).first
+
     candidate = Candidate.find(match['candidate_id'])
     if fraud_match.present?
       fraud_match.candidates << candidate unless fraud_match.candidates.include?(candidate)

--- a/app/services/update_duplicate_matches.rb
+++ b/app/services/update_duplicate_matches.rb
@@ -30,13 +30,11 @@ private
   end
 
   def create_or_update_fraud_match(match)
-    fraud_match = FraudMatch.where(
-      'TRIM(UPPER(last_name)) = ?',
-      match['last_name'].upcase.strip,
-    ).where(
-      "REPLACE(UPPER(postcode), ' ', '') = ?",
-      match['postcode'].upcase.gsub(' ', ''),
-    ).where(date_of_birth: match['date_of_birth']).first
+    fraud_match = FraudMatch.match_for(
+      last_name: match['last_name'],
+      postcode: match['postcode'],
+      date_of_birth: match['date_of_birth'],
+    )
 
     candidate = Candidate.find(match['candidate_id'])
     if fraud_match.present?

--- a/app/services/update_fraud_matches.rb
+++ b/app/services/update_fraud_matches.rb
@@ -5,7 +5,12 @@ class UpdateFraudMatches
 
   def save!
     @matches.each do |match|
-      fraud_match = FraudMatch.find_by(last_name: match['last_name'], postcode: match['postcode'], date_of_birth: match['date_of_birth'])
+      fraud_match = FraudMatch.match_for(
+        last_name: match['last_name'],
+        postcode: match['postcode'],
+        date_of_birth: match['date_of_birth'],
+      )
+
       candidate = Candidate.find(match['candidate_id'])
       if fraud_match.present?
         fraud_match.candidates << candidate unless fraud_match.candidates.include?(candidate)

--- a/spec/services/data_migrations/fixup_single_candidate_duplicate_matches_spec.rb
+++ b/spec/services/data_migrations/fixup_single_candidate_duplicate_matches_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe DataMigrations::FixupSingleCandidateDuplicateMatches do
 
   it 'fixes one single candidate and one double candidate fraud match that should have been one' do
     alice = create(:candidate, email_address: 'alice@example.com')
-    alices_application_form = create(
+    create(
       :application_form,
       :duplicate_candidates,
       candidate: alice,
@@ -138,7 +138,7 @@ RSpec.describe DataMigrations::FixupSingleCandidateDuplicateMatches do
 
   it 'ignores fraud matches with two candidates' do
     alice = create(:candidate, email_address: 'alice@example.com')
-    alices_application_form = create(
+    create(
       :application_form,
       :duplicate_candidates,
       candidate: alice,

--- a/spec/services/data_migrations/fixup_single_candidate_duplicate_matches_spec.rb
+++ b/spec/services/data_migrations/fixup_single_candidate_duplicate_matches_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::FixupSingleCandidateDuplicateMatches do
+  it 'fixes two single candidate fraud matches that should have been one' do
+    alice = create(:candidate, email_address: 'alice@example.com')
+    alices_application_form = create(
+      :application_form,
+      :duplicate_candidates,
+      candidate: alice,
+    )
+    create(
+      :fraud_match,
+      last_name: alices_application_form.last_name,
+      postcode: alices_application_form.postcode,
+      date_of_birth: alices_application_form.date_of_birth,
+      candidates: [alice],
+    )
+
+    bob = create(:candidate, email_address: 'bob@example.com')
+    bobs_application_form = create(
+      :application_form,
+      :duplicate_candidates,
+      last_name: " #{ApplicationForm.last.last_name.upcase} ",
+      postcode: "#{ApplicationForm.last.postcode.downcase} ",
+      candidate: bob,
+    )
+    create(
+      :fraud_match,
+      last_name: bobs_application_form.last_name,
+      postcode: bobs_application_form.postcode,
+      date_of_birth: bobs_application_form.date_of_birth,
+      candidates: [bob],
+    )
+
+    described_class.new.change
+
+    expect(FraudMatch.count).to be(1)
+    expect(FraudMatch.first.candidates).to match_array([bob, alice])
+  end
+end

--- a/spec/services/data_migrations/fixup_single_candidate_duplicate_matches_spec.rb
+++ b/spec/services/data_migrations/fixup_single_candidate_duplicate_matches_spec.rb
@@ -37,4 +37,33 @@ RSpec.describe DataMigrations::FixupSingleCandidateDuplicateMatches do
     expect(FraudMatch.count).to be(1)
     expect(FraudMatch.first.candidates).to match_array([bob, alice])
   end
+
+  it 'ignores fraud matches with two candidates' do
+    alice = create(:candidate, email_address: 'alice@example.com')
+    alices_application_form = create(
+      :application_form,
+      :duplicate_candidates,
+      candidate: alice,
+    )
+    bob = create(:candidate, email_address: 'bob@example.com')
+    bobs_application_form = create(
+      :application_form,
+      :duplicate_candidates,
+      last_name: " #{ApplicationForm.last.last_name.upcase} ",
+      postcode: "#{ApplicationForm.last.postcode.downcase} ",
+      candidate: bob,
+    )
+    fraud_match = create(
+      :fraud_match,
+      last_name: bobs_application_form.last_name,
+      postcode: bobs_application_form.postcode,
+      date_of_birth: bobs_application_form.date_of_birth,
+      candidates: [alice, bob],
+    )
+
+    described_class.new.change
+
+    expect(FraudMatch.count).to be(1)
+    expect(fraud_match.reload.candidates).to match_array([bob, alice])
+  end
 end

--- a/spec/services/data_migrations/fixup_single_candidate_duplicate_matches_spec.rb
+++ b/spec/services/data_migrations/fixup_single_candidate_duplicate_matches_spec.rb
@@ -38,6 +38,104 @@ RSpec.describe DataMigrations::FixupSingleCandidateDuplicateMatches do
     expect(FraudMatch.first.candidates).to match_array([bob, alice])
   end
 
+  it 'fixes three single candidate fraud matches that should have been one' do
+    alice = create(:candidate, email_address: 'alice@example.com')
+    alices_application_form = create(
+      :application_form,
+      :duplicate_candidates,
+      candidate: alice,
+    )
+    create(
+      :fraud_match,
+      last_name: alices_application_form.last_name,
+      postcode: alices_application_form.postcode,
+      date_of_birth: alices_application_form.date_of_birth,
+      candidates: [alice],
+    )
+
+    bob = create(:candidate, email_address: 'bob@example.com')
+    bobs_application_form = create(
+      :application_form,
+      :duplicate_candidates,
+      last_name: "#{ApplicationForm.last.last_name.upcase} ",
+      postcode: "#{ApplicationForm.last.postcode.downcase} ",
+      candidate: bob,
+    )
+    create(
+      :fraud_match,
+      last_name: bobs_application_form.last_name,
+      postcode: bobs_application_form.postcode,
+      date_of_birth: bobs_application_form.date_of_birth,
+      candidates: [bob],
+    )
+
+    jim = create(:candidate, email_address: 'jim@example.com')
+    jims_application_form = create(
+      :application_form,
+      :duplicate_candidates,
+      last_name: " #{ApplicationForm.last.last_name.upcase}",
+      postcode: " #{ApplicationForm.last.postcode.downcase}",
+      candidate: jim,
+    )
+    create(
+      :fraud_match,
+      last_name: jims_application_form.last_name,
+      postcode: jims_application_form.postcode,
+      date_of_birth: jims_application_form.date_of_birth,
+      candidates: [jim],
+    )
+
+    described_class.new.change
+
+    expect(FraudMatch.count).to be(1)
+    expect(FraudMatch.first.candidates).to match_array([jim, bob, alice])
+  end
+
+  it 'fixes one single candidate and one double candidate fraud match that should have been one' do
+    alice = create(:candidate, email_address: 'alice@example.com')
+    alices_application_form = create(
+      :application_form,
+      :duplicate_candidates,
+      candidate: alice,
+    )
+    bob = create(:candidate, email_address: 'bob@example.com')
+    bobs_application_form = create(
+      :application_form,
+      :duplicate_candidates,
+      last_name: " #{ApplicationForm.last.last_name.upcase} ",
+      postcode: "#{ApplicationForm.last.postcode.downcase} ",
+      candidate: bob,
+    )
+    create(
+      :fraud_match,
+      last_name: bobs_application_form.last_name,
+      postcode: bobs_application_form.postcode,
+      date_of_birth: bobs_application_form.date_of_birth,
+      candidates: [alice, bob],
+    )
+
+    jim = create(:candidate, email_address: 'jim@example.com')
+    jims_application_form = create(
+      :application_form,
+      :duplicate_candidates,
+      last_name: " #{ApplicationForm.last.last_name.upcase}",
+      postcode: " #{ApplicationForm.last.postcode.downcase}",
+      candidate: jim,
+    )
+    create(
+      :fraud_match,
+      last_name: jims_application_form.last_name,
+      postcode: jims_application_form.postcode,
+      date_of_birth: jims_application_form.date_of_birth,
+      candidates: [jim],
+    )
+
+    described_class.new.change
+
+    expect(FraudMatch.count).to be(1)
+    expect(FraudMatch.first.candidates).to match_array([jim, bob, alice])
+  end
+
   it 'ignores fraud matches with two candidates' do
     alice = create(:candidate, email_address: 'alice@example.com')
     alices_application_form = create(

--- a/spec/services/update_duplicate_matches_spec.rb
+++ b/spec/services/update_duplicate_matches_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe UpdateDuplicateMatches, sidekiq: true do
 
         match = FraudMatch.first
 
-        expect(match.candidates.count).to eql(3)
+        expect(match.candidates.count).to be(3)
         expect(match.candidates.third.email_address).to eq('exemplar3@example.com')
 
         expect(match.postcode).to eq('W6 9BH')
@@ -118,15 +118,15 @@ RSpec.describe UpdateDuplicateMatches, sidekiq: true do
         create(
           :application_form,
           :duplicate_candidates,
-          last_name: ' ' + ApplicationForm.last&.last_name.upcase + ' ',
-          postcode: ApplicationForm.last&.postcode.downcase + ' ',
+          last_name: " #{ApplicationForm.last.last_name.upcase} ",
+          postcode: "#{ApplicationForm.last.postcode.downcase} ",
           candidate: create(:candidate, email_address: 'exemplar3@example.com'),
         )
         described_class.new.save!
 
         match = FraudMatch.first
 
-        expect(match.candidates.count).to eql(3)
+        expect(match.candidates.count).to be(3)
         expect(match.candidates.third.email_address).to eq('exemplar3@example.com')
 
         expect(match.postcode).to eq('W6 9BH')


### PR DESCRIPTION
## Context

This PR adds a fix for some single-candidate duplicate matches that have been introduced since https://github.com/DFE-Digital/apply-for-teacher-training/pull/6311

These matches should be grouped together rather than appearing as single candidate items in the list of duplicate matches. This is happening because the logic to determine whether we need to insert a new or update an existing fraud match in `UpdateDuplicateMatches` did not take into account the new inexact `postcode` and `last_name` matching strategy. So we have been unnecessarily adding new fraud matches.

## Changes proposed in this pull request

- [x] Fix the logic in `UpdateDuplicateMatches`
- [x] Add a data migration to fix-up the existing single candidate fraud matches.

## Guidance to review



## Link to Trello card

https://trello.com/c/yyuNTrTG/4372-duplicate-matches-with-one-candidate

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
