### PR TITLE
remove unnecessary headings  

### DIFF
--- a/app/views/authentication_mailer/sign_up_email.text.erb
+++ b/app/views/authentication_mailer/sign_up_email.text.erb
@@ -1,7 +1,3 @@
-# <%= t('authentication.sign_up.email.subject') %>
-
 Confirm your email address and go back to <%= t('service_name.apply') %>:
 
 <%= @magic_link %>
-
-You can then save and return to your application.

--- a/app/views/candidate_mailer/_still_interested_in_teaching.text.erb
+++ b/app/views/candidate_mailer/_still_interested_in_teaching.text.erb
@@ -1,3 +1,3 @@
-# Are you still interested in teaching?
+# You can apply again
 
 <%= render 'still_interested_content' %>

--- a/app/views/candidate_mailer/_wait_or_respond.text.erb
+++ b/app/views/candidate_mailer/_wait_or_respond.text.erb
@@ -1,7 +1,11 @@
-^You can wait to hear back about your other application(s) before making a decision. When the last decision is in, you’ll have 10 working days to respond.
+You can wait to hear back about your other application(s) before making a decision. 
 
-^Or
+When the last decision is in, you’ll have 10 working days to respond.
 
-^You can respond to the offer now. If you accept the offer, your other teacher training application(s) will be withdrawn. Sign in to your account if you want to respond:
+If you prefer, you can respond to the offer now. 
+
+If you accept the offer, your other teacher training application(s) will be withdrawn. 
+
+Sign in to your account if you want to respond:
 
 <%= candidate_magic_link(@application_form.candidate) %>

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -20,11 +20,11 @@ Sign in to your account to check the progress of your application:
 
 <% if @application_form.application_choices.count > 1 %>
 
-  If your training providers decide to progress your application, they’ll contact you to organise an interview.
+  Your teacher training provider will be in touch if they want to arrange an interview. 
 
 <% else %>
 
-  If your training provider decides to progress your application, they’ll contact you to organise an interview.
+  Your teacher training providers will be in touch if they want to arrange an interview. 
 
 <% end %>
 

--- a/app/views/candidate_mailer/application_submitted_apply_again.text.erb
+++ b/app/views/candidate_mailer/application_submitted_apply_again.text.erb
@@ -6,6 +6,6 @@ Sign in to your account to check the progress of your application:
 
 <%= candidate_magic_link(@application_form.candidate) %>
 
-If your training provider decides to progress your application, they’ll contact you to organise an interview.
+Your teacher training provider will be in touch if they want to arrange an interview.
 
 They have until <%= @reject_by_default_date %> to make a decision on your application.

--- a/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# Update on your application
-
 At your request, <%= @course.provider.name %> has withdrawn your application to study <%= @course.name_and_code %>.
 
 Get in touch if you did not ask them to do this:

--- a/app/views/candidate_mailer/changed_offer.text.erb
+++ b/app/views/candidate_mailer/changed_offer.text.erb
@@ -15,7 +15,7 @@ Your new offer is:
 ^ <%= render "conditions_list" %>
 <% end %>
 
-If you were not expecting this change, contact <%= @course_option.course.provider.name %> to find out more.
+Contact <%= @course_option.course.provider.name %> if you were not expecting this change.
 
 <% if @is_awaiting_decision %>
 

--- a/app/views/candidate_mailer/chase_candidate_decision.text.erb
+++ b/app/views/candidate_mailer/chase_candidate_decision.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# Respond by <%= @dbd_date %>
-
 <% if @application_choices.count > 1 %>
 
 You have until <%= @dbd_date %> to respond to your offers.

--- a/app/views/candidate_mailer/chase_reference.text.erb
+++ b/app/views/candidate_mailer/chase_reference.text.erb
@@ -1,4 +1,4 @@
-# <%= @reference.name %> has not responded yet
+<%= @reference.name %> has not responded yet.
 
 You can add as many referees as you like to increase the chances of getting 2 references quickly.
 

