### PR TITLE
API cleanup standardise error codes and types

### DIFF
--- a/app/controllers/concerns/vendor_api/api_validations_and_error_handling.rb
+++ b/app/controllers/concerns/vendor_api/api_validations_and_error_handling.rb
@@ -42,7 +42,7 @@ module VendorAPI
       render status: :unauthorized, json: {
         errors: [
           {
-            error: 'NotAuthorisedError',
+            error: 'Unauthorized',
             message: e.message,
           },
         ],
@@ -64,27 +64,45 @@ module VendorAPI
 
     def render_validation_errors(errors)
       error_responses = errors.full_messages.map { |message| { error: 'UnprocessableEntity', message: message } }
-      render status: :unprocessable_entity, json: { errors: error_responses }
+
+      render status: :unprocessable_entity, json: {
+        errors: error_responses,
+      }
     end
 
     def parameter_missing(e)
       error_message = e.message.split("\n").first
-      render json: { errors: [{ error: 'ParameterMissing', message: error_message }] }, status: :unprocessable_entity
+
+      render status: :unprocessable_entity, json: {
+        errors: [
+          {
+            error: 'ParameterMissing',
+            message: error_message,
+          },
+        ],
+      }
     end
 
     def parameter_invalid(e)
-      render json: { errors: [{ error: 'ParameterInvalid', message: e }] }, status: :unprocessable_entity
+      render status: :unprocessable_entity, json: {
+        errors: [
+          {
+            error: 'ParameterInvalid',
+            message: e,
+          },
+        ],
+      }
     end
 
     def statement_timeout
-      render json: {
+      render status: :internal_server_error, json: {
         errors: [
           {
             error: 'InternalServerError',
             message: 'The server encountered an unexpected condition that prevented it from fulfilling the request',
           },
         ],
-      }, status: :internal_server_error
+      }
     end
 
     def render_validation_error(e)

--- a/app/controllers/concerns/vendor_api/api_validations_and_error_handling.rb
+++ b/app/controllers/concerns/vendor_api/api_validations_and_error_handling.rb
@@ -48,7 +48,7 @@ module VendorAPI
     end
 
     def render_validation_errors(errors)
-      error_responses = errors.full_messages.map { |message| { error: 'ValidationError', message: message } }
+      error_responses = errors.full_messages.map { |message| { error: 'UnprocessableEntity', message: message } }
       render status: :unprocessable_entity, json: { errors: error_responses }
     end
 

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -1,7 +1,6 @@
 module VendorAPI
   class ApplicationsController < VendorAPIController
     include ApplicationDataConcerns
-    include APIValidationsAndErrorHandling
 
     skip_before_action :validate_metadata!
 

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -1,6 +1,9 @@
 module VendorAPI
   class ApplicationsController < VendorAPIController
     include ApplicationDataConcerns
+    include APIValidationsAndErrorHandling
+
+    skip_before_action :validate_metadata!
 
     rescue_from Pagy::OverflowError, with: :page_parameter_invalid
     rescue_from PerPageParameterInvalid, with: :per_page_parameter_invalid

--- a/app/controllers/vendor_api/confirm_deferred_offers_controller.rb
+++ b/app/controllers/vendor_api/confirm_deferred_offers_controller.rb
@@ -1,6 +1,5 @@
 module VendorAPI
   class ConfirmDeferredOffersController < VendorAPIController
-    include APIValidationsAndErrorHandling
     include ApplicationDataConcerns
 
     def create

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -1,6 +1,7 @@
 module VendorAPI
   class DecisionsController < VendorAPIController
     include ApplicationDataConcerns
+    include APIValidationsAndErrorHandling
 
     before_action :validate_metadata!
     rescue_from ValidationException, with: :render_validation_error

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -89,7 +89,7 @@ module VendorAPI
 
     # Takes errors from ActiveModel::Validations and render them in the API response
     def render_validation_errors(errors)
-      error_responses = errors.full_messages.map { |message| { error: 'ValidationError', message: message } }
+      error_responses = errors.full_messages.map { |message| { error: 'UnprocessableEntity', message: message } }
       render status: :unprocessable_entity, json: { errors: error_responses }
     end
 

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -1,7 +1,6 @@
 module VendorAPI
   class DecisionsController < VendorAPIController
     include ApplicationDataConcerns
-    include APIValidationsAndErrorHandling
 
     def make_offer
       validate_course_is_in_current_recruitment_cycle!

--- a/app/controllers/vendor_api/deferred_offers_controller.rb
+++ b/app/controllers/vendor_api/deferred_offers_controller.rb
@@ -1,7 +1,6 @@
 module VendorAPI
   class DeferredOffersController < VendorAPIController
     include ApplicationDataConcerns
-    include APIValidationsAndErrorHandling
 
     def create
       DeferOffer.new(actor: audit_user, application_choice: application_choice).save!

--- a/app/controllers/vendor_api/interviews_controller.rb
+++ b/app/controllers/vendor_api/interviews_controller.rb
@@ -1,7 +1,6 @@
 module VendorAPI
   class InterviewsController < VendorAPIController
     include ApplicationDataConcerns
-    include APIValidationsAndErrorHandling
 
     rescue_from InterviewWorkflowConstraints::WorkflowError, with: :handle_as_validation_error
 

--- a/app/controllers/vendor_api/interviews_controller.rb
+++ b/app/controllers/vendor_api/interviews_controller.rb
@@ -3,9 +3,7 @@ module VendorAPI
     include ApplicationDataConcerns
     include APIValidationsAndErrorHandling
 
-    rescue_from InterviewWorkflowConstraints::WorkflowError, with: :render_error_as_json
-    rescue_from InvalidProviderCode, with: :render_error_as_json
-    rescue_from InvalidDateError, with: :render_error_as_json
+    rescue_from InterviewWorkflowConstraints::WorkflowError, with: :handle_as_validation_error
 
     def create
       CreateInterview.new(
@@ -46,27 +44,21 @@ module VendorAPI
 
   private
 
-    def render_error_as_json(e)
-      render status: :unprocessable_entity, json: {
-        errors: [
-          {
-            error: e.class.to_s,
-            message: e.message,
-          },
-        ],
-      }
+    def handle_as_validation_error(e)
+      render status: :unprocessable_entity,
+             json: { errors: [{ error: 'UnprocessableEntityResponse', message: e.message }] }
     end
 
     def provider_for_interview(code)
       if code.present? # supporting partial updates
-        Provider.find_by(code: code) || raise(InvalidProviderCode, 'Provider code is not valid')
+        Provider.find_by(code: code) || raise(ValidationException, ['Provider code is not valid'])
       end
     end
 
     def date_and_time(date_time_string)
       DateTime.parse(date_time_string) if date_time_string.present? # supporting partial updates
     rescue Date::Error
-      raise InvalidDateError, 'Date string provided is not a valid date'
+      raise ValidationException, ['Date string provided is not a valid date']
     end
 
     def existing_interview

--- a/app/controllers/vendor_api/notes_controller.rb
+++ b/app/controllers/vendor_api/notes_controller.rb
@@ -1,7 +1,6 @@
 module VendorAPI
   class NotesController < VendorAPIController
     include ApplicationDataConcerns
-    include APIValidationsAndErrorHandling
 
     def create
       CreateNote.new(user: audit_user,

--- a/app/controllers/vendor_api/ping_controller.rb
+++ b/app/controllers/vendor_api/ping_controller.rb
@@ -1,5 +1,7 @@
 module VendorAPI
   class PingController < VendorAPIController
+    skip_before_action :validate_metadata!
+
     def ping
       render json: { data: 'pong' }
     end

--- a/app/controllers/vendor_api/reference_data_controller.rb
+++ b/app/controllers/vendor_api/reference_data_controller.rb
@@ -1,5 +1,7 @@
 module VendorAPI
   class ReferenceDataController < VendorAPIController
+    skip_before_action :validate_metadata!
+
     def gcse_subjects
       render json: { data: GCSE_SUBJECTS }
     end

--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -1,6 +1,7 @@
 module VendorAPI
   class TestDataController < VendorAPIController
     before_action :check_this_is_a_test_environment
+    skip_before_action :validate_metadata!
 
     MAX_COUNT = 100
     DEFAULT_COUNT = 100

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -4,6 +4,7 @@ module VendorAPI
     include RequestQueryParams
     include RemoveBrowserOnlyHeaders
     include Versioning
+    include APIValidationsAndErrorHandling
 
     rescue_from ActionController::ParameterMissing, with: :parameter_missing
     rescue_from ParameterInvalid, with: :parameter_invalid

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -7,7 +7,6 @@ module VendorAPI
     include APIValidationsAndErrorHandling
 
     before_action :set_cors_headers
-    before_action :require_valid_api_token!
     before_action :set_user_context
 
     def audit_user
@@ -31,18 +30,6 @@ module VendorAPI
 
     def set_cors_headers
       headers['Access-Control-Allow-Origin'] = '*'
-    end
-
-    def require_valid_api_token!
-      return @current_vendor_api_token.update!(last_used_at: Time.zone.now) if valid_api_token?
-
-      raise ProviderAuthorisation::NotAuthorisedError, 'Please provide a valid authentication token'
-    end
-
-    def valid_api_token?
-      authenticate_with_http_token do |unhashed_token|
-        @current_vendor_api_token = VendorAPIToken.find_by_unhashed_token(unhashed_token)
-      end
     end
 
     def current_provider

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -5,7 +5,6 @@ module VendorAPI
     include RemoveBrowserOnlyHeaders
     include Versioning
 
-    rescue_from ActiveRecord::RecordNotFound, with: :application_not_found
     rescue_from ActionController::ParameterMissing, with: :parameter_missing
     rescue_from ParameterInvalid, with: :parameter_invalid
 
@@ -35,12 +34,6 @@ module VendorAPI
       vendor_api_user.full_name = @metadata.attribution.full_name
       vendor_api_user.save!
       vendor_api_user
-    end
-
-    def application_not_found(_e)
-      render json: {
-        errors: [{ error: 'NotFound', message: "Could not find an application with ID #{params[:application_id]}" }],
-      }, status: :not_found
     end
 
     def parameter_missing(e)

--- a/app/controllers/vendor_api/withdraw_or_decline_offer_controller.rb
+++ b/app/controllers/vendor_api/withdraw_or_decline_offer_controller.rb
@@ -1,7 +1,6 @@
 module VendorAPI
   class WithdrawOrDeclineOfferController < VendorAPIController
     include ApplicationDataConcerns
-    include APIValidationsAndErrorHandling
 
     def create
       DeclineOrWithdrawApplication.new(actor: audit_user,

--- a/app/errors/invalid_date_error.rb
+++ b/app/errors/invalid_date_error.rb
@@ -1,1 +1,0 @@
-class InvalidDateError < StandardError; end

--- a/app/errors/invalid_provider_code.rb
+++ b/app/errors/invalid_provider_code.rb
@@ -1,1 +1,0 @@
-class InvalidProviderCode < StandardError; end

--- a/spec/requests/vendor_api/v1.0/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/v1.0/get_multiple_applications_spec.rb
@@ -52,34 +52,31 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
     expect(parsed_response).to be_valid_against_openapi_schema('MultipleApplicationsResponse')
   end
 
-  it 'returns an error if the `since` parameter is missing' do
+  it 'returns a ParameterMissingResponse if the `since` parameter is missing' do
     get_api_request '/api/v1/applications'
 
     expect(response).to have_http_status(:unprocessable_entity)
-
-    expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse')
-
-    expect(error_response['message']).to eql('param is missing or the value is empty: since')
+    expect(parsed_response).to contain_schema_with_error('ParameterMissingResponse',
+                                                         'param is missing or the value is empty: since',
+                                                         '1.0')
   end
 
   it 'returns HTTP status 422 given an unparseable `since` date value' do
     get_api_request '/api/v1/applications?since=17/07/2020T12:00:42Z'
 
     expect(response).to have_http_status(:unprocessable_entity)
-
-    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-
-    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): since')
+    expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                         'Parameter is invalid (should be ISO8601): since',
+                                                         '1.0')
   end
 
   it 'returns HTTP status 422 when encountering a KeyError from ActiveSupport::TimeZone' do
     get_api_request '/api/v1/applications?since=12936'
 
     expect(response).to have_http_status(:unprocessable_entity)
-
-    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-
-    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): since')
+    expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                         'Parameter is invalid (should be ISO8601): since',
+                                                         '1.0')
   end
 
   it 'returns HTTP status 422 given a parseable but nonsensensical `since` date value' do
