### PR TITLE
Add XA and XB for EU and non-EU versions of Cyprus

### DIFF
--- a/config/initializers/countries_and_territories.rb
+++ b/config/initializers/countries_and_territories.rb
@@ -280,4 +280,6 @@ COUNTRIES_AND_TERRITORIES = {
   'ZM' => 'Zambia',
   'ZW' => 'Zimbabwe',
   'AX' => 'Åland Islands',
+  'XA' => 'Cyprus (European Union)',
+  'XB' => 'Cyprus (non European Union)',
 }.freeze

--- a/config/initializers/nationalities.rb
+++ b/config/initializers/nationalities.rb
@@ -265,6 +265,7 @@ EU_COUNTRY_CODES = [
   'SI',
   'ES',
   'SE',
+  'XA',
 ].freeze
 
 PROVISIONALLY_ELIGIBLE_FOR_GOV_FUNDING_COUNTRY_CODES = %w[GB IE IM].freeze


### PR DESCRIPTION
Required by HESA

https://www.hesa.ac.uk/collection/c21053/e/nation

## Context

HESA require this information, but we don't collect it. Currently candidates can only choose CY for Cyprus, without indicating whether they're EU or not.

We have 4 CY candidates so far this cycle.

Add the codes from the above HESA link (we already have most of the rest of them since https://github.com/DFE-Digital/apply-for-teacher-training/pull/5895). Also add the EU part of Cyprus to the EU countries list so candidates are correctly bucketed when we're considering that, eg in reporting.

## Things to check

- [X] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