--- a/app/views/candidate_mailer/chase_reference_again.text.erb
+++ b/app/views/candidate_mailer/chase_reference_again.text.erb
@@ -1,4 +1,4 @@
-# <%= @referee.name %> has not responded yet
+<%= @referee.name %> has not responded yet.
 
 You can add as many referees as you like to increase the chances of getting 2 references quickly.
 

--- a/app/views/candidate_mailer/conditions_met.text.erb
+++ b/app/views/candidate_mailer/conditions_met.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# You’ve met your conditions
-
 Congratulations, <%= @application_choice.current_course_option.course.provider.name %> has confirmed that you’ve met your conditions for <%= @application_choice.current_course_option.course.name_and_code %>.
 
 # Next steps

--- a/app/views/candidate_mailer/conditions_not_met.text.erb
+++ b/app/views/candidate_mailer/conditions_not_met.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# You have not met your conditions
-
 You cannot enrol on <%= @application_choice.current_course_option.course.name_and_code %> because <%= @application_choice.current_course_option.course.provider.name %> told us you have not met your conditions.
 
 Get in touch with <%= @application_choice.current_course_option.course.provider.name %> if you need further advice.

--- a/app/views/candidate_mailer/eoc_deadline_reminder.erb
+++ b/app/views/candidate_mailer/eoc_deadline_reminder.erb
@@ -12,8 +12,6 @@ Submit your application as soon as you can to get on a course starting in the <%
 <%= apply_1_copy if @application_form.phase == 'apply_1' %>
 <%= apply_2_copy if @application_form.phase == 'apply_2' %>
 
-Courses fill up quickly at this time of year.
-
 # Get help
 
 A teacher training adviser can help you write a strong application:

--- a/app/views/candidate_mailer/feedback_received_for_application_rejected_by_default.text.erb
+++ b/app/views/candidate_mailer/feedback_received_for_application_rejected_by_default.text.erb
@@ -1,7 +1,7 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 As you know, your application for <%= @course.name_and_code %> could not progress because <%= @course.provider.name %>
-did not respond by their deadline of <%= @application_choice.rejected_at.to_s(:govuk_date) %>.
+did not respond by their deadline.
 
 They’ve now given you the following feedback:
 
@@ -9,7 +9,7 @@ They’ve now given you the following feedback:
 <%= render 'reasons_for_rejection' %>
 
 <% if @show_apply_again_guidance %>
-  If this feedback was useful, consider using it to strengthen your application and apply again:
+  If this feedback was useful, make any changes to your application before you apply again:
 
   <%= @candidate_magic_link %>
 <% end %>

--- a/app/views/candidate_mailer/find_has_opened.erb
+++ b/app/views/candidate_mailer/find_has_opened.erb
@@ -2,9 +2,7 @@
   Dear <%= @application_form.first_name %>
 <% end %>
 
-You can now find teacher training courses starting in the <%= @academic_year %> academic year.
-
-Find your courses:
+You can now find teacher training courses starting in the <%= @academic_year %> academic year:
 
 https://www.find-postgraduate-teacher-training.service.gov.uk/
 

--- a/app/views/candidate_mailer/new_cycle_has_started.erb
+++ b/app/views/candidate_mailer/new_cycle_has_started.erb
@@ -3,13 +3,13 @@
 <% end %>
 
 <% unless @application_form.submitted? %>
-  Applications are now open.
+  Teacher training applications are now open.
 
   Complete your application to get on a course starting in the <%= @academic_year %> academic year:
 <% end %>
 
 <% if @application_form.ended_without_success? %>
-  Applications are now open - apply for teacher training again.
+  Teacher training applications are now open.
 
   You could get on a course starting in the <%= @academic_year %> academic year.
 

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -8,7 +8,7 @@ You have an offer from <%= @provider_name %> to study <%= @course_name %>.
   <%= render "candidate_mailer/offer_conditions" %>
 <% end %>
 
-Contact <%= @provider_name %> if you have any questions about this.
+Contact <%= @provider_name %> if you have any questions about the offer.
 
 # Next steps
 

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -10,7 +10,7 @@ You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
 Contact <%= @provider_name %> if you have any questions about the offer.
 
