### PR TITLE
Add feature flag for the 'apply again' work

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -41,6 +41,7 @@ class FeatureFlag
     [:draft_vendor_api_specification, 'The specification for Draft Vendor API v1.1', 'Abeer Salameh'],
     [:immigration_entry_date, 'Extends the restructured_immigration_status feature to include the "Date of entry into the UK" question', 'Steve Hook'],
     [:duplicate_matching, 'Replaces the fraud matching feature including a re-designed support interface', 'Steve Hook'],
+    [:apply_again_with_three_choices, 'Replaces the current apply again logic which only allows one choice', 'Avin & Tomas'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day


### PR DESCRIPTION
## Context

We are changing the apply again functionality to support 3 applications instead of 1. This will be behind a new feature flag called `apply_again_with_three_choices`

## Changes proposed in this pull request

- Add new feature flag: `apply_again_with_three_choices`

## Guidance to review

- Should we call this `apply_again` or `apply2` 🤔 

## Link to Trello card

https://trello.com/c/eEp4oy1H/4394-apply-again-create-feature-flag