### PR TITLE
Style edits emails

### DIFF
--- a/app/components/candidate_interface/offers_call_to_action_component.rb
+++ b/app/components/candidate_interface/offers_call_to_action_component.rb
@@ -12,7 +12,7 @@ module CandidateInterface
     end
 
     def message
-      "You have #{pluralize(days_left_to_respond, 'day')} (until #{decline_by_default_date.to_s(:govuk_date)}) to respond. If you do not respond, your #{'offer'.pluralize(offer_count)} will automatically be declined."
+      "You have #{pluralize(days_left_to_respond, 'day')} (until #{decline_by_default_date.to_s(:govuk_date)}) to respond. If you do not respond, your #{'offer'.pluralize(offer_count)} will be automatically declined."
     end
 
     def render?

--- a/app/views/authentication_mailer/sign_in_email.text.erb
+++ b/app/views/authentication_mailer/sign_in_email.text.erb
@@ -1,5 +1,5 @@
 # <%= t('authentication.sign_in.email.subject') %>
 
-Click the link below to sign in to the <%= t('service_name.apply') %> service.
+Sign in:
 
 <%= @magic_link %>

--- a/app/views/authentication_mailer/sign_in_email.text.erb
+++ b/app/views/authentication_mailer/sign_in_email.text.erb
@@ -1,5 +1,3 @@
-# <%= t('authentication.sign_in.email.subject') %>
-
-Sign in:
+Sign in to apply for teacher training:
 
 <%= @magic_link %>

--- a/app/views/authentication_mailer/sign_in_without_account_email.text.erb
+++ b/app/views/authentication_mailer/sign_in_without_account_email.text.erb
@@ -1,8 +1,7 @@
 # <%= t('authentication.sign_in_without_account.email.subject') %>
 
-You attempted to sign in to the <%= t('service_name.apply') %> service, but we could not find an account with your email address.
+You attempted to sign in to <%= t('service_name.apply') %>, but we could not find an account with your email address.
 
-Click the link below to sign up to the <%= t('service_name.apply') %> service.
+Sign up:
 
 <%= candidate_interface_sign_up_url %>
-

--- a/app/views/authentication_mailer/sign_in_without_account_email.text.erb
+++ b/app/views/authentication_mailer/sign_in_without_account_email.text.erb
@@ -1,7 +1,5 @@
-# <%= t('authentication.sign_in_without_account.email.subject') %>
+You tried to sign in to apply for teacher training. It looks like you do not have an account yet.
 
-You attempted to sign in to <%= t('service_name.apply') %>, but we could not find an account with your email address.
-
-Sign up:
+Create an account:
 
 <%= candidate_interface_sign_up_url %>

--- a/app/views/authentication_mailer/sign_up_email.text.erb
+++ b/app/views/authentication_mailer/sign_up_email.text.erb
@@ -1,7 +1,7 @@
 # <%= t('authentication.sign_up.email.subject') %>
 
-Click the link below to confirm your email address and go back to the <%= t('service_name.apply') %> service.
+Confirm your email address and go back to <%= t('service_name.apply') %>:
 
 <%= @magic_link %>
 
-You will then be able to save and return to your application.
+You can then save and return to your application.

--- a/app/views/candidate_mailer/_rejected_by_default_intro.text.erb
+++ b/app/views/candidate_mailer/_rejected_by_default_intro.text.erb
@@ -1,4 +1,4 @@
-Your application to study <%= @course.name_and_code %> cannot progress because <%= @course.provider.name %> did not make a decision before their deadline to respond.
+Your application to study <%= @course.name_and_code %> cannot progress because <%= @course.provider.name %> did not make a decision by their deadline.
 
 Unless the provider has indicated that they want to progress your application, you should consider this application closed and choose another course or provider.
 

--- a/app/views/candidate_mailer/application_rejected_all_applications_rejected.text.erb
+++ b/app/views/candidate_mailer/application_rejected_all_applications_rejected.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 <% if @application_choice.rejected_by_default %>
 

--- a/app/views/candidate_mailer/application_rejected_awaiting_decision_only.text.erb
+++ b/app/views/candidate_mailer/application_rejected_awaiting_decision_only.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 <% if @application_choice.rejected_by_default %>
 

--- a/app/views/candidate_mailer/application_rejected_offers_only.text.erb
+++ b/app/views/candidate_mailer/application_rejected_offers_only.text.erb
@@ -30,7 +30,7 @@ You’re not waiting for any other decisions.
 
 <% end %>
 
-The <%= 'offer'.pluralize(@offers.length) %> will automatically be withdrawn if you do not respond by <%= @respond_by_date %>.
+The <%= 'offer'.pluralize(@offers.length) %> will be automatically declined if you do not respond by <%= @respond_by_date %>.
 
 Sign in to your account to respond:
 

--- a/app/views/candidate_mailer/application_rejected_offers_only.text.erb
+++ b/app/views/candidate_mailer/application_rejected_offers_only.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 <% if @application_choice.rejected_by_default %>
 

--- a/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # Update on your application
 

--- a/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# Update on your application
-
 <% if @application_choice.rejected_by_default %>
 
   <%= render 'rejected_by_default_intro' %>

--- a/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
@@ -20,6 +20,6 @@ You have an offer from <%= @offer.course_option.course.provider.name %> to study
 
 <%= @awaiting_decision.course_option.course.provider.name %> has until <%= @awaiting_decision_by %> to make a decision about your application to study <%= @awaiting_decision.course_option.course.name %>.
 
-You can wait until you’ve received both decisions before you respond. Alternatively you can sign in to your account and accept the offer you’ve already got:
+You can wait until you’ve received both decisions before you respond. Alternatively, you can sign in to your account and accept your existing offer:
 
 <%= @candidate_magic_link %>

--- a/app/views/candidate_mailer/application_withdrawn_on_request_all_applications_withdrawn.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_all_applications_withdrawn.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# Update on your application
-
 At your request, <%= @course.provider.name %> has withdrawn your application to study <%= @course.name_and_code %>.
 
 Get in touch if you did not ask them to do this:

--- a/app/views/candidate_mailer/application_withdrawn_on_request_all_applications_withdrawn.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_all_applications_withdrawn.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # Update on your application
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_all_applications_withdrawn.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_all_applications_withdrawn.text.erb
@@ -8,8 +8,6 @@ Get in touch if you did not ask them to do this:
 
 https://getintoteaching.education.gov.uk/#talk-to-us
 
-You can also call for free on 0800 389 2500, <%= t('get_into_teaching.opening_times') %>.
-
 # You can apply again
 
 <% if @multiple_applications %>

--- a/app/views/candidate_mailer/application_withdrawn_on_request_awaiting_decision_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_awaiting_decision_only.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# Update on your application
-
 At your request, <%= @course.provider.name %> has withdrawn your application to study <%= @course.name_and_code %>.
 
 Get in touch if you did not ask them to do this:

--- a/app/views/candidate_mailer/application_withdrawn_on_request_awaiting_decision_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_awaiting_decision_only.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # Update on your application
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_awaiting_decision_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_awaiting_decision_only.text.erb
@@ -8,8 +8,6 @@ Get in touch if you did not ask them to do this:
 
 https://getintoteaching.education.gov.uk/#talk-to-us
 
-You can also call for free on 0800 389 2500, <%= t('get_into_teaching.opening_times') %>.
-
 <% if @awaiting_decision.length == 1 %>
 
 # You’re waiting for a decision

--- a/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # Update on your application
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
@@ -26,7 +26,7 @@ You’re not waiting for any other decisions.
 
 <% end %>
 
-The <%= 'offer'.pluralize(@offers.length) %> will automatically be withdrawn if you do not respond by <%= @respond_by_date %>.
+The <%= 'offer'.pluralize(@offers.length) %> will be automatically declined if you do not respond by <%= @respond_by_date %>.
 
 Sign in to your account to respond:
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
@@ -8,8 +8,6 @@ Get in touch if you did not ask them to do this:
 
 https://getintoteaching.education.gov.uk/#talk-to-us
 
-You can also call for free on 0800 389 2500, <%= t('get_into_teaching.opening_times') %>.
-
 # Respond to your <%= 'offer'.pluralize(@offers.length) %> by <%= @respond_by_date %>
 
 <% if @offers.length == 1 %>

--- a/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
@@ -16,6 +16,6 @@ You have an offer from <%= @offer.course_option.course.provider.name %> to study
 
 <%= @awaiting_decision.course_option.course.provider.name %> has until <%= @awaiting_decision_by %> to make a decision about your application to study <%= @awaiting_decision.course_option.course.name %>.
 
-You can wait until you’ve received both decisions before you respond. Alternatively you can sign in to your account and accept the offer you’ve already got:
+You can wait until you’ve received both decisions before you respond. Alternatively, you can sign in to your account and accept your existing offer:
 
 <%= @candidate_magic_link %>

--- a/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# Update on your application
-
 At your request, <%= @course.provider.name %> has withdrawn your application to study <%= @course.name_and_code %>.
 
 Get in touch if you did not ask them to do this:

--- a/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # Update on your application
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
@@ -8,8 +8,6 @@ Get in touch if you did not ask them to do this:
 
 https://getintoteaching.education.gov.uk/#talk-to-us
 
-You can also call for free on 0800 389 2500, <%= t('get_into_teaching.opening_times') %>.
-
 # You have an offer and are waiting for a decision about another course
 
 You have an offer from <%= @offer.course_option.course.provider.name %> to study <%= @offer.course_option.course.name %>.

--- a/app/views/candidate_mailer/apply_again_call_to_action.text.erb
+++ b/app/views/candidate_mailer/apply_again_call_to_action.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # You can still apply for teacher training
 

--- a/app/views/candidate_mailer/changed_offer.text.erb
+++ b/app/views/candidate_mailer/changed_offer.text.erb
@@ -27,7 +27,7 @@ If you were not expecting this change, contact <%= @course_option.course.provide
 
 # Make a decision by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>
 
-If you do not reply by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>, your application will be withdrawn.
+If you do not reply by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>, your offer(s) will be declined automatically.
 
 <% if @offers.count > 1 %>
   <%= render "offer_list" %>

--- a/app/views/candidate_mailer/changed_offer.text.erb
+++ b/app/views/candidate_mailer/changed_offer.text.erb
@@ -27,7 +27,7 @@ If you were not expecting this change, contact <%= @course_option.course.provide
 
 # Respond by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>
 
-If you do not respond by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>, your offer(s) will be declined automatically.
+If you do not respond by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>, your <%= 'offer'.pluralize(@offers.length) %> will be declined automatically.
 
 <% if @offers.count > 1 %>
   <%= render "offer_list" %>

--- a/app/views/candidate_mailer/changed_offer.text.erb
+++ b/app/views/candidate_mailer/changed_offer.text.erb
@@ -25,9 +25,9 @@ If you were not expecting this change, contact <%= @course_option.course.provide
 
 <% else %>
 
-# Make a decision by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>
+# Respond by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>
 
-If you do not reply by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>, your offer(s) will be declined automatically.
+If you do not respond by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>, your offer(s) will be declined automatically.
 
 <% if @offers.count > 1 %>
   <%= render "offer_list" %>

--- a/app/views/candidate_mailer/chase_candidate_decision.text.erb
+++ b/app/views/candidate_mailer/chase_candidate_decision.text.erb
@@ -6,7 +6,7 @@ Dear <%= @application_form.first_name %>
 
 You have until <%= @dbd_date %> to respond to your offers.
 
-If you do not respond by <%= @dbd_date %>, your application will be withdrawn.
+If you do not respond by <%= @dbd_date %>, your offers will be declined automatically.
 
   <%= render "offer_list" %>
 
@@ -14,7 +14,7 @@ If you do not respond by <%= @dbd_date %>, your application will be withdrawn.
 
 You have until <%= @dbd_date %> to respond to your offer to study <%= @application_choices.first.course_option.course.name %> at <%= @application_choices.first.course_option.course.provider.name %>.
 
