### PR TITLE
Use #update for reference selection so we run callbacks

### DIFF
--- a/app/forms/candidate_interface/reference/selection_form.rb
+++ b/app/forms/candidate_interface/reference/selection_form.rb
@@ -9,14 +9,14 @@ module CandidateInterface
     validate :correct_number_chosen?
 
     def available_references
-      application_form.application_references.feedback_provided
+      application_form.application_references.includes([:application_form]).feedback_provided
     end
 
     def save!
       return false unless valid?
 
-      available_references.where.not(id: selected).update_all(selected: false)
-      available_references.where(id: selected).update_all(selected: true)
+      available_references.where.not(id: selected).update(selected: false)
+      available_references.where(id: selected).update(selected: true)
       application_form.update!(references_completed: true)
     end
 


### PR DESCRIPTION
This information wasn't going to BigQuery or touching `updated_at` because we used `update_all`.

Had to add an `includes` to keep Bullet happy — I think because there's a transitive touch on `ApplicationForm`.