### PR TITLE
too many email headings

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -44,7 +44,7 @@ class CandidateMailer < ApplicationMailer
 
     email_for_candidate(
       reference.application_form,
-      subject: I18n.t!("candidate_mailer.new_referee_request.{@reason}.subject", referee_name: @reference.name),
+      subject: I18n.t!("candidate_mailer.new_referee_request.#{@reason}.subject", referee_name: @reference.name),
     )
   end
 

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -44,7 +44,7 @@ class CandidateMailer < ApplicationMailer
 
     email_for_candidate(
       reference.application_form,
-      subject: I18n.t!("candidate_mailer.new_referee_request.#{@reason}.subject", referee_name: @reference.name),
+      subject: I18n.t!("candidate_mailer.new_referee_request.{@reason}.subject", referee_name: @reference.name),
     )
   end
 

--- a/app/views/authentication_mailer/sign_up_email.text.erb
+++ b/app/views/authentication_mailer/sign_up_email.text.erb
@@ -1,6 +1,5 @@
-# <%= t('authentication.sign_up.email.subject') %>
 
-Confirm your email address and go back to <%= t('service_name.apply') %>:
+Confirm your email address to apply for teacher training:
 
 <%= @magic_link %>
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# Update on your application
-
 At your request, <%= @course.provider.name %> has withdrawn your application to study <%= @course.name_and_code %>.
 
 Get in touch if you did not ask them to do this:

--- a/app/views/candidate_mailer/chase_candidate_decision.text.erb
+++ b/app/views/candidate_mailer/chase_candidate_decision.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# Respond by <%= @dbd_date %>
-
 <% if @application_choices.count > 1 %>
 
 You have until <%= @dbd_date %> to respond to your offers.

--- a/app/views/candidate_mailer/chase_reference.text.erb
+++ b/app/views/candidate_mailer/chase_reference.text.erb
@@ -1,4 +1,4 @@
-# <%= @reference.name %> has not responded yet
+<%= @reference.name %> has not responded yet.
 
 You can add as many referees as you like to increase the chances of getting 2 references quickly.
 

--- a/app/views/candidate_mailer/chase_reference_again.text.erb
+++ b/app/views/candidate_mailer/chase_reference_again.text.erb
@@ -1,4 +1,4 @@
-# <%= @referee.name %> has not responded yet
+<%= @referee.name %> has not responded yet.
 
 You can add as many referees as you like to increase the chances of getting 2 references quickly.
 

--- a/app/views/candidate_mailer/conditions_met.text.erb
+++ b/app/views/candidate_mailer/conditions_met.text.erb
@@ -1,9 +1,7 @@
 Dear <%= @application_form.first_name %>
 
-# You’ve met your conditions
-
 Congratulations, <%= @application_choice.current_course_option.course.provider.name %> has confirmed that you’ve met your conditions for <%= @application_choice.current_course_option.course.name_and_code %>.
 
-# Next steps
+If they have not already, <%= @application_choice.current_course_option.course.provider.name %> should be in contact about enrolling on the course.
 
-If they have not already, <%= @application_choice.current_course_option.course.provider.name %> should be in contact about enrolling on the course. Contact them directly if you have any questions about this process.
+Contact them directly if you have any questions about this process.

--- a/app/views/candidate_mailer/conditions_not_met.text.erb
+++ b/app/views/candidate_mailer/conditions_not_met.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# You have not met your conditions
-
 You cannot enrol on <%= @application_choice.current_course_option.course.name_and_code %> because <%= @application_choice.current_course_option.course.provider.name %> told us you have not met your conditions.
 
 Get in touch with <%= @application_choice.current_course_option.course.provider.name %> if you need further advice.

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -1,11 +1,11 @@
 <% if @reason == :email_bounced %>
-# Referee request did not reach <%= @reference.name %>
+Your referee request did not reach <%= @reference.name %>.
 
 Check you gave the correct email address and request the reference again.
 <% elsif @reason == :refused %>
-# <%= @reference.name %> has declined your reference request
+<%= @reference.name %> has declined your reference request.
 <% else %>
-# <%= @reference.name %> has not responded yet
+<%= @reference.name %> has not responded yet.
 <% end %>
 
 You can add as many referees as you like to increase the chances of getting 2 references quickly.

--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -1,4 +1,4 @@
-# You have a reference from <%= @reference.name %>
+You have a reference from <%= @reference.name %>.
 
 <% if @selected_references.count >= ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
 You’ve selected 2 references to submit with your application already, but you can change your selection if you want.

