### PR TITLE
Persist 'You can apply for up to 3 courses' text

### DIFF
--- a/app/components/candidate_interface/application_form_course_choices_component.html.erb
+++ b/app/components/candidate_interface/application_form_course_choices_component.html.erb
@@ -1,7 +1,7 @@
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.courses') %></h2>
 
-  <% unless number_of_choices == 3 %>
+  <% unless maximum_number_of_choices? %>
     <p class="govuk-body"><%= t('application_form.courses.intro') %></p>
   <% end %>
 

--- a/app/components/candidate_interface/application_form_course_choices_component.html.erb
+++ b/app/components/candidate_interface/application_form_course_choices_component.html.erb
@@ -1,7 +1,7 @@
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.courses') %></h2>
 
-  <% unless choices_are_present? %>
+  <% unless number_of_choices == 3 %>
     <p class="govuk-body"><%= t('application_form.courses.intro') %></p>
   <% end %>
 

--- a/app/components/candidate_interface/application_form_course_choices_component.rb
+++ b/app/components/candidate_interface/application_form_course_choices_component.rb
@@ -1,14 +1,12 @@
 module CandidateInterface
   class ApplicationFormCourseChoicesComponent < ViewComponent::Base
-    def initialize(choices_are_present:, completed:, number_of_choices:)
-      @choices_are_present = choices_are_present
+    def initialize(completed:, number_of_choices:)
       @completed = completed
       @number_of_choices = number_of_choices
     end
 
-    attr_reader :choices_are_present, :completed, :number_of_choices
+    attr_reader :completed, :number_of_choices
     alias completed? completed
-    alias choices_are_present? choices_are_present
 
     def view_courses_path
       if completed? || choices_are_present?
@@ -16,6 +14,14 @@ module CandidateInterface
       else
         candidate_interface_course_choices_choose_path
       end
+    end
+
+    def maximum_number_of_choices?
+      number_of_choices == ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES
+    end
+
+    def choices_are_present?
+      number_of_choices.positive?
     end
   end
 end

--- a/app/components/candidate_interface/application_form_course_choices_component.rb
+++ b/app/components/candidate_interface/application_form_course_choices_component.rb
@@ -1,11 +1,12 @@
 module CandidateInterface
   class ApplicationFormCourseChoicesComponent < ViewComponent::Base
-    def initialize(choices_are_present:, completed:)
+    def initialize(choices_are_present:, completed:, number_of_choices:)
       @choices_are_present = choices_are_present
       @completed = completed
+      @number_of_choices = number_of_choices
     end
 
-    attr_reader :choices_are_present, :completed
+    attr_reader :choices_are_present, :completed, :number_of_choices
     alias completed? completed
     alias choices_are_present? choices_are_present
 

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -51,7 +51,6 @@
 
       <% if FeatureFlag.active?(:apply_again_with_three_choices) %>
         <%= render(CandidateInterface::ApplicationFormCourseChoicesComponent.new(
-              choices_are_present: @application_form_presenter.application_choices_added?,
               number_of_choices: @application_form_presenter.application_form.application_choices.count,
               completed: @application_form_presenter.course_choices_completed?,
             )) %>
@@ -63,7 +62,6 @@
               )) %>
         <% else %>
           <%= render(CandidateInterface::ApplicationFormCourseChoicesComponent.new(
-                choices_are_present: @application_form_presenter.application_choices_added?,
                 completed: @application_form_presenter.course_choices_completed?,
                 number_of_choices: @application_form_presenter.application_form.application_choices.count,
               )) %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -52,6 +52,7 @@
       <% if FeatureFlag.active?(:apply_again_with_three_choices) %>
         <%= render(CandidateInterface::ApplicationFormCourseChoicesComponent.new(
               choices_are_present: @application_form_presenter.application_choices_added?,
+              number_of_choices: @application_form_presenter.application_form.application_choices.count,
               completed: @application_form_presenter.course_choices_completed?,
             )) %>
       <% else %>
@@ -64,6 +65,7 @@
           <%= render(CandidateInterface::ApplicationFormCourseChoicesComponent.new(
                 choices_are_present: @application_form_presenter.application_choices_added?,
                 completed: @application_form_presenter.course_choices_completed?,
+                number_of_choices: @application_form_presenter.application_form.application_choices.count,
               )) %>
         <% end %>
       <% end %>

