### PR TITLE
Add offer deferred details to offer object in draft API spec

### DIFF
--- a/config/vendor_api/draft.yml
+++ b/config/vendor_api/draft.yml
@@ -579,6 +579,32 @@ components:
           type: string
           description: Author’s name
           example: John Smith
+    Offer:
+      type: object
+      additionalProperties: false
+      required:
+      - conditions
+      - course
+      - status_before_deferral
+      - offer_made_at
+      - offer_accepted_at
+      - offer_declined_at
+      - offer_deferred_at
+      properties:
+        status_before_deferral:
+          type: string
+          nullable: true
+          description: Application status before the deferral (pending_conditions or recruited)
+          enum:
+          - pending_conditions
+          - recruited
+          example: pending_conditions
+        offer_deferred_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When this application was deferred
+          example: 2019-06-10T23:59:59Z
     ConfirmDeferredOffer:
       type: object
       additionalProperties: false


### PR DESCRIPTION
## Context

We are merging draft API spec now into v1. We've cleaned up any old fields, however we missed two new deferred offers ones

## Changes proposed in this pull request

Add back missing offer fields for deferrals: `offer_deferred_at` and `status_before_deferral`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
