### PR TITLE
Course Change - Add the training provider wizard

### DIFF
--- a/app/components/provider_interface/change_course_details_component.html.erb
+++ b/app/components/provider_interface/change_course_details_component.html.erb
@@ -1,14 +1,5 @@
 <section class="app-section govuk-!-width-two-thirds">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="course-details">Course applied for</h2>
 
-  <%= render SummaryListComponent.new(rows: [
-    { key: 'Training provider', value: provider_name_and_code, action: { href: change_provider_path } },
-    { key: 'Course', value: course_name_and_code },
-    { key: 'Cycle', value: cycle },
-    { key: 'Full or part time', value: study_mode },
-    { key: 'Location', value: preferred_location },
-    { key: 'Accredited body', value: accredited_body },
-    { key: 'Qualification', value: qualification },
-    { key: 'Funding type', value: funding_type },
-  ]) %>
+  <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/provider_interface/change_course_details_component.html.erb
+++ b/app/components/provider_interface/change_course_details_component.html.erb
@@ -1,0 +1,14 @@
+<section class="app-section govuk-!-width-two-thirds">
+  <h2 class="govuk-heading-m govuk-!-font-size-27" id="course-details">Course applied for</h2>
+
+  <%= render SummaryListComponent.new(rows: [
+    { key: 'Training provider', value: provider_name_and_code, action: { href: change_provider_path } },
+    { key: 'Course', value: course_name_and_code },
+    { key: 'Cycle', value: cycle },
+    { key: 'Full or part time', value: study_mode },
+    { key: 'Location', value: preferred_location },
+    { key: 'Accredited body', value: accredited_body },
+    { key: 'Qualification', value: qualification },
+    { key: 'Funding type', value: funding_type },
+  ]) %>
+</section>

--- a/app/components/provider_interface/change_course_details_component.rb
+++ b/app/components/provider_interface/change_course_details_component.rb
@@ -1,0 +1,7 @@
+module ProviderInterface
+  class ChangeCourseDetailsComponent < CourseDetailsComponent
+    def change_provider_path
+      available_providers.length > 1 ? edit_provider_interface_application_choice_course_providers_path(application_choice) : nil
+    end
+  end
+end

--- a/app/components/provider_interface/change_course_details_component.rb
+++ b/app/components/provider_interface/change_course_details_component.rb
@@ -1,5 +1,62 @@
 module ProviderInterface
-  class ChangeCourseDetailsComponent < CourseDetailsComponent
+  class ChangeCourseDetailsComponent < ViewComponent::Base
+    include ViewHelper
+    include QualificationValueHelper
+
+    FUNDING_TYPES = { apprenticeship: :apprenticeship, salary: :salaried, fee: :fee_paying }.freeze
+
+    attr_reader :application_choice, :provider_name_and_code, :course_name_and_code,
+                :cycle, :preferred_location, :study_mode, :qualification, :available_providers
+
+    def initialize(application_choice:, available_providers: [])
+      @application_choice = application_choice
+      @provider_name_and_code = application_choice.provider.name_and_code
+      @course_name_and_code = application_choice.course.name_and_code
+      @cycle = application_choice.course.recruitment_cycle_year
+      @preferred_location = preferred_location_text
+      @study_mode = application_choice.course_option.study_mode.humanize
+      @qualification = qualification_text(application_choice.course_option)
+      @available_providers = available_providers
+    end
+
+    def rows
+      [
+        { key: 'Training provider', value: provider_name_and_code, action: { href: change_provider_path } },
+        { key: 'Course', value: course_name_and_code },
+        { key: 'Cycle', value: cycle },
+        { key: 'Full or part time', value: study_mode },
+        { key: 'Location', value: preferred_location },
+        { key: 'Accredited body', value: accredited_body },
+        { key: 'Qualification', value: qualification },
+        { key: 'Funding type', value: funding_type },
+      ]
+    end
+
+    def preferred_location_text
+      "#{application_choice.site.name_and_code}\n" \
+        "#{formatted_address}"
+    end
+
+    def accredited_body
+      accredited_body = @application_choice.course.accredited_provider
+      accredited_body.present? ? accredited_body.name_and_code : provider_name_and_code
+    end
+
+    def funding_type
+      key = @application_choice.course.funding_type.to_sym
+      FUNDING_TYPES[key].to_s.humanize
+    end
+
+  private
+
+    def formatted_address
+      site = application_choice.site
+      "#{site.address_line1}, " \
+        "#{site.address_line2}, " \
+        "#{site.address_line3}\n" \
+        "#{site.postcode}"
+    end
+
     def change_provider_path
       available_providers.length > 1 ? edit_provider_interface_application_choice_course_providers_path(application_choice) : nil
     end