--- a/spec/components/candidate_interface/application_form_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_form_course_choices_component_spec.rb
@@ -4,12 +4,13 @@ RSpec.describe CandidateInterface::ApplicationFormCourseChoicesComponent do
   context 'completed: true' do
     let(:completed) { true }
 
-    context 'choices present' do
+    context 'one choice present' do
       let(:result) do
         render_inline(
           described_class.new(
             choices_are_present: true,
             completed: completed,
+            number_of_choices: 1,
           ),
         )
       end
@@ -19,7 +20,7 @@ RSpec.describe CandidateInterface::ApplicationFormCourseChoicesComponent do
         expect(link_text(result)).to eq 'Choose your courses'
         expect(href(result)).to eq '/candidate/application/courses/review'
         expect(status_text(result)).to eq 'Completed'
-        expect(first_paragraph(result)).not_to be_present
+        expect(first_paragraph(result).text).to eq 'You can apply for up to 3 courses.'
       end
     end
 
@@ -29,6 +30,7 @@ RSpec.describe CandidateInterface::ApplicationFormCourseChoicesComponent do
           described_class.new(
             choices_are_present: true,
             completed: completed,
+            number_of_choices: 0,
           ),
         )
       end
@@ -36,6 +38,10 @@ RSpec.describe CandidateInterface::ApplicationFormCourseChoicesComponent do
       it 'renders without error' do
         # should render without errors but is not an expected state
         expect { result }.not_to raise_error
+      end
+
+      it 'renders expected content' do
+        expect(first_paragraph(result).text).to eq 'You can apply for up to 3 courses.'
       end
     end
   end
@@ -48,6 +54,7 @@ RSpec.describe CandidateInterface::ApplicationFormCourseChoicesComponent do
         render_inline(
           described_class.new(
             choices_are_present: false,
+            number_of_choices: 0,
             completed: completed,
           ),
         )
@@ -62,12 +69,13 @@ RSpec.describe CandidateInterface::ApplicationFormCourseChoicesComponent do
       end
     end
 
-    context 'choices present' do
+    context 'three choices present' do
       let(:result) do
         render_inline(
           described_class.new(
             choices_are_present: true,
             completed: completed,
+            number_of_choices: 3,
           ),
         )
       end

--- a/spec/components/candidate_interface/application_form_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_form_course_choices_component_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe CandidateInterface::ApplicationFormCourseChoicesComponent do
       let(:result) do
         render_inline(
           described_class.new(
-            choices_are_present: true,
             completed: completed,
             number_of_choices: 1,
           ),
@@ -28,7 +27,6 @@ RSpec.describe CandidateInterface::ApplicationFormCourseChoicesComponent do
       let(:result) do
         render_inline(
           described_class.new(
-            choices_are_present: true,
             completed: completed,
             number_of_choices: 0,
           ),
@@ -53,7 +51,6 @@ RSpec.describe CandidateInterface::ApplicationFormCourseChoicesComponent do
       let(:result) do
         render_inline(
           described_class.new(
-            choices_are_present: false,
             number_of_choices: 0,
             completed: completed,
           ),
@@ -73,7 +70,6 @@ RSpec.describe CandidateInterface::ApplicationFormCourseChoicesComponent do
       let(:result) do
         render_inline(
           described_class.new(
-            choices_are_present: true,
             completed: completed,
             number_of_choices: 3,
           ),


### PR DESCRIPTION
## Context

In line with the apply again with three choices feature, we want to make the fact that you can apply for three courses more prominent. This PR keeps the 'hint' text after a course is selected . 

<img width="544" alt="image" src="https://user-images.githubusercontent.com/50492247/155293957-056cf2af-998e-4668-8f9c-3417599b7ad1.png">

## Changes proposed in this pull request

- Text persists as long as there is less than 3 choices
- Text also persists if the section is marked as complete
- When 3 choices are selected the text is removed

## Guidance to review

🤷🏼‍♀️ 

## Link to Trello card

https://trello.com/c/dWqEYKjO/4398-apply-again-after-production-delete-old-code-and-remove-feature-flag
