### PR TITLE
4465 abstract all of our links from apply into a single locale file

### DIFF
--- a/app/components/candidate_interface/application_dashboard_guidance_component.html.erb
+++ b/app/components/candidate_interface/application_dashboard_guidance_component.html.erb
@@ -6,17 +6,17 @@
     <p class="govuk-body">Your application has been submitted and is with the training provider.</p>
   <% end %>
 
-  <p class="govuk-body">Our <%= govuk_link_to('teacher training advisers', 'https://beta-adviser-getintoteaching.education.gov.uk/') %> can help you prepare for any interviews.</p>
+  <p class="govuk-body">Our <%= govuk_link_to('teacher training advisers', I18n.t('get_into_teaching.url_get_an_adviser_start')) %> can help you prepare for any interviews.</p>
 
 <% elsif multiple_offers_but_awaiting_decisions? %>
 
   <p class="govuk-body">2 of your training providers have made a decision on your application.</p>
-  <p class="govuk-body">Our <%= govuk_link_to('teacher training advisers', 'https://beta-adviser-getintoteaching.education.gov.uk/') %> can help you prepare for any interviews.</p>
+  <p class="govuk-body">Our <%= govuk_link_to('teacher training advisers', I18n.t('get_into_teaching.url_get_an_adviser_start')) %> can help you prepare for any interviews.</p>
 
 <% elsif single_offer_but_awaiting_decisions? %>
 
   <p class="govuk-body">One of your training providers has made a decision on your application.</p>
-  <p class="govuk-body">Our <%= govuk_link_to('teacher training advisers', 'https://beta-adviser-getintoteaching.education.gov.uk/') %> can help you prepare for any interviews.</p>
+  <p class="govuk-body">Our <%= govuk_link_to('teacher training advisers', I18n.t('get_into_teaching.url_get_an_adviser_start')) %> can help you prepare for any interviews.</p>
 
 <% elsif offer_accepted? %>
 

--- a/app/components/candidate_interface/application_dashboard_guidance_component.html.erb
+++ b/app/components/candidate_interface/application_dashboard_guidance_component.html.erb
@@ -6,17 +6,17 @@
     <p class="govuk-body">Your application has been submitted and is with the training provider.</p>
   <% end %>
 
-  <p class="govuk-body">Our <%= govuk_link_to('teacher training advisers', I18n.t('get_into_teaching.url_get_an_adviser_start')) %> can help you prepare for any interviews.</p>
+  <p class="govuk-body">Our <%= govuk_link_to('teacher training advisers', I18n.t('get_into_teaching.url_get_an_adviser')) %> can help you prepare for any interviews.</p>
 
 <% elsif multiple_offers_but_awaiting_decisions? %>
 
   <p class="govuk-body">2 of your training providers have made a decision on your application.</p>
-  <p class="govuk-body">Our <%= govuk_link_to('teacher training advisers', I18n.t('get_into_teaching.url_get_an_adviser_start')) %> can help you prepare for any interviews.</p>
+  <p class="govuk-body">Our <%= govuk_link_to('teacher training advisers', I18n.t('get_into_teaching.url_get_an_adviser')) %> can help you prepare for any interviews.</p>
 
 <% elsif single_offer_but_awaiting_decisions? %>
 
   <p class="govuk-body">One of your training providers has made a decision on your application.</p>
-  <p class="govuk-body">Our <%= govuk_link_to('teacher training advisers', I18n.t('get_into_teaching.url_get_an_adviser_start')) %> can help you prepare for any interviews.</p>
+  <p class="govuk-body">Our <%= govuk_link_to('teacher training advisers', I18n.t('get_into_teaching.url_get_an_adviser')) %> can help you prepare for any interviews.</p>
 
 <% elsif offer_accepted? %>
 