-If you do not respond by <%= @dbd_date %>, your application will be withdrawn.
+If you do not respond by <%= @dbd_date %>, your offer will be declined automatically.
 
 <% end %>
 

--- a/app/views/candidate_mailer/chase_candidate_decision.text.erb
+++ b/app/views/candidate_mailer/chase_candidate_decision.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # Respond by <%= @dbd_date %>
 

--- a/app/views/candidate_mailer/conditions_met.text.erb
+++ b/app/views/candidate_mailer/conditions_met.text.erb
@@ -6,4 +6,4 @@ Congratulations, <%= @application_choice.current_course_option.course.provider.n
 
 # Next steps
 
-If they have not already, <%= @application_choice.current_course_option.course.provider.name %> should be in contact about enrolling on the course. You can contact them directly if you have any questions about this process.
+If they have not already, <%= @application_choice.current_course_option.course.provider.name %> should be in contact about enrolling on the course. Contact them directly if you have any questions about this process.

--- a/app/views/candidate_mailer/conditions_met.text.erb
+++ b/app/views/candidate_mailer/conditions_met.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # You’ve met your conditions
 

--- a/app/views/candidate_mailer/conditions_not_met.text.erb
+++ b/app/views/candidate_mailer/conditions_not_met.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # You have not met your conditions
 

--- a/app/views/candidate_mailer/decline_last_application_choice.text.erb
+++ b/app/views/candidate_mailer/decline_last_application_choice.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# Offer declined
-
 You’ve declined your offer to study <%= @declined_course_name %>.
 
 <%= render 'still_interested_in_teaching' %>

--- a/app/views/candidate_mailer/decline_last_application_choice.text.erb
+++ b/app/views/candidate_mailer/decline_last_application_choice.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # Offer declined
 

--- a/app/views/candidate_mailer/declined_by_default.text.erb
+++ b/app/views/candidate_mailer/declined_by_default.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # <%= 'Application'.pluralize(@declined_course_names.size) %> withdrawn automatically
 

--- a/app/views/candidate_mailer/declined_by_default.text.erb
+++ b/app/views/candidate_mailer/declined_by_default.text.erb
@@ -1,5 +1,3 @@
 Dear <%= @application_form.first_name %>
 
-# <%= 'Application'.pluralize(@declined_course_names.size) %> withdrawn automatically
-
-We withdrew your application for <%= @declined_course_names.to_sentence %> because you did not respond to the <%= 'offer'.pluralize(@declined_course_names.size) %> within <%= @declined_courses.first.decline_by_default_days %> working days.
+You did not respond within <%= @declined_courses.first.decline_by_default_days %> working days so we declined your <%= 'offer'.pluralize(@declined_course_names.size) %> for <%= @declined_course_names.to_sentence %>.

--- a/app/views/candidate_mailer/declined_by_default_with_rejections.text.erb
+++ b/app/views/candidate_mailer/declined_by_default_with_rejections.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # <%= 'Application'.pluralize(@declined_course_names.size) %> withdrawn automatically
 

--- a/app/views/candidate_mailer/declined_by_default_with_rejections.text.erb
+++ b/app/views/candidate_mailer/declined_by_default_with_rejections.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# <%= 'Application'.pluralize(@declined_course_names.size) %> withdrawn automatically
-
-You did not respond within <%= @declined_courses.first.decline_by_default_days %> working days so we declined your <%= 'offer'.pluralize(@declined_course_names.size) %> for <%= @declined_course_names.to_sentence %>
+You did not respond within <%= @declined_courses.first.decline_by_default_days %> working days so we declined your <%= 'offer'.pluralize(@declined_course_names.size) %> for <%= @declined_course_names.to_sentence %>.
 
 <%= render 'still_interested_in_teaching' %>

--- a/app/views/candidate_mailer/declined_by_default_without_rejections.text.erb
+++ b/app/views/candidate_mailer/declined_by_default_without_rejections.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # <%= 'Application'.pluralize(@declined_course_names.size) %> withdrawn automatically
 

--- a/app/views/candidate_mailer/declined_by_default_without_rejections.text.erb
+++ b/app/views/candidate_mailer/declined_by_default_without_rejections.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# <%= 'Application'.pluralize(@declined_course_names.size) %> withdrawn automatically
-
-You did not respond within <%= @declined_courses.first.decline_by_default_days %> working days so we declined your <%= 'offer'.pluralize(@declined_course_names.size) %> for <%= @declined_course_names.to_sentence %>
+You did not respond within <%= @declined_courses.first.decline_by_default_days %> working days so we declined your <%= 'offer'.pluralize(@declined_course_names.size) %> for <%= @declined_course_names.to_sentence %>.
 
 <%= render 'still_interested_in_teaching' %>

--- a/app/views/candidate_mailer/deferred_offer.text.erb
+++ b/app/views/candidate_mailer/deferred_offer.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# Your offer has been deferred
-
 <%= @course.provider.name %> has deferred your offer to study <%= @course.name_and_code %> until the next academic year (<%= @new_course_academic_year %>).
 
 Any conditions for this offer will be confirmed closer to the start date of the course.
@@ -10,4 +8,4 @@ Any conditions for this offer will be confirmed closer to the start date of the 
 
 <%= @course.provider.name %> will send you an email shortly after October <%= @course.recruitment_cycle_year %>, to confirm the offer.
 
-If you don’t receive a message from <%= @course.provider.name %>, you should contact us.
+Contact us if you do not receive a message from <%= @course.provider.name %>.

--- a/app/views/candidate_mailer/deferred_offer.text.erb
+++ b/app/views/candidate_mailer/deferred_offer.text.erb
@@ -4,8 +4,6 @@ Dear <%= @application_form.first_name %>
 
 Any conditions for this offer will be confirmed closer to the start date of the course.
 
-# Next steps
-
 <%= @course.provider.name %> will send you an email shortly after October <%= @course.recruitment_cycle_year %>, to confirm the offer.
 
 Contact us if you do not receive a message from <%= @course.provider.name %>.

--- a/app/views/candidate_mailer/deferred_offer.text.erb
+++ b/app/views/candidate_mailer/deferred_offer.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # Your offer has been deferred
 