@@ -87,9 +84,9 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
 
     expect(response).to have_http_status(:unprocessable_entity)
 
-    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-
-    expect(error_response['message']).to eql('Parameter is invalid (date is nonsense): since')
+    expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                         'Parameter is invalid (date is nonsense): since',
+                                                         '1.0')
   end
 
   it 'returns applications that are in a viewable state' do

--- a/spec/requests/vendor_api/v1.0/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/v1.0/get_multiple_applications_spec.rb
@@ -57,8 +57,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response).to contain_schema_with_error('ParameterMissingResponse',
-                                                         'param is missing or the value is empty: since',
-                                                         '1.0')
+                                                         'param is missing or the value is empty: since')
   end
 
   it 'returns HTTP status 422 given an unparseable `since` date value' do
@@ -66,8 +65,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
-                                                         'Parameter is invalid (should be ISO8601): since',
-                                                         '1.0')
+                                                         'Parameter is invalid (should be ISO8601): since')
   end
 
   it 'returns HTTP status 422 when encountering a KeyError from ActiveSupport::TimeZone' do
@@ -75,8 +73,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
-                                                         'Parameter is invalid (should be ISO8601): since',
-                                                         '1.0')
+                                                         'Parameter is invalid (should be ISO8601): since')
   end
 
   it 'returns HTTP status 422 given a parseable but nonsensensical `since` date value' do
