### PR TITLE
4897 email reminders backfill the new chaseproviderdecision fields

### DIFF
--- a/app/services/data_migrations/backfill_chase_provider_decision_setting.rb
+++ b/app/services/data_migrations/backfill_chase_provider_decision_setting.rb
@@ -1,0 +1,12 @@
+module DataMigrations
+  class BackfillChaseProviderDecisionSetting
+    TIMESTAMP = 20220225092605
+    MANUAL_RUN = false
+
+    def change
+      ProviderUserNotificationPreferences.where(application_received: false).find_each do |preference|
+        preference.update!(chase_provider_decision: false)
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillChaseProviderDecisionSetting',
   'DataMigrations::BackfillWithdrawnOrDeclinedForCandidateByProvider',
   'DataMigrations::BackfillUserColumnsOnNotes',
   'DataMigrations::RemoveDuplicateProvider',

--- a/spec/services/data_migrations/backfill_chase_provider_decision_setting_spec.rb
+++ b/spec/services/data_migrations/backfill_chase_provider_decision_setting_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillChaseProviderDecisionSetting do
+  it 'backfills chase provider decision columns' do
+    application_received_on = create(:provider_user_notification_preferences, application_received: true)
+    application_received_off = create(:provider_user_notification_preferences, application_received: false)
+
+    described_class.new.change
+
+    expect(application_received_on.reload.chase_provider_decision).to be(true)
+    expect(application_received_off.reload.chase_provider_decision).to be(false)
+  end
+end


### PR DESCRIPTION
## Context

https://trello.com/c/kUr8tTaw/4897-email-reminders-backfill-the-new-chaseproviderdecision-fields

## Changes proposed in this pull request

Set up a data migration that finds every `application_received` notification preference that's set to false, and flips the `chase_provider_decision` to false as well. This needs to go in after https://github.com/DFE-Digital/apply-for-teacher-training/pull/6586, as they need to layer in the right order

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
