### PR TITLE
Make coverage change icon accurate and respective of change threshold

### DIFF
--- a/.github/scripts/compare_coverage.js
+++ b/.github/scripts/compare_coverage.js
@@ -19,10 +19,12 @@ module.exports = ({github, context}) => {
   }
 
   const emoji = (difference) => {
-    if (difference > DELTA) {
+    if (difference < (DELTA * -1)) {
+      return ':arrow_down:';
+    } else if (difference > DELTA) {
       return ':arrow_up:';
     } else {
-      return ':arrow_down:';
+      return ':left_right_arrow:';
     }
   }
 


### PR DESCRIPTION


## Context

If the coverage change is within 0.1 or -0.1 we should display a 'no change' icon. Currently show that the coverage has dropped, this is inaccurate.

eg.
![image](https://user-images.githubusercontent.com/93511/151809941-8eb77f10-658e-4f7d-9eb0-70a2877d9421.png)

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Use :left_right_arrow: icon when coverage change is with +- 0.1% change threshold.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
