### PR TITLE
Make API controllers log to BigQuery

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,10 @@
+require:
+  - rubocop-rails
+  - ./lib/rubocop/cop/application_api_controller.rb
+  - ./lib/rubocop/cop/govuk/govuk_button_to.rb
+  - ./lib/rubocop/cop/govuk/govuk_link_to.rb
+  - ./lib/rubocop/cop/govuk/govuk_submit.rb
+
 inherit_from:
   - .rubocop_todo.yml
   - ./config/rubocop/config/rspec.yml
@@ -8,11 +15,6 @@ inherit_from:
   - ./config/rubocop/config/lint.yml
   - ./config/rubocop/config/metrics.yml
   - ./config/rubocop/config/naming.yml
-
-require:
-  - ./lib/rubocop/cop/govuk/govuk_button_to.rb
-  - ./lib/rubocop/cop/govuk/govuk_link_to.rb
-  - ./lib/rubocop/cop/govuk/govuk_submit.rb
 
 AllCops:
   NewCops: enable

--- a/app/controllers/application_api_controller.rb
+++ b/app/controllers/application_api_controller.rb
@@ -1,0 +1,17 @@
+class ApplicationAPIController < ActionController::API
+  include EmitRequestEvents
+  include RequestQueryParams
+  include RemoveBrowserOnlyHeaders
+
+  rescue_from ActionController::ParameterMissing, with: :parameter_missing
+  rescue_from ParameterInvalid, with: :parameter_invalid
+
+  def parameter_missing(e)
+    error_message = e.message.split("\n").first
+    render json: { errors: [{ error: 'ParameterMissing', message: error_message }] }, status: :unprocessable_entity
+  end
+
+  def parameter_invalid(e)
+    render json: { errors: [{ error: 'ParameterInvalid', message: e }] }, status: :unprocessable_entity
+  end
+end

--- a/app/controllers/candidate_api/candidates_controller.rb
+++ b/app/controllers/candidate_api/candidates_controller.rb
@@ -1,11 +1,7 @@
 module CandidateAPI
-  class CandidatesController < ActionController::API
+  class CandidatesController < ApplicationAPIController
     include ServiceAPIUserAuthentication
-    include RemoveBrowserOnlyHeaders
     include Pagy::Backend
-
-    rescue_from ActionController::ParameterMissing, with: :parameter_missing
-    rescue_from ParameterInvalid, with: :parameter_invalid
 
     # Makes PG::QueryCanceled statement timeout errors appear in Skylight
     # against the controller action that triggered them
@@ -20,15 +16,6 @@ module CandidateAPI
 
     def index
       render json: { data: serialized_candidates }
-    end
-
-    def parameter_missing(e)
-      error_message = e.message.split("\n").first
-      render json: { errors: [{ error: 'ParameterMissing', message: error_message }] }, status: :unprocessable_entity
-    end
-
-    def parameter_invalid(e)
-      render json: { errors: [{ error: 'ParameterInvalid', message: e }] }, status: :unprocessable_entity
     end
 
     def statement_timeout

--- a/app/controllers/data_api/tad_data_exports_controller.rb
+++ b/app/controllers/data_api/tad_data_exports_controller.rb
@@ -1,10 +1,6 @@
 module DataAPI
-  class TADDataExportsController < ActionController::API
+  class TADDataExportsController < ApplicationAPIController
     include ServiceAPIUserAuthentication
-    include RemoveBrowserOnlyHeaders
-
-    rescue_from ParameterInvalid, with: :parameter_invalid
-    rescue_from ActionController::ParameterMissing, with: :parameter_missing
 
     # Makes PG::QueryCanceled statement timeout errors appear in Skylight
     # against the controller action that triggered them
@@ -81,15 +77,6 @@ module DataAPI
       data_export = all.last
 
       serve_export(data_export)
-    end
-
-    def parameter_invalid(e)
-      render json: { errors: [{ error: 'ParameterInvalid', message: e }] }, status: :unprocessable_entity
-    end
-
-    def parameter_missing(e)
-      error_message = e.message.split("\n").first
-      render json: { errors: [{ error: 'ParameterMissing', message: error_message }] }, status: :unprocessable_entity
     end
 
   private

