### PR TITLE
Change email validation to exclude accented characters

### DIFF
--- a/app/validators/valid_for_notify_validator.rb
+++ b/app/validators/valid_for_notify_validator.rb
@@ -1,7 +1,7 @@
 class ValidForNotifyValidator < ActiveModel::EachValidator
-  NUMBERS_AND_LETTERS = 'a-zA-Z0-9àèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêîôûÂÊÎÔÛãñõÃÑÕäëïöüÿÄËÏÖÜŸçÇßØøÅåÆæœ'.freeze
+  NUMBERS_AND_LETTERS = 'a-zA-Z0-9'.freeze
   CHINESE_JAPANESE_AND_KOREAN_CHARS = '\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\uFF00-\uFFEF\u4E00-\u9FAF\u2605-\u2606\u2190-\u2195\u203B'.freeze
-  ALPHANUMERIC = NUMBERS_AND_LETTERS + CHINESE_JAPANESE_AND_KOREAN_CHARS
+  ALPHANUMERIC = NUMBERS_AND_LETTERS
   EMAIL_REGEX = %r{\A[#{ALPHANUMERIC}.!\#$%&'*+/=?^_`{|}~-] # Local part
                   +@[#{ALPHANUMERIC}](?:[#{ALPHANUMERIC}-] # Domain name
                   {0,61}[#{ALPHANUMERIC}])?(?:\. # Allow periods in domain name

--- a/spec/validators/valid_for_notify_validator_spec.rb
+++ b/spec/validators/valid_for_notify_validator_spec.rb
@@ -26,9 +26,7 @@ RSpec.describe ValidForNotifyValidator do
         'email@domain.superlongtld',
         'email@domain.co.jp',
         'firstname-lastname@domain.com',
-        'info@german-financial-services.vermögensberatung',
         'info@german-financial-services.reallylongarbitrarytldthatiswaytoohugejustincase',
-        'japanese-info@例え.テスト',
       ]
     end
 
@@ -71,6 +69,9 @@ RSpec.describe ValidForNotifyValidator do
         'local-with-”-quotes@domain.com',
         'domain-starts-with-a-dot@.domain.com',
         'brackets(in)local@domain.com',
+        'infö@german-financial-services.de',
+        'info@german-financial-services.vermögensberatung',
+        'japanese-info@例え.テスト',
       ]
     end
 


### PR DESCRIPTION
## Context

Email addresses such as `böb@example.com` are not accepted by GOV.UK Notify but to date we have validated them. We have had a handful of errors in production as a result.

## Changes proposed in this pull request

This PR changes the validation rules we use for candidate and reference email addresses to exclude all accented characters.

- [x] Update regex used in `ValidForNotifyValidator`.
- [x] Update unit tests for `ValidForNotifyValidator`.
- [x] Check production DB.

There are 4 reference email addresses in the production DB that have accented characters. 1 is unsent, the other 3 have been bounced by Notify with a validation error. Details in the linked Trello card.

## Guidance to review

I think the relevant validation in Notify is https://github.com/alphagov/notify-frontend/blob/509695a0e462bef711bc73de3978aa0683f5603a/app/csv_parser.py#L6

## Link to Trello card

https://trello.com/c/BSbDAFbg/4266-its-possible-to-submit-a-reference-email-with-invalid-characters

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
