### PR TITLE
Course Change - Add the course wizard

### DIFF
--- a/app/components/provider_interface/change_course_details_component.rb
+++ b/app/components/provider_interface/change_course_details_component.rb
@@ -6,9 +6,10 @@ module ProviderInterface
     FUNDING_TYPES = { apprenticeship: :apprenticeship, salary: :salaried, fee: :fee_paying }.freeze
 
     attr_reader :application_choice, :provider_name_and_code, :course_name_and_code,
-                :cycle, :preferred_location, :study_mode, :qualification, :available_providers
+                :cycle, :preferred_location, :study_mode, :qualification, :available_providers,
+                :available_courses
 
-    def initialize(application_choice:, available_providers: [])
+    def initialize(application_choice:, available_providers: [], available_courses: [])
       @application_choice = application_choice
       @provider_name_and_code = application_choice.provider.name_and_code
       @course_name_and_code = application_choice.course.name_and_code
@@ -17,12 +18,13 @@ module ProviderInterface
       @study_mode = application_choice.course_option.study_mode.humanize
       @qualification = qualification_text(application_choice.course_option)
       @available_providers = available_providers
+      @available_courses = available_courses
     end
 
     def rows
       [
         { key: 'Training provider', value: provider_name_and_code, action: { href: change_provider_path } },
-        { key: 'Course', value: course_name_and_code },
+        { key: 'Course', value: course_name_and_code, action: { href: change_course_path } },
         { key: 'Cycle', value: cycle },
         { key: 'Full or part time', value: study_mode },
         { key: 'Location', value: preferred_location },
@@ -59,6 +61,10 @@ module ProviderInterface
 
     def change_provider_path
       available_providers.length > 1 ? edit_provider_interface_application_choice_course_providers_path(application_choice) : nil
+    end
+
+    def change_course_path
+      available_courses.length > 1 ? edit_provider_interface_application_choice_course_courses_path(application_choice) : nil
     end
   end
 end

--- a/app/controllers/provider_interface/courses/courses_controller.rb
+++ b/app/controllers/provider_interface/courses/courses_controller.rb
@@ -1,0 +1,37 @@
+module ProviderInterface
+  module Courses
+    class CoursesController < ProviderInterface::CoursesController
+      def edit
+        @wizard = CourseWizard.new(change_course_store, { current_step: 'courses', action: action })
+        @wizard.save_state!
+
+        @courses = available_courses(@wizard.provider_id)
+      end
+
+      def update
+        @wizard = CourseWizard.new(change_course_store, attributes_for_wizard)
+
+        if @wizard.valid_for_current_step?
+          @wizard.save_state!
+
+          redirect_to [:edit, :provider_interface, @application_choice, :offer, @wizard.next_step]
+        else
+          @courses = available_courses(@wizard.provider_id)
+          track_validation_error(@wizard)
+
+          render :edit
+        end
+      end
+
+    private
+
+      def course_params
+        params.require(:provider_interface_course_wizard).permit(:course_id)
+      end
+
+      def attributes_for_wizard
+        course_params.to_h.merge!(current_step: 'courses')
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/courses/providers_controller.rb
+++ b/app/controllers/provider_interface/courses/providers_controller.rb
@@ -14,7 +14,7 @@ module ProviderInterface
         if @wizard.valid_for_current_step?
           @wizard.save_state!
 
-          redirect_to [:edit, :provider_interface, @application_choice, :offer, @wizard.next_step]
+          redirect_to [:edit, :provider_interface, @application_choice, :course, @wizard.next_step]
         else
           track_validation_error(@wizard)
           @providers = available_providers

--- a/app/controllers/provider_interface/courses_controller.rb
+++ b/app/controllers/provider_interface/courses_controller.rb
@@ -22,6 +22,10 @@ module ProviderInterface
       query_service.available_providers
     end
 
+    def available_courses(provider_id)
+      query_service.available_courses(provider: Provider.find(provider_id))
+    end
+
     def query_service
       @query_service ||= GetChangeOfferOptions.new(
         user: current_provider_user,

--- a/app/forms/provider_interface/course_wizard.rb
+++ b/app/forms/provider_interface/course_wizard.rb
@@ -8,6 +8,8 @@ module ProviderInterface
     attr_accessor :path_history, :provider_id, :decision, :application_choice_id,
                   :course_option_id, :course_id, :provider_user_id, :study_mode
 
+    validates :course_id, presence: true, on: %i[courses save]
+
     def self.build_from_application_choice(state_store, application_choice, options = {})
       course_option = application_choice.current_course_option
 

--- a/app/forms/provider_interface/course_wizard.rb
+++ b/app/forms/provider_interface/course_wizard.rb
@@ -5,7 +5,21 @@ module ProviderInterface
 
     STEPS = %i[select_option providers courses study_modes locations check].freeze
 
-    attr_accessor :path_history, :provider_id, :decision, :provider_user, :application_choice_id
+    attr_accessor :path_history, :provider_id, :decision, :application_choice_id,
+                  :course_option_id, :course_id, :provider_user_id, :study_mode
+
+    def self.build_from_application_choice(state_store, application_choice, options = {})
+      course_option = application_choice.current_course_option
+
+      attrs = {
+        application_choice_id: application_choice.id,
+        course_id: course_option.course.id,
+        course_option_id: course_option.id,
+        provider_id: course_option.provider.id,
+      }.merge(options)
+
+      new(state_store, attrs)
+    end
 
     def next_step(step = current_step)
       index = STEPS.index(step.to_sym)
@@ -14,11 +28,25 @@ module ProviderInterface
       next_step = STEPS[index + 1]
 
       return save_and_go_to_next_step(next_step) if next_step.eql?(:providers) && available_providers.length == 1
+      return save_and_go_to_next_step(next_step) if next_step.eql?(:courses) && available_courses.length == 1
+      return save_and_go_to_next_step(next_step) if next_step.eql?(:study_modes) && available_study_modes.length == 1
 
       next_step
     end
 
   private
+
+    def provider
+      Provider.find(provider_id)
+    end
+
+    def course
+      Course.find(course_id)
+    end
+
+    def provider_user
+      ProviderUser.find(provider_user_id)
+    end
 
     def application_choice
       ApplicationChoice.find(application_choice_id)
@@ -33,6 +61,14 @@ module ProviderInterface
 
     def available_providers
       query_service.available_providers
+    end
+
+    def available_courses
+      query_service.available_courses(provider: provider)
+    end
+
+    def available_study_modes
+      query_service.available_study_modes(course: course)
     end
 
     def save_and_go_to_next_step(step)

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -46,7 +46,11 @@
 <% end %>
 
 <% if @provider_can_respond && FeatureFlag.active?(:change_course_details_before_offer) %>
-  <%= render ProviderInterface::ChangeCourseDetailsComponent.new(application_choice: @application_choice, available_providers: @available_training_providers) %>
+  <%= render ProviderInterface::ChangeCourseDetailsComponent.new(
+    application_choice: @application_choice,
+    available_providers: @available_training_providers,
+    available_courses: @available_courses,
+  ) %>
 <% else %>
   <%= render ProviderInterface::CourseDetailsComponent.new(application_choice: @application_choice) %>
 <% end %>

--- a/app/views/provider_interface/courses/courses/edit.html.erb
+++ b/app/views/provider_interface/courses/courses/edit.html.erb
@@ -1,0 +1,17 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+
+<%= render CollectionSelectComponent.new(attribute: :course_id,
+                                         collection: @courses,
+                                         value_method: :id,
+                                         text_method: :name_and_code,
+                                         hint_method: :description,
+                                         bold_labels: false,
+                                         form_object: @wizard,
+                                         form_path: provider_interface_application_choice_course_courses_path,
+                                         form_method: :put,
+                                         page_title: t('.title'),
+                                         caption: t('.caption', name: @application_choice.application_form.full_name)) do %>
+  <p class="govuk-body">
+    <%= govuk_link_to t('cancel'), provider_interface_application_choice_offer_path(@application_choice) %>
+  </p>
+<% end %>

--- a/config/locales/provider_interface/change_course.yml
+++ b/config/locales/provider_interface/change_course.yml
@@ -5,3 +5,7 @@ en:
         edit:
           title: Training provider
           caption: Update course - %{name}
+      courses:
+        edit:
+          title: Course
+          caption: Update course - %{name}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -740,6 +740,7 @@ Rails.application.routes.draw do
 
       namespace :courses, as: :application_choice_course do
         resource :providers, only: %i[edit update]
+        resource :courses, only: %i[edit update]
       end
 
       get '/rejection-reasons' => 'reasons_for_rejection#edit_initial_questions', as: :reasons_for_rejection_initial_questions

--- a/spec/components/provider_interface/change_course_details_component_spec.rb
+++ b/spec/components/provider_interface/change_course_details_component_spec.rb
@@ -28,7 +28,16 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
 
   let(:course) do
     instance_double(Course,
-                    name_and_code: 'Geograpghy (H234)',
+                    name_and_code: 'Geography (H234)',
+                    recruitment_cycle_year: 2020,
+                    accredited_provider: nil,
+                    qualifications: %w[qts pgce],
+                    funding_type: 'fee')
+  end
+
+  let(:course2) do
+    instance_double(Course,
+                    name_and_code: 'Geography (H234)',
                     recruitment_cycle_year: 2020,
                     accredited_provider: nil,
                     qualifications: %w[qts pgce],
@@ -43,6 +52,8 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
                     site: site)
   end
 
+  let(:render) { render_inline(described_class.new(application_choice: application_choice)) }
+
   def row_text_selector(row_name, render)
     rows = { provider: 0,
              course: 1,
@@ -54,6 +65,10 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
              funding_type: 7 }
 
     render.css('.govuk-summary-list__row')[rows[row_name]].text
+  end
+
+  def row_link_selector(row_number)
+    render.css('.govuk-summary-list__row')[row_number].css('a')&.first&.attr('href')
   end
 
   context 'when there are multiple available providers' do
@@ -69,13 +84,33 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
   end
 
   context 'when there are not multiple available providers' do
-    let(:render) { render_inline(described_class.new(application_choice: application_choice)) }
-
     it 'does not renders the change link' do
       render_text = row_text_selector(:provider, render)
 
       expect(render_text).to include('Training provider')
       expect(render_text).to include('Best Training (B54)')
+      expect(render_text).not_to include('Change')
+    end
+  end
+
+  context 'when multiple courses' do
+    let(:render) { render_inline(described_class.new(application_choice: application_choice, available_courses: [course, course2])) }
+
+    it 'renders a change link' do
+      render_text = row_text_selector(:course, render)
+
+      expect(render_text).to include('Course')
+      expect(render_text).to include('Geography (H234)')
+      expect(render_text).to include('Change')
+    end
+  end
+
+  context 'when only one course' do
+    it 'does not render a change link' do
+      render_text = row_text_selector(:course, render)
+
+      expect(render_text).to include('Course')
+      expect(render_text).to include('Geography (H234)')
       expect(render_text).not_to include('Change')
     end
   end

--- a/spec/forms/provider_interface/course_wizard_spec.rb
+++ b/spec/forms/provider_interface/course_wizard_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe ProviderInterface::CourseWizard do
   let(:application_choice_id) { create(:application_choice).id }
   let(:current_step) { nil }
 
+  before { allow(store).to receive(:read) }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:course_id).on(:courses).on(:save) }
+  end
+
   context 'when changing an offer' do
     let(:decision) { :change_offer }
     let(:query_service) { instance_double(GetChangeOfferOptions) }
