### PR TITLE
Add create/update/cancel interview endpoints to API v1.1

### DIFF
--- a/app/controllers/vendor_api/interviews_controller.rb
+++ b/app/controllers/vendor_api/interviews_controller.rb
@@ -1,0 +1,68 @@
+module VendorAPI
+  class InterviewsController < VendorAPIController
+    include ApplicationDataConcerns
+    include APIValidationsAndErrorHandling
+
+    def create
+      CreateInterview.new(
+        actor: audit_user,
+        application_choice: application_choice,
+        provider: provider_for_interview,
+        date_and_time: interview_params[:date_and_time],
+        location: interview_params[:location],
+        additional_details: interview_params[:additional_details],
+      ).save!
+
+      render_application
+    end
+
+    def update
+      UpdateInterview.new(
+        actor: audit_user,
+        interview: existing_interview,
+        provider: provider_for_interview,
+        date_and_time: interview_params[:date_and_time],
+        location: interview_params[:location],
+        additional_details: interview_params[:additional_details],
+      ).save!
+
+      render_application
+    end
+
+    def cancel
+      CancelInterview.new(
+        actor: audit_user,
+        application_choice: application_choice,
+        interview: existing_interview,
+        cancellation_reason: cancel_interview_params[:reason],
+      ).save!
+
+      render_application
+    end
+
+  private
+
+    def provider_for_interview
+      Provider.find_by(code: interview_params[:provider_code])
+    end
+
+    def existing_interview
+      application_choice.interviews.find params[:interview_id]
+    end
+
+    def interview_params
+      params.require(:data).permit(
+        :provider_code,
+        :date_and_time,
+        :location,
+        :additional_details,
+      ) || {}
+    end
+
+    def cancel_interview_params
+      params.require(:data).permit(
+        :reason,
+      ) || {}
+    end
+  end
+end

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -24,10 +24,13 @@ module VendorAPI
     ],
     '1.1' => [
       Changes::DeferAnOffer,
-      Changes::AddInterviewsToApplication,
       Changes::CreateNote,
       Changes::NotesForApplication,
       Changes::WithdrawOrDeclineApplication,
+      Changes::AddInterviewsToApplication,
+      Changes::CreateInterview,
+      Changes::UpdateInterview,
+      Changes::CancelInterview,
     ],
   }.freeze
 end

--- a/app/lib/vendor_api/changes/cancel_interview.rb
+++ b/app/lib/vendor_api/changes/cancel_interview.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  module Changes
+    class CancelInterview < VersionChange
+      description 'Cancel interviews via the API.'
+
+      action InterviewsController, :cancel
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/create_interview.rb
+++ b/app/lib/vendor_api/changes/create_interview.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  module Changes
+    class CreateInterview < VersionChange
+      description 'Create interviews via the API.'
+
+      action InterviewsController, :create
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/update_interview.rb
+++ b/app/lib/vendor_api/changes/update_interview.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  module Changes
+    class UpdateInterview < VersionChange
+      description 'Update interviews via the API.'
+
+      action InterviewsController, :update
+    end
+  end
+end

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -72,8 +72,9 @@ class ProviderAuthorisation
     course_associated_with_user_providers?(course: course)
 
     add_error(:set_up_interviews, :requires_provider_user_permission) unless
-    user_level_can?(permission: :set_up_interviews, provider: course.provider) ||
-    user_level_can?(permission: :set_up_interviews, provider: course.accredited_provider)
+      @actor.is_a?(VendorApiUser) ||
+      user_level_can?(permission: :set_up_interviews, provider: course.provider) ||
+      user_level_can?(permission: :set_up_interviews, provider: course.accredited_provider)
 
     errors.blank?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -633,6 +633,10 @@ Rails.application.routes.draw do
       post '/withdraw' => 'withdraw_or_decline_offer#create'
 
       resource :deferred_offer, only: :create, path: 'defer-offer'
+
+      post '/interviews/create' => 'interviews#create', as: :interviews_create
+      post '/interviews/:interview_id/update' => 'interviews#update', as: :interviews_update
+      post '/interviews/:interview_id/cancel' => 'interviews#cancel', as: :interviews_cancel
     end
 
     post '/test-data/regenerate' => 'test_data#regenerate'

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -43,7 +43,7 @@ FactoryBot.define do
 
       after(:build) do |application_choice, _evaluator|
         application_choice.status = :interviewing
