### PR TITLE
Fix DataExport sidekiq deprecation

### DIFF
--- a/app/controllers/support_interface/data_exports_controller.rb
+++ b/app/controllers/support_interface/data_exports_controller.rb
@@ -29,7 +29,7 @@ module SupportInterface
     def create
       export_type = DataExport::EXPORT_TYPES.fetch(params.fetch(:export_type_id).to_sym)
       data_export = DataExport.create!(name: export_type.fetch(:name), initiator: current_support_user, export_type: export_type.fetch(:export_type))
-      DataExporter.perform_async(export_type.fetch(:class), data_export.id, export_options)
+      DataExporter.perform_async(export_type.fetch(:class).to_s, data_export.id, export_options)
 
       redirect_to support_interface_data_export_path(data_export)
     end

--- a/app/services/data_api/tad_export.rb
+++ b/app/services/data_api/tad_export.rb
@@ -5,7 +5,7 @@ module DataAPI
         name: 'Daily export of applications for TAD',
         export_type: :tad_applications,
       )
-      DataExporter.perform_async(DataAPI::TADExport, data_export.id)
+      DataExporter.perform_async(DataAPI::TADExport.to_s, data_export.id)
     end
 
     def self.all

--- a/app/services/data_api/tad_subject_domicile_nationality_export.rb
+++ b/app/services/data_api/tad_subject_domicile_nationality_export.rb
@@ -5,7 +5,7 @@ module DataAPI
         name: 'Weekly export of subjects, candidate nationality, domicile and application status for TAD',
         export_type: :tad_subject_domicile_nationality,
       )
-      DataExporter.perform_async(DataAPI::TADSubjectDomicileNationalityExport, data_export.id)
+      DataExporter.perform_async(DataAPI::TADSubjectDomicileNationalityExport.to_s, data_export.id)
     end
 
     def self.all

--- a/app/services/support_interface/applications_by_demographic_domicile_and_degree_class_export.rb
+++ b/app/services/support_interface/applications_by_demographic_domicile_and_degree_class_export.rb
@@ -7,7 +7,7 @@ module SupportInterface
         name: 'Weekly export of the tad applications by demographic domicile and degree class',
         export_type: :applications_by_demographic_domicile_and_degree_class,
       )
-      DataExporter.perform_async(SupportInterface::ApplicationsByDemographicDomicileAndDegreeClassExport, data_export.id)
+      DataExporter.perform_async(SupportInterface::ApplicationsByDemographicDomicileAndDegreeClassExport.to_s, data_export.id)
     end
 
     def call(*)

--- a/app/services/support_interface/applications_by_subject_route_and_degree_grade_export.rb
+++ b/app/services/support_interface/applications_by_subject_route_and_degree_grade_export.rb
@@ -14,7 +14,7 @@ module SupportInterface
         name: 'Weekly export of the applications export grouped by subject, route and degree grade',
         export_type: :applications_by_subject_route_and_degree_grade,
       )
-      DataExporter.perform_async(SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport, data_export.id)
+      DataExporter.perform_async(SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport.to_s, data_export.id)
     end
 
     def call(*)

--- a/app/services/support_interface/ministerial_report_applications_export.rb
+++ b/app/services/support_interface/ministerial_report_applications_export.rb
@@ -5,7 +5,7 @@ module SupportInterface
         name: 'Daily export of the applications ministerial report',
         export_type: :ministerial_report_applications_export,
       )
-      DataExporter.perform_async(SupportInterface::MinisterialReportApplicationsExport, data_export.id)
+      DataExporter.perform_async(SupportInterface::MinisterialReportApplicationsExport.to_s, data_export.id)
     end
 
     def call(*)

--- a/app/services/support_interface/ministerial_report_candidates_export.rb
+++ b/app/services/support_interface/ministerial_report_candidates_export.rb
@@ -5,7 +5,7 @@ module SupportInterface
         name: 'Daily export of the candidates ministerial report',
         export_type: :ministerial_report_candidates_export,
       )
-      DataExporter.perform_async(SupportInterface::MinisterialReportCandidatesExport, data_export.id)
+      DataExporter.perform_async(SupportInterface::MinisterialReportCandidatesExport.to_s, data_export.id)
     end
 
     def call(*)

--- a/spec/requests/data_api/applications_by_demographic_domicile_and_degree_class_export_spec.rb
+++ b/spec/requests/data_api/applications_by_demographic_domicile_and_degree_class_export_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'GET /data-api/tad-data-exports/applications-by-demographic-domic
       export_type: :applications_by_demographic_domicile_and_degree_class,
     )
 
-    DataExporter.perform_async(SupportInterface::ApplicationsByDemographicDomicileAndDegreeClassExport, data_export.id)
+    DataExporter.perform_async(SupportInterface::ApplicationsByDemographicDomicileAndDegreeClassExport.to_s, data_export.id)
 
     get_api_request '/data-api/applications-by-demographic-domicile-and-degree-class/latest', token: tad_api_token
 

