### PR TITLE
Mark all fraudulent duplicate matches as resolved

### DIFF
--- a/app/services/data_migrations/resolve_all_fraudulent_duplicate_matches.rb
+++ b/app/services/data_migrations/resolve_all_fraudulent_duplicate_matches.rb
@@ -1,0 +1,12 @@
+module DataMigrations
+  class ResolveAllFraudulentDuplicateMatches
+    TIMESTAMP = 20220126171018
+    MANUAL_RUN = false
+
+    def change
+      FraudMatch.where(fraudulent: true).each do |fraud_match|
+        fraud_match.update(resolved: true)
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::ResolveAllFraudulentDuplicateMatches',
   'DataMigrations::FixupCandidatesSubmissionBlocked',
   'DataMigrations::BackfillWithdrawnOrDeclinedForCandidateByProvider',
   'DataMigrations::BackfillUserColumnsOnNotes',

--- a/spec/services/data_migrations/resolve_all_fraudulent_duplicate_matches_spec.rb
+++ b/spec/services/data_migrations/resolve_all_fraudulent_duplicate_matches_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::ResolveAllFraudulentDuplicateMatches do
+  before do
+    @fraud_match = create(:fraud_match, fraudulent: true, resolved: false)
+  end
+
+  it 'marks all fraudulent matches as resolved' do
+    described_class.new.change
+    expect(@fraud_match.reload).to be_resolved
+  end
+end


### PR DESCRIPTION
## Context

As part of the transition to the new duplicate matching feature, support wanted to shorten the number of duplicate matches in the list and asked for us to mark all fraudulent duplicate matches as resolved.

## Changes proposed in this pull request

- Data migration to update all `fraudulent` `FraudMatches` to `resolved` 

## Guidance to review

is the data migration script ok?

## Link to Trello card

https://trello.com/c/tEdre0jW/4375-all-duplicate-matches-marked-as-fraudulent-should-be-marked-as-resolved

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