-        application_choice.interviews << build(:interview, provider: application_choice.current_provider)
+        application_choice.interviews << build(:interview, provider: application_choice.current_course_option.provider)
       end
     end
 
@@ -52,7 +52,7 @@ FactoryBot.define do
 
       after(:build) do |application_choice, _evaluator|
         application_choice.status = :awaiting_provider_decision
-        application_choice.interviews << build(:interview, :cancelled, provider: application_choice.current_provider)
+        application_choice.interviews << build(:interview, :cancelled, provider: application_choice.current_course_option.provider)
       end
     end
 

--- a/spec/requests/vendor_api/v1.1/get_single_application_spec.rb
+++ b/spec/requests/vendor_api/v1.1/get_single_application_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Vendor API - GET /api/v1.1/applications/:application_id', type: 
   end
 
   it 'returns a response that is valid according to the OpenAPI schema' do
-    skip 'depends on validation versions spike'
+    skip 'Depends on validation versions spike'
 
     application_choice = create_application_choice_for_currently_authenticated_provider(
       status: 'awaiting_provider_decision',

--- a/spec/requests/vendor_api/v1.1/post_cancel_interview_spec.rb
+++ b/spec/requests/vendor_api/v1.1/post_cancel_interview_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/interviews/:interview_id/cancel', type: :request do
+  include VendorAPISpecHelpers
+
+  let(:application_choice) do
+    create_application_choice_for_currently_authenticated_provider({}, :with_scheduled_interview)
+  end
+
+  let(:interview) { application_choice.interviews.first }
+
+  before do
+    stub_const('VendorAPI::VERSION', '1.1')
+  end
+
+  def post_cancellation!(reason:, skip_schema_check: false)
+    request_body = { data: { reason: reason } }
+    expect(request_body[:data]).to be_valid_against_openapi_schema('CancelInterview', '1.1') \
+      unless skip_schema_check
+
+    post_api_request "/api/v1.1/applications/#{application_choice.id}/interviews/#{interview.id}/cancel", params: request_body
+  end
+
+  describe 'cancel interview' do
+    context 'in the future' do
+      it 'succeeds and renders a SingleApplicationResponse' do
+        post_cancellation! reason: 'A reason'
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response['data']['attributes']['interviews'].first['cancelled_at']).not_to be_nil
+        expect(parsed_response['data']['attributes']['interviews'].first['cancellation_reason']).to eq('A reason')
+        # expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse', '1.1')
+      end
+    end
+
+    context 'reason too long' do
+      it 'fails and renders an Unprocessable Entity error' do
+        skip 'Depends on interview validations work'
+
+        post_cancellation! reason: 'A' * 2001, skip_schema_check: true
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+        expect(parsed_response['errors'].map { |error| error['message'] })
+          .to contain_exactly('Too long.')
+      end
+    end
+
+    context 'in the past' do
+      it 'fails and renders an Unprocessable Entity error' do
+        skip 'Depends on interview validations work'
+
+        application_choice.interviews.first.update_columns(date_and_time: 1.day.ago)
+
+        post_cancellation! reason: 'A reason'
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+        expect(parsed_response['errors'].map { |error| error['message'] })
+          .to contain_exactly("It's not possible to cancel an interview in the past.")
+      end
+    end
+
+    context 'already cancelled' do
+      let(:application_choice) do
+        create_application_choice_for_currently_authenticated_provider({}, :with_cancellation_interview)
+      end
+
+      it 'fails and renders an Unprocessable Entity error' do
+        skip 'Depends on interview validations work'
+
+        post_cancellation! reason: 'A reason'
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+        expect(parsed_response['errors'].map { |error| error['message'] })
+          .to contain_exactly("It's not possible to cancel an interview already cancelled.")
+      end
+    end
+
+    context 'wrong api key' do
+      let(:provider) { create(:provider) }
+      let(:api_token) { VendorAPIToken.create_with_random_token!(provider: provider) }
+
+      it 'fails and renders an Not Found response' do
+        post_cancellation! reason: 'A reason'
+
+        expect(response).to have_http_status(:not_found)
+        expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
+        expect(parsed_response['errors'].map { |error| error['message'] })
+          .to contain_exactly('Unable to find Application(s)')
+      end
+    end
+  end
+end

