### PR TITLE
Feature flag - allow providers to change course choice details before point of offer

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -41,6 +41,7 @@ class FeatureFlag
     [:draft_vendor_api_specification, 'The specification for Draft Vendor API v1.1', 'Abeer Salameh'],
     [:immigration_entry_date, 'Extends the restructured_immigration_status feature to include the "Date of entry into the UK" question', 'Steve Hook'],
     [:apply_again_with_three_choices, 'Replaces the current apply again logic which only allows one choice', 'Avin & Tomas'],
+    [:change_course_details_before_offer, 'Allows providers to change course choice details before the point of offer', 'James Glenn'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day


### PR DESCRIPTION
## Context

We're going to build functionality for providers to change the details of a candidates course choice, before the point of offer. This work needs to be locked behind a feature flag until it's ready for release.

## Changes proposed in this pull request

<img width="1116" alt="image" src="https://user-images.githubusercontent.com/47917431/154293683-325ba6f4-fea4-4988-ada0-e17bbe37ed1e.png">

## Link to Trello card

https://trello.com/c/avGNv2Ue

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