@@ -85,8 +82,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
     expect(response).to have_http_status(:unprocessable_entity)
 
     expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
-                                                         'Parameter is invalid (date is nonsense): since',
-                                                         '1.0')
+                                                         'Parameter is invalid (date is nonsense): since')
   end
 
   it 'returns applications that are in a viewable state' do

--- a/spec/requests/vendor_api/v1.0/get_single_application_spec.rb
+++ b/spec/requests/vendor_api/v1.0/get_single_application_spec.rb
@@ -14,23 +14,23 @@ RSpec.describe 'Vendor API - GET /api/v1/applications/:application_id', type: :r
     expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
   end
 
-  it 'returns a not found error if the application cannot be found' do
+  it 'returns a NotFoundResponse if the application cannot be found' do
     get_api_request '/api/v1/applications/asu7dvt87asd'
 
     expect(response).to have_http_status(:not_found)
-
-    expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
-
-    expect(error_response['message']).to eql('Could not find an application with ID asu7dvt87asd')
+    expect(parsed_response).to contain_schema_with_error('NotFoundResponse',
+                                                         'Could not find an application with ID asu7dvt87asd',
+                                                         '1.0')
   end
 
-  it 'returns a not found error if the application does not belong to the provider' do
+  it 'returns a NotFoundResponse if the application does not belong to the provider' do
     application_choice = create(:application_choice)
 
     get_api_request "/api/v1/applications/#{application_choice.id}"
 
     expect(response).to have_http_status(:not_found)
-    expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
-    expect(error_response['message']).to eql("Could not find an application with ID #{application_choice.id}")
+    expect(parsed_response).to contain_schema_with_error('NotFoundResponse',
+                                                         "Could not find an application with ID #{application_choice.id}",
+                                                         '1.0')
   end
 end

--- a/spec/requests/vendor_api/v1.0/get_single_application_spec.rb
+++ b/spec/requests/vendor_api/v1.0/get_single_application_spec.rb
@@ -18,9 +18,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications/:application_id', type: :r
     get_api_request '/api/v1/applications/asu7dvt87asd'
 
     expect(response).to have_http_status(:not_found)
-    expect(parsed_response).to contain_schema_with_error('NotFoundResponse',
-                                                         'Could not find an application with ID asu7dvt87asd',
-                                                         '1.0')
+    expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)', '1.0')
   end
 
   it 'returns a NotFoundResponse if the application does not belong to the provider' do
@@ -29,8 +27,6 @@ RSpec.describe 'Vendor API - GET /api/v1/applications/:application_id', type: :r
     get_api_request "/api/v1/applications/#{application_choice.id}"
 
     expect(response).to have_http_status(:not_found)
-    expect(parsed_response).to contain_schema_with_error('NotFoundResponse',
-                                                         "Could not find an application with ID #{application_choice.id}",
-                                                         '1.0')
+    expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)', '1.0')
   end
 end

--- a/spec/requests/vendor_api/v1.0/get_single_application_spec.rb
+++ b/spec/requests/vendor_api/v1.0/get_single_application_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications/:application_id', type: :r
     get_api_request '/api/v1/applications/asu7dvt87asd'
 
     expect(response).to have_http_status(:not_found)
-    expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)', '1.0')
+    expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)')
   end
 
   it 'returns a NotFoundResponse if the application does not belong to the provider' do
@@ -27,6 +27,6 @@ RSpec.describe 'Vendor API - GET /api/v1/applications/:application_id', type: :r
     get_api_request "/api/v1/applications/#{application_choice.id}"
 
     expect(response).to have_http_status(:not_found)
-    expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)', '1.0')
+    expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)')
   end
 end

--- a/spec/requests/vendor_api/v1.0/post_conditions_met_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_conditions_met_spec.rb
@@ -26,17 +26,13 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-conditio
     expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response)
       .to contain_schema_with_error('UnprocessableEntityResponse',
-                                    "It's not possible to perform this action while the application is in its current state",
-                                    '1.0')
+                                    "It's not possible to perform this action while the application is in its current state")
   end
 
   it 'returns a NotFoundResponse when the application was not found' do
     post_api_request '/api/v1/applications/non-existent-id/confirm-conditions-met'
 
     expect(response).to have_http_status(:not_found)
-    expect(parsed_response)
-      .to contain_schema_with_error('NotFoundResponse',
-                                    'Unable to find Application(s)',
-                                    '1.0')
+    expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)')
   end
 end

--- a/spec/requests/vendor_api/v1.0/post_conditions_met_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_conditions_met_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-conditio
     expect(response).to have_http_status(:not_found)
     expect(parsed_response)
       .to contain_schema_with_error('NotFoundResponse',
-                                    'Could not find an application with ID non-existent-id',
+                                    'Unable to find Application(s)',
                                     '1.0')
   end
 end

--- a/spec/requests/vendor_api/v1.0/post_conditions_met_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_conditions_met_spec.rb
@@ -18,21 +18,25 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-conditio
     expect(parsed_response['data']['attributes']['status']).to eq 'recruited'
   end
 
-  it 'returns an error when trying to transition to an invalid state' do
+  it 'returns an UnprocessableEntityResponse when trying to transition to an invalid state' do
     application_choice = create_application_choice_for_currently_authenticated_provider(status: 'rejected')
 
     post_api_request "/api/v1/applications/#{application_choice.id}/confirm-conditions-met", params: {}
 
     expect(response).to have_http_status(:unprocessable_entity)
-    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-    expect(error_response['message']).to eq "It's not possible to perform this action while the application is in its current state"
+    expect(parsed_response)
+      .to contain_schema_with_error('UnprocessableEntityResponse',
+                                    "It's not possible to perform this action while the application is in its current state",
+                                    '1.0')
   end
 
-  it 'returns not found error when the application was not found' do
+  it 'returns a NotFoundResponse when the application was not found' do
     post_api_request '/api/v1/applications/non-existent-id/confirm-conditions-met'
 
     expect(response).to have_http_status(:not_found)
