### PR TITLE
Production snapshot

### DIFF
--- a/.github/workflows/restore-production-snapshot.yml
+++ b/.github/workflows/restore-production-snapshot.yml
@@ -1,0 +1,56 @@
+name: Restore Snapshot Database 
+#Restores Snapshot Database apply-postgres-snapshot instance from nightly backup
+
+on:
+  workflow_dispatch:
+    inputs:
+      date-to-restore-from:
+        description: The date of the backup to use in the restore in yyyy-MM-dd format
+        required: true
+      environment:
+        description: GitHub environment to run the restore in
+        type: choice
+        default: qa
+        options:
+          - qa
+          - prod
+
+jobs:
+  backup:
+    name: Restore Snapshot Database (production)
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event.inputs.environment }}
+    steps:
+      - name: Setup cf cli
+        uses: DFE-Digital/github-actions/setup-cf-cli@master
+        with:
+          CF_USERNAME:   ${{ secrets.CF_USERNAME }}
+          CF_PASSWORD:   ${{ secrets.CF_PASSWORD }}
+          CF_SPACE_NAME: ${{ secrets.CF_SPACE }}
+          INSTALL_CONDUIT: true
+
+      - name: Setup postgres client
+        uses: DFE-Digital/github-actions/install-postgres-client@master
+        
+      - name: Validate date-to-restore-from input
+        run: if [[ ${{ github.event.inputs.date-to-restore-from }} =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then echo "BACKUP_DATE=${BASH_REMATCH[0]}" >> $GITHUB_ENV; else exit 1; fi
+
+      - name: Get backup file name
+        run: | 
+          az storage blob list --container ${{ github.event.inputs.environment }}-db-backup \
+          --connection-string '${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}' \
+          --query "[? contains(name, 'apply_${{ github.event.inputs.environment }}_${BACKUP_DATE}') && ends_with(name,'tar.gz')].name" | echo "BACKUP_ARCHIVE_NAME=$(jq -r .[0])" >> $GITHUB_ENV
+
+      - name: Download backup
+        run: |
+          az storage blob download --container-name prod-db-backup --name ${BACKUP_ARCHIVE_NAME} --file ${BACKUP_ARCHIVE_NAME} \
+          --connection-string '${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}'
+
+      - name: Extract backup
+        run: |
+          BACKUP_FILE_NAME=$(tar -xvzf ${BACKUP_ARCHIVE_NAME})
+          echo "BACKUP_FILE_NAME=${BACKUP_FILE_NAME}" >> $GITHUB_ENV
+
+      - name: Restore backup to snapshot database
+        run: cf conduit apply-postgres-snapshot -- psql < ${BACKUP_FILE_NAME}

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -155,6 +155,18 @@ resource "cloudfoundry_service_instance" "postgres" {
   }
 }
 
+resource "cloudfoundry_service_instance" "postgres_snapshot" {
+  count        = var.snapshot_databases_to_deploy
+  name         = local.postgres_snapshot_service_name
+  space        = data.cloudfoundry_space.space.id
+  service_plan = data.cloudfoundry_service.postgres.service_plans[var.postgres_snapshot_service_plan]
+  json_params  = jsonencode(local.postgres_params)
+  timeouts {
+    create = "60m"
+    update = "60m"
+  }
+}
+
 resource "cloudfoundry_service_key" "postgres" {
   name = "postgres-${var.app_environment}"
   service_instance = cloudfoundry_service_instance.postgres.id

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -22,6 +22,10 @@ variable "app_environment_variables" {}
 
 variable "postgres_service_plan" {}
 
+variable "postgres_snapshot_service_plan" {}
+
+variable "snapshot_databases_to_deploy" { }
+
 variable "worker_redis_service_plan" {}
 
 variable "cache_redis_service_plan" {}
@@ -55,14 +59,15 @@ variable "assets_host_names" {
 }
 
 locals {
-  web_app_name                = "apply-${var.app_environment}"
-  clock_app_name              = "apply-clock-${var.app_environment}"
-  worker_app_name             = "apply-worker-${var.app_environment}"
-  secondary_worker_app_name   = "apply-secondary-worker-${var.app_environment}"
-  postgres_service_name       = "apply-postgres-${var.app_environment}"
-  worker_redis_service_name   = "apply-worker-redis-${var.app_environment}"
-  cache_redis_service_name    = "apply-cache-redis-${var.app_environment}"
-  logging_service_name        = "apply-logit-${var.app_environment}"
+  web_app_name                    = "apply-${var.app_environment}"
+  clock_app_name                  = "apply-clock-${var.app_environment}"
+  worker_app_name                 = "apply-worker-${var.app_environment}"
+  secondary_worker_app_name       = "apply-secondary-worker-${var.app_environment}"
+  postgres_service_name           = "apply-postgres-${var.app_environment}"
+  postgres_snapshot_service_name  = "apply-postgres-snapshot"
+  worker_redis_service_name       = "apply-worker-redis-${var.app_environment}"
+  cache_redis_service_name        = "apply-cache-redis-${var.app_environment}"
+  logging_service_name            = "apply-logit-${var.app_environment}"
   default_postgres_params = {
     enable_extensions = ["pg_buffercache", "pg_stat_statements", "pgcrypto"]
   }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -45,6 +45,8 @@ module "paas" {
   app_environment_variables      = local.paas_app_environment_variables
   logstash_url                   = local.infra_secrets.LOGSTASH_URL
   postgres_service_plan          = var.paas_postgres_service_plan
+  postgres_snapshot_service_plan = var.paas_postgres_snapshot_service_plan
+  snapshot_databases_to_deploy   = var.paas_snapshot_databases_to_deploy
   worker_redis_service_plan      = var.paas_worker_redis_service_plan
   cache_redis_service_plan       = var.paas_cache_redis_service_plan
   clock_app_memory               = var.paas_clock_app_memory

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,6 +15,10 @@ variable "paas_web_app_instances" {}
 
 variable "paas_postgres_service_plan" {}
 
+variable "paas_postgres_snapshot_service_plan" { default = "small-11" }
+
+variable "paas_snapshot_databases_to_deploy" { default = 0 }
+
 variable "paas_worker_redis_service_plan" {}
 
 variable "paas_cache_redis_service_plan" {}

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -8,6 +8,7 @@
   "paas_worker_app_instances": 8,
   "paas_worker_secondary_app_instances": 2,
   "paas_postgres_service_plan": "medium-ha-11",
+  "paas_snapshot_databases_to_deploy": 1,
   "paas_worker_redis_service_plan": "micro-ha-5_x",
   "paas_cache_redis_service_plan": "micro-ha-5_x",
   "key_vault_resource_group": "s121p01-shared-rg",

--- a/terraform/workspace_variables/qa.tfvars.json
+++ b/terraform/workspace_variables/qa.tfvars.json
@@ -4,6 +4,7 @@
   "paas_web_app_memory": 1024,
   "paas_web_app_instances": 2,
   "paas_postgres_service_plan": "small-11",
+  "paas_snapshot_databases_to_deploy": 1,
   "paas_worker_redis_service_plan": "micro-5_x",
   "paas_cache_redis_service_plan": "micro-5_x",
   "key_vault_resource_group": "s121d01-shared-rg",


### PR DESCRIPTION
## Context

There is a requirement to access production data from a particular point in time.  This workflow restores a nightly backup to the
apply-postgres-snapshot instance.

## Changes proposed in this pull request

- Creates a new postgres database resource called `apply-postgres-snapshot`
- Adds a new workflow that accepts a date on dispatch and will restore the overnight backup from Azure storage into `apply-postgres-snapshot`

## Guidance to review

- Confirm that the process restores the database as expected.  This can be tested in QA, backups of the QA database have been created for this purpose.  Command to test is `gh workflow run "Restore Snapshot Database" --repo DFE-Digital/apply-for-teacher-training --ref production_snapshot -f date-to-restore-from=2022-02-04 -
f environment=qa`
- Consider whether sufficient safeguards are in place to prevent an accidental restore against `apply-postgres-prod` instead of `apply-postgres-snapshot`

## Link to Trello card

https://trello.com/c/mnoKZh5K

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
