### PR TITLE
SR4R reasons configuration

### DIFF
--- a/app/models/rejection_reasons.rb
+++ b/app/models/rejection_reasons.rb
@@ -1,0 +1,15 @@
+class RejectionReasons
+  CONFIG_PATH = 'config/rejection_reasons.yml'.freeze
+
+  attr_reader :reasons
+
+  def initialize(config: configuration)
+    @reasons = config[:reasons].map { |hash| Reason.new(hash) }
+  end
+
+private
+
+  def configuration
+    @configuration ||= YAML.load_file(CONFIG_PATH)
+  end
+end

--- a/app/models/rejection_reasons/details.rb
+++ b/app/models/rejection_reasons/details.rb
@@ -1,0 +1,7 @@
+class RejectionReasons
+  class Details
+    include ActiveModel::Model
+
+    attr_accessor :id, :label, :text
+  end
+end

--- a/app/models/rejection_reasons/reason.rb
+++ b/app/models/rejection_reasons/reason.rb
@@ -1,0 +1,13 @@
+class RejectionReasons
+  class Reason
+    include ActiveModel::Model
+
+    attr_accessor :id, :details, :label, :reasons
+
+    def initialize(attrs)
+      super(attrs)
+      @details = Details.new(attrs[:details]) if attrs.key?(:details)
+      @reasons = attrs[:reasons].map { |hash| self.class.new(hash) } if attrs.key?(:reasons)
+    end
+  end
+end

--- a/config/rejection_reasons.yml
+++ b/config/rejection_reasons.yml
@@ -1,0 +1,119 @@
+---
+:reasons:
+- :id: qualifications
+  :label: Qualifications
+  :reasons:
+  - :id: no_maths_gcse
+    :label: No maths GCSE at minimum grade 4 or C, or equivalent
+  - :id: no_english_gcse
+    :label: No English GCSE at minimum grade 4 or C, or equivalent
+  - :id: no_science_gcse
+    :label: No science GCSE at minimum grade 4 or C, or equivalent
+  - :id: no_degree
+    :label: No bachelor’s or equivalent
+  - :id: unsuitable_degree
+    :label: No bachelor’s degree or equivalent
+    :details:
+      :id: unsuitable_degree_details
+      :label: Details
+  - :id: unverified_qualifications
+    :label: Could not verify qualifications
+    :details:
+      :id: unverified_qualifications_details
+      :label: Details
+  - :id: qualifications_other
+    :label: Other
+    :details:
+      :id: qualifications_other_details
+      :label: Details
+- :id: personal_statement
+  :label: Personal statement
+  :reasons:
+  - :id: quality_of_writing
+    :label: Quality of writing
+    :details:
+      :id: quality_of_writing_details
+      :label: Details
+  - :id: personal_statement_other
+    :label: Other
+    :details:
+      :id: personal_statement_other_details
+      :label: Details
+- :id: teaching_knowledge
+  :label: Teaching knowledge and ability
+  :reasons:
+  - :id: subject_knowledge
+    :label: Subject knowledge
+    :details:
+      :id: subject_knowledge_details
+      :label: Details
+  - :id: safeguarding_knowledge
+    :label: Safeguarding knowledge
+    :details:
+      :id: safeguarding_details
+      :label: Details
+  - :id: teaching_method_knowledge
+    :label: Teaching method knowledge
+    :details:
+      :id: teaching_method_knowledge_details
+      :label: Details
+  - :id: teaching_role_knowledge
+    :label: Teaching role knowledge
+    :details:
+      :id: teaching_role_knowledge_details
+      :label: Details
+  - :id: teaching_demonstration_knowledge
+    :label: Teaching demonstration knowledge
+    :details:
+      :id: teaching_demonstration_knowledge_details
+      :label: Details
+  - :id: teaching_knowledge_other
+    :label: Other
+    :details:
+      :id: teaching_knowledge_other_details
+      :label: Details
+- :id: communication_and_scheduling
+  :label: Communication, attendance and scheduling
+  :reasons:
+  - :id: did_not_reply
+    :label: Did not reply to messages
+    :details:
+      :id: did_not_reply_details
+      :label: Details
+  - :id: did_not_attend_interview
+    :label: Did not attend interview
+    :details:
+      :id: did_not_attend_interview_details
+      :label: Details
+  - :id: could_not_arrange_interview
+    :label: Could not arrange interview
+    :details:
+      :id: could_not_arrange_interview_details
+      :label: Details
+  - :id: communication_and_scheduling_other
+    :label: Other
+    :details:
+      :id: communication_and_scheduling_other_details
+      :label: Details
+- :id: references
+  :label: References
+  :details:
+    :id: references_details
+    :label: Details
+- :id: safeguarding
+  :label: Safeguarding
+  :details:
+    :id: safeguarding_details
+    :label: Details
+- :id: visa_sponsorship
+  :label: Visa sponsorship
+  :details:
+    :id: visa_sponsorship_details
+    :label: Details
+- :id: course_full
+  :label: Course full
+- :id: other
+  :label: Other
+  :details:
+    :id: other_details
+    :label: Details

--- a/spec/models/rejection_reasons_spec.rb
+++ b/spec/models/rejection_reasons_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe RejectionReasons do
+  subject(:instance) { described_class.new }
+
+  describe 'initialize' do
+    it 'builds top level rejection reasons' do
+      expect(instance.reasons).to be_a(Array)
+      expect(instance.reasons.first).to be_a(RejectionReasons::Reason)
+      expect(instance.reasons.map(&:id)).to eq(%w[
+        qualifications personal_statement teaching_knowledge communication_and_scheduling
+        references safeguarding visa_sponsorship course_full other
+      ])
+    end
+
+    it 'builds nested reasons' do
+      qualifications = instance.reasons.first
+
+      expect(qualifications.reasons).to be_a(Array)
+      expect(qualifications.reasons.first).to be_a(RejectionReasons::Reason)
+      expect(qualifications.reasons.map(&:id)).to eq(%w[
+        no_maths_gcse no_english_gcse no_science_gcse no_degree unsuitable_degree
+        unverified_qualifications qualifications_other
+      ])
+    end
+
+    it 'builds details for reasons' do
+      qualifications = instance.reasons.first
+      qualifications_other = qualifications.reasons.last
+
+      expect(qualifications_other).to be_a(RejectionReasons::Reason)
+      expect(qualifications_other.details).to be_a(RejectionReasons::Details)
+
+      other = instance.reasons.last
+
+      expect(other).to be_a(RejectionReasons::Reason)
+      expect(other.details).to be_a(RejectionReasons::Details)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Structured reasons for rejection has been redesigned and has a more consistent form structure.
We'd like to drive the wizard, presenter(s), components and views from a configuration which expresses the structure of the reasons to reduce the repetition of attributes across the various pieces of code.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds a basic configuration of nested `Reason` and `Details` objects
- Adds a `RejectionReasons` class to inflate the objects from configuration

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

The config will likely change as we build the wizard and views for SR4R.
Things like i18n keys and unique ids may be desirable/necessary as we build this feature. 

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/6a2M2Xfb/4833-sr4r-redesign-add-dynamic-reasons-configuration-wizard
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