--- a/app/components/candidate_interface/apply_again_call_to_action_component.html.erb
+++ b/app/components/candidate_interface/apply_again_call_to_action_component.html.erb
@@ -4,7 +4,7 @@
   <p class="govuk-body">If now’s the right time for you, you can still apply for courses that start this academic year.</p>
 
   <p class="govuk-body">
-    A <%= govuk_link_to('teacher training adviser', 'https://getintoteaching.education.gov.uk/teacher-training-advisers') %> can help you apply again.
+    A <%= govuk_link_to('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser_start')) %> can help you apply again.
   </p>
 
   <%= govuk_button_to(

--- a/app/components/shared/reasons_for_rejection_component.html.erb
+++ b/app/components/shared/reasons_for_rejection_component.html.erb
@@ -73,7 +73,7 @@
         </li>
       <% end %>
         <% if @render_link_to_find_when_rejected_on_qualifications %>
-          View the course requirements on <%= govuk_link_to 'Find postgraduate teacher training courses', "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry" %>.
+          View the course requirements on <%= govuk_link_to 'Find postgraduate teacher training courses', "#{I18n.t('find_postgraduate_teacher_training.production_url')}course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry" %>.
         <% end %>
     </ul>
     <% if editable? %>

--- a/app/views/candidate_interface/apply_from_find/not_found.html.erb
+++ b/app/views/candidate_interface/apply_from_find/not_found.html.erb
@@ -8,7 +8,7 @@
 
     <p class="govuk-body">
       We could not find the course you’re looking for – there may be a problem with the training provider and/or course code(s).
-      You can go back to <%= govuk_link_to 'Find postgraduate teacher training', 'https://www.find-postgraduate-teacher-training.service.gov.uk' %> and try selecting your course again, or choose a different course.
+      You can go back to <%= govuk_link_to 'Find postgraduate teacher training', I18n.t('find_postgraduate_teacher_training.production_url') %> and try selecting your course again, or choose a different course.
     </p>
   </div>
 </div>

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
@@ -22,7 +22,7 @@
 <p class="govuk-body">Contact your chosen training provider if you're not sure if they are university or a SCITT.</p>
 
 <p class="govuk-body">
-  <%= govuk_link_to 'Check if a provider has a student visa sponsor licence', 'https://www.gov.uk/government/publications/register-of-licensed-sponsors-students' %>.
+  <%= govuk_link_to 'Check if a provider has a student visa sponsor licence', I18n.t('register_of_sponsor_licences.url') %>.
 </p>
 
 <p class="govuk-body">

--- a/app/views/candidate_interface/references/start/show.html.erb
+++ b/app/views/candidate_interface/references/start/show.html.erb
@@ -19,7 +19,7 @@
 
     <p class="govuk-body">You can use one character reference if you also have a professional or academic reference.</p>
 
-    <p class="govuk-body">Get more tips on <%= govuk_link_to('choosing your referees', 'https://getintoteaching.education.gov.uk/tips-on-applying-for-teacher-training/#choose-your-referees') %>.</p>
+    <p class="govuk-body">Get more tips on <%= govuk_link_to('choosing your referees', I18n.t('get_into_teaching.url_choose_your_referees')) %>.</p>
 
     <h2 class="govuk-heading-m">Contact your referee</h2>
 

--- a/app/views/candidate_interface/training_with_a_disability/_form.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/_form.html.erb
@@ -16,7 +16,7 @@
   <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
   <li>reject your application because you’re disabled</li>
 </ul>
-<p class="govuk-body"><%= govuk_link_to "Get support training to teach if you're disabled", I18n.t("get_into_teaching.url_support_if_you_are_disabled") %>.</p>
+<p class="govuk-body"><%= govuk_link_to "Get support training to teach if you're disabled", I18n.t('get_into_teaching.url_support_if_you_are_disabled') %>.</p>
 
 <%= f.govuk_radio_buttons_fieldset :disclose_disability, legend: { text: t('application_form.training_with_a_disability.disclose_disability.label'), size: 'm' } do %>
   <%= f.govuk_radio_button :disclose_disability, 'yes', label: { text: t('application_form.training_with_a_disability.disclose_disability.yes') }, link_errors: true do %>

--- a/app/views/candidate_interface/training_with_a_disability/_form.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/_form.html.erb
@@ -16,7 +16,7 @@
   <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
   <li>reject your application because you’re disabled</li>
 </ul>
-<p class="govuk-body"><%= govuk_link_to "Get support training to teach if you're disabled", 'https://getintoteaching.education.gov.uk/get-support-training-to-teach-if-you-are-disabled' %>.</p>
+<p class="govuk-body"><%= govuk_link_to "Get support training to teach if you're disabled", I18n.t("get_into_teaching.url_support_if_you_are_disabled") %>.</p>
 
 <%= f.govuk_radio_buttons_fieldset :disclose_disability, legend: { text: t('application_form.training_with_a_disability.disclose_disability.label'), size: 'm' } do %>
   <%= f.govuk_radio_button :disclose_disability, 'yes', label: { text: t('application_form.training_with_a_disability.disclose_disability.yes') }, link_errors: true do %>

--- a/app/views/candidate_mailer/application_withdrawn_on_request_all_applications_withdrawn.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_all_applications_withdrawn.text.erb
@@ -4,7 +4,7 @@ At your request, <%= @course.provider.name %> has withdrawn your application to 
 
 Get in touch if you did not ask them to do this:
 
-https://getintoteaching.education.gov.uk/#talk-to-us
+<%= I18n.t('get_into_teaching.url_online_chat') %>
 
 # You can apply again
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_awaiting_decision_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_awaiting_decision_only.text.erb
@@ -4,7 +4,7 @@ At your request, <%= @course.provider.name %> has withdrawn your application to 
 
 Get in touch if you did not ask them to do this:
 
-https://getintoteaching.education.gov.uk/#talk-to-us
+<%= I18n.t('get_into_teaching.url_online_chat') %>
 
 <% if @awaiting_decision.length == 1 %>
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
@@ -4,7 +4,7 @@ At your request, <%= @course.provider.name %> has withdrawn your application to 
 
 Get in touch if you did not ask them to do this:
 
-https://getintoteaching.education.gov.uk/#talk-to-us
+<%= I18n.t('get_into_teaching.url_online_chat') %>
 
 # Respond to your <%= 'offer'.pluralize(@offers.length) %> by <%= @respond_by_date %>
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
@@ -4,7 +4,7 @@ At your request, <%= @course.provider.name %> has withdrawn your application to 
 
 Get in touch if you did not ask them to do this:
 
-https://getintoteaching.education.gov.uk/#talk-to-us
+<%= I18n.t('get_into_teaching.url_online_chat') %>
 
 # You have an offer and are waiting for a decision about another course
 

--- a/app/views/candidate_mailer/eoc_deadline_reminder.erb
+++ b/app/views/candidate_mailer/eoc_deadline_reminder.erb
@@ -18,4 +18,4 @@ Courses fill up quickly at this time of year.
 
 A teacher training adviser can help you write a strong application:
 
-https://getintoteaching.education.gov.uk/teacher-training-advisers
+<%= I18n.t('get_into_teaching.url_get_an_adviser_start') %>

--- a/app/views/candidate_mailer/find_another_course.text.erb
+++ b/app/views/candidate_mailer/find_another_course.text.erb
@@ -10,7 +10,7 @@ We cannot send your application to <%= @provider_name %> to be considered for th
 
 Find out if there are any other suitable courses available:
 
-https://www.find-postgraduate-teacher-training.service.gov.uk/
+<%= I18n.t('find_postgraduate_teacher_training.production_url') %>
 
 If you find a course, sign in to your account to add the course as soon as possible:
 

--- a/app/views/candidate_mailer/find_has_opened.erb
+++ b/app/views/candidate_mailer/find_has_opened.erb
@@ -6,7 +6,7 @@ You can now find teacher training courses starting in the <%= @academic_year %> 
 
 Find your courses:
 
-https://www.find-postgraduate-teacher-training.service.gov.uk/
+<%= I18n.t('find_postgraduate_teacher_training.production_url') %>
 
 Apply early to have the best chance of getting onto the course you want, as courses fill up throughout the year.
 

--- a/app/views/candidate_mailer/new_cycle_has_started.erb
+++ b/app/views/candidate_mailer/new_cycle_has_started.erb
@@ -22,4 +22,4 @@
 
 A teacher training adviser can help you write a strong application:
 
-https://getintoteaching.education.gov.uk/teacher-training-advisers
+<%= I18n.t('get_into_teaching.url_get_an_adviser_start') %>

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -221,7 +221,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l govuk-!-padding-top-4" id="applications-by-route">8. Route into teaching</h2>
-    <p class="govuk-body">Apply for teaching training allows candidates to apply for most <%= govuk_link_to('routes into teaching', 'https://getintoteaching.education.gov.uk/ways-to-train/') %>, outlined
+    <p class="govuk-body">Apply for teaching training allows candidates to apply for most <%= govuk_link_to('routes into teaching', I18n.t('get_into_teaching.url_ways_to_train')) %>, outlined
        in the table below, but it does not include applications made direct to providers, Teach First or undergraduate teacher training.</p>
     <p class="govuk-body">This table counts all applications by the training route chosen.</p>
     <p class="govuk-body">This table is comparable to previous figures published by UCAS for applications to providers in England.</p>

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/change_offered_course_search.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/change_offered_course_search.html.erb
@@ -21,7 +21,7 @@
         Find courses by searching on
         <%= govuk_link_to(
           'Find postgraduate teacher training',
-          'https://www.find-postgraduate-teacher-training.service.gov.uk/',
+          I18n.t('find_postgraduate_teacher_training.production_url'),
           target: '_blank',
           rel: 'nofollow',
         ) %>.

--- a/app/views/support_interface/application_forms/courses/new_search.html.erb
+++ b/app/views/support_interface/application_forms/courses/new_search.html.erb
@@ -22,7 +22,7 @@
         Find courses by searching on
         <%= govuk_link_to(
           'Find postgraduate teacher training',
-          'https://www.find-postgraduate-teacher-training.service.gov.uk/',
+          I18n.t('find_postgraduate_teacher_training.production_url'),
           target: '_blank',
           rel: 'nofollow',
         ) %>.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,7 @@ en:
     url: https://getintoteaching.education.gov.uk
     url_applying: https://getintoteaching.education.gov.uk/steps-to-become-a-teacher#step-5
     url_get_an_adviser: https://adviser-getintoteaching.education.gov.uk
+    url_get_an_adviser_start: https://getintoteaching.education.gov.uk/teacher-training-advisers
     url_international_candidates: https://getintoteaching.education.gov.uk/international-candidates
     url_training_with_a_disability: https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#training-to-teach-if-you-have-a-disability
     url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,8 @@ en:
     url_choose_your_referees: https://getintoteaching.education.gov.uk/tips-on-applying-for-teacher-training/#choose-your-referees
   train_to_teach_in_england:
     url: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration
+  register_of_sponsor_licences:
+    url: https://www.gov.uk/government/publications/register-of-licensed-sponsors-students
   page_titles:
     application_form: Your application
     application_dashboard: Your application

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,8 +35,11 @@ en:
     url_get_an_adviser_start: https://getintoteaching.education.gov.uk/teacher-training-advisers
     url_international_candidates: https://getintoteaching.education.gov.uk/international-candidates
     url_training_with_a_disability: https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#training-to-teach-if-you-have-a-disability
+    url_support_if_you_are_disabled: https://getintoteaching.education.gov.uk/get-support-training-to-teach-if-you-are-disabled
     url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
     url_get_school_experience: https://getintoteaching.education.gov.uk/get-school-experience
+    url_ways_to_train: https://getintoteaching.education.gov.uk/ways-to-train
+    url_choose_your_referees: https://getintoteaching.education.gov.uk/tips-on-applying-for-teacher-training/#choose-your-referees
   train_to_teach_in_england:
     url: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration
   page_titles:

--- a/spec/mailers/candidate_mailer_withdrawn_on_request_spec.rb
+++ b/spec/mailers/candidate_mailer_withdrawn_on_request_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       I18n.t!('candidate_mailer.application_withdrawn_on_request_all_applications_withdrawn.subject', provider_name: 'Arithmetic College'),
       'heading' => 'Dear Fred',
       'withdrawn sentence' => 'At your request, Arithmetic College has withdrawn your application to study Mathematics (M101)',
-      'link to support' => 'https://getintoteaching.education.gov.uk/#talk-to-us',
+      'link to support' => I18n.t('get_into_teaching.url_online_chat'),
       'apply again' => 'You can apply again',
     )
   end