--- a/spec/requests/data_api/applications_by_subject_route_and_degree_grade_export_spec.rb
+++ b/spec/requests/data_api/applications_by_subject_route_and_degree_grade_export_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'GET /data-api/applications-by-subject-route-and-degree-grade/lat
       name: 'Weekly export of the applications export grouped by subject, route and degree grade',
       export_type: :applications_by_subject_route_and_degree_grade,
     )
-    DataExporter.perform_async(SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport, data_export.id)
+    DataExporter.perform_async(SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport.to_s, data_export.id)
 
     get_api_request '/data-api/applications-by-subject-route-and-degree-grade/latest', token: tad_api_token
 

--- a/spec/requests/data_api/ministerial_report_applications_export_spec.rb
+++ b/spec/requests/data_api/ministerial_report_applications_export_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'GET /data-api/ministerial-report/applications/latest', type: :re
       name: 'Daily export of the applications ministerial report',
       export_type: :ministerial_report_applications_export,
     )
-    DataExporter.perform_async(SupportInterface::MinisterialReportApplicationsExport, data_export.id)
+    DataExporter.perform_async(SupportInterface::MinisterialReportApplicationsExport.to_s, data_export.id)
 
     get_api_request '/data-api/ministerial-report/applications/latest', token: tad_api_token
 

--- a/spec/requests/data_api/ministerial_report_candidates_export_spec.rb
+++ b/spec/requests/data_api/ministerial_report_candidates_export_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'GET /data-api/ministerial-report/candidates/latest', type: :requ
       name: 'Daily export of the candidates ministerial report',
       export_type: :ministerial_report_candidates_export,
     )
-    DataExporter.perform_async(SupportInterface::MinisterialReportCandidatesExport, data_export.id)
+    DataExporter.perform_async(SupportInterface::MinisterialReportCandidatesExport.to_s, data_export.id)
 
     get_api_request '/data-api/ministerial-report/candidates/latest', token: tad_api_token
 

--- a/spec/requests/data_api/tad_exports_spec.rb
+++ b/spec/requests/data_api/tad_exports_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'GET /data-api/tad-data-exports', type: :request, sidekiq: true d
       create(:submitted_application_choice, :with_completed_application_form)
 
       data_export = DataExport.create!(name: 'Daily export of applications for TAD', export_type: :tad_applications)
-      DataExporter.perform_async(DataAPI::TADExport, data_export.id)
+      DataExporter.perform_async(DataAPI::TADExport.to_s, data_export.id)
     end
 
     it 'returns data exports response JSON values as expected' do
@@ -45,7 +45,7 @@ RSpec.describe 'GET /data-api/tad-data-exports', type: :request, sidekiq: true d
       Timecop.travel(2.days.ago) do
         create(:submitted_application_choice, :with_completed_application_form)
         data_export = DataExport.create!(name: 'Daily export of applications for TAD', export_type: :tad_applications)
-        DataExporter.perform_async(DataAPI::TADExport, data_export.id)
+        DataExporter.perform_async(DataAPI::TADExport.to_s, data_export.id)
       end
 
       get_api_request "/data-api/tad-data-exports?updated_since=#{CGI.escape(1.day.ago.iso8601)}", token: tad_api_token

--- a/spec/requests/data_api/tad_latest_spec.rb
+++ b/spec/requests/data_api/tad_latest_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'GET /data-api/tad-data-exports/latest', type: :request, sidekiq:
       name: 'Daily export of applications for TAD',
       export_type: :tad_applications,
     )
-    DataExporter.perform_async(DataAPI::TADExport, data_export.id)
+    DataExporter.perform_async(DataAPI::TADExport.to_s, data_export.id)
 
     get_api_request '/data-api/tad-data-exports/latest', token: tad_api_token
 

--- a/spec/requests/data_api/tad_single_export_spec.rb
+++ b/spec/requests/data_api/tad_single_export_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'GET /data-api/tad-data-exports/:id', type: :request, sidekiq: tr
       name: 'Daily export of applications for TAD',
       export_type: :tad_applications,
     )
-    DataExporter.perform_async(DataAPI::TADExport, data_export.id)
+    DataExporter.perform_async(DataAPI::TADExport.to_s, data_export.id)
 
     get_api_request "/data-api/tad-data-exports/#{data_export.id}", token: tad_api_token
 


### PR DESCRIPTION
We passed constants, not strings to sidekiq — these were being cast
implicitly in the JSON conversion, causing the following warning since a
recent sidekiq bump.

WARN: Job arguments to DataExporter do not serialize to JSON safely. This will raise an error in
Sidekiq 7.0. See https://github.com/mperham/sidekiq/wiki/Best-Practices or raise an error today

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1643728680536089