--- a/app/views/candidate_mailer/deferred_offer_reminder.text.erb
+++ b/app/views/candidate_mailer/deferred_offer_reminder.text.erb
@@ -1,11 +1,9 @@
 Dear <%= @application_form.first_name %>
 
-# Reminder of your deferred offer
-
 On <%= @application_choice.offer_deferred_at.to_s(:govuk_date) %>, <%= @course_option.course.provider.name %> deferred your offer to study <%= @course_option.course.name_and_code %>.
 
 You’ll shortly receive an email to confirm the offer. If you do not receive this, you should contact <%= @course_option.course.provider.name %>.
 
-Sign in to your account to view the details of your deferred offer:
+Sign in to your account to see your deferred offer:
 
 <%= candidate_magic_link(@application_choice.application_form.candidate) %>

--- a/app/views/candidate_mailer/deferred_offer_reminder.text.erb
+++ b/app/views/candidate_mailer/deferred_offer_reminder.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # Reminder of your deferred offer
 

--- a/app/views/candidate_mailer/eoc_deadline_reminder.erb
+++ b/app/views/candidate_mailer/eoc_deadline_reminder.erb
@@ -1,5 +1,5 @@
 <% if @application_form.first_name.present? %>
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 <% end %>
 
 # Complete your teacher training application – courses fill up quickly at this time of year

--- a/app/views/candidate_mailer/eoc_deadline_reminder.erb
+++ b/app/views/candidate_mailer/eoc_deadline_reminder.erb
@@ -2,8 +2,6 @@
 Dear <%= @application_form.first_name %>
 <% end %>
 
-# Complete your teacher training application – courses fill up quickly at this time of year
-
 Submit your application as soon as you can to get on a course starting in the <%= RecruitmentCycle.current_year %> to <%= RecruitmentCycle.next_year %> academic year:
 
 <%= candidate_magic_link(@application_form.candidate) %>
@@ -14,7 +12,9 @@ Submit your application as soon as you can to get on a course starting in the <%
 <%= apply_1_copy if @application_form.phase == 'apply_1' %>
 <%= apply_2_copy if @application_form.phase == 'apply_2' %>
 
-# Get help to complete your application
+Courses fill up quickly at this time of year.
+
+# Get help
 
 A teacher training adviser can help you write a strong application:
 

--- a/app/views/candidate_mailer/find_another_course.text.erb
+++ b/app/views/candidate_mailer/find_another_course.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # Your course is not available anymore
 

--- a/app/views/candidate_mailer/find_has_opened.erb
+++ b/app/views/candidate_mailer/find_has_opened.erb
@@ -16,7 +16,10 @@ Get your application ready:
 
 You can submit from 9am on <%= @apply_opens %>.
 
-# Get support
+# Get help
 
-Talk to us about your application
+Call <%= t('get_into_teaching.tel') %> or chat online:
+
 <%= t('get_into_teaching.url_online_chat') %>
+
+<%= t('get_into_teaching.opening_times') %>.

--- a/app/views/candidate_mailer/find_has_opened.erb
+++ b/app/views/candidate_mailer/find_has_opened.erb
@@ -4,17 +4,17 @@
 
 You can now find teacher training courses starting in the <%= @academic_year %> academic year.
 
-Find your course and get your application ready:
+Find your courses:
 
 https://www.find-postgraduate-teacher-training.service.gov.uk/
-
-You can submit from 9am on <%= @apply_opens %>.
 
 Apply early to have the best chance of getting onto the course you want, as courses fill up throughout the year.
 
 Get your application ready:
 
 <%= candidate_magic_link(@application_form.candidate) %>
+
+You can submit from 9am on <%= @apply_opens %>.
 
 # Get support
 

--- a/app/views/candidate_mailer/find_has_opened.erb
+++ b/app/views/candidate_mailer/find_has_opened.erb
@@ -1,5 +1,5 @@
 <% if @application_form.first_name.present? %>
-  Dear <%= @application_form.first_name %>,
+  Dear <%= @application_form.first_name %>
 <% end %>
 
 You can now find teacher training courses starting in the <%= @academic_year %> academic year.

--- a/app/views/candidate_mailer/interview_cancelled.text.erb
+++ b/app/views/candidate_mailer/interview_cancelled.text.erb
@@ -1,8 +1,6 @@
 Dear <%= @application_form.first_name %>
 
-# Interview cancelled
-
-<%= @provider_name %> has cancelled the interview on <%= @interview.date_and_time.to_s(:govuk_date_and_time) %> about your application to study <%= @course_name %>.
+<%= @provider_name %> has cancelled your interview on <%= @interview.date_and_time.to_s(:govuk_date_and_time) %> for <%= @course_name %>.
 
 They’ve given the following reason for cancelling the interview:
 

--- a/app/views/candidate_mailer/interview_cancelled.text.erb
+++ b/app/views/candidate_mailer/interview_cancelled.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # Interview cancelled
 

--- a/app/views/candidate_mailer/interview_updated.text.erb
+++ b/app/views/candidate_mailer/interview_updated.text.erb
@@ -1,8 +1,6 @@
 Dear <%= @application_form.first_name %>
 
-# Interview details updated
-
-<%= @provider_name %> has updated the details of the interview about your application to study <%= @course_name %>.
+<%= @provider_name %> has updated the details of your interview for <%= @course_name %>.
 
 The new details are as follows:
 
@@ -12,4 +10,4 @@ The new details are as follows:
 
 ^ <%= @interview.additional_details %>
 
-Contact <%= @provider_name %> if you have any questions or you will not be able to attend the interview.
+Contact <%= @provider_name %> if you have any questions. Let them know if you cannot attend the interview.

--- a/app/views/candidate_mailer/interview_updated.text.erb
+++ b/app/views/candidate_mailer/interview_updated.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # Interview details updated
 

--- a/app/views/candidate_mailer/new_cycle_has_started.erb
+++ b/app/views/candidate_mailer/new_cycle_has_started.erb
@@ -3,13 +3,13 @@
 <% end %>
 
 <% unless @application_form.submitted? %>
