### PR TITLE
Unresolve matches when there are new duplicates

### DIFF
--- a/app/services/update_duplicate_matches.rb
+++ b/app/services/update_duplicate_matches.rb
@@ -37,6 +37,7 @@ private
     if existing_fraud_match.present?
       unless existing_fraud_match.candidates.include?(candidate)
         existing_fraud_match.candidates << candidate
+        unresolve_match(existing_fraud_match)
         process_match(candidate, existing_fraud_match)
       end
     else
@@ -77,5 +78,9 @@ private
 
   def block_submission(candidate)
     candidate.update!(submission_blocked: true)
+  end
+
+  def unresolve_match(fraud_match)
+    fraud_match.update!(resolved: false)
   end
 end

--- a/spec/services/update_duplicate_matches_spec.rb
+++ b/spec/services/update_duplicate_matches_spec.rb
@@ -40,18 +40,16 @@ RSpec.describe UpdateDuplicateMatches, sidekiq: true do
         end
       end
 
-      context 'when the candidates have been mannually resolved and new candidate is added to the match' do
+      context 'when a duplicate match has been manually resolved and a new candidate is added to the match' do
         let(:candidate3) { create(:candidate, email_address: 'exemplar3@example.com') }
 
         before do
-          FraudMatch.update_all(resolved: true)
-          Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
-            create(:application_form, :duplicate_candidates, candidate: candidate3, submitted_at: Time.zone.now)
-          end
+          FraudMatch.first.update(resolved: true)
+          create(:application_form, :duplicate_candidates, candidate: candidate3)
           described_class.new.save!
         end
 
-        it 'mark the match as unresolved' do
+        it 'marks the match as unresolved' do
           expect(FraudMatch.first).not_to be_resolved
         end
       end


### PR DESCRIPTION
## Context

If a resolved match:
"2 candidates with postcode W6 BHT and DOB 04/06/1989"

now has 3 candidates, when a new candidate is added to the match,
we should mark this match as unresolved again.

## Guidance to review

1. Enable feature duplicate_matching
2. Run the worker `UpdateFraudMatchesWorker.perform_async`
3. Then mark one match as resolved
4. Add one more duplicate candidate to this resolved match
5. Run the worker `UpdateFraudMatchesWorker.perform_async`
3. Verify the fraud_matches is in the database unresolved (or in the support UI)

## Link to Trello card

https://trello.com/c/wJRKYuMn/4383-new-candidate-duplicates-should-be-mark-unresolved

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
