### PR TITLE
Display `(Vendor API)` user type next to timeline event author consistently

### DIFF
--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -53,7 +53,7 @@ module ProviderInterface
         application_choice.notes.order('created_at').map do |note|
           Event.new(
             'Note added',
-            note.user.full_name,
+            actor_for(note),
             note.created_at,
             'View note',
             provider_interface_application_choice_note_path(application_choice, note),
@@ -118,10 +118,10 @@ module ProviderInterface
         'Candidate'
       elsif change.user.is_a?(ProviderUser)
         change.user.full_name
-      elsif change_by_support?(change.audit)
-        'Apply support'
       elsif change.user.is_a?(VendorApiUser)
         "#{change.user.full_name} (Vendor API)"
+      elsif note_by_support?(change) || change_by_support?(change.audit)
+        'Apply support'
       else
         'System'
       end
@@ -143,6 +143,10 @@ module ProviderInterface
       return [nil, nil] if interview.discarded?
 
       ['View interview', provider_interface_application_choice_interviews_path(application_choice, anchor: "interview-#{interview.id}")]
+    end
+
+    def note_by_support?(change)
+      change.is_a?(Note) && change.user.is_a?(SupportUser)
     end
   end
 end

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -81,8 +81,9 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
   end
 
   context 'for an application with a note' do
+    let(:application_choice) { create(:application_choice) }
+
     it 'renders note event' do
-      application_choice = create(:application_choice)
       note = Note.new(
         message: 'Notes are a new feature',
         user: provider_user,
@@ -95,6 +96,26 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       expect(rendered.css('a').text).to include 'View note'
       expect(rendered.css('.govuk-visually-hidden').text).to eq Time.zone.now.to_s(:govuk_date_and_time)
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/notes/#{note.id}"
+    end
+
+    it 'renders note events by API users' do
+      note = Note.new(
+        message: 'Notes are a new feature',
+        user: create(:vendor_api_user, full_name: 'Jane Smith'),
+      )
+      application_choice.notes << note
+      rendered = render_inline(described_class.new(application_choice: application_choice))
+      expect(rendered.css('.app-timeline__actor_and_date').text).to include 'Jane Smith (Vendor API)'
+    end
+
+    it 'renders note events by support users' do
+      note = Note.new(
+        message: 'Notes are a new feature',
+        user: create(:support_user),
+      )
+      application_choice.notes << note
+      rendered = render_inline(described_class.new(application_choice: application_choice))
+      expect(rendered.css('.app-timeline__actor_and_date').text).to include 'Apply support'
     end
   end
 


### PR DESCRIPTION
## Context

This wasn't present for the 'Note Added' event whereas other events contained this identifier.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Displays `(Vendor API)` after the note author's full name similar to other timeline events.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/PiVOtNGU/4813-application-timeline-note-added-make-sure-author-type-is-displayed
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