-  # Applications are open - submit your teacher training application
+  Applications are now open.
 
   Complete your application to get on a course starting in the <%= @academic_year %> academic year:
 <% end %>
 
 <% if @application_form.ended_without_success? %>
-  # Applications are open - apply for teacher training again
+  Applications are now open - apply for teacher training again.
 
   You could get on a course starting in the <%= @academic_year %> academic year.
 
@@ -18,7 +18,7 @@
 
 <%= candidate_magic_link(@application_form.candidate) %>
 
-# Get help to complete your application
+# Get help
 
 A teacher training adviser can help you write a strong application:
 

--- a/app/views/candidate_mailer/new_cycle_has_started.erb
+++ b/app/views/candidate_mailer/new_cycle_has_started.erb
@@ -1,5 +1,5 @@
 <% if @application_form.first_name.present? %>
-  Dear <%= @application_form.first_name %>,
+  Dear <%= @application_form.first_name %>
 <% end %>
 
 <% unless @application_form.submitted? %>

--- a/app/views/candidate_mailer/new_interview.text.erb
+++ b/app/views/candidate_mailer/new_interview.text.erb
@@ -1,8 +1,6 @@
 Dear <%= @application_form.first_name %>
 
-# Interview arranged
-
-You have an interview with <%= @provider_name %> about your application to study <%= @course_name %>.
+You have an interview with <%= @provider_name %> for <%= @course_name %>.
 
 The details are as follows:
 
@@ -12,4 +10,4 @@ The details are as follows:
 
 ^ <%= @interview.additional_details %>
 
-Contact <%= @provider_name %> if you have any questions or you will not be able to attend the interview.
+Contact <%= @provider_name %> if you have any questions. Let them know if you cannot attend the interview.

--- a/app/views/candidate_mailer/new_interview.text.erb
+++ b/app/views/candidate_mailer/new_interview.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # Interview arranged
 

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# You have an offer
-
 You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
 <% if @conditions.blank? %>

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # You have an offer
 

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -14,7 +14,7 @@ Contact <%= @provider_name %> if you have any questions about this.
 
 # Make a decision by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>
 
-If you do not reply by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>, your application will be withdrawn.
+If you do not reply by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>, your offers will be declined automatically.
 
 <%= render "offer_list" %>
 

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# You have an offer
-
 You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
 <% if @conditions.blank? %>
@@ -12,9 +10,9 @@ You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
 Contact <%= @provider_name %> if you have any questions about this.
 
-# Make a decision by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>
+# Respond by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>
 
-If you do not reply by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>, your offers will be declined automatically.
+If you do not respond by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>, your offers will be declined automatically.
 
 <%= render "offer_list" %>
 

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # You have an offer
 

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -10,9 +10,9 @@ You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
 Contact <%= @provider_name %> if you have any questions about this.
 
-# Make a decision by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>
+# Respond by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>
 
-If you do not reply by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>, your offer will be declined automatically.
+If you do not respond by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>, your offer will be declined automatically.
 
 Sign in to your account to respond:
 

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# You have an offer
-
 You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
 <% if @conditions.blank? %>

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # You have an offer
 

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -14,7 +14,7 @@ Contact <%= @provider_name %> if you have any questions about this.
 
 # Make a decision by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>
 
-If you do not reply by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>, your application will be withdrawn.
+If you do not reply by <%= @application_choice.decline_by_default_at.to_s(:govuk_date) %>, your offer will be declined automatically.
 
 Sign in to your account to respond:
 

--- a/app/views/candidate_mailer/offer_accepted.text.erb
+++ b/app/views/candidate_mailer/offer_accepted.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 #You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_code %>
 

--- a/app/views/candidate_mailer/offer_accepted.text.erb
+++ b/app/views/candidate_mailer/offer_accepted.text.erb
@@ -1,10 +1,10 @@
 Dear <%= @application_form.first_name %>
 
-#You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_code %>
+You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_code %>.
 
-If everything goes well with meeting your conditions, you’ll start <%= @course_name_and_code %> <%= @provider_name %> on <%= @start_date %>.
+If you meet your conditions, you’ll start <%= @course_name_and_code %> <%= @provider_name %> on <%= @start_date %>.
 
-You can check your conditions anytime by signing in to your account:
+Check your conditions by signing in to your account:
 
 <%= candidate_magic_link(@application_form.candidate) %>
 

--- a/app/views/candidate_mailer/offer_withdrawn.text.erb
+++ b/app/views/candidate_mailer/offer_withdrawn.text.erb
@@ -1,13 +1,11 @@
 Dear <%= @application_form.first_name %>
 
-# Offer withdrawn
-
 <%= @provider_name %> has withdrawn their offer for you to study <%= @course_name_and_code %>. They’ve given feedback to explain this decision.
 
 ^ # Why the offer was withdrawn
 ^ <%= @withdrawal_reason %>
 
-Contact <%= @provider_name %> directly if you have questions about why they’ve withdrawn the offer.
+Contact <%= @provider_name %> directly if you have questions about this.
 
 # You can apply again
 

--- a/app/views/candidate_mailer/offer_withdrawn.text.erb
+++ b/app/views/candidate_mailer/offer_withdrawn.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # Offer withdrawn
 

--- a/app/views/candidate_mailer/reinstated_offer.text.erb
+++ b/app/views/candidate_mailer/reinstated_offer.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # Your deferred offer has been confirmed
 

--- a/app/views/candidate_mailer/reinstated_offer.text.erb
+++ b/app/views/candidate_mailer/reinstated_offer.text.erb
@@ -1,17 +1,15 @@
 Dear <%= @application_form.first_name %>
 
-# Your deferred offer has been confirmed
+<%= @course_option.course.provider.name %> has confirmed your deferred offer to study <%= @course_option.course.name_and_code %> in <%= @course_option.course.start_date.to_s(:month_and_year) %>.
 
