### PR TITLE
Set the request store to not allow unsafe touches

### DIFF
--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe ApplicationForm do
     end
 
     context 'when the form belongs to a previous recruitment cycle' do
+      before { RequestStore.store[:allow_unsafe_application_choice_touches] = false }
+
       it 'throws an exception rather than touch an application choice' do
         application_form = create(
           :completed_application_form,


### PR DESCRIPTION
## Context

We are getting flakey test failures when attempting to check we raise an error when attempting to touch applications from the previous cycle. 
This is controlled by a `RequestStore` value. Since those tests are run in parallel we are setting this value which is leaking into this test.

## Changes proposed in this pull request

Set the `RequestStore` value explicitly before each test to avoid flakiness.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[<!-- http://trello.com/123-example-card -->
](https://trello.com/c/KGaHgbfA/4814-flakey-spec-spec-models-applicationformspecrb)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
