### PR TITLE
Add Mandarin HECOS mapping

### DIFF
--- a/app/services/provider_interface/hesa_data_export.rb
+++ b/app/services/provider_interface/hesa_data_export.rb
@@ -108,11 +108,13 @@ module Hesa
   class SubjectCode
     PRIMARY_CODES = %w[00 01 02 03 04 05 06 07].freeze
     LANGUAGE_CODES = %w[15 17 22 24].freeze
+    CHINESE_LANGUAGE_CODES = ['20'].freeze
 
     def self.find_by_code(code)
       return if code.blank?
       return '100511' if PRIMARY_CODES.include?(code)
       return '100329' if LANGUAGE_CODES.include?(code)
+      return '101165' if CHINESE_LANGUAGE_CODES.include?(code)
 
       mappings[code.ljust(4, '0')]
     end

--- a/spec/services/provider_interface/hesa_data_export_spec.rb
+++ b/spec/services/provider_interface/hesa_data_export_spec.rb
@@ -132,6 +132,21 @@ RSpec.describe ProviderInterface::HesaDataExport do
 
       it_behaves_like 'an exported HESA row'
     end
+
+    context 'when there is an unknown subject code' do
+      let(:subjects) { [create(:subject, code: 'F3'), create(:subject, code: 'X9'), create(:subject, code: 'missing-value')] }
+
+      before { allow(Sentry).to receive(:capture_exception).with(an_instance_of(described_class::MissingSubjectCodeHECOSMapping)) }
+
+      it 'captures code in Sentry error' do
+        export_row
+        expect(Sentry).to have_received(:capture_exception).with(
+          described_class::MissingSubjectCodeHECOSMapping.new("Could not map Subject code: 'missing-value' to HECOS code"),
+        )
+      end
+
+      it_behaves_like 'an exported HESA row'
+    end
   end
 
   describe '#export_data' do


### PR DESCRIPTION
## Context

We received a [Sentry error](https://sentry.io/organizations/dfe-teacher-services/issues/3013308734/?project=1765973&referrer=slack) when a user attempted to download a HESA report with a subject code that doesn't map to our JACS to HECOS mapping.

The unknown code: "20" maps to the subject "Mandarin". This mapping exists for a different JACS code however which maps to Chinese languages.

## Changes proposed in this pull request

- Map the code 20 to the correct HECOS code
-  Remove `nil` mapping values to allow reports to be downloaded if no mapping exists
- Raise an error internally to inform us of missing code
- 
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
