### PR TITLE
Remove rogue sentence from changed_offer email

### DIFF
--- a/app/views/candidate_mailer/changed_offer.text.erb
+++ b/app/views/candidate_mailer/changed_offer.text.erb
@@ -38,5 +38,3 @@ Sign in to your account to respond:
 <%= candidate_magic_link(@application_choice.application_form.candidate) %>
 
 <% end %>
-
-Contact <%= @course_option.course.provider.name %> directly if you have any questions about this.


### PR DESCRIPTION
## Context

Remove rogue sentence from `changed_offer` email

## Changes proposed in this pull request

### Before

<img width="348" alt="image" src="https://user-images.githubusercontent.com/50492247/153459341-e1985105-ca2b-4c4b-bc12-8b07eed0fdf3.png">

### After

<img width="372" alt="image" src="https://user-images.githubusercontent.com/50492247/153459436-345ad58f-3893-40b2-bebc-c12fc67ca895.png">


## Link to Trello card

https://trello.com/c/ZgSHcMbo/4431-rogue-sentence-in-changedoffer-email

