### PR TITLE
Withhold publication of Feb XR

### DIFF
--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -39,8 +39,8 @@ module Publications
     def current_report
       if params[:month].present?
         MonthlyStatisticsTimetable.report_for(params[:month])
-      elsif FeatureFlag.active? :lock_external_report_to_december_2021
-        MonthlyStatisticsTimetable.report_for('2021-12')
+      elsif FeatureFlag.active? :lock_external_report_to_january_2022
+        MonthlyStatisticsTimetable.report_for('2022-01')
       else
         MonthlyStatisticsTimetable.report_for_current_period
       end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -21,7 +21,7 @@ class FeatureFlag
     [:service_unavailable_page, 'Displays a maintenance page on the whole application', 'Apply team'],
     [:send_request_data_to_bigquery, 'Send request data to Google Bigquery via background worker', 'Apply team'],
     [:enable_chat_support, 'Enable Zendesk chat support', 'Apply team'],
-    [:lock_external_report_to_december_2021, 'Lock the current external report to December 2021', 'Apply team'],
+    [:lock_external_report_to_january_2022, 'Lock the current external report to January 2022', 'Apply team'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [

--- a/spec/requests/publications/monthly_statistics_spec.rb
+++ b/spec/requests/publications/monthly_statistics_spec.rb
@@ -48,19 +48,19 @@ RSpec.describe 'Monthly Statistics', type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    context 'when the "lock external report to December 2021" feature flag is on' do
+    context 'when the "lock external report to January 2022" feature flag is on' do
       before do
-        report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: '2021-12')
+        report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: '2022-01')
         report.load_table_data
         report.save
 
-        FeatureFlag.activate('lock_external_report_to_december_2021')
+        FeatureFlag.activate('lock_external_report_to_january_2022')
       end
 
       it 'displays that month’s report' do
         get '/publications/monthly-statistics/'
 
-        expect(response.body).to include('to 20 December 2021')
+        expect(response.body).to include('to 17 January 2022')
         expect(response).to have_http_status(:ok)
       end
     end


### PR DESCRIPTION
## Context

The QA on the Feb report isn't complete, so dust off the feature flag we used in Jan. It would be better to be able to specify that we'd like to not publish a _new_ report, but that's considerably more complicated.

## Changes proposed in this pull request

See commit