--- a/spec/requests/vendor_api/v1.1/post_create_interview_spec.rb
+++ b/spec/requests/vendor_api/v1.1/post_create_interview_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/interviews/create', type: :request do
+  include VendorAPISpecHelpers
+
+  let(:application_choice) do
+    create_application_choice_for_currently_authenticated_provider(status: 'awaiting_provider_decision')
+  end
+
+  before do
+    stub_const('VendorAPI::VERSION', '1.1')
+  end
+
+  def post_interview!(params:)
+    request_body = { data: params }
+    expect(request_body[:data]).to be_valid_against_openapi_schema('CreateInterview', '1.1')
+
+    post_api_request "/api/v1.1/applications/#{application_choice.id}/interviews/create", params: request_body
+  end
+
+  describe 'create interview' do
+    context 'in the future' do
+      let(:create_interview_params) do
+        {
+          provider_code: currently_authenticated_provider.code,
+          date_and_time: 1.day.from_now.iso8601,
+          location: 'Zoom call',
+          additional_details: 'Candidate requires assistance',
+        }
+      end
+
+      it 'succeeds and renders a SingleApplicationResponse' do
+        post_interview! params: create_interview_params
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response['data']['attributes']['interviews'].count).to eq(1)
+        # expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse', '1.1')
+      end
+    end
+
+    context 'in the past' do
+      let(:create_interview_params) do
+        {
+          provider_code: currently_authenticated_provider.code,
+          date_and_time: 1.day.ago.iso8601,
+          location: 'Zoom call',
+          additional_details: 'This should fail',
+        }
+      end
+
+      it 'fails and renders an Unprocessable Entity error' do
+        skip 'Depends on interview validations work'
+
+        post_interview! params: create_interview_params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+        expect(parsed_response['errors'].map { |error| error['message'] })
+          .to contain_exactly("It's not possible to schedule an interview in the past.")
+      end
+    end
+
+    context 'wrong provider code' do
+      let(:create_interview_params) do
+        {
+          provider_code: create(:provider).code,
+          date_and_time: 1.day.from_now.iso8601,
+          location: 'Zoom call',
+          additional_details: 'This should fail',
+        }
+      end
+
+      it 'fails and renders an Unprocessable Entity error' do
+        skip 'Depends on interview validations work'
+
+        post_interview! params: create_interview_params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+        expect(parsed_response['errors'].map { |error| error['message'] })
+          .to contain_exactly('Provider code must correspond to training or ratifying provider for the course.')
+      end
+    end
+
+    context 'wrong api key' do
+      let(:create_interview_params) do
+        {
+          provider_code: provider.code,
+          date_and_time: 1.day.from_now.iso8601,
+          location: 'Zoom call',
+          additional_details: 'This should fail',
+        }
+      end
+      let(:provider) { create(:provider) }
+      let(:api_token) { VendorAPIToken.create_with_random_token!(provider: provider) }
+
+      it 'fails and renders an Not Found response' do
+        post_interview! params: create_interview_params
+
+        expect(response).to have_http_status(:not_found)
+        expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
+        expect(parsed_response['errors'].map { |error| error['message'] })
+          .to contain_exactly('Unable to find Application(s)')
+      end
+    end
+  end
+end

