### PR TITLE
Only sends duplicate match emails if new match or new candidate

### DIFF
--- a/spec/services/update_duplicate_matches_spec.rb
+++ b/spec/services/update_duplicate_matches_spec.rb
@@ -42,16 +42,6 @@ RSpec.describe UpdateDuplicateMatches, sidekiq: true do
         expect(candidate2.reload.submission_blocked).to be(true)
       end
 
-      it 'sends an email to each candidate' do
-        expect { described_class.new.save! }.to change { ActionMailer::Base.deliveries.count }.by(2)
-        expect(ActionMailer::Base.deliveries.map(&:to)).to match_array(
-          [
-            ['exemplar1@example.com'],
-            ['exemplar2@example.com'],
-          ],
-        )
-      end
-
       it 'sends a slack message' do
         application_form1 = create(:application_form, :duplicate_candidates, submitted_at: Time.zone.now)
         application_form2 = create(:application_form, :duplicate_candidates)
@@ -97,8 +87,8 @@ RSpec.describe UpdateDuplicateMatches, sidekiq: true do
         expect(candidate2.reload.submission_blocked).to be(true)
       end
 
-      it 'sends an email to each candidate' do
-        expect { described_class.new.save! }.to change { ActionMailer::Base.deliveries.count }.by(2)
+      it 'sends email to candidate from a new match or newly candidate to an existing match' do
+        expect { 2.times { described_class.new.save! } }.to change { ActionMailer::Base.deliveries.count }.by(2)
         expect(ActionMailer::Base.deliveries.map(&:to)).to match_array(
           [
             ['exemplar1@example.com'],


### PR DESCRIPTION
## Context

Before it was sending emails to everyone again and again.
This PR address the issue.

## Changes proposed in this pull request

The duplicate match email that should be sent to the candidates we will send only if:

1. More candidate matches are detected for the same match (e.g it was 2 candidates and now it is 3)
2. A new match is created

## Link to Trello card

https://trello.com/c/ret3TvOh/4371-dont-send-repetitive-emails-of-duplicate-matches

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
