### PR TITLE
Stop Manage updates to interviews with past date_and_time

### DIFF
--- a/app/components/provider_interface/interview_and_course_summary_component.html.erb
+++ b/app/components/provider_interface/interview_and_course_summary_component.html.erb
@@ -5,15 +5,19 @@
         <div class="app-summary-card__actions">
           <ul class="app-summary-card__actions-list">
             <li class="app-summary-card__actions-list-item">
-              <%= govuk_link_to edit_provider_interface_application_choice_interview_path(application_choice, interview), no_visited_state: true, class: 'app-summary-card__actions-list-item' do %>
-                Change details
-                <span class="govuk-visually-hidden"> <%= interview.date_and_time.to_s(:govuk_date_and_time) %> </span>
+              <% unless interview_in_the_past? %>
+                <%= govuk_link_to edit_provider_interface_application_choice_interview_path(application_choice, interview), no_visited_state: true, class: 'app-summary-card__actions-list-item' do %>
+                  Change details
+                  <span class="govuk-visually-hidden"> <%= interview.date_and_time.to_s(:govuk_date_and_time) %> </span>
+                <% end %>
               <% end %>
             </li>
             <li class="app-summary-card__actions-list-item">
-              <%= govuk_link_to new_provider_interface_application_choice_interview_cancel_path(application_choice, interview), no_visited_state: true, class: 'app-summary-card__actions-list-item' do %>
-                Cancel interview
-                <span class="govuk-visually-hidden"> <%= interview.date_and_time.to_s(:govuk_date_and_time) %> </span>
+              <% unless interview_in_the_past? %>
+                <%= govuk_link_to new_provider_interface_application_choice_interview_cancel_path(application_choice, interview), no_visited_state: true, class: 'app-summary-card__actions-list-item' do %>
+                  Cancel interview
+                  <span class="govuk-visually-hidden"> <%= interview.date_and_time.to_s(:govuk_date_and_time) %> </span>
+                <% end %>
               <% end %>
             </li>
           </ul>

--- a/app/components/provider_interface/interview_and_course_summary_component.rb
+++ b/app/components/provider_interface/interview_and_course_summary_component.rb
@@ -41,5 +41,9 @@ module ProviderInterface
     def additional_details
       interview.additional_details.presence || 'None'
     end
+
+    def interview_in_the_past?
+      interview.date_and_time < Time.zone.now.beginning_of_day
+    end
   end
 end

--- a/app/controllers/provider_interface/interviews/cancel_controller.rb
+++ b/app/controllers/provider_interface/interviews/cancel_controller.rb
@@ -2,24 +2,22 @@ module ProviderInterface
   module Interviews
     class CancelController < InterviewsController
       skip_before_action :redirect_to_index_if_store_cleared
+      before_action :confirm_interview_is_not_in_the_past, only: %i[new create]
 
       def new
         clear_wizard_if_new_entry(CancelInterviewWizard.new(cancel_interview_store(interview_id), {}))
 
-        @interview = @application_choice.interviews.find(interview_id)
         @wizard = CancelInterviewWizard.new(cancel_interview_store(interview_id), { current_step: 'new', action: action })
         @wizard.referer ||= request.referer
         @wizard.save_state!
       end
 
       def create
-        @interview = @application_choice.interviews.find(interview_id)
-
         @wizard = CancelInterviewWizard.new(cancel_interview_store(interview_id), cancellation_params)
         @wizard.save_state!
 
         if @wizard.valid?
-          redirect_to provider_interface_application_choice_interview_cancel_path(@application_choice, @interview)
+          redirect_to provider_interface_application_choice_interview_cancel_path(@application_choice, interview)
         else
           track_validation_error(@wizard)
           render 'provider_interface/interviews/cancel/new'
@@ -33,6 +31,17 @@ module ProviderInterface
       end
 
     private
+
+      def interview
+        @interview ||= @application_choice.interviews.find(interview_id)
+      end
+
+      def confirm_interview_is_not_in_the_past
+        return if interview.date_and_time >= Time.zone.now.beginning_of_day
+
+        flash[:warning] = t('activemodel.errors.models.interview_workflow_constraints.attributes.changing_a_past_interview')
+        redirect_to provider_interface_application_choice_interviews_path(@application_choice)
+      end
 
       def cancellation_params
         params.require(:provider_interface_cancel_interview_wizard).permit(:cancellation_reason)

