### PR TITLE
Resolve deprecated `Redis.current` warning

### DIFF
--- a/app/lib/state_stores/redis_store.rb
+++ b/app/lib/state_stores/redis_store.rb
@@ -3,7 +3,7 @@ require 'redis'
 module StateStores
   class RedisStore
     def initialize(key:)
-      @redis = Redis.current
+      @redis = Redis.new
       @key = key
     end
 

--- a/app/models/teacher_training_public_api/sync_check.rb
+++ b/app/models/teacher_training_public_api/sync_check.rb
@@ -3,15 +3,15 @@ module TeacherTrainingPublicAPI
     LAST_SUCCESSFUL_SYNC = 'last-successful-sync-with-teacher-training-api'.freeze
 
     def self.set_last_sync(time)
-      Redis.current.set(LAST_SUCCESSFUL_SYNC, time)
+      Redis.new.set(LAST_SUCCESSFUL_SYNC, time)
     end
 
     def self.clear_last_sync
-      Redis.current.del(LAST_SUCCESSFUL_SYNC)
+      Redis.new.del(LAST_SUCCESSFUL_SYNC)
     end
 
     def self.last_sync
-      Redis.current.get(LAST_SUCCESSFUL_SYNC)
+      Redis.new.get(LAST_SUCCESSFUL_SYNC)
     end
 
     def self.updated_since

--- a/spec/lib/wizard_state_stores/redis_store_spec.rb
+++ b/spec/lib/wizard_state_stores/redis_store_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe WizardStateStores::RedisStore do
 
     store.write('value')
 
-    redis = Redis.current
+    redis = Redis.new
     expect(redis.ttl('any_old_key')).to be_within(5).of(4.hours.to_i)
   end
 end


### PR DESCRIPTION
## Context

`Redis.current=` is deprecated and will be removed in 5.0.

## Changes proposed in this pull request

Use `Redis.new` https://github.com/redis/redis-rb

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