-You have an offer from <%= @course_option.course.provider.name %> to study <%= @course_option.course.name_and_code %> in <%= @course_option.course.start_date.to_s(:month_and_year) %>. This was deferred from last year (<%= @application_choice.offer_deferred_at.to_s(:month_and_year) %>).
+This was deferred from (<%= @application_choice.offer_deferred_at.to_s(:month_and_year) %>).
 
 <% if @conditions.any? %>
   <%= render "candidate_mailer/offer_conditions" %>
 <% else %>
-  <%= @course_option.course.provider.name %> will let you know if they need further information before you can start training.
+  <%= @course_option.course.provider.name %> will let you know if they need further information before you start training.
 <% end %>
 
-# Next steps
-
-You can see further details of the offer by signing in to your account:
+Sign in to your account to see your offer details:
 
 <%= candidate_magic_link(@application_choice.application_form.candidate) %>

--- a/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
+++ b/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
@@ -1,8 +1,8 @@
 Dear <%= @application_form.first_name %>
 
-#You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_code %>
+You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_code %>.
 
-The course will start on <%= @start_date %>.
+The course starts <%= @start_date %>.
 
 <%= @provider_name %> will let you know if they need further information before you can start training.
 

--- a/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
+++ b/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 #You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_code %>
 

--- a/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
+++ b/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 # <%= 'Application'.pluralize(@withdrawn_course_names.size) %> withdrawn
 

--- a/app/views/referee_mailer/reference_cancelled_email.text.erb
+++ b/app/views/referee_mailer/reference_cancelled_email.text.erb
@@ -1,5 +1,3 @@
 Dear <%= @name %>
 
-# You do not need to give a reference for <%= @candidate_name %>
-
-The candidate has cancelled their request.
+<%= @candidate_name %> said they do not need you to give a reference anymore.

--- a/app/views/referee_mailer/reference_confirmation_email.text.erb
+++ b/app/views/referee_mailer/reference_confirmation_email.text.erb
@@ -1,9 +1,9 @@
 Dear <%= @name %>
 
-# Thank you for your reference
-
-You have submitted a reference for <%= @candidate_name %>’s teacher training application.
+Thank you for your reference for <%= @candidate_name %>.
 
 # Your data
 
-We’ll only use your data to process <%= @candidate_name %>’s application, unless you agreed to be contacted by us about your experience of giving a reference.
+Find out how we use and look after your data:
+
+<%= candidate_interface_privacy_policy_url %>

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -22,7 +22,7 @@ Teacher training places can fill up at any time. Your reference will help <%= @c
 
 The candidate will not be able to see what you write about them.
 
-# Get support
+# Get help
 
 Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
 

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @reference.name %>,
+Dear <%= @reference.name %>
 
 <%= @candidate_name %> is asking for a reference for their teacher training application.
 

--- a/app/views/support_mailer/fallback_sign_in_email.text.erb
+++ b/app/views/support_mailer/fallback_sign_in_email.text.erb
@@ -1,5 +1,3 @@
-# <%= t('authentication.sign_in.email.subject') %>
-
-Sign in:
+Sign in to apply for teacher training:
 
 <%= support_interface_authenticate_with_token_url(token: @token) %>

--- a/app/views/support_mailer/fallback_sign_in_email.text.erb
+++ b/app/views/support_mailer/fallback_sign_in_email.text.erb
@@ -1,5 +1,5 @@
 # <%= t('authentication.sign_in.email.subject') %>
 
-Click the link below to sign in to the <%= t('service_name.apply') %> service.
+Sign in:
 
 <%= support_interface_authenticate_with_token_url(token: @token) %>

--- a/spec/components/candidate_interface/offers_call_to_action_component_spec.rb
+++ b/spec/components/candidate_interface/offers_call_to_action_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CandidateInterface::OffersCallToActionComponent do
     )
     result = render_inline(described_class.new(application_form: application_form))
     expect(result.text).to include('Congratulations on your offer')
-    expect(result.text).to include('You have 10 days (until 3 April 2021) to respond. If you do not respond, your offer will automatically be declined.')
+    expect(result.text).to include('You have 10 days (until 3 April 2021) to respond. If you do not respond, your offer will be automatically declined.')
   end
 
   it 'displays correct title and message when there are multiple offers' do
@@ -30,7 +30,7 @@ RSpec.describe CandidateInterface::OffersCallToActionComponent do
     )
     result = render_inline(described_class.new(application_form: application_form))
     expect(result.text).to include('Congratulations on your offers')
-    expect(result.text).to include('You have 10 days (until 3 April 2021) to respond. If you do not respond, your offers will automatically be declined.')
+    expect(result.text).to include('You have 10 days (until 3 April 2021) to respond. If you do not respond, your offers will be automatically declined.')
   end
 
   def create_application_form_with_course_choices(statuses:, apply_again: false)

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     it_behaves_like(
       'a mail with subject and content',
       I18n.t('authentication.sign_in_without_account.email.subject'),
-      'heading' => I18n.t('authentication.sign_in_without_account.email.subject'),
+      'heading' => 'You tried to sign in to apply for teacher training',
       'sign up link' => 'http://localhost:3000/candidate/sign-up',
     )
   end

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe CandidateMailer, type: :mailer do
         'rejection reasons' => 'Do not refer to yourself in the third person',
         'other application details' => 'You’re not waiting for any other decisions.',
         'first application details' => 'Brighthurst Technical College to study Applied Science (Psychology)',
-        'respond by date' => "The offers will automatically be withdrawn if you do not respond by #{10.business_days.from_now.to_s(:govuk_date)}",
+        'respond by date' => "The offers will be declined automatically if you do not respond by #{10.business_days.from_now.to_s(:govuk_date)}",
       )
     end
   end

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       'a mail with subject and content',
       'Make a decision: successful application for Brighthurst Technical College',
       'heading' => 'Dear Bob',
-      'decline by default date' => "Make a decision by #{10.business_days.from_now.to_s(:govuk_date)}",
+      'decline by default date' => "Respond by #{10.business_days.from_now.to_s(:govuk_date)}",
       'first_condition' => 'Be cool',
       'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.',
     )
