### PR TITLE
Add candidate join to export data HESA export

### DIFF
--- a/app/services/provider_interface/hesa_data_export.rb
+++ b/app/services/provider_interface/hesa_data_export.rb
@@ -49,6 +49,7 @@ module ProviderInterface
     def export_data
       GetApplicationChoicesForProviders.call(providers: actor.providers, recruitment_cycle_year: recruitment_cycle_year)
         .where('candidates.hide_in_reporting' => false, 'status' => ApplicationStateChange::ACCEPTED_STATES)
+        .joins(application_form: :candidate)
         .find_each(batch_size: BATCH_SIZE)
     end
 


### PR DESCRIPTION
## Context
When a provider is attempting to download a HESA export from reports, they are seeing a timeout error even for data sets of 300 records only.

Sentry error https://sentry.io/organizations/dfe-teacher-services/issues/3017767267/?project=1765973&referrer=slack

We currently stream data from a query which builds on top of `GetApplicationChoicesForProviders`. However reaching into the candidate's table to check `hide_in_reporting` is causing the query to take too long

## Changes proposed in this pull request

Make sure to join on the candidate table through application form to ensure a snappy query.

## Guidance to review

I've tried this in the console in prod for the offending query and it's now snappy.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
