### PR TITLE
Fix `StateChangeNotifier` flakey tests

### DIFF
--- a/spec/lib/state_change_notifier_spec.rb
+++ b/spec/lib/state_change_notifier_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe StateChangeNotifier do
   let(:helpers) { Rails.application.routes.url_helpers }
 
   before do
+    RequestStore.store[:disable_state_change_notifications] = false
     allow(SlackNotificationWorker).to receive(:perform_async)
   end
 


### PR DESCRIPTION
## Context

We are getting flakey specs in the state notifier due to the disable slack notification being set in other specs

## Changes proposed in this pull request

Set this value explicitly to false to avoid any flakey specs

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