--- a/app/components/provider_interface/course_details_component.html.erb
+++ b/app/components/provider_interface/course_details_component.html.erb
@@ -1,14 +1,5 @@
 <section class="app-section govuk-!-width-two-thirds">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="course-details">Course applied for</h2>
 
-  <%= render SummaryListComponent.new(rows: [
-    { key: 'Training provider', value: provider_name_and_code },
-    { key: 'Course', value: course_name_and_code },
-    { key: 'Cycle', value: cycle },
-    { key: 'Full or part time', value: study_mode },
-    { key: 'Location', value: preferred_location },
-    { key: 'Accredited body', value: accredited_body },
-    { key: 'Qualification', value: qualification },
-    { key: 'Funding type', value: funding_type },
-  ]) %>
+  <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/provider_interface/course_details_component.rb
+++ b/app/components/provider_interface/course_details_component.rb
@@ -6,9 +6,9 @@ module ProviderInterface
     FUNDING_TYPES = { apprenticeship: :apprenticeship, salary: :salaried, fee: :fee_paying }.freeze
 
     attr_reader :application_choice, :provider_name_and_code, :course_name_and_code,
-                :cycle, :preferred_location, :study_mode, :qualification
+                :cycle, :preferred_location, :study_mode, :qualification, :available_providers
 
-    def initialize(application_choice:)
+    def initialize(application_choice:, available_providers: [])
       @application_choice = application_choice
       @provider_name_and_code = application_choice.provider.name_and_code
       @course_name_and_code = application_choice.course.name_and_code
@@ -16,6 +16,7 @@ module ProviderInterface
       @preferred_location = preferred_location_text
       @study_mode = application_choice.course_option.study_mode.humanize
       @qualification = qualification_text(application_choice.course_option)
+      @available_providers = available_providers
     end
 
     def preferred_location_text

--- a/app/components/provider_interface/course_details_component.rb
+++ b/app/components/provider_interface/course_details_component.rb
@@ -1,47 +1,16 @@
 module ProviderInterface
-  class CourseDetailsComponent < ViewComponent::Base
-    include ViewHelper
-    include QualificationValueHelper
-
-    FUNDING_TYPES = { apprenticeship: :apprenticeship, salary: :salaried, fee: :fee_paying }.freeze
-
-    attr_reader :application_choice, :provider_name_and_code, :course_name_and_code,
-                :cycle, :preferred_location, :study_mode, :qualification, :available_providers
-
-    def initialize(application_choice:, available_providers: [])
-      @application_choice = application_choice
-      @provider_name_and_code = application_choice.provider.name_and_code
-      @course_name_and_code = application_choice.course.name_and_code
-      @cycle = application_choice.course.recruitment_cycle_year
-      @preferred_location = preferred_location_text
-      @study_mode = application_choice.course_option.study_mode.humanize
-      @qualification = qualification_text(application_choice.course_option)
-      @available_providers = available_providers
-    end
-
-    def preferred_location_text
-      "#{application_choice.site.name_and_code}\n" \
-        "#{formatted_address}"
-    end
-
-    def accredited_body
-      accredited_body = @application_choice.course.accredited_provider
-      accredited_body.present? ? accredited_body.name_and_code : provider_name_and_code
-    end
-
-    def funding_type
-      key = @application_choice.course.funding_type.to_sym
-      FUNDING_TYPES[key].to_s.humanize
-    end
-
-  private
-
-    def formatted_address
-      site = application_choice.site
-      "#{site.address_line1}, " \
-        "#{site.address_line2}, " \
-        "#{site.address_line3}\n" \
-        "#{site.postcode}"
+  class CourseDetailsComponent < ChangeCourseDetailsComponent
+    def rows
+      [
+        { key: 'Training provider', value: provider_name_and_code },
+        { key: 'Course', value: course_name_and_code },
+        { key: 'Cycle', value: cycle },
+        { key: 'Full or part time', value: study_mode },
+        { key: 'Location', value: preferred_location },
+        { key: 'Accredited body', value: accredited_body },
+        { key: 'Qualification', value: qualification },
+        { key: 'Funding type', value: funding_type },
+      ]
     end
   end
 end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -38,6 +38,8 @@ module ProviderInterface
         .application_form
         .english_main_language(fetch_database_value: true)
         .present?
