### PR TITLE
Fix Generate test applications flakey spec

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -539,7 +539,7 @@ private
       end
     else
       earliest_date = CycleTimetable.apply_opens(recruitment_cycle_year)
-      latest_date = CycleTimetable.apply_1_deadline(recruitment_cycle_year + 1)
+      latest_date = CycleTimetable.apply_1_deadline(recruitment_cycle_year)
     end
 
     @time = rand(earliest_date..latest_date)

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -54,7 +54,7 @@ class OfferValidations
       errors.add(:base, :other_offer_already_accepted)
     end
 
-    if candidate_in_apply_2? && application_choice.candidate.current_application_choices.exclude?(application_choice)
+    if application_choice.candidate.current_application_choices.exclude?(application_choice)
       errors.add(:base, :only_latest_application_rejection_can_be_reverted_on_apply_2)
     end
   end


### PR DESCRIPTION
## Context

After amending our offer validations (which are called when making or changing an offer) to be flexible to support both apply 2 versions (1 application and 3 applications), we removed a check which validates that an application is in apply 2 before checking its the latest application. This caused the generate test applications spec to fail, as the way we create carry over applications does not set the application form timestamp correctly, meaning when running validations on the most recent applications, we are retrieving the older "current_application" due to the timestamp of creation.

## Changes proposed in this pull request

Amend the date range allowed for generating an application from the previous cycle, where it should never intersect with the current cycle (by removing the extra year). This means applications from the previous cycle will always be ordered before applications in the current cycle.

Also remove intermediate fix from offer validations which stopped those failures.

## Guidance to review

Rerunning multiple times to verify
## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