-# Next steps
+# You do not have to respond yet
 
 <%= render "candidate_mailer/wait_or_respond" %>
 

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -3,7 +3,7 @@ Dear <%= @application_form.first_name %>
 You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
 <% if @conditions.blank? %>
-  They’ll let you know if they need further information before you can start training.
+  They’ll let you know if they need further information before you start training.
 <% else %>
   <%= render "candidate_mailer/offer_conditions" %>
 <% end %>

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -3,7 +3,7 @@ Dear <%= @application_form.first_name %>
 You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
 <% if @conditions.blank? %>
-  They’ll let you know if they need further information before you can start training.
+  They’ll let you know if they need further information before you start training.
 <% else %>
   <%= render "candidate_mailer/offer_conditions" %>
 <% end %>

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -3,7 +3,7 @@ Dear <%= @application_form.first_name %>
 You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
 <% if @conditions.blank? %>
-  They’ll let you know if they need further information before you can start training.
+  They’ll let you know if they need further information before you start training.
 <% else %>
   <%= render "candidate_mailer/offer_conditions" %>
 <% end %>

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -1,5 +1,5 @@
 <% if @reason == :email_bounced %>
-# Referee request did not reach <%= @reference.name %>
+Referee request did not reach <%= @reference.name %>.
 
 Check you gave the correct email address and request the reference again.
 <% elsif @reason == :refused %>

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -1,11 +1,14 @@
 <% if @reason == :email_bounced %>
 Your referee request did not reach <%= @reference.name %>.
 
-Check you gave the correct email address and request the reference again.
+Check you gave the correct email address and request the reference again:
+
+<%= candidate_magic_link(@candidate) %>
+
 <% elsif @reason == :refused %>
-# <%= @reference.name %> has declined your reference request
+<%= @reference.name %> has declined your reference request.
 <% else %>
-# <%= @reference.name %> has not responded yet
+<%= @reference.name %> has not responded yet.
 <% end %>
 
 You can add as many referees as you like to increase the chances of getting 2 references quickly.

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -1,5 +1,5 @@
 <% if @reason == :email_bounced %>
-Referee request did not reach <%= @reference.name %>.
+Your referee request did not reach <%= @reference.name %>.
 
 Check you gave the correct email address and request the reference again.
 <% elsif @reason == :refused %>

--- a/app/views/candidate_mailer/offer_accepted.text.erb
+++ b/app/views/candidate_mailer/offer_accepted.text.erb
@@ -2,9 +2,11 @@ Dear <%= @application_form.first_name %>
 
 You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_code %>.
 
-If you meet your conditions, you’ll start <%= @course_name_and_code %> <%= @provider_name %> on <%= @start_date %>.
+The course starts <%= @start_date %>. 
 
-Check your conditions by signing in to your account:
+You need to meet your conditions to start the course.
+
+Sign in to your account to check your conditions:
 
 <%= candidate_magic_link(@application_form.candidate) %>
 

--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -11,7 +11,7 @@ Sign in and select the 2 references you want to include in your application:
 <% elsif @provided_references.count == ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
 You have enough references to send your application to training providers.
 
-Sign in and select the 2 references you want to include in your application:
+Sign in to select 2 references to include in your application:
 <% else %>
 You need another reference before you can send your application to training providers.
 

--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -1,4 +1,4 @@
-You have a reference from <%= @reference.name %>
+You have a reference from <%= @reference.name %>.
 
 <% if @selected_references.count >= ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
 You’ve selected 2 references to submit with your application already, but you can change your selection if you want.

--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -17,7 +17,7 @@ You need another reference before you can send your application to training prov
 
 You can request as many references as you like to increase the chances of getting 2 quickly.
 
-Sign in to manage your reference requests:
+Sign in to manage your references:
 <% end %>
 
 <%= candidate_magic_link(@application_form.candidate) %>

--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -1,4 +1,4 @@
-# You have a reference from <%= @reference.name %>
+You have a reference from <%= @reference.name %>
 
 <% if @selected_references.count >= ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
 You’ve selected 2 references to submit with your application already, but you can change your selection if you want.

