### PR TITLE
Remove success flash message from apply again flow

### DIFF
--- a/app/services/candidate_interface/add_or_update_course_choice.rb
+++ b/app/services/candidate_interface/add_or_update_course_choice.rb
@@ -58,8 +58,10 @@ module CandidateInterface
       )
 
       if pick_site_form.save
-        course_choices = application_form.application_choices
-        flash[:success] = "You’ve added #{course_choices.last.course.name_and_code} to your application"
+        unless FeatureFlag.active?(:apply_again_with_three_choices)
+          course_choices = application_form.application_choices
+          flash[:success] = "You’ve added #{course_choices.last.course.name_and_code} to your application"
+        end
 
         if application_form.can_add_more_choices? && !FeatureFlag.active?(:apply_again_with_three_choices)
           redirect_to candidate_interface_course_choices_add_another_course_path

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -139,7 +139,7 @@ RSpec.feature 'Carry over' do
     choose 'Primary (2XT2)'
     click_button t('continue')
 
-    expect(page).to have_content 'You’ve added Primary (2XT2) to your application'
+    expect(page).to have_content 'Primary (2XT2)'
     expect(page).to have_content 'You can add 2 more courses'
   end
 
@@ -163,7 +163,7 @@ RSpec.feature 'Carry over' do
     choose 'Drama (2397)'
     click_button t('continue')
 
-    expect(page).to have_content 'You’ve added Drama (2397) to your application'
+    expect(page).to have_content 'Drama (2397)'
     expect(page).to have_content 'You can add 1 more course'
   end
 

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
@@ -134,7 +134,6 @@ RSpec.feature 'Carry over' do
     choose 'Primary (2XT2)'
     click_button t('continue')
 
-    expect(page).to have_content 'You’ve added Primary (2XT2) to your application'
     expect(page).to have_content 'You can add 2 more courses'
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_sees_add_additional_courses_after_adding_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_sees_add_additional_courses_after_adding_course_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'Add additional courses flow' do
     and_i_choose_a_provider
     and_i_choose_my_first_course_choice
     then_i_should_be_on_the_course_review_page
-    and_i_should_receive_a_message_that_ive_added_the_first_course
+    and_i_should_see_the_first_course_i_added
     and_i_should_be_told_i_can_add_2_more_courses
     and_i_should_be_prompted_to_add_an_additional_course
     then_i_should_be_on_the_course_choice_review_page
@@ -27,7 +27,7 @@ RSpec.feature 'Add additional courses flow' do
     and_i_choose_a_provider
     and_i_choose_my_second_course_choice
     then_i_should_be_on_the_course_review_page
-    and_i_should_receive_a_message_that_ive_added_the_second_course
+    and_i_should_see_the_second_course_i_added
     and_i_should_be_told_i_can_add_1_more_courses
     and_i_should_be_prompted_to_add_an_additional_course
     and_i_click_on_add_another_course
@@ -35,7 +35,7 @@ RSpec.feature 'Add additional courses flow' do
     and_i_choose_a_provider
     and_i_choose_my_third_course_choice
     then_i_should_be_on_the_course_choice_review_page
-    and_i_should_receive_a_message_that_ive_added_the_third_course
+    and_i_should_see_the_third_course_i_added
   end
 
   def given_there_are_course_options
@@ -85,8 +85,16 @@ RSpec.feature 'Add additional courses flow' do
     expect(page).to have_current_path(candidate_interface_course_choices_review_path)
   end
 
-  def and_i_should_receive_a_message_that_ive_added_the_first_course
-    expect(page).to have_content("You’ve added #{@provider.courses.first.name_and_code} to your application")
+  def and_i_should_see_the_first_course_i_added
+    expect(page).to have_content(@provider.courses.first.name_and_code)
+  end
+
+  def and_i_should_see_the_second_course_i_added
+    expect(page).to have_content(@provider.courses.second.name_and_code)
+  end
+
+  def and_i_should_see_the_third_course_i_added
+    expect(page).to have_content(@provider.courses.third.name_and_code)
   end
 
   def and_i_should_be_told_i_can_add_2_more_courses
@@ -105,10 +113,6 @@ RSpec.feature 'Add additional courses flow' do
     expect(page).to have_current_path(candidate_interface_course_choices_choose_path)
   end
 
-  def and_i_should_receive_a_message_that_ive_added_the_second_course
-    expect(page).to have_content("You’ve added #{@provider.courses.second.name_and_code} to your application")
-  end
-
   def and_i_choose_my_second_course_choice
     choose @provider.courses.second.name_and_code
     click_button t('continue')
@@ -125,9 +129,5 @@ RSpec.feature 'Add additional courses flow' do
 
   def then_i_should_be_on_the_course_choice_review_page
     expect(page).to have_current_path(candidate_interface_course_choices_review_path)
-  end
-
-  def and_i_should_receive_a_message_that_ive_added_the_third_course
-    expect(page).to have_content("You’ve added #{@provider.courses.third.name_and_code} to your application")
   end
 end

--- a/spec/system/provider_interface/provider_views_application_submitted_in_new_cycle_spec.rb
+++ b/spec/system/provider_interface/provider_views_application_submitted_in_new_cycle_spec.rb
@@ -142,7 +142,7 @@ RSpec.feature 'Provider views application submitted in new cycle' do
 
     choose 'Primary (2XT2)'
     click_button t('continue')
-    expect(page).to have_content 'You’ve added Primary (2XT2) to your application'
+    expect(page).to have_content 'Primary (2XT2)'
     expect(page).to have_content 'You can add 2 more courses'
   end
 


### PR DESCRIPTION
## Context

Removing the success flash message from the apply again with three choices flow. This was a change which came from a product review.

## Changes proposed in this pull request

- Remove flash message
- Put behind the `apply_again_with_three_choices`

## Guidance to review

- Switch on the above feature flag
- Find a candidate in `Apply2` and sign in as them
- Add some courses and check the flash message doesn't appear

## Link to Trello card

https://trello.com/c/QZiKIOJr/4435-remove-flash-message-from-the-apply-again-with-three-choices-flow
