### PR TITLE
Validate completeness of contact and personal details before application submission

### DIFF
--- a/app/components/candidate_interface/contact_details_review_component.html.erb
+++ b/app/components/candidate_interface/contact_details_review_component.html.erb
@@ -1,8 +1,19 @@
 <% if show_missing_banner? %>
-  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :contact_details, section_path: candidate_interface_edit_phone_number_path, error: @missing_error)) %>
+  <%= render(
+    CandidateInterface::IncompleteSectionComponent.new(
+      section: :contact_details,
+      section_path: candidate_interface_edit_phone_number_path,
+      error: @missing_error,
+    ),
+  ) %>
 <% else %>
   <% if show_invalid_banner? %>
-    <%= render(CandidateInterface::InvalidSectionComponent.new(section: :contact_details, section_path: candidate_interface_edit_phone_number_path)) %>
+    <%= render(
+      CandidateInterface::InvalidSectionComponent.new(
+        section: :contact_details,
+        section_path: candidate_interface_contact_information_review_path,
+      ),
+    ) %>
   <% end %>
   <%= render(SummaryCardComponent.new(rows: contact_details_form_rows, editable: @editable)) %>
 <% end %>

--- a/app/components/candidate_interface/contact_details_review_component.html.erb
+++ b/app/components/candidate_interface/contact_details_review_component.html.erb
@@ -1,5 +1,8 @@
 <% if show_missing_banner? %>
   <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :contact_details, section_path: candidate_interface_edit_phone_number_path, error: @missing_error)) %>
 <% else %>
+  <% if show_invalid_banner? %>
+    <%= render(CandidateInterface::InvalidSectionComponent.new(section: :contact_details, section_path: candidate_interface_edit_phone_number_path)) %>
+  <% end %>
   <%= render(SummaryCardComponent.new(rows: contact_details_form_rows, editable: @editable)) %>
 <% end %>

--- a/app/components/candidate_interface/contact_details_review_component.rb
+++ b/app/components/candidate_interface/contact_details_review_component.rb
@@ -19,6 +19,12 @@ module CandidateInterface
       !@application_form.contact_details_completed && @editable if @submitting_application
     end
 
+    def show_invalid_banner?
+      @editable &&
+        @submitting_application &&
+        !ContactDetailsForm.build_from_application(@application_form).valid_for_submission?
+    end
+
   private
 
     attr_reader :application_form

--- a/app/components/candidate_interface/invalid_section_component.html.erb
+++ b/app/components/candidate_interface/invalid_section_component.html.erb
@@ -1,0 +1,4 @@
+<%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--#{@error ? 'error' : 'important'}", html_attributes: { id: "invalid-#{section}-error" }) do %>
+  <p class="app-inset-text__title"><%= message %></p>
+  <p class="govuk-body"><%= govuk_link_to link_text, @section_path, no_visited_state: true, 'data-qa': "invalid-#{section}" %></p>
+<% end %>

--- a/app/components/candidate_interface/invalid_section_component.rb
+++ b/app/components/candidate_interface/invalid_section_component.rb
@@ -1,0 +1,27 @@
+module CandidateInterface
+  class InvalidSectionComponent < ViewComponent::Base
+    include ViewHelper
+
+    def initialize(
+      section:,
+      section_path:,
+      text: t("review_application.#{section}.invalid"),
+      link_text: t("review_application.#{section}.complete_section"),
+      error: false,
+      review_needed: false
+    )
+      @section = section
+      @section_path = section_path
+      @text = text
+      @error = error
+      @link_text = link_text
+      @review_needed = review_needed
+    end
+
+    attr_reader :section, :section_path, :text, :link_text
+
+    def message
+      text
+    end
+  end
+end

--- a/app/components/candidate_interface/personal_details_review_component.html.erb
+++ b/app/components/candidate_interface/personal_details_review_component.html.erb
@@ -1,8 +1,19 @@
 <% if show_missing_banner? %>