+
+      @available_training_providers = available_training_providers
     end
 
     def timeline; end
@@ -64,6 +66,17 @@ module ProviderInterface
 
     def available_providers
       current_provider_user.providers
+    end
+
+    def available_training_providers
+      query_service.available_providers
+    end
+
+    def query_service
+      @query_service ||= GetChangeOfferOptions.new(
+        user: current_provider_user,
+        current_course: @application_choice.current_course,
+      )
     end
 
     def set_workflow_flags

--- a/app/controllers/provider_interface/courses/providers_controller.rb
+++ b/app/controllers/provider_interface/courses/providers_controller.rb
@@ -1,0 +1,37 @@
+module ProviderInterface
+  module Courses
+    class ProvidersController < CoursesController
+      def edit
+        @wizard = CourseWizard.new(change_course_store, { current_step: 'providers', action: action })
+        @wizard.save_state!
+
+        @providers = available_providers
+      end
+
+      def update
+        @wizard = CourseWizard.new(change_course_store, attributes_for_wizard)
+
+        if @wizard.valid_for_current_step?
+          @wizard.save_state!
+
+          redirect_to [:edit, :provider_interface, @application_choice, :offer, @wizard.next_step]
+        else
+          track_validation_error(@wizard)
+          @providers = available_providers
+
+          render :edit
+        end
+      end
+
+    private
+
+      def provider_params
+        params.require(:provider_interface_course_wizard).permit(:provider_id)
+      end
+
+      def attributes_for_wizard
+        provider_params.to_h.merge!(current_step: 'providers')
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/courses_controller.rb
+++ b/app/controllers/provider_interface/courses_controller.rb
@@ -1,6 +1,7 @@
 module ProviderInterface
   class CoursesController < ProviderInterfaceController
     before_action :set_application_choice
+    before_action :redirect_to_application_page_unless_feature_flag_is_active
 
     def edit
       redirect_to provider_interface_application_choice_course_path(@application_choice)
@@ -26,6 +27,10 @@ module ProviderInterface
         user: current_provider_user,
         current_course: @application_choice.current_course,
       )
+    end
+
+    def redirect_to_application_page_unless_feature_flag_is_active
+      redirect_to provider_interface_application_choice_path(@application_choice) unless FeatureFlag.active?(:change_course_details_before_offer)
     end
   end
 end

--- a/app/controllers/provider_interface/courses_controller.rb
+++ b/app/controllers/provider_interface/courses_controller.rb
@@ -1,0 +1,31 @@
+module ProviderInterface
+  class CoursesController < ProviderInterfaceController
+    before_action :set_application_choice
+
+    def edit
+      redirect_to provider_interface_application_choice_course_path(@application_choice)
+    end
+
+  private
+
+    def change_course_store
+      key = "change_course_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
+      WizardStateStores::RedisStore.new(key: key)
+    end
+
+    def action
+      'back' if !!params[:back]
+    end
+
+    def available_providers
+      query_service.available_providers
+    end
+
+    def query_service
+      @query_service ||= GetChangeOfferOptions.new(
+        user: current_provider_user,
+        current_course: @application_choice.current_course,
+      )
+    end
+  end
+end

