### PR TITLE
Redesign Apply again add another course button

### DIFF
--- a/app/components/candidate_interface/apply_again_add_another_course_component.erb
+++ b/app/components/candidate_interface/apply_again_add_another_course_component.erb
@@ -1,0 +1,6 @@
+<div class="govuk-inset-text">
+  <%= number_of_courses_remaining %>
+  <br>
+  <br>
+  <%= add_another_course_button %>
+</div>

--- a/app/components/candidate_interface/apply_again_add_another_course_component.rb
+++ b/app/components/candidate_interface/apply_again_add_another_course_component.rb
@@ -1,0 +1,17 @@
+module CandidateInterface
+  class ApplyAgainAddAnotherCourseComponent < ViewComponent::Base
+    attr_accessor :application_form
+
+    def initialize(application_form:)
+      @application_form = application_form
+    end
+
+    def number_of_courses_remaining
+      "You can add #{pluralize(@application_form.choices_left_to_make, 'more course')}"
+    end
+
+    def add_another_course_button
+      govuk_button_link_to t('application_form.courses.another.button'), candidate_interface_course_choices_choose_path, secondary: true
+    end
+  end
+end

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -15,7 +15,11 @@
       </h1>
 
       <% if @application_form.can_add_more_choices? %>
-        <%= govuk_button_link_to t('application_form.courses.another.button'), candidate_interface_course_choices_choose_path, secondary: true %>
+        <% if FeatureFlag.active?(:apply_again_with_three_choices) %>
+          <%= render CandidateInterface::ApplyAgainAddAnotherCourseComponent.new(application_form: @application_form) %>
+        <% else %>
+          <%= govuk_button_link_to t('application_form.courses.another.button'), candidate_interface_course_choices_choose_path, secondary: true %>
+       <% end %>
       <% end %>
     </div>
   </div>

--- a/spec/components/candidate_interface/apply_again_add_another_course_component_spec.rb
+++ b/spec/components/candidate_interface/apply_again_add_another_course_component_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ApplyAgainAddAnotherCourseComponent do
+  before do
+    FeatureFlag.activate(:apply_again_with_three_choices)
+  end
+
+  subject(:result) { render_inline(described_class.new(application_form: application_form)) }
+
+  let(:application_form) { create(:application_form, phase: 'apply_2') }
+
+  context 'when the number of courses chosen is 1' do
+    before do
+      create(:application_choice, application_form: application_form)
+    end
+
+    it 'renders you can add 2 more courses' do
+      expect(result.text).to include('You can add 2 more courses')
+    end
+  end
+
+  context 'when the number of courses chosen is 2' do
+    before do
+      create(:application_choice, application_form: application_form)
+      create(:application_choice, application_form: application_form)
+    end
+
+    it 'renders you can add 1 more course' do
+      expect(result.text).to include('You can add 1 more course')
+    end
+  end
+end

--- a/spec/components/previews/candidate_interface/apply_again_add_another_course_component_preview.rb
+++ b/spec/components/previews/candidate_interface/apply_again_add_another_course_component_preview.rb
@@ -1,0 +1,16 @@
+module CandidateInterface
+  class ApplyAgainAddAnotherCourseComponentPreview < ViewComponent::Preview
+    def with_one_course_choice
+      application_choice = FactoryBot.build_stubbed(:application_choice)
+      application_form = FactoryBot.build_stubbed(:application_form, application_choices: [application_choice])
+      render ApplyAgainAddAnotherCourseComponent.new(application_form: application_form)
+    end
+
+    def with_two_course_choices
+      application_choice = FactoryBot.build_stubbed(:application_choice)
+      second_application_choice = FactoryBot.build_stubbed(:application_choice)
+      application_form = FactoryBot.build_stubbed(:application_form, application_choices: [application_choice, second_application_choice])
+      render ApplyAgainAddAnotherCourseComponent.new(application_form: application_form)
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR aims to draw more attention to the `Add another course` button for the new Apply again flow which enables selection of three choices.
 
## Changes proposed in this pull request

 - Redesign the Apply again `Add another course` button

- Add view component which renders if the `apply_again_with_three_choices` feature flag is enabled

- Add view preview

## Screenshots

### Application with one course

<img width="905" alt="image" src="https://user-images.githubusercontent.com/50492247/152859774-4f5f83db-c7c9-4e10-9d3d-2e70421d4ee9.png">


### Application with two courses

<img width="782" alt="image" src="https://user-images.githubusercontent.com/50492247/152859924-46bb05ea-8b63-4228-9ad1-1c717bb0c29b.png">

## Guidance to review

- Enable the `apply_again_with_three_choices` feature flag
- Find a candidate in `Apply2` and sign in as this candidate
- Add a course, click `Back to application` and you should see the new component
- Repeat the above step and you should see the number of courses you can add text change appropriately

- I've added a couple of line breaks to space out the button from the text, anyone know a neater way to achieve this?

## Link to Trello card

https://trello.com/c/RMCOPSNU/4424-redesign-the-add-another-course-button-in-new-apply2-flow
