### PR TITLE
Amend offer validations to prepare for Apply 2 multiple applications 

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -47,12 +47,8 @@ class Candidate < ApplicationRecord
                         end
   end
 
-  def current_application_choice
-    current_application_choices.last
-  end
-
   def current_application_choices
-    current_application.application_choices.order(:created_at)
+    current_application.application_choices
   end
 
   def last_updated_application

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -48,7 +48,11 @@ class Candidate < ApplicationRecord
   end
 
   def current_application_choice
-    current_application.application_choices.order(:created_at).last
+    current_application_choices.last
+  end
+
+  def current_application_choices
+    current_application.application_choices.order(:created_at)
   end
 
   def last_updated_application

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -50,11 +50,11 @@ class OfferValidations
       errors.add(:base, :application_rejected_by_default)
     end
 
-    if !candidate_in_apply_2? && application_choice.application_form.apply_1? && any_accepted_offers?
+    if any_accepted_offers?
       errors.add(:base, :other_offer_already_accepted)
     end
 
-    if candidate_in_apply_2? && !application_choice.candidate.current_application_choice.eql?(application_choice)
+    if candidate_in_apply_2? && application_choice.candidate.current_application_choices.exclude?(application_choice)
       errors.add(:base, :only_latest_application_rejection_can_be_reverted_on_apply_2)
     end
   end

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -54,7 +54,7 @@ class OfferValidations
       errors.add(:base, :other_offer_already_accepted)
     end
 
-    if candidate_in_apply_2? && application_choice.candidate.current_application_choices.exclude?(application_choice)
+    if application_choice.candidate.current_application_choices.exclude?(application_choice)
       errors.add(:base, :only_latest_application_rejection_can_be_reverted_on_apply_2)
     end
   end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -141,38 +141,6 @@ RSpec.describe Candidate, type: :model do
     end
   end
 
-  describe '#current_application_choice' do
-    let(:candidate) { create(:candidate) }
-
-    context 'with a single application choice' do
-      let!(:application_choice) { create(:application_choice, candidate: candidate) }
-
-      it 'returns the application choice' do
-        expect(candidate.current_application_choice).to eq(application_choice)
-      end
-    end
-
-    context 'with multiple application choices' do
-      let!(:application_choice) { create(:application_choice, candidate: candidate, created_at: 1.week.ago) }
-      let!(:most_recent_application_choice) { create(:application_choice, candidate: candidate) }
-
-      it 'returns the most recent application choice' do
-        expect(candidate.current_application_choice).to eq(most_recent_application_choice)
-      end
-    end
-
-    context 'with multiple application forms' do
-      let(:application_choice) { create(:application_choice, candidate: candidate) }
-      let(:most_recent_application_choice) { create(:application_choice, candidate: candidate) }
-      let!(:application_form_apply_1) { create(:application_form, candidate: candidate, application_choices: [application_choice], created_at: 1.week.ago) }
-      let!(:application_form_apply_2) { create(:application_form, candidate: candidate, phase: 'apply_2', application_choices: [most_recent_application_choice]) }
-
-      it 'returns the most recent application choice' do
-        expect(candidate.current_application_choice).to eq(most_recent_application_choice)
-      end
-    end
-  end
-
   describe '#current_application_choices' do
     let(:candidate) { create(:candidate) }
 
@@ -190,8 +158,8 @@ RSpec.describe Candidate, type: :model do
       let(:application_choice_3) { create(:application_choice, candidate: candidate) }
       let!(:application_form) { create(:application_form, candidate: candidate, application_choices: [application_choice_2, application_choice_1, application_choice_3]) }
 
-      it 'returns all the application choices ordered by `created_at`' do
-        expect(candidate.current_application_choices).to eq([application_choice_1, application_choice_2, application_choice_3])
+      it 'returns all the application choices' do
+        expect(candidate.current_application_choices).to contain_exactly(application_choice_1, application_choice_2, application_choice_3)
       end
     end
 

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -113,9 +113,11 @@ RSpec.describe OfferValidations, type: :model do
       end
 
       context 'when a provider attempts to revert a rejection on an application that is not the last one on apply_2' do
