### PR TITLE
Implement versioning api documentation

### DIFF
--- a/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
+++ b/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
@@ -1,14 +1,25 @@
 module APIDocs
   module VendorAPIDocs
     class ReferenceController < APIDocsController
+      include VersioningHelpers
+
+      helper_method :render_api_docs_version_navigation?
+      helper_method :api_docs_version_navigation_items
+
       def reference
-        @api_reference = APIReference.new(VendorAPISpecification.new.as_hash)
+        @api_reference = APIReference.new(VendorAPISpecification.new(version: version).as_hash, version: version)
       end
 
       def draft
         return redirect_to api_docs_reference_path unless FeatureFlag.active?(:draft_vendor_api_specification)
 
-        @api_reference = APIReference.new(VendorAPISpecification.new(draft: true).as_hash)
+        @api_reference = APIReference.new(VendorAPISpecification.new(draft: true).as_hash, draft: true)
+      end
+
+    private
+
+      def version
+        extract_version(params[:api_version])
       end
     end
   end

--- a/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
+++ b/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
@@ -3,9 +3,6 @@ module APIDocs
     class ReferenceController < APIDocsController
       include VersioningHelpers
 
-      helper_method :render_api_docs_version_navigation?
-      helper_method :api_docs_version_navigation_items
-
       def reference
         @api_reference = APIReference.new(VendorAPISpecification.new(version: version).as_hash, version: version)
       end

--- a/app/lib/allowed_cross_namespace_usage.rb
+++ b/app/lib/allowed_cross_namespace_usage.rb
@@ -8,4 +8,5 @@ module AllowedCrossNamespaceUsage
   VendorAPIApplicationPresenter = VendorAPI::ApplicationPresenter
   RegisterAPISingleApplicationPresenter = RegisterAPI::SingleApplicationPresenter
   VENDOR_API_VERSION = VendorAPI::VERSION
+  VENDOR_API_VERSIONS = VendorAPI::VERSIONS
 end

--- a/app/lib/concerns/versioning_helpers.rb
+++ b/app/lib/concerns/versioning_helpers.rb
@@ -14,14 +14,4 @@ module VersioningHelpers
   def version_number(version)
     "#{major_version_number(version)}.#{minor_version_number(version)}"
   end
-
-  def api_docs_version_navigation_items
-    VendorAPI::VERSIONS.keys.select { |v| v <= VendorAPI::VERSION }.sort.map do |v|
-      { name: v, url: api_docs_versioned_reference_path(api_version: "v#{v}") }
-    end
-  end
-
-  def render_api_docs_version_navigation?
-    api_docs_version_navigation_items.size > 1
-  end
 end

--- a/app/lib/concerns/versioning_helpers.rb
+++ b/app/lib/concerns/versioning_helpers.rb
@@ -14,4 +14,14 @@ module VersioningHelpers
   def version_number(version)
     "#{major_version_number(version)}.#{minor_version_number(version)}"
   end
+
+  def api_docs_version_navigation_items
+    VendorAPI::VERSIONS.keys.select { |v| v <= VendorAPI::VERSION }.sort.map do |v|
+      { name: v, url: api_docs_versioned_reference_path(api_version: "v#{v}") }
+    end
+  end
+
+  def render_api_docs_version_navigation?
+    api_docs_version_navigation_items.size > 1
+  end
 end

--- a/app/presenters/api_docs/api_reference.rb
+++ b/app/presenters/api_docs/api_reference.rb
@@ -3,9 +3,10 @@ module APIDocs
     attr_reader :document
     delegate :servers, to: :document
 
-    def initialize(spec, version: nil)
+    def initialize(spec, version: nil, draft: false)
       @document = Openapi3Parser.load(spec)
       @version = version || AllowedCrossNamespaceUsage::VENDOR_API_VERSION
+      @draft = draft
     end
 
     def operations
@@ -39,12 +40,26 @@ module APIDocs
       end
     end
 
+    def self.draft_schema
+      @draft_schema ||= YAML.load_file(VendorAPISpecification::DRAFT_YAML_FILE_PATH)
+    end
+
+    def self.current_schema
+      path = "#{VendorAPISpecification::SPEC_FILE_DIR}/v#{AllowedCrossNamespaceUsage::VENDOR_API_VERSION}.yml"
+      @current_schema ||= YAML.load_file(path)
+    end
+
   private
 
+    def draft?
+      @draft == true
+    end
+
     def new_path?(path)
+      return false unless draft?
       return false unless draft_schema_file_exists?
 
-      draft_schema['paths'].include?(path) && current_schema['paths'].exclude?(path)
+      draft_schema_paths.include?(path) && current_schema_paths.exclude?(path)
     end
 
     def flatten_hash(hash)
@@ -59,20 +74,16 @@ module APIDocs
       end
     end
 
-    def draft_schema
-      @draft_schema ||= YAML.load_file(draft_yaml_file_path)
+    def draft_schema_paths
+      self.class.draft_schema['paths']
+    end
+
+    def current_schema_paths
+      self.class.current_schema['paths']
     end
 
     def draft_schema_file_exists?
-      @draft_schema_file_exists ||= File.exist?(draft_yaml_file_path)
-    end
-
-    def draft_yaml_file_path
-      VendorAPISpecification::DRAFT_YAML_FILE_PATH
-    end
-
-    def current_schema
-      @current_schema ||= YAML.load_file("#{VendorAPISpecification::SPEC_FILE_DIR}/v#{@version}.yml")
+      @draft_schema_file_exists ||= File.exist?(VendorAPISpecification::DRAFT_YAML_FILE_PATH)
     end
   end
 end