@@ -28,7 +34,6 @@ RSpec.describe ProviderInterface::CourseWizard do
       allow(provider_user).to receive(:id).and_return(1)
       allow(GetChangeOfferOptions).to receive(:new).and_return(query_service)
       allow(store).to receive(:write)
-      allow(store).to receive(:read)
     end
 
     context 'when current_step is :select_option' do

--- a/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
@@ -30,6 +30,10 @@ RSpec.feature 'Provider changes a course' do
     and_i_click_an_application_choice_that_is_interviewing
     and_i_click_on_change_the_training_provider
     then_i_see_a_list_of_training_providers_to_select_from
+
+    when_i_select_a_different_provider
+    and_i_click_continue
+    then_i_see_a_list_of_courses_to_select_from
   end
 
   def given_i_am_a_provider_user
@@ -104,5 +108,18 @@ RSpec.feature 'Provider changes a course' do
   def then_i_see_a_list_of_training_providers_to_select_from
     expect(page).to have_content "Update course - #{application_form.full_name}"
     expect(page).to have_content 'Training provider'
+  end
+
+  def when_i_select_a_different_provider
+    choose @selected_provider.name_and_code
+  end
+
+  def and_i_click_continue
+    click_on t('continue')
+  end
+
+  def then_i_see_a_list_of_courses_to_select_from
+    expect(page).to have_content "Update course - #{application_form.full_name}"
+    expect(page).to have_content 'Course'
   end
 end


### PR DESCRIPTION
## Context

Currently providers can change the details of a course at the point of offer. We'd like to let providers do this before the point of offer.

Following from [#6563](https://github.com/DFE-Digital/apply-for-teacher-training/pull/6563), this is the second PR in the series which will allow the user to change the course choice.

## Changes proposed in this pull request

<img width="668" alt="image" src="https://user-images.githubusercontent.com/47917431/155540922-7df91bd3-c23b-478e-bf53-756f7144fd7e.png">


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/7VseoacH

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
