### PR TITLE
API v1.1 Confirm deferred offer

### DIFF
--- a/app/controllers/vendor_api/confirm_deferred_offers_controller.rb
+++ b/app/controllers/vendor_api/confirm_deferred_offers_controller.rb
@@ -1,0 +1,23 @@
+module VendorAPI
+  class ConfirmDeferredOffersController < VendorAPIController
+    include APIValidationsAndErrorHandling
+    include ApplicationDataConcerns
+
+    def create
+      ConfirmDeferredOffer.new(actor: audit_user,
+                               application_choice: application_choice,
+                               course_option: application_choice.current_course_option.in_next_cycle,
+                               conditions_met: conditions_met).save!
+
+      render_application
+    end
+
+  private
+
+    def conditions_met
+      params.require(:data).permit(:conditions_met).tap do |data|
+        data.require(:conditions_met)
+      end[:conditions_met]
+    end
+  end
+end

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -24,6 +24,7 @@ module VendorAPI
     ],
     '1.1' => [
       Changes::DeferAnOffer,
+      Changes::ConfirmADeferredOffer,
       Changes::CreateNote,
       Changes::NotesForApplication,
       Changes::WithdrawOrDeclineApplication,

--- a/app/lib/vendor_api/changes/confirm_a_deferred_offer.rb
+++ b/app/lib/vendor_api/changes/confirm_a_deferred_offer.rb
@@ -1,0 +1,11 @@
+module VendorAPI
+  module Changes
+    class ConfirmADeferredOffer < VersionChange
+      description \
+        "Confirm a deferred offer.\n" \
+        'Confirms a deferred offer from the previous cycle to the current one.'
+
+      action ConfirmDeferredOffersController, :create
+    end
+  end
+end

--- a/app/services/reinstate_conditions_met.rb
+++ b/app/services/reinstate_conditions_met.rb
@@ -10,10 +10,10 @@ class ReinstateConditionsMet
   end
 
   def save!
-    auth.assert_can_make_decisions!(application_choice: application_choice,
-                                    course_option: course_option)
-
     if deferred_offer.valid?
+      auth.assert_can_make_decisions!(application_choice: application_choice,
+                                      course_option: course_option)
+
       audit(actor) do
         ActiveRecord::Base.transaction do
           ApplicationStateChange.new(application_choice).reinstate_conditions_met!

--- a/app/services/reinstate_pending_conditions.rb
+++ b/app/services/reinstate_pending_conditions.rb
@@ -10,10 +10,10 @@ class ReinstatePendingConditions
   end
 
   def save!
-    auth.assert_can_make_decisions!(application_choice: application_choice,
-                                    course_option: course_option)
-
     if deferred_offer.valid?
+      auth.assert_can_make_decisions!(application_choice: application_choice,
+                                      course_option: course_option)
+
       audit(actor) do
         ActiveRecord::Base.transaction do
           ApplicationStateChange.new(application_choice).reinstate_pending_conditions!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -381,7 +381,7 @@ en:
             course_option:
               blank: The offered course does not exist in this recruitment cycle
               not_open_on_apply: The requested course is not open for applications via the Apply service
-              not_in_current_cycle: The requested course does not exist in the current cycle
+              not_in_current_cycle: Only applications deferred in the previous recruitment cycle can be confirmed
         provider_interface/rejected_by_default_feedback_form:
           attributes:
             rejection_reason:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -379,6 +379,7 @@ en:
         confirm_deferred_offer_validations:
           attributes:
             course_option:
+              blank: The offered course does not exist in this recruitment cycle
               not_open_on_apply: The requested course is not open for applications via the Apply service
               not_in_current_cycle: The requested course does not exist in the current cycle
         provider_interface/rejected_by_default_feedback_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -633,6 +633,7 @@ Rails.application.routes.draw do
       post '/withdraw' => 'withdraw_or_decline_offer#create'
 
       resource :deferred_offer, only: :create, path: 'defer-offer'
+      resource :confirm_deferred_offer, only: :create, path: 'confirm-deferred-offer'
 
       post '/interviews/create' => 'interviews#create', as: :interviews_create
       post '/interviews/:interview_id/update' => 'interviews#update', as: :interviews_update

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -72,5 +72,15 @@ FactoryBot.define do
         new_course.save
       end
     end
+
+    trait :available_in_current_and_next_year do
+      recruitment_cycle_year { RecruitmentCycle.current_year }
+
+      after(:create) do |course|
+        new_course = course.dup
+        new_course.recruitment_cycle_year = RecruitmentCycle.next_year
+        new_course.save
+      end
+    end
   end
 end

--- a/spec/factories/course_option.rb
+++ b/spec/factories/course_option.rb
@@ -46,5 +46,21 @@ FactoryBot.define do
         create(:course_option, course: new_course, site: course_option.site)
       end
     end
+
+    trait :available_in_current_and_next_year do
+      course { create(:course, recruitment_cycle_year: RecruitmentCycle.current_year) }
+
+      after(:create) do |course_option|
+        new_course = course_option.course.in_next_cycle
+        unless new_course
+          new_course = course_option.course.dup
+          new_course.recruitment_cycle_year = RecruitmentCycle.next_year
+          new_course.open_on_apply = true
+          new_course.save
+        end
+
+        create(:course_option, course: new_course, site: course_option.site)
+      end
+    end
   end
 end

--- a/spec/requests/vendor_api/v1.1/post_confirm_deferred_offer_spec.rb
+++ b/spec/requests/vendor_api/v1.1/post_confirm_deferred_offer_spec.rb
@@ -1,0 +1,138 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/confirm-deferred-offer', type: :request do
+  include VendorAPISpecHelpers
+
+  before do
+    stub_const('VendorAPI::VERSION', '1.1')
+  end
+
+  let(:application_trait) { :with_deferred_offer }
+  let(:request_body) { { data: { conditions_met: false } } }
+  let!(:application_choice) do
+    create(:submitted_application_choice,
+           :with_completed_application_form,
+           application_trait,
+           course_option: original_course_option,
+           current_course_option: original_course_option)
+  end
+  let(:original_course) do
+    create(:course,
+           :open_on_apply,
+           :previous_year_but_still_available,
+           provider: currently_authenticated_provider)
+  end
+  let(:original_course_option) do
+    create(:course_option,
+           :previous_year_but_still_available,
+           course: original_course)
+  end
+
+  it_behaves_like 'an endpoint that requires metadata', '/confirm-deferred-offer', '1.1'
+
+  describe 'request body' do
+    context 'when valid' do
+      let(:request_body) { { data: { conditions_met: false } } }
+
+      it 'has conditions_met set' do
+        expect(request_body[:data]).to be_valid_against_openapi_schema('ConfirmDeferredOffer', '1.1')
+      end
+    end
+
+    context 'when invalid' do
+      it 'when `data` is missing from the request_body it renders an error' do
+        post_api_request "/api/v1.1/applications/#{application_choice.id}/confirm-deferred-offer", params: { data: {} }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response['errors'].map { |error| error['error'] })
+          .to contain_exactly('ParameterMissing')
+        expect(parsed_response['errors'].map { |error| error['message'] })
+          .to contain_exactly('param is missing or the value is empty: data')
+      end
+
+      it 'when `conditions_met` is missing from the request_body it renders an error' do
+        post_api_request "/api/v1.1/applications/#{application_choice.id}/confirm-deferred-offer", params: { data: { any_param: '' } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response['errors'].map { |error| error['error'] })
+          .to contain_exactly('ParameterMissing')
+        expect(parsed_response['errors'].map { |error| error['message'] })
+          .to contain_exactly('param is missing or the value is empty: conditions_met')
+      end
+    end
+  end
+
+  describe 'confirming a deffered offer' do
+    context 'when the application is not in a state that allows offer deferal' do
+      let(:application_trait) { :with_offer }
+
+      it 'renders an Unprocessable Entity error' do
+        post_api_request "/api/v1.1/applications/#{application_choice.id}/confirm-deferred-offer", params: request_body
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+        expect(parsed_response['errors'].map { |error| error['message'] })
+          .to contain_exactly("It's not possible to perform this action while the application is in its current state")
+      end
+    end
+
+    context 'when the offered course does not exist in the new cycle' do
+      let(:original_course_option) { create(:course_option, course: original_course) }
+
+      it 'renders an Unprocessable Entity error' do
+        post_api_request "/api/v1.1/applications/#{application_choice.id}/confirm-deferred-offer", params: request_body
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+        expect(parsed_response['errors'].map { |error| error['message'] })
+          .to contain_exactly('The offered course does not exist in this recruitment cycle')
+      end
+    end
+
+    context 'when the application choice cannot be found for the authorised provider' do
+      let(:application_choice) do
+        create(:application_choice, :awaiting_provider_decision)
+      end
+
+      it 'renders a NotFound error' do
+        post_api_request "/api/v1.1/applications/#{application_choice.id}/confirm-deferred-offer", params: request_body
+
+        expect(response).to have_http_status(:not_found)
+        expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
+        expect(parsed_response['errors'].map { |error| error['error'] })
+          .to contain_exactly('NotFound')
+      end
+    end
+
+    describe 'when successful' do
+      xit 'renders a SingleApplicationResponse' do
+        post_api_request "/api/v1.1/applications/#{application_choice.id}/confirm-deferred-offer", params: request_body
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse', '1.1')
+      end
+
+      context 'when conditions_met is false' do
+        let(:request_body) { { data: { conditions_met: false } } }
+
+        it 'transitions the application to the pending_conditions state' do
+          post_api_request "/api/v1.1/applications/#{application_choice.id}/confirm-deferred-offer", params: request_body
+
+          expect(response).to have_http_status(:ok)
+          expect(parsed_response['data']['attributes']['status']).to eq('pending_conditions')
+        end
+      end
+
+      context 'when conditions_met is true' do
+        let(:request_body) { { data: { conditions_met: true } } }
+
+        it 'transitions the application to the recruited state' do
+          post_api_request "/api/v1.1/applications/#{application_choice.id}/confirm-deferred-offer", params: request_body
+
+          expect(response).to have_http_status(:ok)
+          expect(parsed_response['data']['attributes']['status']).to eq('recruited')
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/confirm_deferred_offer_validations.rb
+++ b/spec/support/shared_examples/confirm_deferred_offer_validations.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples 'confirm deferred offer validations' do |transition_event|
 
     it 'raises a ValidationException' do
       expect { service.save! }
-        .to raise_error(ValidationException, 'Please provide a course_option or course_option_id')
+        .to raise_error(ValidationException, 'The offered course does not exist in this recruitment cycle')
     end
   end
 

--- a/spec/support/shared_examples/confirm_deferred_offer_validations.rb
+++ b/spec/support/shared_examples/confirm_deferred_offer_validations.rb
@@ -25,7 +25,7 @@ RSpec.shared_examples 'confirm deferred offer validations' do |transition_event|
 
     it 'raises a ValidationException' do
       expect { service.save! }
-        .to raise_error(ValidationException, 'The requested course does not exist in the current cycle')
+        .to raise_error(ValidationException, 'Only applications deferred in the previous recruitment cycle can be confirmed')
     end
   end
 


### PR DESCRIPTION
## Context
Expose endpoint for confirming a deferred offer and test all use cases and errors as specified in v1.1 spec

## Link to Trello card

https://trello.com/c/gzThcQJ4/4725-api-v11-deferrals-confirm-deferred-offer

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