--- a/app/presenters/api_docs/api_reference.rb
+++ b/app/presenters/api_docs/api_reference.rb
@@ -1,5 +1,7 @@
 module APIDocs
   class APIReference
+    include Rails.application.routes.url_helpers
+
     attr_reader :document
     delegate :servers, to: :document
 
@@ -47,6 +49,16 @@ module APIDocs
     def self.current_schema
       path = "#{VendorAPISpecification::SPEC_FILE_DIR}/v#{AllowedCrossNamespaceUsage::VENDOR_API_VERSION}.yml"
       @current_schema ||= YAML.load_file(path)
+    end
+
+    def api_docs_version_navigation_items
+      AllowedCrossNamespaceUsage::VENDOR_API_VERSIONS.keys.select { |v| v <= AllowedCrossNamespaceUsage::VENDOR_API_VERSION }.sort.map do |v|
+        { name: v, url: api_docs_versioned_reference_path(api_version: "v#{v}") }
+      end
+    end
+
+    def render_api_docs_version_navigation?
+      api_docs_version_navigation_items.size > 1
     end
 
   private

--- a/app/views/api_docs/vendor_api_docs/reference/reference.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/reference.html.erb
@@ -1,6 +1,6 @@
 <h1 class="govuk-heading-xl"><%= t('page_titles.api_docs.vendor_api_docs.reference') %></h1>
 
-<%= render TabNavigationComponent.new(items: api_docs_version_navigation_items) if render_api_docs_version_navigation? %>
+<%= render TabNavigationComponent.new(items: @api_reference.api_docs_version_navigation_items) if @api_reference.render_api_docs_version_navigation? %>
 
 <h2 class="app-contents-list__title">Contents</h2>
 

--- a/app/views/api_docs/vendor_api_docs/reference/reference.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/reference.html.erb
@@ -1,5 +1,7 @@
 <h1 class="govuk-heading-xl"><%= t('page_titles.api_docs.vendor_api_docs.reference') %></h1>
 
+<%= render TabNavigationComponent.new(items: api_docs_version_navigation_items) if render_api_docs_version_navigation? %>
+
 <h2 class="app-contents-list__title">Contents</h2>
 
 <ol class="app-contents-list__list">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1153,7 +1153,8 @@ Rails.application.routes.draw do
     scope module: :vendor_api_docs, path: '/api-docs' do
       get '/' => 'pages#home', as: :home
       get '/usage-scenarios' => 'pages#usage', as: :usage
-      get '/reference' => 'reference#reference', as: :reference
+      get '/reference' => redirect("/api-docs/v#{VendorAPI::VERSION}/reference"), as: :reference
+      get '/:api_version/reference' => 'reference#reference', constraints: { api_version: /v[.0-9]+/ }, as: :versioned_reference
       get '/release-notes' => 'pages#release_notes', as: :release_notes
       get '/alpha-release-notes' => 'pages#alpha_release_notes'
       get '/lifecycle' => 'pages#lifecycle'

--- a/spec/requests/api_docs/reference_spec.rb
+++ b/spec/requests/api_docs/reference_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'API Docs - GET /api-docs/reference', type: :request do
   end
 
   it 'renders version navigation when more than one version is available' do
-    stub_const('VendorAPI::VERSION', '1.1')
+    stub_const('AllowedCrossNamespaceUsage::VENDOR_API_VERSION', '1.1')
 
     get '/api-docs/v1.1/reference'
 

--- a/spec/requests/api_docs/reference_spec.rb
+++ b/spec/requests/api_docs/reference_spec.rb
@@ -1,17 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe 'API Docs - GET /api-docs/reference', type: :request do
-  VendorAPI::VERSIONS.each_key do |version|
-    before { stub_const('VendorAPI::VERSION', version) }
+  include Capybara::RSpecMatchers
 
+  VendorAPI::VERSIONS.each_key do |version|
     it "returns paths and components for version #{version}" do
-      get '/api-docs/reference'
+      stub_const('VendorAPI::VERSION', version)
+
+      get "/api-docs/v#{version}/reference"
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to match 'API reference'
       expect(response.body).to match 'GET /applications'
       expect(response.body).to match 'MultipleApplicationsResponse'
     end
+  end
+
+  it 'redirects /api-docs/reference to the current version docs' do
+    get '/api-docs/reference'
+
+    expect(response).to have_http_status(:moved_permanently)
+    expect(response).to redirect_to("/api-docs/v#{VendorAPI::VERSION}/reference")
+  end
+
+  it 'renders version navigation when more than one version is available' do
+    stub_const('VendorAPI::VERSION', '1.1')
+
+    get '/api-docs/v1.1/reference'
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to have_link '1.0', href: '/api-docs/v1.0/reference'
+    expect(response.body).to have_link '1.1', href: '/api-docs/v1.1/reference'
   end
 
   it 'returns paths and components for the draft version' do


### PR DESCRIPTION
## Context

We would like documentation to be easy to navigate between different API versions once we have released our first minor version of the API.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Allows version specific routes for API docs eg. `/api-docs/v1.0/reference`
- `/api-docs/reference` redirects to the current version documentation
- Renders additional sub navigation once we have more than one released version...

![image](https://user-images.githubusercontent.com/93511/152200170-34a55050-1697-4ed7-8543-b1ce96b4019a.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/9mbdACSx/4758-implement-versioning-api-documentation
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