-        let!(:application_form) { create(:application_form, phase: 'apply_2', application_choices: [application_choice, other_application_choice]) }
-        let(:application_choice) { build(:application_choice, :with_offer, current_course_option: course_option) }
-        let!(:other_application_choice) { build(:application_choice, :awaiting_provider_decision) }
+        let(:candidate) { create(:candidate) }
+        let(:application_choice) { build(:application_choice, :rejected, current_course_option: course_option, created_at: 1.day.ago) }
+        let(:other_application_choice) { build(:application_choice, :awaiting_provider_decision) }
+        let!(:application_form) { create(:application_form, phase: 'apply_2', application_choices: [application_choice], created_at: 1.day.ago, candidate: candidate) }
+        let!(:other_application_form) { create(:application_form, phase: 'apply_2', application_choices: [other_application_choice], candidate: candidate) }
 
         it 'adds an :only_latest_application_rejection_can_be_reverted_on_apply_2 error' do
           expect(offer).to be_invalid

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -66,16 +66,12 @@ RSpec.describe OfferValidations, type: :model do
 
     describe '#ratifying_provider_changed?' do
       context 'when the ratifying provider is different than the one of the requested course' do
-        let(:application_choice) { build_stubbed(:application_choice, :with_offer, current_course_option: current_course_option) }
+        let(:candidate) { create(:candidate) }
+        let(:application_choice) { create(:application_choice, :with_offer, current_course_option: current_course_option) }
+        let!(:application_form) { create(:application_form, phase: 'apply_1', candidate: candidate, application_choices: [application_choice]) }
         let(:current_course_option) { create(:course_option, :open_on_apply) }
         let(:course_option) { build(:course_option, :open_on_apply) }
         let(:conditions) { application_choice.offer.conditions_text }
-        let(:application_form) { build_stubbed(:application_form, phase: 'apply_1') }
-        let(:candidate) { build_stubbed(:candidate, application_forms: [application_form]) }
-
-        before do
-          allow(application_choice).to receive(:candidate).and_return(candidate)
-        end
 
         it 'adds a :different_ratifying_provider error' do
           expect(offer).to be_invalid
@@ -87,13 +83,9 @@ RSpec.describe OfferValidations, type: :model do
 
     describe '#restrict_reverting_rejection' do
       context 'when a provider attempts to revert an application rejected by default' do
-        let(:application_choice) { build_stubbed(:application_choice, :rejected, current_course_option: course_option, rejected_by_default: true) }
-        let(:application_form) { build_stubbed(:application_form, phase: 'apply_1', application_choices: [application_choice]) }
-        let(:candidate) { build_stubbed(:candidate, application_forms: [application_form]) }
-
-        before do
-          allow(application_choice).to receive(:candidate).and_return(candidate)
-        end
+        let(:candidate) { create(:candidate) }
+        let(:application_choice) { create(:application_choice, :rejected, current_course_option: course_option, rejected_by_default: true) }
+        let!(:application_form) { create(:application_form, phase: 'apply_1', application_choices: [application_choice], candidate: candidate) }
 
         it 'adds an :application_rejected_by_default error' do
           expect(offer).to be_invalid


### PR DESCRIPTION
## Context

Currently we only support 1 application in apply 2. If we were to turn on the feature flag to support multiple applications, the current offer validations will fail. This is due to us only looking for a single application in apply 2 to match our "current_application" query.

## Changes proposed in this pull request

Support both 1 application as well as multiple in our Offer validations, to avoid raising an error if a provider makes an offer on not the latest application choice in apply 2. Also support raising an error for an offered application in apply again as well.

## Guidance to review

I have gone with supporting both single and multiple together, as we will be supporting both those cases in our system even after the feature flag for 3 applications in apply again is turned on

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