--- a/app/controllers/integrations/integrations_controller.rb
+++ b/app/controllers/integrations/integrations_controller.rb
@@ -1,5 +1,5 @@
 module Integrations
-  class IntegrationsController < ActionController::API
+  class IntegrationsController < ApplicationAPIController
   protected
 
     def render_error(name:, message:, status:)

--- a/app/controllers/register_api/applications_controller.rb
+++ b/app/controllers/register_api/applications_controller.rb
@@ -1,9 +1,7 @@
 module RegisterAPI
-  class ApplicationsController < ActionController::API
+  class ApplicationsController < ApplicationAPIController
     include ServiceAPIUserAuthentication
-    include RemoveBrowserOnlyHeaders
 
-    rescue_from ActionController::ParameterMissing, with: :parameter_missing
     rescue_from ParameterInvalid, with: :parameter_invalid
 
     # Makes PG::QueryCanceled statement timeout errors appear in Skylight
@@ -13,15 +11,6 @@ module RegisterAPI
 
     def index
       render json: { data: serialized_application_choices }
-    end
-
-    def parameter_missing(e)
-      error_message = e.message.split("\n").first
-      render json: { errors: [{ error: 'ParameterMissing', message: error_message }] }, status: :unprocessable_entity
-    end
-
-    def parameter_invalid(e)
-      render json: { errors: [{ error: 'ParameterInvalid', message: e }] }, status: :unprocessable_entity
     end
 
     def statement_timeout

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -1,13 +1,9 @@
 module VendorAPI
-  class VendorAPIController < ActionController::API
+  class VendorAPIController < ApplicationAPIController
     include ActionController::HttpAuthentication::Token::ControllerMethods
-    include RequestQueryParams
-    include RemoveBrowserOnlyHeaders
     include Versioning
 
     rescue_from ActiveRecord::RecordNotFound, with: :application_not_found
-    rescue_from ActionController::ParameterMissing, with: :parameter_missing
-    rescue_from ParameterInvalid, with: :parameter_invalid
 
     # Makes PG::QueryCanceled statement timeout errors appear in Skylight
     # against the controller action that triggered them
@@ -41,15 +37,6 @@ module VendorAPI
       render json: {
         errors: [{ error: 'NotFound', message: "Could not find an application with ID #{params[:application_id]}" }],
       }, status: :not_found
-    end
-
-    def parameter_missing(e)
-      error_message = e.message.split("\n").first
-      render json: { errors: [{ error: 'ParameterMissing', message: error_message }] }, status: :unprocessable_entity
-    end
-
-    def parameter_invalid(e)
-      render json: { errors: [{ error: 'ParameterInvalid', message: e }] }, status: :unprocessable_entity
     end
 
     def statement_timeout

--- a/config/rubocop/config/rails.yml
+++ b/config/rubocop/config/rails.yml
@@ -1,5 +1,3 @@
-require: rubocop-rails
-
 Rails/BulkChangeTable:
   Enabled: false
 

--- a/lib/rubocop/cop/application_api_controller.rb
+++ b/lib/rubocop/cop/application_api_controller.rb
@@ -1,0 +1,13 @@
+module RuboCop
+  module Cop
+    class ApplicationAPIController < Base
+      extend AutoCorrector
+
+      MSG = 'API controllers should subclass `ApplicationAPIController`.'.freeze
+      SUPERCLASS = 'ApplicationAPIController'.freeze
+      BASE_PATTERN = '(const (const nil? :ActionController) :API)'.freeze
+
+      include RuboCop::Cop::EnforceSuperclass
+    end
+  end
+end


### PR DESCRIPTION
## Context

We missed these when we added `EmitRequestEvents` to `ApplicationController`... because the API controllers don't inherit from `ApplicationController`!

## Changes proposed in this pull request

- Create a new `ApplicationAPIController` and have the base API controllers inherit from it
- Deduplicate the BigQuery behaviour (and a couple of other common pieces) into it
- Forbid the creation of new subclasses of `ActionController::API` using a cop

## Guidance to review

Is the deduping correct?

## Link to Trello card

Bug spotted in Slack https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1643289785245700

## Things to check

- [X] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