@@ -63,7 +63,7 @@ RSpec.describe CandidateMailer, type: :mailer do
         'Make a decision: successful application for Falconholt Technical College',
         'heading' => 'Dear Bob',
         'course and provider' => 'offer from Falconholt Technical College to study Computer Science (X0FO)',
-        'decline by default date' => "Make a decision by #{10.business_days.from_now.to_s(:govuk_date)}",
+        'decline by default date' => "Respond by #{10.business_days.from_now.to_s(:govuk_date)}",
         'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.',
       )
     end
@@ -78,7 +78,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       'a mail with subject and content',
       'Make a decision: successful application for Brighthurst Technical College',
       'heading' => 'Dear Bob',
-      'decline by default date' => "Make a decision by #{10.business_days.from_now.to_s(:govuk_date)}",
+      'decline by default date' => "Respond by #{10.business_days.from_now.to_s(:govuk_date)}",
       'first_condition' => 'Be cool',
       'first_offer' => 'Applied Science (Psychology) (3TT5) at Brighthurst Technical College',
       'second_offers' => 'Forensic Science (E0FO) at Falconholt Technical College',
@@ -259,7 +259,7 @@ RSpec.describe CandidateMailer, type: :mailer do
         'rejection reasons' => 'Do not refer to yourself in the third person',
         'other application details' => 'You’re not waiting for any other decisions.',
         'first application details' => 'Brighthurst Technical College to study Applied Science (Psychology)',
-        'respond by date' => "The offers will be declined automatically if you do not respond by #{10.business_days.from_now.to_s(:govuk_date)}",
+        'respond by date' => "The offers will automatically be withdrawn if you do not respond by #{10.business_days.from_now.to_s(:govuk_date)}",
       )
     end
   end
@@ -339,10 +339,10 @@ RSpec.describe CandidateMailer, type: :mailer do
       'a mail with subject and content',
       'Your deferred offer has been confirmed',
       'heading' => 'Dear Bob',
-      'provider name' => 'You have an offer from Falconholt Technical College',
+      'provider name' => 'Falconholt Technical College has confirmed your deferred offer to study',
       'name and code for course' => 'Forensic Science (E0FO)',
       'start date of new course' => 'June 2020',
-      'date offer was deferred' => 'This was deferred from last year (October 2019)',
+      'date offer was deferred' => 'This was deferred from (October 2019)',
     )
 
     describe 'with pending conditions' do
@@ -350,10 +350,10 @@ RSpec.describe CandidateMailer, type: :mailer do
         'a mail with subject and content',
         'Your deferred offer has been confirmed',
         'heading' => 'Dear Bob',
-        'provider name' => 'You have an offer from Falconholt Technical College',
+        'provider name' => 'Falconholt Technical College has confirmed your deferred offer to study',
         'name and code for course' => 'Forensic Science (E0FO)',
         'start date of new course' => 'June 2020',
-        'date offer was deferred' => 'This was deferred from last year (October 2019)',
+        'date offer was deferred' => 'This was deferred from (October 2019)',
         'conditions of offer' => 'Be cool',
       )
     end

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe CandidateMailer, type: :mailer do
         'rejection reasons' => 'Do not refer to yourself in the third person',
         'other application details' => 'You’re not waiting for any other decisions.',
         'first application details' => 'Brighthurst Technical College to study Applied Science (Psychology)',
-        'respond by date' => "The offers will automatically be withdrawn if you do not respond by #{10.business_days.from_now.to_s(:govuk_date)}",
+        'respond by date' => "will be automatically declined if you do not respond by #{10.business_days.from_now.to_s(:govuk_date)}",
       )
     end
   end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe CandidateMailer, type: :mailer do
     it_behaves_like(
       'a mail with subject and content',
       'Offer withdrawn by Arachnid College',
-      'greeting' => 'Dear Fred,',
+      'greeting' => 'Dear Fred',
       'offer details' => 'Arachnid College has withdrawn their offer for you to study Mathematics (M101)',
       'withdrawal reason' => 'You lied to us about secretly being Spiderman',
     )
@@ -326,7 +326,7 @@ RSpec.describe CandidateMailer, type: :mailer do
     it_behaves_like(
       'a mail with subject and content',
       'You’ve accepted Arithmetic College’s offer to study Mathematics (M101)',
-      'greeting' => 'Dear Fred,',
+      'greeting' => 'Dear Fred',
       'offer_details' => 'You’ve accepted Arithmetic College’s offer to study Mathematics (M101)',
       'course start' => 'September 2021',
     )
@@ -375,7 +375,7 @@ RSpec.describe CandidateMailer, type: :mailer do
     it_behaves_like(
       'a mail with subject and content',
       'You’ve accepted Arithmetic College’s offer to study Mathematics (M101)',
-      'greeting' => 'Dear Fred,',
+      'greeting' => 'Dear Fred',
       'offer_details' => 'You’ve accepted Arithmetic College’s offer to study Mathematics (M101)',
       'course start' => 'September 2021',
     )
@@ -405,7 +405,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a mail with subject and content',
         'Interview arranged - Hogwards',
-        'greeting' => 'Dear Fred,',
+        'greeting' => 'Dear Fred',
         'details' => 'You have an interview with Hogwards',
         'interview date and time' => '15 January 2021 at 9:30am',
         'interview location' => 'Hogwarts Castle',
@@ -419,8 +419,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a mail with subject and content',
         'Interview details updated - Hogwards',
-        'greeting' => 'Dear Fred,',
-        'details' => 'Hogwards has updated the details of the interview',
+        'greeting' => 'Dear Fred',
+        'details' => 'Hogwards has updated the details of your interview',
         'interview date and time' => '15 January 2021 at 9:30am',
         'interview location' => 'Hogwarts Castle',
         'additional interview details' => 'Bring your magic wand for the spells test',
@@ -433,8 +433,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a mail with subject and content',
         'Interview cancelled - Hogwards',
-        'greeting' => 'Dear Fred,',
-        'details' => 'Hogwards has cancelled the interview on 15 January 2021 at 9:30am',
+        'greeting' => 'Dear Fred',
+        'details' => 'Hogwards has cancelled your interview on 15 January 2021 at 9:30am',
         'cancellation reason' => 'We recruited someone else',
       )
     end