-    expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
-    expect(error_response['message']).to eql('Could not find an application with ID non-existent-id')
+    expect(parsed_response)
+      .to contain_schema_with_error('NotFoundResponse',
+                                    'Could not find an application with ID non-existent-id',
+                                    '1.0')
   end
 end

--- a/spec/requests/vendor_api/v1.0/post_confirm_enrolment_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_confirm_enrolment_spec.rb
@@ -30,9 +30,6 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-enrolmen
     post_api_request '/api/v1/applications/non-existent-id/confirm-enrolment'
 
     expect(response).to have_http_status(:not_found)
-    expect(parsed_response)
-      .to contain_schema_with_error('NotFoundResponse',
-                                    'Could not find an application with ID non-existent-id',
-                                    '1.0')
+    expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)', '1.0')
   end
 end

--- a/spec/requests/vendor_api/v1.0/post_confirm_enrolment_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_confirm_enrolment_spec.rb
@@ -30,6 +30,6 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-enrolmen
     post_api_request '/api/v1/applications/non-existent-id/confirm-enrolment'
 
     expect(response).to have_http_status(:not_found)
-    expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)', '1.0')
+    expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)')
   end
 end

--- a/spec/requests/vendor_api/v1.0/post_confirm_enrolment_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_confirm_enrolment_spec.rb
@@ -26,11 +26,13 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-enrolmen
     expect(Sentry).to have_received(:capture_exception)
   end
 
-  it 'returns a not found error when the application was not found' do
+  it 'returns a NotFoundResponse when the application was not found' do
     post_api_request '/api/v1/applications/non-existent-id/confirm-enrolment'
 
     expect(response).to have_http_status(:not_found)
-    expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
-    expect(error_response['message']).to eql('Could not find an application with ID non-existent-id')
+    expect(parsed_response)
+      .to contain_schema_with_error('NotFoundResponse',
+                                    'Could not find an application with ID non-existent-id',
+                                    '1.0')
   end
 end

--- a/spec/requests/vendor_api/v1.0/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_make_an_offer_spec.rb
@@ -267,10 +267,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       post_api_request '/api/v1/applications/non-existent-id/offer', params: request_body
 
       expect(response).to have_http_status(:not_found)
-      expect(parsed_response)
-        .to contain_schema_with_error('NotFoundResponse',
-                                      'Could not find an application with ID non-existent-id',
-                                      '1.0')
+      expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)', '1.0')
     end
 
     it 'does not process the conditions if they are not provided correctly' do

--- a/spec/requests/vendor_api/v1.0/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_make_an_offer_spec.rb
@@ -159,8 +159,10 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       }
 
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-      expect(error_response['message']).to match 'The specified course is not associated with any of your organisations.'
+      expect(parsed_response)
+        .to contain_schema_with_error('UnprocessableEntityResponse',
+                                      'The specified course is not associated with any of your organisations.',
+                                      '1.0')
     end
 
     it 'logs the actual error in a VendorAPIRequest when a 422 is returned', sidekiq: true do
@@ -205,8 +207,9 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       }
 
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-      expect(error_response['message']).to match 'Provider ABC does not exist'
+      expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                           'Provider ABC does not exist',
+                                                           '1.0')
     end
 
     it 'returns an error when specifying ambiguous course parameters' do
@@ -231,8 +234,10 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       }
 
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-      expect(error_response['message']).to match "Found multiple full_time options for course #{course_payload['course_code']}"
+      expect(parsed_response)
+        .to contain_schema_with_error('UnprocessableEntityResponse',
+                                      "Found multiple full_time options for course #{course_payload['course_code']}",
+                                      '1.0')
     end
 
     it 'returns an error when trying to transition to an invalid state' do
@@ -243,11 +248,13 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: { data: { conditions: [] } }
 
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-      expect(error_response['message']).to eq "It's not possible to perform this action while the application is in its current state"
+      expect(parsed_response)
+        .to contain_schema_with_error('UnprocessableEntityResponse',
+                                      "It's not possible to perform this action while the application is in its current state",
+                                      '1.0')
     end
 
-    it 'returns a not found error if the application cannot be found' do
+    it 'returns a NotFoundResponse if the application cannot be found' do
       request_body = {
         data: {
           conditions: [
@@ -260,8 +267,10 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       post_api_request '/api/v1/applications/non-existent-id/offer', params: request_body
 
       expect(response).to have_http_status(:not_found)
-      expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
-      expect(error_response['message']).to eql('Could not find an application with ID non-existent-id')
+      expect(parsed_response)
+        .to contain_schema_with_error('NotFoundResponse',
+                                      'Could not find an application with ID non-existent-id',
+                                      '1.0')
     end
 
     it 'does not process the conditions if they are not provided correctly' do

--- a/spec/requests/vendor_api/v1.0/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_make_an_offer_spec.rb
@@ -161,8 +161,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       expect(response).to have_http_status(:unprocessable_entity)
       expect(parsed_response)
         .to contain_schema_with_error('UnprocessableEntityResponse',
-                                      'The specified course is not associated with any of your organisations.',
-                                      '1.0')
+                                      'The specified course is not associated with any of your organisations.')
     end
 
     it 'logs the actual error in a VendorAPIRequest when a 422 is returned', sidekiq: true do
@@ -207,9 +206,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       }
 
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
-                                                           'Provider ABC does not exist',
-                                                           '1.0')
+      expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse', 'Provider ABC does not exist')
     end
 
     it 'returns an error when specifying ambiguous course parameters' do
@@ -236,8 +233,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       expect(response).to have_http_status(:unprocessable_entity)
       expect(parsed_response)
         .to contain_schema_with_error('UnprocessableEntityResponse',
-                                      "Found multiple full_time options for course #{course_payload['course_code']}",
-                                      '1.0')
+                                      "Found multiple full_time options for course #{course_payload['course_code']}")
     end
 
     it 'returns an error when trying to transition to an invalid state' do
@@ -250,8 +246,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       expect(response).to have_http_status(:unprocessable_entity)
       expect(parsed_response)
         .to contain_schema_with_error('UnprocessableEntityResponse',
-                                      "It's not possible to perform this action while the application is in its current state",
-                                      '1.0')
+                                      "It's not possible to perform this action while the application is in its current state")
     end
 
     it 'returns a NotFoundResponse if the application cannot be found' do
@@ -267,7 +262,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       post_api_request '/api/v1/applications/non-existent-id/offer', params: request_body
 
       expect(response).to have_http_status(:not_found)
-      expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)', '1.0')
+      expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)')
     end
 
     it 'does not process the conditions if they are not provided correctly' do

