### PR TITLE
Accommodate different model not found errors

### DIFF
--- a/app/controllers/concerns/vendor_api/api_validations_and_error_handling.rb
+++ b/app/controllers/concerns/vendor_api/api_validations_and_error_handling.rb
@@ -1,6 +1,9 @@
 module VendorAPI
   module APIValidationsAndErrorHandling
     extend ActiveSupport::Concern
+    NOT_FOUND_MODEL_MAPPINGS = {
+      'ApplicationChoice' => 'Application',
+    }.freeze
 
     included do
       before_action :validate_metadata!
@@ -31,12 +34,14 @@ module VendorAPI
       }
     end
 
-    def render_not_found_error(_)
+    def render_not_found_error(e)
+      model_name = NOT_FOUND_MODEL_MAPPINGS[e.model] || e.model
+
       render status: :not_found, json: {
         errors: [
           {
             error: 'NotFound',
-            message: 'Unable to find Application(s)',
+            message: "Unable to find #{model_name}(s)",
           },
         ],
       }


### PR DESCRIPTION
## Context

When entering a non existent interview ID in a request, we are getting an application not found error. 

## Changes proposed in this pull request

Return the model causing the error to capture where this error is coming from rather than always defaults to application choice.

## Guidance to review

Did I miss anything? This is the only nested model we have, notes only allows creation so we don't ever attempt actions on any of it's ids.

## Link to Trello card

https://trello.com/c/L8VkAq9v/4815-api-cleanup-change-404-error-to-handle-interviews-as-well-as-applications

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
