### PR TITLE
Fixes for TAD export

### DIFF
--- a/app/controllers/support_interface/data_exports_controller.rb
+++ b/app/controllers/support_interface/data_exports_controller.rb
@@ -16,6 +16,7 @@ module SupportInterface
         .order(created_at: :desc)
         .page(params[:page] || 1)
         .per(PAGE_SIZE)
+        .select(DataExport.column_names - %w[data])
     end
 
     def view_export_information
@@ -23,7 +24,13 @@ module SupportInterface
     end
 
     def view_history
-      @data_exports = DataExport.includes(:initiator).send(params[:data_export_type]).order(created_at: :desc).page(params[:page] || 1).per(PAGE_SIZE)
+      @data_exports = DataExport
+        .includes(:initiator)
+        .send(params[:data_export_type])
+        .order(created_at: :desc)
+        .page(params[:page] || 1)
+        .per(PAGE_SIZE)
+        .select(DataExport.column_names - %w[data])
     end
 
     def create

--- a/app/services/data_api/tad_export.rb
+++ b/app/services/data_api/tad_export.rb
@@ -19,7 +19,7 @@ module DataAPI
     end
 
     def data_for_export(*)
-      relevant_applications.flat_map do |application_form|
+      relevant_applications.find_each.flat_map do |application_form|
         # if a form belongs to previous year, we only want to consider the choice that was deferred
         # for non-deferred apps this set will be equivalent to all choices
         application_form.application_choices.select { |ac| ac.current_recruitment_cycle_year == RecruitmentCycle.current_year }.map do |application_choice|
@@ -43,7 +43,7 @@ module DataAPI
           :candidate,
         ).preload(
           :application_qualifications,
-          application_choices: [{ current_course: :subjects }, :provider, :accredited_provider, :audits],
+          application_choices: [{ current_course: :subjects }, :provider, :current_accredited_provider, :audits],
         )
         .where('candidates.hide_in_reporting' => false)
         .where.not(submitted_at: nil)

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -33,14 +33,14 @@ RSpec.describe ApplicationForm do
     end
 
     it 'updates the candidates `candidate_api_updated_at` on the first update' do
-      application_form = create(:application_form)
+      application_form = create(:application_form, first_name: 'Bob')
 
       expect { application_form.update(first_name: 'David') }
         .to(change { application_form.candidate.candidate_api_updated_at })
     end
 
     it 'does not update the candidates `candidate_api_updated_at` on subsequent updates' do
-      application_form = create(:application_form)
+      application_form = create(:application_form, first_name: 'Bob')
 
       application_form.update(first_name: 'Divad')
 
@@ -54,6 +54,7 @@ RSpec.describe ApplicationForm do
           :completed_application_form,
           recruitment_cycle_year: RecruitmentCycle.previous_year,
           application_choices_count: 1,
+          first_name: 'Mary',
         )
 
         expect { application_form.update(first_name: 'Maria') }
@@ -87,7 +88,12 @@ RSpec.describe ApplicationForm do
       end
 
       it 'does nothing when there are no application choices' do
-        application_form = create(:completed_application_form, recruitment_cycle_year: RecruitmentCycle.previous_year, application_choices_count: 0)
+        application_form = create(
+          :completed_application_form,
+          recruitment_cycle_year: RecruitmentCycle.previous_year,
+          application_choices_count: 0,
+          first_name: 'Mary',
+        )
 
         expect { application_form.update(first_name: 'Maria') }
           .not_to raise_error


### PR DESCRIPTION
## Context

It has been reported that the TAD data export is broken on production at the moment.

We are seeing database query timeouts.

Ideally we should merge https://github.com/DFE-Digital/apply-for-teacher-training/pull/6552 first to fix the flakey spec that has been flagged here.

## Changes proposed in this pull request

- [x] Add a `find_each` to ensure that we don't load all the data at once. This adds a `LIMIT 1000 OFFSET n` to the main query. Adhoc testing of the query in blazer seems to suggest that this helps - the original query times out pretty much every time whereas with `LIMIT 1000 OFFSET 20000` the query only takes a few seconds (it's still not fast).
- [x] Attempt to fix a 1+n query. (It seems the report depends on `current_course` but we are preloading `course`).
- [x] Fix slowness in the support interface when listing and viewing data exports caused by us loading the actual report data when we don't render it. It's huge and caused timeouts or at best multi-second response times. My quick and dirty fix is just to add a `select` to the query.

## Guidance to review

- Does the query still timeout?
- Do we need any further testing? (I've not changed any tests because behaviour should be unchanged).

## Link to Trello card

https://trello.com/c/41EJI78g/4440-fix-errors-with-tad-data-export

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
