### PR TITLE
Add pagination to v1.1 of the Vendor API

### DIFF
--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -7,7 +7,7 @@ module VendorAPI
     end
 
     def show
-      render_application
+      render json: SingleApplicationPresenter.new(version_number, application_choice).serialized_json
     end
 
   private

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -19,7 +19,6 @@ module VendorAPI
     def get_application_choices_for_provider_since(since:)
       application_choices_visible_to_provider
         .where('application_choices.updated_at > ?', since)
-        .order('application_choices.updated_at DESC')
     end
 
     def pagination_params

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -16,7 +16,7 @@ module VendorAPI
   private
 
     def serialized_application_choices_data
-      MultipleApplicationsPresenter.new(version_number, get_application_choices_for_provider_since(since: since_param), pagination_params).serialized_applications_data
+      MultipleApplicationsPresenter.new(version_number, get_application_choices_for_provider_since(since: since_param), request, pagination_params).serialized_applications_data
     end
 
     def get_application_choices_for_provider_since(since:)
@@ -29,13 +29,7 @@ module VendorAPI
         since: since_param.iso8601,
         page: params[:page],
         per_page: params[:per_page],
-        api_version: params[:api_version],
-        url: url_for(
-          controller: params[:controller],
-          action: params[:action],
-          host: request.host,
-          api_version: params[:api_version],
-        ),
+        url: request.original_url,
       }
     end
 

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -32,6 +32,7 @@ module VendorAPI
       Changes::CreateInterview,
       Changes::UpdateInterview,
       Changes::CancelInterview,
+      Changes::Pagination,
     ],
   }.freeze
 end

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -33,6 +33,7 @@ module VendorAPI
       Changes::UpdateInterview,
       Changes::CancelInterview,
       Changes::Pagination,
+      Changes::ApplicationMeta,
     ],
   }.freeze
 end

--- a/app/lib/vendor_api/changes/application_meta.rb
+++ b/app/lib/vendor_api/changes/application_meta.rb
@@ -3,6 +3,7 @@ module VendorAPI
     class ApplicationMeta < VersionChange
       description 'Includes top level meta object'
 
+      resource MetaPresenter
       resource SingleApplicationPresenter, [APIMeta]
     end
   end

--- a/app/lib/vendor_api/changes/application_meta.rb
+++ b/app/lib/vendor_api/changes/application_meta.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  module Changes
+    class ApplicationMeta < VersionChange
+      description 'Includes top level meta object'
+
+      resource SingleApplicationPresenter, [APIMeta]
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/pagination.rb
+++ b/app/lib/vendor_api/changes/pagination.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  module Changes
+    class Pagination < VersionChange
+      description 'Includes pagination'
+
+      resource MultipleApplicationsPresenter, [PaginationAPIData]
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/pagination.rb
+++ b/app/lib/vendor_api/changes/pagination.rb
@@ -3,6 +3,7 @@ module VendorAPI
     class Pagination < VersionChange
       description 'Includes pagination'
 
+      resource MetaPresenter
       resource MultipleApplicationsPresenter, [PaginationAPIData]
     end
   end

--- a/app/lib/vendor_api/changes/retrieve_applications.rb
+++ b/app/lib/vendor_api/changes/retrieve_applications.rb
@@ -9,6 +9,7 @@ module VendorAPI
 
       action ApplicationsController, :index
 
+      resource MultipleApplicationsPresenter
       resource ApplicationPresenter
     end
   end

--- a/app/lib/vendor_api/changes/retrieve_single_application.rb
+++ b/app/lib/vendor_api/changes/retrieve_single_application.rb
@@ -4,6 +4,7 @@ module VendorAPI
       description 'Get single application'
 
       action ApplicationsController, :show
+      resource SingleApplicationPresenter
     end
   end
 end

