### PR TITLE
Fix content for apply 2

### DIFF
--- a/app/views/candidate_mailer/_still_interested_content.text.erb
+++ b/app/views/candidate_mailer/_still_interested_content.text.erb
@@ -6,7 +6,6 @@ You can apply again for courses starting in the <%= "#{RecruitmentCycle.next_yea
 Your last application is saved. All you need to do is:
 
 - make any changes
-- choose up to 3 courses
 - submit from <%= CycleTimetable.apply_reopens.to_s(:govuk_time) %> on <%= CycleTimetable.apply_reopens.to_s(:govuk_date) %>
 <% else %>
 Your last application has been saved. Make any changes and re-submit from <%= CycleTimetable.apply_reopens.to_s(:govuk_time) %> on <%= CycleTimetable.apply_reopens.to_s(:govuk_date) %>.


### PR DESCRIPTION
## Context

Candidates will not be able to apply for courses at this stage, so we are removing this guidance. 

## Changes proposed in this pull request
- Remove the bullet `choose up to 3 courses`

