### PR TITLE
make support policy clearer

### DIFF
--- a/app/views/content/terms_candidate.md
+++ b/app/views/content/terms_candidate.md
@@ -36,7 +36,7 @@ Once you submit your application it’s sent to your teacher training providers 
 
 Contact us within 5 working days at <%= bat_contact_mail_to %> if you need to change something.
 
-You can ask us to add courses if you have not used all your course choices, or change your personal details.
+You can ask us to update your personal or contact details any time.
 
 ### Withdrawing your application
 


### PR DESCRIPTION
Atm it looks like you need to contact Support within 5 days to update your personal or contact details. It also looks like you can only update your course choices within 5 days, when in fact Support help people to change a range of things.