--- a/spec/requests/vendor_api/v1.0/post_reject_application_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_reject_application_spec.rb
@@ -60,8 +60,10 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
     post_api_request "/api/v1/applications/#{application_choice.id}/reject", params: request_body
 
     expect(response).to have_http_status(:unprocessable_entity)
-    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-    expect(error_response['message']).to eq "It's not possible to perform this action while the application is in its current state"
+    expect(parsed_response)
+      .to contain_schema_with_error('UnprocessableEntityResponse',
+                                    "It's not possible to perform this action while the application is in its current state",
+                                    '1.0')
   end
 
   it 'returns an error when a proper reason is not provided' do
@@ -76,15 +78,19 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
     }
 
     expect(response).to have_http_status(:unprocessable_entity)
-    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-    expect(error_response['message']).to eql 'Rejection reason Explain why you’re rejecting the application'
+    expect(parsed_response)
+      .to contain_schema_with_error('UnprocessableEntityResponse',
+                                    'Rejection reason Explain why you’re rejecting the application',
+                                    '1.0')
   end
 
   it 'returns not found error when the application was not found' do
     post_api_request '/api/v1/applications/non-existent-id/reject'
 
     expect(response).to have_http_status(:not_found)
-    expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
-    expect(error_response['message']).to eql('Could not find an application with ID non-existent-id')
+    expect(parsed_response)
+      .to contain_schema_with_error('NotFoundResponse',
+                                    'Could not find an application with ID non-existent-id',
+                                    '1.0')
   end
 end

--- a/spec/requests/vendor_api/v1.0/post_reject_application_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_reject_application_spec.rb
@@ -62,8 +62,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
     expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response)
       .to contain_schema_with_error('UnprocessableEntityResponse',
-                                    "It's not possible to perform this action while the application is in its current state",
-                                    '1.0')
+                                    "It's not possible to perform this action while the application is in its current state")
   end
 
   it 'returns an error when a proper reason is not provided' do
@@ -80,8 +79,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
     expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response)
       .to contain_schema_with_error('UnprocessableEntityResponse',
-                                    'Rejection reason Explain why you’re rejecting the application',
-                                    '1.0')
+                                    'Rejection reason Explain why you’re rejecting the application')
   end
 
   it 'returns not found error when the application was not found' do
@@ -89,8 +87,6 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
 
     expect(response).to have_http_status(:not_found)
     expect(parsed_response)
-      .to contain_schema_with_error('NotFoundResponse',
-                                    'Unable to find Application(s)',
-                                    '1.0')
+      .to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)')
   end
 end

--- a/spec/requests/vendor_api/v1.0/post_reject_application_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_reject_application_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
     expect(response).to have_http_status(:not_found)
     expect(parsed_response)
       .to contain_schema_with_error('NotFoundResponse',
-                                    'Could not find an application with ID non-existent-id',
+                                    'Unable to find Application(s)',
                                     '1.0')
   end
 end

--- a/spec/requests/vendor_api/v1.1/create_notes_spec.rb
+++ b/spec/requests/vendor_api/v1.1/create_notes_spec.rb
@@ -27,15 +27,17 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/notes/create', t
     post_api_request "/api/v1.1/applications/#{application_choice.id}/notes/create", params: { data: { wrong_param: '' } }
 
     expect(response).to have_http_status(:unprocessable_entity)
-    expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse', '1.1')
-    expect(parsed_response['errors'].map { |error| error['message'] })
-      .to contain_exactly('param is missing or the value is empty: message')
+    expect(parsed_response).to contain_schema_with_error('ParameterMissingResponse',
+                                                         'param is missing or the value is empty: message',
+                                                         '1.1')
   end
 
   it 'responds with 404 when the application is not valid for the request' do
     post_api_request "/api/v1.1/applications/#{build_stubbed(:application_choice).id}/notes/create", params: note_payload
 
     expect(response).to have_http_status(:not_found)
-    expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse', '1.1')
+    expect(parsed_response).to contain_schema_with_error('NotFoundResponse',
+                                                         'Unable to find Application(s)',
+                                                         '1.1')
   end
 end

--- a/spec/requests/vendor_api/v1.1/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/v1.1/get_multiple_applications_spec.rb
@@ -151,7 +151,9 @@ RSpec.describe 'Vendor API - GET /api/v1.1/applications', type: :request do
       get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=3&per_page=2"
 
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(error_response['message']).to eql("expected 'page' parameter to be between 1 and 2, got 3")
+      expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                           "expected 'page' parameter to be between 1 and 2, got 3",
+                                                           '1.1')
     end
 
     it 'returns HTTP status 422 when given a parseable per_page value that exceeds the max value' do
@@ -167,7 +169,9 @@ RSpec.describe 'Vendor API - GET /api/v1.1/applications', type: :request do
       get_api_request "/api/v1.1/applications?since=#{CGI.escape(1.day.ago.iso8601)}&page=1&per_page=#{max_value + 1}"
 
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(error_response['message']).to eql("The 'per_page' parameter cannot exceed #{max_value} results per page")
+      expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                           "The 'per_page' parameter cannot exceed #{max_value} results per page",
+                                                           '1.1')
     end
   end
 end

--- a/spec/requests/vendor_api/v1.1/post_cancel_interview_spec.rb
+++ b/spec/requests/vendor_api/v1.1/post_cancel_interview_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
-                                                             'Cancellation reason must be 10240 characters or fewer')
+                                                             'Cancellation reason must be 10240 characters or fewer',
+                                                             '1.1')
       end
     end
 
@@ -49,7 +50,8 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
-                                                             'The interview cannot be changed as it is in the past')
+                                                             'The interview cannot be changed as it is in the past',
+                                                             '1.1')
       end
     end
 
@@ -63,7 +65,8 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
-                                                             'The interview cannot be changed as it has already been cancelled')
+                                                             'The interview cannot be changed as it has already been cancelled',
+                                                             '1.1')
       end
     end
 
@@ -71,11 +74,11 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
       let(:provider) { create(:provider) }
       let(:api_token) { VendorAPIToken.create_with_random_token!(provider: provider) }
 
-      it 'fails and renders an Not Found response' do
+      it 'fails and renders a NotFoundResponse' do
         post_cancellation! reason: 'A reason'
 
         expect(response).to have_http_status(:not_found)
-        expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)')
+        expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)', '1.1')
       end
     end
 
@@ -83,12 +86,13 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
       context 'data' do
         let(:request_data) { { data: {} } }
 