@@ -45,7 +45,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       I18n.t!('candidate_mailer.application_withdrawn_on_request_awaiting_decision_only.subject', provider_name: 'Arithmetic College'),
       'heading' => 'Dear Fred',
       'withdrawn sentence' => 'At your request, Arithmetic College has withdrawn your application to study Mathematics (M101)',
-      'link to support' => 'https://getintoteaching.education.gov.uk/#talk-to-us',
+      'link to support' => I18n.t('get_into_teaching.url_online_chat'),
       'awaiting decision content' => 'You’re waiting for Arithmetic College to make a decision about your application to study Mathematics.',
     )
   end
@@ -59,7 +59,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       I18n.t!('candidate_mailer.application_withdrawn_on_request_offers_only.subject', provider_name: 'Arithmetic College', date: Time.zone.local(2021, 6, 22).to_s(:govuk_date)),
       'heading' => 'Dear Fred',
       'withdrawn sentence' => 'At your request, Arithmetic College has withdrawn your application to study Mathematics (M101)',
-      'link to support' => 'https://getintoteaching.education.gov.uk/#talk-to-us',
+      'link to support' => I18n.t('get_into_teaching.url_online_chat'),
       'offer content' => 'You’ve received an offer from Arithmetic College to study Mathematics',
     )
   end