--- a/app/views/candidate_mailer/reinstated_offer.text.erb
+++ b/app/views/candidate_mailer/reinstated_offer.text.erb
@@ -2,8 +2,6 @@ Dear <%= @application_form.first_name %>
 
 <%= @course_option.course.provider.name %> has confirmed your deferred offer to study <%= @course_option.course.name_and_code %> in <%= @course_option.course.start_date.to_s(:month_and_year) %>.
 
-This was deferred from (<%= @application_choice.offer_deferred_at.to_s(:month_and_year) %>).
-
 <% if @conditions.any? %>
   <%= render "candidate_mailer/offer_conditions" %>
 <% else %>

--- a/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
+++ b/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
@@ -4,7 +4,7 @@ You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_
 
 The course starts <%= @start_date %>.
 
-<%= @provider_name %> will let you know if they need further information before you can start training.
+<%= @provider_name %> will let you know if they need further information before you start training.
 
 #What to do if you’re unable to start training in <%= @start_date %>
 

--- a/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
+++ b/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# <%= 'Application'.pluralize(@withdrawn_course_names.size) %> withdrawn
-
 You’ve withdrawn your <%= 'application'.pluralize(@withdrawn_course_names.size) %> for <%= @withdrawn_course_names.to_sentence %>.
 
 <%= render 'still_interested_in_teaching' %>

--- a/app/views/referee_mailer/reference_cancelled_email.text.erb
+++ b/app/views/referee_mailer/reference_cancelled_email.text.erb
@@ -1,3 +1,5 @@
 Dear <%= @name %>
 
-<%= @candidate_name %> said they do not need you to give a reference anymore.
+<%= @candidate_name %> is no longer asking for a reference for their teacher training application.
+
+You do not need to do anything.

--- a/app/views/referee_mailer/reference_confirmation_email.text.erb
+++ b/app/views/referee_mailer/reference_confirmation_email.text.erb
@@ -1,9 +1,3 @@
 Dear <%= @name %>
 
 Thank you for your reference for <%= @candidate_name %>.
-
-# Your data
-
-Find out how we use and look after your data:
-
-<%= candidate_interface_privacy_policy_url %>

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -49,8 +49,8 @@ en:
         other: Applications withdrawn automatically
     decline_by_default_last_course_choice:
       subject:
-        one: "You did not respond to your offer: next steps"
-        other: "You did not respond to your offers: next steps"
+        one: "You did not respond to your offer, but you can apply again"
+        other: "You did not respond to your offers, but you can apply again"
     application_rejected_all_applications_rejected:
       subject: Update on your application - all decisions now made
     application_rejected_one_offer_one_awaiting_decision:

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -69,8 +69,8 @@ en:
       subject: Update on your application - respond by %{date}
     application_withdrawn:
       subject:
-        one: "You’ve withdrawn your application: next steps"
-        other: "You’ve withdrawn your applications: next steps"
+        one: "You’ve withdrawn your application: are you still interested in teaching?"
+        other: "You’ve withdrawn your applications: are you still interested in teaching?"
     application_declined:
       subject: "You’ve declined an offer: next steps"
     conditions_statuses_changed:

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -76,9 +76,9 @@ en:
     conditions_statuses_changed:
       subject: "%{provider_name} has updated the status of your conditions for %{course_name}"
     conditions_met:
-      subject: "You have met your conditions for %{course_name}: next steps"
+      subject: "You have met your conditions for %{course_name}"
     conditions_not_met:
-      subject: "You have not met your conditions for %{course_name}: next steps"
+      subject: "You have not met your conditions for %{course_name}"
     changed_offer:
       subject: "Offer changed by %{provider_name}"
     deferred_offer:


### PR DESCRIPTION
We've been reviewing how we write emails across services and found the need to be more consistent - to help content designers know how to structure emails. 

We're removing the headings which appear immediately after 'Dear [candidate]', as they often repeat what's already said in both the subject line and the first sentence. 