-        it 'fails and renders a MissingParameterResponse' do
+        it 'fails and renders a ParameterMissingResponse' do
           post_api_request "/api/v1.1/applications/#{application_choice.id}/interviews/#{interview.id}/cancel", params: request_data
 
           expect(response).to have_http_status(:unprocessable_entity)
           expect(parsed_response).to contain_schema_with_error('ParameterMissingResponse',
-                                                               'param is missing or the value is empty: data')
+                                                               'param is missing or the value is empty: data',
+                                                               '1.1')
         end
       end
 
@@ -97,12 +101,13 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
           { data: { cancellation_reason: nil } }
         end
 
-        it 'fails and renders a MissingParameterResponse' do
+        it 'fails and renders a ParameterMissingResponse' do
           post_api_request "/api/v1.1/applications/#{application_choice.id}/interviews/#{interview.id}/cancel", params: request_data
 
           expect(response).to have_http_status(:unprocessable_entity)
           expect(parsed_response).to contain_schema_with_error('ParameterMissingResponse',
-                                                               'param is missing or the value is empty: reason')
+                                                               'param is missing or the value is empty: reason',
+                                                               '1.1')
         end
       end
     end

--- a/spec/requests/vendor_api/v1.1/post_cancel_interview_spec.rb
+++ b/spec/requests/vendor_api/v1.1/post_cancel_interview_spec.rb
@@ -32,26 +32,24 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
     end
 
     context 'reason too long' do
-      it 'fails and renders an Unprocessable Entity error' do
+      it 'fails and renders an UnprocessableEntityResponse' do
         post_cancellation! reason: 'A' * 10241, skip_schema_check: true
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('Cancellation reason must be 10240 characters or fewer')
+        expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                             'Cancellation reason must be 10240 characters or fewer')
       end
     end
 
     context 'in the past' do
-      it 'fails and renders an Unprocessable Entity error' do
+      it 'fails and renders an UnprocessableEntityResponse' do
         application_choice.interviews.first.update_columns(date_and_time: 1.day.ago)
 
         post_cancellation! reason: 'A reason'
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('The interview cannot be changed as it is in the past')
+        expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                             'The interview cannot be changed as it is in the past')
       end
     end
 
@@ -60,13 +58,12 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
         create_application_choice_for_currently_authenticated_provider({}, :with_cancelled_interview)
       end
 
-      it 'fails and renders an Unprocessable Entity error' do
+      it 'fails and renders a UnprocessableEntityResponse' do
         post_cancellation! reason: 'A reason'
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('The interview cannot be changed as it has already been cancelled')
+        expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                             'The interview cannot be changed as it has already been cancelled')
       end
     end
 
@@ -78,9 +75,7 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
         post_cancellation! reason: 'A reason'
 
         expect(response).to have_http_status(:not_found)
-        expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('Unable to find Application(s)')
+        expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)')
       end
     end
 
@@ -92,9 +87,8 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
           post_api_request "/api/v1.1/applications/#{application_choice.id}/interviews/#{interview.id}/cancel", params: request_data
 
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse', '1.1')
-          expect(parsed_response['errors'].map { |error| error['message'] })
-            .to contain_exactly('param is missing or the value is empty: data')
+          expect(parsed_response).to contain_schema_with_error('ParameterMissingResponse',
+                                                               'param is missing or the value is empty: data')
         end
       end
 
@@ -107,9 +101,8 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
           post_api_request "/api/v1.1/applications/#{application_choice.id}/interviews/#{interview.id}/cancel", params: request_data
 
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse', '1.1')
-          expect(parsed_response['errors'].map { |error| error['message'] })
-            .to contain_exactly('param is missing or the value is empty: reason')
+          expect(parsed_response).to contain_schema_with_error('ParameterMissingResponse',
+                                                               'param is missing or the value is empty: reason')
         end
       end
     end

--- a/spec/requests/vendor_api/v1.1/post_confirm_deferred_offer_spec.rb
+++ b/spec/requests/vendor_api/v1.1/post_confirm_deferred_offer_spec.rb
@@ -40,18 +40,18 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/confirm
         post_api_request "/api/v1.1/applications/#{application_choice.id}/confirm-deferred-offer", params: { data: {} }
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('param is missing or the value is empty: data')
+        expect(parsed_response).to contain_schema_with_error('ParameterMissingResponse',
+                                                             'param is missing or the value is empty: data',
+                                                             '1.1')
       end
 
       it 'when `conditions_met` is missing from the request_body it renders an error' do
         post_api_request "/api/v1.1/applications/#{application_choice.id}/confirm-deferred-offer", params: { data: { any_param: '' } }
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('param is missing or the value is empty: conditions_met')
+        expect(parsed_response).to contain_schema_with_error('ParameterMissingResponse',
+                                                             'param is missing or the value is empty: conditions_met',
+                                                             '1.1')
       end
     end
   end
@@ -60,26 +60,26 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/confirm
     context 'when the application is not in a state that allows offer deferal' do
       let(:application_trait) { :with_offer }
 
-      it 'renders an Unprocessable Entity error' do
+      it 'renders an UnprocessableEntityResponse' do
         post_api_request "/api/v1.1/applications/#{application_choice.id}/confirm-deferred-offer", params: request_body
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly("It's not possible to perform this action while the application is in its current state")
+        expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                             "It's not possible to perform this action while the application is in its current state",
+                                                             '1.1')
       end
     end
 
     context 'when the offered course does not exist in the new cycle' do
       let(:original_course_option) { create(:course_option, course: original_course) }
 
-      it 'renders an Unprocessable Entity error' do
+      it 'renders an UnprocessableEntityResponse' do
         post_api_request "/api/v1.1/applications/#{application_choice.id}/confirm-deferred-offer", params: request_body
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('The offered course does not exist in this recruitment cycle')
+        expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                             'The offered course does not exist in this recruitment cycle',
+                                                             '1.1')
       end
     end
 
@@ -96,13 +96,13 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/confirm
                course: original_course)
       end
 
-      it 'renders an Unprocessable Entity error' do
+      it 'renders an UnprocessableEntityResponse' do
         post_api_request "/api/v1.1/applications/#{application_choice.id}/confirm-deferred-offer", params: request_body
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('Only applications deferred in the previous recruitment cycle can be confirmed')
+        expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                             'Only applications deferred in the previous recruitment cycle can be confirmed',
+                                                             '1.1')
       end
     end
 
@@ -111,13 +111,11 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/confirm
         create(:application_choice, :awaiting_provider_decision)
       end
 
-      it 'renders a NotFound error' do
+      it 'renders a NotFoundResponse' do
         post_api_request "/api/v1.1/applications/#{application_choice.id}/confirm-deferred-offer", params: request_body
 
         expect(response).to have_http_status(:not_found)
-        expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
-        expect(parsed_response['errors'].map { |error| error['error'] })
-          .to contain_exactly('NotFound')
+        expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)', '1.1')
       end
     end
 