--- a/app/forms/provider_interface/course_wizard.rb
+++ b/app/forms/provider_interface/course_wizard.rb
@@ -1,0 +1,50 @@
+module ProviderInterface
+  class CourseWizard
+    include Wizard
+    include Wizard::PathHistory
+
+    STEPS = %i[select_option providers courses study_modes locations check].freeze
+
+    attr_accessor :path_history, :provider_id, :decision, :provider_user, :application_choice_id
+
+    def next_step(step = current_step)
+      index = STEPS.index(step.to_sym)
+      return unless index
+
+      next_step = STEPS[index + 1]
+
+      return save_and_go_to_next_step(next_step) if next_step.eql?(:providers) && available_providers.length == 1
+
+      next_step
+    end
+
+  private
+
+    def application_choice
+      ApplicationChoice.find(application_choice_id)
+    end
+
+    def query_service
+      @query_service ||= GetChangeOfferOptions.new(
+        user: provider_user,
+        current_course: application_choice.current_course,
+      )
+    end
+
+    def available_providers
+      query_service.available_providers
+    end
+
+    def save_and_go_to_next_step(step)
+      attrs = { provider_id: available_providers.first.id } if step.eql?(:providers)
+      attrs = { course_id: available_courses.first.id } if step.eql?(:courses)
+      attrs = { study_mode: available_study_modes.first } if step.eql?(:study_modes)
+      attrs = { course_option_id: available_course_options.first.id } if step.eql?(:locations)
+
+      assign_attributes(last_saved_state.merge(attrs))
+      save_state!
+
+      next_step(step)
+    end
+  end
+end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -45,7 +45,11 @@
   </div>
 <% end %>
 
-<%= render ProviderInterface::CourseDetailsComponent.new(application_choice: @application_choice) %>
+<% if @provider_can_respond && FeatureFlag.active?(:change_course_details_before_offer) %>
+  <%= render ProviderInterface::ChangeCourseDetailsComponent.new(application_choice: @application_choice, available_providers: @available_training_providers) %>
+<% else %>
+  <%= render ProviderInterface::CourseDetailsComponent.new(application_choice: @application_choice) %>
+<% end %>
 
 <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_choice: @application_choice, current_provider_user: current_provider_user) %>
 

--- a/app/views/provider_interface/courses/providers/edit.html.erb
+++ b/app/views/provider_interface/courses/providers/edit.html.erb
@@ -1,0 +1,16 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+
+<%= render CollectionSelectComponent.new(attribute: :provider_id,
+                                         collection: @providers,
+                                         value_method: :id,
+                                         text_method: :name_and_code,
+                                         hint_method: nil,
+                                         form_object: @wizard,
+                                         form_path: provider_interface_application_choice_course_providers_path,
+                                         form_method: :put,
+                                         page_title: t('.title'),
+                                         caption: t('.caption', name: @application_choice.application_form.full_name)) do %>
+  <p class="govuk-body">
+    <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice) %>
+  </p>
+<% end %>

--- a/config/locales/provider_interface/change_course.yml
+++ b/config/locales/provider_interface/change_course.yml
@@ -1,0 +1,7 @@
+en:
+  provider_interface:
+    courses:
+      providers:
+        edit:
+          title: Training provider
+          caption: Update course - %{name}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -738,6 +738,10 @@ Rails.application.routes.draw do
         resource :check, only: %i[new edit]
       end
 
+      namespace :courses, as: :application_choice_course do
+        resource :providers, only: %i[edit update]
+      end
+
       get '/rejection-reasons' => 'reasons_for_rejection#edit_initial_questions', as: :reasons_for_rejection_initial_questions
       post '/rejection-reasons' => 'reasons_for_rejection#update_initial_questions', as: :reasons_for_rejection_update_initial_questions
       get '/rejection-reasons/other-reasons-for-rejection' => 'reasons_for_rejection#edit_other_reasons', as: :reasons_for_rejection_other_reasons

