### PR TITLE
Release Vendor API version 1.1 to sandbox

### DIFF
--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -2,7 +2,7 @@ module VendorAPI
   extend VersioningHelpers
 
   VERSION_1_0 = '1.0'.freeze
-  VERSION = '1.0'.freeze
+  VERSION = '1.1'.freeze
 
   VERSIONS = {
     '1.0' => [

--- a/app/lib/vendor_api_specification.rb
+++ b/app/lib/vendor_api_specification.rb
@@ -5,7 +5,7 @@ class VendorAPISpecification
   DRAFT_YAML_FILE_PATH = "#{SPEC_FILE_DIR}/draft.yml".freeze
 
   def initialize(version: nil, draft: false)
-    @version = version || VendorAPI::VERSION
+    @version = version || VendorAPI::VERSION_1_0
     @draft = draft
   end
 


### PR DESCRIPTION
## Context

We are ready to release version v1.1 of the Vendor API to sandbox for testing

## Changes proposed in this pull request

Setting the version constant will release the API only to sandbox, as we still have the `pre` tag set.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