--- a/spec/requests/vendor_api/v1.1/post_update_interview_spec.rb
+++ b/spec/requests/vendor_api/v1.1/post_update_interview_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/interviews/:interview_id/update', type: :request do
+  include VendorAPISpecHelpers
+
+  let(:application_choice) do
+    create_application_choice_for_currently_authenticated_provider({}, :with_scheduled_interview)
+  end
+
+  let(:interview) { application_choice.interviews.first }
+
+  before do
+    stub_const('VendorAPI::VERSION', '1.1')
+  end
+
+  def post_interview!(params:)
+    request_body = { data: params }
+    expect(request_body[:data]).to be_valid_against_openapi_schema('UpdateInterview', '1.1')
+
+    post_api_request "/api/v1.1/applications/#{application_choice.id}/interviews/#{interview.id}/update", params: request_body
+  end
+
+  describe 'update interview' do
+    context 'in the future' do
+      let(:update_interview_params) do
+        {
+          provider_code: currently_authenticated_provider.code,
+          date_and_time: 100.days.from_now.iso8601,
+          location: 'Zoom call',
+          additional_details: 'Changed details',
+        }
+      end
+
+      it 'succeeds and renders a SingleApplicationResponse' do
+        post_interview! params: update_interview_params
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response['data']['attributes']['interviews'].first['date_and_time']).to eq(update_interview_params[:date_and_time])
+        # expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse', '1.1')
+      end
+    end
+
+    context 'in the past' do
+      let(:update_interview_params) do
+        {
+          provider_code: currently_authenticated_provider.code,
+          date_and_time: 1.day.ago.iso8601,
+          location: 'Zoom call',
+          additional_details: 'This should fail',
+        }
+      end
+
+      it 'fails and renders an Unprocessable Entity error' do
+        skip 'Depends on interview validations work'
+
+        post_interview! params: update_interview_params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+        expect(parsed_response['errors'].map { |error| error['message'] })
+          .to contain_exactly("It's not possible to schedule an interview in the past.")
+      end
+    end
+
+    context 'wrong provider code' do
+      let(:update_interview_params) do
+        {
+          provider_code: create(:provider).code,
+          date_and_time: 1.day.from_now.iso8601,
+          location: 'Zoom call',
+          additional_details: 'This should fail',
+        }
+      end
+
+      it 'fails and renders an Unprocessable Entity error' do
+        skip 'Depends on interview validations work'
+
+        post_interview! params: update_interview_params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+        expect(parsed_response['errors'].map { |error| error['message'] })
+          .to contain_exactly('Provider code must correspond to training or ratifying provider for the course.')
+      end
+    end
+
+    context 'wrong api key' do
+      let(:update_interview_params) do
+        {
+          provider_code: provider.code,
+          date_and_time: 1.day.from_now.iso8601,
+          location: 'Zoom call',
+          additional_details: 'This should fail',
+        }
+      end
+      let(:provider) { create(:provider) }
+      let(:api_token) { VendorAPIToken.create_with_random_token!(provider: provider) }
+
+      it 'fails and renders an Not Found response' do
+        post_interview! params: update_interview_params
+
+        expect(response).to have_http_status(:not_found)
+        expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
+        expect(parsed_response['errors'].map { |error| error['message'] })
+          .to contain_exactly('Unable to find Application(s)')
+      end
+    end
+  end
+end

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -478,6 +478,40 @@ RSpec.describe ProviderAuthorisation do
       end
     end
 
+    context 'for a vendor api user' do
+      subject(:auth_context) { described_class.new(actor: vendor_api_user) }
+
+      let(:vendor_api_user) { create(:vendor_api_user) }
+      let(:provider) { vendor_api_user.vendor_api_token.provider }
+
+      context 'associated with the training provider' do
+        let(:course) { create(:course, provider: provider) }
+
+        it 'is true' do
+          expect(auth_context.can_set_up_interviews?(application_choice: application_choice, course_option: course_option))
+            .to be_truthy
+        end
+      end
+
+      context 'associated with the ratifying provider' do
+        let(:course) { create(:course, accredited_provider: provider) }
+
+        it 'is true' do
+          expect(auth_context.can_set_up_interviews?(application_choice: application_choice, course_option: course_option))
+            .to be_truthy
+        end
+      end
+
+      context 'associated with a random provider' do
+        let(:course) { create(:course) }
+
+        it 'is false' do
+          expect(auth_context.can_set_up_interviews?(application_choice: application_choice, course_option: course_option))
+            .to be_falsy
+        end
+      end
+    end
+
     context 'for a provider user' do
       subject(:auth_context) { described_class.new(actor: provider_user) }
 


### PR DESCRIPTION
## Context

Following on from https://github.com/DFE-Digital/apply-for-teacher-training/pull/6387, which includes interviews in application responses, this PR adds API v1.1 endpoints for creating, updating and cancelling interviews.

## Changes proposed in this pull request

Add the following endpoints:
```
vendor_api_interviews_create POST /api/:api_version/applications/:application_id/interviews/create(.:format)
vendor_api_interviews_update POST /api/:api_version/applications/:application_id/interviews/:interview_id/update(.:format)                                  
vendor_api_interviews_cancel POST /api/:api_version/applications/:application_id/interviews/:interview_id/cancel(.:format)
```

These call the respective interview services and make changes, but some validations are not in place yet. We're mostly checking permissions so far.

## Guidance to review

The focus of this PR is API v1.1 plumbing from API endpoint to the relevant services.

A bunch of rspec scenarios and steps are skipped until we have the relevant validations in place.

PENDING: We may need to add some code that allows partial resource updates akin to a `PATCH` (e.g. only supplying a new `date_and_time`). The api-docs are not clear about this.

PENDING: Business rules around current vs past interviews and changes to cancelled interviews are to be fine-tuned.

## Link to Trello card

https://trello.com/c/uqOf564K

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
