### PR TITLE
Touch application choice when interviews are created or modified

### DIFF
--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -6,7 +6,7 @@ class Interview < ApplicationRecord
 
   audited associated_with: :application_choice
 
-  belongs_to :application_choice
+  belongs_to :application_choice, touch: true
   belongs_to :provider
 
   validates :date_and_time, presence: true

--- a/spec/services/cancel_interview_spec.rb
+++ b/spec/services/cancel_interview_spec.rb
@@ -46,5 +46,11 @@ RSpec.describe CancelInterview do
 
       expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('interview_cancelled')
     end
+
+    it 'touches the application choice' do
+      expect {
+        described_class.new(service_params).save!
+      }.to change(application_choice, :updated_at)
+    end
   end
 end

--- a/spec/services/create_interview_spec.rb
+++ b/spec/services/create_interview_spec.rb
@@ -44,5 +44,11 @@ RSpec.describe CreateInterview do
 
       expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('new_interview')
     end
+
+    it 'touches the application choice' do
+      expect {
+        described_class.new(service_params).save!
+      }.to change(application_choice, :updated_at)
+    end
   end
 end

--- a/spec/services/update_interview_spec.rb
+++ b/spec/services/update_interview_spec.rb
@@ -66,5 +66,11 @@ RSpec.describe UpdateInterview do
 
       expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('interview_updated')
     end
+
+    it 'touches the application choice' do
+      expect {
+        described_class.new(service_params).save!
+      }.to change(application_choice, :updated_at)
+    end
   end
 end


### PR DESCRIPTION
## Context

If we create an interview for the first time, the application choice is updated because we are changing the status. 
However if we continue to create/update interviews on the same application, the updated at field will not be touched again.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Add `touch: true` to interviews `belongs_to :application_choice` association

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/zQgbaZT7/4783-touch-application-choice-if-interview-updated
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