--- a/spec/components/provider_interface/interview_and_course_summary_component_spec.rb
+++ b/spec/components/provider_interface/interview_and_course_summary_component_spec.rb
@@ -59,4 +59,14 @@ RSpec.describe ProviderInterface::InterviewAndCourseSummaryComponent do
       expect(component).not_to include('Cancel interview')
     end
   end
+
+  context 'interview date_and_time has passed' do
+    let(:interview) { create(:interview, :past_date_and_time) }
+
+    it 'both change and cancel links are hidden' do
+      component = render_inline(described_class.new(interview: interview, user_can_change_interview: true))
+      expect(component).not_to include('Change details')
+      expect(component).not_to include('Cancel interview')
+    end
+  end
 end

--- a/spec/requests/provider_interface/interviews/cancel_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews/cancel_controller_spec.rb
@@ -40,6 +40,29 @@ RSpec.describe ProviderInterface::Interviews::CancelController, type: :request d
     end
   end
 
+  describe 'if interview date_and_time has passed' do
+    let(:application_choice) do
+      create(:application_choice, :awaiting_provider_decision, application_form: application_form, course_option: course_option)
+    end
+    let!(:interview) { create(:interview, :past_date_and_time, application_choice: application_choice) }
+
+    context 'GET cancel' do
+      it 'responds with 302' do
+        get new_provider_interface_application_choice_interview_cancel_path(application_choice, interview)
+
+        expect(response.status).to eq(302)
+      end
+    end
+
+    context 'POST cancel' do
+      it 'responds with 302' do
+        post provider_interface_application_choice_interview_cancel_path(application_choice, interview)
+
+        expect(response.status).to eq(302)
+      end
+    end
+  end
+
   describe 'validation errors' do
     let(:application_choice) do
       create(:application_choice, :awaiting_provider_decision, application_form: application_form, course_option: course_option)

--- a/spec/requests/provider_interface/interviews_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews_controller_spec.rb
@@ -56,6 +56,37 @@ RSpec.describe ProviderInterface::InterviewsController, type: :request do
     end
   end
 
+  describe 'if interview date_and_time has passed' do
+    let(:application_choice) do
+      create(:application_choice, :awaiting_provider_decision, application_form: application_form, course_option: course_option)
+    end
+    let!(:interview) { create(:interview, :past_date_and_time, application_choice: application_choice) }
+
+    context 'GET edit' do
+      it 'responds with 302' do
+        get edit_provider_interface_application_choice_interview_path(application_choice, interview)
+
+        expect(response.status).to eq(302)
+      end
+    end
+
+    context 'POST create' do
+      it 'responds with 302' do
+        post provider_interface_application_choice_interviews_path(application_choice)
+
+        expect(response.status).to eq(302)
+      end
+    end
+
+    context 'DELETE destroy' do
+      it 'responds with 302' do
+        delete provider_interface_application_choice_interview_path(application_choice, interview)
+
+        expect(response.status).to eq(302)
+      end
+    end
+  end
+
   describe 'going back when the interview store has been cleared' do
     let!(:application_choice) do
       create(:application_choice, :awaiting_provider_decision, application_form: application_form, course_option: course_option)


### PR DESCRIPTION
## Context

Now we have merged https://github.com/DFE-Digital/apply-for-teacher-training/pull/6478 we are getting errors in Manage because the UI still allows updates and cancellations for past interviews.

## Changes proposed in this pull request

Restrict changing past interviews in Manage.

Before: 
![image](https://user-images.githubusercontent.com/107591/153409078-f390c838-3ed9-49b0-946e-c1817107a284.png)

After:
![image](https://user-images.githubusercontent.com/107591/153409116-4eb5ae16-649f-4ba4-9fc6-ecde825a4975.png)

If you try to craft your own url and bypass:
![image](https://user-images.githubusercontent.com/107591/153409174-1edd9056-7eaa-415e-b537-83f1dd86dc56.png)

## Guidance to review

Easy

## Link to Trello card

https://trello.com/c/bfwkjxl8/4811-past-manage-interviews-bug

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
