### PR TITLE
Disable `strict_args` warning in Sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -8,4 +8,6 @@ Sidekiq.configure_server do |config|
   Yabeda::Prometheus::Exporter.start_metrics_server!
 end
 
+Sidekiq.strict_args!(false)
+
 require 'sidekiq/web'


### PR DESCRIPTION
## Context

A new warning was introduced in latest Sidekiq: https://github.com/mperham/sidekiq/pull/5071 which will become an error in version 7.0.0. 

 This is raising errors in the following workers:
```
VendorAPIRequestWorker
DataExporter
```

I've added the following tickets to address those later:
https://trello.com/c/VDFAN4u0/2274-rework-vendorapirequestworker
https://trello.com/c/ZpGm6nOH/2275-change-dataexporter-to-use-native-json-types

For now disable this warning

## Changes proposed in this pull request

Disable Sidekiq warning in the Sidekiq initializer

## Guidance to review

## Link to Trello card

https://github.com/mperham/sidekiq/pull/5071/files

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