--- a/app/presenters/concerns/api_meta.rb
+++ b/app/presenters/concerns/api_meta.rb
@@ -1,0 +1,12 @@
+module APIMeta
+  def serialized_json
+    %({"data":#{VendorAPI::ApplicationPresenter.new(active_version, application).serialized_json}, "meta": #{meta.to_json}})
+  end
+
+  def meta
+    {
+      version: "v#{active_version}",
+      timestamp: Time.zone.now.iso8601,
+    }
+  end
+end

--- a/app/presenters/concerns/api_meta.rb
+++ b/app/presenters/concerns/api_meta.rb
@@ -1,12 +1,5 @@
 module APIMeta
   def serialized_json
-    %({"data":#{VendorAPI::ApplicationPresenter.new(active_version, application).serialized_json}, "meta": #{meta.to_json}})
-  end
-
-  def meta
-    {
-      version: "v#{active_version}",
-      timestamp: Time.zone.now.iso8601,
-    }
+    %({"data":#{VendorAPI::ApplicationPresenter.new(active_version, application).serialized_json}, "meta": #{VendorAPI::MetaPresenter.new(active_version).as_json}})
   end
 end

--- a/app/presenters/concerns/pagination_api_data.rb
+++ b/app/presenters/concerns/pagination_api_data.rb
@@ -1,0 +1,66 @@
+module PaginationAPIData
+  include Pagy::Backend
+
+  DEFAULT_PER_PAGE = 50
+  MAX_PER_PAGE = 50
+
+  def serialized_applications_data
+    %({"data":[#{serialized_applications.join(',')}], "links": #{links.to_json}, "meta": #{meta.to_json}})
+  end
+
+  def links
+    url = options[:url]
+    link_options = options.except(:url, :api_version)
+    links_hash = {
+      first: pagination_link(url, link_options, 1),
+      last: pagination_link(url, link_options, @pagy.last),
+      self: pagination_link(url, link_options, @pagy.page),
+    }
+    links_hash[:prev] = pagination_link(url, link_options, @pagy.prev) if @pagy.prev
+    links_hash[:next] = pagination_link(url, link_options, @pagy.next) if @pagy.next
+
+    links_hash
+  end
+
+  def meta
+    {
+      api_version: options[:api_version],
+      timestamp: Time.zone.now.iso8601,
+      total_count: @pagy.count,
+    }
+  end
+
+  def serialized_applications
+    paginate(applications).map do |application|
+      VendorAPI::ApplicationPresenter.new(active_version, application).serialized_json
+    end
+  end
+
+  def pagination_link(url, options, page)
+    "#{url}?#{build_query(options.merge(page: page.to_s))}"
+  end
+
+  def paginate(scope)
+    @pagy, paginated_records = pagy(scope, items: per_page, page: page)
+
+    paginated_records
+  end
+
+  def per_page
+    [(options[:per_page] || DEFAULT_PER_PAGE).to_i, MAX_PER_PAGE].min
+  end
+
+  def page
+    (options[:page] || 1).to_i
+  end
+
+  def build_query(params)
+    params.stringify_keys.map do |k, v|
+      if v.instance_of?(Array)
+        build_query(v.map { |x| [k, x] })
+      else
+        "#{k}=#{v}"
+      end
+    end.join('&')
+  end
+end

--- a/app/presenters/concerns/pagination_api_data.rb
+++ b/app/presenters/concerns/pagination_api_data.rb
@@ -5,7 +5,7 @@ module PaginationAPIData
   MAX_PER_PAGE = 50
 
   def serialized_applications_data
-    %({"data":[#{serialized_applications.join(',')}], "links": #{links.to_json}, "meta": #{meta.to_json}})
+    %({"data":[#{serialized_applications.join(',')}], "links": #{links.to_json}, "meta": #{VendorAPI::MetaPresenter.new(active_version, @pagy.count).as_json}})
   end
 
   def links

--- a/app/presenters/concerns/pagination_api_data.rb
+++ b/app/presenters/concerns/pagination_api_data.rb
@@ -30,10 +30,8 @@ module PaginationAPIData
     }
   end
 
-  def serialized_applications
-    paginate(applications).map do |application|
-      VendorAPI::ApplicationPresenter.new(active_version, application).serialized_json
-    end
+  def applications_scope
+    paginate(applications.order('application_choices.updated_at DESC'))
   end
 
   def pagination_link(url, options, page)

--- a/app/presenters/concerns/pagination_api_data.rb
+++ b/app/presenters/concerns/pagination_api_data.rb
@@ -45,6 +45,8 @@ module PaginationAPIData
   end
 
   def per_page
+    raise PerPageParameterInvalid unless options[:per_page].to_i <= MAX_PER_PAGE
+
     [(options[:per_page] || DEFAULT_PER_PAGE).to_i, MAX_PER_PAGE].min
   end
 

--- a/app/presenters/vendor_api/meta_presenter.rb
+++ b/app/presenters/vendor_api/meta_presenter.rb
@@ -1,0 +1,19 @@
+module VendorAPI
+  class MetaPresenter < Base
+    attr_reader :count
+
+    def initialize(version, count = nil)
+      super(version)
+      @count = count
+    end
+
+    def as_json
+      meta_hash = {
+        api_version: "v#{active_version}",
+        timestamp: Time.zone.now.iso8601,
+      }
+      meta_hash[:total_count] = count if count
+      meta_hash.to_json
+    end
+  end
+end

--- a/app/presenters/vendor_api/multiple_applications_presenter.rb
+++ b/app/presenters/vendor_api/multiple_applications_presenter.rb
@@ -2,7 +2,7 @@ module VendorAPI
   class MultipleApplicationsPresenter < Base
     attr_reader :applications, :options
 
-    def initialize(version, applications, options)
+    def initialize(version, applications, options = {})
       super(version)
       @applications = applications
       @options = options
@@ -13,9 +13,16 @@ module VendorAPI
     end
 
     def serialized_applications
-      applications.map do |application|
+      applications_scope.map do |application|
         ApplicationPresenter.new(active_version, application).serialized_json
       end
+    end
+
+    def applications_scope
+      applications
+      .find_each(batch_size: 500)
+      .sort_by(&:updated_at)
+      .reverse
     end
   end
 end

--- a/app/presenters/vendor_api/multiple_applications_presenter.rb
+++ b/app/presenters/vendor_api/multiple_applications_presenter.rb
@@ -1,0 +1,21 @@
+module VendorAPI
+  class MultipleApplicationsPresenter < Base
+    attr_reader :applications, :options
+
+    def initialize(version, applications, options)
+      super(version)
+      @applications = applications
+      @options = options
+    end
+
+    def serialized_applications_data
+      %({"data":[#{serialized_applications.join(',')}]})
+    end
+
+    def serialized_applications
+      applications.map do |application|
+        ApplicationPresenter.new(active_version, application).serialized_json
+      end
+    end
+  end
+end

--- a/app/presenters/vendor_api/multiple_applications_presenter.rb
+++ b/app/presenters/vendor_api/multiple_applications_presenter.rb
@@ -1,10 +1,11 @@
 module VendorAPI
   class MultipleApplicationsPresenter < Base
-    attr_reader :applications, :options
+    attr_reader :applications, :options, :request
 
-    def initialize(version, applications, options = {})
+    def initialize(version, applications, request = {}, options = {})
       super(version)
       @applications = applications
+      @request = request
       @options = options
     end
 

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -1,0 +1,14 @@
+module VendorAPI
+  class SingleApplicationPresenter < Base
+    attr_reader :application
+
+    def initialize(version, application)
+      super(version)
+      @application = application
+    end
+
+    def serialized_json
+      %({"data":#{ApplicationPresenter.new(active_version, application).serialized_json}})
+    end
+  end
+end

--- a/spec/presenters/vendor_api/v1.1/multiple_applications_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.1/multiple_applications_presenter_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe VendorAPI::MultipleApplicationsPresenter do
+  describe '#applications_scope' do
+    let(:applications) { ApplicationChoice }
+
+    it 'performs a batch find' do
+      allow(applications).to receive(:find_each).and_call_original
+      described_class.new('1.0', applications).applications_scope
+      expect(applications).to have_received(:find_each).with(batch_size: 500)
+    end
+  end
+end

--- a/spec/requests/vendor_api/v1.1/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/v1.1/get_multiple_applications_spec.rb
@@ -149,9 +149,89 @@ RSpec.describe 'Vendor API - GET /api/v1.1/applications', type: :request do
     expect(response_data.last['id']).to eq(application_choices.last.id.to_s)
   end
 
-  it 'navigates through the pages' do
-    Timecop.freeze(Time.zone.now) do
-      application_choices = create_list(
+  describe 'pagination' do
+    it 'navigates through the pages' do
+      Timecop.freeze(Time.zone.now) do
+        application_choices = create_list(
+          :submitted_application_choice,
+          3,
+          :with_completed_application_form,
+          course_option: course_option_for_provider(provider: currently_authenticated_provider),
+          status: :awaiting_provider_decision,
+        )
+
+        application_choices.first.update(updated_at: 1.hour.ago)
+        application_choices.second.update(updated_at: 1.minute.ago)
+        application_choices.last.update(updated_at: 10.minutes.ago)
+
+        get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=1&per_page=2"
+
+        response_data = parsed_response['data']
+        links_object = parsed_response['links']
+
+        expect(links_object['self']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=1&per_page=2"
+        expect(links_object['prev']).to be_nil
+        expect(links_object['next']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=2&per_page=2"
+        expect(links_object['last']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=2&per_page=2"
+
+        expect(response_data.first['id']).to eq(application_choices.second.id.to_s)
+        expect(response_data.second['id']).to eq(application_choices.last.id.to_s)
+
+        expect(response).to have_http_status(:ok)
+
+        get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=2&per_page=2"
+
+        links_object = parsed_response['links']
+
+        expect(links_object['self']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=2&per_page=2"
+        expect(links_object['prev']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=1&per_page=2"
+        expect(links_object['next']).to be_nil
+
+        expect(parsed_response['data'].first['id']).to eq(application_choices.first.id.to_s)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    it 'returns the correct total_count in the meta data object' do
+      create_list(
+        :submitted_application_choice,
+        10,
+        :with_completed_application_form,
+        course_option: course_option_for_provider(provider: currently_authenticated_provider),
+        status: :awaiting_provider_decision,
+      )
+
+      get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&per_page=20"
+
+      expect(response).to have_http_status(:ok)
+      expect(parsed_response['meta']['api_version']).to eq 'v1.1'
+      expect(parsed_response['meta']['total_count']).to eq 10
+    end
+
+    it 'does not paginate when no params are provided' do
+      create_list(
+        :submitted_application_choice,
+        10,
+        :with_completed_application_form,
+        course_option: course_option_for_provider(provider: currently_authenticated_provider),
+        status: :awaiting_provider_decision,
+      )
+
+      get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+
+      expect(response).to have_http_status(:ok)
+      expect(parsed_response['links']).to include({
+        'first' => 'http://www.example.com/api/v1.1/applications',
+        'last' => 'http://www.example.com/api/v1.1/applications',
+        'self' => 'http://www.example.com/api/v1.1/applications',
+        'prev' => 'http://www.example.com/api/v1.1/applications',
+        'next' => 'http://www.example.com/api/v1.1/applications',
+      })
+    end
+
+    it 'returns HTTP status 422 when given a parseable page value that exceeds the range' do
+      create_list(
         :submitted_application_choice,
         3,
         :with_completed_application_form,
@@ -159,83 +239,26 @@ RSpec.describe 'Vendor API - GET /api/v1.1/applications', type: :request do
         status: :awaiting_provider_decision,
       )
 
-      application_choices.first.update(updated_at: 1.hour.ago)
-      application_choices.second.update(updated_at: 1.minute.ago)
-      application_choices.last.update(updated_at: 10.minutes.ago)
+      get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=3&per_page=2"
 
-      get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=1&per_page=2"
-
-      response_data = parsed_response['data']
-      links_object = parsed_response['links']
-
-      expect(links_object['self']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=1&per_page=2"
-      expect(links_object['prev']).to be_nil
-      expect(links_object['next']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=2&per_page=2"
-      expect(links_object['last']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=2&per_page=2"
-
-      expect(response_data.first['id']).to eq(application_choices.second.id.to_s)
-      expect(response_data.second['id']).to eq(application_choices.last.id.to_s)
-
-      expect(response).to have_http_status(:ok)
-
-      get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=2&per_page=2"
-
-      links_object = parsed_response['links']
-
-      expect(links_object['self']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=2&per_page=2"
-      expect(links_object['prev']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=1&per_page=2"
-      expect(links_object['next']).to be_nil
-
-      expect(parsed_response['data'].first['id']).to eq(application_choices.first.id.to_s)
-
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(error_response['message']).to eql("expected 'page' parameter to be between 1 and 2, got 3")
     end
-  end
 
-  it 'returns the correct total_count in the meta data object' do
-    create_list(
-      :submitted_application_choice,
-      10,
-      :with_completed_application_form,
-      course_option: course_option_for_provider(provider: currently_authenticated_provider),
-      status: :awaiting_provider_decision,
-    )
+    it 'returns HTTP status 422 when given a parseable per_page value that exceeds the max value' do
+      create_list(
+        :submitted_application_choice,
+        3,
+        :with_completed_application_form,
+        course_option: course_option_for_provider(provider: currently_authenticated_provider),
+        status: :awaiting_provider_decision,
+      )
 
-    get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&per_page=20"
+      max_value = PaginationAPIData::MAX_PER_PAGE
+      get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=1&per_page=#{max_value + 1}"
 
-    expect(response).to have_http_status(:ok)
-    expect(parsed_response['meta']['api_version']).to eq 'v1.1'
-    expect(parsed_response['meta']['total_count']).to eq 10
-  end
-
-  it 'returns HTTP status 422 when given a parseable page value that exceeds the range' do
-    create_list(
-      :submitted_application_choice,
-      3,
-      :with_completed_application_form,
-      course_option: course_option_for_provider(provider: currently_authenticated_provider),
-      status: :awaiting_provider_decision,
-    )
-
-    get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=3&per_page=2"
-
-    expect(response).to have_http_status(:unprocessable_entity)
-    expect(error_response['message']).to eql("expected 'page' parameter to be between 1 and 2, got 3")
-  end
-
-  it 'returns HTTP status 422 when given a parseable per_page value that exceeds the max value' do
-    create_list(
-      :submitted_application_choice,
-      3,
-      :with_completed_application_form,
-      course_option: course_option_for_provider(provider: currently_authenticated_provider),
-      status: :awaiting_provider_decision,
-    )
-
-    max_value = PaginationAPIData::MAX_PER_PAGE
-    get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=1&per_page=#{max_value + 1}"
-
-    expect(response).to have_http_status(:unprocessable_entity)
-    expect(error_response['message']).to eql("the 'per_page' parameter cannot exceed #{max_value} results per page")
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(error_response['message']).to eql("the 'per_page' parameter cannot exceed #{max_value} results per page")
+    end
   end
 end

--- a/spec/requests/vendor_api/v1.1/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/v1.1/get_multiple_applications_spec.rb
@@ -8,147 +8,6 @@ RSpec.describe 'Vendor API - GET /api/v1.1/applications', type: :request do
     stub_const('VendorAPI::VERSION', '1.1')
   end
 
-  it 'returns applications of the authenticated provider' do
-    create_list(
-      :submitted_application_choice,
-      2,
-      :with_completed_application_form,
-      course_option: course_option_for_provider(provider: currently_authenticated_provider),
-      status: 'awaiting_provider_decision',
-    )
-
-    alternate_provider = create(:provider, code: 'DIFFERENT')
-
-    create_list(
-      :submitted_application_choice,
-      1,
-      course_option: course_option_for_provider(provider: alternate_provider),
-      status: 'awaiting_provider_decision',
-    )
-
-    get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
-    expect(parsed_response['data'].size).to eq(2)
-  end
-
-  it 'returns applications filtered with `since`' do
-    Timecop.travel(2.days.ago) do
-      create_application_choice_for_currently_authenticated_provider(
-        status: 'awaiting_provider_decision',
-      )
-    end
-
-    create_application_choice_for_currently_authenticated_provider(
-      status: 'awaiting_provider_decision',
-    )
-
-    get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
-
-    expect(parsed_response['data'].size).to eq(1)
-  end
-
-  it 'returns a response that is valid according to the OpenAPI schema' do
-    create_application_choice_for_currently_authenticated_provider(
-      status: 'awaiting_provider_decision',
-    )
-
-    get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
-
-    expect(parsed_response).to be_valid_against_openapi_schema('MultipleApplicationsResponse')
-  end
-
-  it 'returns an error if the `since` parameter is missing' do
-    get_api_request '/api/v1.1/applications'
-
-    expect(response).to have_http_status(:unprocessable_entity)
-
-    expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse')
-
-    expect(error_response['message']).to eql('param is missing or the value is empty: since')
-  end
-
-  it 'returns HTTP status 422 given an unparseable `since` date value' do
-    get_api_request '/api/v1.1/applications?since=17/07/2020T12:00:42Z'
-
-    expect(response).to have_http_status(:unprocessable_entity)
-
-    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-
-    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): since')
-  end
-
-  it 'returns HTTP status 422 when encountering a KeyError from ActiveSupport::TimeZone' do
-    get_api_request '/api/v1.1/applications?since=12936'
-
-    expect(response).to have_http_status(:unprocessable_entity)
-
-    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-
-    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): since')
-  end
-
-  it 'returns HTTP status 422 given a parseable but nonsensensical `since` date value' do
-    get_api_request '/api/v1.1/applications?since=-004713-03-23T11:52:19.448Z' # this happened
-
-    expect(response).to have_http_status(:unprocessable_entity)
-
-    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-
-    expect(error_response['message']).to eql('Parameter is invalid (date is nonsense): since')
-  end
-
-  it 'returns applications that are in a viewable state' do
-    create_list(
-      :submitted_application_choice,
-      2,
-      :with_completed_application_form,
-      course_option: course_option_for_provider(provider: currently_authenticated_provider),
-      status: :awaiting_provider_decision,
-    )
-
-    create_list(
-      :submitted_application_choice,
-      3,
-      course_option: course_option_for_provider(provider: currently_authenticated_provider),
-      status: :unsubmitted,
-    )
-
-    get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
-
-    expect(parsed_response['data'].size).to eq(2)
-  end
-
-  it 'returns applications ordered by updated_at timestamp' do
-    application_choices = create_list(
-      :submitted_application_choice,
-      3,
-      :with_completed_application_form,
-      course_option: course_option_for_provider(provider: currently_authenticated_provider),
-      status: :awaiting_provider_decision,
-    )
-    application_choices.first.update(updated_at: 1.hour.ago)
-    application_choices.second.update(updated_at: 1.minute.ago)
-    application_choices.last.update(updated_at: 10.minutes.ago)
-
-    get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
-
-    response_data = parsed_response['data']
-    expect(response_data.size).to eq(3)
-
-    expect(response_data.first['id']).to eq(application_choices.second.id.to_s)
-    expect(response_data.second['id']).to eq(application_choices.last.id.to_s)
-    expect(response_data.last['id']).to eq(application_choices.first.id.to_s)
-
-    application_choices.first.update(updated_at: 10.seconds.ago)
-
-    get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
-
-    response_data = parsed_response['data']
-
-    expect(response_data.first['id']).to eq(application_choices.first.id.to_s)
-    expect(response_data.second['id']).to eq(application_choices.second.id.to_s)
-    expect(response_data.last['id']).to eq(application_choices.last.id.to_s)
-  end
-
   describe 'pagination' do
     it 'navigates through the pages' do
       Timecop.freeze(Time.zone.now) do
@@ -169,10 +28,10 @@ RSpec.describe 'Vendor API - GET /api/v1.1/applications', type: :request do
         response_data = parsed_response['data']
         links_object = parsed_response['links']
 
-        expect(links_object['self']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=1&per_page=2"
-        expect(links_object['prev']).to be_nil
-        expect(links_object['next']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=2&per_page=2"
-        expect(links_object['last']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=2&per_page=2"
+        expect(links_object['self']).to eq "http://www.example.com/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=1&per_page=2"
+        expect(links_object['prev']).to eq "http://www.example.com/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=&per_page=2"
+        expect(links_object['next']).to eq "http://www.example.com/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=2&per_page=2"
+        expect(links_object['last']).to eq "http://www.example.com/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=2&per_page=2"
 
         expect(response_data.first['id']).to eq(application_choices.second.id.to_s)
         expect(response_data.second['id']).to eq(application_choices.last.id.to_s)
@@ -183,9 +42,9 @@ RSpec.describe 'Vendor API - GET /api/v1.1/applications', type: :request do
 
         links_object = parsed_response['links']
 
-        expect(links_object['self']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=2&per_page=2"
-        expect(links_object['prev']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=1&per_page=2"
-        expect(links_object['next']).to be_nil
+        expect(links_object['self']).to eq "http://www.example.com/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=2&per_page=2"
+        expect(links_object['prev']).to eq "http://www.example.com/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=1&per_page=2"
+        expect(links_object['next']).to eq "http://www.example.com/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=&per_page=2"
 
         expect(parsed_response['data'].first['id']).to eq(application_choices.first.id.to_s)
 
@@ -193,41 +52,83 @@ RSpec.describe 'Vendor API - GET /api/v1.1/applications', type: :request do
       end
     end
 
-    it 'returns the correct total_count in the meta data object' do
-      create_list(
-        :submitted_application_choice,
-        10,
-        :with_completed_application_form,
-        course_option: course_option_for_provider(provider: currently_authenticated_provider),
-        status: :awaiting_provider_decision,
-      )
+    it 'returns the first page if no page param is provided' do
+      Timecop.freeze(Time.zone.now) do
+        create_list(
+          :submitted_application_choice,
+          3,
+          :with_completed_application_form,
+          course_option: course_option_for_provider(provider: currently_authenticated_provider),
+          status: :awaiting_provider_decision,
+        )
 
-      get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&per_page=20"
+        get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=&per_page=2"
 
-      expect(response).to have_http_status(:ok)
-      expect(parsed_response['meta']['api_version']).to eq 'v1.1'
-      expect(parsed_response['meta']['total_count']).to eq 10
+        links_object = parsed_response['links']
+
+        expect(links_object['self']).to eq "http://www.example.com/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=1&per_page=2"
+      end
+    end
+
+    it 'returns the correct meta data object when paginating' do
+      Timecop.freeze(Time.zone.now) do
+        create_list(
+          :submitted_application_choice,
+          10,
+          :with_completed_application_form,
+          course_option: course_option_for_provider(provider: currently_authenticated_provider),
+          status: :awaiting_provider_decision,
+        )
+
+        get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&per_page=20"
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response['meta']['api_version']).to eq 'v1.1'
+        expect(parsed_response['meta']['total_count']).to eq 10
+        expect(parsed_response['meta']['timestamp']).to eq Time.zone.now.iso8601
+      end
     end
 
     it 'does not paginate when no params are provided' do
-      create_list(
-        :submitted_application_choice,
-        10,
-        :with_completed_application_form,
-        course_option: course_option_for_provider(provider: currently_authenticated_provider),
-        status: :awaiting_provider_decision,
-      )
+      Timecop.freeze(Time.zone.now) do
+        create_list(
+          :submitted_application_choice,
+          10,
+          :with_completed_application_form,
+          course_option: course_option_for_provider(provider: currently_authenticated_provider),
+          status: :awaiting_provider_decision,
+        )
 
-      get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+        get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
 
-      expect(response).to have_http_status(:ok)
-      expect(parsed_response['links']).to include({
-        'first' => 'http://www.example.com/api/v1.1/applications',
-        'last' => 'http://www.example.com/api/v1.1/applications',
-        'self' => 'http://www.example.com/api/v1.1/applications',
-        'prev' => 'http://www.example.com/api/v1.1/applications',
-        'next' => 'http://www.example.com/api/v1.1/applications',
-      })
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response['links']).to include({
+          'first' => "http://www.example.com/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}",
+          'last' => "http://www.example.com/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}",
+          'self' => "http://www.example.com/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}",
+          'prev' => "http://www.example.com/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}",
+          'next' => "http://www.example.com/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}",
+        })
+      end
+    end
+
+    it 'returns the correct meta data object when not paginating' do
+      Timecop.freeze(Time.zone.now) do
+        create_list(
+          :submitted_application_choice,
+          10,
+          :with_completed_application_form,
+          course_option: course_option_for_provider(provider: currently_authenticated_provider),
+          status: :awaiting_provider_decision,
+        )
+
+        get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response['meta']['api_version']).to eq 'v1.1'
+        expect(parsed_response['meta']['total_count']).to eq 10
+        expect(parsed_response['meta']['timestamp']).to eq Time.zone.now.iso8601
+      end
     end
 
     it 'returns HTTP status 422 when given a parseable page value that exceeds the range' do

--- a/spec/requests/vendor_api/v1.1/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/v1.1/get_multiple_applications_spec.rb
@@ -204,6 +204,7 @@ RSpec.describe 'Vendor API - GET /api/v1.1/applications', type: :request do
     get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&per_page=20"
 
     expect(response).to have_http_status(:ok)
+    expect(parsed_response['meta']['api_version']).to eq 'v1.1'
     expect(parsed_response['meta']['total_count']).to eq 10
   end
 end

--- a/spec/requests/vendor_api/v1.1/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/v1.1/get_multiple_applications_spec.rb
@@ -1,0 +1,209 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - GET /api/v1.1/applications', type: :request do
+  include VendorAPISpecHelpers
+  include CourseOptionHelpers
+
+  before do
+    stub_const('VendorAPI::VERSION', '1.1')
+  end
+
+  it 'returns applications of the authenticated provider' do
+    create_list(
+      :submitted_application_choice,
+      2,
+      :with_completed_application_form,
+      course_option: course_option_for_provider(provider: currently_authenticated_provider),
+      status: 'awaiting_provider_decision',
+    )
+
+    alternate_provider = create(:provider, code: 'DIFFERENT')
+
+    create_list(
+      :submitted_application_choice,
+      1,
+      course_option: course_option_for_provider(provider: alternate_provider),
+      status: 'awaiting_provider_decision',
+    )
+
+    get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+    expect(parsed_response['data'].size).to eq(2)
+  end
+
+  it 'returns applications filtered with `since`' do
+    Timecop.travel(2.days.ago) do
+      create_application_choice_for_currently_authenticated_provider(
+        status: 'awaiting_provider_decision',
+      )
+    end
+
+    create_application_choice_for_currently_authenticated_provider(
+      status: 'awaiting_provider_decision',
+    )
+
+    get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+
+    expect(parsed_response['data'].size).to eq(1)
+  end
+
+  it 'returns a response that is valid according to the OpenAPI schema' do
+    create_application_choice_for_currently_authenticated_provider(
+      status: 'awaiting_provider_decision',
+    )
+
+    get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+
+    expect(parsed_response).to be_valid_against_openapi_schema('MultipleApplicationsResponse')
+  end
+
+  it 'returns an error if the `since` parameter is missing' do
+    get_api_request '/api/v1.1/applications'
+
+    expect(response).to have_http_status(:unprocessable_entity)
+
+    expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse')
+
+    expect(error_response['message']).to eql('param is missing or the value is empty: since')
+  end
+
+  it 'returns HTTP status 422 given an unparseable `since` date value' do
+    get_api_request '/api/v1.1/applications?since=17/07/2020T12:00:42Z'
+
+    expect(response).to have_http_status(:unprocessable_entity)
+
+    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+
+    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): since')
+  end
+
+  it 'returns HTTP status 422 when encountering a KeyError from ActiveSupport::TimeZone' do
+    get_api_request '/api/v1.1/applications?since=12936'
+
+    expect(response).to have_http_status(:unprocessable_entity)
+
+    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+
+    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): since')
+  end
+
+  it 'returns HTTP status 422 given a parseable but nonsensensical `since` date value' do
+    get_api_request '/api/v1.1/applications?since=-004713-03-23T11:52:19.448Z' # this happened
+
+    expect(response).to have_http_status(:unprocessable_entity)
+
+    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+
+    expect(error_response['message']).to eql('Parameter is invalid (date is nonsense): since')
+  end
+
+  it 'returns applications that are in a viewable state' do
+    create_list(
+      :submitted_application_choice,
+      2,
+      :with_completed_application_form,
+      course_option: course_option_for_provider(provider: currently_authenticated_provider),
+      status: :awaiting_provider_decision,
+    )
+
+    create_list(
+      :submitted_application_choice,
+      3,
+      course_option: course_option_for_provider(provider: currently_authenticated_provider),
+      status: :unsubmitted,
+    )
+
+    get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+
+    expect(parsed_response['data'].size).to eq(2)
+  end
+
+  it 'returns applications ordered by updated_at timestamp' do
+    application_choices = create_list(
+      :submitted_application_choice,
+      3,
+      :with_completed_application_form,
+      course_option: course_option_for_provider(provider: currently_authenticated_provider),
+      status: :awaiting_provider_decision,
+    )
+    application_choices.first.update(updated_at: 1.hour.ago)
+    application_choices.second.update(updated_at: 1.minute.ago)
+    application_choices.last.update(updated_at: 10.minutes.ago)
+
+    get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+
+    response_data = parsed_response['data']
+    expect(response_data.size).to eq(3)
+
+    expect(response_data.first['id']).to eq(application_choices.second.id.to_s)
+    expect(response_data.second['id']).to eq(application_choices.last.id.to_s)
+    expect(response_data.last['id']).to eq(application_choices.first.id.to_s)
+
+    application_choices.first.update(updated_at: 10.seconds.ago)
+
+    get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+
+    response_data = parsed_response['data']
+
+    expect(response_data.first['id']).to eq(application_choices.first.id.to_s)
+    expect(response_data.second['id']).to eq(application_choices.second.id.to_s)
+    expect(response_data.last['id']).to eq(application_choices.last.id.to_s)
+  end
+
+  it 'navigates through the pages' do
+    Timecop.freeze(Time.zone.now) do
+      application_choices = create_list(
+        :submitted_application_choice,
+        3,
+        :with_completed_application_form,
+        course_option: course_option_for_provider(provider: currently_authenticated_provider),
+        status: :awaiting_provider_decision,
+      )
+
+      application_choices.first.update(updated_at: 1.hour.ago)
+      application_choices.second.update(updated_at: 1.minute.ago)
+      application_choices.last.update(updated_at: 10.minutes.ago)
+
+      get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=1&per_page=2"
+
+      response_data = parsed_response['data']
+      links_object = parsed_response['links']
+
+      expect(links_object['self']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=1&per_page=2"
+      expect(links_object['prev']).to be_nil
+      expect(links_object['next']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=2&per_page=2"
+      expect(links_object['last']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=2&per_page=2"
+
+      expect(response_data.first['id']).to eq(application_choices.second.id.to_s)
+      expect(response_data.second['id']).to eq(application_choices.last.id.to_s)
+
+      expect(response).to have_http_status(:ok)
+
+      get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=2&per_page=2"
+
+      links_object = parsed_response['links']
+
+      expect(links_object['self']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=2&per_page=2"
+      expect(links_object['prev']).to eq "http://www.example.com/api/v1.1/applications?since=#{1.day.ago.iso8601}&page=1&per_page=2"
+      expect(links_object['next']).to be_nil
+
+      expect(parsed_response['data'].first['id']).to eq(application_choices.first.id.to_s)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  it 'returns the correct total_count in the meta data object' do
+    create_list(
+      :submitted_application_choice,
+      10,
+      :with_completed_application_form,
+      course_option: course_option_for_provider(provider: currently_authenticated_provider),
+      status: :awaiting_provider_decision,
+    )
+
+    get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&per_page=20"
+
+    expect(response).to have_http_status(:ok)
+    expect(parsed_response['meta']['total_count']).to eq 10
+  end
+end

--- a/spec/requests/vendor_api/v1.1/get_single_application_spec.rb
+++ b/spec/requests/vendor_api/v1.1/get_single_application_spec.rb
@@ -30,27 +30,4 @@ RSpec.describe 'Vendor API - GET /api/v1.1/applications/:application_id', type: 
     expect(response).to have_http_status(:ok)
     expect(parsed_response['data']['attributes']['interviews']).not_to be_nil
   end
-
-  it 'does not return the links object' do
-    application_choice = create_application_choice_for_currently_authenticated_provider(
-      status: 'awaiting_provider_decision',
-    )
-
-    get_api_request "/api/v1.1/applications/#{application_choice.id}"
-
-    expect(response).to have_http_status(:ok)
-    expect(parsed_response['links']).to be_nil
-  end
-
-  it 'returns the correct meta data object' do
-    application_choice = create_application_choice_for_currently_authenticated_provider(
-      status: 'awaiting_provider_decision',
-    )
-
-    get_api_request "/api/v1.1/applications/#{application_choice.id}"
-
-    expect(response).to have_http_status(:ok)
-    expect(parsed_response['meta']['version']).to eq 'v1.1'
-    expect(parsed_response['meta']['total_count']).to be_nil
-  end
 end

--- a/spec/requests/vendor_api/v1.1/get_single_application_spec.rb
+++ b/spec/requests/vendor_api/v1.1/get_single_application_spec.rb
@@ -30,4 +30,27 @@ RSpec.describe 'Vendor API - GET /api/v1.1/applications/:application_id', type: 
     expect(response).to have_http_status(:ok)
     expect(parsed_response['data']['attributes']['interviews']).not_to be_nil
   end
+
+  it 'does not return the links object' do
+    application_choice = create_application_choice_for_currently_authenticated_provider(
+      status: 'awaiting_provider_decision',
+    )
+
+    get_api_request "/api/v1.1/applications/#{application_choice.id}"
+
+    expect(response).to have_http_status(:ok)
+    expect(parsed_response['links']).to be_nil
+  end
+
+  it 'returns the correct meta data object' do
+    application_choice = create_application_choice_for_currently_authenticated_provider(
+      status: 'awaiting_provider_decision',
+    )
+
+    get_api_request "/api/v1.1/applications/#{application_choice.id}"
+
+    expect(response).to have_http_status(:ok)
+    expect(parsed_response['meta']['version']).to eq 'v1.1'
+    expect(parsed_response['meta']['total_count']).to be_nil
+  end
 end


### PR DESCRIPTION
## Context

We're adding pagination to the Vendor API in the v1.1 release, using the `pagy` gem.

This will add introduce two optional parameters: `page` and `per_page`, with a default max value of 50 items per page.

It also adds two new objects to the response, a `links` object and a `meta` object:

<img src=https://user-images.githubusercontent.com/47917431/152302015-6d8b2c62-29fe-4199-8b9c-43edba9ecffb.png width="40%">

The links object won't be returned on single application responses.

## Changes proposed in this pull request

- Add a `PaginationAPIData` module that implements the `pagy` methods and returns the paginated records
- Add a `MultipleApplicationsPresenter`
- Add a `SingleApplicationPresenter`
- Add a `MetaPresenter` that will return the `meta` object


## Link to Trello card

https://trello.com/c/9kKZ2tfZ
https://trello.com/c/P62AzVcG
https://trello.com/c/A9IWI1d5

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
