### PR TITLE
Strip invisible whitespace chars from candidate input params

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -102,6 +102,7 @@ module CandidateInterface
 
     def strip_whitespace(params)
       StripWhitespace.from_hash(params)
+      StripInvisibleWhitespace.from_hash(params)
     end
 
     def append_info_to_payload(payload)

--- a/app/lib/strip_invisible_whitespace.rb
+++ b/app/lib/strip_invisible_whitespace.rb
@@ -3,7 +3,10 @@ class StripInvisibleWhitespace
     hash.transform_values { |v| from_string(v) }
   end
 
-  def self.from_string(string)
-    string.gsub(/[#{StripAttributes::MULTIBYTE_WHITE}]+/, '')
+  def self.from_string(value)
+    return value unless value.is_a?(String)
+    return value if value.frozen?
+
+    value.gsub(/[#{StripAttributes::MULTIBYTE_WHITE}]+/, '')
   end
 end

--- a/app/lib/strip_invisible_whitespace.rb
+++ b/app/lib/strip_invisible_whitespace.rb
@@ -1,0 +1,9 @@
+class StripInvisibleWhitespace
+  def self.from_hash(hash)
+    hash.transform_values { |v| from_string(v) }
+  end
+
+  def self.from_string(string)
+    string.gsub(/[#{StripAttributes::MULTIBYTE_WHITE}]+/, '')
+  end
+end

--- a/spec/lib/strip_invisible_whitespace_spec.rb
+++ b/spec/lib/strip_invisible_whitespace_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe StripInvisibleWhitespace do
+  describe '.from_hash' do
+    it 'removes non-printable whitespace characters from hash values' do
+      hash = {
+        key1: "v\u180Ea\u200Bl\u200Cu\u200De\u20601\uFEFF",
+        key2: 'value2',
+        'key3 ' => 'value3',
+      }
+
+      expect(described_class.from_hash(hash)).to eq(
+        {
+          key1: 'value1',
+          key2: 'value2',
+          'key3 ' => 'value3',
+        },
+      )
+    end
+  end
+
+  describe '.from_string' do
+    it 'removes whitespace characters from the string argument' do
+      expect(
+        described_class.from_string(
+          "\u180Et\u200Be\u200C\u200Ds\u2060t\uFEFF",
+        ),
+      ).to eq('test')
+    end
+  end
+end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_spec.rb
@@ -21,6 +21,7 @@ RSpec.feature 'Entering their personal details' do
     and_i_submit_the_form
     then_i_see_the_review_page
     and_i_can_check_my_answers
+    and_invisible_whitespace_has_been_removed
 
     when_i_click_to_change_my_answer
     and_i_fill_in_a_different_answer
@@ -71,6 +72,7 @@ RSpec.feature 'Entering their personal details' do
   end
 
   def when_i_fill_in_the_rest_of_my_details
+    fill_in t('first_name.label', scope: @scope), with: "La\u200Bndo"
     fill_in 'Day', with: '6'
     fill_in 'Month', with: '4'
     fill_in 'Year', with: '1937'
@@ -104,6 +106,10 @@ RSpec.feature 'Entering their personal details' do
     expect(page).to have_content 'Name'
     expect(page).to have_content 'Lando Calrissian'
     expect(page).to have_content 'British and American'
+  end
+
+  def and_invisible_whitespace_has_been_removed
+    expect(ApplicationForm.last.first_name).to eq('Lando')
   end
 
   def when_i_click_to_change_my_answer


### PR DESCRIPTION
## Context

As a candidate it's possible to enter values that contain some non-printable whitespace characters. This has caused problems with certain student record systems that consume our API.

## Changes proposed in this pull request

In the same way that we remove all trailing and leading whitespace we
can remove non-printable whitespace characters from all candidate inputs.

We currently use the `strip_attributes` gem to remove leading and trailing whitespace. This gem contains a list of non-printable characters:

https://github.com/rmm5t/strip_attributes/blob/master/lib/strip_attributes.rb#L22-L27

This PR adds a new helper class `StripInvisibleWhitespace` that sits alongside the existing `StripWhitespace` class to remove these characters from all input strings, wherever they appear in the string (not just trailing and leading whitespace).

## Guidance to review

- Can you see any unintended consequences?
- Are the tests adequate?

## Link to Trello card

https://trello.com/c/xG05elcU/4433-a-candidate-was-able-to-submit-the-form-with-an-invisible-character-in-their-name

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