@@ -490,9 +490,9 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a mail with subject and content',
         'Teacher training applications are open - apply for the 2022 to 2023 academic year',
-        'greeting' => 'Dear Fred,',
+        'greeting' => 'Dear Fred',
         'academic_year' => '2022 to 2023',
-        'details' => 'Applications are open - submit your teacher training application',
+        'details' => 'Applications are now open',
       )
     end
 
@@ -504,9 +504,9 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a mail with subject and content',
         'Teacher training applications are open - apply for the 2022 to 2023 academic year',
-        'greeting' => 'Dear Fred,',
+        'greeting' => 'Dear Fred',
         'academic_year' => '2022 to 2023',
-        'details' => 'Applications are open - apply for teacher training again',
+        'details' => 'Applications are now open - apply for teacher training again.',
       )
     end
 
@@ -533,9 +533,9 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a mail with subject and content',
         'Find your teacher training course now',
-        'greeting' => 'Dear Fred,',
+        'greeting' => 'Dear Fred',
         'academic_year' => '2022 to 2023',
-        'details' => 'Find your course and get your application ready:',
+        'details' => 'Find your courses:',
       )
     end
 

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_receives_rejection_email_spec.rb
@@ -98,6 +98,6 @@ RSpec.feature 'Receives rejection email' do
     expect(current_email.text).to include(@offer.course.name)
     expect(current_email.text).to include(@offer2.provider.name)
     expect(current_email.text).to include(@offer2.course.name)
-    expect(current_email.text).to include("The offers will automatically be withdrawn if you do not respond by #{@offer.decline_by_default_at.to_s(:govuk_date)}")
+    expect(current_email.text).to include("The offers will be declined automatically if you do not respond by #{@offer.decline_by_default_at.to_s(:govuk_date)}")
   end
 end

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_receives_rejection_email_spec.rb
@@ -90,7 +90,7 @@ RSpec.feature 'Receives rejection email' do
     expect(current_email.text).to include(@offer.provider.name)
     expect(current_email.text).to include(@offer.course.name)
 
-    expect(current_email.text).to include("The offer will be declined automatically if you do not respond by #{@offer.decline_by_default_at.to_s(:govuk_date)}")
+    expect(current_email.text).to include("The offer will automatically be withdrawn if you do not respond by #{@offer.decline_by_default_at.to_s(:govuk_date)}")
   end
 
   def and_it_includes_details_of_my_offers
@@ -98,6 +98,6 @@ RSpec.feature 'Receives rejection email' do
     expect(current_email.text).to include(@offer.course.name)
     expect(current_email.text).to include(@offer2.provider.name)
     expect(current_email.text).to include(@offer2.course.name)
-    expect(current_email.text).to include("The offers will be declined automatically if you do not respond by #{@offer.decline_by_default_at.to_s(:govuk_date)}")
+    expect(current_email.text).to include("The offers will automatically be withdrawn if you do not respond by #{@offer.decline_by_default_at.to_s(:govuk_date)}")
   end
 end

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_receives_rejection_email_spec.rb
@@ -90,7 +90,7 @@ RSpec.feature 'Receives rejection email' do
     expect(current_email.text).to include(@offer.provider.name)
     expect(current_email.text).to include(@offer.course.name)
 
-    expect(current_email.text).to include("The offer will automatically be withdrawn if you do not respond by #{@offer.decline_by_default_at.to_s(:govuk_date)}")
+    expect(current_email.text).to include("The offer will be declined automatically if you do not respond by #{@offer.decline_by_default_at.to_s(:govuk_date)}")
   end
 
   def and_it_includes_details_of_my_offers

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_receives_rejection_email_spec.rb
@@ -90,7 +90,7 @@ RSpec.feature 'Receives rejection email' do
     expect(current_email.text).to include(@offer.provider.name)
     expect(current_email.text).to include(@offer.course.name)
 
-    expect(current_email.text).to include("The offer will automatically be withdrawn if you do not respond by #{@offer.decline_by_default_at.to_s(:govuk_date)}")
+    expect(current_email.text).to include("The offer will be automatically declined if you do not respond by #{@offer.decline_by_default_at.to_s(:govuk_date)}")
   end
 
   def and_it_includes_details_of_my_offers
@@ -98,6 +98,6 @@ RSpec.feature 'Receives rejection email' do
     expect(current_email.text).to include(@offer.course.name)
     expect(current_email.text).to include(@offer2.provider.name)
     expect(current_email.text).to include(@offer2.course.name)
-    expect(current_email.text).to include("The offers will automatically be withdrawn if you do not respond by #{@offer.decline_by_default_at.to_s(:govuk_date)}")
+    expect(current_email.text).to include("The offers will be automatically declined if you do not respond by #{@offer.decline_by_default_at.to_s(:govuk_date)}")
   end
 end

--- a/spec/system/candidate_interface/references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_requests_a_reference_spec.rb
@@ -129,7 +129,7 @@ RSpec.feature 'Candidate requests a reference' do
 
   def and_an_email_is_sent_to_the_referee
     open_email(@reference.email_address)
-    expect(current_email).to have_content "Dear #{@reference.name},"
+    expect(current_email).to have_content "Dear #{@reference.name}"
   end
 
   def when_i_have_added_a_second_reference

--- a/spec/system/candidate_interface/references/candidate_reviews_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_reviews_references_spec.rb
@@ -152,7 +152,7 @@ RSpec.feature 'Review references' do
     open_email(@requested_reference.email_address)
 
     expect(current_email.subject).to include 'Reference request cancelled by'
-    expect(current_email.text).to include 'The candidate has cancelled their request.'
+    expect(current_email.text).to include 'said they do not need you to give a reference anymore.'
   end
 
   def and_i_can_return_to_the_application_page


### PR DESCRIPTION
Make style guide changes to candidate and referee mailers. This improves consistency with other parts of the service and across the service line. 

This has nothing to do with applying again to 3 courses - but auditing the emails for that purpose made me spot a lot of style inconsistencies. 