### PR TITLE
Mark duplicate candidates as submission blocked and send emails

### DIFF
--- a/app/services/duplicate_match_block_submissions.rb
+++ b/app/services/duplicate_match_block_submissions.rb
@@ -1,0 +1,17 @@
+class DuplicateMatchBlockSubmissions
+  attr_reader :duplicate_matches
+
+  def initialize(start_date: Date.new(2022, 1, 25), end_date: Date.new(2022, 2, 2))
+    @duplicate_matches = FraudMatch.where(
+      'created_at between ? AND ?', start_date, end_date
+    )
+  end
+
+  def call
+    @duplicate_matches.each do |duplicate_match|
+      duplicate_match.candidates.each do |candidate|
+        candidate.update(submission_blocked: true)
+      end
+    end
+  end
+end

--- a/app/services/duplicate_match_send_email.rb
+++ b/app/services/duplicate_match_send_email.rb
@@ -1,0 +1,18 @@
+class DuplicateMatchSendEmail
+  attr_reader :duplicate_matches
+
+  def initialize(start_date: Date.new(2022, 1, 26), end_date: Date.new(2022, 2, 2))
+    @duplicate_matches = FraudMatch.where(
+      'created_at between ? AND ?', start_date, end_date
+    )
+  end
+
+  def call
+    @duplicate_matches.each do |duplicate_match|
+      duplicate_match.candidates.each do |candidate|
+        SupportInterface::SendDuplicateMatchEmail.new(candidate).call
+        duplicate_match.update!(candidate_last_contacted_at: Time.zone.now)
+      end
+    end
+  end
+end

--- a/spec/services/duplicate_match_block_submissions_spec.rb
+++ b/spec/services/duplicate_match_block_submissions_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe DuplicateMatchBlockSubmissions do
+  subject(:block_submissions) { described_class.new.call }
+
+  let(:candidate1) { create(:candidate, email_address: 'exemplar1@example.com') }
+  let(:candidate2) { create(:candidate, email_address: 'exemplar2@example.com') }
+  let(:candidate3) { create(:candidate, email_address: 'exemplar3@example.com') }
+
+  before do
+    Timecop.freeze(Time.zone.local(2022, 1, 28)) do
+      create(:fraud_match, candidates: [candidate1, candidate2])
+    end
+
+    Timecop.freeze(Time.zone.local(2022, 1, 1)) do
+      create(:fraud_match, candidates: [candidate3])
+    end
+
+    block_submissions
+  end
+
+  context 'when is the right period' do
+    it 'marks candidates as submission blocked' do
+      expect(candidate1.reload.submission_blocked).to be(true)
+      expect(candidate2.reload.submission_blocked).to be(true)
+    end
+  end
+
+  context 'when is outside of the right period' do
+    it 'does not mark candidates as submission blocked' do
+      expect(candidate3.reload.submission_blocked).to be(false)
+    end
+  end
+end

--- a/spec/services/duplicate_match_send_email_spec.rb
+++ b/spec/services/duplicate_match_send_email_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe DuplicateMatchSendEmail, sidekiq: true do
+  subject(:send_email) { described_class.new.call }
+
+  let(:candidate1) { create(:candidate, email_address: 'exemplar1@example.com') }
+  let(:candidate2) { create(:candidate, email_address: 'exemplar2@example.com') }
+  let(:candidate3) { create(:candidate, email_address: 'exemplar3@example.com') }
+
+  before do
+    Timecop.freeze(Time.zone.local(2022, 1, 28)) do
+      create(:fraud_match, candidates: [candidate1, candidate2])
+    end
+
+    Timecop.freeze(Time.zone.local(2022, 1, 1)) do
+      create(:fraud_match, candidates: [candidate3])
+    end
+
+    send_email
+  end
+
+  it 'sends email to the right candidates in the right period' do
+    expect(ActionMailer::Base.deliveries.map(&:to)).to match_array(
+      [
+        ['exemplar1@example.com'],
+        ['exemplar2@example.com'],
+      ],
+    )
+  end
+end


### PR DESCRIPTION
## Context

We need to send the duplicate match emails to the duplicate candidates from the period of January 26th - February 2nd which is the period that we turn off the duplicate matching feature flag and those new matches weren't notified.

We need to mark the duplicate match candidates as submission blocked from the period of
January 25th - February 2nd which is the period that those candidates weren't marked as submission blocked.

## How to run

So I could have done a Data Migration, but the reason I choose classes is to inspect the number of fraud matches before sending the email or marked as submission blocked.

In order to run

```
   block_submissions = DuplicateMatchBlockSubmissions

   # See how many matches
   block_submissions.duplicate_matches.size

   # Block candidates submissions
   block_submissions.call

   send_email = DuplicateMatchSendEmail

   # See how many matches
   send_email.duplicate_matches.size

   # Send duplicate match emails
   send_email.call
```

## Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/sty3ct38/4401-duplicate-matching-send-duplicate-matching-emails-to-some-candidates)