--- a/spec/requests/vendor_api/v1.1/post_create_interview_spec.rb
+++ b/spec/requests/vendor_api/v1.1/post_create_interview_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
-                                                             'Cannot schedule interview in the past')
+                                                             'Cannot schedule interview in the past',
+                                                             '1.1')
       end
     end
 
@@ -70,7 +71,8 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
-                                                             'Provider must be training or ratifying provider')
+                                                             'Provider must be training or ratifying provider',
+                                                             '1.1')
       end
     end
 
@@ -93,7 +95,8 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
-                                                             'Application is not in an interviewing state')
+                                                             'Application is not in an interviewing state',
+                                                             '1.1')
       end
     end
 
@@ -109,25 +112,25 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
       let(:provider) { create(:provider) }
       let(:api_token) { VendorAPIToken.create_with_random_token!(provider: provider) }
 
-      it 'fails and renders a NotFound response' do
+      it 'fails and renders a NotFoundResponse' do
         post_interview! params: create_interview_params
 
         expect(response).to have_http_status(:not_found)
-        expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('Unable to find Application(s)')
+        expect(parsed_response).to contain_schema_with_error('NotFoundResponse',
+                                                             'Unable to find Application(s)',
+                                                             '1.1')
       end
     end
 
     context 'when missing parameters' do
       context 'data' do
-        it 'fails and renders a MissingParameterResponse' do
+        it 'fails and renders a ParameterMissingResponse' do
           post_api_request "/api/v1.1/applications/#{application_choice.id}/interviews/create", params: {}
 
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse', '1.1')
-          expect(parsed_response['errors'].map { |error| error['message'] })
-            .to contain_exactly('param is missing or the value is empty: data')
+          expect(parsed_response).to contain_schema_with_error('ParameterMissingResponse',
+                                                               'param is missing or the value is empty: data',
+                                                               '1.1')
         end
       end
 
@@ -140,13 +143,13 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
           }
         end
 
-        it 'fails and renders a MissingParameterResponse' do
+        it 'fails and renders a ParameterMissingResponse' do
           post_api_request "/api/v1.1/applications/#{application_choice.id}/interviews/create", params: { data: interview_params }
 
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse', '1.1')
-          expect(parsed_response['errors'].map { |error| error['message'] })
-            .to contain_exactly('param is missing or the value is empty: date_and_time')
+          expect(parsed_response).to contain_schema_with_error('ParameterMissingResponse',
+                                                               'param is missing or the value is empty: date_and_time',
+                                                               '1.1')
         end
       end
 
@@ -159,13 +162,13 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
           }
         end
 
-        it 'fails and renders a MissingParameterResponse' do
+        it 'fails and renders a ParameterMissingResponse' do
           post_api_request "/api/v1.1/applications/#{application_choice.id}/interviews/create", params: { data: interview_params }
 
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse', '1.1')
-          expect(parsed_response['errors'].map { |error| error['message'] })
-            .to contain_exactly('param is missing or the value is empty: provider_code')
+          expect(parsed_response).to contain_schema_with_error('ParameterMissingResponse',
+                                                               'param is missing or the value is empty: provider_code',
+                                                               '1.1')
         end
       end
 
@@ -178,13 +181,13 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
           }
         end
 
-        it 'fails and renders a MissingParameterResponse' do
+        it 'fails and renders a ParameterMissingResponse' do
           post_api_request "/api/v1.1/applications/#{application_choice.id}/interviews/create", params: { data: interview_params }
 
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse', '1.1')
-          expect(parsed_response['errors'].map { |error| error['message'] })
-            .to contain_exactly('param is missing or the value is empty: location')
+          expect(parsed_response).to contain_schema_with_error('ParameterMissingResponse',
+                                                               'param is missing or the value is empty: location',
+                                                               '1.1')
         end
       end
 

--- a/spec/requests/vendor_api/v1.1/post_create_interview_spec.rb
+++ b/spec/requests/vendor_api/v1.1/post_create_interview_spec.rb
@@ -46,13 +46,12 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
         }
       end
 
-      it 'fails and renders an Unprocessable Entity error' do
+      it 'fails and renders an UnprocessableEntityResponse' do
         post_interview! params: create_interview_params
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('Cannot schedule interview in the past')
+        expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                             'Cannot schedule interview in the past')
       end
     end
 
@@ -66,13 +65,12 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
         }
       end
 
-      it 'fails and renders an Unprocessable Entity error' do
+      it 'fails and renders an UnprocessableEntityResponse' do
         post_interview! params: create_interview_params
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('Provider must be training or ratifying provider')
+        expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                             'Provider must be training or ratifying provider')
       end
     end
 
@@ -90,13 +88,12 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
         }
       end
 
-      it 'fails and renders an Unprocessable Entity error' do
+      it 'fails and renders an UnprocessableEntityResponse' do
         post_interview! params: create_interview_params
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('Application is not in an interviewing state')
+        expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                             'Application is not in an interviewing state')
       end
     end
 
@@ -112,7 +109,7 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
       let(:provider) { create(:provider) }
       let(:api_token) { VendorAPIToken.create_with_random_token!(provider: provider) }
 
-      it 'fails and renders an Not Found response' do
+      it 'fails and renders a NotFound response' do
         post_interview! params: create_interview_params
 
         expect(response).to have_http_status(:not_found)

--- a/spec/requests/vendor_api/v1.1/post_defer_offer_spec.rb
+++ b/spec/requests/vendor_api/v1.1/post_defer_offer_spec.rb
@@ -11,13 +11,14 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/defer-o
     end
 
     describe 'when the application is not in a state that allows offer deferal' do
-      it 'renders an Unprocessable Entity error' do
+      it 'renders an UnprocessableEntityResponse' do
         post_api_request "/api/v1.1/applications/#{application_choice.id}/defer-offer"
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly("It's not possible to perform this action while the application is in its current state")
+        expect(parsed_response)
+          .to contain_schema_with_error('UnprocessableEntityResponse',
+                                        "It's not possible to perform this action while the application is in its current state",
+                                        '1.1')
       end
     end
 
@@ -26,13 +27,13 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/defer-o
         create(:application_choice, :awaiting_provider_decision)
       end
 
-      it 'renders a NotFound error' do
+      it 'renders a NotFoundResponse' do
         post_api_request "/api/v1.1/applications/#{application_choice.id}/defer-offer"
 
         expect(response).to have_http_status(:not_found)
-        expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('Unable to find Application(s)')
+        expect(parsed_response).to contain_schema_with_error('NotFoundResponse',
+                                                             'Unable to find Application(s)',
+                                                             '1.1')
       end
     end
 