--- a/spec/components/provider_interface/change_course_details_component_spec.rb
+++ b/spec/components/provider_interface/change_course_details_component_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
+  let(:course_option) do
+    instance_double(CourseOption,
+                    study_mode: 'Full time',
+                    course: course)
+  end
+
+  let(:site) do
+    instance_double(Site,
+                    name_and_code: 'First Road (F34)',
+                    address_line1: 'Fountain Street',
+                    address_line2: 'Morley',
+                    address_line3: 'Leeds',
+                    postcode: 'LS27 OPD')
+  end
+
+  let(:provider) do
+    instance_double(Provider,
+                    name_and_code: 'Best Training (B54)')
+  end
+
+  let(:accredited_provider) do
+    instance_double(Provider,
+                    name_and_code: 'Accredit Now (A78)')
+  end
+
+  let(:course) do
+    instance_double(Course,
+                    name_and_code: 'Geograpghy (H234)',
+                    recruitment_cycle_year: 2020,
+                    accredited_provider: nil,
+                    qualifications: %w[qts pgce],
+                    funding_type: 'fee')
+  end
+
+  let(:application_choice) do
+    instance_double(ApplicationChoice,
+                    course_option: course_option,
+                    provider: provider,
+                    course: course,
+                    site: site)
+  end
+
+  def row_text_selector(row_name, render)
+    rows = { provider: 0,
+             course: 1,
+             cycle: 2,
+             full_or_part_time: 3,
+             location: 4,
+             accredited_body: 5,
+             qualification: 6,
+             funding_type: 7 }
+
+    render.css('.govuk-summary-list__row')[rows[row_name]].text
+  end
+
+  context 'when there are multiple available providers' do
+    let(:render) { render_inline(described_class.new(application_choice: application_choice, available_providers: [provider, accredited_provider])) }
+
+    it 'renders a link to change' do
+      render_text = row_text_selector(:provider, render)
+
+      expect(render_text).to include('Training provider')
+      expect(render_text).to include('Best Training (B54)')
+      expect(render_text).to include('Change')
+    end
+  end
+
+  context 'when there are not multiple available providers' do
+    let(:render) { render_inline(described_class.new(application_choice: application_choice)) }
+
+    it 'does not renders the change link' do
+      render_text = row_text_selector(:provider, render)
+
+      expect(render_text).to include('Training provider')
+      expect(render_text).to include('Best Training (B54)')
+      expect(render_text).not_to include('Change')
+    end
+  end
+end