-  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :personal_details, section_path: candidate_interface_edit_name_and_dob_path, error: @missing_error)) %>
+  <%= render(
+    CandidateInterface::IncompleteSectionComponent.new(
+      section: :personal_details,
+      section_path: candidate_interface_edit_name_and_dob_path,
+      error: @missing_error,
+    ),
+  ) %>
 <% else %>
   <% if show_invalid_banner? %>
-    <%= render(CandidateInterface::InvalidSectionComponent.new(section: :personal_details, section_path: candidate_interface_edit_name_and_dob_path)) %>
+    <%= render(
+      CandidateInterface::InvalidSectionComponent.new(
+        section: :personal_details,
+        section_path: candidate_interface_personal_details_show_path,
+      ),
+    ) %>
   <% end %>
   <%= render(SummaryCardComponent.new(rows: rows, editable: @editable)) %>
 <% end %>

--- a/app/components/candidate_interface/personal_details_review_component.html.erb
+++ b/app/components/candidate_interface/personal_details_review_component.html.erb
@@ -1,5 +1,8 @@
 <% if show_missing_banner? %>
   <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :personal_details, section_path: candidate_interface_edit_name_and_dob_path, error: @missing_error)) %>
 <% else %>
+  <% if show_invalid_banner? %>
+    <%= render(CandidateInterface::InvalidSectionComponent.new(section: :personal_details, section_path: candidate_interface_edit_name_and_dob_path)) %>
+  <% end %>
   <%= render(SummaryCardComponent.new(rows: rows, editable: @editable)) %>
 <% end %>

--- a/app/components/candidate_interface/personal_details_review_component.rb
+++ b/app/components/candidate_interface/personal_details_review_component.rb
@@ -34,6 +34,11 @@ module CandidateInterface
       @editable && !@application_form.personal_details_completed
     end
 
+    def show_invalid_banner?
+      @editable &&
+        !PersonalDetailsForm.build_from_application(@application_form).valid_for_submission?
+    end
+
   private
 
     attr_reader :application_form

--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -24,7 +24,6 @@ module CandidateInterface
         @incomplete_sections = @application_form_presenter.incomplete_sections
         @application_choice_errors = @application_form_presenter.application_choice_errors
         @reference_section_errors = @application_form_presenter.reference_section_errors
-        @contact_details_section_errors = @application_form_presenter.contact_details_section_errors
 
         render 'candidate_interface/unsubmitted_application_form/review' and return
       end

--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -24,6 +24,7 @@ module CandidateInterface
         @incomplete_sections = @application_form_presenter.incomplete_sections
         @application_choice_errors = @application_form_presenter.application_choice_errors
         @reference_section_errors = @application_form_presenter.reference_section_errors
+        @contact_details_section_errors = @application_form_presenter.contact_details_section_errors
 
         render 'candidate_interface/unsubmitted_application_form/review' and return
       end

--- a/app/forms/candidate_interface/contact_details_form.rb
+++ b/app/forms/candidate_interface/contact_details_form.rb
@@ -95,7 +95,7 @@ module CandidateInterface
     end
 
     def all_errors
-      validate([:base, :address, :address_type])
+      validate(%i[base address address_type])
       errors
     end
 

--- a/app/forms/candidate_interface/contact_details_form.rb
+++ b/app/forms/candidate_interface/contact_details_form.rb
@@ -93,5 +93,14 @@ module CandidateInterface
 
       errors.add(:address_line1, :international_blank)
     end
+
+    def all_errors
+      validate([:base, :address, :address_type])
+      errors
+    end
+
+    def valid_for_submission?
+      all_errors.blank?
+    end
   end
 end

--- a/app/forms/candidate_interface/personal_details_form.rb
+++ b/app/forms/candidate_interface/personal_details_form.rb
@@ -40,5 +40,14 @@ module CandidateInterface
         Struct.new(:day, :month, :year).new(day, month, year)
       end
     end
