### PR TITLE
Improve no vacancies page

### DIFF
--- a/app/views/candidate_interface/course_choices/course_selection/full.html.erb
+++ b/app/views/candidate_interface/course_choices/course_selection/full.html.erb
@@ -12,9 +12,9 @@
     <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-8">
       <li>
         <%= govuk_link_to(
-          'choose another course',
-          candidate_interface_course_choices_course_path(@course.provider),
-        ) %>
+              'choose another course',
+              candidate_interface_course_choices_choose_path,
+            ) %>
       </li>
       <li>
         contact

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
@@ -8,6 +8,8 @@ RSpec.feature 'Selecting a full course' do
     and_there_is_a_full_course
     when_i_select_the_full_course
     then_i_see_a_page_telling_me_i_cannot_apply
+    and_i_click_the_choose_another_course_link
+    then_i_should_be_on_the_course_choices_page
   end
 
   def given_i_am_signed_in
@@ -40,5 +42,13 @@ RSpec.feature 'Selecting a full course' do
   def then_i_see_a_page_telling_me_i_cannot_apply
     expect(page).to have_text('You cannot apply to this course because it has no vacancies')
     expect(page).to have_text("The course ‘#{@course.name_and_code}’ is full")
+  end
+
+  def and_i_click_the_choose_another_course_link
+    click_link 'choose another course'
+  end
+
+  def then_i_should_be_on_the_course_choices_page
+    expect(page).to have_current_path(candidate_interface_course_choices_choose_path)
   end
 end


### PR DESCRIPTION
## Context

We are improving the page that you are taken to if you select a course with no vacancies. 

## Changes proposed in this pull request

- Link back to the "Do you know where you want to apply" page

<img width="883" alt="image" src="https://user-images.githubusercontent.com/50492247/156017173-32edafd1-1cca-4d49-a707-9f8f2cd231e4.png">


## Guidance to review
 :shipit: 

## Link to Trello card

https://trello.com/c/A8ryjRs1/4474-ensure-that-selecting-a-course-with-no-vacancies-gives-you-the-right-options-for-other-courses