### PR TITLE
Remove docker credentials from terraform

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -28,7 +28,6 @@ resource "cloudfoundry_app" "web_app" {
   enable_ssh                 = true
   timeout                    = 180
   environment                = local.web_app_env_variables
-  docker_credentials         = var.docker_credentials
   dynamic "routes" {
     for_each = local.web_app_routes
     content {
@@ -51,7 +50,6 @@ resource "cloudfoundry_app" "clock" {
   space                = data.cloudfoundry_space.space.id
   timeout              = 180
   environment          = local.clock_app_env_variables
-  docker_credentials   = var.docker_credentials
   service_binding {
     service_instance = cloudfoundry_user_provided_service.logging.id
   }
@@ -69,7 +67,6 @@ resource "cloudfoundry_app" "worker" {
   space                = data.cloudfoundry_space.space.id
   timeout              = 180
   environment          = local.worker_app_env_variables
-  docker_credentials   = var.docker_credentials
   service_binding {
     service_instance = cloudfoundry_user_provided_service.logging.id
   }
@@ -90,7 +87,6 @@ resource "cloudfoundry_app" "worker_secondary" {
   space                = data.cloudfoundry_space.space.id
   timeout              = 180
   environment          = local.worker_app_env_variables
-  docker_credentials   = var.docker_credentials
   service_binding {
     service_instance = cloudfoundry_user_provided_service.logging.id
   }

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -12,8 +12,6 @@ variable "web_app_instances" {}
 
 variable "web_app_memory" {}
 
-variable "docker_credentials" {}
-
 variable "app_docker_image" {}
 
 variable "app_environment" {}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -37,7 +37,6 @@ module "paas" {
   cf_sso_passcode                = var.paas_sso_code
   cf_space                       = var.paas_cf_space
   prometheus_app                 = var.prometheus_app
-  docker_credentials             = local.docker_credentials
   web_app_instances              = var.paas_web_app_instances
   web_app_memory                 = var.paas_web_app_memory
   app_docker_image               = var.paas_docker_image

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -86,9 +86,4 @@ locals {
     local.app_secrets, # Values in app secrets can override anything before it
     local.app_env_values # Utilimately app_env_values can override anything in the merged map
   )
-
-  docker_credentials = {
-    username = local.infra_secrets.GHCR_USERNAME
-    password = local.infra_secrets.GHCR_PASSWORD
-  }
 }


### PR DESCRIPTION
 ## Context

Since migrating from Dockerhub to GitHub Packages Container Registry we no longer need to authenticate to pull down images.

## Changes proposed in this pull request

This change removes the unneeded docker credentials from terraform files.

## Guidance to review

- Check that review app successfully deploys using GitHub Packages Container Registry image.

## Link to Trello card

https://trello.com/c/wVT0QcJ4

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