+
+    def all_errors
+      validate
+      errors
+    end
+
+    def valid_for_submission?
+      all_errors.blank?
+    end
   end
 end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -131,7 +131,10 @@ module CandidateInterface
       [].tap do |errors|
         # A defensive check, in case the candidate somehow ends up in this state
         if application_form.references_completed? && application_form.selected_incorrect_number_of_references?
-          errors << ErrorMessage.new(I18n.t('application_form.references.review.incorrect_number_selected'), '#references')
+          errors << ErrorMessage.new(
+            I18n.t('application_form.references.review.incorrect_number_selected'),
+            '#references',
+          )
         end
       end
     end
@@ -139,7 +142,8 @@ module CandidateInterface
     def ready_to_submit?
       sections_with_completion.map(&:second).all? &&
         application_choice_errors.empty? &&
-        reference_section_errors.empty?
+        reference_section_errors.empty? &&
+        contact_details_section_errors.empty?
     end
 
     def application_choices_added?
@@ -152,9 +156,14 @@ module CandidateInterface
       application_form.contact_details_completed
     end
 
-    def contact_details_valid?
+    def contact_details_section_errors
       form = ContactDetailsForm.build_from_application(application_form)
-      form.valid?(:base) && form.valid?(:address) && form.valid?(:address_type)
+      form.validate([:base, :address, :address_type])
+      form.errors
+    end
+
+    def contact_details_valid?
+      contact_details_section_errors.empty?
     end
 
     def work_experience_completed?

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -4,9 +4,9 @@
 
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.personal_details') %></h2>
-  <h3 class="govuk-heading-m"><%= t('page_titles.personal_information') %></h3>
+  <h3 class="govuk-heading-m" id="personal_details"><%= t('page_titles.personal_information') %></h3>
   <%= render(CandidateInterface::PersonalDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, return_to_application_review: true)) %>
-  <h3 class="govuk-heading-m"><%= t('page_titles.contact_information') %></h3>
+  <h3 class="govuk-heading-m" id="contact_details"><%= t('page_titles.contact_information') %></h3>
   <%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true, return_to_application_review: true)) %>
 </section>
 

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -27,9 +27,7 @@
           <li><%= link_to error.message, error.anchor %></li>
         <% end %>
 
-        <% @contact_details_section_errors.each do |error| %>
-          <li><%= link_to error.message, error.anchor %></li>
-        <% end %>
+        TODO: add additional validations here...
       </ul>
     </div>
   </div>

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -4,7 +4,7 @@
 <%= render(CandidateInterface::DeadlineBannerComponent.new(application_form: @application_form, flash_empty: flash.empty?)) %>
 <%= render(CandidateInterface::ReopenBannerComponent.new(phase: @application_form.phase, flash_empty: flash.empty?)) %>
 
-<% if @incomplete_sections.present? || @application_choice_errors.present? || @reference_section_errors.present? %>
+<% if @incomplete_sections.present? || @application_choice_errors.present? || @reference_section_errors || @contact_details_section_errors.present? %>
   <div class="govuk-error-summary" role="alert" data-module="govuk-error-summary" aria-labelledby="error-summary-title">
     <h2 id="error-summary-title" class="govuk-error-summary__title">
       There is a problem
@@ -24,6 +24,10 @@
         <% end %>
 
         <% @reference_section_errors.each do |error| %>
+          <li><%= link_to error.message, error.anchor %></li>
+        <% end %>
+
+        <% @contact_details_section_errors.each do |error| %>
           <li><%= link_to error.message, error.anchor %></li>
         <% end %>
       </ul>

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -4,7 +4,7 @@
 <%= render(CandidateInterface::DeadlineBannerComponent.new(application_form: @application_form, flash_empty: flash.empty?)) %>
 <%= render(CandidateInterface::ReopenBannerComponent.new(phase: @application_form.phase, flash_empty: flash.empty?)) %>
 