@@ -78,7 +78,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       I18n.t!('candidate_mailer.application_withdrawn_on_request_one_offer_one_awaiting_decision.subject', provider_name: 'Arithmetic College'),
       'heading' => 'Dear Fred',
       'withdrawn sentence' => 'At your request, Arithmetic College has withdrawn your application to study Mathematics (M101)',
-      'link to support' => 'https://getintoteaching.education.gov.uk/#talk-to-us',
+      'link to support' => I18n.t('get_into_teaching.url_online_chat'),
       'offer content' => 'You have an offer from Arithmetic College to study Mathematics.',
       'awaiting decision content' => 'Falconholt Technical College has until 1 July 2021 to make a decision about your application to study Forensic Science.',
     )


### PR DESCRIPTION
## Context

This is a follow up to #6473. Where we decided we should move the raw links to translations. 

I've also moved the chat links and the Find production links to the translation file as we already had translations for them, but were using raw links in a few different files. 

I've only moved links that we have used more than once into the translation file.

## Changes proposed in this pull request

Move the following into translations:

- Get an advisor start links
- Get an advisor links
- GIT talk to us links
- Find production links

## Guidance to review

- Did I miss any?
- Are there any other duplicated links in the codebase that would be good to move to translations? 
- I didn't use the translations for some of the more complex links as I thought they made them less readable and more trouble than its worth... Thoughts welcome?

## Link to Trello card

https://trello.com/c/nWE2wKGS/4465-abstract-all-of-our-links-from-apply-into-a-single-locale-file