--- a/spec/requests/vendor_api/v1.1/post_update_interview_spec.rb
+++ b/spec/requests/vendor_api/v1.1/post_update_interview_spec.rb
@@ -49,17 +49,17 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
         }
       end
 
-      it 'fails and renders an Unprocessable Entity error' do
+      it 'fails and renders an UnprocessableEntityResponse' do
         post_interview! params: update_interview_params
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('Cannot re-schedule interview in the past')
+        expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                             'Cannot re-schedule interview in the past',
+                                                             '1.1')
       end
     end
 
-    context 'a cancelled interview (WorkflowError)' do
+    context 'a cancelled interview' do
       let(:interview) { create(:interview, :cancelled, application_choice: application_choice) }
       let(:update_interview_params) do
         {
@@ -70,17 +70,18 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
         }
       end
 
-      it 'fails and renders an Unprocessable Entity error' do
+      it 'fails and renders an UnprocessableEntityResponse' do
         post_interview! params: update_interview_params
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('The interview cannot be changed as it has already been cancelled')
+        expect(parsed_response)
+          .to contain_schema_with_error('UnprocessableEntityResponse',
+                                        'The interview cannot be changed as it has already been cancelled',
+                                        '1.1')
       end
     end
 
-    context 'wrong provider code (ValidationError)' do
+    context 'wrong provider code' do
       let(:update_interview_params) do
         {
           provider_code: create(:provider).code,
@@ -90,13 +91,13 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
         }
       end
 
-      it 'fails and renders an Unprocessable Entity error' do
+      it 'fails and renders an UnprocessableEntityResponse' do
         post_interview! params: update_interview_params
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('Provider must be training or ratifying provider')
+        expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                             'Provider must be training or ratifying provider',
+                                                             '1.1')
       end
     end
 
@@ -123,13 +124,13 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
         }
       end
 
-      it 'fails and renders an Unprocessable Entity error' do
+      it 'fails and renders an UnprocessableEntityResponse' do
         post_interview! params: update_interview_params, skip_validation: true
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('Provider code is not valid')
+        expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                             'Provider code is not valid',
+                                                             '1.1')
       end
     end
 
@@ -140,13 +141,13 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
         }
       end
 
-      it 'fails and renders an Unprocessable Entity error' do
+      it 'fails and renders an UnprocessableEntityResponse' do
         post_interview! params: update_interview_params, skip_validation: true
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('Date string provided is not a valid date')
+        expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
+                                                             'Date string provided is not a valid date',
+                                                             '1.1')
       end
     end
 
@@ -158,25 +159,25 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/intervi
         }
       end
 
-      it 'fails and renders a NotFoundResponse error' do
+      it 'fails and renders a NotFoundResponse' do
         post_interview! params: update_interview_params, skip_validation: true
 
         expect(response).to have_http_status(:not_found)
-        expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
-        expect(parsed_response['errors'].map { |error| error['message'] })
-          .to contain_exactly('Unable to find Interview(s)')
+        expect(parsed_response).to contain_schema_with_error('NotFoundResponse',
+                                                             'Unable to find Interview(s)',
+                                                             '1.1')
       end
     end
 
     context 'when missing parameters' do
       context 'data' do
-        it 'fails and renders a MissingParameterResponse' do
+        it 'fails and renders a ParameterMissingResponse' do
           post_api_request "/api/v1.1/applications/#{application_choice.id}/interviews/create", params: {}
 
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse', '1.1')
-          expect(parsed_response['errors'].map { |error| error['message'] })
-            .to contain_exactly('param is missing or the value is empty: data')
+          expect(parsed_response).to contain_schema_with_error('ParameterMissingResponse',
+                                                               'param is missing or the value is empty: data',
+                                                               '1.1')
         end
       end
     end

--- a/spec/support/vendor_api/shared_examples.rb
+++ b/spec/support/vendor_api/shared_examples.rb
@@ -24,7 +24,7 @@ RSpec.shared_examples 'an endpoint that requires metadata' do |action, version =
 
     expect(errors.count).to eq(2)
 
-    expect(errors.map { |e| e['error'] }).to all(eq 'ValidationError')
+    expect(errors.map { |e| e['error'] }).to all(eq 'UnprocessableEntity')
     expect(errors.map { |e| e['message'] }).to include(
       "meta.timestamp can't be blank",
       "meta.attribution is invalid: full_name can't be blank, email can't be blank, and user_id can't be blank",

--- a/spec/support/vendor_api/vendor_api_spec_helpers.rb
+++ b/spec/support/vendor_api/vendor_api_spec_helpers.rb
@@ -70,9 +70,11 @@ module VendorAPISpecHelpers
   end
 
   RSpec::Matchers.define :contain_schema_with_error do |schema, message, version = nil, draft = false|
-    ValidAgainstOpenAPISchemaMatcher.new(schema, VendorAPISpecification.new(version: version, draft: draft).as_hash)
     match do |actual|
-      actual['errors'].first['message'].eql?(message)
+      ValidAgainstOpenAPISchemaMatcher.new(schema,
+                                           VendorAPISpecification.new(version: version,
+                                                                      draft: draft).as_hash).matches?(actual)
+      (actual['errors'].map { |error| error['message'] } - [message]).empty?
     end
   end
 end

--- a/spec/support/vendor_api/vendor_api_spec_helpers.rb
+++ b/spec/support/vendor_api/vendor_api_spec_helpers.rb
@@ -68,4 +68,11 @@ module VendorAPISpecHelpers
   def be_valid_against_draft_openapi_schema(expected, version = nil)
     be_valid_against_openapi_schema(expected, version, draft: true)
   end
+
+  RSpec::Matchers.define :contain_schema_with_error do |schema, message, version = nil, draft = false|
+    ValidAgainstOpenAPISchemaMatcher.new(schema, VendorAPISpecification.new(version: version, draft: draft).as_hash)
+    match do |actual|
+      actual['errors'].first['message'].eql?(message)
+    end
+  end
 end


### PR DESCRIPTION
## Changes proposed in this pull request

- Changed all unprocessable entity errors to return `UnprocessableEntityResponse` as part of error JSON for consistency
- Introduced new matches that  checks for errors name and message for simplicity 
- Changed unauthorised error to return `Unauthorised` instead of `NotAuthorised` to match API docs
- Removed custom validation errors
- Reuse APIValidationsAndErrorHandling across all VendorAPI controllers
- Improved example wording in relation to expected errors and tested against specific API versions
<!-- If there are UI changes, please include Before and After screenshots. -->

## Link to Trello card

https://trello.com/c/Ag22HqdJ/4816-api-cleanup-standardise-error-codes-and-types

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