-<% if @incomplete_sections.present? || @application_choice_errors.present? || @reference_section_errors || @contact_details_section_errors.present? %>
+<% if @incomplete_sections.present? || @application_choice_errors.present? || @reference_section_errors %>
   <div class="govuk-error-summary" role="alert" data-module="govuk-error-summary" aria-labelledby="error-summary-title">
     <h2 id="error-summary-title" class="govuk-error-summary__title">
       There is a problem

--- a/config/locales/candidate_interface/review_application.yml
+++ b/config/locales/candidate_interface/review_application.yml
@@ -7,11 +7,13 @@ en:
       complete_section: Complete your course choices
     personal_details:
       incomplete: Personal details not marked as complete
+      invalid: Personal details not complete
       not_marked_complete: Personal details not marked as completed
       complete_section: Complete your personal details
       mark_as_complete: Mark as complete
     contact_details:
       incomplete: Contact details not marked as complete
+      invalid: Contact details not complete
       complete_section: Complete your contact details
     training_with_a_disability:
       incomplete: Any disability or other needs not marked as complete
@@ -27,6 +29,7 @@ en:
       complete_section: Do you have any experience working with children and young people?
     degrees:
       incomplete: Degree section not marked as complete
+      invalid: Degree not complete
       complete_section: Complete degrees section
     maths_gcse:
       incomplete: Maths GCSE or equivalent not marked as complete

--- a/spec/components/candidate_interface/invalid_section_component_spec.rb
+++ b/spec/components/candidate_interface/invalid_section_component_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::InvalidSectionComponent do
+  it 'renders a section invalid banner component' do
+    result = render_inline(described_class.new(section: 'degrees', section_path: '#'))
+    expect(result.css('.app-inset-text__title').text).to include('Degree not complete')
+    expect(result.css('.app-inset-text--important .govuk-link')).to be_present
+    expect(result.css('.app-inset-text--important .govuk-link').text).to include('Complete degrees section')
+  end
+
+  it 'renders custom link text if given' do
+    result = render_inline(described_class.new(section: 'degrees', section_path: '#', link_text: 'Click here to win'))
+    expect(result.css('.app-inset-text__title').text).to include('Degree not complete')
+    expect(result.css('.app-inset-text--important .govuk-link')).to be_present
+    expect(result.css('.app-inset-text--important .govuk-link').text).to include('Click here to win')
+  end
+end

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -55,6 +55,22 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
   end
 
+  describe '#personal_details_valid?' do
+    it 'returns true if personal details section is completed' do
+      application_form = build(:completed_application_form)
+      presenter = described_class.new(application_form)
+
+      expect(presenter).to be_personal_details_valid
+    end
+
+    it 'returns false if personal details section is invalid' do
+      application_form = build(:completed_application_form, first_name: '')
+      presenter = described_class.new(application_form)
+
+      expect(presenter).not_to be_personal_details_valid
+    end
+  end
+
   describe '#contact_details_valid?' do
     it 'returns true if contact details section is completed' do
       application_form = build(:completed_application_form, contact_details_completed: true)

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -56,34 +56,42 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   end
 
   describe '#personal_details_valid?' do
-    it 'returns true if personal details section is completed' do
-      application_form = build(:completed_application_form)
-      presenter = described_class.new(application_form)
+    subject(:presenter) { described_class.new(application_form) }
 
-      expect(presenter).to be_personal_details_valid
+    context 'when personal details are valid' do
+      let(:application_form) { build(:completed_application_form) }
+
+      it 'returns true' do
+        expect(presenter).to be_personal_details_valid
+      end
     end
 
-    it 'returns false if personal details section is invalid' do
-      application_form = build(:completed_application_form, first_name: '')
-      presenter = described_class.new(application_form)
+    context 'when personal details are invalid' do
+      let(:application_form) { build(:completed_application_form, first_name: '') }
 
-      expect(presenter).not_to be_personal_details_valid
+      it 'returns false' do
+        expect(presenter).not_to be_personal_details_valid
+      end
     end
   end
 
   describe '#contact_details_valid?' do