--- a/spec/forms/provider_interface/course_wizard_spec.rb
+++ b/spec/forms/provider_interface/course_wizard_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+RSpec.describe ProviderInterface::CourseWizard do
+  subject(:wizard) do
+    described_class.new(store,
+                        provider_id: provider_id,
+                        application_choice_id: application_choice_id,
+                        current_step: current_step)
+  end
+
+  let(:store) { instance_double(WizardStateStores::RedisStore) }
+  let(:provider_id) { nil }
+  let(:application_choice_id) { create(:application_choice).id }
+  let(:current_step) { nil }
+
+  context 'when changing an offer' do
+    let(:decision) { :change_offer }
+    let(:query_service) { instance_double(GetChangeOfferOptions) }
+    let(:provider_user) { instance_double(ProviderUser) }
+    let(:provider_id) { create(:provider).id }
+
+    before do
+      allow(ProviderUser).to receive(:find).and_return(provider_user)
+      allow(provider_user).to receive(:id).and_return(1)
+      allow(GetChangeOfferOptions).to receive(:new).and_return(query_service)
+      allow(store).to receive(:write)
+      allow(store).to receive(:read)
+    end
+
+    context 'when current_step is :select_option' do
+      let(:current_step) { :select_option }
+
+      context 'when there are multiple available providers' do
+        before do
+          allow(query_service).to receive(:available_providers).and_return(create_list(:provider, 2))
+        end
+
+        it 'returns :providers' do
+          expect(wizard.next_step).to eq(:providers)
+        end
+      end
+
+      context 'when there is only one available provider' do
+        before do
+          allow(query_service).to receive(:available_providers).and_return([create(:provider)])
+          allow(query_service).to receive(:available_courses).and_return(create_list(:course, 2))
+        end
+
+        it 'returns :courses' do
+          expect(wizard.next_step).to eq(:courses)
+        end
+      end
+    end
+
+    context 'when current_step is :providers' do
+      let(:current_step) { :providers }
+
+      context 'when there are multiple available courses' do
+        before do
+          allow(query_service).to receive(:available_courses).and_return(create_list(:course, 2))
+        end
+
+        it 'returns :courses' do
+          expect(wizard.next_step).to eq(:courses)
+        end
+      end
+
+      context 'when there is only one available course' do
+        before do
+          allow(query_service).to receive(:available_courses).and_return([create(:course)])
+          allow(query_service).to receive(:available_study_modes).and_return(%w[full_time part_time])
+        end
+
+        it 'returns :study_modes' do
+          expect(wizard.next_step).to eq(:courses)
+        end
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider changes a course' do
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
+  let(:provider) { provider_user.providers.first }
+  let(:ratifying_provider) { create(:provider) }
+  let(:application_form) { build(:application_form, :minimum_info) }
+  let!(:application_choice) do
+    create(:application_choice, :awaiting_provider_decision,
+           application_form: application_form,
+           course_option: course_option)
+  end
+  let(:course) do
+    build(:course, :full_time, provider: provider, accredited_provider: ratifying_provider)
+  end
+  let(:course_option) { build(:course_option, course: course) }
+
+  scenario 'Changing a course choice before point of offer' do
+    given_i_am_a_provider_user
+    and_the_feature_flag_is_enabled
+    and_i_am_permitted_to_make_decisions_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+    and_the_provider_has_multiple_courses
+    and_the_provider_user_can_offer_multiple_provider_courses
+
+    when_i_visit_the_provider_interface
+    and_i_click_an_application_choice_that_is_interviewing
+    and_i_click_on_change_the_training_provider
+    then_i_see_a_list_of_training_providers_to_select_from
+  end
+
+  def given_i_am_a_provider_user
+    user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+  end
+
+  def and_the_feature_flag_is_enabled
+    FeatureFlag.activate(:change_course_details_before_offer)
+  end
+
+  def and_i_am_permitted_to_make_decisions_for_my_provider
+    permit_make_decisions!
+  end
+
+  def and_i_sign_in_to_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_the_provider_has_multiple_courses
+    @provider_available_course = create(:course, :open_on_apply, study_mode: :full_time, provider: provider, accredited_provider: ratifying_provider)
+    create(:course, :open_on_apply, provider: provider)
+    course_options = [create(:course_option, :full_time, course: @provider_available_course),
+                      create(:course_option, :full_time, course: @provider_available_course),
+                      create(:course_option, :full_time, course: @provider_available_course)]
+
+    @provider_available_course_option = course_options.sample
+  end
+
+  def and_the_provider_user_can_offer_multiple_provider_courses
+    @selected_provider = create(:provider, :with_signed_agreement)
+    create(:provider_permissions, provider: @selected_provider, provider_user: provider_user, make_decisions: true)
+    courses = [create(:course, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider),
+               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)]
+    @selected_course = courses.sample
+
+    course_options = [create(:course_option, :part_time, course: @selected_course),
+                      create(:course_option, :full_time, course: @selected_course),
+                      create(:course_option, :full_time, course: @selected_course),
+                      create(:course_option, :part_time, course: @selected_course)]
+
+    create(
+      :provider_relationship_permissions,
+      training_provider: provider,
+      ratifying_provider: ratifying_provider,
+      ratifying_provider_can_make_decisions: true,
+    )
+
+    create(
+      :provider_relationship_permissions,
+      training_provider: @selected_provider,
+      ratifying_provider: ratifying_provider,
+      ratifying_provider_can_make_decisions: true,
+    )
+
+    @selected_course_option = course_options.sample
+  end
+
+  def when_i_visit_the_provider_interface
+    visit provider_interface_applications_path
+  end
+
+  def and_i_click_an_application_choice_that_is_interviewing
+    click_on application_choice.application_form.full_name
+  end
+
+  def and_i_click_on_change_the_training_provider
+    within(all('.govuk-summary-list__row')[11]) do
+      click_on 'Change'
+    end
+  end
+
+  def then_i_see_a_list_of_training_providers_to_select_from
+    expect(page).to have_content "Update course - #{application_form.full_name}"
+    expect(page).to have_content 'Training provider'
+  end
+end


### PR DESCRIPTION
## Context

Currently providers can change the details of a course at the point of offer. We'd like to let providers do this before the point of offer.

This is the first in a series of PRs that will introduce functionality into the applications view, for providers to change attributes of a candidates course choice.

This PR allows the user to change the training provider.

## Changes proposed in this pull request

<img width="683" alt="image" src="https://user-images.githubusercontent.com/47917431/154996320-7040b43c-a2aa-4a26-88e3-d1940ea017e3.png">

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/VZJ6LDB1

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
