### PR TITLE
Fix duplicate pagination in duplicate matching support UI

### DIFF
--- a/app/components/support_interface/duplicate_matches_table_component.html.erb
+++ b/app/components/support_interface/duplicate_matches_table_component.html.erb
@@ -19,5 +19,3 @@
     <% end %>
   </tbody>
 </table>
-
-<%= render(PaginatorComponent.new(scope: @matches)) %>


### PR DESCRIPTION
## Context

The PaginatedFilter component already adds the pagination.

So when PR #6453 was merged the pagination became duplicated.

So removing the call from the paginator component directly solves
the issue

## Changes proposed in this pull request

Before

<img width="993" alt="Screenshot 2022-02-03 at 07 03 21" src="https://user-images.githubusercontent.com/27509/152323678-d05129f5-67d8-4778-9f98-41a8e7e396b3.png">

After
<img width="980" alt="Screenshot 2022-02-03 at 07 18 41" src="https://user-images.githubusercontent.com/27509/152323743-d596907c-c2b2-462c-8fce-41629e2cf377.png">


## Link to Trello card

https://trello.com/c/ZJJ0iXoa/4400-duplicate-matching-fix-duplicate-pagination