-    it 'returns true if contact details section is completed' do
-      application_form = build(:completed_application_form, contact_details_completed: true)
-      presenter = described_class.new(application_form)
+    subject(:presenter) { described_class.new(application_form) }
 
-      expect(presenter).to be_contact_details_valid
+    context 'when contact details are valid' do
+      let(:application_form) { build(:completed_application_form, contact_details_completed: true) }
+
+      it 'returns true' do
+        expect(presenter).to be_contact_details_valid
+      end
     end
 
-    it 'returns false if contact details section is invalid' do
-      application_form = build(:completed_application_form, phone_number: '')
-      presenter = described_class.new(application_form)
+    context 'when contact details are invalid' do
+      let(:application_form) { build(:completed_application_form, phone_number: '') }
 
-      expect(presenter).not_to be_contact_details_valid
+      it 'returns false' do
+        expect(presenter).not_to be_contact_details_valid
+      end
     end
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_a_missing_address_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_a_missing_address_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate attempts to submit their application without a valid address' do
+  include CandidateHelper
+
+  scenario 'The candidate has completed their contact details without entering an address' do
+    given_i_complete_my_application
+    and_my_address_details_are_blank
+    when_i_submit_my_application
+    then_i_cannot_proceed
+    when_i_complete_my_contact_details
+    then_i_can_proceed
+  end
+
+  def given_i_complete_my_application
+    candidate_completes_application_form
+  end
+
+  def and_my_address_details_are_blank
+    current_candidate.current_application.update(
+      address_line1: nil,
+      address_line2: nil,
+      address_line3: nil,
+      address_line4: nil,
+      postcode: nil,
+    )
+  end
+
+  def when_i_submit_my_application
+    click_link 'Check and submit your application'
+    click_link t('continue')
+  end
+
+  def then_i_cannot_proceed
+    expect(page).to have_content('There is a problem')
+    expect(page).to have_content('Contact details not complete')
+  end
+
+  def when_i_complete_my_contact_details
+    click_link 'Complete your contact details'
+    click_link 'Change address'
+
+    choose 'In the UK'
+    click_button t('save_and_continue')
+    find(:css, "[autocomplete='address-line1']").fill_in with: '42 Much Wow Street'
+    fill_in t('application_form.contact_details.address_line3.label.uk'), with: 'London'
+    fill_in t('application_form.contact_details.postcode.label.uk'), with: 'SW1P 3BT'
+    click_button t('save_and_continue')
+
+    choose t('application_form.completed_radio')
+    click_button t('continue')
+  end
+
+  def then_i_can_proceed
+    click_link 'Check and submit your application'
+    click_link t('continue')
+
+    expect(page).to have_content('Equality and diversity questions')
+  end
+end


### PR DESCRIPTION
## Context

It's currently possible for candidates to submit an application with missing address details (though not as part of the normal application flow). The PR attempts to plug that loophole by enforcing existing validation rules at submission time.

Because we enforce these validation rules in the normal flow we don't expect the additional enforcement logic introduced by this PR to be activated very often.

## Changes proposed in this pull request

- [x] Run the validation rules for `ContactDetailsForm` and `PersonalDetailsForm` when rendering the application review form.
- [x] If any validation errors are triggered the user is notified on the application review form and they are prevented from continuing with form submission.

<img width="1031" alt="image" src="https://user-images.githubusercontent.com/450843/155040317-fa66b716-357f-437e-810f-acf7fb71b30a.png">

- [x] Update system specs that deal with form submission to cover validation errors in contact details.

## Guidance to review

- Should we mark sections with validation errors as incomplete? If we did this we may not even need a separate mechanism to report validation errors because we already enforce rules to ensure that a form cannot be submitted if it contains any incomplete sections.
- I've not tried to enumerate the validation errors on the review form, there is a just a message to say that the section is incomplete and link to drill down to see why exactly. Should we be aiming to give full details of validation errors on the review page?

## Link to Trello card

https://trello.com/c/A46QrWfq/4192-validate-completeness-of-personal-details-in-application-review-pre-submit

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
