### PR TITLE
4896 email reminders connect the new field to the current applicationreceived setting

### DIFF
--- a/app/services/save_provider_user_notification_preferences.rb
+++ b/app/services/save_provider_user_notification_preferences.rb
@@ -8,6 +8,10 @@ class SaveProviderUserNotificationPreferences
   def update_all_notification_preferences!(notification_preferences_params: {})
     return false if notification_preferences_params.empty?
 
+    unless FeatureFlag.active?(:make_decision_reminder_notification_setting)
+      notification_preferences_params.merge!(chase_provider_decision: notification_preferences_params[:application_received])
+    end
+
     provider_user_notification_preferences.update!(notification_preferences_params)
   end
 

--- a/spec/factories/provider_user_notification_preferences.rb
+++ b/spec/factories/provider_user_notification_preferences.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     application_rejected_by_default { true }
     offer_accepted { true }
     offer_declined { true }
+    chase_provider_decision { true }
 
     trait :all_off do
       application_received { false }
@@ -14,6 +15,7 @@ FactoryBot.define do
       application_rejected_by_default { false }
       offer_accepted { false }
       offer_declined { false }
+      chase_provider_decision { false }
     end
   end
 end

--- a/spec/services/save_provider_user_notification_preferences_spec.rb
+++ b/spec/services/save_provider_user_notification_preferences_spec.rb
@@ -54,5 +54,30 @@ RSpec.describe SaveProviderUserNotificationPreferences do
         )
       end
     end
+
+    context 'when the :make_decision_reminder_notification_setting feature flag is off' do
+      before do
+        FeatureFlag.deactivate(:make_decision_reminder_notification_setting)
+      end
+
+      let(:notification_preferences_params) do
+        {
+          application_received: false,
+          application_withdrawn: false,
+          application_rejected_by_default: false,
+          offer_accepted: false,
+          offer_declined: false,
+        }
+      end
+
+      it 'updates the chase_provider_decision alongside the application_received' do
+        service.update_all_notification_preferences!(notification_preferences_params: notification_preferences_params)
+
+        expect(provider_user.reload.notification_preferences.attributes).to include(
+          'application_received' => false,
+          'chase_provider_decision' => false,
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

https://trello.com/c/vyN04trE/4896-email-reminders-connect-the-new-field-to-the-current-applicationreceived

## Changes proposed in this pull request

Changes to the `SaveProviderUserNotificationPreferences` service so that the `chase_provider_decision` field is tied to the `application_received` field going forwards. This is contingent on the featureflag not yet being turned on.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
