### PR TITLE
Fix the setup interview button bug

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -68,7 +68,7 @@ module ProviderInterface
     end
 
     def set_up_interview?
-      application_choice.decision_pending? && provider_can_set_up_interviews
+      application_choice.decision_pending? && provider_can_set_up_interviews && !application_choice.interviewing?
     end
 
     def inset_text_title

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     then_i_see_a_success_message
     and_an_interview_has_been_created(1.day.from_now.to_s(:govuk_date))
 
+    when_i_navigate_to_notes_tab
+    and_i_do_not_see_the_set_up_interview_button
+    then_i_navigate_back_to_the_interviews_tab
+
     when_i_set_up_another_interview(days_in_future: 2)
     then_another_interview_has_been_created(2.days.from_now.to_s(:govuk_date))
 
@@ -144,6 +148,18 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   end
 
   alias_method :then_another_interview_has_been_created, :and_an_interview_has_been_created
+
+  def when_i_navigate_to_notes_tab
+    click_on 'Notes'
+  end
+
+  def and_i_do_not_see_the_set_up_interview_button
+    expect(page).not_to have_button 'Set up interview'
+  end
+
+  def then_i_navigate_back_to_the_interviews_tab
+    click_on 'Interviews'
+  end
 
   def when_i_change_the_interview_details
     click_on 'Change details', match: :first


### PR DESCRIPTION
## Context

When accessing an application that is on the interviewing state, the Setup interview button should not be available is an interview has already been setup for it.

When accessing Application, Notes or Timeline tabs however, the button is still available.

## Changes proposed in this pull request

Add an additional check to the `set_up_interview?` method to prevent the button from rendering for any applications that ### are currently in an interviewing state.

## Link to Trello card

https://trello.com/c/rBawodQl

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