--- a/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
+++ b/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
@@ -1,7 +1,5 @@
 Dear <%= @application_form.first_name %>
 
-# <%= 'Application'.pluralize(@withdrawn_course_names.size) %> withdrawn
-
 You’ve withdrawn your <%= 'application'.pluralize(@withdrawn_course_names.size) %> for <%= @withdrawn_course_names.to_sentence %>.
 
 <%= render 'still_interested_in_teaching' %>

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     it_behaves_like(
       'a mail with subject and content',
       I18n.t('authentication.sign_up.email.subject'),
-      'heading' => I18n.t('authentication.sign_up.email.subject'),
+      'body' => 'Confirm your email address to apply for teacher training',
       'magic_link' => 'http://localhost:3000/candidate/sign-in/confirm?token=blub',
     )
 

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     it_behaves_like(
       'a mail with subject and content',
       I18n.t('authentication.sign_up.email.subject'),
-      'heading' => I18n.t('authentication.sign_up.email.subject'),
       'magic_link' => 'http://localhost:3000/candidate/sign-in/confirm?token=blub',
     )
 

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     it_behaves_like(
       'a mail with subject and content',
       I18n.t('authentication.sign_up.email.subject'),
+      'heading' => I18n.t('authentication.sign_up.email.subject'),
       'magic_link' => 'http://localhost:3000/candidate/sign-in/confirm?token=blub',
     )
 

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -384,6 +384,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       'a mail with subject and content',
       'You have not met your conditions for Forensic Science (E0FO) at Falconholt Technical College: next steps',
       'heading' => 'Dear Bob',
+
       'name and code for course' => 'Forensic Science (E0FO)',
       'provider name' => 'Falconholt Technical College',
     )

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -384,7 +384,6 @@ RSpec.describe CandidateMailer, type: :mailer do
       'a mail with subject and content',
       'You have not met your conditions for Forensic Science (E0FO) at Falconholt Technical College: next steps',
       'heading' => 'Dear Bob',
-      'title' => 'You have not met your conditions',
       'name and code for course' => 'Forensic Science (E0FO)',
       'provider name' => 'Falconholt Technical College',
     )
@@ -399,7 +398,6 @@ RSpec.describe CandidateMailer, type: :mailer do
       'a mail with subject and content',
       'You have met your conditions for Forensic Science (E0FO) at Falconholt Technical College: next steps',
       'heading' => 'Dear Bob',
-      'title' => 'You’ve met your conditions',
       'name and code for course' => 'Forensic Science (E0FO)',
       'provider name' => 'Falconholt Technical College',
     )

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       'a mail with subject and content',
       'You have not met your conditions for Forensic Science (E0FO) at Falconholt Technical College: next steps',
       'heading' => 'Dear Bob',
-
+      'title' => 'you have not met your conditions',
       'name and code for course' => 'Forensic Science (E0FO)',
       'provider name' => 'Falconholt Technical College',
     )
@@ -399,6 +399,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       'a mail with subject and content',
       'You have met your conditions for Forensic Science (E0FO) at Falconholt Technical College: next steps',
       'heading' => 'Dear Bob',
+      'title' => 'you’ve met your conditions',
       'name and code for course' => 'Forensic Science (E0FO)',
       'provider name' => 'Falconholt Technical College',
     )

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a mail with subject and content',
         I18n.t!('candidate_mailer.new_referee_request.email_bounced.subject', referee_name: 'Scott Knowles'),
-        'heading' => 'Referee request did not reach Scott Knowles',
+        'Your referee request did not reach Scott Knowles.',
       )
     end
   end

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a mail with subject and content',
         I18n.t!('candidate_mailer.new_referee_request.refused.subject', referee_name: 'Scott Knowles'),
-        'heading' => 'Scott Knowles has declined your reference request',
+        'Scott Knowles has declined your reference request',
       )
     end
 

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a mail with subject and content',
         I18n.t!('candidate_mailer.new_referee_request.refused.subject', referee_name: 'Scott Knowles'),
-        'Scott Knowles has declined your reference request',
+        body: 'Scott Knowles has declined your reference request',
       )
     end
 
@@ -46,7 +46,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a mail with subject and content',
         I18n.t!('candidate_mailer.new_referee_request.email_bounced.subject', referee_name: 'Scott Knowles'),
-        'Your referee request did not reach Scott Knowles.',
+        body: 'Your referee request did not reach Scott Knowles',
       )
     end
   end


### PR DESCRIPTION
Our email headings often repeat the subject line and first line of the email, so they're potentially unnecessary. 